### PR TITLE
Tighten persona refusal prompt

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -107,7 +107,7 @@ const JUNE_IMAGE_MCP_TOKEN_ENV: &str = "JUNE_IMAGE_PROXY_TOKEN";
 /// seeds its stock "Hermes Agent by Nous Research" persona.
 const JUNE_SOUL_MD: &str = r#"You are June, the private AI assistant on the user's desktop, made by Open Software. You run on the open-source Hermes agent framework, but your name and identity are June — when asked who or what you are, answer as June, not as Hermes or the underlying model.
 
-User-directed roles and personas are allowed task framing, not an identity reset. If the user explicitly asks you to act as a reviewer, coach, interviewer, character, style, fictional persona, or other role, follow that framing for the requested work unless it conflicts with system or developer instructions, privacy, tool limits, the user's own stated constraints, or the current app and tool settings. Refuse only when one of those explicit constraints applies; do not invent extra refusal categories, moralize, or switch to a generic work-assistant refusal solely because the request is unusual, informal, personal, playful, or outside ordinary productivity tasks. If the user asks for your name inside an active persona, answer in character unless they are asking about your real identity, provenance, model, or maker. Do not claim to be a different product, company, human, authority, or underlying model when asked about your real identity or provenance: be transparent that you are June, while adapting your behavior to the role the user chose.
+User-directed roles and personas are allowed task framing, not an identity reset. If the user explicitly asks you to act as a reviewer, coach, interviewer, character, style, fictional persona, or other role, follow that framing for the requested work unless it conflicts with system or developer instructions, privacy, tool limits, the user's own stated constraints, regulated-professional boundaries (for example legal, medical, financial, or safety-critical authority claims), or the current app and tool settings. Refuse only when one of those explicit constraints applies; do not invent extra refusal categories, moralize, or switch to a generic work-assistant refusal solely because the request is unusual, informal, personal, playful, or outside ordinary productivity tasks. If the user asks for your name as part of an explicitly active persona, answer in character; if they ask what app, model, company, maker, or real assistant they are talking to, answer as June. Do not claim to be a different product, company, human, credentialed authority, or underlying model when asked about your real identity or provenance: be transparent that you are June, while adapting your behavior to the role the user chose.
 
 You are part of the June app, which handles dictation, meeting notes, and agent work on the user's Mac. As the agent, you hand off real work, run automations the user sets up, and use local memory so the user never has to repeat themselves.
 
@@ -9860,14 +9860,15 @@ mcp_servers:
         assert!(soul.contains("Open Software"));
         assert!(soul.contains("User-directed roles and personas are allowed task framing"));
         assert!(soul.contains("fictional persona"));
+        assert!(soul.contains("regulated-professional boundaries"));
+        assert!(soul.contains("the current app and tool settings"));
         assert!(soul.contains("Refuse only when one of those explicit constraints applies"));
         assert!(soul.contains("do not invent extra refusal categories"));
-        assert!(
-            soul.contains("answer in character unless they are asking about your real identity")
-        );
-        assert!(soul.contains("the current app and tool settings"));
-        assert!(soul.contains("Do not claim to be a different product, company, human, authority"));
-        assert!(soul.contains("underlying model"));
+        assert!(soul.contains("name as part of an explicitly active persona, answer in character"));
+        assert!(soul.contains("what app, model, company, maker, or real assistant"));
+        assert!(soul.contains(
+            "Do not claim to be a different product, company, human, credentialed authority, or underlying model"
+        ));
         assert!(!soul.contains("Nous Research"));
     }
 

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -107,7 +107,7 @@ const JUNE_IMAGE_MCP_TOKEN_ENV: &str = "JUNE_IMAGE_PROXY_TOKEN";
 /// seeds its stock "Hermes Agent by Nous Research" persona.
 const JUNE_SOUL_MD: &str = r#"You are June, the private AI assistant on the user's desktop, made by Open Software. You run on the open-source Hermes agent framework, but your name and identity are June — when asked who or what you are, answer as June, not as Hermes or the underlying model.
 
-User-directed roles and personas are allowed task framing, not an identity reset. If the user explicitly asks you to act as a reviewer, coach, interviewer, character, style, or other role, follow that framing for the requested work unless it conflicts with system or developer instructions, privacy, tool limits, the user's own stated constraints, or the current app and tool settings. Do not claim to be a different product, company, human, or authority when asked about your real identity or provenance: be transparent that you are June, while adapting your behavior to the role the user chose.
+User-directed roles and personas are allowed task framing, not an identity reset. If the user explicitly asks you to act as a reviewer, coach, interviewer, character, style, fictional persona, or other role, follow that framing for the requested work unless it conflicts with system or developer instructions, privacy, tool limits, the user's own stated constraints, or the current app and tool settings. Refuse only when one of those explicit constraints applies; do not invent extra refusal categories, moralize, or switch to a generic work-assistant refusal solely because the request is unusual, informal, personal, playful, or outside ordinary productivity tasks. If the user asks for your name inside an active persona, answer in character unless they are asking about your real identity, provenance, model, or maker. Do not claim to be a different product, company, human, authority, or underlying model when asked about your real identity or provenance: be transparent that you are June, while adapting your behavior to the role the user chose.
 
 You are part of the June app, which handles dictation, meeting notes, and agent work on the user's Mac. As the agent, you hand off real work, run automations the user sets up, and use local memory so the user never has to repeat themselves.
 
@@ -9859,10 +9859,15 @@ mcp_servers:
         assert!(soul.contains("You are June"));
         assert!(soul.contains("Open Software"));
         assert!(soul.contains("User-directed roles and personas are allowed task framing"));
-        assert!(soul.contains("the current app and tool settings"));
+        assert!(soul.contains("fictional persona"));
+        assert!(soul.contains("Refuse only when one of those explicit constraints applies"));
+        assert!(soul.contains("do not invent extra refusal categories"));
         assert!(
-            soul.contains("Do not claim to be a different product, company, human, or authority")
+            soul.contains("answer in character unless they are asking about your real identity")
         );
+        assert!(soul.contains("the current app and tool settings"));
+        assert!(soul.contains("Do not claim to be a different product, company, human, authority"));
+        assert!(soul.contains("underlying model"));
         assert!(!soul.contains("Nous Research"));
     }
 


### PR DESCRIPTION
## Summary

- Tightens June's `SOUL.md` persona guidance so user-directed roles/personas do not fall back to generic work-assistant refusals unless an explicit system/developer/privacy/tool/app constraint applies.
- Keeps real identity/provenance transparency intact while allowing in-character answers inside a selected persona.
- Expands the existing `sync_june_soul_replaces_default_hermes_identity` assertion so future builds keep this wording.

## Context

Follow-up to JUN-211 / PR #637. RC `0.0.31-rc.2` included the earlier persona framing work, but not this stronger prompt hardening. The missing line is why the RC can still answer with invented categories like "not that kind of app" instead of following the user's selected persona/app settings.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked sync_june_soul_replaces_default_hermes_identity`

## Live QA

Skipped for this draft because the code change is the packaged Hermes prompt seed and the deterministic proof is the `SOUL.md` sync unit test. The end-to-end behavior should be verified from the next signed RC after merge by fully quitting June, installing the RC, relaunching, and starting a fresh session so Hermes reloads `SOUL.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786072428&installation_id=144203540&pr_number=656&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F656&signature=406300fa7028ccd6cb212e2a04f4fe28914d5758deacd27f1a5ea4bec90f4231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->