### PR TITLE
feat: collapse image models behind "All models" in settings picker

### DIFF
--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1744,7 +1744,6 @@ export function AppSettings({
                       triggerRef={modelPickerTriggerRef}
                       popoverRef={modelPickerPopoverRef}
                       searchRef={modelPickerSearchRef}
-                      directCatalog
                       onToggle={() =>
                         pickerMode === "image" ? closeModelPicker() : openModelPicker("image")
                       }
@@ -2355,7 +2354,6 @@ function ModelRow({
   triggerRef,
   popoverRef,
   searchRef,
-  directCatalog,
   onToggle,
   onFlyoutChange,
   onSearchChange,
@@ -2372,7 +2370,6 @@ function ModelRow({
   triggerRef: RefObject<HTMLButtonElement>;
   popoverRef: RefObject<HTMLDivElement>;
   searchRef: RefObject<HTMLInputElement>;
-  directCatalog?: boolean;
   onToggle: () => void;
   onFlyoutChange: (flyout: ModelPickerFlyout) => void;
   onSearchChange: (value: string) => void;
@@ -2420,7 +2417,6 @@ function ModelRow({
             popoverRef={popoverRef}
             searchRef={searchRef}
             className="settings-model-popover"
-            directCatalog={directCatalog}
             title={modelLabel[0].toUpperCase() + modelLabel.slice(1)}
             ariaLabel={`Choose ${modelLabel}`}
             onFlyoutChange={onFlyoutChange}

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -29,7 +29,6 @@ export function ModelPickerPopover({
   popoverRef,
   searchRef,
   className,
-  directCatalog = false,
   title = "Model",
   ariaLabel = `Choose ${modelModeLabel(mode)} model`,
   suggestedListLabel = `Suggested ${modelModeLabel(mode)} models`,
@@ -46,7 +45,6 @@ export function ModelPickerPopover({
   popoverRef: RefObject<HTMLDivElement>;
   searchRef: RefObject<HTMLInputElement>;
   className?: string;
-  directCatalog?: boolean;
   title?: string;
   ariaLabel?: string;
   suggestedListLabel?: string;
@@ -132,7 +130,7 @@ export function ModelPickerPopover({
 
   useLayoutEffect(() => {
     updateFade();
-  }, [directCatalog, flyout, options, search, updateFade]);
+  }, [flyout, options, search, updateFade]);
 
   useEffect(() => {
     setCatalogHover(null);
@@ -274,78 +272,65 @@ export function ModelPickerPopover({
       className={["agent-composer-model-popover", className].filter(Boolean).join(" ")}
       role="dialog"
       aria-label={ariaLabel}
-      data-direct-catalog={directCatalog || undefined}
       onMouseLeave={() => {
         cancelHoverIntent();
         if (flyout?.kind === "model") onFlyoutChange(null);
       }}
     >
       <p className="agent-composer-model-title">{title}</p>
-      {directCatalog ? (
-        <div className="agent-composer-model-direct" role="group" aria-label={allModelsLabel}>
-          {catalogList(allModelsLabel)}
-        </div>
-      ) : (
-        <>
-          <div className="agent-composer-model-menu" role="listbox" aria-label={suggestedListLabel}>
-            {suggested.length ? (
-              suggested.map(({ model: option }) => (
-                <button
-                  key={option.id}
-                  type="button"
-                  className="agent-composer-model-row"
-                  role="option"
-                  aria-selected={option.id === model.id}
-                  data-active={(flyout?.kind === "model" && flyout.id === option.id) || undefined}
-                  onMouseEnter={() =>
-                    hoverIntent(() => onFlyoutChange({ kind: "model", id: option.id }))
-                  }
-                  onFocus={() => {
-                    cancelHoverIntent();
-                    onFlyoutChange({ kind: "model", id: option.id });
-                  }}
-                  onClick={() => onSelect(option.id)}
-                >
-                  <ModelPickerOptionText model={option} />
-                  {option.id === model.id ? (
-                    <IconCheckmark2Small
-                      size={14}
-                      aria-hidden
-                      className="agent-composer-model-row-check"
-                    />
-                  ) : null}
-                </button>
-              ))
-            ) : (
-              <p className="agent-composer-model-empty">Loading suggested models.</p>
-            )}
-          </div>
-          <button
-            type="button"
-            className="agent-composer-model-row agent-composer-model-all"
-            aria-haspopup="true"
-            aria-expanded={flyout?.kind === "all"}
-            data-active={flyout?.kind === "all" || undefined}
-            onMouseEnter={() => hoverIntent(() => onFlyoutChange({ kind: "all" }))}
-            onFocus={() => {
-              cancelHoverIntent();
-              onFlyoutChange({ kind: "all" });
-            }}
-            onClick={() => {
-              cancelHoverIntent();
-              onFlyoutChange({ kind: "all" });
-              searchRef.current?.focus();
-            }}
-          >
-            <span className="agent-composer-model-row-name">All models</span>
-            <IconChevronRightSmall
-              size={16}
-              aria-hidden
-              className="agent-composer-model-row-chevron"
-            />
-          </button>
-        </>
-      )}
+      <div className="agent-composer-model-menu" role="listbox" aria-label={suggestedListLabel}>
+        {suggested.length ? (
+          suggested.map(({ model: option }) => (
+            <button
+              key={option.id}
+              type="button"
+              className="agent-composer-model-row"
+              role="option"
+              aria-selected={option.id === model.id}
+              data-active={(flyout?.kind === "model" && flyout.id === option.id) || undefined}
+              onMouseEnter={() =>
+                hoverIntent(() => onFlyoutChange({ kind: "model", id: option.id }))
+              }
+              onFocus={() => {
+                cancelHoverIntent();
+                onFlyoutChange({ kind: "model", id: option.id });
+              }}
+              onClick={() => onSelect(option.id)}
+            >
+              <ModelPickerOptionText model={option} />
+              {option.id === model.id ? (
+                <IconCheckmark2Small
+                  size={14}
+                  aria-hidden
+                  className="agent-composer-model-row-check"
+                />
+              ) : null}
+            </button>
+          ))
+        ) : (
+          <p className="agent-composer-model-empty">Loading suggested models.</p>
+        )}
+      </div>
+      <button
+        type="button"
+        className="agent-composer-model-row agent-composer-model-all"
+        aria-haspopup="true"
+        aria-expanded={flyout?.kind === "all"}
+        data-active={flyout?.kind === "all" || undefined}
+        onMouseEnter={() => hoverIntent(() => onFlyoutChange({ kind: "all" }))}
+        onFocus={() => {
+          cancelHoverIntent();
+          onFlyoutChange({ kind: "all" });
+        }}
+        onClick={() => {
+          cancelHoverIntent();
+          onFlyoutChange({ kind: "all" });
+          searchRef.current?.focus();
+        }}
+      >
+        <span className="agent-composer-model-row-name">All models</span>
+        <IconChevronRightSmall size={16} aria-hidden className="agent-composer-model-row-chevron" />
+      </button>
       {detail ? (
         <div ref={flyoutRef} className="agent-composer-model-flyout agent-composer-model-detail">
           <div className="agent-composer-model-surface">
@@ -366,7 +351,7 @@ export function ModelPickerPopover({
           <div className="agent-composer-model-surface">{catalogList(allModelsLabel)}</div>
         </div>
       ) : null}
-      {(flyout?.kind === "all" || directCatalog) && catalogHover ? (
+      {flyout?.kind === "all" && catalogHover ? (
         <div
           ref={hovercardRef}
           className="agent-composer-model-hovercard agent-composer-model-detail"

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -11,8 +11,8 @@ export type SuggestedModel = {
  * Curated picks for the model picker's "Suggested" tab — the handful of
  * models we actually recommend, weighed on benchmark performance, price,
  * tool use, and privacy (June's agent needs tool calling, and June's pitch
- * is zero-retention privacy, so every pick here is a "private" catalog model
- * that supports tools).
+ * is zero-retention privacy, so every text pick here is a "private" catalog
+ * model that supports tools).
  *
  * Curation snapshot (June 2026), from the live Venice catalog plus public
  * benchmarks (SWE-bench agentic coding, Artificial Analysis intelligence
@@ -63,10 +63,29 @@ export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
       reason: "Best multilingual accuracy at the same low price, with zero data retention.",
     },
   ],
-  // Image models are a curated local list (see lib/image-models.ts), not a
-  // priced catalog the picker fetches, so there is no "Suggested" subset to
-  // surface — the picker shows the full curated list.
-  image: [],
+  // Image models come from the curated local list in lib/image-models.ts, not
+  // a fetched catalog; these picks are the shortlist the picker surfaces above
+  // "All models". The default (DEFAULT_IMAGE_MODEL, venice-sd35) stays first so
+  // it is always visible without expanding.
+  image: [
+    {
+      id: "venice-sd35",
+      reason:
+        "Default pick: Venice's Stable Diffusion 3.5 model, a private all-rounder for everyday images.",
+    },
+    {
+      id: "z-image-turbo",
+      reason: "Fastest pick: quick, low-cost generations with zero data retention.",
+    },
+    {
+      id: "qwen-image",
+      reason: "Quality pick: strong text rendering and prompt adherence for detailed images.",
+    },
+    {
+      id: "lustify-v8",
+      reason: "Uncensored pick: the least restricted image model, with zero data retention.",
+    },
+  ],
 };
 
 /**

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5173,13 +5173,6 @@ input:focus-visible,
   padding: var(--sp-1);
 }
 
-.agent-composer-model-direct {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-height: 0;
-}
-
 .agent-composer-model-search {
   display: grid;
   grid-template-columns: 14px minmax(0, 1fr);

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -2663,34 +2663,43 @@ describe("AppSettings", () => {
     await user.click(screen.getByRole("button", { name: /More options/ }));
     expect(screen.getByRole("switch", { name: "Blur adult content in images" })).toBeChecked();
 
-    // The picker opens with the curated image options (no backend fetch).
+    // The picker opens with the curated image options (no backend fetch) and,
+    // like text/voice, shows only the suggested picks up top — the rest of the
+    // catalog lives behind the All models flyout.
     await user.click(screen.getByRole("button", { name: "Change image model" }));
     const defaultImageOption = await screen.findByRole("option", { name: /Venice SD3\.5/ });
     expect(defaultImageOption).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: /FLUX 2 Pro/ })).toBeInTheDocument();
-    // Expanded image catalog (from main) rendered through the shared popover:
-    // the models are listed, but their metadata is revealed on hover, not inline.
-    expect(screen.getByText("GPT Image 2")).toBeInTheDocument();
-    expect(screen.getByText("Lustify v8")).toBeInTheDocument();
-    expect(screen.getByText("Z-Image Turbo")).toBeInTheDocument();
-    expect(defaultImageOption).not.toHaveTextContent(
+    expect(screen.getByRole("option", { name: /Z-Image Turbo/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Qwen Image/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Lustify v8/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /FLUX 2 Pro/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /GPT Image 2/ })).not.toBeInTheDocument();
+
+    // All models reveals the full curated catalog in the flyout, with model
+    // metadata revealed on hover, not inline.
+    await user.click(screen.getByRole("button", { name: "All models" }));
+    const panel = await screen.findByRole("group", { name: "All image models" });
+    expect(within(panel).getByRole("option", { name: /FLUX 2 Pro/ })).toBeInTheDocument();
+    expect(within(panel).getByRole("option", { name: /GPT Image 2/ })).toBeInTheDocument();
+    const panelDefaultOption = within(panel).getByRole("option", { name: /Venice SD3\.5/ });
+    expect(panelDefaultOption).not.toHaveTextContent(
       "Venice's default Stable Diffusion 3.5 image model.",
     );
-    await user.hover(defaultImageOption);
+    await user.hover(panelDefaultOption);
     expect(
       await screen.findByText("Venice's default Stable Diffusion 3.5 image model."),
     ).toBeInTheDocument();
-    await user.unhover(defaultImageOption);
+    await user.unhover(panelDefaultOption);
     expect(screen.queryByText("Model details unavailable")).not.toBeInTheDocument();
-    await user.type(screen.getByLabelText("Search models"), "uncensored");
-    expect(screen.getByRole("option", { name: /Lustify v7/ })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: /Lustify v8/ })).toBeInTheDocument();
-    expect(screen.queryByRole("option", { name: /FLUX 2 Pro/ })).not.toBeInTheDocument();
-    await user.clear(screen.getByLabelText("Search models"));
+    await user.type(within(panel).getByLabelText("Search models"), "uncensored");
+    expect(within(panel).getByRole("option", { name: /Lustify v7/ })).toBeInTheDocument();
+    expect(within(panel).getByRole("option", { name: /Lustify v8/ })).toBeInTheDocument();
+    expect(within(panel).queryByRole("option", { name: /FLUX 2 Pro/ })).not.toBeInTheDocument();
+    await user.clear(within(panel).getByLabelText("Search models"));
     // Image models are not fetched from the catalog.
     expect(mocks.listVeniceModels).not.toHaveBeenCalledWith("image");
 
-    await user.click(await screen.findByRole("option", { name: /FLUX 2 Pro/ }));
+    await user.click(await within(panel).findByRole("option", { name: /FLUX 2 Pro/ }));
     expect(mocks.setVeniceModel).toHaveBeenCalledWith("image", "flux-2-pro");
     // The picker closes after a selection.
     await waitFor(() =>


### PR DESCRIPTION
## Summary

In Settings → Models, the image picker listed all 34 curated models flat, while the transcription and text pickers show a short **Suggested** list with the rest tucked behind an **All models** expander. This makes image behave the same:

- Curated shortlist up top: **Venice SD3.5** (the default, always visible), **Z-Image Turbo** (fastest), **Qwen Image** (quality), **Lustify v8** (uncensored).
- Everything else behind **All models** with search + hover metadata, exactly like text/voice.
- Removes the `directCatalog` bypass entirely. The image row was its only consumer, so the `ModelRow` prop, the inline-catalog branch in `ModelPickerPopover`, and the `.agent-composer-model-direct` CSS are all deleted rather than left as a dead path.

## Validation

- `pnpm typecheck` clean
- `pnpm exec vitest run src/test/app-settings.test.tsx` → 61/61 pass (image test rewritten to assert suggested picks at top level, full catalog + search behind All models)
- `pnpm exec biome check` clean on touched files
- Visually verified in a faked-bridge frontend preview — suggested list and the All models flyout both render correctly (screenshots attached in the PR thread).

- [x] Tested visually where it matters (UI change; screenshots attached).
- [ ] Needs a June API (backend) deploy before it works end to end. **No** — frontend-only; image models come from the local curated list, not a fetched catalog.

## Out of scope

- Does not add, remove, or reprice any image model — pure reorganization, so image ids stay in sync with `june-config` `image_pricing`.
- No change to the text or transcription pickers.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. (None — UI-only.)
- [x] User-facing copy follows the repo UI conventions (sentence case, design tokens, no uppercase).

https://claude.ai/code/session_019AyF1p3VYcMFHEfsLJmrAK

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786092539&installation_id=144203540&pr_number=658&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F658&signature=3c4d055bb7a69bfb46da0c22cf56df71920bc751661d9444f4c914ce8289ee34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->