### PR TITLE
Rename agent sessions anywhere and title them from the first exchange (JUN-205)

### DIFF
--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -2,8 +2,43 @@
 
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import net from "node:net";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+// A port is "free" when a connection is refused. Mirrors the probe in
+// tauri-before-dev.mjs so both scripts agree on which port to use.
+function portIsFree(port) {
+  return new Promise((resolveProbe) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const done = (free) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolveProbe(free);
+    };
+    socket.once("connect", () => done(false));
+    socket.once("error", () => done(true));
+    socket.setTimeout(300, () => done(true));
+  });
+}
+
+// Pick the frontend port before Tauri reads its config, so Vite, the devUrl,
+// and before-dev's probe all agree. An explicit VITE_PORT is honored as-is;
+// otherwise scan upward from 1421 for a free port so parallel worktrees never
+// collide (and never silently reuse each other's Vite).
+async function resolveFrontendPort() {
+  const explicit = Number.parseInt(process.env.VITE_PORT ?? "", 10);
+  if (Number.isInteger(explicit) && explicit > 0) {
+    return explicit;
+  }
+  const base = 1421;
+  for (let port = base; port < base + 100; port += 1) {
+    if (await portIsFree(port)) {
+      return port;
+    }
+  }
+  throw new Error(`No free Vite port found in ${base}..${base + 99}`);
+}
 
 const REPLAY_ONBOARDING_FLAG = "--replay-onboarding";
 const platformConfigs = {
@@ -32,9 +67,18 @@ if (config && !hasConfigOverride) {
   tauriArgs.unshift("--config", config);
 }
 
+const frontendPort = await resolveFrontendPort();
+// Merge a devUrl override last so it wins over the file configs, pointing the
+// native window at the Vite server that before-dev will start on this port.
+tauriArgs.push(
+  "--config",
+  JSON.stringify({ build: { devUrl: `http://127.0.0.1:${frontendPort}` } }),
+);
+
 const child = spawn(tauriCommand(), ["dev", ...tauriArgs], {
   env: {
     ...process.env,
+    VITE_PORT: String(frontendPort),
     ...(replayOnboarding ? { VITE_JUNE_REPLAY_ONBOARDING: "1" } : {}),
   },
   shell: process.platform === "win32",

--- a/sessions-rename-preview.html
+++ b/sessions-rename-preview.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<!--
+  Dev-only preview for the agent-sessions sidebar rename (JUN-205). Renders the
+  real AgentSessionsList in a plain browser by faking the Tauri IPC bridge and
+  logging ensure_hermes_bridge_session calls, so the inline rename flow can be
+  driven and recorded without the native build. Nothing here ships (vite builds
+  only the configured entries). Usage: pnpm dev, open /sessions-rename-preview.html.
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>June session rename preview</title>
+    <script>
+      (function () {
+        const callbacks = new Map();
+        let nextId = 1;
+        const listeners = new Map();
+        window.__TAURI_INTERNALS__ = {
+          transformCallback(cb) {
+            const id = nextId++;
+            callbacks.set(id, cb);
+            return id;
+          },
+          unregisterCallback(id) {
+            callbacks.delete(id);
+          },
+          convertFileSrc(p) {
+            return p;
+          },
+          async invoke(cmd, args = {}) {
+            switch (cmd) {
+              case "plugin:event|listen": {
+                listeners.set(args.event, args.handler);
+                return args.handler;
+              }
+              case "plugin:event|unlisten":
+                return null;
+              case "ensure_hermes_bridge_session":
+                console.log(
+                  "[preview] ensure_hermes_bridge_session:",
+                  JSON.stringify(args.request),
+                );
+                return { object: "hermes.session.ensure", id: args.request.sessionId };
+              default:
+                console.log("[preview] unstubbed invoke:", cmd, args);
+                return null;
+            }
+          },
+        };
+        window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+          unregisterListener() {},
+        };
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/sessions-rename-preview.tsx"></script>
+  </body>
+</html>

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -426,7 +426,9 @@ pub async fn save_agent_hermes_session(
 pub async fn suggest_agent_session_title(
     request: SuggestAgentSessionTitleRequest,
 ) -> Result<SuggestAgentSessionTitleResponse, AppError> {
-    let title = crate::june_api::suggest_agent_session_title(&request.prompt).await?;
+    let title =
+        crate::june_api::suggest_agent_session_title(&request.prompt, request.response.as_deref())
+            .await?;
     Ok(SuggestAgentSessionTitleResponse { title })
 }
 

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -591,6 +591,8 @@ pub struct SaveAgentHermesSessionRequest {
 #[serde(rename_all = "camelCase")]
 pub struct SuggestAgentSessionTitleRequest {
     pub prompt: String,
+    #[serde(default)]
+    pub response: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -937,7 +937,10 @@ fn drop_leading_orphan_tool_messages(messages: &mut Vec<serde_json::Value>) {
     }
 }
 
-pub async fn suggest_agent_session_title(prompt: &str) -> Result<String, AppError> {
+pub async fn suggest_agent_session_title(
+    prompt: &str,
+    response: Option<&str>,
+) -> Result<String, AppError> {
     let prompt = prompt.trim();
     if prompt.is_empty() {
         return Err(AppError::new(
@@ -945,15 +948,16 @@ pub async fn suggest_agent_session_title(prompt: &str) -> Result<String, AppErro
             "Cannot title an empty agent request.",
         ));
     }
+    let user_content = agent_session_title_user_content(prompt, response);
     let response = proxy_agent_chat_completions(serde_json::json!({
         "messages": [
             {
                 "role": "system",
-                "content": "Name this agent session by the work being done, not by repeating the user's request. Return only a concrete 2 to 5 word title in sentence case: capitalize the first word and proper nouns only, never every word. Avoid first person, words like please/help/you, trailing ellipses, quotes, punctuation wrappers, markdown, or explanations."
+                "content": "Name this agent session by the work being done, not by repeating the user's request. Return only a concrete 2 to 5 word title in sentence case: capitalize the first word and proper nouns only, never every word. Avoid first person, words like please/help/you, trailing ellipses, quotes, punctuation wrappers, markdown, or explanations. When an assistant reply excerpt is provided, name the session by the work described there."
             },
             {
                 "role": "user",
-                "content": prompt
+                "content": user_content
             }
         ],
         "temperature": 0.1,
@@ -1391,6 +1395,15 @@ fn strip_source_label_prefix(value: &str) -> Option<&str> {
         }
     }
     None
+}
+
+fn agent_session_title_user_content(prompt: &str, response: Option<&str>) -> String {
+    let prompt = prompt.trim();
+    let Some(response) = response.map(str::trim).filter(|value| !value.is_empty()) else {
+        return prompt.to_string();
+    };
+    let response: String = response.chars().take(1200).collect();
+    format!("User request:\n{prompt}\n\nAssistant reply excerpt:\n{response}")
 }
 
 fn clean_agent_session_title(value: &str) -> Option<String> {
@@ -1854,6 +1867,44 @@ mod tests {
             Some("Create a quarterly planning briefing with follow")
         );
         assert_eq!(clean_agent_session_title("   "), None);
+    }
+
+    #[test]
+    fn agent_session_title_user_content_passes_through_prompt_only() {
+        assert_eq!(
+            agent_session_title_user_content("  Refactor this parser  ", None),
+            "Refactor this parser"
+        );
+    }
+
+    #[test]
+    fn agent_session_title_user_content_treats_whitespace_response_as_absent() {
+        assert_eq!(
+            agent_session_title_user_content("  Refactor this parser  ", Some(" \n\t ")),
+            "Refactor this parser"
+        );
+    }
+
+    #[test]
+    fn agent_session_title_user_content_formats_prompt_and_response() {
+        assert_eq!(
+            agent_session_title_user_content(
+                "  Refactor this parser  ",
+                Some("  I rewrote the tokenizer and added coverage.  "),
+            ),
+            "User request:\nRefactor this parser\n\nAssistant reply excerpt:\nI rewrote the tokenizer and added coverage."
+        );
+    }
+
+    #[test]
+    fn agent_session_title_user_content_truncates_response_on_char_boundary() {
+        let response = "é".repeat(1201);
+        let content = agent_session_title_user_content("Summarize the work", Some(&response));
+        let excerpt = content
+            .strip_prefix("User request:\nSummarize the work\n\nAssistant reply excerpt:\n")
+            .expect("formatted content should include assistant reply prefix");
+        assert_eq!(excerpt.chars().count(), 1200);
+        assert_eq!(excerpt, "é".repeat(1200));
     }
 
     #[test]

--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -1402,6 +1402,10 @@ fn agent_session_title_user_content(prompt: &str, response: Option<&str>) -> Str
     let Some(response) = response.map(str::trim).filter(|value| !value.is_empty()) else {
         return prompt.to_string();
     };
+    // 1200 chars keeps the excerpt a few hundred tokens: enough signal to name
+    // the work, small enough that the reply never drowns out the request or
+    // crowds the shared max_tokens budget. The frontend caps to the same
+    // length before invoking; this cap is the trust-boundary backstop.
     let response: String = response.chars().take(1200).collect();
     format!("User request:\n{prompt}\n\nAssistant reply excerpt:\n{response}")
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -91,6 +91,7 @@ import {
   AGENT_OPEN_EVENT,
   AGENT_SESSION_STATUS_EVENT,
   dispatchAgentSessionStatus,
+  emitAgentSessionsChanged,
   type AgentGalleryDetail,
   type AgentSessionStatusDetail,
 } from "../lib/agent-events";
@@ -1949,6 +1950,14 @@ export function App() {
           detail: { sessionId, title: next },
         }),
       );
+      // The Agent HUD is a separate window listening on the cross-window
+      // sessions channel; without this emit it would show the old title until
+      // an unrelated sessions-changed broadcast.
+      emitAgentSessionsChanged({
+        sessions: agentMenuBarSessionsRef.current,
+        workingSessionIds: [...agentMenuBarWorkingSessionIdsRef.current],
+        waitingSessionIds: [...agentMenuBarWaitingSessionIdsRef.current],
+      });
     },
     [agentSessions, publishAgentMenuBarState],
   );

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1920,6 +1920,7 @@ export function App() {
     }, 0);
   }, []);
 
+  /** stored session id (not the runtime session id). */
   const handleRenameAgentSession = useCallback(
     (sessionId: string, title: string) => {
       const next = title.trim();
@@ -1935,7 +1936,9 @@ export function App() {
       setAgentSessions((current) => current.map(renameSession));
       agentMenuBarSessionsRef.current = agentMenuBarSessionsRef.current.map(renameSession);
       publishAgentMenuBarState();
-      void ensureHermesBridgeSession({ sessionId, title: next }).catch(() => {});
+      void ensureHermesBridgeSession({ sessionId, title: next }).catch(() => {
+        setError("Could not save the session name. It may revert after a restart.");
+      });
       recordManualAgentSessionTitle(sessionId, next);
     },
     [agentSessions, publishAgentMenuBarState],
@@ -2824,6 +2827,7 @@ export function App() {
           setActiveAgentSession(undefined);
           setActiveView("agent");
         }}
+        onRenameAgentSession={handleRenameAgentSession}
         onSelectAgentSession={(session) => {
           if (takeNewTabIntent()) {
             openTab({ view: "agent", agentSessionId: session.id });

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -15,6 +15,7 @@ import {
   AGENT_SESSIONS_CHANGED_EVENT,
   AgentWorkspace,
   markAgentNewSessionPending,
+  recordManualAgentSessionTitle,
   type AgentNewSessionDetail,
   type AgentSessionsChangedDetail,
 } from "../components/agent/AgentWorkspace";
@@ -1919,6 +1920,27 @@ export function App() {
     }, 0);
   }, []);
 
+  const handleRenameAgentSession = useCallback(
+    (sessionId: string, title: string) => {
+      const next = title.trim();
+      const currentSession = agentSessions.find((session) => session.id === sessionId);
+      const currentTitle =
+        currentSession?.title?.trim() ||
+        currentSession?.preview?.trim() ||
+        (currentSession ? "Untitled session" : "");
+      if (!next || next === currentTitle) return;
+
+      const renameSession = (session: HermesSessionInfo) =>
+        session.id === sessionId ? { ...session, title: next } : session;
+      setAgentSessions((current) => current.map(renameSession));
+      agentMenuBarSessionsRef.current = agentMenuBarSessionsRef.current.map(renameSession);
+      publishAgentMenuBarState();
+      void ensureHermesBridgeSession({ sessionId, title: next }).catch(() => {});
+      recordManualAgentSessionTitle(sessionId, next);
+    },
+    [agentSessions, publishAgentMenuBarState],
+  );
+
   useEffect(() => {
     if (
       appBlocked ||
@@ -3034,6 +3056,7 @@ export function App() {
                     setActiveView("agent");
                   }}
                   onNewSession={handleNewAgentSession}
+                  onRenameSession={handleRenameAgentSession}
                   onOpenMoveDialog={(sessionId) => setMoveDialogSessionIds([sessionId])}
                   onOpenMoveSessions={(sessionIds) => setMoveDialogSessionIds(sessionIds)}
                   onRemoveFromProject={(sessionId, folderId) =>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -12,11 +12,13 @@ import { OnboardingFlow } from "../components/onboarding/OnboardingFlow";
 import {
   AGENT_DELETE_SESSION_EVENT,
   AGENT_NEW_SESSION_EVENT,
+  AGENT_SESSION_RENAMED_EVENT,
   AGENT_SESSIONS_CHANGED_EVENT,
   AgentWorkspace,
   markAgentNewSessionPending,
   recordManualAgentSessionTitle,
   type AgentNewSessionDetail,
+  type AgentSessionRenamedDetail,
   type AgentSessionsChangedDetail,
 } from "../components/agent/AgentWorkspace";
 import { AgentSessionsList } from "../components/agent/AgentSessionsList";
@@ -1940,6 +1942,11 @@ export function App() {
         setError("Could not save the session name. It may revert after a restart.");
       });
       recordManualAgentSessionTitle(sessionId, next);
+      window.dispatchEvent(
+        new CustomEvent<AgentSessionRenamedDetail>(AGENT_SESSION_RENAMED_EVENT, {
+          detail: { sessionId, title: next },
+        }),
+      );
     },
     [agentSessions, publishAgentMenuBarState],
   );

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -95,6 +95,7 @@ import {
   type AgentSessionStatusDetail,
 } from "../lib/agent-events";
 import { notifyAgentSessionStatus } from "../lib/agent-notifications";
+import { rememberSessionManuallyTitled } from "../lib/agent-session-titles";
 import { messageFromError } from "../lib/errors";
 import { parseDictationHelperEvent } from "../lib/dictation-events";
 import { listHermesSessions, titleFromPrompt } from "../lib/hermes-adapter";
@@ -1941,6 +1942,7 @@ export function App() {
       void ensureHermesBridgeSession({ sessionId, title: next }).catch(() => {
         setError("Could not save the session name. It may revert after a restart.");
       });
+      rememberSessionManuallyTitled(sessionId);
       recordManualAgentSessionTitle(sessionId, next);
       window.dispatchEvent(
         new CustomEvent<AgentSessionRenamedDetail>(AGENT_SESSION_RENAMED_EVENT, {

--- a/src/components/agent/AgentSessionsList.tsx
+++ b/src/components/agent/AgentSessionsList.tsx
@@ -41,6 +41,7 @@ type AgentSessionsListProps = {
   waitingSessionIds?: ReadonlySet<string>;
   onSelectSession: (session: HermesSessionInfo) => void;
   onNewSession: () => void;
+  /** stored session id (not the runtime session id). */
   onRenameSession: (sessionId: string, title: string) => void;
   onOpenMoveDialog: (sessionId: string) => void;
   onOpenMoveSessions: (sessionIds: string[]) => void;

--- a/src/components/agent/AgentSessionsList.tsx
+++ b/src/components/agent/AgentSessionsList.tsx
@@ -7,6 +7,7 @@ import { IconFolderAddRight } from "central-icons/IconFolderAddRight";
 import { IconFolderDelete } from "central-icons/IconFolderDelete";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconMoveFolder } from "central-icons/IconMoveFolder";
+import { IconPencil } from "central-icons/IconPencil";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconTrashCan } from "central-icons/IconTrashCan";
 import {
@@ -40,6 +41,7 @@ type AgentSessionsListProps = {
   waitingSessionIds?: ReadonlySet<string>;
   onSelectSession: (session: HermesSessionInfo) => void;
   onNewSession: () => void;
+  onRenameSession: (sessionId: string, title: string) => void;
   onOpenMoveDialog: (sessionId: string) => void;
   onOpenMoveSessions: (sessionIds: string[]) => void;
   onRemoveFromProject: (sessionId: string, folderId: string) => void;
@@ -62,6 +64,7 @@ export const AgentSessionsList = forwardRef<AgentSessionsListHandle, AgentSessio
       waitingSessionIds = EMPTY_SESSION_IDS,
       onSelectSession,
       onNewSession,
+      onRenameSession,
       onOpenMoveDialog,
       onOpenMoveSessions,
       onRemoveFromProject,
@@ -285,6 +288,7 @@ export const AgentSessionsList = forwardRef<AgentSessionsListHandle, AgentSessio
                 checked={selectedIds.has(session.id)}
                 onToggleSelected={() => toggleSelected(session.id)}
                 onSelect={() => onSelectSession(session)}
+                onRename={(title) => onRenameSession(session.id, title)}
                 onOpenMove={() => onOpenMoveDialog(session.id)}
                 onRemoveFromProject={(folderId) => onRemoveFromProject(session.id, folderId)}
               />
@@ -418,6 +422,7 @@ function AgentSessionListRow({
   checked,
   onToggleSelected,
   onSelect,
+  onRename,
   onOpenMove,
   onRemoveFromProject,
 }: {
@@ -428,6 +433,7 @@ function AgentSessionListRow({
   checked: boolean;
   onToggleSelected: () => void;
   onSelect: () => void;
+  onRename: (title: string) => void;
   onOpenMove: () => void;
   onRemoveFromProject: (folderId: string) => void;
 }) {
@@ -438,6 +444,22 @@ function AgentSessionListRow({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(title);
+  const titleInputRef = useRef<HTMLInputElement | null>(null);
+  const titleEditFinalizedRef = useRef(false);
+
+  useEffect(() => {
+    if (editingTitle && titleInputRef.current) {
+      titleEditFinalizedRef.current = false;
+      titleInputRef.current.focus();
+      titleInputRef.current.select();
+    }
+  }, [editingTitle]);
+
+  useEffect(() => {
+    if (!editingTitle) setTitleDraft(title);
+  }, [editingTitle, title]);
 
   useEffect(() => {
     if (!menu) return;
@@ -476,6 +498,66 @@ function AgentSessionListRow({
     }
   }
 
+  function commitRename(value: string) {
+    if (titleEditFinalizedRef.current) return;
+    titleEditFinalizedRef.current = true;
+    setEditingTitle(false);
+    const next = value.trim();
+    if (!next || next === title) {
+      setTitleDraft(title);
+      return;
+    }
+    onRename(next);
+  }
+
+  function cancelRename() {
+    titleEditFinalizedRef.current = true;
+    setTitleDraft(title);
+    setEditingTitle(false);
+  }
+
+  const rowMain = (
+    <>
+      <span className="folder-note-icon" aria-hidden>
+        {isScheduledRunSession(session) ? (
+          <IconArrowsRepeat size={15} />
+        ) : (
+          <IconBubble3 size={15} />
+        )}
+      </span>
+      <span className="folder-note-body">
+        {editingTitle ? (
+          <input
+            ref={titleInputRef}
+            className="folder-note-title-input"
+            aria-label="Session name"
+            value={titleDraft}
+            onChange={(event) => setTitleDraft(event.currentTarget.value)}
+            onClick={(event) => event.stopPropagation()}
+            onMouseDown={(event) => event.stopPropagation()}
+            onBlur={(event) => commitRename(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              event.stopPropagation();
+              if (event.key === "Enter") {
+                event.preventDefault();
+                commitRename(event.currentTarget.value);
+              }
+              if (event.key === "Escape") {
+                event.preventDefault();
+                cancelRename();
+              }
+            }}
+          />
+        ) : (
+          <span className="folder-note-title">{title}</span>
+        )}
+        <span className="folder-note-subtitle">
+          {projectName ? `${projectName} · ${preview}` : preview}
+        </span>
+      </span>
+    </>
+  );
+
   return (
     <li>
       <div
@@ -496,21 +578,13 @@ function AgentSessionListRow({
             {checked ? <IconCheckmark2Medium size={10} /> : null}
           </span>
         </label>
-        <button type="button" className="folder-note-main" onClick={onSelect}>
-          <span className="folder-note-icon" aria-hidden>
-            {isScheduledRunSession(session) ? (
-              <IconArrowsRepeat size={15} />
-            ) : (
-              <IconBubble3 size={15} />
-            )}
-          </span>
-          <span className="folder-note-body">
-            <span className="folder-note-title">{title}</span>
-            <span className="folder-note-subtitle">
-              {projectName ? `${projectName} · ${preview}` : preview}
-            </span>
-          </span>
-        </button>
+        {editingTitle ? (
+          <div className="folder-note-main">{rowMain}</div>
+        ) : (
+          <button type="button" className="folder-note-main" onClick={onSelect}>
+            {rowMain}
+          </button>
+        )}
         {status ? (
           <span
             className="agent-session-list-status"
@@ -555,6 +629,19 @@ function AgentSessionListRow({
             role="menu"
             onClick={(event) => event.stopPropagation()}
           >
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setMenu(null);
+                setTitleDraft(title);
+                titleEditFinalizedRef.current = false;
+                setEditingTitle(true);
+              }}
+            >
+              <IconPencil size={14} />
+              Rename
+            </button>
             <button
               type="button"
               role="menuitem"

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1573,6 +1573,32 @@ function updateContinuityAfterIssueReportFollowUpSubmitFailed(
   });
 }
 
+export function recordManualAgentSessionTitle(sessionId: string, title: string) {
+  if (!sessionContinuity) return;
+  sessionContinuity = captureSessionContinuity({
+    sessionItems: sessionContinuity.sessionItems.map((session) =>
+      session.id === sessionId ? { ...session, title } : session,
+    ),
+    pendingMessages: sessionContinuity.pendingMessages,
+    runtimeSessionIds: sessionContinuity.runtimeSessionIds,
+    liveEvents: sessionContinuity.liveEvents,
+    titleOverrides: {
+      ...sessionContinuity.titleOverrides,
+      [sessionId]: title,
+    },
+    titleSources: {
+      ...sessionContinuity.titleSources,
+      [sessionId]: "manual",
+    },
+    pendingIssueReports: sessionContinuity.pendingIssueReports,
+    reviewableIssueReports: sessionContinuity.reviewableIssueReports,
+    diagnosisRefreshIssueReportSessionIds: new Set(
+      sessionContinuity.diagnosisRefreshIssueReportSessionIds,
+    ),
+    submittingIssueReportSessionIds: new Set(sessionContinuity.submittingIssueReportSessionIds),
+  });
+}
+
 function dispatchIssueReportDeliverySettled(detail: IssueReportDeliverySettledDetail) {
   updateContinuityAfterIssueReportDelivery(detail);
   window.dispatchEvent(
@@ -6718,14 +6744,25 @@ export function AgentWorkspace({
   // use) and marks the session so the suggester won't clobber the user's name.
   // The sessions-changed effect propagates it to the sidebar.
   function renameHermesSession(sessionId: string, title: string) {
+    const next = title.trim();
+    const currentTitle =
+      sessionTitleOverridesRef.current[sessionId] ??
+      hermesSessionItems.find((item) => item.id === sessionId)?.title ??
+      "";
+    if (!next || next === currentTitle.trim()) return;
     titleSuggestionSessionIdsRef.current.add(sessionId);
     sessionTitleOverridesRef.current = {
       ...sessionTitleOverridesRef.current,
-      [sessionId]: title,
+      [sessionId]: next,
+    };
+    sessionTitleSourceRef.current = {
+      ...sessionTitleSourceRef.current,
+      [sessionId]: "manual",
     };
     setHermesSessionItems((current) =>
-      current.map((item) => (item.id === sessionId ? { ...item, title } : item)),
+      current.map((item) => (item.id === sessionId ? { ...item, title: next } : item)),
     );
+    void ensureHermesBridgeSession({ sessionId, title: next }).catch(() => {});
   }
 
   // Drops a deleted session from local state. Removing it from items fires
@@ -8426,8 +8463,7 @@ function AgentSessionBar({
 
   function commitRename() {
     setRenaming(false);
-    const next = draft.trim();
-    if (onRename && next && next !== title) onRename(next);
+    onRename?.(draft);
   }
 
   const hasMenu = Boolean(

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5223,7 +5223,7 @@ export function AgentWorkspace({
     const titlePromise =
       targetSessionId || options?.issueReport
         ? undefined
-        : agentSessionTitleForPrompt(titleContent);
+        : agentSessionTitleForPrompt(titleContent).then((suggestion) => suggestion.title);
     const fallbackSessionTitle = options?.issueReport
       ? "Issue report"
       : explicitSession?.title?.trim() ||
@@ -6925,9 +6925,14 @@ export function AgentWorkspace({
     titleSuggestionInFlightSessionIdsRef.current.add(sessionId);
     let shouldRecheckLatestMessages = false;
     try {
-      const title = await agentSessionTitleForPrompt(prompt, hasReply ? reply : undefined);
+      const suggestion = await agentSessionTitleForPrompt(prompt, hasReply ? reply : undefined);
       if (titleSuggestionSessionIdsRef.current.has(sessionId)) return;
-      const nextSource: AgentSessionTitleSource = hasReply ? "exchange" : "prompt";
+      if (!suggestion.fromModel && sessionTitleOverridesRef.current[sessionId]) {
+        return;
+      }
+      const title = suggestion.title;
+      const nextSource: AgentSessionTitleSource =
+        suggestion.fromModel && hasReply ? "exchange" : "prompt";
       sessionTitleOverridesRef.current = {
         ...sessionTitleOverridesRef.current,
         [sessionId]: title,
@@ -6936,9 +6941,9 @@ export function AgentWorkspace({
         ...sessionTitleSourceRef.current,
         [sessionId]: nextSource,
       };
-      if (nextSource === "exchange") {
+      if (suggestion.fromModel && nextSource === "exchange") {
         rememberSessionExchangeTitled(sessionId);
-      } else {
+      } else if (suggestion.fromModel && nextSource === "prompt") {
         shouldRecheckLatestMessages = true;
       }
       setHermesSessionItems((current) =>
@@ -8739,9 +8744,12 @@ async function agentSessionTitleForPrompt(prompt: string, response?: string) {
       suggestAgentSessionTitle(prompt, response),
       AGENT_TITLE_TIMEOUT_MS,
     );
-    return suggestion.title.trim() || titleFromPrompt(prompt);
+    const title = suggestion.title.trim();
+    return title
+      ? { title, fromModel: true }
+      : { title: titleFromPrompt(prompt), fromModel: false };
   } catch {
-    return titleFromPrompt(prompt);
+    return { title: titleFromPrompt(prompt), fromModel: false };
   }
 }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -736,6 +736,14 @@ function shuffleAgentShortcuts(): AgentShortcut[] {
   return pool;
 }
 
+export const AGENT_SESSION_RENAMED_EVENT = "june:agent:session-renamed";
+
+/** stored session id (not the runtime session id). */
+export type AgentSessionRenamedDetail = {
+  sessionId: string;
+  title: string;
+};
+
 export {
   AGENT_DELETE_SESSION_EVENT,
   AGENT_NEW_SESSION_EVENT,
@@ -3329,11 +3337,13 @@ export function AgentWorkspace({
   // bridge is still { running: false }, so a post-submit loadHermesSessions
   // silently no-ops and the sidebar never refreshes after event-driven runs.
   const windowEventHandlersRef = useRef({
+    applyManualHermesSessionTitleLocally,
     startNewTask,
     removeHermesSessionLocally,
   });
   useEffect(() => {
     windowEventHandlersRef.current = {
+      applyManualHermesSessionTitleLocally,
       startNewTask,
       removeHermesSessionLocally,
     };
@@ -3359,6 +3369,15 @@ export function AgentWorkspace({
       windowEventHandlersRef.current.removeHermesSessionLocally(detail.sessionId);
     }
 
+    function handleRenameSession(event: Event) {
+      const detail = (event as CustomEvent<AgentSessionRenamedDetail>).detail;
+      if (!detail?.sessionId) return;
+      windowEventHandlersRef.current.applyManualHermesSessionTitleLocally(
+        detail.sessionId,
+        detail.title,
+      );
+    }
+
     const pending = pendingNewSessionRequest();
     if (pending) {
       void windowEventHandlersRef.current.startNewTask(pending, {
@@ -3368,9 +3387,11 @@ export function AgentWorkspace({
 
     window.addEventListener(AGENT_NEW_SESSION_EVENT, handleNewSession);
     window.addEventListener(AGENT_DELETE_SESSION_EVENT, handleDeleteSession);
+    window.addEventListener(AGENT_SESSION_RENAMED_EVENT, handleRenameSession);
     return () => {
       window.removeEventListener(AGENT_NEW_SESSION_EVENT, handleNewSession);
       window.removeEventListener(AGENT_DELETE_SESSION_EVENT, handleDeleteSession);
+      window.removeEventListener(AGENT_SESSION_RENAMED_EVENT, handleRenameSession);
     };
   }, []);
 
@@ -6744,13 +6765,9 @@ export function AgentWorkspace({
   // Manual rename. Records an override (same channel the auto-suggested titles
   // use) and marks the session so the suggester won't clobber the user's name.
   // The sessions-changed effect propagates it to the sidebar.
-  function renameHermesSession(sessionId: string, title: string) {
+  function applyManualHermesSessionTitleLocally(sessionId: string, title: string) {
     const next = title.trim();
-    const currentTitle =
-      sessionTitleOverridesRef.current[sessionId] ??
-      hermesSessionItems.find((item) => item.id === sessionId)?.title ??
-      "";
-    if (!next || next === currentTitle.trim()) return;
+    if (!next) return null;
     titleSuggestionSessionIdsRef.current.add(sessionId);
     sessionTitleOverridesRef.current = {
       ...sessionTitleOverridesRef.current,
@@ -6760,10 +6777,23 @@ export function AgentWorkspace({
       ...sessionTitleSourceRef.current,
       [sessionId]: "manual",
     };
-    setHermesSessionItems((current) =>
-      current.map((item) => (item.id === sessionId ? { ...item, title: next } : item)),
-    );
-    void ensureHermesBridgeSession({ sessionId, title: next }).catch(() => {
+    const applyTitle = (sessions: HermesSessionInfo[]) =>
+      sessions.map((item) => (item.id === sessionId ? { ...item, title: next } : item));
+    hermesSessionItemsRef.current = applyTitle(hermesSessionItemsRef.current);
+    setHermesSessionItems((current) => applyTitle(current));
+    return next;
+  }
+
+  function renameHermesSession(sessionId: string, title: string) {
+    const next = title.trim();
+    const currentTitle =
+      sessionTitleOverridesRef.current[sessionId] ??
+      hermesSessionItems.find((item) => item.id === sessionId)?.title ??
+      "";
+    if (!next || next === currentTitle.trim()) return;
+    const appliedTitle = applyManualHermesSessionTitleLocally(sessionId, next);
+    if (!appliedTitle) return;
+    void ensureHermesBridgeSession({ sessionId, title: appliedTitle }).catch(() => {
       setError("Could not save the session name. It may revert after a restart.", { sessionId });
     });
   }
@@ -6835,8 +6865,7 @@ export function AgentWorkspace({
         ? messages
             .slice(firstUserMessageIndex + 1)
             .find(
-              (message) =>
-                message.role === "assistant" && visibleHermesMessageText(message).trim(),
+              (message) => message.role === "assistant" && visibleHermesMessageText(message).trim(),
             )
         : undefined;
     const reply = truncateAgentTitleResponseExcerpt(

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1573,6 +1573,7 @@ function updateContinuityAfterIssueReportFollowUpSubmitFailed(
   });
 }
 
+/** stored session id (not the runtime session id). */
 export function recordManualAgentSessionTitle(sessionId: string, title: string) {
   if (!sessionContinuity) return;
   sessionContinuity = captureSessionContinuity({
@@ -6762,7 +6763,9 @@ export function AgentWorkspace({
     setHermesSessionItems((current) =>
       current.map((item) => (item.id === sessionId ? { ...item, title: next } : item)),
     );
-    void ensureHermesBridgeSession({ sessionId, title: next }).catch(() => {});
+    void ensureHermesBridgeSession({ sessionId, title: next }).catch(() => {
+      setError("Could not save the session name. It may revert after a restart.", { sessionId });
+    });
   }
 
   // Drops a deleted session from local state. Removing it from items fires
@@ -6831,7 +6834,10 @@ export function AgentWorkspace({
       firstUserMessageIndex >= 0
         ? messages
             .slice(firstUserMessageIndex + 1)
-            .find((message) => message.role === "assistant")
+            .find(
+              (message) =>
+                message.role === "assistant" && visibleHermesMessageText(message).trim(),
+            )
         : undefined;
     const reply = truncateAgentTitleResponseExcerpt(
       visibleHermesMessageText(firstAssistantReply).trim(),

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -6953,6 +6953,16 @@ export function AgentWorkspace({
       );
       void ensureHermesBridgeSession({ sessionId, title })
         .then(() => {
+          // A manual rename can land while this auto-title PATCH is in
+          // flight and finish first; the stored title must end at the
+          // user's name, so re-assert it instead of settling the auto title.
+          if (sessionTitleSourceRef.current[sessionId] === "manual") {
+            const manualTitle = sessionTitleOverridesRef.current[sessionId];
+            if (manualTitle && manualTitle !== title) {
+              void ensureHermesBridgeSession({ sessionId, title: manualTitle }).catch(() => {});
+            }
+            return;
+          }
           if (settleExchangeAfterPersist) rememberSessionExchangeTitled(sessionId);
         })
         .catch(() => {});

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -6941,15 +6941,21 @@ export function AgentWorkspace({
         ...sessionTitleSourceRef.current,
         [sessionId]: nextSource,
       };
-      if (suggestion.fromModel && nextSource === "exchange") {
-        rememberSessionExchangeTitled(sessionId);
-      } else if (suggestion.fromModel && nextSource === "prompt") {
+      if (suggestion.fromModel && nextSource === "prompt") {
         shouldRecheckLatestMessages = true;
       }
+      // The durable exchange marker only lands once the title is known to be
+      // stored: marking first and failing the PATCH would freeze a stale
+      // stored title as settled on the next launch.
+      const settleExchangeAfterPersist = suggestion.fromModel && nextSource === "exchange";
       setHermesSessionItems((current) =>
         current.map((item) => (item.id === sessionId ? { ...item, title } : item)),
       );
-      void ensureHermesBridgeSession({ sessionId, title }).catch(() => {});
+      void ensureHermesBridgeSession({ sessionId, title })
+        .then(() => {
+          if (settleExchangeAfterPersist) rememberSessionExchangeTitled(sessionId);
+        })
+        .catch(() => {});
     } finally {
       titleSuggestionInFlightSessionIdsRef.current.delete(sessionId);
     }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -177,8 +177,9 @@ import {
 } from "../../lib/hermes-image-attach";
 import { parseSessionUsage, type SessionUsage } from "../../lib/hermes-session-usage";
 import {
+  rememberSessionExchangeTitled,
   rememberSessionManuallyTitled,
-  sessionManuallyTitled,
+  sessionSettledTitleKind,
 } from "../../lib/agent-session-titles";
 import {
   parseCompressSessionResult,
@@ -1889,6 +1890,7 @@ export function AgentWorkspace({
   const [hermesSessionMessages, setHermesSessionMessages] = useState<
     Record<string, HermesSessionMessage[]>
   >({});
+  const hermesSessionMessagesRef = useRef<Record<string, HermesSessionMessage[]>>({});
   const [pendingHermesMessages, setPendingHermesMessages] = useState<
     Record<string, HermesSessionMessage[]>
   >(() => continuity?.pendingMessages ?? {});
@@ -2297,9 +2299,11 @@ export function AgentWorkspace({
     workingSessionIdsRef.current = workingSessionIds;
     toolCallSessionIdsRef.current = toolCallSessionIds;
     waitingSessionIdsRef.current = waitingSessionIds;
+    hermesSessionMessagesRef.current = hermesSessionMessages;
     pendingHermesMessagesRef.current = pendingHermesMessages;
     hermesSessionItemsRef.current = hermesSessionItems;
   }, [
+    hermesSessionMessages,
     hermesSessionItems,
     pendingHermesMessages,
     selectedHermesSessionId,
@@ -2349,7 +2353,11 @@ export function AgentWorkspace({
   // Both delete paths (sidebar event and session-bar menu) run this so neither
   // leaves a phantom "working" session with a leaked listener behind.
   const scrubHermesSessionState = useCallback((sessionId: string) => {
-    setHermesSessionMessages((current) => omitRecordKey(current, sessionId));
+    setHermesSessionMessages((current) => {
+      const next = omitRecordKey(current, sessionId);
+      hermesSessionMessagesRef.current = next;
+      return next;
+    });
     setPendingHermesMessages((current) => {
       const next = omitRecordKey(current, sessionId);
       pendingHermesMessagesRef.current = next;
@@ -3410,10 +3418,14 @@ export function AgentWorkspace({
           pendingHermesMessagesRef.current[selectedHermesSessionId] ?? [],
           messages,
         );
-        setHermesSessionMessages((current) => ({
-          ...current,
-          [selectedHermesSessionId]: messages,
-        }));
+        setHermesSessionMessages((current) => {
+          const next = {
+            ...current,
+            [selectedHermesSessionId]: messages,
+          };
+          hermesSessionMessagesRef.current = next;
+          return next;
+        });
         setPendingHermesMessages((current) => {
           const next = {
             ...current,
@@ -4905,7 +4917,11 @@ export function AgentWorkspace({
       });
       return replaced ? next : [replacement, ...next];
     });
-    setHermesSessionMessages((current) => moveRecordKey(current, fromSessionId, toSessionId));
+    setHermesSessionMessages((current) => {
+      const next = moveRecordKey(current, fromSessionId, toSessionId);
+      hermesSessionMessagesRef.current = next;
+      return next;
+    });
     setPendingHermesMessages((current) => {
       const next = moveRecordKey(current, fromSessionId, toSessionId);
       pendingHermesMessagesRef.current = next;
@@ -4929,6 +4945,7 @@ export function AgentWorkspace({
     setHermesSessionMessages((current) => {
       let next = current;
       for (const id of ids) next = omitRecordKey(next, id);
+      hermesSessionMessagesRef.current = next;
       return next;
     });
     setPendingHermesMessages((current) => {
@@ -5789,10 +5806,14 @@ export function AgentWorkspace({
         pendingHermesMessagesRef.current[sessionId] ?? [],
         messages,
       );
-      setHermesSessionMessages((current) => ({
-        ...current,
-        [sessionId]: messages,
-      }));
+      setHermesSessionMessages((current) => {
+        const next = {
+          ...current,
+          [sessionId]: messages,
+        };
+        hermesSessionMessagesRef.current = next;
+        return next;
+      });
       setPendingHermesMessages((current) => {
         const next = {
           ...current,
@@ -6229,10 +6250,14 @@ export function AgentWorkspace({
       setDraft(branchComposerText);
       setCategory(null);
       setAttachments([]);
-      setHermesSessionMessages((current) => ({
-        ...current,
-        [result.sessionId]: branchSeedMessages,
-      }));
+      setHermesSessionMessages((current) => {
+        const next = {
+          ...current,
+          [result.sessionId]: branchSeedMessages,
+        };
+        hermesSessionMessagesRef.current = next;
+        return next;
+      });
       setPendingHermesMessages((current) => {
         const next = {
           ...current,
@@ -6852,8 +6877,20 @@ export function AgentWorkspace({
     sessionId: string,
     messages: HermesSessionMessage[],
   ) {
+    hermesSessionMessagesRef.current = {
+      ...hermesSessionMessagesRef.current,
+      [sessionId]: messages,
+    };
     const source = sessionTitleSourceRef.current[sessionId];
-    if (source === "manual" || source === "exchange" || sessionManuallyTitled(sessionId)) return;
+    const settledTitleKind = sessionSettledTitleKind(sessionId);
+    if (
+      source === "manual" ||
+      source === "exchange" ||
+      settledTitleKind === "manual" ||
+      settledTitleKind === "exchange"
+    ) {
+      return;
+    }
     if (
       titleSuggestionSessionIdsRef.current.has(sessionId) ||
       titleSuggestionInFlightSessionIdsRef.current.has(sessionId)
@@ -6886,23 +6923,36 @@ export function AgentWorkspace({
       if (!session || !isReplaceableAgentSessionTitle(session.title)) return;
     }
     titleSuggestionInFlightSessionIdsRef.current.add(sessionId);
+    let shouldRecheckLatestMessages = false;
     try {
       const title = await agentSessionTitleForPrompt(prompt, hasReply ? reply : undefined);
       if (titleSuggestionSessionIdsRef.current.has(sessionId)) return;
+      const nextSource: AgentSessionTitleSource = hasReply ? "exchange" : "prompt";
       sessionTitleOverridesRef.current = {
         ...sessionTitleOverridesRef.current,
         [sessionId]: title,
       };
       sessionTitleSourceRef.current = {
         ...sessionTitleSourceRef.current,
-        [sessionId]: hasReply ? "exchange" : "prompt",
+        [sessionId]: nextSource,
       };
+      if (nextSource === "exchange") {
+        rememberSessionExchangeTitled(sessionId);
+      } else {
+        shouldRecheckLatestMessages = true;
+      }
       setHermesSessionItems((current) =>
         current.map((item) => (item.id === sessionId ? { ...item, title } : item)),
       );
       void ensureHermesBridgeSession({ sessionId, title }).catch(() => {});
     } finally {
       titleSuggestionInFlightSessionIdsRef.current.delete(sessionId);
+    }
+    if (shouldRecheckLatestMessages) {
+      const latestMessages = hermesSessionMessagesRef.current[sessionId];
+      if (latestMessages) {
+        void suggestTitleForUntitledSession(sessionId, latestMessages);
+      }
     }
   }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1247,11 +1247,14 @@ type AgentSessionContinuity = {
   runtimeSessionIds: Record<string, string>;
   liveEvents: Record<string, JuneHermesEvent[]>;
   titleOverrides: Record<string, string>;
+  titleSources: Record<string, AgentSessionTitleSource>;
   pendingIssueReports: Record<string, PendingIssueReport>;
   reviewableIssueReports: Record<string, PendingIssueReport>;
   diagnosisRefreshIssueReportSessionIds: string[];
   submittingIssueReportSessionIds: string[];
 };
+
+type AgentSessionTitleSource = "prompt" | "exchange" | "manual";
 
 type IssueReportDeliveryResult = { sent: true } | { sent: false; errorMessage: string };
 
@@ -1389,6 +1392,7 @@ function captureSessionContinuity(state: {
   runtimeSessionIds: Record<string, string>;
   liveEvents: Record<string, JuneHermesEvent[]>;
   titleOverrides: Record<string, string>;
+  titleSources: Record<string, AgentSessionTitleSource>;
   pendingIssueReports: Record<string, PendingIssueReport>;
   reviewableIssueReports: Record<string, PendingIssueReport>;
   diagnosisRefreshIssueReportSessionIds: Set<string>;
@@ -1419,6 +1423,7 @@ function captureSessionContinuity(state: {
     runtimeSessionIds: pick(state.runtimeSessionIds),
     liveEvents: pick(state.liveEvents),
     titleOverrides: pick(state.titleOverrides),
+    titleSources: pick(state.titleSources),
     pendingIssueReports: pick(state.pendingIssueReports),
     reviewableIssueReports: pick(state.reviewableIssueReports),
     diagnosisRefreshIssueReportSessionIds: [...state.diagnosisRefreshIssueReportSessionIds].filter(
@@ -1525,6 +1530,7 @@ function updateContinuityAfterIssueReportDelivery(detail: IssueReportDeliverySet
     runtimeSessionIds: sessionContinuity.runtimeSessionIds,
     liveEvents: sessionContinuity.liveEvents,
     titleOverrides: sessionContinuity.titleOverrides,
+    titleSources: sessionContinuity.titleSources,
     pendingIssueReports,
     reviewableIssueReports,
     diagnosisRefreshIssueReportSessionIds,
@@ -1557,6 +1563,7 @@ function updateContinuityAfterIssueReportFollowUpSubmitFailed(
     runtimeSessionIds: sessionContinuity.runtimeSessionIds,
     liveEvents: sessionContinuity.liveEvents,
     titleOverrides: sessionContinuity.titleOverrides,
+    titleSources: sessionContinuity.titleSources,
     pendingIssueReports,
     reviewableIssueReports,
     diagnosisRefreshIssueReportSessionIds: new Set(
@@ -2063,7 +2070,11 @@ export function AgentWorkspace({
   // selecting an existing chat from the sidebar (that should swap instantly).
   const heroExitViaThreadRef = useRef(false);
   const sessionTitleOverridesRef = useRef<Record<string, string>>(continuity?.titleOverrides ?? {});
+  const sessionTitleSourceRef = useRef<Record<string, AgentSessionTitleSource>>(
+    continuity?.titleSources ?? {},
+  );
   const titleSuggestionSessionIdsRef = useRef<Set<string>>(new Set());
+  const titleSuggestionInFlightSessionIdsRef = useRef<Set<string>>(new Set());
   const listRef = useRef<HTMLDivElement | null>(null);
   const agentScrollRef = useRef<HTMLDivElement | null>(null);
   const composerEditorRef = useRef<ComposerEditorHandle | null>(null);
@@ -3475,6 +3486,7 @@ export function AgentWorkspace({
         runtimeSessionIds: runtimeSessionIdsRef.current,
         liveEvents: liveEventsRef.current,
         titleOverrides: sessionTitleOverridesRef.current,
+        titleSources: sessionTitleSourceRef.current,
         pendingIssueReports: Object.fromEntries(pendingIssueReportsRef.current),
         reviewableIssueReports: reviewableIssueReportsRef.current,
         diagnosisRefreshIssueReportSessionIds: diagnosisRefreshIssueReportSessionIdsRef.current,
@@ -5236,6 +5248,10 @@ export function AgentWorkspace({
         ...sessionTitleOverridesRef.current,
         [storedSessionId]: sessionTitle,
       };
+      sessionTitleSourceRef.current = {
+        ...sessionTitleSourceRef.current,
+        [storedSessionId]: "prompt",
+      };
       // The mount-time session load races this store: when its merge lands
       // first, the fetched placeholder title is already rendered and nothing
       // re-reads the override (the post-submit reload can no-op on a stale
@@ -6761,26 +6777,56 @@ export function AgentWorkspace({
     sessionId: string,
     messages: HermesSessionMessage[],
   ) {
+    const source = sessionTitleSourceRef.current[sessionId];
+    if (source === "manual" || source === "exchange") return;
     if (
-      sessionTitleOverridesRef.current[sessionId] ||
-      titleSuggestionSessionIdsRef.current.has(sessionId)
+      titleSuggestionSessionIdsRef.current.has(sessionId) ||
+      titleSuggestionInFlightSessionIdsRef.current.has(sessionId)
     ) {
       return;
     }
-    const session = hermesSessionItems.find((item) => item.id === sessionId);
-    if (!session || !isReplaceableAgentSessionTitle(session.title)) return;
-    const firstUserMessage = messages.find((message) => message.role === "user");
+    const firstUserMessageIndex = messages.findIndex((message) => message.role === "user");
+    const firstUserMessage =
+      firstUserMessageIndex >= 0 ? messages[firstUserMessageIndex] : undefined;
     const prompt = firstUserMessage ? visibleHermesMessageText(firstUserMessage).trim() : "";
     if (!prompt) return;
-    titleSuggestionSessionIdsRef.current.add(sessionId);
-    const title = await agentSessionTitleForPrompt(prompt);
-    sessionTitleOverridesRef.current = {
-      ...sessionTitleOverridesRef.current,
-      [sessionId]: title,
-    };
-    setHermesSessionItems((current) =>
-      current.map((item) => (item.id === sessionId ? { ...item, title } : item)),
+    const firstAssistantReply =
+      firstUserMessageIndex >= 0
+        ? messages
+            .slice(firstUserMessageIndex + 1)
+            .find((message) => message.role === "assistant")
+        : undefined;
+    const reply = truncateAgentTitleResponseExcerpt(
+      visibleHermesMessageText(firstAssistantReply).trim(),
     );
+    const hasReply = Boolean(reply);
+    if (source === "prompt") {
+      if (!hasReply) return;
+    } else if (sessionTitleOverridesRef.current[sessionId]) {
+      return;
+    } else {
+      const session = hermesSessionItems.find((item) => item.id === sessionId);
+      if (!session || !isReplaceableAgentSessionTitle(session.title)) return;
+    }
+    titleSuggestionInFlightSessionIdsRef.current.add(sessionId);
+    try {
+      const title = await agentSessionTitleForPrompt(prompt, hasReply ? reply : undefined);
+      if (titleSuggestionSessionIdsRef.current.has(sessionId)) return;
+      sessionTitleOverridesRef.current = {
+        ...sessionTitleOverridesRef.current,
+        [sessionId]: title,
+      };
+      sessionTitleSourceRef.current = {
+        ...sessionTitleSourceRef.current,
+        [sessionId]: hasReply ? "exchange" : "prompt",
+      };
+      setHermesSessionItems((current) =>
+        current.map((item) => (item.id === sessionId ? { ...item, title } : item)),
+      );
+      void ensureHermesBridgeSession({ sessionId, title }).catch(() => {});
+    } finally {
+      titleSuggestionInFlightSessionIdsRef.current.delete(sessionId);
+    }
   }
 
   async function setSkillEnabled(skill: HermesSkillInfo, enabled: boolean) {
@@ -8561,13 +8607,20 @@ function AgentSessionBar({
   );
 }
 
-async function agentSessionTitleForPrompt(prompt: string) {
+async function agentSessionTitleForPrompt(prompt: string, response?: string) {
   try {
-    const response = await withTimeout(suggestAgentSessionTitle(prompt), AGENT_TITLE_TIMEOUT_MS);
-    return response.title.trim() || titleFromPrompt(prompt);
+    const suggestion = await withTimeout(
+      suggestAgentSessionTitle(prompt, response),
+      AGENT_TITLE_TIMEOUT_MS,
+    );
+    return suggestion.title.trim() || titleFromPrompt(prompt);
   } catch {
     return titleFromPrompt(prompt);
   }
+}
+
+function truncateAgentTitleResponseExcerpt(response: string) {
+  return Array.from(response).slice(0, 1200).join("");
 }
 
 function isReplaceableAgentSessionTitle(title: unknown) {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -177,6 +177,10 @@ import {
 } from "../../lib/hermes-image-attach";
 import { parseSessionUsage, type SessionUsage } from "../../lib/hermes-session-usage";
 import {
+  rememberSessionManuallyTitled,
+  sessionManuallyTitled,
+} from "../../lib/agent-session-titles";
+import {
   parseCompressSessionResult,
   type CompressSessionResult,
 } from "../../lib/hermes-session-compress";
@@ -6768,6 +6772,7 @@ export function AgentWorkspace({
   function applyManualHermesSessionTitleLocally(sessionId: string, title: string) {
     const next = title.trim();
     if (!next) return null;
+    rememberSessionManuallyTitled(sessionId);
     titleSuggestionSessionIdsRef.current.add(sessionId);
     sessionTitleOverridesRef.current = {
       ...sessionTitleOverridesRef.current,
@@ -6848,7 +6853,7 @@ export function AgentWorkspace({
     messages: HermesSessionMessage[],
   ) {
     const source = sessionTitleSourceRef.current[sessionId];
-    if (source === "manual" || source === "exchange") return;
+    if (source === "manual" || source === "exchange" || sessionManuallyTitled(sessionId)) return;
     if (
       titleSuggestionSessionIdsRef.current.has(sessionId) ||
       titleSuggestionInFlightSessionIdsRef.current.has(sessionId)

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -52,7 +52,9 @@ import {
   useState,
 } from "react";
 import {
+  AGENT_SESSION_RENAMED_EVENT,
   markAgentNewSessionPending,
+  type AgentSessionRenamedDetail,
   type AgentSessionsChangedDetail,
 } from "../agent/AgentWorkspace";
 import { CategoryIcon } from "../agent/composer/CategoryIcon";
@@ -863,9 +865,21 @@ export function Sidebar({
       setWaitingAgentSessionIds(nextWaiting);
     }
 
+    function handleSessionRenamed(event: Event) {
+      const detail = (event as CustomEvent<AgentSessionRenamedDetail>).detail;
+      if (!detail?.sessionId) return;
+      setAgentSessions((current) =>
+        current.map((session) =>
+          session.id === detail.sessionId ? { ...session, title: detail.title } : session,
+        ),
+      );
+    }
+
     window.addEventListener(AGENT_SESSIONS_CHANGED_EVENT, handleSessionsChanged);
+    window.addEventListener(AGENT_SESSION_RENAMED_EVENT, handleSessionRenamed);
     return () => {
       window.removeEventListener(AGENT_SESSIONS_CHANGED_EVENT, handleSessionsChanged);
+      window.removeEventListener(AGENT_SESSION_RENAMED_EVENT, handleSessionRenamed);
     };
   }, []);
 

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -23,6 +23,7 @@ import { IconMicrophoneSparkle } from "central-icons/IconMicrophoneSparkle";
 import { IconMoveFolder } from "central-icons/IconMoveFolder";
 import { IconNoteText } from "central-icons/IconNoteText";
 import { IconPeople } from "central-icons/IconPeople";
+import { IconPencil } from "central-icons/IconPencil";
 import { IconPin } from "central-icons/IconPin";
 import { IconGithub } from "central-icons/IconGithub";
 import { IconPlugin2 } from "central-icons/IconPlugin2";
@@ -121,6 +122,8 @@ type SidebarProps = {
   onOpenMoveDialog: (noteId: string) => void;
   onRemoveNoteFromFolder: (noteId: string, folderId: string) => void;
   onNewAgentSession: () => void;
+  /** stored session id (not the runtime session id). */
+  onRenameAgentSession: (sessionId: string, title: string) => void;
   onSelectAgentSession: (session: HermesSessionInfo) => void;
   recoverableNoteIds?: ReadonlySet<string>;
   recordingStatus?: RecordingStatusDto | null;
@@ -348,6 +351,7 @@ export function Sidebar({
   onOpenMoveDialog,
   onRemoveNoteFromFolder,
   onNewAgentSession,
+  onRenameAgentSession,
   onSelectAgentSession,
   recoverableNoteIds,
   recordingStatus,
@@ -385,6 +389,7 @@ export function Sidebar({
   const [selectedAgentSessionId, setSelectedAgentSessionId] = useState<string>();
   const [agentSessionToDelete, setAgentSessionToDelete] = useState<HermesSessionInfo | null>(null);
   const [agentSessionDeleteError, setAgentSessionDeleteError] = useState<string | null>(null);
+  const [renamingAgentSessionId, setRenamingAgentSessionId] = useState<string | null>(null);
   const [deletingAgentSessionIds, setDeletingAgentSessionIds] = useState<Set<string>>(
     () => new Set(),
   );
@@ -1087,11 +1092,14 @@ export function Sidebar({
                     waiting={waitingAgentSessionIds.has(session.id)}
                     unread={unreadAgentSessionIds.has(session.id)}
                     deleting={deletingAgentSessionIds.has(session.id)}
+                    renaming={renamingAgentSessionId === session.id}
                     menuOpen={menu?.kind === "agent-session" && menu.sessionId === session.id}
                     onSelect={() => {
                       setSelectedAgentSessionId(session.id);
                       onSelectAgentSession(session);
                     }}
+                    onRename={(title) => onRenameAgentSession(session.id, title)}
+                    onRenameEnd={() => setRenamingAgentSessionId(null)}
                     onOpenMenu={(anchor) => openMenuForAgentSession(session.id, anchor)}
                   />
                 ))}
@@ -1134,11 +1142,14 @@ export function Sidebar({
                       waiting={waitingAgentSessionIds.has(session.id)}
                       unread={unreadAgentSessionIds.has(session.id)}
                       deleting={deletingAgentSessionIds.has(session.id)}
+                      renaming={renamingAgentSessionId === session.id}
                       menuOpen={menu?.kind === "agent-session" && menu.sessionId === session.id}
                       onSelect={() => {
                         setSelectedAgentSessionId(session.id);
                         onSelectAgentSession(session);
                       }}
+                      onRename={(title) => onRenameAgentSession(session.id, title)}
+                      onRenameEnd={() => setRenamingAgentSessionId(null)}
                       onOpenMenu={(anchor) => openMenuForAgentSession(session.id, anchor)}
                     />
                   ))
@@ -1227,6 +1238,7 @@ export function Sidebar({
           right={menu.right}
           top={menu.top}
           onTogglePinned={() => togglePinnedAgentSession(menuAgentSession.id)}
+          onRename={() => setRenamingAgentSessionId(menuAgentSession.id)}
           onDelete={() => {
             setAgentSessionDeleteError(null);
             setAgentSessionToDelete(menuAgentSession);
@@ -1899,8 +1911,11 @@ function AgentSessionRow({
   waiting,
   unread,
   deleting,
+  renaming,
   menuOpen,
   onSelect,
+  onRename,
+  onRenameEnd,
   onOpenMenu,
 }: {
   session: HermesSessionInfo;
@@ -1909,14 +1924,52 @@ function AgentSessionRow({
   waiting: boolean;
   unread: boolean;
   deleting: boolean;
+  renaming: boolean;
   menuOpen: boolean;
   onSelect: () => void;
+  onRename: (title: string) => void;
+  onRenameEnd: () => void;
   onOpenMenu: (anchor: HTMLElement) => void;
 }) {
   const title = session.title || session.preview || "Untitled session";
   const status = waiting ? "waitingForUser" : working ? "running" : undefined;
   const time = formatSessionTime(sessionTimestamp(session));
   const menuRef = useRef<HTMLButtonElement>(null);
+  const titleInputRef = useRef<HTMLInputElement | null>(null);
+  const titleEditFinalizedRef = useRef(false);
+  const [titleDraft, setTitleDraft] = useState(title);
+
+  useEffect(() => {
+    if (renaming && titleInputRef.current) {
+      titleEditFinalizedRef.current = false;
+      setTitleDraft(title);
+      titleInputRef.current.focus();
+      titleInputRef.current.select();
+    }
+  }, [renaming, title]);
+
+  useEffect(() => {
+    if (!renaming) setTitleDraft(title);
+  }, [renaming, title]);
+
+  function commitRename(value: string) {
+    if (titleEditFinalizedRef.current) return;
+    titleEditFinalizedRef.current = true;
+    onRenameEnd();
+    const next = value.trim();
+    if (!next || next === title) {
+      setTitleDraft(title);
+      return;
+    }
+    onRename(next);
+  }
+
+  function cancelRename() {
+    titleEditFinalizedRef.current = true;
+    setTitleDraft(title);
+    onRenameEnd();
+  }
+
   return (
     <article
       className="note-row agent-sidebar-row"
@@ -1932,18 +1985,46 @@ function AgentSessionRow({
     >
       <div
         className="note-row-main"
-        role="button"
-        tabIndex={0}
-        onClick={onSelect}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            onSelect();
-          }
-        }}
+        role={renaming ? undefined : "button"}
+        tabIndex={renaming ? undefined : 0}
+        onClick={renaming ? undefined : onSelect}
+        onKeyDown={
+          renaming
+            ? undefined
+            : (event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onSelect();
+                }
+              }
+        }
       >
         <span className="note-row-title">
-          <span className="note-row-title-text">{title}</span>
+          {renaming ? (
+            <input
+              ref={titleInputRef}
+              className="folder-note-title-input"
+              aria-label="Session name"
+              value={titleDraft}
+              onChange={(event) => setTitleDraft(event.currentTarget.value)}
+              onClick={(event) => event.stopPropagation()}
+              onMouseDown={(event) => event.stopPropagation()}
+              onBlur={(event) => commitRename(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                event.stopPropagation();
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  commitRename(event.currentTarget.value);
+                }
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  cancelRename();
+                }
+              }}
+            />
+          ) : (
+            <span className="note-row-title-text">{title}</span>
+          )}
         </span>
       </div>
       {waiting ? (
@@ -2001,6 +2082,7 @@ function AgentSessionContextMenu({
   right,
   top,
   onTogglePinned,
+  onRename,
   onDelete,
   onClose,
 }: {
@@ -2009,6 +2091,7 @@ function AgentSessionContextMenu({
   right: number;
   top: number;
   onTogglePinned: () => void;
+  onRename: () => void;
   onDelete: () => void;
   onClose: () => void;
 }) {
@@ -2029,6 +2112,17 @@ function AgentSessionContextMenu({
       >
         {pinned ? <IconUnpin size={14} /> : <IconPin size={14} />}
         {pinned ? "Unpin session" : "Pin session"}
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onRename();
+          onClose();
+        }}
+      >
+        <IconPencil size={14} />
+        Rename session
       </button>
       <div className="context-menu-separator" role="separator" />
       <button

--- a/src/lib/agent-session-titles.ts
+++ b/src/lib/agent-session-titles.ts
@@ -1,5 +1,5 @@
 /**
- * Per-session record of manual title edits. Keyed by stored session id (not
+ * Per-session record of settled title edits. Keyed by stored session id (not
  * runtime session id) because June's session list and persistence use the
  * durable id, while live Hermes processes may resume under a different
  * runtime id. Absence means auto-titling is allowed, so sessions from before
@@ -12,7 +12,9 @@
 
 const STORAGE_KEY = "june.agent.manuallyTitledSessions";
 
-function readStore(): Record<string, true> {
+export type AgentSessionSettledTitleKind = "manual" | "exchange";
+
+function readStore(): Record<string, AgentSessionSettledTitleKind> {
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (!raw) return {};
@@ -20,13 +22,21 @@ function readStore(): Record<string, true> {
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       return {};
     }
-    return parsed as Record<string, true>;
+    const store: Record<string, AgentSessionSettledTitleKind> = {};
+    for (const [sessionId, value] of Object.entries(parsed)) {
+      if (value === true || value === "manual") {
+        store[sessionId] = "manual";
+      } else if (value === "exchange") {
+        store[sessionId] = "exchange";
+      }
+    }
+    return store;
   } catch {
     return {};
   }
 }
 
-function writeStore(store: Record<string, true>) {
+function writeStore(store: Record<string, AgentSessionSettledTitleKind>) {
   try {
     if (Object.keys(store).length === 0) {
       window.localStorage.removeItem(STORAGE_KEY);
@@ -34,18 +44,27 @@ function writeStore(store: Record<string, true>) {
     }
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
   } catch {
-    // Ignore; worst case a manually titled session can be auto-titled again.
+    // Ignore; worst case a settled session can be auto-titled again.
   }
 }
 
-/** Whether this session has an explicit user-authored title. */
-export function sessionManuallyTitled(sessionId: string | undefined): boolean {
-  if (!sessionId) return false;
-  return readStore()[sessionId] === true;
+/** Why this session's title is settled, or null when auto-titling is allowed. */
+export function sessionSettledTitleKind(
+  sessionId: string | undefined,
+): AgentSessionSettledTitleKind | null {
+  if (!sessionId) return null;
+  return readStore()[sessionId] ?? null;
 }
 
 export function rememberSessionManuallyTitled(sessionId: string) {
   const store = readStore();
-  store[sessionId] = true;
+  store[sessionId] = "manual";
+  writeStore(store);
+}
+
+export function rememberSessionExchangeTitled(sessionId: string) {
+  const store = readStore();
+  if (store[sessionId] === "manual") return;
+  store[sessionId] = "exchange";
   writeStore(store);
 }

--- a/src/lib/agent-session-titles.ts
+++ b/src/lib/agent-session-titles.ts
@@ -1,0 +1,51 @@
+/**
+ * Per-session record of manual title edits. Keyed by stored session id (not
+ * runtime session id) because June's session list and persistence use the
+ * durable id, while live Hermes processes may resume under a different
+ * runtime id. Absence means auto-titling is allowed, so sessions from before
+ * this record existed fall back to the safe default.
+ *
+ * localStorage (not the backend) because the runtime's session store is
+ * machine-local too, and the map must be readable synchronously before the
+ * title suggester decides whether a loaded title is replaceable.
+ */
+
+const STORAGE_KEY = "june.agent.manuallyTitledSessions";
+
+function readStore(): Record<string, true> {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as Record<string, true>;
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: Record<string, true>) {
+  try {
+    if (Object.keys(store).length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // Ignore; worst case a manually titled session can be auto-titled again.
+  }
+}
+
+/** Whether this session has an explicit user-authored title. */
+export function sessionManuallyTitled(sessionId: string | undefined): boolean {
+  if (!sessionId) return false;
+  return readStore()[sessionId] === true;
+}
+
+export function rememberSessionManuallyTitled(sessionId: string) {
+  const store = readStore();
+  store[sessionId] = true;
+  writeStore(store);
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -827,9 +827,13 @@ export async function saveAgentHermesSession(input: { taskId: string; hermesSess
   });
 }
 
-export async function suggestAgentSessionTitle(prompt: string) {
+export async function suggestAgentSessionTitle(prompt: string, response?: string) {
+  const trimmedResponse = response?.trim();
   return invoke<SuggestAgentSessionTitleResponse>("suggest_agent_session_title", {
-    request: { prompt },
+    request: {
+      prompt,
+      ...(trimmedResponse ? { response: trimmedResponse } : {}),
+    },
   });
 }
 

--- a/src/sessions-rename-preview.tsx
+++ b/src/sessions-rename-preview.tsx
@@ -1,0 +1,64 @@
+// Dev-only preview entry: renders the real AgentSessionsList against the faked
+// Tauri bridge in sessions-rename-preview.html so the sidebar rename flow can
+// be driven and recorded in a plain browser (no native build). The rename
+// handler mirrors App.tsx's handleRenameAgentSession: local state update plus
+// a best-effort ensure_hermes_bridge_session persistence call (logged by the
+// fake bridge). Nothing here ships: vite builds only the configured entries.
+import { useState } from "react";
+import ReactDOM from "react-dom/client";
+import { AgentSessionsList } from "./components/agent/AgentSessionsList";
+import { ensureHermesBridgeSession, type HermesSessionInfo } from "./lib/tauri";
+import { initTheme } from "./lib/theme";
+import "./styles/app.css";
+
+initTheme();
+
+const initialSessions: HermesSessionInfo[] = [
+  {
+    id: "session-1",
+    title: "Untitled session",
+    preview: "Can you look at the flaky checkout test?",
+    last_active: "2026-07-07T09:12:00Z",
+    message_count: 6,
+  },
+  {
+    id: "session-2",
+    title: "Fix payment retries",
+    preview: "Retries now back off exponentially",
+    last_active: "2026-07-06T16:40:00Z",
+    message_count: 12,
+  },
+  {
+    id: "session-3",
+    title: "Summarize sprint notes",
+    preview: "Drafted the sprint summary",
+    last_active: "2026-07-05T11:05:00Z",
+    message_count: 4,
+  },
+];
+
+function Preview() {
+  const [sessions, setSessions] = useState(initialSessions);
+  return (
+    <div style={{ height: "100vh", display: "flex" }}>
+      <AgentSessionsList
+        sessions={sessions}
+        folders={[]}
+        sessionFolderIds={{}}
+        onSelectSession={() => {}}
+        onNewSession={() => {}}
+        onRenameSession={(sessionId, title) => {
+          setSessions((current) =>
+            current.map((session) => (session.id === sessionId ? { ...session, title } : session)),
+          );
+          void ensureHermesBridgeSession({ sessionId, title }).catch(() => {});
+        }}
+        onOpenMoveDialog={() => {}}
+        onOpenMoveSessions={() => {}}
+        onRemoveFromProject={() => {}}
+      />
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(<Preview />);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -17367,6 +17367,27 @@ input:focus-visible,
   white-space: nowrap;
 }
 
+.folder-note-title-input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  border-radius: var(--r-xs);
+  padding: 0 var(--sp-1);
+  outline: 0;
+  background: var(--surface-subtle);
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  font-size: var(--fs-md);
+  font-weight: 400;
+  line-height: 1.2;
+}
+
+.folder-note-title-input:focus,
+.folder-note-title-input:focus-visible {
+  outline: none;
+  box-shadow: none;
+}
+
 .folder-note-subtitle {
   display: inline-flex;
   align-items: center;

--- a/src/test/agent-sessions-list.test.tsx
+++ b/src/test/agent-sessions-list.test.tsx
@@ -67,6 +67,7 @@ describe("AgentSessionsList", () => {
         waitingSessionIds={new Set(["waiting-session"])}
         onSelectSession={vi.fn()}
         onNewSession={vi.fn()}
+        onRenameSession={vi.fn()}
         onOpenMoveDialog={vi.fn()}
         onOpenMoveSessions={vi.fn()}
         onRemoveFromProject={vi.fn()}
@@ -100,6 +101,7 @@ describe("AgentSessionsList", () => {
         waitingSessionIds={new Set(["waiting-session"])}
         onSelectSession={vi.fn()}
         onNewSession={vi.fn()}
+        onRenameSession={vi.fn()}
         onOpenMoveDialog={vi.fn()}
         onOpenMoveSessions={onOpenMoveSessions}
         onRemoveFromProject={vi.fn()}
@@ -128,6 +130,7 @@ describe("AgentSessionsList", () => {
         waitingSessionIds={new Set(["waiting-session"])}
         onSelectSession={vi.fn()}
         onNewSession={vi.fn()}
+        onRenameSession={vi.fn()}
         onOpenMoveDialog={vi.fn()}
         onOpenMoveSessions={onOpenMoveSessions}
         onRemoveFromProject={vi.fn()}
@@ -158,6 +161,7 @@ describe("AgentSessionsList", () => {
         waitingSessionIds={new Set(["waiting-session"])}
         onSelectSession={vi.fn()}
         onNewSession={vi.fn()}
+        onRenameSession={vi.fn()}
         onOpenMoveDialog={vi.fn()}
         onOpenMoveSessions={vi.fn()}
         onRemoveFromProject={vi.fn()}
@@ -172,6 +176,100 @@ describe("AgentSessionsList", () => {
     expect(hermesMocks.deleteHermesSession).toHaveBeenCalledTimes(2);
     expect(hermesMocks.deleteHermesSession).toHaveBeenNthCalledWith(1, "waiting-session");
     expect(hermesMocks.deleteHermesSession).toHaveBeenNthCalledWith(2, "running-session");
+  });
+
+  it("renames a session row from the action menu", async () => {
+    const user = userEvent.setup();
+    const onRenameSession = vi.fn();
+    render(
+      <AgentSessionsList
+        sessions={sessions}
+        folders={[]}
+        sessionFolderIds={{}}
+        onSelectSession={vi.fn()}
+        onNewSession={vi.fn()}
+        onRenameSession={onRenameSession}
+        onOpenMoveDialog={vi.fn()}
+        onOpenMoveSessions={vi.fn()}
+        onRemoveFromProject={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Actions for Idle session" }));
+    await user.click(screen.getByRole("menuitem", { name: "Rename" }));
+    const input = screen.getByRole("textbox", { name: "Session name" });
+
+    await user.clear(input);
+    await user.type(input, "Manual session name{Enter}");
+
+    expect(onRenameSession).toHaveBeenCalledWith("idle-session", "Manual session name");
+  });
+
+  it("cancels row rename on Escape", async () => {
+    const user = userEvent.setup();
+    const onRenameSession = vi.fn();
+    render(
+      <AgentSessionsList
+        sessions={sessions}
+        folders={[]}
+        sessionFolderIds={{}}
+        onSelectSession={vi.fn()}
+        onNewSession={vi.fn()}
+        onRenameSession={onRenameSession}
+        onOpenMoveDialog={vi.fn()}
+        onOpenMoveSessions={vi.fn()}
+        onRemoveFromProject={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Actions for Idle session" }));
+    await user.click(screen.getByRole("menuitem", { name: "Rename" }));
+    await user.type(screen.getByRole("textbox", { name: "Session name" }), "{Escape}");
+
+    expect(onRenameSession).not.toHaveBeenCalled();
+    expect(screen.getByText("Idle session")).toBeInTheDocument();
+  });
+
+  it("does not commit unchanged or empty row rename text", async () => {
+    const user = userEvent.setup();
+    const onRenameSession = vi.fn();
+    const { rerender } = render(
+      <AgentSessionsList
+        sessions={sessions}
+        folders={[]}
+        sessionFolderIds={{}}
+        onSelectSession={vi.fn()}
+        onNewSession={vi.fn()}
+        onRenameSession={onRenameSession}
+        onOpenMoveDialog={vi.fn()}
+        onOpenMoveSessions={vi.fn()}
+        onRemoveFromProject={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Actions for Idle session" }));
+    await user.click(screen.getByRole("menuitem", { name: "Rename" }));
+    await user.type(screen.getByRole("textbox", { name: "Session name" }), "{Enter}");
+
+    rerender(
+      <AgentSessionsList
+        sessions={sessions}
+        folders={[]}
+        sessionFolderIds={{}}
+        onSelectSession={vi.fn()}
+        onNewSession={vi.fn()}
+        onRenameSession={onRenameSession}
+        onOpenMoveDialog={vi.fn()}
+        onOpenMoveSessions={vi.fn()}
+        onRemoveFromProject={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Actions for Idle session" }));
+    await user.click(screen.getByRole("menuitem", { name: "Rename" }));
+    await user.clear(screen.getByRole("textbox", { name: "Session name" }));
+    await user.type(screen.getByRole("textbox", { name: "Session name" }), "{Enter}");
+
+    expect(onRenameSession).not.toHaveBeenCalled();
   });
 });
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -5,6 +5,7 @@ import {
   AGENT_DELETE_SESSION_EVENT,
   AGENT_NEW_SESSION_EVENT,
   AGENT_NEW_SESSION_PENDING_KEY,
+  AGENT_SESSION_RENAMED_EVENT,
   AGENT_SESSIONS_CHANGED_EVENT,
   AgentWorkspace,
   HERO_GREETINGS,
@@ -282,6 +283,7 @@ function mockGlmCapabilities(capabilities: string[]) {
 describe("AgentWorkspace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.suggestAgentSessionTitle.mockReset();
     mocks.gatewayEventHandlers.clear();
     mocks.gatewayInstances.length = 0;
     // Auto-cleanup unmounts the workspace after each test, which snapshots
@@ -3295,6 +3297,144 @@ describe("AgentWorkspace", () => {
       "I found the failing path and isolated the missing persistence call.",
     );
     expect(await screen.findByText("Persistence Fix")).toBeInTheDocument();
+  }, 10_000);
+
+  it("keeps a sidebar rename from being overwritten by a prompt-title exchange upgrade", async () => {
+    const rawTitle = "I want you to summarize latest failures";
+    const userMessage = {
+      id: "u1",
+      role: "user",
+      content: "summarize latest failures",
+      timestamp: "2026-06-04T12:00:00Z",
+    };
+    const assistantMessage = {
+      id: "a1",
+      role: "assistant",
+      content: "I found the failing path and isolated the missing persistence call.",
+      timestamp: "2026-06-04T12:00:01Z",
+    };
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-sidebar-prompt",
+        title: rawTitle,
+        preview: rawTitle,
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages
+      .mockResolvedValueOnce([userMessage])
+      .mockResolvedValue([userMessage, assistantMessage]);
+    mocks.suggestAgentSessionTitle.mockResolvedValueOnce({ title: "Failure Summary" });
+    hermesActivityStore.record(
+      {
+        kind: "lifecycle",
+        sessionId: "session-sidebar-prompt",
+        flavor: "running",
+        status: "running",
+        text: "",
+        receivedAt: "2026-06-04T12:00:00Z",
+      },
+      "sandboxed",
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Failure Summary")).toBeInTheDocument();
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(1);
+    mocks.ensureHermesBridgeSession.mockClear();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_SESSION_RENAMED_EVENT, {
+          detail: {
+            sessionId: "session-sidebar-prompt",
+            title: "Manual sidebar name",
+          },
+        }),
+      );
+    });
+
+    expect(await screen.findByText("Manual sidebar name")).toBeInTheDocument();
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+    });
+
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages).toHaveBeenCalledWith("session-sidebar-prompt"),
+    );
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(1);
+    expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalled();
+    expect(screen.getByText("Manual sidebar name")).toBeInTheDocument();
+  }, 10_000);
+
+  it("keeps a sidebar rename from being overwritten by a fresh suggestion", async () => {
+    const userMessage = {
+      id: "u1",
+      role: "user",
+      content: "review the import retry path",
+      timestamp: "2026-06-04T12:00:00Z",
+    };
+    const assistantMessage = {
+      id: "a1",
+      role: "assistant",
+      content: "The retry path skipped the persisted session title update.",
+      timestamp: "2026-06-04T12:00:01Z",
+    };
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-sidebar-fresh",
+        title: "Untitled session",
+        preview: "review the import retry path",
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([userMessage, assistantMessage]);
+    mocks.suggestAgentSessionTitle.mockResolvedValue({ title: "Import Retry Review" });
+    hermesActivityStore.record(
+      {
+        kind: "lifecycle",
+        sessionId: "session-sidebar-fresh",
+        flavor: "running",
+        status: "running",
+        text: "",
+        receivedAt: "2026-06-04T12:00:00Z",
+      },
+      "sandboxed",
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Untitled session")).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_SESSION_RENAMED_EVENT, {
+          detail: {
+            sessionId: "session-sidebar-fresh",
+            title: "Manual import notes",
+          },
+        }),
+      );
+    });
+
+    expect(await screen.findByText("Manual import notes")).toBeInTheDocument();
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+    });
+
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages).toHaveBeenCalledWith("session-sidebar-fresh"),
+    );
+    expect(mocks.suggestAgentSessionTitle).not.toHaveBeenCalled();
+    expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
+      sessionId: "session-sidebar-fresh",
+      title: "Import Retry Review",
+    });
+    expect(screen.getByText("Manual import notes")).toBeInTheDocument();
   }, 10_000);
 
   it("persists manual header renames and blocks later title suggestions", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3305,6 +3305,151 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("Persistence Fix")).toBeInTheDocument();
   }, 10_000);
 
+  it("keeps a prompt title when an exchange title suggestion fails and retries later", async () => {
+    const rawTitle = "I want you to summarize latest failures";
+    const userMessage = {
+      id: "u1",
+      role: "user",
+      content: "summarize latest failures",
+      timestamp: "2026-06-04T12:00:00Z",
+    };
+    const assistantMessage = {
+      id: "a1",
+      role: "assistant",
+      content: "I found the failing path and isolated the missing persistence call.",
+      timestamp: "2026-06-04T12:00:01Z",
+    };
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-upgrade-reject",
+        title: rawTitle,
+        preview: rawTitle,
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages
+      .mockResolvedValueOnce([userMessage])
+      .mockResolvedValue([userMessage, assistantMessage]);
+    mocks.suggestAgentSessionTitle
+      .mockResolvedValueOnce({ title: "Failure Summary" })
+      .mockRejectedValueOnce(new Error("title service unavailable"))
+      .mockResolvedValueOnce({ title: "Persistence Fix" });
+    hermesActivityStore.record(
+      {
+        kind: "lifecycle",
+        sessionId: "session-upgrade-reject",
+        flavor: "running",
+        status: "running",
+        text: "",
+        receivedAt: "2026-06-04T12:00:00Z",
+      },
+      "sandboxed",
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Failure Summary")).toBeInTheDocument();
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+    });
+
+    await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("Failure Summary")).toBeInTheDocument();
+    expect(window.localStorage.getItem("june.agent.manuallyTitledSessions")).toBeNull();
+
+    hermesActivityStore.record(
+      {
+        kind: "lifecycle",
+        sessionId: "session-upgrade-reject",
+        flavor: "running",
+        status: "running",
+        text: "",
+        receivedAt: "2026-06-04T12:00:02Z",
+      },
+      "sandboxed",
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+    });
+
+    await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(3));
+    expect(await screen.findByText("Persistence Fix")).toBeInTheDocument();
+  }, 10_000);
+
+  it("keeps a failed fresh title fallback retry to a later natural refresh", async () => {
+    const rawTitle = "I want you to summarize latest failures";
+    const userMessage = {
+      id: "u1",
+      role: "user",
+      content: "summarize latest failures",
+      timestamp: "2026-06-04T12:00:00Z",
+    };
+    const assistantMessage = {
+      id: "a1",
+      role: "assistant",
+      content: "I found the failing path and isolated the missing persistence call.",
+      timestamp: "2026-06-04T12:00:01Z",
+    };
+    const secondSession = {
+      id: "session-other",
+      title: "Other session",
+      preview: "Other preview",
+      last_active: "2026-06-04T12:05:00Z",
+    };
+    let rejectPromptTitle: (reason?: unknown) => void = () => {};
+    const promptTitle = new Promise<{ title: string }>((_resolve, reject) => {
+      rejectPromptTitle = reject;
+    });
+    const targetSession = {
+      id: "session-fresh-reject",
+      title: rawTitle,
+      preview: rawTitle,
+      last_active: "2026-06-04T12:00:00Z",
+    };
+    mocks.listHermesSessions.mockResolvedValue([targetSession, secondSession]);
+    mocks.listHermesSessionMessages
+      .mockResolvedValueOnce([userMessage])
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([userMessage, assistantMessage]);
+    mocks.suggestAgentSessionTitle
+      .mockImplementationOnce(() => promptTitle)
+      .mockResolvedValueOnce({ title: "Persistence Fix" });
+
+    const { rerender } = render(<AgentWorkspace initialSession={targetSession} />);
+
+    await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(1));
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenLastCalledWith(
+      "summarize latest failures",
+      undefined,
+    );
+
+    rerender(<AgentWorkspace initialSession={secondSession} />);
+    expect(await screen.findByText("Other session")).toBeInTheDocument();
+    rerender(<AgentWorkspace initialSession={targetSession} />);
+
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages.mock.calls.length).toBeGreaterThanOrEqual(3),
+    );
+
+    await act(async () => {
+      rejectPromptTitle(new Error("title service unavailable"));
+      await promptTitle.catch(() => undefined);
+    });
+
+    await waitFor(() =>
+      expect(screen.getAllByText("summarize latest failures").length).toBeGreaterThan(0),
+    );
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem("june.agent.manuallyTitledSessions")).toBeNull();
+    expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
+      sessionId: "session-fresh-reject",
+      title: "summarize latest failures",
+    });
+  }, 10_000);
+
   it("upgrades a prompt-only title from the first non-empty assistant reply", async () => {
     const rawTitle = "I want you to summarize latest failures";
     const userMessage = {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3234,6 +3234,69 @@ describe("AgentWorkspace", () => {
     expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2);
   }, 10_000);
 
+  it("upgrades a prompt-only title from the first non-empty assistant reply", async () => {
+    const rawTitle = "I want you to summarize latest failures";
+    const userMessage = {
+      id: "u1",
+      role: "user",
+      content: "summarize latest failures",
+      timestamp: "2026-06-04T12:00:00Z",
+    };
+    const emptyAssistantMessage = {
+      id: "a-empty",
+      role: "assistant",
+      content: "",
+      timestamp: "2026-06-04T12:00:01Z",
+    };
+    const assistantMessage = {
+      id: "a1",
+      role: "assistant",
+      content: "I found the failing path and isolated the missing persistence call.",
+      timestamp: "2026-06-04T12:00:02Z",
+    };
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-upgrade-empty",
+        title: rawTitle,
+        preview: rawTitle,
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages
+      .mockResolvedValueOnce([userMessage])
+      .mockResolvedValue([userMessage, emptyAssistantMessage, assistantMessage]);
+    mocks.suggestAgentSessionTitle
+      .mockResolvedValueOnce({ title: "Failure Summary" })
+      .mockResolvedValueOnce({ title: "Persistence Fix" });
+    hermesActivityStore.record(
+      {
+        kind: "lifecycle",
+        sessionId: "session-upgrade-empty",
+        flavor: "running",
+        status: "running",
+        text: "",
+        receivedAt: "2026-06-04T12:00:00Z",
+      },
+      "sandboxed",
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Failure Summary")).toBeInTheDocument();
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+    });
+
+    await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2));
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenLastCalledWith(
+      "summarize latest failures",
+      "I found the failing path and isolated the missing persistence call.",
+    );
+    expect(await screen.findByText("Persistence Fix")).toBeInTheDocument();
+  }, 10_000);
+
   it("persists manual header renames and blocks later title suggestions", async () => {
     const userMessage = {
       id: "u1",
@@ -3277,6 +3340,7 @@ describe("AgentWorkspace", () => {
       await screen.findByText("I want you to summarize the billing retry failure"),
     ).toBeInTheDocument();
     expect(mocks.suggestAgentSessionTitle).not.toHaveBeenCalled();
+    mocks.ensureHermesBridgeSession.mockRejectedValueOnce(new Error("patch failed"));
 
     await user.click(screen.getByRole("button", { name: "Session actions" }));
     await user.click(screen.getByRole("menuitem", { name: "Rename" }));
@@ -3289,6 +3353,9 @@ describe("AgentWorkspace", () => {
       sessionId: "session-manual",
       title: "Billing retry notes",
     });
+    expect(
+      await screen.findByText("Could not save the session name. It may revert after a restart."),
+    ).toBeInTheDocument();
 
     await act(async () => {
       await new Promise((resolve) => window.setTimeout(resolve, 2600));

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3156,6 +3156,54 @@ describe("AgentWorkspace", () => {
         title: "Flaky Timer Fix",
       }),
     );
+    await waitFor(() =>
+      expect(window.localStorage.getItem("june.agent.manuallyTitledSessions")).toBe(
+        JSON.stringify({ "session-exchange": "exchange" }),
+      ),
+    );
+  });
+
+  it("skips the durable exchange marker when title persistence fails", async () => {
+    const rawTitle = "I need you to inspect the flaky tests";
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-exchange-unsaved",
+        title: rawTitle,
+        preview: rawTitle,
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "u1",
+        role: "user",
+        content: "inspect the flaky tests",
+        timestamp: "2026-06-04T12:00:00Z",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "I traced the failure to stale timers and updated the regression test.",
+        timestamp: "2026-06-04T12:00:01Z",
+      },
+    ]);
+    mocks.suggestAgentSessionTitle.mockResolvedValue({
+      title: "Flaky Timer Fix",
+    });
+    mocks.ensureHermesBridgeSession.mockRejectedValue(new Error("bridge offline"));
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Flaky Timer Fix")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
+        sessionId: "session-exchange-unsaved",
+        title: "Flaky Timer Fix",
+      }),
+    );
+    // A failed PATCH must not settle the title durably: the next launch has to
+    // be able to retry, or a stale stored title would be frozen forever.
+    expect(window.localStorage.getItem("june.agent.manuallyTitledSessions")).toBeNull();
   });
 
   it("upgrades a prompt-only loaded-message title once when the assistant reply appears", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3206,6 +3206,80 @@ describe("AgentWorkspace", () => {
     expect(window.localStorage.getItem("june.agent.manuallyTitledSessions")).toBeNull();
   });
 
+  it("re-asserts a manual rename that lands while the auto-title persist is in flight", async () => {
+    const rawTitle = "I need you to inspect the flaky tests";
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-race",
+        title: rawTitle,
+        preview: rawTitle,
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "u1",
+        role: "user",
+        content: "inspect the flaky tests",
+        timestamp: "2026-06-04T12:00:00Z",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "I traced the failure to stale timers and updated the regression test.",
+        timestamp: "2026-06-04T12:00:01Z",
+      },
+    ]);
+    mocks.suggestAgentSessionTitle.mockResolvedValue({
+      title: "Flaky Timer Fix",
+    });
+    let releaseAutoPatch: (() => void) | undefined;
+    mocks.ensureHermesBridgeSession.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseAutoPatch = () => resolve({});
+        }),
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Flaky Timer Fix")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
+        sessionId: "session-race",
+        title: "Flaky Timer Fix",
+      }),
+    );
+
+    // Manual rename while the auto-title PATCH is still pending.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_SESSION_RENAMED_EVENT, {
+          detail: { sessionId: "session-race", title: "My real session name" },
+        }),
+      );
+    });
+    expect(await screen.findByText("My real session name")).toBeInTheDocument();
+
+    await act(async () => {
+      releaseAutoPatch?.();
+      await Promise.resolve();
+    });
+
+    // The resolving auto PATCH must re-assert the manual title (so Hermes does
+    // not keep the auto title) and must not settle an exchange marker over the
+    // manual record.
+    await waitFor(() =>
+      expect(mocks.ensureHermesBridgeSession).toHaveBeenLastCalledWith({
+        sessionId: "session-race",
+        title: "My real session name",
+      }),
+    );
+    expect(window.localStorage.getItem("june.agent.manuallyTitledSessions")).toBe(
+      JSON.stringify({ "session-race": "manual" }),
+    );
+  });
+
   it("upgrades a prompt-only loaded-message title once when the assistant reply appears", async () => {
     const rawTitle = "I want you to summarize latest failures";
     const userMessage = {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3234,6 +3234,72 @@ describe("AgentWorkspace", () => {
     expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2);
   }, 10_000);
 
+  it("persists manual header renames and blocks later title suggestions", async () => {
+    const userMessage = {
+      id: "u1",
+      role: "user",
+      content: "summarize the billing retry failure",
+      timestamp: "2026-06-04T12:00:00Z",
+    };
+    const assistantMessage = {
+      id: "a1",
+      role: "assistant",
+      content: "The retry path skipped the persisted session title update.",
+      timestamp: "2026-06-04T12:00:01Z",
+    };
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-manual",
+        title: "I want you to summarize the billing retry failure",
+        preview: "I want you to summarize the billing retry failure",
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([userMessage, assistantMessage]);
+    hermesActivityStore.record(
+      {
+        kind: "lifecycle",
+        sessionId: "session-manual",
+        flavor: "running",
+        status: "running",
+        text: "",
+        receivedAt: "2026-06-04T12:00:00Z",
+      },
+      "sandboxed",
+    );
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace />);
+
+    expect(
+      await screen.findByText("I want you to summarize the billing retry failure"),
+    ).toBeInTheDocument();
+    expect(mocks.suggestAgentSessionTitle).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Session actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Rename" }));
+    const input = screen.getByRole("textbox", { name: "Session name" });
+    await user.clear(input);
+    await user.type(input, "Billing retry notes{Enter}");
+
+    expect(await screen.findByText("Billing retry notes")).toBeInTheDocument();
+    expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
+      sessionId: "session-manual",
+      title: "Billing retry notes",
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+    });
+
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages).toHaveBeenCalledWith("session-manual"),
+    );
+    expect(mocks.suggestAgentSessionTitle).not.toHaveBeenCalled();
+  }, 10_000);
+
   it("does not suggest a title for non-replaceable loaded sessions without a title source", async () => {
     mocks.listHermesSessions.mockResolvedValue([
       {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3236,6 +3236,75 @@ describe("AgentWorkspace", () => {
     expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2);
   }, 10_000);
 
+  it("rechecks latest messages when a fresh prompt-only suggestion resolves after the reply loads", async () => {
+    const rawTitle = "I want you to summarize latest failures";
+    const userMessage = {
+      id: "u1",
+      role: "user",
+      content: "summarize latest failures",
+      timestamp: "2026-06-04T12:00:00Z",
+    };
+    const assistantMessage = {
+      id: "a1",
+      role: "assistant",
+      content: "I found the failing path and isolated the missing persistence call.",
+      timestamp: "2026-06-04T12:00:01Z",
+    };
+    const secondSession = {
+      id: "session-other",
+      title: "Other session",
+      preview: "Other preview",
+      last_active: "2026-06-04T12:05:00Z",
+    };
+    let resolvePromptTitle: (value: { title: string }) => void = () => {};
+    const promptTitle = new Promise<{ title: string }>((resolve) => {
+      resolvePromptTitle = resolve;
+    });
+    const targetSession = {
+      id: "session-upgrade-pending",
+      title: rawTitle,
+      preview: rawTitle,
+      last_active: "2026-06-04T12:00:00Z",
+    };
+    mocks.listHermesSessions.mockResolvedValue([targetSession, secondSession]);
+    mocks.listHermesSessionMessages
+      .mockResolvedValueOnce([userMessage])
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([userMessage, assistantMessage]);
+    mocks.suggestAgentSessionTitle
+      .mockImplementationOnce(() => promptTitle)
+      .mockResolvedValueOnce({ title: "Persistence Fix" });
+
+    const { rerender } = render(<AgentWorkspace initialSession={targetSession} />);
+
+    await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(1));
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenLastCalledWith(
+      "summarize latest failures",
+      undefined,
+    );
+
+    rerender(<AgentWorkspace initialSession={secondSession} />);
+    expect(await screen.findByText("Other session")).toBeInTheDocument();
+    rerender(<AgentWorkspace initialSession={targetSession} />);
+
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages.mock.calls.length).toBeGreaterThanOrEqual(3),
+    );
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolvePromptTitle({ title: "Failure Summary" });
+      await promptTitle;
+    });
+
+    await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2));
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenLastCalledWith(
+      "summarize latest failures",
+      "I found the failing path and isolated the missing persistence call.",
+    );
+    expect(await screen.findByText("Persistence Fix")).toBeInTheDocument();
+  }, 10_000);
+
   it("upgrades a prompt-only title from the first non-empty assistant reply", async () => {
     const rawTitle = "I want you to summarize latest failures";
     const userMessage = {
@@ -3474,6 +3543,48 @@ describe("AgentWorkspace", () => {
     expect(mocks.suggestAgentSessionTitle).not.toHaveBeenCalled();
     expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
       sessionId: "session-durable-manual",
+      title: "Staging Deploy Setup",
+    });
+    expect(screen.getByText("Set up staging deploy")).toBeInTheDocument();
+  });
+
+  it("keeps a durable exchange title marker from being overwritten on fresh mount", async () => {
+    const userMessage = {
+      id: "u1",
+      role: "user",
+      content: "set up staging deploy",
+      timestamp: "2026-06-04T12:00:00Z",
+    };
+    const assistantMessage = {
+      id: "a1",
+      role: "assistant",
+      content: "I checked the deployment steps and found the staging settings.",
+      timestamp: "2026-06-04T12:00:01Z",
+    };
+    window.localStorage.setItem(
+      "june.agent.manuallyTitledSessions",
+      JSON.stringify({ "session-durable-exchange": "exchange" }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-durable-exchange",
+        title: "Set up staging deploy",
+        preview: "set up staging deploy",
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages.mockResolvedValue([userMessage, assistantMessage]);
+    mocks.suggestAgentSessionTitle.mockResolvedValue({ title: "Staging Deploy Setup" });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Set up staging deploy")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages).toHaveBeenCalledWith("session-durable-exchange"),
+    );
+    expect(mocks.suggestAgentSessionTitle).not.toHaveBeenCalled();
+    expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
+      sessionId: "session-durable-exchange",
       title: "Staging Deploy Setup",
     });
     expect(screen.getByText("Set up staging deploy")).toBeInTheDocument();

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3074,6 +3074,12 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
 
     expect(await screen.findByText("CLI Run Tracking")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
+        sessionId: "session-raw",
+        title: "CLI Run Tracking",
+      }),
+    );
   });
 
   it("keeps chunk boundary spaces when suggesting session titles", async () => {
@@ -3103,7 +3109,166 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("Release Details")).toBeInTheDocument();
     expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledWith(
       "Find the full details more efficiently",
+      undefined,
     );
+  });
+
+  it("suggests a loaded-message title from the first exchange when available", async () => {
+    const rawTitle = "I need you to inspect the flaky tests";
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-exchange",
+        title: rawTitle,
+        preview: rawTitle,
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "u1",
+        role: "user",
+        content: "inspect the flaky tests",
+        timestamp: "2026-06-04T12:00:00Z",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "I traced the failure to stale timers and updated the regression test.",
+        timestamp: "2026-06-04T12:00:01Z",
+      },
+    ]);
+    mocks.suggestAgentSessionTitle.mockResolvedValue({
+      title: "Flaky Timer Fix",
+    });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Flaky Timer Fix")).toBeInTheDocument();
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledWith(
+      "inspect the flaky tests",
+      "I traced the failure to stale timers and updated the regression test.",
+    );
+    await waitFor(() =>
+      expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
+        sessionId: "session-exchange",
+        title: "Flaky Timer Fix",
+      }),
+    );
+  });
+
+  it("upgrades a prompt-only loaded-message title once when the assistant reply appears", async () => {
+    const rawTitle = "I want you to summarize latest failures";
+    const userMessage = {
+      id: "u1",
+      role: "user",
+      content: "summarize latest failures",
+      timestamp: "2026-06-04T12:00:00Z",
+    };
+    const assistantMessage = {
+      id: "a1",
+      role: "assistant",
+      content: "I found the failing path and isolated the missing persistence call.",
+      timestamp: "2026-06-04T12:00:01Z",
+    };
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-upgrade",
+        title: rawTitle,
+        preview: rawTitle,
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages
+      .mockResolvedValueOnce([userMessage])
+      .mockResolvedValue([userMessage, assistantMessage]);
+    mocks.suggestAgentSessionTitle
+      .mockResolvedValueOnce({ title: "Failure Summary" })
+      .mockResolvedValueOnce({ title: "Persistence Fix" });
+    hermesActivityStore.record(
+      {
+        kind: "lifecycle",
+        sessionId: "session-upgrade",
+        flavor: "running",
+        status: "running",
+        text: "",
+        receivedAt: "2026-06-04T12:00:00Z",
+      },
+      "sandboxed",
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Failure Summary")).toBeInTheDocument();
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(1);
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenLastCalledWith(
+      "summarize latest failures",
+      undefined,
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+    });
+
+    await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2));
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenLastCalledWith(
+      "summarize latest failures",
+      "I found the failing path and isolated the missing persistence call.",
+    );
+    expect(await screen.findByText("Persistence Fix")).toBeInTheDocument();
+    hermesActivityStore.record(
+      {
+        kind: "lifecycle",
+        sessionId: "session-upgrade",
+        flavor: "running",
+        status: "running",
+        text: "",
+        receivedAt: "2026-06-04T12:00:02Z",
+      },
+      "sandboxed",
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+    });
+
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2);
+  }, 10_000);
+
+  it("does not suggest a title for non-replaceable loaded sessions without a title source", async () => {
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-specific",
+        title: "Payment architecture review",
+        preview: "Review the billing shape",
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "u1",
+        role: "user",
+        content: "review the billing shape",
+        timestamp: "2026-06-04T12:00:00Z",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "I reviewed the architecture and found no blocking issue.",
+        timestamp: "2026-06-04T12:00:01Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Payment architecture review")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages).toHaveBeenCalledWith("session-specific"),
+    );
+    expect(mocks.suggestAgentSessionTitle).not.toHaveBeenCalled();
+    expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
+      sessionId: "session-specific",
+      title: expect.any(String),
+    });
   });
 
   it("renders June's CLI access request as a card and enables the setting", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3437,6 +3437,48 @@ describe("AgentWorkspace", () => {
     expect(screen.getByText("Manual import notes")).toBeInTheDocument();
   }, 10_000);
 
+  it("keeps a durable manual title marker from being overwritten on fresh mount", async () => {
+    const userMessage = {
+      id: "u1",
+      role: "user",
+      content: "set up staging deploy",
+      timestamp: "2026-06-04T12:00:00Z",
+    };
+    const assistantMessage = {
+      id: "a1",
+      role: "assistant",
+      content: "I checked the deployment steps and found the staging settings.",
+      timestamp: "2026-06-04T12:00:01Z",
+    };
+    window.localStorage.setItem(
+      "june.agent.manuallyTitledSessions",
+      JSON.stringify({ "session-durable-manual": true }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-durable-manual",
+        title: "Set up staging deploy",
+        preview: "set up staging deploy",
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages.mockResolvedValue([userMessage, assistantMessage]);
+    mocks.suggestAgentSessionTitle.mockResolvedValue({ title: "Staging Deploy Setup" });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Set up staging deploy")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages).toHaveBeenCalledWith("session-durable-manual"),
+    );
+    expect(mocks.suggestAgentSessionTitle).not.toHaveBeenCalled();
+    expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
+      sessionId: "session-durable-manual",
+      title: "Staging Deploy Setup",
+    });
+    expect(screen.getByText("Set up staging deploy")).toBeInTheDocument();
+  });
+
   it("persists manual header renames and blocks later title suggestions", async () => {
     const userMessage = {
       id: "u1",

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -131,6 +131,7 @@ describe("Sidebar primary navigation", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -156,6 +157,7 @@ describe("Sidebar primary navigation", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -196,6 +198,7 @@ describe("Sidebar primary navigation", () => {
           onOpenMoveDialog={vi.fn()}
           onRemoveNoteFromFolder={vi.fn()}
           onNewAgentSession={vi.fn()}
+          onRenameAgentSession={vi.fn()}
           onSelectAgentSession={vi.fn()}
         />,
       );
@@ -224,6 +227,7 @@ describe("Sidebar primary navigation", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -249,6 +253,7 @@ describe("Sidebar primary navigation", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -278,6 +283,7 @@ describe("Sidebar primary navigation", () => {
           onOpenMoveDialog={vi.fn()}
           onRemoveNoteFromFolder={vi.fn()}
           onNewAgentSession={vi.fn()}
+          onRenameAgentSession={vi.fn()}
           onSelectAgentSession={vi.fn()}
         />,
       );
@@ -335,6 +341,7 @@ describe("Sidebar primary navigation", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -360,6 +367,7 @@ describe("Sidebar primary navigation", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -405,6 +413,7 @@ describe("Sidebar primary navigation", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -431,6 +440,7 @@ describe("Sidebar primary navigation", () => {
           onOpenMoveDialog={vi.fn()}
           onRemoveNoteFromFolder={vi.fn()}
           onNewAgentSession={vi.fn()}
+          onRenameAgentSession={vi.fn()}
           onSelectAgentSession={vi.fn()}
           onSettingsTabChange={vi.fn()}
         />,
@@ -483,6 +493,7 @@ describe("Sidebar primary navigation", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -531,6 +542,7 @@ describe("Sidebar primary navigation", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -73,6 +73,7 @@ describe("folders UI", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={() => onChangeView("agent")}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -106,6 +107,7 @@ describe("folders UI", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={onSelectAgentSession}
       />,
     );
@@ -151,6 +153,7 @@ describe("folders UI", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={onNewAgentSession}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -203,6 +206,7 @@ describe("folders UI", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -290,6 +294,7 @@ describe("folders UI", () => {
           onOpenMoveDialog={vi.fn()}
           onRemoveNoteFromFolder={vi.fn()}
           onNewAgentSession={vi.fn()}
+          onRenameAgentSession={vi.fn()}
           onSelectAgentSession={vi.fn()}
         />,
       );
@@ -324,6 +329,7 @@ describe("folders UI", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -365,6 +371,7 @@ describe("folders UI", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -411,6 +418,7 @@ describe("folders UI", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -453,6 +461,7 @@ describe("folders UI", () => {
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
         onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
         onSelectAgentSession={vi.fn()}
       />,
     );

--- a/src/test/sidebar-agent-session-rename.test.tsx
+++ b/src/test/sidebar-agent-session-rename.test.tsx
@@ -1,0 +1,98 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AGENT_SESSIONS_CHANGED_EVENT } from "../components/agent/AgentWorkspace";
+import { Sidebar } from "../components/sidebar/Sidebar";
+import type { HermesSessionInfo, NoteListItemDto } from "../lib/tauri";
+
+vi.mock("../lib/hermes-adapter", () => ({
+  deleteHermesSession: vi.fn(),
+  listHermesSessions: vi.fn().mockResolvedValue([]),
+  sessionTimestamp: (session: { last_active?: string; started_at?: string }) =>
+    session.last_active ?? session.started_at ?? "",
+}));
+
+const sessions: HermesSessionInfo[] = [
+  {
+    id: "session-recent",
+    title: "Recent session",
+    preview: "Done yesterday",
+    last_active: "2026-06-04T13:00:00Z",
+  },
+  {
+    id: "session-pinned",
+    title: "Pinned session",
+    preview: "Pinned work",
+    last_active: "2026-06-04T12:00:00Z",
+  },
+];
+
+const notes: NoteListItemDto[] = [];
+
+function renderSidebar(onRenameAgentSession = vi.fn()) {
+  render(
+    <Sidebar
+      notes={notes}
+      activeView="notes"
+      onChangeView={vi.fn()}
+      onSelectNote={vi.fn()}
+      onDeleteNote={vi.fn()}
+      onOpenMoveDialog={vi.fn()}
+      onRemoveNoteFromFolder={vi.fn()}
+      onNewAgentSession={vi.fn()}
+      onRenameAgentSession={onRenameAgentSession}
+      onSelectAgentSession={vi.fn()}
+    />,
+  );
+
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent(AGENT_SESSIONS_CHANGED_EVENT, {
+        detail: {
+          sessions,
+          selectedSessionId: "session-recent",
+          workingSessionIds: [],
+        },
+      }),
+    );
+  });
+}
+
+describe("Sidebar agent session rename", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.removeItem("june:pinned-agent-session-ids");
+  });
+
+  it("renames a recent agent session row from the context menu", async () => {
+    const user = userEvent.setup();
+    const onRenameAgentSession = vi.fn();
+    renderSidebar(onRenameAgentSession);
+
+    await user.click(await screen.findByRole("button", { name: "Actions for Recent session" }));
+    await user.click(screen.getByRole("menuitem", { name: "Rename session" }));
+    const input = screen.getByRole("textbox", { name: "Session name" });
+
+    await user.clear(input);
+    await user.type(input, "Manual sidebar name{Enter}");
+
+    expect(onRenameAgentSession).toHaveBeenCalledWith("session-recent", "Manual sidebar name");
+  });
+
+  it("cancels a pinned agent session row rename on Escape", async () => {
+    const user = userEvent.setup();
+    const onRenameAgentSession = vi.fn();
+    window.localStorage.setItem(
+      "june:pinned-agent-session-ids",
+      JSON.stringify(["session-pinned"]),
+    );
+    renderSidebar(onRenameAgentSession);
+
+    await user.click(await screen.findByRole("button", { name: "Actions for Pinned session" }));
+    await user.click(screen.getByRole("menuitem", { name: "Rename session" }));
+    await user.type(screen.getByRole("textbox", { name: "Session name" }), "{Escape}");
+
+    expect(onRenameAgentSession).not.toHaveBeenCalled();
+    expect(screen.getByText("Pinned session")).toBeInTheDocument();
+  });
+});

--- a/src/test/sidebar-agent-session-rename.test.tsx
+++ b/src/test/sidebar-agent-session-rename.test.tsx
@@ -1,7 +1,10 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { AGENT_SESSIONS_CHANGED_EVENT } from "../components/agent/AgentWorkspace";
+import {
+  AGENT_SESSION_RENAMED_EVENT,
+  AGENT_SESSIONS_CHANGED_EVENT,
+} from "../components/agent/AgentWorkspace";
 import { Sidebar } from "../components/sidebar/Sidebar";
 import type { HermesSessionInfo, NoteListItemDto } from "../lib/tauri";
 
@@ -77,6 +80,26 @@ describe("Sidebar agent session rename", () => {
     await user.type(input, "Manual sidebar name{Enter}");
 
     expect(onRenameAgentSession).toHaveBeenCalledWith("session-recent", "Manual sidebar name");
+  });
+
+  it("updates a renamed agent session row from the rename event", async () => {
+    renderSidebar();
+
+    expect(await screen.findByText("Recent session")).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_SESSION_RENAMED_EVENT, {
+          detail: {
+            sessionId: "session-recent",
+            title: "Manual sidebar name",
+          },
+        }),
+      );
+    });
+
+    expect(screen.getByText("Manual sidebar name")).toBeInTheDocument();
+    expect(screen.queryByText("Recent session")).not.toBeInTheDocument();
   });
 
   it("cancels a pinned agent session row rename on Escape", async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,10 @@ export default defineConfig({
   },
   server: {
     host: "127.0.0.1",
-    port: 1421,
+    // The port is chosen by scripts/tauri-dev.mjs (a free one per worktree) and
+    // handed down via VITE_PORT so Tauri's devUrl points at this exact server.
+    // Falls back to 1421 for a bare `pnpm dev`.
+    port: Number.parseInt(process.env.VITE_PORT ?? "", 10) || 1421,
     strictPort: true,
     // Vite's file watcher must not descend into the Rust build-output dirs.
     // On Windows, cargo locks `.exe`/pdb files in `target/` while linking, and


### PR DESCRIPTION
Closes JUN-205

## Summary

Improves Ask June agent session naming on three fronts:

- **Titles now persist.** AI-suggested titles from the message-load path and
  manual renames were kept only in an in-memory ref and reverted to the stored
  Hermes title (a truncated first prompt, or "Untitled session") on every app
  restart. Both now write back through the existing
  `ensure_hermes_bridge_session` title PATCH.
- **Titles reflect the work, not the ask.** `suggest_agent_session_title`
  accepts an optional assistant-reply excerpt (backward compatible, serde
  default). A session titled from its prompt gets exactly one upgrade to a
  first-exchange title (first user prompt + first non-empty assistant reply)
  once the reply exists. Title sources are tracked
  (`prompt` / `exchange` / `manual`) through session continuity; `manual`
  pins a title against all auto-titling.
- **Rename everywhere sessions are listed.** New "Rename" action with inline
  editing in the agent-sessions list rows and the persistent sidebar rows
  (pinned and recent); the pre-existing workspace-header rename now persists
  too. Failed persistence keeps the optimistic title and surfaces
  "Could not save the session name. It may revert after a restart."

## Root cause

Session names were "not useful or clear" because (1) suggested titles were
never persisted to Hermes, so restarts reverted them to a truncation of the
first user message, and (2) generation only ever saw the first user message,
so titles echoed the ask instead of the work.

## Validation

- `cargo test` (src-tauri, title suite) — 5 helper tests including multibyte
  truncation; command remains backward compatible.
- `pnpm typecheck` + vitest: agent-workspace (incl. one-shot upgrade,
  empty-assistant-message regression, persistence-failure surface),
  agent-sessions-list (rename commit/cancel paths), new
  sidebar-agent-session-rename suite, folders suites — 274 passed, 0 failed.
- Review battery (standards / spec / adversarial) ran on the branch; all
  verified findings fixed in fa5ee99e (empty-reply upgrade blocker, silent
  persistence failure, missing persistent-sidebar rename, stored-session-id
  doc comments). An adversarial convergence re-run on a second harness caught
  one more real ship-blocker - a sidebar rename made while the workspace was
  mounted could be silently overwritten by the one-shot exchange upgrade -
  fixed in 8c1695a5 via a session-renamed window event the mounted workspace
  applies to its live title refs (regression tests failed pre-fix). A final
  re-verification found manual names colliding with the placeholder heuristic
  (e.g. "Set up staging deploy") could still be retitled after a mount cycle -
  fixed in b4a19731 with a durable localStorage manual-title record
  (`june.agent.manuallyTitledSessions`, mirroring the session-modes pattern).
  Full frontend suite after fixes: 135 files, 2148 passed, 0 failed.
- Browser walkthrough (recorded): rename via row menu → inline edit →
  Enter; asserts the renamed title renders and the persistence PATCH fires
  with the new title, via the committed dev-only preview harness
  (`sessions-rename-preview.html`, same pattern as `agent-image-preview.html`).
  Video: https://app.opensoftware.co/api/v1/files/fil_uAagmlnVpP8B/download
- Bot review loop (Octopus, Greptile, Codex): every finding at every surface
  dispositioned - accepted ones fixed with failing-first regression tests
  (103a7f71, b07c772f, 9ab017d7), declined ones answered in-thread with
  rationale. Repo-wide `pnpm check` is error-clean on this branch (a
  pre-existing main-side Biome error was incidentally auto-fixed).

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- prompt lives client-side; no backend change -->

## Out of scope

- Meeting note titles (still derived from generated headings) — explicitly
  scoped out with the user; sessions only.
- Continuous retitling as a conversation evolves (one-shot exchange upgrade
  only, per scope decision).
- Retry/reconciliation machinery for failed title persistence — deliberate;
  the PATCH is best-effort against the pinned runtime, failure is surfaced.

## Followups

- Consider an AI title pass for meeting notes (the JUN-205 complaint applies
  there too; today note titles concatenate generated headings).
- If a "manual" pin should survive a run where the workspace never mounted,
  title sources would need disk persistence rather than continuity.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

https://claude.ai/code/session_01FjcWfCnAhdT5et6Dei4afY
