### PR TITLE
fix: restore image model to models card, safe mode to advanced (JUN-209)

### DIFF
--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1731,6 +1731,28 @@ export function AppSettings({
                     onSearchChange={setModelSearch}
                     onSelect={(modelId) => selectModelFromPicker("generation", modelId)}
                   />
+                  {IMAGE_GENERATION_ENABLED ? (
+                    <ModelRow
+                      mode="image"
+                      title="Image"
+                      description="Used when you generate an image from chat."
+                      value={providerSettings.imageModel}
+                      options={imageOptions}
+                      open={pickerMode === "image"}
+                      flyout={modelPickerFlyout}
+                      search={modelSearch}
+                      triggerRef={modelPickerTriggerRef}
+                      popoverRef={modelPickerPopoverRef}
+                      searchRef={modelPickerSearchRef}
+                      directCatalog
+                      onToggle={() =>
+                        pickerMode === "image" ? closeModelPicker() : openModelPicker("image")
+                      }
+                      onFlyoutChange={setModelPickerFlyout}
+                      onSearchChange={setModelSearch}
+                      onSelect={(modelId) => selectModelFromPicker("image", modelId)}
+                    />
+                  ) : null}
                   <button
                     type="button"
                     className="settings-row settings-more-options-trigger"
@@ -1749,14 +1771,34 @@ export function AppSettings({
                     />
                   </button>
                   {showMoreModelOptions ? (
-                    <VeniceApiKeyRow
-                      id="models-more-options"
-                      configured={providerSettings.veniceApiKeyConfigured}
-                      value={veniceApiKeyDraft}
-                      onValueChange={setVeniceApiKeyDraft}
-                      onSave={() => void saveVeniceApiKey()}
-                      onRemove={() => void removeVeniceApiKey()}
-                    />
+                    <>
+                      <VeniceApiKeyRow
+                        id="models-more-options"
+                        configured={providerSettings.veniceApiKeyConfigured}
+                        value={veniceApiKeyDraft}
+                        onValueChange={setVeniceApiKeyDraft}
+                        onSave={() => void saveVeniceApiKey()}
+                        onRemove={() => void removeVeniceApiKey()}
+                      />
+                      {IMAGE_GENERATION_ENABLED ? (
+                        <div className="settings-row">
+                          <div className="settings-row-info">
+                            <h3 className="settings-row-title">Safe mode</h3>
+                            <p className="settings-row-description">
+                              Blur adult content in generated and edited images. On by default; your
+                              image work stays private either way.
+                            </p>
+                          </div>
+                          <div className="settings-row-control">
+                            <Switch
+                              checked={providerSettings.imageSafeMode}
+                              aria-label="Blur adult content in images"
+                              onCheckedChange={toggleImageSafeMode}
+                            />
+                          </div>
+                        </div>
+                      ) : null}
+                    </>
                   ) : null}
                 </div>
               </div>
@@ -1909,60 +1951,6 @@ export function AppSettings({
                         </div>
                       </div>
                     ) : null}
-                  </div>
-                </div>
-              </section>
-            ) : null}
-
-            {IMAGE_GENERATION_ENABLED ? (
-              <section
-                className="settings-group settings-models-group"
-                aria-labelledby="image-generation-heading"
-              >
-                <h2 id="image-generation-heading" className="settings-group-heading">
-                  Image generation
-                </h2>
-                <p className="settings-group-description">
-                  Choose the model June uses when you ask it to generate an image.
-                </p>
-                <div className="settings-card settings-models-card">
-                  <div className="settings-rows">
-                    <ModelRow
-                      mode="image"
-                      title="Image"
-                      description="Used when you generate an image from chat."
-                      value={providerSettings.imageModel}
-                      options={imageOptions}
-                      open={pickerMode === "image"}
-                      flyout={modelPickerFlyout}
-                      search={modelSearch}
-                      triggerRef={modelPickerTriggerRef}
-                      popoverRef={modelPickerPopoverRef}
-                      searchRef={modelPickerSearchRef}
-                      directCatalog
-                      onToggle={() =>
-                        pickerMode === "image" ? closeModelPicker() : openModelPicker("image")
-                      }
-                      onFlyoutChange={setModelPickerFlyout}
-                      onSearchChange={setModelSearch}
-                      onSelect={(modelId) => selectModelFromPicker("image", modelId)}
-                    />
-                    <div className="settings-row">
-                      <div className="settings-row-info">
-                        <h3 className="settings-row-title">Safe mode</h3>
-                        <p className="settings-row-description">
-                          Blur adult content in generated and edited images. On by default; your
-                          image work stays private either way.
-                        </p>
-                      </div>
-                      <div className="settings-row-control">
-                        <Switch
-                          checked={providerSettings.imageSafeMode}
-                          aria-label="Blur adult content in images"
-                          onCheckedChange={toggleImageSafeMode}
-                        />
-                      </div>
-                    </div>
                   </div>
                 </div>
               </section>

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -2646,21 +2646,22 @@ describe("AppSettings", () => {
 
     await user.click(await screen.findByRole("tab", { name: "Models" }));
 
-    // Our dedicated Image generation section (kept over main's inline row).
-    const imageSection = screen
-      .getByRole("heading", { name: "Image generation" })
-      .closest("section");
-    expect(imageSection).not.toBeNull();
+    // #640 placement (restored, JUN-209): the image model lives inside the
+    // shared "AI models" card, not a standalone "Image generation" section.
+    expect(screen.queryByRole("heading", { name: "Image generation" })).toBeNull();
+    const modelsSection = screen.getByRole("heading", { name: "AI models" }).closest("section");
+    expect(modelsSection).not.toBeNull();
     expect(
-      within(imageSection as HTMLElement).getByRole("button", { name: "Change image model" }),
+      within(modelsSection as HTMLElement).getByRole("button", { name: "Change image model" }),
     ).toBeInTheDocument();
-    expect(within(imageSection as HTMLElement).getByText("Venice SD3.5")).toBeInTheDocument();
-    // Safe mode lives in the image section and defaults on (JUN-209).
+    expect(within(modelsSection as HTMLElement).getByText("Venice SD3.5")).toBeInTheDocument();
+    // Safe mode moved into the advanced "More options" disclosure (collapsed by
+    // default) and still defaults on (JUN-209).
     expect(
-      within(imageSection as HTMLElement).getByRole("switch", {
-        name: "Blur adult content in images",
-      }),
-    ).toBeInTheDocument();
+      screen.queryByRole("switch", { name: "Blur adult content in images" }),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /More options/ }));
+    expect(screen.getByRole("switch", { name: "Blur adult content in images" })).toBeChecked();
 
     // The picker opens with the curated image options (no backend fetch).
     await user.click(screen.getByRole("button", { name: "Change image model" }));


### PR DESCRIPTION
## Summary

Restores the image-settings placement from **#640 (JUN-209)** that **#652 ("Clean up AI settings surfaces")** reverted:

- **Image model** row moves out of the standalone "Image generation" section and back into the shared **AI models** card, right after the Text model row (gated by `IMAGE_GENERATION_ENABLED`).
- **Safe mode** switch moves out of that standalone section into the advanced **"More options"** disclosure, beside the Venice API key row (collapsed by default).
- The now-empty standalone "Image generation" section is removed.

@andrewwashuta — flagging you directly: this reverts the layout your #652 kept. See root cause; I want your read before this merges rather than ping-ponging the file.

## Root cause

#640 relocated these two controls. #652's branch had reworked the same `image-generation-heading` region starting before #640 merged; when it merged `origin/main` (merge commit `624fe110`), the conflict resolved in favor of the branch's standalone-section layout. #652 **kept #640's functional wins** — `imageSafeMode: true` default and the expanded image catalog through the new shared popover — so only the *placement* regressed. A test comment (`app-settings.test.tsx`: "kept over main's inline row") indicates the standalone layout may have been a deliberate choice during that resolution, not purely accidental — hence requesting review rather than asserting it was a mistake.

## Validation

- `pnpm typecheck` — clean.
- `pnpm exec vitest run src/test/app-settings.test.tsx` — 61/61 (rewrote the placement test: image model asserted inside the AI models section, no standalone "Image generation" heading, safe-mode switch absent until "More options" is expanded and checked by default).
- `pnpm exec vitest run src/test/agent-workspace.test.tsx` — 208 passing.
- `pnpm exec biome check` — no errors on changed files.
- **Live walkthrough skipped**: this is a pure relocation of unchanged components (same `ModelRow`, `Switch`, handlers); the new DOM placement is asserted directly by the updated vitest test. Happy to attach a screenshot if you'd like to see the layout.

- [ ] Tested visually where it matters — see note above (DOM-asserted, no screenshot yet).
- [ ] Needs a June API (backend) deploy — **No**, frontend-only.

## Out of scope

- No change to `imageSafeMode: true` default, the safe-mode consent dialog, the image catalog, or the popover picker API — all from #640/#652 and left intact.
- Not touching the `More options` `aria-controls` list (the safe-mode row rides inside the existing disclosure); can tidy separately if desired.

## Followups

- Root-cause writeup for the release/merge-hygiene angle (v0.0.30 also shipped a stale binary from a pre-#640 commit) — separate thread.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. <!-- none; UI placement only, safe-mode default unchanged -->
- [x] Workflow action references are pinned to full-length commit SHAs. <!-- N/A -->
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. <!-- N/A -->
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. <!-- N/A -->
- [x] User-facing copy follows the repo UI conventions. <!-- sentence case, no en/em dashes, existing tokens -->

Relates to JUN-209.

https://claude.ai/code/session_01Y6jAsYLmsZ8arat3uxsMNp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786086550&installation_id=144203540&pr_number=657&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F657&signature=8aacdbe466b8ab00d58c57dec346285c8ffcc1c77832e3ce13a81b738cfc4e06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->