### PR TITLE
[codex] Lock existing session model selection

### DIFF
--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -481,12 +481,20 @@ pub async fn proxy_agent_chat_completions(
     if crate::providers::generation_provider() == PROVIDER_LOCAL {
         return proxy_local_agent_chat_completions(body).await;
     }
-    // Remote provider safety net: a Hermes session started while local mode was
-    // on keeps sending the local model id (Hermes loads its model at spawn and
-    // does not reload on a settings change), which the remote backend rejects
-    // via require_priced_model and would hard-fail every message until restart.
-    // Degrade a stale local model id to the current global model instead.
-    let local_model_id = crate::providers::local_generation_settings().model_id;
+    // Existing sessions are model-locked. A session created while local mode was
+    // active keeps sending the raw local model id even if the global default is
+    // later changed back to Venice from the new-session composer. Honor that
+    // stored model by routing it to the local proxy while the endpoint remains
+    // configured, so the locked session does not silently move off-device.
+    let local_settings = crate::providers::local_generation_settings();
+    let local_model_id = local_settings.model_id.trim().to_string();
+    if should_proxy_request_to_configured_local_model(&body, &local_settings) {
+        return proxy_local_agent_chat_completions(body).await;
+    }
+    // Legacy safety net for invalid/stale local references that cannot be
+    // served locally (for example a prefixed synthetic id after settings were
+    // cleared): degrade to the current global model rather than sending an id
+    // the remote backend rejects via require_priced_model.
     let global_model = crate::providers::generation_model();
     redirect_stale_local_model(&mut body, &local_model_id, &global_model);
     // Computed after the redirect so a degraded stale-local body is gated on the
@@ -767,14 +775,28 @@ fn is_local_model_reference(model: &str, local_model_id: &str) -> bool {
         || model.starts_with(LOCAL_GENERATION_OPTION_ID_PREFIX)
 }
 
-/// Rewrites a request that still carries a local model reference to the
-/// current global generation model, for the remote proxy path only. Mirrors
-/// the local path's unconditional model stomp: when the global provider is
-/// remote, a body still naming the local model is a stale spawn-time default
-/// from a session created while local mode was on, and the remote backend
-/// would reject it. Genuine remote per-session overrides (any non-synthetic
-/// id other than the configured local model id) are left untouched, so an
-/// explicit `/model` switch to a real remote model still wins.
+fn should_proxy_request_to_configured_local_model(
+    body: &serde_json::Value,
+    settings: &LocalGenerationSettings,
+) -> bool {
+    let local_model_id = settings.model_id.trim();
+    if settings.base_url.trim().is_empty() || local_model_id.is_empty() {
+        return false;
+    }
+    body.as_object()
+        .and_then(|object| object.get("model"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .is_some_and(|model| is_local_model_reference(model, local_model_id))
+}
+
+/// Rewrites a request that carries an unservable local model reference to the
+/// current global generation model, for the remote proxy path only. Configured
+/// local references are routed to the local proxy before this runs; this guard
+/// remains for legacy synthetic ids or cleared local settings that would never
+/// be valid remote model ids. Genuine remote per-session overrides (any
+/// non-synthetic id other than the configured local model id) are left
+/// untouched, so an explicit `/model` switch to a real remote model still wins.
 fn redirect_stale_local_model(
     body: &mut serde_json::Value,
     local_model_id: &str,
@@ -1998,10 +2020,61 @@ mod tests {
     }
 
     #[test]
-    fn remote_proxy_redirects_stale_local_model_to_global_model() {
-        // A session started while local mode was on keeps sending the local
-        // model id; on the remote path it must degrade to the global model
-        // rather than hard-fail against require_priced_model.
+    fn remote_proxy_routes_configured_local_model_to_local_proxy() {
+        let body = serde_json::json!({
+            "model": "llama3.1:8b",
+            "messages": [{ "role": "user", "content": "hi" }],
+        });
+        let settings = LocalGenerationSettings {
+            base_url: "http://localhost:11434/v1".to_string(),
+            model_id: "llama3.1:8b".to_string(),
+            api_key: String::new(),
+        };
+
+        assert!(should_proxy_request_to_configured_local_model(
+            &body, &settings
+        ));
+    }
+
+    #[test]
+    fn remote_proxy_routes_configured_synthetic_local_model_to_local_proxy() {
+        let body = serde_json::json!({
+            "model": "__june_local_generation__:llama3.1%3A8b",
+            "messages": [{ "role": "user", "content": "hi" }],
+        });
+        let settings = LocalGenerationSettings {
+            base_url: "http://localhost:11434/v1".to_string(),
+            model_id: "llama3.1:8b".to_string(),
+            api_key: String::new(),
+        };
+
+        assert!(should_proxy_request_to_configured_local_model(
+            &body, &settings
+        ));
+    }
+
+    #[test]
+    fn remote_proxy_does_not_route_unconfigured_local_model_to_local_proxy() {
+        let body = serde_json::json!({
+            "model": "llama3.1:8b",
+            "messages": [{ "role": "user", "content": "hi" }],
+        });
+        let settings = LocalGenerationSettings {
+            base_url: String::new(),
+            model_id: "llama3.1:8b".to_string(),
+            api_key: String::new(),
+        };
+
+        assert!(!should_proxy_request_to_configured_local_model(
+            &body, &settings
+        ));
+    }
+
+    #[test]
+    fn remote_proxy_redirects_unservable_local_model_to_global_model() {
+        // A local model reference with no configured local endpoint cannot be
+        // served locally; on the remote path it degrades to the global model
+        // rather than hard-failing against require_priced_model.
         let mut body = serde_json::json!({
             "model": "llama3.1:8b",
             "messages": [{ "role": "user", "content": "hi" }],

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -227,7 +227,10 @@ import {
   type ModelPrivacyBadge,
   type ProviderModelSettingsChangedDetail,
 } from "../../lib/model-privacy";
-import { resolveModelSwitchOutcome } from "../../lib/hermes-model-switch";
+import {
+  MODEL_CHANGE_LOCKED_NOTICE,
+  MODEL_SWITCH_DEFAULT_ONLY_NOTICE,
+} from "../../lib/hermes-model-switch";
 import {
   LOCAL_GENERATION_OPTION_ID_PREFIX,
   isLoopbackUrl,
@@ -1981,14 +1984,13 @@ export function AgentWorkspace({
   // shows as a name-only stub so the pill never goes blank while configured.
   const [defaultGenerationModelId, setDefaultGenerationModelId] = useState("");
   const defaultGenerationModelIdRef = useRef("");
-  const sessionModelOverridesRef = useRef<Record<string, string>>({});
   const [generationModels, setGenerationModels] = useState<VeniceModelDto[]>([]);
   const generationModelsRef = useRef<VeniceModelDto[]>([]);
   // Bring-your-own local text generation. When the global provider is "local"
   // the model catalog carries a synthetic "Local: <id>" option and the pill
   // resolves to it, so the composer never shows a raw local id or silently
   // reverts the app to metered remote generation. Kept as refs too because the
-  // async model-switch handler reads the latest values.
+  // async provider-selection handler reads the latest values.
   const [localGeneration, setLocalGeneration] = useState<LocalGenerationSettingsDto>({
     baseUrl: "",
     modelId: "",
@@ -2401,6 +2403,8 @@ export function AgentWorkspace({
     onSessionSelected?.(selectedHermesSession);
   }, [onSessionSelected, selectedHermesSession, selectedHermesSessionId]);
   const selectedHermesSessionIsProvisional = isProvisionalHermesSessionId(selectedHermesSessionId);
+  const composerModelLocked =
+    !!selectedHermesSessionId && !newSessionMode && !selectedHermesSessionIsProvisional;
   // When local generation is the active provider, the pill/selection is the
   // synthetic local option so it renders "Local: <id>" and never a raw id or a
   // stale remote override. Every session routes through the local endpoint.
@@ -2483,7 +2487,9 @@ export function AgentWorkspace({
     !modelSupportsImageInput(resolvedGenerationModel);
   const showImageModelWarning = showImageInputWarning || imageSlashBlockedByModel;
   const imageModelWarningText = imageSlashBlockedByModel
-    ? `${resolvedGenerationModel?.name ?? "This model"} can't read images. Switch to a vision model before using /image.`
+    ? composerModelLocked
+      ? `${resolvedGenerationModel?.name ?? "This model"} can't read images. Start a new session with a vision model before using /image.`
+      : `${resolvedGenerationModel?.name ?? "This model"} can't read images. Switch to a vision model before using /image.`
     : `${resolvedGenerationModel?.name ?? "This model"} can't read images.`;
   const composerInputSignature = useMemo(
     () =>
@@ -2915,7 +2921,6 @@ export function AgentWorkspace({
             waitingSessionIds: waitingSessions,
             pendingMessages,
             defaultModelId: defaultGenerationModelIdRef.current,
-            sessionModelOverrides: sessionModelOverridesRef.current,
           }),
         );
         setSelectedHermesSessionId((current) => {
@@ -3067,9 +3072,32 @@ export function AgentWorkspace({
     };
   }, [loadGenerationModel]);
 
+  useEffect(() => {
+    if (composerModelLocked) setComposerModelOpen(false);
+  }, [composerModelLocked]);
+
+  function composerModelSelectionLocked() {
+    const sessionId = selectedHermesSessionIdRef.current;
+    return Boolean(
+      sessionId && !newSessionModeRef.current && !isProvisionalHermesSessionId(sessionId),
+    );
+  }
+
+  function showComposerModelLockedNotice() {
+    setComposerModelOpen(false);
+    setModelSwitchNotice({
+      message: MODEL_CHANGE_LOCKED_NOTICE,
+      sessionId: selectedHermesSessionIdRef.current ?? null,
+    });
+  }
+
   // Stale catalog (the mount fetch can fail while the bridge is starting) is
   // refreshed in the background on every open, like Settings does.
   function openComposerModelPicker() {
+    if (composerModelSelectionLocked()) {
+      showComposerModelLockedNotice();
+      return;
+    }
     setModelSearch("");
     setComposerModelFlyout(null);
     setComposerModelOpen(true);
@@ -3077,13 +3105,6 @@ export function AgentWorkspace({
     void loadGenerationModel();
   }
 
-  // Enables the saved local endpoint as the global generation provider. The
-  // local provider proxy routes EVERY request by the global provider and
-  // rewrites the model to the local id, so flipping the provider is what moves
-  // a running session onto local — a per-chat override could not. That makes
-  // the "switched this session" claim honest here without waiting on the
-  // /model ack; the dispatch is best effort, only to keep Hermes' own session
-  // model aligned (the local id is advertised on /v1/models once local is on).
   // Reflects the global generation selection into composer state directly (not
   // via the backend return value, which tests stub out): the remote flip and
   // the mount fetch already round-trip through commitGenerationSettings.
@@ -3094,9 +3115,8 @@ export function AgentWorkspace({
     setDefaultGenerationModelId(modelId);
   }
 
-  async function selectLocalGeneration(sessionId: string | undefined) {
+  async function selectLocalGeneration() {
     const localModelId = localGenerationRef.current.modelId.trim();
-    const modelName = localModelId ? `Local: ${localModelId}` : "the local model";
     const selectedModelId = localModelId ? localGenerationOptionId(localModelId) : "";
     // An off-device endpoint takes a deliberate second step, same invariant as
     // the Settings toggle: the first selection warns instead of enabling.
@@ -3108,7 +3128,7 @@ export function AgentWorkspace({
         setModelSwitchNotice({
           message:
             "This endpoint is not on this machine. Requests will leave your device. Select the local model again to confirm.",
-          sessionId: sessionId ?? null,
+          sessionId: null,
         });
         return false;
       }
@@ -3129,56 +3149,28 @@ export function AgentWorkspace({
       setError(messageFromError(err));
       return false;
     }
-    if (!sessionId) {
-      setModelSwitchNotice({
-        message: resolveModelSwitchOutcome({
-          hasActiveSession: false,
-          dispatchSucceeded: false,
-          modelName,
-        }).notice,
-        sessionId: null,
-      });
-      return true;
-    }
-    const rawLocalModelId = localGenerationRef.current.modelId.trim();
-    if (rawLocalModelId) {
-      try {
-        const gateway = await ensureHermesGateway(sessionUnrestricted(sessionId));
-        await createHermesMethods(gateway).switchActiveSessionModel({
-          mode: hermesModeFor(sessionId),
-          sessionId,
-          model: rawLocalModelId,
-        });
-      } catch {
-        // Best effort: the proxy already serves this session from local.
-      }
-    }
     setModelSwitchNotice({
-      message: resolveModelSwitchOutcome({
-        hasActiveSession: true,
-        dispatchSucceeded: true,
-        modelName,
-      }).notice,
-      sessionId,
+      message: MODEL_SWITCH_DEFAULT_ONLY_NOTICE,
+      sessionId: null,
     });
     return true;
   }
 
-  // Switching the model always writes the global text-model selection (Settings'
-  // model rows and this pill refresh through the same changed event). When a
-  // session is open, it ALSO switches that live session via Hermes
-  // command.dispatch (/model …), and the UI only claims the running session
-  // moved when Hermes accepts the dispatch (feature 10) — except when the
-  // switch flips the global provider (local <-> remote), where the provider
-  // proxy decides the model for every request and so guarantees the claim.
+  // Switching the model from the composer is only allowed before a thread
+  // exists. It writes the app-wide text-model default (Settings' model rows and
+  // this pill refresh through the same changed event), and new sessions inherit
+  // that choice at creation time.
   async function handleSelectGenerationModel(modelId: string) {
     setComposerModelOpen(false);
-    const sessionId = newSessionModeRef.current ? undefined : selectedHermesSessionIdRef.current;
+    if (composerModelSelectionLocked()) {
+      showComposerModelLockedNotice();
+      return false;
+    }
 
     // Local is a synthetic catalog option (prefixed id), so it routes through
     // the provider switch rather than a remote model set.
     if (modelId.startsWith(LOCAL_GENERATION_OPTION_ID_PREFIX)) {
-      return selectLocalGeneration(sessionId);
+      return selectLocalGeneration();
     }
     // Picking anything else stands down a pending off-device confirm: the
     // next local selection warns afresh instead of enabling in one step.
@@ -3191,85 +3183,18 @@ export function AgentWorkspace({
       setError(`${chosen.name} can't run June's tools, so it can't be used for the agent.`);
       return false;
     }
-    const modelName = chosen?.name ?? modelId;
-    // Selecting a remote model while local is active is an informed switch back
-    // to metered remote generation (the picker showed "Local: …" as current).
-    // The local proxy routes by the GLOBAL provider, so a per-chat override
-    // alone could not move this session off local: flip the global provider
-    // too, or the pill would claim a model the responses do not come from.
-    const wasLocalActive = generationProviderRef.current === "local";
-
-    // No open chat: changing the model updates the global generation default.
-    if (!sessionId) {
-      try {
-        await setVeniceModel("generation", modelId);
-        markRemoteGenerationSelected(modelId);
-        dispatchProviderModelSettingsChanged({ mode: "generation", modelId });
-        setError(null);
-      } catch (err) {
-        setError(messageFromError(err));
-        return false;
-      }
-      setModelSwitchNotice({
-        message: resolveModelSwitchOutcome({
-          hasActiveSession: false,
-          dispatchSucceeded: false,
-          modelName,
-        }).notice,
-        sessionId: null,
-      });
-      return true;
-    }
-
-    // Open chat coming off local: flip the global provider to remote first so
-    // the running session actually leaves the local endpoint before we claim it
-    // did. (In remote mode this is skipped — the switch stays per-chat.)
-    if (wasLocalActive) {
-      try {
-        await setVeniceModel("generation", modelId);
-        markRemoteGenerationSelected(modelId);
-        dispatchProviderModelSettingsChanged({ mode: "generation", modelId });
-      } catch (err) {
-        setError(messageFromError(err));
-        return false;
-      }
-    }
-
-    // Open chat: override the model for THIS chat, then dispatch /model to the
-    // live session so the running turn switches immediately. Hermes session
-    // metadata updates are title-only, so the per-chat override is the source
-    // of truth for this row.
-    sessionModelOverridesRef.current = {
-      ...sessionModelOverridesRef.current,
-      [sessionId]: modelId,
-    };
-    setHermesSessionItems((current) =>
-      current.map((session) =>
-        session.id === sessionId ? { ...session, model: modelId } : session,
-      ),
-    );
-    let dispatchSucceeded = false;
     try {
-      const gateway = await ensureHermesGateway(sessionUnrestricted(sessionId));
-      await createHermesMethods(gateway).switchActiveSessionModel({
-        mode: hermesModeFor(sessionId),
-        sessionId,
-        model: modelId,
-      });
-      dispatchSucceeded = true;
-    } catch {
-      // The per-chat override is saved; the notice explains the running session
-      // is unchanged and the new model applies next session.
-      dispatchSucceeded = false;
+      await setVeniceModel("generation", modelId);
+      markRemoteGenerationSelected(modelId);
+      dispatchProviderModelSettingsChanged({ mode: "generation", modelId });
+      setError(null);
+    } catch (err) {
+      setError(messageFromError(err));
+      return false;
     }
-    setError(null);
     setModelSwitchNotice({
-      message: resolveModelSwitchOutcome({
-        hasActiveSession: true,
-        dispatchSucceeded,
-        modelName,
-      }).notice,
-      sessionId,
+      message: MODEL_SWITCH_DEFAULT_ONLY_NOTICE,
+      sessionId: null,
     });
     return true;
   }
@@ -4128,6 +4053,11 @@ export function AgentWorkspace({
   }
 
   async function runModelSlashCommand(argument: string, commandText: string) {
+    if (composerModelSelectionLocked()) {
+      clearComposerCommandDraft(commandText);
+      showComposerModelLockedNotice();
+      return;
+    }
     const query = argument.trim();
     if (!query) {
       clearComposerCommandDraft(commandText);
@@ -7628,7 +7558,7 @@ export function AgentWorkspace({
                 className="agent-composer-image-warning-icon"
               />
               <span className="agent-composer-image-warning-text">{imageModelWarningText}</span>
-              {preferredVisionModel ? (
+              {preferredVisionModel && !composerModelLocked ? (
                 <button
                   type="button"
                   className="agent-composer-notice-button agent-composer-image-warning-action"
@@ -7639,8 +7569,8 @@ export function AgentWorkspace({
                     // case would drop the user into an unfiltered list that
                     // doesn't surface the eligible models. preferredVisionModel
                     // is pre-filtered to image + tool support and prefers a
-                    // suggested pick; handleSelectGenerationModel routes the
-                    // global default vs per-chat override.
+                    // suggested pick. This only appears before a thread
+                    // exists, where model changes still update the default.
                     void handleSelectGenerationModel(preferredVisionModel.id)
                   }
                 >
@@ -7678,7 +7608,7 @@ export function AgentWorkspace({
                 >
                   Edit message
                 </button>
-                {visibleComposerSizeWarning.switchModel ? (
+                {visibleComposerSizeWarning.switchModel && !composerModelLocked ? (
                   <button
                     type="button"
                     className="agent-composer-notice-button"
@@ -7774,6 +7704,7 @@ export function AgentWorkspace({
               <ComposerModelPicker
                 open={composerModelOpen}
                 model={generationModel}
+                readOnly={composerModelLocked}
                 triggerRef={composerModelTriggerRef}
                 onToggleOpen={() => {
                   if (composerModelOpen) {
@@ -7916,7 +7847,7 @@ export function AgentWorkspace({
             onSent={handleReportDialogSent}
           />
         ) : null}
-        {composerModelOpen ? (
+        {composerModelOpen && !composerModelLocked ? (
           <ModelPickerPopover
             mode="generation"
             flyout={composerModelFlyout}
@@ -12224,15 +12155,11 @@ function mergeActiveHermesSessions(
     waitingSessionIds: Set<string>;
     pendingMessages: Record<string, HermesSessionMessage[]>;
     defaultModelId?: string;
-    sessionModelOverrides?: Record<string, string>;
   },
 ) {
   const currentById = new Map(current.map((session) => [session.id, session]));
   const defaultModelId = options.defaultModelId?.trim();
-  const sessionModelOverrides = options.sessionModelOverrides ?? {};
   const mergedFresh = fresh.map((session) => {
-    const overrideModel = sessionModelOverrides[session.id]?.trim();
-    if (overrideModel) return { ...session, model: overrideModel };
     if (session.model?.trim()) return session;
     const currentModel = currentById.get(session.id)?.model?.trim();
     if (currentModel) return { ...session, model: currentModel };

--- a/src/components/agent/composer/ModelPicker.tsx
+++ b/src/components/agent/composer/ModelPicker.tsx
@@ -25,15 +25,26 @@ import { contextLabel, pricingLabel } from "../../settings/ModelPickerDialog";
 export function ComposerModelPicker({
   open,
   model,
+  readOnly = false,
   triggerRef,
   onToggleOpen,
 }: {
   open: boolean;
   model?: VeniceModelDto;
+  readOnly?: boolean;
   triggerRef: RefObject<HTMLButtonElement>;
   onToggleOpen: () => void;
 }) {
   if (!model) return null;
+  if (readOnly) {
+    return (
+      <div className="agent-composer-model" data-readonly="true">
+        <span className="agent-composer-model-label">
+          <span>{model.name}</span>
+        </span>
+      </div>
+    );
+  }
   return (
     <div className="agent-composer-model" data-open={open || undefined}>
       <button

--- a/src/lib/hermes-control-plane/compatibility/matrix.ts
+++ b/src/lib/hermes-control-plane/compatibility/matrix.ts
@@ -136,7 +136,7 @@ const methods: HermesCompatibilitySection = {
   "command.dispatch": {
     status: "supported",
     rationale:
-      "The composer model picker switches a live session by dispatching /model via switchActiveSessionModel (command.dispatch) and only claims success on the gateway ack; covered by hermes-model-switch and agent-workspace tests.",
+      "The typed switchActiveSessionModel seam dispatches /model via command.dispatch and returns the gateway ack; the composer keeps existing threads model-locked and only changes the default before session creation.",
     since: PIN,
   },
   "subagent.interrupt": {

--- a/src/lib/hermes-model-switch.ts
+++ b/src/lib/hermes-model-switch.ts
@@ -1,78 +1,15 @@
 /**
- * The honest three-state decision behind switching the agent's text model.
+ * User-facing notices for the composer model control.
  *
- * Picking a model in June always writes the app-wide default (so the next
- * session uses it). What it does to the session you are looking at depends on
- * whether one is running and whether Hermes accepted the `/model` dispatch:
- *
- * - `active-session-switched` — a session is live AND Hermes accepted the
- *   `/model` slash command (the gateway result is the only signal June trusts;
- *   raw `model.switch`/`model.changed` events classify as `unsupported`).
- * - `default-changed` — no session is running, so only the default moved; the
- *   copy says it applies to new sessions.
- * - `switch-failed` — a session is live but the dispatch failed or was
- *   rejected. June never claims the running session switched; the default is
- *   still saved, so the new model takes effect on the next session.
- *
- * The model-switch command itself lives in the typed seam
- * (`switchActiveSessionModel` in `hermes-control-plane/methods.ts`); this module
- * owns only the user-facing decision so it stays pure and unit-testable apart
- * from the 9k-line workspace.
+ * June lets the composer choose the text-model default before a Hermes session
+ * exists. Once a session exists, the model is fixed for that thread; the
+ * composer renders the current model as passive status instead of offering a
+ * picker.
  */
-
-/** Which of the three honest states a model switch resolved to. */
-export type ModelSwitchState = "active-session-switched" | "default-changed" | "switch-failed";
-
-export type ModelSwitchOutcome = {
-  state: ModelSwitchState;
-  /** Sentence-case notice for the composer status slot. No dashes (project
-   * copy rule); ranges/joins are rewritten. */
-  notice: string;
-};
-
-/** Shown when the live session accepted the switch. Names the model so the
- * user can trust the running turn actually moved. */
-export function modelSwitchSuccessNotice(modelName: string): string {
-  return `Switched this session to ${modelName}.`;
-}
 
 /** No session was running, so only the default changed. */
 export const MODEL_SWITCH_DEFAULT_ONLY_NOTICE =
   "Default model updated. It applies to new sessions.";
 
-/** A session was running but the switch did not take. Honest: the running
- * session is unchanged. The choice is saved as this chat's per-chat override
- * (never the global default), so it applies the next time this chat runs. */
-export const MODEL_SWITCH_FAILED_NOTICE =
-  "Could not switch the running session. This chat will use the new model next time.";
-
-export type ResolveModelSwitchInput = {
-  /** Whether a Hermes session is currently open and live. */
-  hasActiveSession: boolean;
-  /** Whether the `/model` dispatch to that session was accepted. Only
-   * meaningful when {@link hasActiveSession} is true. */
-  dispatchSucceeded: boolean;
-  /** Human-readable name of the chosen model, for the success copy. */
-  modelName: string;
-};
-
-/**
- * Maps the facts of a model change onto exactly one honest outcome. Pure: it
- * makes no claim the caller has not proven (an accepted gateway dispatch), so
- * the UI can never tell the user a running session switched when it did not.
- */
-export function resolveModelSwitchOutcome(input: ResolveModelSwitchInput): ModelSwitchOutcome {
-  if (!input.hasActiveSession) {
-    return {
-      state: "default-changed",
-      notice: MODEL_SWITCH_DEFAULT_ONLY_NOTICE,
-    };
-  }
-  if (input.dispatchSucceeded) {
-    return {
-      state: "active-session-switched",
-      notice: modelSwitchSuccessNotice(input.modelName),
-    };
-  }
-  return { state: "switch-failed", notice: MODEL_SWITCH_FAILED_NOTICE };
-}
+/** Existing sessions are model-locked; switch by starting a fresh session. */
+export const MODEL_CHANGE_LOCKED_NOTICE = "Start a new session to change models.";

--- a/src/styleguide/sections/Color.tsx
+++ b/src/styleguide/sections/Color.tsx
@@ -29,7 +29,15 @@ const COLOR_GROUPS: { label: string; names: string[] }[] = [
   },
   {
     label: "Border and ring",
-    names: ["--border", "--border-subtle", "--input", "--ring", "--ring-focus", "--focus-ring"],
+    names: [
+      "--border",
+      "--border-subtle",
+      "--detail-bar-border",
+      "--input",
+      "--ring",
+      "--ring-focus",
+      "--focus-ring",
+    ],
   },
   {
     label: "Brand and derived tints",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4889,7 +4889,8 @@ input:focus-visible,
   min-width: 0;
 }
 
-.agent-composer-model-trigger {
+.agent-composer-model-trigger,
+.agent-composer-model-label {
   display: inline-flex;
   align-items: center;
   gap: var(--sp-1);
@@ -4902,9 +4903,18 @@ input:focus-visible,
   color: var(--muted-foreground);
   font: inherit;
   font-size: var(--fs-md);
+}
+
+.agent-composer-model-trigger {
   transition:
     background-color var(--t-fast) var(--ease-out),
     color var(--t-fast) var(--ease-out);
+}
+
+.agent-composer-model-label {
+  padding-inline: var(--sp-2);
+  color: color-mix(in oklch, var(--muted-foreground) 82%, transparent);
+  font-size: var(--fs-sm);
 }
 
 .agent-composer-model-trigger:hover,
@@ -4913,7 +4923,8 @@ input:focus-visible,
   color: var(--foreground);
 }
 
-.agent-composer-model-trigger span {
+.agent-composer-model-trigger span,
+.agent-composer-model-label span {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -15929,7 +15940,7 @@ input:focus-visible,
   /* Full-bleed bar, but the crumb lines up with the content gutter (sp-8)
    * rather than hugging the sidebar edge. */
   padding: var(--sp-2) var(--sp-8);
-  border-bottom: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--detail-bar-border);
   background: color-mix(in oklch, var(--card) 78%, transparent);
   backdrop-filter: saturate(140%) blur(14px);
   -webkit-backdrop-filter: saturate(140%) blur(14px);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -213,9 +213,12 @@
   /* Subtle surface + border — the canonical "quiet chip/track/secondary
    * button" fill and the soft 1px outline used on inset cards. Both
    * derive from existing warm tokens so they inherit the system hue
-   * and adapt across light/dark. */
+   * and adapt across light/dark. The detail-bar border is quieter still:
+   * it separates pinned breadcrumb chrome from content without reading as
+   * a boxed card edge. */
   --surface-subtle: color-mix(in oklch, var(--muted) 65%, transparent);
   --border-subtle: color-mix(in oklch, var(--border) 55%, transparent);
+  --detail-bar-border: color-mix(in oklch, var(--border-subtle) 58%, transparent);
   --body-copy: color-mix(in oklch, var(--foreground) 86%, var(--muted-foreground));
   --popover-border: color-mix(in oklch, var(--foreground) 10%, transparent);
 
@@ -372,6 +375,7 @@
    * 55% mix would dilute it below the visibility floor. Bump to 80%
    * so the subtle border still reads against the dark card. */
   --border-subtle: color-mix(in oklch, var(--border) 80%, transparent);
+  --detail-bar-border: color-mix(in oklch, var(--border-subtle) 66%, transparent);
   --body-copy: color-mix(in oklch, var(--foreground) 88%, var(--muted-foreground));
   --popover-border: color-mix(in oklch, white 12%, transparent);
   /* Dark inverts the roles: a deep brand-tinted surface + a lifted brand

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -193,6 +193,20 @@ const existingSession = {
   last_active: "2026-06-04T12:00:00Z",
 };
 
+function getCurrentModelLabel(name: string) {
+  const text = screen.getByText(name, {
+    selector: ".agent-composer-model-label span",
+  });
+  return text.closest(".agent-composer-model-label") as HTMLElement;
+}
+
+async function findCurrentModelLabel(name: string) {
+  const text = await screen.findByText(name, {
+    selector: ".agent-composer-model-label span",
+  });
+  return text.closest(".agent-composer-model-label") as HTMLElement;
+}
+
 function seedLegacyNewSessionReportDraft() {
   seedAgentComposerDraftForTest("new-session", {
     text: "",
@@ -2479,9 +2493,9 @@ describe("AgentWorkspace", () => {
 
     expect(await screen.findByText("Anonymous mode")).toBeInTheDocument();
     // The session bar badge carries the privacy mode alone; the model name
-    // lives on the composer's model trigger. The badge's accessible name
+    // lives on the composer's current-model status. The badge's accessible name
     // carries the mode description.
-    expect(screen.getByRole("button", { name: "Model: Anonymous Only" })).toBeInTheDocument();
+    expect(getCurrentModelLabel("Anonymous Only")).toBeInTheDocument();
     expect(
       screen.getByLabelText(new RegExp(`^Anonymous mode: ${ANONYMOUS_MODEL_DESCRIPTION}`)),
     ).toBeInTheDocument();
@@ -2527,23 +2541,20 @@ describe("AgentWorkspace", () => {
     await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
   });
 
-  it("opens the model picker from the composer's model trigger", async () => {
+  it("shows the existing chat model as read-only status", async () => {
     const user = userEvent.setup();
 
     render(<AgentWorkspace initialSession={existingSession} />);
 
-    // The session composer carries the same model trigger as the hero.
-    await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
+    const currentModel = await findCurrentModelLabel("GLM 5.2");
+    expect(currentModel).toHaveClass("agent-composer-model-label");
+    expect(screen.queryByRole("button", { name: "Model: GLM 5.2" })).not.toBeInTheDocument();
 
-    const dialog = await screen.findByRole("dialog", {
-      name: "Choose text model",
-    });
-    expect(within(dialog).getByRole("option", { name: /GLM 5\.2/ })).toBeInTheDocument();
+    await user.click(currentModel);
+    expect(screen.queryByRole("dialog", { name: "Choose text model" })).not.toBeInTheDocument();
   });
 
-  it("switches the text model only for the active chat", async () => {
-    // Tool-capable catalog: the picker refuses tool-less models for the
-    // agent, so the switch target must support function calling.
+  it("blocks /model changes in an existing chat", async () => {
     const catalog = [
       {
         provider: "venice",
@@ -2583,34 +2594,25 @@ describe("AgentWorkspace", () => {
 
     render(<AgentWorkspace initialSession={existingSession} />);
 
-    await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
-    const dialog = await screen.findByRole("dialog", {
-      name: "Choose text model",
+    const composer = await screen.findByRole("textbox", {
+      name: "Message June",
     });
-
-    // The popover opens on the suggested picks (GLM 5.2 is curated); the
-    // switch target only exists in the full catalog behind All models.
-    await user.click(within(dialog).getByRole("button", { name: "All models" }));
-    const panel = await screen.findByRole("group", {
-      name: "All text models",
-    });
-    await user.click(within(panel).getByRole("option", { name: /Anonymous Only/ }));
+    await user.type(composer, "/model anonymous");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
 
     expect(mocks.setVeniceModel).not.toHaveBeenCalled();
-    // The composer trigger reflects the new model and the session bar badge
-    // its privacy mode.
-    expect(
-      await screen.findByRole("button", { name: "Model: Anonymous Only" }),
-    ).toBeInTheDocument();
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("command.dispatch", expect.anything());
     expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
       sessionId: "session-1",
       model: "anonymous-only",
     });
-    expect(await screen.findByText("Anonymous mode")).toBeInTheDocument();
-    expect(screen.queryByText("Private mode")).not.toBeInTheDocument();
+    expect(await screen.findByText("Start a new session to change models.")).toBeInTheDocument();
+    expect(await findCurrentModelLabel("GLM 5.2")).toBeInTheDocument();
+    expect(screen.queryByText("Anonymous mode")).not.toBeInTheDocument();
+    expect(await screen.findByText("Private mode")).toBeInTheDocument();
   });
 
-  it("keeps another active chat on its own model after switching the current chat", async () => {
+  it("shows each existing chat's stored model as read-only status", async () => {
     const catalog = [
       {
         provider: "venice",
@@ -2655,28 +2657,15 @@ describe("AgentWorkspace", () => {
       selectedModel: "zai-org-glm-5-2",
       models: catalog,
     });
-    const user = userEvent.setup();
 
     const { rerender } = render(<AgentWorkspace initialSession={existingSession} />);
 
-    await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
-    const dialog = await screen.findByRole("dialog", {
-      name: "Choose text model",
-    });
-    await user.click(within(dialog).getByRole("button", { name: "All models" }));
-    const panel = await screen.findByRole("group", {
-      name: "All text models",
-    });
-    await user.click(within(panel).getByRole("option", { name: /Anonymous Only/ }));
-
-    expect(
-      await screen.findByRole("button", { name: "Model: Anonymous Only" }),
-    ).toBeInTheDocument();
+    expect(await findCurrentModelLabel("GLM 5.2")).toBeInTheDocument();
 
     rerender(<AgentWorkspace initialSession={secondSession} />);
 
-    expect(await screen.findByRole("button", { name: "Model: Kimi K2.6" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Model: Anonymous Only" })).not.toBeInTheDocument();
+    expect(await findCurrentModelLabel("Kimi K2.6")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Model: Kimi K2.6" })).not.toBeInTheDocument();
   });
 
   it("keeps an existing chat model when generation model settings change", async () => {
@@ -2807,67 +2796,8 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(mocks.listVeniceModels.mock.calls.length).toBeGreaterThan(modelListCalls),
     );
-    expect(screen.getByRole("button", { name: "Model: GLM 5.2" })).toBeInTheDocument();
+    expect(getCurrentModelLabel("GLM 5.2")).toBeInTheDocument();
     expect(screen.queryByText("Anonymous mode")).not.toBeInTheDocument();
-  });
-
-  it("keeps an explicit chat model when a refresh returns a stale server model", async () => {
-    const catalog = [
-      {
-        provider: "venice",
-        id: "zai-org-glm-5-2",
-        name: "GLM 5.2",
-        modelType: "text",
-        privacy: "private",
-        traits: [],
-        capabilities: ["functionCalling"],
-      },
-      {
-        provider: "venice",
-        id: "anonymous-only",
-        name: "Anonymous Only",
-        modelType: "text",
-        privacy: "anonymous",
-        traits: [],
-        capabilities: ["functionCalling"],
-      },
-    ];
-    mocks.listVeniceModels.mockResolvedValue({
-      mode: "generation",
-      modelType: "text",
-      selectedModel: "zai-org-glm-5-2",
-      models: catalog,
-    });
-    const user = userEvent.setup();
-
-    render(<AgentWorkspace initialSession={existingSession} />);
-
-    await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
-    const dialog = await screen.findByRole("dialog", {
-      name: "Choose text model",
-    });
-    await user.click(within(dialog).getByRole("button", { name: "All models" }));
-    const panel = await screen.findByRole("group", {
-      name: "All text models",
-    });
-    await user.click(within(panel).getByRole("option", { name: /Anonymous Only/ }));
-    expect(
-      await screen.findByRole("button", { name: "Model: Anonymous Only" }),
-    ).toBeInTheDocument();
-
-    const sessionListCalls = mocks.listHermesSessions.mock.calls.length;
-    mocks.listHermesSessions.mockResolvedValue([{ ...existingSession, model: "zai-org-glm-5-2" }]);
-
-    await user.type(screen.getByRole("textbox"), "continue");
-    await user.click(screen.getByRole("button", { name: "Send message" }));
-
-    await waitFor(() =>
-      expect(mocks.listHermesSessions.mock.calls.length).toBeGreaterThan(sessionListCalls),
-    );
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Model: Anonymous Only" })).toBeInTheDocument(),
-    );
-    expect(screen.queryByText("Private mode")).not.toBeInTheDocument();
   });
 
   it("uses the new-chat composer picker to update the default model", async () => {
@@ -6499,6 +6429,8 @@ describe("AgentWorkspace", () => {
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(2500);
+        await Promise.resolve();
+        await Promise.resolve();
       });
 
       expect(screen.getByText("follow up while pending")).toBeInTheDocument();
@@ -7457,7 +7389,7 @@ describe("AgentWorkspace", () => {
 
   it("warns and offers a one-tap switch when an image is attached to a non-vision model", async () => {
     // Hero mode (no open session) so the switch writes the global text-model
-    // default through setVeniceModel rather than a per-chat gateway dispatch.
+    // default through setVeniceModel.
     mocks.listAgentTasks.mockResolvedValue({ items: [] });
     mocks.listHermesSessions.mockResolvedValue([]);
     mocks.listVeniceModels.mockResolvedValue({
@@ -7547,7 +7479,7 @@ describe("AgentWorkspace", () => {
 
     render(<AgentWorkspace initialSession={existingSession} />);
 
-    await screen.findByRole("button", { name: "Model: Short context" });
+    await findCurrentModelLabel("Short context");
     await user.type(screen.getByRole("textbox"), "a".repeat(100));
     await user.click(screen.getByRole("button", { name: "Send message" }));
 
@@ -7556,7 +7488,9 @@ describe("AgentWorkspace", () => {
     );
     expect(screen.getByRole("button", { name: "Proceed" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Edit message" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Switch to Long context" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Switch to Long context" }),
+    ).not.toBeInTheDocument();
     expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "prompt.submit")).toBe(
       false,
     );
@@ -7571,55 +7505,69 @@ describe("AgentWorkspace", () => {
   });
 
   it("switches to a larger-context model from the oversize composer warning", async () => {
-    mocks.providerModelSettings.mockResolvedValue({
+    let selectedModel = "short-context";
+    const models = [
+      {
+        provider: "venice",
+        id: "short-context",
+        name: "Short context",
+        modelType: "text",
+        privacy: "private",
+        contextTokens: 16,
+        traits: [],
+        capabilities: ["functionCalling"],
+      },
+      {
+        provider: "venice",
+        id: "long-context",
+        name: "Long context",
+        modelType: "text",
+        privacy: "private",
+        contextTokens: 256,
+        traits: [],
+        capabilities: ["functionCalling"],
+      },
+    ];
+    mocks.providerModelSettings.mockImplementation(async () => ({
       settings: {
         transcriptionProvider: "venice",
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-        generationModel: "short-context",
+        generationModel: selectedModel,
       },
-    });
-    mocks.listVeniceModels.mockResolvedValue({
+    }));
+    mocks.listVeniceModels.mockImplementation(async () => ({
       mode: "generation",
       modelType: "text",
-      selectedModel: "short-context",
-      models: [
-        {
-          provider: "venice",
-          id: "short-context",
-          name: "Short context",
-          modelType: "text",
-          privacy: "private",
-          contextTokens: 16,
-          traits: [],
-          capabilities: ["functionCalling"],
-        },
-        {
-          provider: "venice",
-          id: "long-context",
-          name: "Long context",
-          modelType: "text",
-          privacy: "private",
-          contextTokens: 256,
-          traits: [],
-          capabilities: ["functionCalling"],
-        },
-      ],
+      selectedModel,
+      models,
+    }));
+    mocks.setVeniceModel.mockImplementation(async (_mode: string, modelId: string) => {
+      selectedModel = modelId;
     });
     const user = userEvent.setup();
 
-    render(<AgentWorkspace initialSession={existingSession} />);
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now() }),
+    );
+    mocks.listAgentTasks.mockResolvedValue({ items: [] });
+    mocks.listHermesSessions.mockResolvedValue([]);
+    render(<AgentWorkspace />);
 
     await screen.findByRole("button", { name: "Model: Short context" });
     await user.type(screen.getByRole("textbox"), "a".repeat(100));
-    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await user.click(screen.getByRole("button", { name: "Start session" }));
     await user.click(await screen.findByRole("button", { name: "Switch to Long context" }));
 
+    await waitFor(() =>
+      expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "long-context"),
+    );
     expect(await screen.findByRole("button", { name: "Model: Long context" })).toBeInTheDocument();
     await waitFor(() =>
       expect(screen.queryByText(/This message is about/)).not.toBeInTheDocument(),
     );
 
-    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await user.click(screen.getByRole("button", { name: "Start session" }));
 
     await waitFor(() =>
       expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "prompt.submit")).toBe(
@@ -7670,7 +7618,7 @@ describe("AgentWorkspace", () => {
 
     render(<AgentWorkspace initialSession={existingSession} />);
 
-    await screen.findByRole("button", { name: "Model: Short context" });
+    await findCurrentModelLabel("Short context");
     await user.type(screen.getByRole("textbox"), "/large-skill summarize");
     await user.click(screen.getByRole("button", { name: "Send message" }));
 
@@ -8856,81 +8804,6 @@ describe("AgentWorkspace", () => {
         content_base64: "aGVsbG8=",
       });
     }
-  });
-
-  it("falls back to a path-in-prompt for a /image image on a non-vision model (JUN-171 Phase A)", async () => {
-    // `/image` itself must start from a vision-capable chat. If the user later
-    // switches that chat to a text-only model, the held generated image falls
-    // back to a path-in-prompt instead of calling image.attach_bytes.
-    mocks.listHermesSessions.mockResolvedValue([{ ...existingSession, model: "kimi-k2-6" }]);
-    mocks.listVeniceModels.mockResolvedValue({
-      mode: "generation",
-      modelType: "text",
-      selectedModel: "zai-org-glm-5-2",
-      models: [
-        {
-          provider: "venice",
-          id: "zai-org-glm-5-2",
-          name: "GLM 5.2",
-          modelType: "text",
-          privacy: "private",
-          traits: [],
-          capabilities: ["functionCalling"],
-        },
-        {
-          provider: "venice",
-          id: "kimi-k2-6",
-          name: "Kimi K2.6",
-          modelType: "text",
-          privacy: "private",
-          traits: [],
-          capabilities: ["functionCalling", "supportsVision"],
-        },
-      ],
-    });
-    const user = userEvent.setup();
-    render(<AgentWorkspace />);
-    expect(await screen.findByText("Existing session")).toBeInTheDocument();
-    expect(await screen.findByRole("button", { name: "Model: Kimi K2.6" })).toBeInTheDocument();
-
-    mocks.generateImage.mockResolvedValueOnce({
-      imageBase64: "aGVsbG8=",
-      mimeType: "image/png",
-      model: "venice-sd35",
-      provider: "venice",
-    });
-
-    await user.type(await screen.findByRole("textbox"), "/image a red bicycle");
-    fireEvent.submit(document.querySelector(".agent-composer") as HTMLFormElement);
-    await screen.findByRole("img", { name: "a red bicycle" });
-
-    await user.click(screen.getByRole("button", { name: "Model: Kimi K2.6" }));
-    const dialog = await screen.findByRole("dialog", { name: "Choose text model" });
-    await user.click(within(dialog).getByRole("option", { name: /GLM 5\.2/ }));
-    await waitFor(() =>
-      expect(mocks.gatewayRequest).toHaveBeenCalledWith("command.dispatch", {
-        session_id: "session-1",
-        command: "/model zai-org-glm-5-2",
-      }),
-    );
-
-    await user.type(await screen.findByRole("textbox"), "what do you think");
-    const sendButton = screen.getByRole("button", { name: "Send message" });
-    await waitFor(() => expect(sendButton).not.toBeDisabled());
-    await user.click(sendButton);
-
-    await waitFor(() => {
-      const submitCall = mocks.gatewayRequest.mock.calls.find(
-        ([method]) => method === "prompt.submit",
-      );
-      expect(submitCall?.[1]?.text).toContain("Previous /image request: a red bicycle");
-      expect(submitCall?.[1]?.text).toContain("does not support image input");
-      expect(submitCall?.[1]?.text).toMatch(/generated-image-\d+\.png/);
-    });
-    // No structured attach on a non-vision model — the image rides as a path.
-    expect(
-      mocks.gatewayRequest.mock.calls.some(([method]) => method === "image.attach_bytes"),
-    ).toBe(false);
   });
 
   it("chooses one preferred image when paste exposes multiple representations", async () => {
@@ -10127,10 +10000,11 @@ describe("AgentWorkspace", () => {
     expect(onOpenProjects).toHaveBeenCalled();
   });
 
-  // Feature 10: a model change must reach the LIVE session through Hermes
-  // command.dispatch (/model …), not just rewrite the default — and the UI must
-  // never claim the running session switched unless Hermes accepted it.
-  describe("active-session model switching (feature 10)", () => {
+  // Existing sessions are model-locked. The composer picker only changes the
+  // default before session creation; once a thread exists, the toolbar shows a
+  // passive current-model label and `/model` reports that a new session is
+  // required.
+  describe("session model locking", () => {
     const toolCapableCatalog = [
       {
         provider: "venice",
@@ -10152,43 +10026,26 @@ describe("AgentWorkspace", () => {
       },
     ];
 
-    it("dispatches /model to the open session and confirms the switch", async () => {
+    it("renders the open session model as passive status", async () => {
       mocks.listVeniceModels.mockResolvedValue({
         mode: "generation",
         modelType: "text",
         selectedModel: "zai-org-glm-5-2",
         models: toolCapableCatalog,
       });
-      mocks.setVeniceModel.mockResolvedValue(undefined);
       const user = userEvent.setup();
 
       render(<AgentWorkspace initialSession={existingSession} />);
 
-      await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
-      const dialog = await screen.findByRole("dialog", {
-        name: "Choose text model",
-      });
-      await user.click(within(dialog).getByRole("option", { name: /Kimi K2\.6/ }));
+      const currentModel = await findCurrentModelLabel("GLM 5.2");
+      expect(currentModel).toHaveClass("agent-composer-model-label");
+      expect(screen.queryByRole("button", { name: "Model: GLM 5.2" })).not.toBeInTheDocument();
 
-      // The model is overridden for this chat only. The bridge session ensure
-      // path is title-only, so model changes are not persisted through REST.
-      expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
-        sessionId: "session-1",
-        model: "kimi-k2-6",
-      });
-      // The global default is left untouched.
-      expect(mocks.setVeniceModel).not.toHaveBeenCalled();
-      // …AND the live session is switched via command.dispatch (/model …).
-      await waitFor(() =>
-        expect(mocks.gatewayRequest).toHaveBeenCalledWith("command.dispatch", {
-          session_id: "session-1",
-          command: "/model kimi-k2-6",
-        }),
-      );
-      expect(await screen.findByText("Switched this session to Kimi K2.6.")).toBeInTheDocument();
+      await user.click(currentModel);
+      expect(screen.queryByRole("dialog", { name: "Choose text model" })).not.toBeInTheDocument();
     });
 
-    it("dispatches /model from the composer slash command", async () => {
+    it("does not dispatch /model from an existing session slash command", async () => {
       mocks.listVeniceModels.mockResolvedValue({
         mode: "generation",
         modelType: "text",
@@ -10205,12 +10062,8 @@ describe("AgentWorkspace", () => {
       await user.type(composer, "/model kimi");
       await user.click(screen.getByRole("button", { name: "Send message" }));
 
-      await waitFor(() =>
-        expect(mocks.gatewayRequest).toHaveBeenCalledWith("command.dispatch", {
-          session_id: "session-1",
-          command: "/model kimi-k2-6",
-        }),
-      );
+      expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("command.dispatch", expect.anything());
+      expect(mocks.setVeniceModel).not.toHaveBeenCalled();
       expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
         sessionId: "session-1",
         model: "kimi-k2-6",
@@ -10219,7 +10072,7 @@ describe("AgentWorkspace", () => {
         false,
       );
       expect(composer.textContent).toBe("");
-      expect(await screen.findByText("Switched this session to Kimi K2.6.")).toBeInTheDocument();
+      expect(await screen.findByText("Start a new session to change models.")).toBeInTheDocument();
     });
 
     it("changes only the default when no session is active and does not dispatch", async () => {
@@ -10257,42 +10110,6 @@ describe("AgentWorkspace", () => {
       expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("command.dispatch", expect.anything());
     });
 
-    it("shows a failure notice and does not claim success when the dispatch is rejected", async () => {
-      mocks.listVeniceModels.mockResolvedValue({
-        mode: "generation",
-        modelType: "text",
-        selectedModel: "zai-org-glm-5-2",
-        models: toolCapableCatalog,
-      });
-      mocks.setVeniceModel.mockResolvedValue(undefined);
-      mocks.gatewayRequest.mockImplementation((method: string) => {
-        if (method === "command.dispatch") {
-          return Promise.reject(new Error("model switch refused"));
-        }
-        if (method === "session.resume") {
-          return Promise.resolve({ session_id: "runtime-session-1" });
-        }
-        return Promise.resolve({});
-      });
-      const user = userEvent.setup();
-
-      render(<AgentWorkspace initialSession={existingSession} />);
-
-      await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
-      const dialog = await screen.findByRole("dialog", {
-        name: "Choose text model",
-      });
-      await user.click(within(dialog).getByRole("option", { name: /Kimi K2\.6/ }));
-
-      expect(
-        await screen.findByText(
-          "Could not switch the running session. This chat will use the new model next time.",
-        ),
-      ).toBeInTheDocument();
-      // Never the success copy when Hermes rejected the switch.
-      expect(screen.queryByText("Switched this session to Kimi K2.6.")).not.toBeInTheDocument();
-    });
-
     it("keeps tool-incapable models out of the picker for the agent", async () => {
       mocks.listVeniceModels.mockResolvedValue({
         mode: "generation",
@@ -10313,7 +10130,11 @@ describe("AgentWorkspace", () => {
       });
       const user = userEvent.setup();
 
-      render(<AgentWorkspace initialSession={existingSession} />);
+      window.sessionStorage.setItem(
+        AGENT_NEW_SESSION_PENDING_KEY,
+        JSON.stringify({ createdAt: Date.now() }),
+      );
+      render(<AgentWorkspace />);
 
       await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
       const dialog = await screen.findByRole("dialog", {
@@ -10469,56 +10290,36 @@ describe("AgentWorkspace", () => {
       ).toBeInTheDocument();
     });
 
-    it("claims the session switched to local and dispatches the raw local id", async () => {
+    it("does not enable local generation from an existing session", async () => {
       mockRemoteWithLocalConfigured();
       mocks.setLocalGenerationEnabled.mockResolvedValue(undefined);
       const user = userEvent.setup();
       render(<AgentWorkspace initialSession={existingSession} />);
 
-      await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
-      const panel = await openAllModels(user);
-      await user.click(within(panel).getByRole("option", { name: /Local: llama3\.1:8b/ }));
+      const currentModel = await findCurrentModelLabel("GLM 5.2");
+      await user.click(currentModel);
 
-      await waitFor(() => expect(mocks.setLocalGenerationEnabled).toHaveBeenCalledWith(true));
-      // The /model dispatch carries the RAW local id (advertised by the proxy),
-      // never the synthetic catalog id.
-      await waitFor(() =>
-        expect(mocks.gatewayRequest).toHaveBeenCalledWith("command.dispatch", {
-          session_id: "session-1",
-          command: "/model llama3.1:8b",
-        }),
-      );
-      expect(
-        await screen.findByText("Switched this session to Local: llama3.1:8b."),
-      ).toBeInTheDocument();
+      expect(screen.queryByRole("dialog", { name: "Choose text model" })).not.toBeInTheDocument();
+      expect(mocks.setLocalGenerationEnabled).not.toHaveBeenCalled();
+      expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("command.dispatch", expect.anything());
     });
 
-    it("flips the global provider AND dispatches /model when a remote model is picked on an open local session", async () => {
+    it("shows an open local session model as read-only status", async () => {
       mockLocalActive();
       mocks.setVeniceModel.mockResolvedValue(undefined);
       const user = userEvent.setup();
       render(<AgentWorkspace initialSession={existingSession} />);
 
-      await user.click(
-        await screen.findByRole("button", {
-          name: "Model: Local: llama3.1:8b",
-        }),
-      );
-      const panel = await openAllModels(user);
-      await user.click(within(panel).getByRole("option", { name: /Kimi K2\.6/ }));
+      const currentModel = await findCurrentModelLabel("Local: llama3.1:8b");
+      expect(currentModel).toHaveClass("agent-composer-model-label");
+      expect(
+        screen.queryByRole("button", { name: "Model: Local: llama3.1:8b" }),
+      ).not.toBeInTheDocument();
 
-      // Honest: the running session truly leaves the local endpoint (global
-      // provider flip) before the UI claims it did, AND /model is dispatched.
-      await waitFor(() =>
-        expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "kimi-k2-6"),
-      );
-      await waitFor(() =>
-        expect(mocks.gatewayRequest).toHaveBeenCalledWith("command.dispatch", {
-          session_id: "session-1",
-          command: "/model kimi-k2-6",
-        }),
-      );
-      expect(await screen.findByText("Switched this session to Kimi K2.6.")).toBeInTheDocument();
+      await user.click(currentModel);
+      expect(screen.queryByRole("dialog", { name: "Choose text model" })).not.toBeInTheDocument();
+      expect(mocks.setVeniceModel).not.toHaveBeenCalled();
+      expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("command.dispatch", expect.anything());
     });
 
     it("sends the raw local model id to Hermes when creating a session in local mode", async () => {

--- a/src/test/hermes-compatibility-matrix.test.ts
+++ b/src/test/hermes-compatibility-matrix.test.ts
@@ -178,9 +178,9 @@ describe("isHermesFeatureSupported — honest support gate", () => {
   });
 
   it("reports feature 10's command.dispatch as supported once shipped", () => {
-    // Feature 10 wired switchActiveSessionModel (/model via command.dispatch)
-    // into the composer model picker with tests, so its owned key flips to
-    // supported.
+    // Feature 10 shipped the typed switchActiveSessionModel seam
+    // (/model via command.dispatch). The composer now keeps existing
+    // sessions model-locked, but the protocol seam remains supported.
     expect(getFeatureStatus("command.dispatch")).toBe("supported");
     expect(isHermesFeatureSupported("command.dispatch")).toBe(true);
   });

--- a/src/test/hermes-model-switch.test.ts
+++ b/src/test/hermes-model-switch.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { createHermesMethods } from "../lib/hermes-control-plane";
 import {
+  MODEL_CHANGE_LOCKED_NOTICE,
   MODEL_SWITCH_DEFAULT_ONLY_NOTICE,
-  MODEL_SWITCH_FAILED_NOTICE,
-  modelSwitchSuccessNotice,
-  resolveModelSwitchOutcome,
 } from "../lib/hermes-model-switch";
 
 describe("switchActiveSessionModel — typed control-plane seam", () => {
@@ -40,51 +38,18 @@ describe("switchActiveSessionModel — typed control-plane seam", () => {
   });
 });
 
-describe("resolveModelSwitchOutcome — honest three-state decision", () => {
-  it("reports an active-session switch only when the dispatch was accepted", () => {
-    const outcome = resolveModelSwitchOutcome({
-      hasActiveSession: true,
-      dispatchSucceeded: true,
-      modelName: "Kimi K2.6",
-    });
-    expect(outcome.state).toBe("active-session-switched");
-    expect(outcome.notice).toBe(modelSwitchSuccessNotice("Kimi K2.6"));
-  });
-
-  it("reports default-only when there is no active session", () => {
-    const outcome = resolveModelSwitchOutcome({
-      hasActiveSession: false,
-      dispatchSucceeded: false,
-      modelName: "Kimi K2.6",
-    });
-    expect(outcome.state).toBe("default-changed");
-    expect(outcome.notice).toBe(MODEL_SWITCH_DEFAULT_ONLY_NOTICE);
-  });
-
-  it("never claims success when the active-session dispatch failed", () => {
-    const outcome = resolveModelSwitchOutcome({
-      hasActiveSession: true,
-      dispatchSucceeded: false,
-      modelName: "Kimi K2.6",
-    });
-    expect(outcome.state).toBe("switch-failed");
-    expect(outcome.notice).toBe(MODEL_SWITCH_FAILED_NOTICE);
-    // The per-chat override is saved regardless, so the honest copy says this
-    // chat will use the new model next time rather than the running session.
-    expect(outcome.notice).toContain("next time");
-    // It must NOT claim the global default moved — the open-chat path never
-    // touches the default.
-    expect(outcome.notice).not.toContain("default");
-  });
-
+describe("composer model notices", () => {
   it("copy carries no em or en dashes", () => {
-    const notices = [
-      modelSwitchSuccessNotice("Kimi K2.6"),
-      MODEL_SWITCH_DEFAULT_ONLY_NOTICE,
-      MODEL_SWITCH_FAILED_NOTICE,
-    ];
+    const notices = [MODEL_SWITCH_DEFAULT_ONLY_NOTICE, MODEL_CHANGE_LOCKED_NOTICE];
     for (const notice of notices) {
       expect(notice).not.toMatch(/[–—]/);
     }
+  });
+
+  it("distinguishes new-session defaults from locked existing threads", () => {
+    expect(MODEL_SWITCH_DEFAULT_ONLY_NOTICE).toBe(
+      "Default model updated. It applies to new sessions.",
+    );
+    expect(MODEL_CHANGE_LOCKED_NOTICE).toBe("Start a new session to change models.");
   });
 });


### PR DESCRIPTION
## Summary

- Lock the composer model control once a Hermes session exists, rendering the current model as passive status instead of an interactive picker.
- Keep model changes scoped to new sessions/default selection, including `/model`, image-model warnings, oversize warnings, and local generation choices.
- Add a quieter tokenized detail-bar divider for breadcrumb chrome.

## Root cause

Not a bug fix. This reflects the product decision that an existing thread's model should be fixed after session creation.

## Validation

- `pnpm typecheck`
- `pnpm vitest run src/test/agent-workspace.test.tsx src/test/hermes-model-switch.test.ts src/test/hermes-compatibility-matrix.test.ts`
- `pnpm exec biome check src/components/agent/AgentWorkspace.tsx src/components/agent/composer/ModelPicker.tsx src/styles/app.css src/styles/tokens.css src/styleguide/sections/Color.tsx src/lib/hermes-model-switch.ts src/lib/hermes-control-plane/compatibility/matrix.ts src/test/agent-workspace.test.tsx src/test/hermes-model-switch.test.ts src/test/hermes-compatibility-matrix.test.ts`
- `git diff --check`
- Visual checked with a Playwright fixture in light and dark mode.

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy needed.

## Out of scope

- Does not remove the typed Hermes `switchActiveSessionModel` seam; it remains supported outside the composer.
- Does not change model selection behavior in Settings.

## Followups

- None planned.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [ ] Security-sensitive changes were called out in the summary. Not security-sensitive.
- [ ] Workflow action references are pinned to full-length commit SHAs. No workflow changes.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786121569&installation_id=144203540&pr_number=663&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F663&signature=d7a4d2d1e4b41d424aa1728df3504ed3e4e9f68cff68c3ca14853647d45ed5ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<img width="1456" height="244" alt="CleanShot 2026-07-08 at 10 51 52@2x" src="https://github.com/user-attachments/assets/fcecb631-e335-4ec3-9312-74aef755c365" />
<img width="1698" height="370" alt="CleanShot 2026-07-08 at 10 53 37@2x" src="https://github.com/user-attachments/assets/30dc28cd-a083-44f9-8c03-61517f22126d" />
