### PR TITLE
Command prompt cleanup + shared scroll-fade primitive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ distinct from the `specs/` Spec Kit feature specs.)
 - [font-weights](spec/font-weights.md) — only 400 and `var(--fw-medium)`, never raw 500/600/700
 - [font-families](spec/font-families.md) — sans is the voice; serif for headings/display, mono for code
 - [control-sizes](spec/control-sizes.md) — control heights from `--control-*`, no raw min/max-heights
+- [scroll-fade](spec/scroll-fade.md) — clipped scrollers use the shared `useScrollFade` + `.scroll-fade` / `.scroll-fade-mask` primitive
 
 ## PR and description conventions
 

--- a/docs/design/conventions.md
+++ b/docs/design/conventions.md
@@ -37,11 +37,28 @@ modules or scoping. That has consequences:
   near-black, so `data-theme="dark"` re-tunes them.
 - **One ambient shadow per popover composite.** Stacking shadows on nested
   popover layers muddies the edge.
-- **No `mask-image` on scrollers.** It triggers WKWebView compositing bugs; use a
-  contained overlay fade instead.
+- **Scroll edge fades use the shared primitive.** A clipped scroller melts its
+  hidden edge via `useScrollFade` + `.scroll-fade` (contained gradient overlays,
+  WKWebView-safe for popovers) or `.scroll-fade-mask` (`mask-image`, for large
+  in-window panel scrollers only). Never hand-roll the measurement or the CSS.
+  See [spec/scroll-fade](../../spec/scroll-fade.md). Note: a `mask-image` fade on
+  a composited popover scroller triggers WKWebView compositing bugs — reach for
+  the `.scroll-fade` overlay flavor there.
 - **Icons are explicitly sized.** Use `central-icons` / `central-icons-filled`
   only (see [spec/icons-central-only](../../spec/icons-central-only.md)), always
   with the `size` prop.
+- **Radius follows the element's tier, not its pixel size.** The `--r-*` scale
+  maps to element classes, so pick by what the element _is_:
+  - `--r-xs` (4px) — keycaps, badges, chips, pills' inner rows, and other small
+    inline decorations.
+  - `--r-sm` (6px) — **square icon buttons** (`.icon-button`,
+    `.agent-icon-button`) and small interactive controls. A clickable icon
+    square is `--r-sm`, even at 22px; don't drop it to `--r-xs` just because it
+    is small — that reads as a badge, not a button.
+  - `--r-md` (8px) and up — cards, inputs, popovers, dialogs, and larger
+    surfaces.
+  A new button should copy the radius token of the nearest existing button of
+  its kind rather than eyeballing a value.
 
 ## Theming implementation
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -19,6 +19,7 @@ authoritative, reviewable version.
 - [icons-central-only](icons-central-only.md) — icons from `central-icons` / `central-icons-filled` only
 - [design-tokens](design-tokens.md) — use the variables in `src/styles/tokens.css`
 - [no-tabular-numerals](no-tabular-numerals.md) — UI numbers use proportional figures, never `tabular-nums`
+- [scroll-fade](scroll-fade.md) — clipped scrollers use the shared `useScrollFade` + `.scroll-fade` / `.scroll-fade-mask` primitive
 
 ## Frontend — typography
 

--- a/spec/scroll-fade.md
+++ b/spec/scroll-fade.md
@@ -1,0 +1,38 @@
+# Scroll fades
+
+**Rule.** A scrollable region that clips its content uses the shared scroll-fade
+primitive — the `useScrollFade` hook (`src/lib/use-scroll-fade.ts`) plus the
+`.scroll-fade` or `.scroll-fade-mask` CSS utility. Never hand-roll a new fade
+(local `useState({ top, bottom })` + an `updateFade` callback, or bespoke
+`::before`/`::after` overlays or `mask-image` rules keyed off `data-fade-*`).
+
+**Why.** Eight components had each re-derived the same measurement logic
+(`scrollHeight - clientHeight > 1`, `scrollTop <= 1`, ...) and two near-identical
+CSS recipes. One primitive keeps the measurement, the WKWebView-safe overlay
+technique, and the fade sizing consistent, and means a fix lands once instead of
+in nine places.
+
+**How to apply.** Point `useScrollFade(ref)` at the scroll viewport's ref. Spread
+the returned `props` (`data-fade-top` / `data-fade-bottom`) onto the element the
+fade paints on, and add the matching class:
+
+- `.scroll-fade` — contained gradient overlays for popovers/menus. Put the class
+  and `props` on a non-scrolling wrapper; the scroller is its child. Tune with
+  `--scroll-fade-size`, `--scroll-fade-color`, `--scroll-fade-inset-right`.
+- `.scroll-fade-mask` — `mask-image` fade for large panel scrollers. Put the
+  class and `props` on the scroller itself. Tune with `--scroll-fade-size`.
+
+Wire `onScroll={fade.update}` on the scroller, and call `fade.update()` from any
+effect that changes the content or size without a scroll (filtering a list,
+opening a panel). The hook owns the `ResizeObserver` and initial measure.
+
+**Exceptions.**
+
+- `ComposerEditor` writes `data-fade-*` directly inside its ProseMirror update
+  and deliberately drops the fades during a range selection — it drives
+  `.scroll-fade` without the hook. Keep that logic; don't force it onto
+  `useScrollFade`.
+- The sidebar notes-nav fade renders *outside* the scroller (so the scrollbar
+  stays untouched), a different structural need than the shared overlay.
+- Scroll-timeline-driven card-edge fades (CSS `animation-timeline: scroll(...)`)
+  are a pure-CSS effect with no measurement, unrelated to this primitive.

--- a/spec/scroll-fade.md
+++ b/spec/scroll-fade.md
@@ -22,9 +22,11 @@ fade paints on, and add the matching class:
 - `.scroll-fade-mask` — `mask-image` fade for large panel scrollers. Put the
   class and `props` on the scroller itself. Tune with `--scroll-fade-size`.
 
-Wire `onScroll={fade.update}` on the scroller, and call `fade.update()` from any
-effect that changes the content or size without a scroll (filtering a list,
-opening a panel). The hook owns the `ResizeObserver` and initial measure.
+The hook owns the scroll and resize listeners (and the initial measure), so you
+do not wire an `onScroll` handler — just spread `{...fade.props}` on the fade
+element and pass the `ref` to the scroller. Call `fade.update()` only from an
+effect that changes the content or size without a scroll or resize (filtering a
+list, opening a panel).
 
 **Exceptions.**
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -991,7 +991,7 @@ export function App() {
 
   // Modifier state for the click that's about to fire a navigation. A
   // capture-phase listener records it before React's bubble-phase handlers run,
-  // so any nav surface (sidebar, notes list, command palette) can open in a new
+  // so any nav surface (sidebar, notes list, command prompt) can open in a new
   // tab via ⌘/Ctrl-click or middle-click without threading flags through props.
   const newTabIntentRef = useRef(false);
   useEffect(() => {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -196,6 +196,7 @@ import {
   type BranchSessionResult,
 } from "../../lib/hermes-session-branch";
 import { normalizeSteerText, steeringLiveEvent } from "../../lib/hermes-session-steer";
+import { useScrollFade } from "../../lib/use-scroll-fade";
 import { unsupportedEventStore } from "../../lib/hermes-unsupported-events";
 import { pendingActionStore } from "../../lib/hermes-pending-actions";
 import { hermesActivityStore, type AgentActivityRecord } from "../../lib/hermes-activity-store";
@@ -11694,28 +11695,13 @@ function AgentArtifactPanel({
   // dictation history dialog): the header has no divider, so the top fade is
   // what tells you content has scrolled up behind it.
   const bodyRef = useRef<HTMLDivElement>(null);
-  const [fade, setFade] = useState({ top: false, bottom: false });
-  const updateFade = useCallback(() => {
-    const el = bodyRef.current;
-    if (!el) return;
-    const canScroll = el.scrollHeight - el.clientHeight > 1;
-    const atTop = el.scrollTop <= 1;
-    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
-    setFade({ top: canScroll && !atTop, bottom: canScroll && !atBottom });
-  }, []);
+  const fade = useScrollFade(bodyRef);
+  // Re-measure when the panel swaps between the artifact preview and the list,
+  // or when the preview content changes (the hook re-wires its observers on the
+  // element swap; this catches same-element content changes).
   useEffect(() => {
-    const id = requestAnimationFrame(updateFade);
-    const el = bodyRef.current;
-    if (el && typeof ResizeObserver !== "undefined") {
-      const observer = new ResizeObserver(updateFade);
-      observer.observe(el);
-      return () => {
-        cancelAnimationFrame(id);
-        observer.disconnect();
-      };
-    }
-    return () => cancelAnimationFrame(id);
-  }, [updateFade, preview, state.view]);
+    fade.update();
+  }, [fade.update, preview, state.view]);
 
   const q = query.trim().toLowerCase();
   const visibleArtifacts = q
@@ -11844,11 +11830,10 @@ function AgentArtifactPanel({
         {artifact ? (
           <div
             ref={bodyRef}
-            className="agent-artifact-panel-body"
+            className="agent-artifact-panel-body scroll-fade-mask"
             data-kind={preview.kind}
-            data-fade-top={fade.top || undefined}
-            data-fade-bottom={fade.bottom || undefined}
-            onScroll={updateFade}
+            {...fade.props}
+            onScroll={fade.update}
           >
             {preview.kind === "loading" ? (
               <Spinner />
@@ -11882,11 +11867,10 @@ function AgentArtifactPanel({
           <>
             <div
               ref={bodyRef}
-              className="agent-artifact-panel-body"
+              className="agent-artifact-panel-body scroll-fade-mask"
               data-kind="list"
-              data-fade-top={fade.top || undefined}
-              data-fade-bottom={fade.bottom || undefined}
-              onScroll={updateFade}
+              {...fade.props}
+              onScroll={fade.update}
             >
               {visibleArtifacts.length ? (
                 <ul className="agent-artifact-panel-list">

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -11833,7 +11833,6 @@ function AgentArtifactPanel({
             className="agent-artifact-panel-body scroll-fade-mask"
             data-kind={preview.kind}
             {...fade.props}
-            onScroll={fade.update}
           >
             {preview.kind === "loading" ? (
               <Spinner />
@@ -11870,7 +11869,6 @@ function AgentArtifactPanel({
               className="agent-artifact-panel-body scroll-fade-mask"
               data-kind="list"
               {...fade.props}
-              onScroll={fade.update}
             >
               {visibleArtifacts.length ? (
                 <ul className="agent-artifact-panel-list">

--- a/src/components/agent/composer/CategorySuggestionList.tsx
+++ b/src/components/agent/composer/CategorySuggestionList.tsx
@@ -13,6 +13,7 @@ import { IconFileText } from "central-icons/IconFileText";
 
 import type { HermesSkillInfo } from "../../../lib/tauri";
 import type { BuiltinComposerSlashCommandDef } from "../../../lib/agent-composer-slash-commands";
+import { useScrollFade } from "../../../lib/use-scroll-fade";
 
 const SKILL_DETAIL_HOVER_INTENT_MS = 150;
 
@@ -44,8 +45,8 @@ export const CategorySuggestionList = forwardRef<
     top: number;
     side: "left" | "right";
   } | null>(null);
-  const [fade, setFade] = useState({ top: false, bottom: false });
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const fade = useScrollFade(menuRef);
   const rowRefs = useRef(new Map<number, HTMLButtonElement>());
   const hoverTimerRef = useRef<number | null>(null);
   const cancelHoverIntent = useCallback(() => {
@@ -61,19 +62,6 @@ export const CategorySuggestionList = forwardRef<
     },
     [cancelHoverIntent],
   );
-  const updateFade = useCallback(() => {
-    const el = menuRef.current;
-    if (!el) return;
-    const canScroll = el.scrollHeight - el.clientHeight > 1;
-    const atTop = el.scrollTop <= 1;
-    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
-    setFade((prev) => {
-      const top = canScroll && !atTop;
-      const bottom = canScroll && !atBottom;
-      return prev.top === top && prev.bottom === bottom ? prev : { top, bottom };
-    });
-  }, []);
-
   // Snap the highlight back to the top whenever the filtered set changes so a
   // press of Enter never targets a row that just scrolled out of the results.
   useEffect(() => {
@@ -85,19 +73,10 @@ export const CategorySuggestionList = forwardRef<
 
   useEffect(() => cancelHoverIntent, [cancelHoverIntent]);
 
+  // Re-measure the fades when filtering changes the list's content.
   useLayoutEffect(() => {
-    updateFade();
-    const frame = window.requestAnimationFrame(updateFade);
-    return () => window.cancelAnimationFrame(frame);
-  }, [items, updateFade]);
-
-  useEffect(() => {
-    const el = menuRef.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(updateFade);
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [updateFade]);
+    fade.update();
+  }, [items, fade.update]);
 
   const choose = useCallback(
     (index: number) => {
@@ -201,18 +180,14 @@ export const CategorySuggestionList = forwardRef<
         setDetail(null);
       }}
     >
-      <div
-        className="agent-category-menu-scroll-wrap"
-        data-fade-top={fade.top || undefined}
-        data-fade-bottom={fade.bottom || undefined}
-      >
+      <div className="agent-category-menu-scroll-wrap scroll-fade" {...fade.props}>
         <div
           ref={menuRef}
           className="agent-category-menu"
           role="listbox"
           aria-label="Slash commands"
           onScroll={() => {
-            updateFade();
+            fade.update();
             setDetail(null);
           }}
         >

--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -336,7 +336,7 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
     );
 
     return (
-      <div ref={frameRef} className="agent-composer-editor-root">
+      <div ref={frameRef} className="agent-composer-editor-root scroll-fade">
         <EditorContent editor={editor} />
       </div>
     );

--- a/src/components/agent/composer/ModelPicker.tsx
+++ b/src/components/agent/composer/ModelPicker.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../../lib/model-privacy";
 import { suggestedModelsForMode } from "../../../lib/suggested-models";
 import type { VeniceModelDto } from "../../../lib/tauri";
+import { useScrollFade } from "../../../lib/use-scroll-fade";
 import { HoverTip } from "../../ui/HoverTip";
 import { ModelPrivacyChip } from "../../ui/ModelPrivacyChip";
 import { contextLabel, pricingLabel } from "../../settings/ModelPickerDialog";
@@ -133,19 +134,7 @@ export function ComposerModelPopover({
   // Position-aware scroll fades on the catalog list, same treatment as the
   // artifact panel body: only when it overflows, only on edges with hidden
   // content.
-  const [fade, setFade] = useState({ top: false, bottom: false });
-  const updateFade = useCallback(() => {
-    const el = listRef.current;
-    if (!el) return;
-    const canScroll = el.scrollHeight - el.clientHeight > 1;
-    const atTop = el.scrollTop <= 1;
-    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
-    setFade((prev) => {
-      const top = canScroll && !atTop;
-      const bottom = canScroll && !atBottom;
-      return prev.top === top && prev.bottom === bottom ? prev : { top, bottom };
-    });
-  }, []);
+  const fade = useScrollFade(listRef);
 
   // The flyout always opens on the composer side (left of the menu), where
   // there is reliably room — flipping with the window edge made the card
@@ -184,8 +173,8 @@ export function ComposerModelPopover({
   // Re-measure the fades whenever the list's content or cap changes: panel
   // open (after the max-height effect above), and every search keystroke.
   useLayoutEffect(() => {
-    updateFade();
-  }, [flyout, search, options, updateFade]);
+    fade.update();
+  }, [flyout, search, options, fade.update]);
 
   // Row positions shift under the pointer on filter/reflow, so a lingering
   // card would point at the wrong row.
@@ -341,18 +330,14 @@ export function ComposerModelPopover({
                 aria-label="Search models"
               />
             </label>
-            <div
-              className="agent-composer-model-list-wrap"
-              data-fade-top={fade.top || undefined}
-              data-fade-bottom={fade.bottom || undefined}
-            >
+            <div className="agent-composer-model-list-wrap scroll-fade" {...fade.props}>
               <div
                 ref={listRef}
                 className="agent-composer-model-list"
                 role="listbox"
                 aria-label="All text models"
                 onScroll={() => {
-                  updateFade();
+                  fade.update();
                   cancelHoverIntent();
                   setCatalogHover(null);
                 }}

--- a/src/components/agent/composer/NoteSuggestionList.tsx
+++ b/src/components/agent/composer/NoteSuggestionList.tsx
@@ -1,7 +1,6 @@
 import {
   forwardRef,
   useCallback,
-  useEffect,
   useImperativeHandle,
   useLayoutEffect,
   useRef,
@@ -10,6 +9,7 @@ import {
 import { IconNoteText } from "central-icons/IconNoteText";
 
 import type { NoteListItemDto } from "../../../lib/tauri";
+import { useScrollFade } from "../../../lib/use-scroll-fade";
 
 export type NoteSuggestionListProps = {
   items: NoteListItemDto[];
@@ -47,23 +47,10 @@ export const NoteSuggestionList = forwardRef<NoteSuggestionListHandle, NoteSugge
   ({ items, command }, ref) => {
     const [selected, setSelected] = useState(0);
     const [activeSource, setActiveSource] = useState<"keyboard" | "pointer" | null>(null);
-    const [fade, setFade] = useState({ top: false, bottom: false });
     const menuRef = useRef<HTMLDivElement | null>(null);
+    const fade = useScrollFade(menuRef);
     const itemIds = items.map((item) => item.id).join("\u0000");
     const lastItemIdsRef = useRef(itemIds);
-
-    const updateFade = useCallback(() => {
-      const el = menuRef.current;
-      if (!el) return;
-      const canScroll = el.scrollHeight - el.clientHeight > 1;
-      const atTop = el.scrollTop <= 1;
-      const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
-      setFade((prev) => {
-        const top = canScroll && !atTop;
-        const bottom = canScroll && !atBottom;
-        return prev.top === top && prev.bottom === bottom ? prev : { top, bottom };
-      });
-    }, []);
 
     useLayoutEffect(() => {
       // Reset the highlight whenever filtering changes the result set so Enter
@@ -73,18 +60,8 @@ export const NoteSuggestionList = forwardRef<NoteSuggestionListHandle, NoteSugge
         setSelected(0);
         setActiveSource(null);
       }
-      updateFade();
-      const frame = window.requestAnimationFrame(updateFade);
-      return () => window.cancelAnimationFrame(frame);
-    }, [itemIds, updateFade]);
-
-    useEffect(() => {
-      const el = menuRef.current;
-      if (!el || typeof ResizeObserver === "undefined") return;
-      const observer = new ResizeObserver(updateFade);
-      observer.observe(el);
-      return () => observer.disconnect();
-    }, [updateFade]);
+      fade.update();
+    }, [itemIds, fade.update]);
 
     const choose = useCallback(
       (index: number) => {
@@ -129,18 +106,14 @@ export const NoteSuggestionList = forwardRef<NoteSuggestionListHandle, NoteSugge
 
     return (
       <div className="agent-category-menu-shell agent-note-suggestion-menu-shell">
-        <div
-          className="agent-category-menu-scroll-wrap"
-          data-fade-top={fade.top || undefined}
-          data-fade-bottom={fade.bottom || undefined}
-        >
+        <div className="agent-category-menu-scroll-wrap scroll-fade" {...fade.props}>
           <div
             ref={menuRef}
             className="agent-category-menu agent-note-suggestion-menu"
             role="listbox"
             aria-label="Reference a note"
             onScroll={() => {
-              updateFade();
+              fade.update();
             }}
           >
             {items.map((item, index) => {

--- a/src/components/dictation/DictationHistoryView.tsx
+++ b/src/components/dictation/DictationHistoryView.tsx
@@ -410,12 +410,7 @@ function DictationHistoryRow({
           </button>
         }
       >
-        <div
-          className="transcript-dialog-scroll scroll-fade-mask"
-          ref={scrollRef}
-          onScroll={fade.update}
-          {...fade.props}
-        >
+        <div className="transcript-dialog-scroll scroll-fade-mask" ref={scrollRef} {...fade.props}>
           <p>{item.text}</p>
         </div>
       </Dialog>

--- a/src/components/dictation/DictationHistoryView.tsx
+++ b/src/components/dictation/DictationHistoryView.tsx
@@ -34,6 +34,7 @@ import {
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
 import { isMacLikePlatform } from "../../lib/platform";
+import { useScrollFade } from "../../lib/use-scroll-fade";
 
 const NO_DICTATIONS: DictationHistoryItemDto[] = [];
 
@@ -316,7 +317,7 @@ function DictationHistoryRow({
   const [open, setOpen] = useState(false);
   // Position-aware scroll fades: only when the body actually overflows, and
   // only on the edge(s) with hidden content.
-  const [fade, setFade] = useState({ top: false, bottom: false });
+  const fade = useScrollFade(scrollRef);
 
   useEffect(() => {
     const el = textRef.current;
@@ -332,20 +333,11 @@ function DictationHistoryRow({
     return () => observer.disconnect();
   }, [item.text]);
 
-  const updateFade = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const canScroll = el.scrollHeight - el.clientHeight > 1;
-    const atTop = el.scrollTop <= 1;
-    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
-    setFade({ top: canScroll && !atTop, bottom: canScroll && !atBottom });
-  }, []);
-
   useEffect(() => {
     if (!open) return;
-    const id = requestAnimationFrame(updateFade);
+    const id = requestAnimationFrame(fade.update);
     return () => cancelAnimationFrame(id);
-  }, [open, updateFade]);
+  }, [open, fade.update]);
 
   const expandProps = truncated
     ? {
@@ -419,11 +411,10 @@ function DictationHistoryRow({
         }
       >
         <div
-          className="transcript-dialog-scroll"
+          className="transcript-dialog-scroll scroll-fade-mask"
           ref={scrollRef}
-          onScroll={updateFade}
-          data-fade-top={fade.top || undefined}
-          data-fade-bottom={fade.bottom || undefined}
+          onScroll={fade.update}
+          {...fade.props}
         >
           <p>{item.text}</p>
         </div>

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -402,7 +402,7 @@ export function NoteChatPanel({
             <IconCrossMedium size={15} />
           </button>
         </header>
-        <div ref={scrollerRef} className="note-chat-scroll" {...fade.props} onScroll={fade.update}>
+        <div ref={scrollerRef} className="note-chat-scroll scroll-fade-mask" {...fade.props}>
           {turns.length === 0 && !loading ? (
             <div className="note-chat-empty">
               <p className="note-chat-empty-lead">

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -16,6 +16,7 @@ import type { PointerEvent as ReactPointerEvent, ReactNode } from "react";
 import type { AgentChatPart, AgentChatTurn } from "../../lib/agent-chat-runtime";
 import { messageFromError } from "../../lib/errors";
 import { attachmentStateFrom } from "../../lib/hermes-image-attach";
+import { useScrollFade } from "../../lib/use-scroll-fade";
 import {
   dictationHelperCommand,
   importHermesBridgeFile,
@@ -314,28 +315,7 @@ export function NoteChatPanel({
   // Edge fades on the thread (same trick as the files panel): the bar has no
   // divider, so the top fade is what signals content scrolled up behind it.
   const scrollerRef = useRef<HTMLDivElement>(null);
-  const [fade, setFade] = useState({ top: false, bottom: false });
-  const updateFade = useCallback(() => {
-    const el = scrollerRef.current;
-    if (!el) return;
-    const canScroll = el.scrollHeight - el.clientHeight > 1;
-    const atTop = el.scrollTop <= 1;
-    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
-    setFade({ top: canScroll && !atTop, bottom: canScroll && !atBottom });
-  }, []);
-  useEffect(() => {
-    const id = requestAnimationFrame(updateFade);
-    const el = scrollerRef.current;
-    if (el && typeof ResizeObserver !== "undefined") {
-      const observer = new ResizeObserver(updateFade);
-      observer.observe(el);
-      return () => {
-        cancelAnimationFrame(id);
-        observer.disconnect();
-      };
-    }
-    return () => cancelAnimationFrame(id);
-  }, [updateFade]);
+  const fade = useScrollFade(scrollerRef);
 
   // Keep the newest turn in view as the conversation grows or streams.
   const lastTurn = turns.at(-1);
@@ -346,8 +326,8 @@ export function NoteChatPanel({
   useEffect(() => {
     const scroller = scrollerRef.current;
     if (scroller) scroller.scrollTop = scroller.scrollHeight;
-    updateFade();
-  }, [turns.length, lastTurnSize, working, updateFade]);
+    fade.update();
+  }, [turns.length, lastTurnSize, working, fade.update]);
 
   async function handleSend(text: string) {
     if (working || importing) return;
@@ -422,13 +402,7 @@ export function NoteChatPanel({
             <IconCrossMedium size={15} />
           </button>
         </header>
-        <div
-          ref={scrollerRef}
-          className="note-chat-scroll"
-          data-fade-top={fade.top || undefined}
-          data-fade-bottom={fade.bottom || undefined}
-          onScroll={updateFade}
-        >
+        <div ref={scrollerRef} className="note-chat-scroll" {...fade.props} onScroll={fade.update}>
           {turns.length === 0 && !loading ? (
             <div className="note-chat-empty">
               <p className="note-chat-empty-lead">

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import type { RefObject } from "react";
 import { modelAvailableForMode, modelPrivacyBadge } from "../../lib/model-privacy";
 import { suggestedModelsForMode } from "../../lib/suggested-models";
+import { useScrollFade } from "../../lib/use-scroll-fade";
 import type { ProviderModelMode, VeniceModelDto } from "../../lib/tauri";
 import { HoverTip } from "../ui/HoverTip";
 import { ModelPrivacyChip } from "../ui/ModelPrivacyChip";
@@ -91,19 +92,7 @@ export function ModelPickerPopover({
   }, [cancelCatalogClose]);
   useEffect(() => cancelCatalogClose, [cancelCatalogClose]);
 
-  const [fade, setFade] = useState({ top: false, bottom: false });
-  const updateFade = useCallback(() => {
-    const el = listRef.current;
-    if (!el) return;
-    const canScroll = el.scrollHeight - el.clientHeight > 1;
-    const atTop = el.scrollTop <= 1;
-    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
-    setFade((prev) => {
-      const top = canScroll && !atTop;
-      const bottom = canScroll && !atBottom;
-      return prev.top === top && prev.bottom === bottom ? prev : { top, bottom };
-    });
-  }, []);
+  const fade = useScrollFade(listRef);
 
   useLayoutEffect(() => {
     const el = flyoutRef.current;
@@ -129,8 +118,8 @@ export function ModelPickerPopover({
   }, [flyout]);
 
   useLayoutEffect(() => {
-    updateFade();
-  }, [flyout, options, search, updateFade]);
+    fade.update();
+  }, [flyout, options, search, fade.update]);
 
   useEffect(() => {
     setCatalogHover(null);
@@ -222,18 +211,14 @@ export function ModelPickerPopover({
             aria-label="Search models"
           />
         </label>
-        <div
-          className="agent-composer-model-list-wrap"
-          data-fade-top={fade.top || undefined}
-          data-fade-bottom={fade.bottom || undefined}
-        >
+        <div className="agent-composer-model-list-wrap scroll-fade" {...fade.props}>
           <div
             ref={listRef}
             className="agent-composer-model-list"
             role="listbox"
             aria-label={label}
             onScroll={() => {
-              updateFade();
+              fade.update();
               cancelHoverIntent();
               setCatalogHover(null);
             }}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1738,6 +1738,7 @@ function CommandPrompt({
                           data-active={index === activeIndex}
                           key={item.id}
                           onMouseEnter={() => onActiveIndexChange(index)}
+                          onFocus={() => onActiveIndexChange(index)}
                           onClick={() => onSelect(item)}
                         >
                           <span className="command-prompt-item-icon">{item.icon}</span>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
 import { IconClipboard } from "central-icons/IconClipboard";
+import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconArrowBoxRight } from "central-icons/IconArrowBoxRight";
 import { IconZap } from "central-icons/IconZap";
 import { IconBubble3 } from "central-icons/IconBubble3";
@@ -59,7 +60,7 @@ import {
 } from "../agent/AgentWorkspace";
 import { CategoryIcon } from "../agent/composer/CategoryIcon";
 import { JuneWordmark } from "../brand/JuneWordmark";
-import type { ReportCategory } from "../agent/composer/reportCategory";
+import { type ReportCategory, reportCategoryDef } from "../agent/composer/reportCategory";
 import {
   AGENT_DELETE_SESSION_EVENT,
   AGENT_NEW_SESSION_EVENT,
@@ -74,6 +75,7 @@ import {
 import { errorCode, messageFromError } from "../../lib/errors";
 import { NOTE_DND_MIME } from "../../lib/dnd";
 import { useDismiss } from "../../lib/use-dismiss";
+import { useScrollFade } from "../../lib/use-scroll-fade";
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
 import { useRecordingPresenceBounds } from "../../lib/recording-presence-bounds";
 import { isPrimaryShortcut, primaryShortcutLabel } from "../../lib/platform";
@@ -139,7 +141,7 @@ type MenuState =
   | { kind: "note"; noteId: string; right: number; top: number }
   | { kind: "agent-session"; sessionId: string; right: number; top: number };
 
-type CommandPaletteItem = {
+type CommandPromptItem = {
   id: string;
   label: string;
   meta?: string;
@@ -148,9 +150,9 @@ type CommandPaletteItem = {
   action: () => void;
 };
 
-type CommandPaletteGroup = {
+type CommandPromptGroup = {
   title: string;
-  items: CommandPaletteItem[];
+  items: CommandPromptItem[];
 };
 
 const AGENT_SIDEBAR_SESSION_FETCH_LIMIT = 100;
@@ -364,7 +366,7 @@ export function Sidebar({
 }: SidebarProps) {
   const [query, setQuery] = useState("");
   const commandInputRef = useRef<HTMLInputElement>(null);
-  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [commandPromptOpen, setCommandPromptOpen] = useState(false);
   const [commandQuery, setCommandQuery] = useState("");
   const [commandActiveIndex, setCommandActiveIndex] = useState(0);
   const [menu, setMenu] = useState<MenuState | null>(null);
@@ -519,12 +521,12 @@ export function Sidebar({
     return () => window.clearTimeout(timer);
   }, [referralCopied]);
 
-  const commandPaletteGroups = useMemo<CommandPaletteGroup[]>(() => {
+  const commandPromptGroups = useMemo<CommandPromptGroup[]>(() => {
     const normalized = normalizeCommandQuery(commandQuery);
-    const matches = (item: CommandPaletteItem) =>
+    const matches = (item: CommandPromptItem) =>
       !normalized || item.searchText.includes(normalized);
 
-    const recentItems: CommandPaletteItem[] = [
+    const recentItems: CommandPromptItem[] = [
       ...notes.slice(0, 5).map((note) => {
         const title = note.title.trim() || "New note";
         return {
@@ -554,7 +556,7 @@ export function Sidebar({
       .filter(matches)
       .slice(0, 6);
 
-    const quickItems: CommandPaletteItem[] = [
+    const quickItems: CommandPromptItem[] = [
       {
         id: "quick:new-session",
         label: "New session",
@@ -562,6 +564,19 @@ export function Sidebar({
         searchText: normalizeCommandQuery("new session agent"),
         action: handleNewAgentSession,
       },
+      // "Open recording" only makes sense while a recording is live, mirroring
+      // the sidebar recording indicator that renders under the same condition.
+      ...(onOpenRecording && recordingStatus
+        ? [
+            {
+              id: "quick:open-recording",
+              label: "Open recording",
+              icon: <IconAudio size={15} />,
+              searchText: normalizeCommandQuery("open recording meeting audio"),
+              action: onOpenRecording,
+            } satisfies CommandPromptItem,
+          ]
+        : []),
       {
         id: "quick:meetings",
         label: "Go to Meeting notes",
@@ -605,7 +620,7 @@ export function Sidebar({
             (tab) =>
               !HIDDEN_SETTINGS_TABS.has(tab.id) && !(account.localDev && tab.id === "billing"),
           ).map(
-            (tab): CommandPaletteItem => ({
+            (tab): CommandPromptItem => ({
               id: `quick:settings-${tab.id}`,
               label: `Settings -> ${tab.label}`,
               icon: <IconSettingsGear4 size={15} />,
@@ -623,31 +638,77 @@ export function Sidebar({
         : []),
     ].filter(matches);
 
+    // Support: the report entry points (reusing the identity menu's items and
+    // CategoryIcon), invite friends, and sign out — each guarded exactly like
+    // the identity menu so the prompt never offers an action the menu hides.
+    const supportItems: CommandPromptItem[] = [
+      ...(onReportIssue
+        ? REPORT_MENU_ITEMS.map((item): CommandPromptItem => {
+            const def = reportCategoryDef(item.category);
+            return {
+              id: `support:report-${item.category}`,
+              label: item.label,
+              icon: <CategoryIcon category={item.category} size={15} />,
+              searchText: normalizeCommandQuery(`${item.label} ${def?.keywords.join(" ") ?? ""}`),
+              action: () => onReportIssue(item.category),
+            };
+          })
+        : []),
+      ...(account.signedIn && !account.localDev
+        ? [
+            {
+              id: "support:invite-friends",
+              label: "Invite friends",
+              icon: <IconGift1 size={15} />,
+              searchText: normalizeCommandQuery("invite friends referral share"),
+              action: () => openReferralDialog(),
+            } satisfies CommandPromptItem,
+          ]
+        : []),
+      ...(account.signedIn && !account.localDev && onSignOut
+        ? [
+            {
+              id: "support:sign-out",
+              label: "Sign out",
+              icon: <IconArrowBoxRight size={15} />,
+              searchText: normalizeCommandQuery("sign out log out logout"),
+              action: onSignOut,
+            } satisfies CommandPromptItem,
+          ]
+        : []),
+    ].filter(matches);
+
     return [
       { title: "Recents", items: recentItems },
       { title: "Quick actions", items: quickItems },
+      { title: "Support", items: supportItems },
     ].filter((group) => group.items.length > 0);
   }, [
     account.localDev,
+    account.signedIn,
     agentSessions,
     commandQuery,
     notes,
     onChangeView,
+    onOpenRecording,
+    onReportIssue,
     onSelectAgentSession,
     onSelectNote,
     onSettingsTabChange,
+    onSignOut,
+    recordingStatus,
   ]);
 
-  const commandPaletteItems = commandPaletteGroups.flatMap((group) => group.items);
+  const commandPromptItems = commandPromptGroups.flatMap((group) => group.items);
 
   useEffect(() => {
     setCommandActiveIndex(0);
-  }, [commandPaletteOpen, commandQuery]);
+  }, [commandPromptOpen, commandQuery]);
 
   useEffect(() => {
-    if (commandActiveIndex < commandPaletteItems.length) return;
-    setCommandActiveIndex(Math.max(commandPaletteItems.length - 1, 0));
-  }, [commandActiveIndex, commandPaletteItems.length]);
+    if (commandActiveIndex < commandPromptItems.length) return;
+    setCommandActiveIndex(Math.max(commandPromptItems.length - 1, 0));
+  }, [commandActiveIndex, commandPromptItems.length]);
 
   useEffect(() => {
     if (!import.meta.env.DEV) return;
@@ -692,7 +753,7 @@ export function Sidebar({
       setQuery("");
       setMenu(null);
       setIdentityMenuOpen(false);
-      setCommandPaletteOpen(false);
+      setCommandPromptOpen(false);
       setAgentSessions(buildSidebarDevStateSessions());
       setSelectedAgentSessionId(SIDEBAR_DEV_SESSION_IDS.selected);
       setWorkingAgentSessionIds(new Set([SIDEBAR_DEV_SESSION_IDS.working]));
@@ -747,20 +808,20 @@ export function Sidebar({
     });
   }
 
-  function openCommandPalette() {
+  function openCommandPrompt() {
     setMenu(null);
     setIdentityMenuOpen(false);
     setCommandQuery("");
     setCommandActiveIndex(0);
-    setCommandPaletteOpen(true);
+    setCommandPromptOpen(true);
   }
 
-  function closeCommandPalette() {
-    setCommandPaletteOpen(false);
+  function closeCommandPrompt() {
+    setCommandPromptOpen(false);
   }
 
-  function runCommandPaletteItem(item: CommandPaletteItem) {
-    closeCommandPalette();
+  function runCommandPromptItem(item: CommandPromptItem) {
+    closeCommandPrompt();
     item.action();
   }
 
@@ -771,7 +832,7 @@ export function Sidebar({
       if (!isSearchShortcut(event)) return;
       if (document.querySelector('[role="dialog"]')) return;
       event.preventDefault();
-      openCommandPalette();
+      openCommandPrompt();
     }
 
     window.addEventListener("keydown", onKeyDown);
@@ -779,12 +840,12 @@ export function Sidebar({
   });
 
   useEffect(() => {
-    if (!commandPaletteOpen) return;
+    if (!commandPromptOpen) return;
     const frame = window.requestAnimationFrame(() => {
       commandInputRef.current?.focus();
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [commandPaletteOpen]);
+  }, [commandPromptOpen]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1001,7 +1062,7 @@ export function Sidebar({
             className="sidebar-search"
             onMouseDown={(event) => {
               event.preventDefault();
-              openCommandPalette();
+              openCommandPrompt();
             }}
           >
             <IconMagnifyingGlass size={15} />
@@ -1260,17 +1321,17 @@ export function Sidebar({
           onClose={() => setMenu(null)}
         />
       ) : null}
-      {commandPaletteOpen ? (
-        <CommandPalette
+      {commandPromptOpen ? (
+        <CommandPrompt
           inputRef={commandInputRef}
           query={commandQuery}
-          groups={commandPaletteGroups}
-          items={commandPaletteItems}
+          groups={commandPromptGroups}
+          items={commandPromptItems}
           activeIndex={commandActiveIndex}
           onQueryChange={setCommandQuery}
           onActiveIndexChange={setCommandActiveIndex}
-          onClose={closeCommandPalette}
-          onSelect={runCommandPaletteItem}
+          onClose={closeCommandPrompt}
+          onSelect={runCommandPromptItem}
         />
       ) : null}
       <ConfirmDialog
@@ -1543,7 +1604,7 @@ function SettingsSidebarNav({
   );
 }
 
-function CommandPalette({
+function CommandPrompt({
   inputRef,
   query,
   groups,
@@ -1556,30 +1617,60 @@ function CommandPalette({
 }: {
   inputRef: RefObject<HTMLInputElement>;
   query: string;
-  groups: CommandPaletteGroup[];
-  items: CommandPaletteItem[];
+  groups: CommandPromptGroup[];
+  items: CommandPromptItem[];
   activeIndex: number;
   onQueryChange: (value: string) => void;
   onActiveIndexChange: (index: number) => void;
   onClose: () => void;
-  onSelect: (item: CommandPaletteItem) => void;
+  onSelect: (item: CommandPromptItem) => void;
 }) {
-  function onKeyDown(event: ReactKeyboardEvent<HTMLInputElement>) {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      onClose();
-      return;
+  const resultsRef = useRef<HTMLDivElement>(null);
+  const fade = useScrollFade(resultsRef);
+  // Re-measure the edge fades when the query or result groups change.
+  useEffect(() => {
+    fade.update();
+  }, [fade.update, query, groups]);
+
+  // Escape always closes, from anywhere — the prompt has no focus trap, so a
+  // handler bound to the input alone would miss Esc once focus moves to a row,
+  // the clear button, or out to the background. A window listener (mounted only
+  // while the prompt is open) guarantees there's no way to get stuck in here.
+  useEffect(() => {
+    function onWindowKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
     }
+    window.addEventListener("keydown", onWindowKeyDown);
+    return () => window.removeEventListener("keydown", onWindowKeyDown);
+  }, [onClose]);
+
+  // Scroll the active row into view, but only from keyboard navigation — doing
+  // it on mouse-hover activation would fight the pointer and cause jumps.
+  function moveActive(nextIndex: number) {
+    onActiveIndexChange(nextIndex);
+    window.requestAnimationFrame(() => {
+      document
+        .getElementById(`command-prompt-item-${nextIndex}`)
+        ?.scrollIntoView({ block: "nearest" });
+    });
+  }
+
+  function onKeyDown(event: ReactKeyboardEvent<HTMLInputElement>) {
+    // Escape is handled by a window listener (see above) so it works no matter
+    // where focus is; here we only drive list navigation from the input.
     if (event.key === "ArrowDown") {
       event.preventDefault();
       if (items.length === 0) return;
-      onActiveIndexChange(Math.min(activeIndex + 1, items.length - 1));
+      moveActive(Math.min(activeIndex + 1, items.length - 1));
       return;
     }
     if (event.key === "ArrowUp") {
       event.preventDefault();
       if (items.length === 0) return;
-      onActiveIndexChange(Math.max(activeIndex - 1, 0));
+      moveActive(Math.max(activeIndex - 1, 0));
       return;
     }
     if (event.key === "Enter") {
@@ -1593,72 +1684,77 @@ function CommandPalette({
 
   return (
     <div
-      className="command-palette-backdrop"
+      className="command-prompt-backdrop"
       role="presentation"
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
     >
-      <div className="command-palette" role="dialog" aria-modal="true" aria-label="Search">
-        <label className="command-palette-search">
+      <div className="command-prompt" role="dialog" aria-modal="true" aria-label="Search">
+        <label className="command-prompt-search">
           <IconMagnifyingGlass size={16} />
           <input
             ref={inputRef}
-            type="search"
+            type="text"
             value={query}
             onChange={(event) => onQueryChange(event.currentTarget.value)}
             onKeyDown={onKeyDown}
             placeholder="Search meeting notes, sessions, or jump to..."
             aria-label="Search"
             aria-activedescendant={
-              items[activeIndex] ? `command-palette-item-${activeIndex}` : undefined
+              items[activeIndex] ? `command-prompt-item-${activeIndex}` : undefined
             }
           />
+          {query ? (
+            <button
+              type="button"
+              className="command-prompt-clear"
+              aria-label="Clear search"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => {
+                onQueryChange("");
+                inputRef.current?.focus();
+              }}
+            >
+              <IconCrossSmall size={13} />
+            </button>
+          ) : null}
         </label>
-        <div className="command-palette-results">
-          {groups.length > 0 ? (
-            groups.map((group) => (
-              <section className="command-palette-group" key={group.title}>
-                <div className="command-palette-group-title">{group.title}</div>
-                <div className="command-palette-group-list">
-                  {group.items.map((item) => {
-                    const index = itemIndex;
-                    itemIndex += 1;
-                    return (
-                      <button
-                        type="button"
-                        id={`command-palette-item-${index}`}
-                        className="command-palette-item"
-                        data-active={index === activeIndex}
-                        key={item.id}
-                        onMouseEnter={() => onActiveIndexChange(index)}
-                        onClick={() => onSelect(item)}
-                      >
-                        <span className="command-palette-item-icon">{item.icon}</span>
-                        <span className="command-palette-item-label">{item.label}</span>
-                        {item.meta ? (
-                          <span className="command-palette-item-meta">{item.meta}</span>
-                        ) : null}
-                      </button>
-                    );
-                  })}
-                </div>
-              </section>
-            ))
-          ) : (
-            <div className="command-palette-empty">No results</div>
-          )}
-        </div>
-        <div className="command-palette-footer" aria-hidden="true">
-          <span>
-            <kbd>↵</kbd> Open
-          </span>
-          <span>
-            <kbd>↑↓</kbd> Navigate
-          </span>
-          <span>
-            <kbd>Esc</kbd> Close
-          </span>
+        <div className="command-prompt-results-wrap scroll-fade" {...fade.props}>
+          <div className="command-prompt-results" ref={resultsRef} onScroll={fade.update}>
+            {groups.length > 0 ? (
+              groups.map((group) => (
+                <section className="command-prompt-group" key={group.title}>
+                  <div className="command-prompt-group-title">{group.title}</div>
+                  <div className="command-prompt-group-list">
+                    {group.items.map((item) => {
+                      const index = itemIndex;
+                      itemIndex += 1;
+                      return (
+                        <button
+                          type="button"
+                          id={`command-prompt-item-${index}`}
+                          className="command-prompt-item"
+                          data-active={index === activeIndex}
+                          key={item.id}
+                          onMouseEnter={() => onActiveIndexChange(index)}
+                          onClick={() => onSelect(item)}
+                        >
+                          <span className="command-prompt-item-icon">{item.icon}</span>
+                          <span className="command-prompt-item-label">{item.label}</span>
+                          {item.meta ? (
+                            <span className="command-prompt-item-meta">{item.meta}</span>
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </section>
+              ))
+            ) : (
+              <div className="command-prompt-empty">No results for "{query.trim()}"</div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -374,6 +374,8 @@ export function Sidebar({
   const [referralDialogOpen, setReferralDialogOpen] = useState(false);
   const [referralSummary, setReferralSummary] = useState<ReferralSummary | null>(null);
   const [referralLoading, setReferralLoading] = useState(false);
+  // Guards against a stale closure double-firing the summary fetch.
+  const referralLoadingRef = useRef(false);
   const [referralError, setReferralError] = useState<string | null>(null);
   // The deployment can simply not offer referrals (a 404 from /referrals/me).
   // That's not a transient failure, so it gets a calm message with no retry.
@@ -478,6 +480,8 @@ export function Sidebar({
 
   async function loadReferralSummary() {
     if (!account.signedIn || account.localDev) return;
+    if (referralLoadingRef.current) return;
+    referralLoadingRef.current = true;
     setReferralLoading(true);
     setReferralError(null);
     setReferralUnavailable(false);
@@ -487,6 +491,7 @@ export function Sidebar({
       setReferralUnavailable(errorCode(error) === "referrals_unavailable");
       setReferralError(messageFromError(error));
     } finally {
+      referralLoadingRef.current = false;
       setReferralLoading(false);
     }
   }
@@ -1636,15 +1641,19 @@ function CommandPrompt({
   // handler bound to the input alone would miss Esc once focus moves to a row,
   // the clear button, or out to the background. A window listener (mounted only
   // while the prompt is open) guarantees there's no way to get stuck in here.
+  // It runs in the capture phase and calls stopPropagation so the prompt claims
+  // Escape before any earlier-registered window handler (note chat panel, an
+  // active agent run) also reacts to it.
   useEffect(() => {
     function onWindowKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         event.preventDefault();
+        event.stopPropagation();
         onClose();
       }
     }
-    window.addEventListener("keydown", onWindowKeyDown);
-    return () => window.removeEventListener("keydown", onWindowKeyDown);
+    window.addEventListener("keydown", onWindowKeyDown, true);
+    return () => window.removeEventListener("keydown", onWindowKeyDown, true);
   }, [onClose]);
 
   // Scroll the active row into view, but only from keyboard navigation — doing
@@ -1721,7 +1730,7 @@ function CommandPrompt({
           ) : null}
         </label>
         <div className="command-prompt-results-wrap scroll-fade" {...fade.props}>
-          <div className="command-prompt-results" ref={resultsRef} onScroll={fade.update}>
+          <div className="command-prompt-results" ref={resultsRef}>
             {groups.length > 0 ? (
               groups.map((group) => (
                 <section className="command-prompt-group" key={group.title}>

--- a/src/lib/use-scroll-fade.ts
+++ b/src/lib/use-scroll-fade.ts
@@ -25,11 +25,14 @@ export type ScrollFade = {
  * the shared `.scroll-fade` / `.scroll-fade-mask` CSS can melt the clipped edge.
  *
  * The returned `props` carry `data-fade-top` / `data-fade-bottom`; spread them
- * onto the element the fade paints on. The hook owns the scroll listener and a
- * `ResizeObserver` (on the element and its first child, to catch content
- * growth) and re-wires them whenever `ref.current` changes, so conditionally
- * mounted or swapped scrollers stay covered. For data-driven changes that don't
- * resize the element, call `update()` from the relevant effect.
+ * onto the element the fade paints on. The hook owns the scroll listener (its
+ * single source — consumers do NOT wire an `onScroll` handler) and a
+ * `ResizeObserver` on the element plus its content child, re-pointed when that
+ * child swaps via a `childList` `MutationObserver`, to catch content growth. All
+ * listeners re-wire whenever `ref.current` changes, so conditionally mounted or
+ * swapped scrollers stay covered. Consumers only spread `props` / pass the
+ * `ref`; call `update()` only for data-driven changes that neither scroll nor
+ * resize the element (e.g. filtering a list, opening a panel).
  */
 export function useScrollFade(ref: RefObject<HTMLElement | null>): ScrollFade {
   const [fade, setFade] = useState({ top: false, bottom: false });
@@ -66,16 +69,35 @@ export function useScrollFade(ref: RefObject<HTMLElement | null>): ScrollFade {
     const frame = requestAnimationFrame(update);
     el.addEventListener("scroll", update, { passive: true });
     let observer: ResizeObserver | undefined;
+    let observedChild: Element | null = null;
     if (typeof ResizeObserver !== "undefined") {
       observer = new ResizeObserver(update);
       observer.observe(el);
-      const child = el.firstElementChild;
-      if (child) observer.observe(child);
+      observedChild = el.firstElementChild;
+      if (observedChild) observer.observe(observedChild);
+    }
+    // Re-point the ResizeObserver when the scroller swaps its content child
+    // (e.g. an empty/loading body replaced by the real list). Watch only direct
+    // children — not the subtree — to stay cheap for large lists.
+    let mutationObserver: MutationObserver | undefined;
+    if (typeof MutationObserver !== "undefined") {
+      mutationObserver = new MutationObserver(() => {
+        const nextChild = el.firstElementChild;
+        if (nextChild === observedChild) return;
+        if (observer) {
+          if (observedChild) observer.unobserve(observedChild);
+          if (nextChild) observer.observe(nextChild);
+        }
+        observedChild = nextChild;
+        update();
+      });
+      mutationObserver.observe(el, { childList: true });
     }
     teardownRef.current = () => {
       cancelAnimationFrame(frame);
       el.removeEventListener("scroll", update);
       observer?.disconnect();
+      mutationObserver?.disconnect();
     };
   });
 

--- a/src/lib/use-scroll-fade.ts
+++ b/src/lib/use-scroll-fade.ts
@@ -1,0 +1,100 @@
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+
+/** Data attributes the scroll-fade CSS primitives (`.scroll-fade` /
+ * `.scroll-fade-mask`) key off. Spread onto whichever element the fade paints
+ * on — the scroller itself for the mask flavor, or the non-scrolling wrapper
+ * for the contained-overlay flavor. Present only on the edges that hide
+ * content, so a fade never shows when everything fits. */
+export type ScrollFadeProps = {
+  "data-fade-top"?: "true";
+  "data-fade-bottom"?: "true";
+};
+
+export type ScrollFade = {
+  top: boolean;
+  bottom: boolean;
+  /** Force a re-measure — call from effects that change the scroller's content
+   * or size without firing a scroll (filtering a list, opening a panel). */
+  update: () => void;
+  props: ScrollFadeProps;
+};
+
+/**
+ * Position-aware scroll edge fades. Measures a scroll container and reports
+ * whether content is hidden above (`top`) or below (`bottom`) the viewport, so
+ * the shared `.scroll-fade` / `.scroll-fade-mask` CSS can melt the clipped edge.
+ *
+ * The returned `props` carry `data-fade-top` / `data-fade-bottom`; spread them
+ * onto the element the fade paints on. The hook owns the scroll listener and a
+ * `ResizeObserver` (on the element and its first child, to catch content
+ * growth) and re-wires them whenever `ref.current` changes, so conditionally
+ * mounted or swapped scrollers stay covered. For data-driven changes that don't
+ * resize the element, call `update()` from the relevant effect.
+ */
+export function useScrollFade(ref: RefObject<HTMLElement | null>): ScrollFade {
+  const [fade, setFade] = useState({ top: false, bottom: false });
+
+  const update = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    const canScroll = el.scrollHeight - el.clientHeight > 1;
+    const atTop = el.scrollTop <= 1;
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
+    setFade((prev) => {
+      const top = canScroll && !atTop;
+      const bottom = canScroll && !atBottom;
+      // Bail when nothing changed so a scroll inside a stable region never
+      // churns a re-render.
+      return prev.top === top && prev.bottom === bottom ? prev : { top, bottom };
+    });
+  }, [ref]);
+
+  // Re-wire whenever the observed element changes identity. Runs every render
+  // but guards on element identity, so it only does work on mount, unmount, and
+  // an actual swap (e.g. a panel that flips between two scrollers).
+  const observedRef = useRef<HTMLElement | null>(null);
+  const teardownRef = useRef<(() => void) | null>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (el === observedRef.current) return;
+    teardownRef.current?.();
+    observedRef.current = el;
+    if (!el) {
+      teardownRef.current = null;
+      return;
+    }
+    const frame = requestAnimationFrame(update);
+    el.addEventListener("scroll", update, { passive: true });
+    let observer: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== "undefined") {
+      observer = new ResizeObserver(update);
+      observer.observe(el);
+      const child = el.firstElementChild;
+      if (child) observer.observe(child);
+    }
+    teardownRef.current = () => {
+      cancelAnimationFrame(frame);
+      el.removeEventListener("scroll", update);
+      observer?.disconnect();
+    };
+  });
+
+  useEffect(
+    () => () => {
+      teardownRef.current?.();
+      teardownRef.current = null;
+      observedRef.current = null;
+    },
+    [],
+  );
+
+  return {
+    top: fade.top,
+    bottom: fade.bottom,
+    update,
+    props: {
+      "data-fade-top": fade.top ? "true" : undefined,
+      "data-fade-bottom": fade.bottom ? "true" : undefined,
+    },
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6924,14 +6924,17 @@ input:focus-visible,
   cursor: pointer;
 }
 
-/* Keyboard focus (Tab) reuses the same subtle-gray highlight as arrow-key
- * activation and hover — one row treatment for every way of landing on a row,
- * no separate focus ring. */
-.command-prompt-item[data-active="true"],
-.command-prompt-item:focus-visible {
+.command-prompt-item[data-active="true"] {
   /* Same subtle gray wash as the identity/context menus — lighter than
-   * --sidebar-accent, quieter than a brand tint. */
+   * --sidebar-accent, quieter than a brand tint. The single highlight for
+   * every way of landing on a row: hover, arrow keys, and Tab focus all
+   * drive the same active index, so only one row is ever lit. */
   background: color-mix(in oklch, var(--muted) 50%, transparent);
+}
+
+/* Tab focus reuses that active-row highlight (via onFocus syncing the active
+ * index) — so the row needs no separate focus ring of its own. */
+.command-prompt-item:focus-visible {
   outline: none;
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -23170,35 +23170,6 @@ input:focus-visible,
   padding: var(--sp-3) var(--note-chat-inset) var(--sp-4);
   overflow-y: auto;
   overscroll-behavior: contain;
-  --fade: 28px;
-}
-
-/* Same edge-fade recipe as the files panel body. */
-.note-chat-scroll[data-fade-top][data-fade-bottom] {
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    transparent,
-    #000 var(--fade),
-    #000 calc(100% - var(--fade)),
-    transparent
-  );
-  mask-image: linear-gradient(
-    to bottom,
-    transparent,
-    #000 var(--fade),
-    #000 calc(100% - var(--fade)),
-    transparent
-  );
-}
-
-.note-chat-scroll[data-fade-top]:not([data-fade-bottom]) {
-  -webkit-mask-image: linear-gradient(to bottom, transparent, #000 var(--fade));
-  mask-image: linear-gradient(to bottom, transparent, #000 var(--fade));
-}
-
-.note-chat-scroll:not([data-fade-top])[data-fade-bottom] {
-  -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - var(--fade)), transparent);
-  mask-image: linear-gradient(to bottom, #000 calc(100% - var(--fade)), transparent);
 }
 
 .note-chat-thread {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2882,40 +2882,98 @@ input:focus-visible,
   padding: var(--sp-1) var(--sp-6) 0;
 }
 
+/* ============================================================================
+ * Scroll fades (design system)
+ *
+ * A scroller melts its clipped edge when content is hidden above or below the
+ * viewport. Driven by the `useScrollFade` hook, which sets `data-fade-top` /
+ * `data-fade-bottom` only on the edge(s) with hidden content (so a fade never
+ * shows when everything fits). Two flavors, one contract:
+ *
+ *  - `.scroll-fade`      — contained overlays: `::before`/`::after` gradients
+ *    pinned to the wrapper's edges. WKWebView-safe for popovers (a mask on the
+ *    scroller rides the scrolled content in WebKit and bleeds past the bounds).
+ *    Put the class + data attributes on a non-scrolling wrapper; the scroller
+ *    is its child. Tunables: `--scroll-fade-size`, `--scroll-fade-color`,
+ *    `--scroll-fade-inset-right`.
+ *  - `.scroll-fade-mask` — mask-image gradient on the scroller itself. Reveals
+ *    the real content at the edge (clean in light + dark) for large panel
+ *    scrollers. Put the class + data attributes on the scroller. Tunable:
+ *    `--scroll-fade-size`.
+ * ============================================================================ */
+.scroll-fade {
+  position: relative;
+}
+
+.scroll-fade::before,
+.scroll-fade::after {
+  content: "";
+  position: absolute;
+  right: var(--scroll-fade-inset-right, 0);
+  left: 0;
+  z-index: 1;
+  height: var(--scroll-fade-size, 24px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--t-fast) var(--ease-out);
+}
+
+.scroll-fade::before {
+  top: 0;
+  background: linear-gradient(to bottom, var(--scroll-fade-color, var(--popover)), transparent);
+}
+
+.scroll-fade::after {
+  bottom: 0;
+  background: linear-gradient(to top, var(--scroll-fade-color, var(--popover)), transparent);
+}
+
+.scroll-fade[data-fade-top]::before,
+.scroll-fade[data-fade-bottom]::after {
+  opacity: 1;
+}
+
+.scroll-fade-mask[data-fade-top][data-fade-bottom] {
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    #000 var(--scroll-fade-size, 28px),
+    #000 calc(100% - var(--scroll-fade-size, 28px)),
+    transparent
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    #000 var(--scroll-fade-size, 28px),
+    #000 calc(100% - var(--scroll-fade-size, 28px)),
+    transparent
+  );
+}
+
+.scroll-fade-mask[data-fade-top]:not([data-fade-bottom]) {
+  -webkit-mask-image: linear-gradient(to bottom, transparent, #000 var(--scroll-fade-size, 28px));
+  mask-image: linear-gradient(to bottom, transparent, #000 var(--scroll-fade-size, 28px));
+}
+
+.scroll-fade-mask:not([data-fade-top])[data-fade-bottom] {
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    #000 calc(100% - var(--scroll-fade-size, 28px)),
+    transparent
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    #000 calc(100% - var(--scroll-fade-size, 28px)),
+    transparent
+  );
+}
+
 .agent-artifact-panel-body {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
   padding: var(--sp-5) var(--sp-6) var(--sp-7);
   overscroll-behavior: contain;
-  --fade: 28px;
-}
-
-.agent-artifact-panel-body[data-fade-top][data-fade-bottom] {
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    transparent,
-    #000 var(--fade),
-    #000 calc(100% - var(--fade)),
-    transparent
-  );
-  mask-image: linear-gradient(
-    to bottom,
-    transparent,
-    #000 var(--fade),
-    #000 calc(100% - var(--fade)),
-    transparent
-  );
-}
-
-.agent-artifact-panel-body[data-fade-top]:not([data-fade-bottom]) {
-  -webkit-mask-image: linear-gradient(to bottom, transparent, #000 var(--fade));
-  mask-image: linear-gradient(to bottom, transparent, #000 var(--fade));
-}
-
-.agent-artifact-panel-body:not([data-fade-top])[data-fade-bottom] {
-  -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - var(--fade)), transparent);
-  mask-image: linear-gradient(to bottom, #000 calc(100% - var(--fade)), transparent);
 }
 
 .agent-artifact-panel-body[data-kind="list"] {
@@ -3119,7 +3177,7 @@ input:focus-visible,
 }
 
 /* Session usage / context / cost panel (feature 09). A centered modal over the
- * session, modeled on the command palette: scrim + frosted popover card. The
+ * session, modeled on the command prompt: scrim + frosted popover card. The
  * card is a compact usage summary: a segmented context meter, lean breakdown
  * rows, and a footer total behind a hairline. */
 .agent-usage-overlay {
@@ -5227,6 +5285,7 @@ input:focus-visible,
   min-height: 0;
   overflow: hidden;
   contain: paint;
+  --scroll-fade-size: 16px;
 }
 
 .agent-composer-model-list {
@@ -5236,38 +5295,6 @@ input:focus-visible,
   gap: var(--sp-px);
   min-height: 0;
   overflow-y: auto;
-}
-
-/* Scroll fades, contained: overlays pinned to the scroll viewport's edges
- * (a mask on the scroller rides the scrolled content in WebKit and bleeds
- * past the bounds). Rows melt into the popover surface at the boundary and
- * nothing can paint outside the panel. */
-.agent-composer-model-list-wrap::before,
-.agent-composer-model-list-wrap::after {
-  content: "";
-  position: absolute;
-  right: 0;
-  left: 0;
-  z-index: 1;
-  height: 16px;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity var(--t-fast) var(--ease-out);
-}
-
-.agent-composer-model-list-wrap::before {
-  top: 0;
-  background: linear-gradient(to bottom, var(--popover), transparent);
-}
-
-.agent-composer-model-list-wrap::after {
-  bottom: 0;
-  background: linear-gradient(to top, var(--popover), transparent);
-}
-
-.agent-composer-model-list-wrap[data-fade-top="true"]::before,
-.agent-composer-model-list-wrap[data-fade-bottom="true"]::after {
-  opacity: 1;
 }
 
 .agent-composer-model-empty {
@@ -5496,42 +5523,19 @@ input:focus-visible,
   word-break: break-word;
 }
 
+/* Uses the shared `.scroll-fade` primitive. `.agent-composer-editor-root`
+ * itself is the scroll viewport (it is not React-state driven — ComposerEditor
+ * writes `data-fade-*` directly inside its ProseMirror update, and drops the
+ * fades while a range selection is active), so the class + overrides live here
+ * and the overlays inset from the right to clear the composer's gutter. */
 .agent-composer-editor-root {
   position: relative;
   width: 100%;
   min-height: var(--control-lg);
   overflow: hidden;
-}
-
-/* Same edge-fade recipe as the composer model list: overlays are pinned to the
- * scroll viewport, and data-fade-* only appears when that edge has hidden
- * content. This turns the capped editor's hard clip into a soft melt. */
-.agent-composer-editor-root::before,
-.agent-composer-editor-root::after {
-  content: "";
-  position: absolute;
-  right: var(--sp-1);
-  left: 0;
-  z-index: 1;
-  height: 18px;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity var(--t-fast) var(--ease-out);
-}
-
-.agent-composer-editor-root::before {
-  top: 0;
-  background: linear-gradient(to bottom, var(--agent-composer-scroll-fade), transparent);
-}
-
-.agent-composer-editor-root::after {
-  bottom: 0;
-  background: linear-gradient(to top, var(--agent-composer-scroll-fade), transparent);
-}
-
-.agent-composer-editor-root[data-fade-top="true"]::before,
-.agent-composer-editor-root[data-fade-bottom="true"]::after {
-  opacity: 1;
+  --scroll-fade-size: 18px;
+  --scroll-fade-color: var(--agent-composer-scroll-fade);
+  --scroll-fade-inset-right: var(--sp-1);
 }
 
 .agent-composer-editor p {
@@ -5692,6 +5696,7 @@ input:focus-visible,
   width: 100%;
   overflow: hidden;
   contain: paint;
+  --scroll-fade-size: 16px;
 }
 
 .agent-category-menu,
@@ -5709,34 +5714,6 @@ input:focus-visible,
   max-height: var(--agent-category-menu-max-height, 280px);
   overflow-y: auto;
   overscroll-behavior: contain;
-}
-
-.agent-category-menu-scroll-wrap::before,
-.agent-category-menu-scroll-wrap::after {
-  content: "";
-  position: absolute;
-  right: 0;
-  left: 0;
-  z-index: 1;
-  height: 16px;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity var(--t-fast) var(--ease-out);
-}
-
-.agent-category-menu-scroll-wrap::before {
-  top: 0;
-  background: linear-gradient(to bottom, var(--popover), transparent);
-}
-
-.agent-category-menu-scroll-wrap::after {
-  bottom: 0;
-  background: linear-gradient(to top, var(--popover), transparent);
-}
-
-.agent-category-menu-scroll-wrap[data-fade-top="true"]::before,
-.agent-category-menu-scroll-wrap[data-fade-bottom="true"]::after {
-  opacity: 1;
 }
 
 .agent-attach-menu {
@@ -6811,9 +6788,9 @@ input:focus-visible,
   display: none;
 }
 
-/* Command palette ---------------------------------------------------- */
+/* Command prompt ----------------------------------------------------- */
 
-.command-palette-backdrop {
+.command-prompt-backdrop {
   position: fixed;
   inset: 0;
   /* Above the titlebar chrome (drag layer 100, tab bar 101, sidebar toggle
@@ -6822,16 +6799,22 @@ input:focus-visible,
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding: 18px 16px;
-  background: oklch(0% 0 none / 36%);
-  backdrop-filter: blur(8px);
+  /* Sit the panel in the upper third (Linear/Raycast convention) rather than
+   * dead center — centering would make it jump as the result count changes.
+   * Keep flex-start so the top edge is stable; the clamp scales the offset
+   * with viewport height. */
+  padding: clamp(48px, 14vh, 160px) 16px 16px;
+  /* Same scrim treatment as the dialog system (.dialog-backdrop). */
+  background: var(--scrim);
+  backdrop-filter: saturate(140%) blur(8px);
+  -webkit-backdrop-filter: saturate(140%) blur(8px);
 }
 
-.command-palette {
+.command-prompt {
   width: min(512px, calc(100vw - 32px));
   max-height: min(72vh, 520px);
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr);
   overflow: hidden;
   border: 1px solid var(--popover-border);
   border-radius: 12px;
@@ -6842,18 +6825,20 @@ input:focus-visible,
     0 0 0 1px oklch(100% 0 none / 4%);
 }
 
-.command-palette-search {
+.command-prompt-search {
   display: grid;
-  grid-template-columns: 18px minmax(0, 1fr);
+  grid-template-columns: 18px minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--sp-2);
   height: 44px;
   padding: 0 14px;
-  border-bottom: 1px solid var(--border-subtle);
+  /* Barely-there hairline: half the strength of --border-subtle, just enough
+   * to seat the search row without drawing a visible divider. */
+  border-bottom: 1px solid color-mix(in oklch, var(--border-subtle) 50%, transparent);
   color: var(--muted-foreground);
 }
 
-.command-palette-search input {
+.command-prompt-search input {
   min-width: 0;
   border: 0;
   outline: 0;
@@ -6862,33 +6847,68 @@ input:focus-visible,
   font-size: var(--fs-md);
 }
 
-.command-palette-search input::placeholder {
+.command-prompt-search input::placeholder {
   color: var(--muted-foreground);
 }
 
-.command-palette-results {
+/* Clear button: a quiet keycap-like gray square replacing the native
+ * type="search" clear affordance. */
+.command-prompt-clear {
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  /* --r-sm matches the app's other square icon buttons (.icon-button);
+   * --r-xs is the keycap/badge tier. */
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 70%, transparent);
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.command-prompt-clear:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+/* The wrapper is the non-scrolling grid row that carries the shared
+ * `.scroll-fade` overlays; the results list scrolls inside it. */
+.command-prompt-results-wrap {
+  display: flex;
+  flex-direction: column;
   min-height: 280px;
+  overflow: hidden;
+}
+
+.command-prompt-results {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
   padding: 8px;
 }
 
-.command-palette-group + .command-palette-group {
+.command-prompt-group + .command-prompt-group {
   margin-top: 8px;
 }
 
-.command-palette-group-title {
+.command-prompt-group-title {
   padding: 5px 9px 7px;
   color: var(--muted-foreground);
   font-size: var(--fs-xs);
   font-weight: var(--fw-medium);
 }
 
-.command-palette-group-list {
+.command-prompt-group-list {
   display: grid;
   gap: 2px;
 }
 
-.command-palette-item {
+.command-prompt-item {
   display: grid;
   grid-template-columns: 18px minmax(0, 1fr) auto;
   align-items: center;
@@ -6904,18 +6924,25 @@ input:focus-visible,
   cursor: pointer;
 }
 
-.command-palette-item[data-active="true"] {
-  background: var(--sidebar-accent);
+/* Keyboard focus (Tab) reuses the same subtle-gray highlight as arrow-key
+ * activation and hover — one row treatment for every way of landing on a row,
+ * no separate focus ring. */
+.command-prompt-item[data-active="true"],
+.command-prompt-item:focus-visible {
+  /* Same subtle gray wash as the identity/context menus — lighter than
+   * --sidebar-accent, quieter than a brand tint. */
+  background: color-mix(in oklch, var(--muted) 50%, transparent);
+  outline: none;
 }
 
-.command-palette-item-icon {
+.command-prompt-item-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   color: var(--muted-foreground);
 }
 
-.command-palette-item-label {
+.command-prompt-item-label {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -6923,13 +6950,13 @@ input:focus-visible,
   font-size: var(--fs-md);
 }
 
-.command-palette-item-meta {
+.command-prompt-item-meta {
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
   white-space: nowrap;
 }
 
-.command-palette-empty {
+.command-prompt-empty {
   display: grid;
   min-height: 160px;
   place-items: center;
@@ -6937,47 +6964,11 @@ input:focus-visible,
   font-size: var(--fs-sm);
 }
 
-.command-palette-footer {
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  min-height: 28px;
-  padding: 0 12px;
-  border-top: 1px solid var(--border-subtle);
-  background: color-mix(in oklch, var(--muted) 35%, transparent);
-  color: var(--muted-foreground);
-  font-size: var(--fs-xs);
-}
-
-.command-palette-footer span {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-}
-
-.command-palette-footer kbd {
-  min-width: 20px;
-  height: 17px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 5px;
-  border: 0;
-  border-radius: var(--r-xs);
-  background: color-mix(in oklch, var(--muted) 70%, transparent);
-  color: var(--muted-foreground);
-  font-family: var(--font-sans);
-  font-size: var(--fs-2xs);
-  font-weight: var(--fw-medium);
-}
-
 @media (max-width: 560px) {
-  .command-palette {
-    max-height: calc(100vh - 32px);
-  }
-
-  .command-palette-footer {
-    gap: 10px;
+  .command-prompt {
+    /* Fit under the upper-third top padding: leave room for the clamp offset
+     * above plus the 16px bottom gutter (32px covers it with breathing room). */
+    max-height: min(100vh - clamp(48px, 14vh, 160px) - 32px, 640px);
   }
 }
 
@@ -18527,34 +18518,7 @@ input:focus-visible,
 .transcript-dialog-scroll {
   max-height: min(52vh, 420px);
   overflow-y: auto;
-  --fade: 26px;
-}
-
-.transcript-dialog-scroll[data-fade-top][data-fade-bottom] {
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    transparent,
-    #000 var(--fade),
-    #000 calc(100% - var(--fade)),
-    transparent
-  );
-  mask-image: linear-gradient(
-    to bottom,
-    transparent,
-    #000 var(--fade),
-    #000 calc(100% - var(--fade)),
-    transparent
-  );
-}
-
-.transcript-dialog-scroll[data-fade-top]:not([data-fade-bottom]) {
-  -webkit-mask-image: linear-gradient(to bottom, transparent, #000 var(--fade));
-  mask-image: linear-gradient(to bottom, transparent, #000 var(--fade));
-}
-
-.transcript-dialog-scroll:not([data-fade-top])[data-fade-bottom] {
-  -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - var(--fade)), transparent);
-  mask-image: linear-gradient(to bottom, #000 calc(100% - var(--fade)), transparent);
+  --scroll-fade-size: 26px;
 }
 
 .transcript-dialog-scroll p {

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -146,7 +146,7 @@ describe("Sidebar primary navigation", () => {
     expect(onChangeView).toHaveBeenCalledWith("agent-sessions");
   });
 
-  it("opens the command palette with Command-K", async () => {
+  it("opens the command prompt with Command-K", async () => {
     render(
       <Sidebar
         notes={notes}
@@ -166,23 +166,53 @@ describe("Sidebar primary navigation", () => {
 
     fireEvent.keyDown(window, { key: "k", metaKey: true });
 
-    const palette = screen.getByRole("dialog", { name: "Search" });
-    const search = within(palette).getByRole("searchbox", { name: "Search" });
+    const prompt = screen.getByRole("dialog", { name: "Search" });
+    const search = within(prompt).getByRole("textbox", { name: "Search" });
     await waitFor(() => expect(search).toHaveFocus());
     expect(
-      within(palette).getByPlaceholderText("Search meeting notes, sessions, or jump to..."),
+      within(prompt).getByPlaceholderText("Search meeting notes, sessions, or jump to..."),
     ).toBeInTheDocument();
-    expect(within(palette).getByText("Recents")).toBeInTheDocument();
-    expect(within(palette).getByText("Roadmap")).toBeInTheDocument();
-    expect(within(palette).getByText("Quick actions")).toBeInTheDocument();
-    expect(within(palette).getByText("New session")).toBeInTheDocument();
+    expect(within(prompt).getByText("Recents")).toBeInTheDocument();
+    expect(within(prompt).getByText("Roadmap")).toBeInTheDocument();
+    expect(within(prompt).getByText("Quick actions")).toBeInTheDocument();
+    expect(within(prompt).getByText("New session")).toBeInTheDocument();
 
     fireEvent.keyDown(search, { key: "Escape" });
 
     expect(screen.queryByRole("dialog", { name: "Search" })).toBeNull();
   });
 
-  it("shows and accepts the Windows command palette shortcut", async () => {
+  it("closes the command prompt on Escape even when a result row is focused", async () => {
+    render(
+      <Sidebar
+        notes={notes}
+        activeView="notes"
+        onChangeView={vi.fn()}
+        onSelectNote={vi.fn()}
+        onDeleteNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onRemoveNoteFromFolder={vi.fn()}
+        onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
+        onSelectAgentSession={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const prompt = screen.getByRole("dialog", { name: "Search" });
+
+    // Move focus off the input onto a result row (the prompt has no focus trap,
+    // so Esc must still close from here — the "can't get stuck" guarantee).
+    const row = within(prompt).getByRole("button", { name: /Roadmap/ });
+    row.focus();
+    expect(row).toHaveFocus();
+
+    fireEvent.keyDown(row, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog", { name: "Search" })).toBeNull();
+  });
+
+  it("shows and accepts the Windows command prompt shortcut", async () => {
     const restoreNavigator = stubNavigatorPlatform(
       "Win32",
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
@@ -207,15 +237,15 @@ describe("Sidebar primary navigation", () => {
 
       fireEvent.keyDown(window, { key: "k", ctrlKey: true });
 
-      const palette = screen.getByRole("dialog", { name: "Search" });
-      const search = within(palette).getByRole("searchbox", { name: "Search" });
+      const prompt = screen.getByRole("dialog", { name: "Search" });
+      const search = within(prompt).getByRole("textbox", { name: "Search" });
       await waitFor(() => expect(search).toHaveFocus());
     } finally {
       restoreNavigator();
     }
   });
 
-  it("opens the command palette when clicking the sidebar search", async () => {
+  it("opens the command prompt when clicking the sidebar search", async () => {
     const user = userEvent.setup();
     render(
       <Sidebar
@@ -234,9 +264,9 @@ describe("Sidebar primary navigation", () => {
 
     await user.click(screen.getByRole("searchbox", { name: "Search" }));
 
-    const palette = screen.getByRole("dialog", { name: "Search" });
+    const prompt = screen.getByRole("dialog", { name: "Search" });
     await waitFor(() =>
-      expect(within(palette).getByRole("searchbox", { name: "Search" })).toHaveFocus(),
+      expect(within(prompt).getByRole("textbox", { name: "Search" })).toHaveFocus(),
     );
   });
 
@@ -426,7 +456,7 @@ describe("Sidebar primary navigation", () => {
     expect(screen.queryByRole("menuitem", { name: "Sign out" })).toBeNull();
   });
 
-  it("omits the billing settings jump from the palette in local dev mode", async () => {
+  it("omits the billing settings jump from the prompt in local dev mode", async () => {
     const user = userEvent.setup();
     const renderSidebar = (account: AccountStatus) =>
       render(
@@ -446,12 +476,12 @@ describe("Sidebar primary navigation", () => {
         />,
       );
 
-    const openPaletteAndSearch = async () => {
+    const openPromptAndSearch = async () => {
       await user.click(screen.getByRole("searchbox", { name: "Search" }));
-      const palette = screen.getByRole("dialog", { name: "Search" });
-      const search = within(palette).getByRole("searchbox", { name: "Search" });
+      const prompt = screen.getByRole("dialog", { name: "Search" });
+      const search = within(prompt).getByRole("textbox", { name: "Search" });
       await user.type(search, "billing");
-      return palette;
+      return prompt;
     };
 
     // A regular account surfaces the billing jump once a query is typed.
@@ -460,19 +490,19 @@ describe("Sidebar primary navigation", () => {
       configured: true,
       user: { id: "usr_regular", handle: "regular" },
     });
-    const regularPalette = await openPaletteAndSearch();
-    expect(within(regularPalette).getByText("Settings -> Billing")).toBeInTheDocument();
+    const regularPrompt = await openPromptAndSearch();
+    expect(within(regularPrompt).getByText("Settings -> Billing")).toBeInTheDocument();
     regular.unmount();
 
-    // Local dev hides billing everywhere, including the palette jump.
+    // Local dev hides billing everywhere, including the prompt jump.
     renderSidebar({
       signedIn: true,
       configured: true,
       localDev: true,
       user: { id: "usr_local_dev", handle: "local-dev" },
     });
-    const localDevPalette = await openPaletteAndSearch();
-    expect(within(localDevPalette).queryByText("Settings -> Billing")).toBeNull();
+    const localDevPrompt = await openPromptAndSearch();
+    expect(within(localDevPrompt).queryByText("Settings -> Billing")).toBeNull();
   });
 
   it("opens the referral dialog and copies the invite link", async () => {

--- a/src/test/use-scroll-fade.test.ts
+++ b/src/test/use-scroll-fade.test.ts
@@ -1,0 +1,61 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { useScrollFade } from "../lib/use-scroll-fade";
+
+/** Build a detached element with fake scroll metrics and a ref pointing at it,
+ * mirroring how the fade components measure a real scroll viewport. */
+function scroller(metrics: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
+  const el = document.createElement("div");
+  Object.defineProperties(el, {
+    scrollHeight: { configurable: true, value: metrics.scrollHeight },
+    clientHeight: { configurable: true, value: metrics.clientHeight },
+    scrollTop: { configurable: true, writable: true, value: metrics.scrollTop },
+  });
+  document.body.appendChild(el);
+  return { el, ref: { current: el as HTMLElement } };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("useScrollFade", () => {
+  it("shows no fades when the content fits", () => {
+    const { ref } = scroller({ scrollHeight: 100, clientHeight: 100, scrollTop: 0 });
+    const { result } = renderHook(() => useScrollFade(ref));
+    act(() => result.current.update());
+    expect(result.current.top).toBe(false);
+    expect(result.current.bottom).toBe(false);
+    expect(result.current.props["data-fade-top"]).toBeUndefined();
+    expect(result.current.props["data-fade-bottom"]).toBeUndefined();
+  });
+
+  it("shows both fades when scrolled to the middle", () => {
+    const { el, ref } = scroller({ scrollHeight: 300, clientHeight: 100, scrollTop: 100 });
+    const { result } = renderHook(() => useScrollFade(ref));
+    act(() => {
+      el.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current.top).toBe(true);
+    expect(result.current.bottom).toBe(true);
+    expect(result.current.props["data-fade-top"]).toBe("true");
+    expect(result.current.props["data-fade-bottom"]).toBe("true");
+  });
+
+  it("shows only the bottom fade at the top of the scroll", () => {
+    const { ref } = scroller({ scrollHeight: 300, clientHeight: 100, scrollTop: 0 });
+    const { result } = renderHook(() => useScrollFade(ref));
+    act(() => result.current.update());
+    expect(result.current.top).toBe(false);
+    expect(result.current.bottom).toBe(true);
+  });
+
+  it("shows only the top fade at the bottom of the scroll", () => {
+    const { ref } = scroller({ scrollHeight: 300, clientHeight: 100, scrollTop: 200 });
+    const { result } = renderHook(() => useScrollFade(ref));
+    act(() => result.current.update());
+    expect(result.current.top).toBe(true);
+    expect(result.current.bottom).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

A cleanup pass on the cmd-K **command prompt** (renamed from "command palette"), plus extraction of the repeated scroll-edge-fade logic into a shared design-system primitive.

**Command prompt** (`src/components/sidebar/Sidebar.tsx`):
- Renamed `CommandPalette` → `CommandPrompt` throughout (component, types, state, handlers, CSS classes, element ids, comments).
- **Hover was too dark:** active/hover/focus rows now use a subtle gray wash (`color-mix` of `--muted`), matching the identity/context menus, instead of the darker `--sidebar-accent` / brand tint.
- **Position:** panel now sits in the upper third (Linear/Raycast convention) rather than pinned to the titlebar. Deliberately not vertically centered — a centered panel jumps as the result count changes.
- **Missing actions added:** "Open recording" in Quick actions, plus a new **Support** group (Report a bug / Send feedback / Request a feature, Invite friends, Sign out), reusing the identity menu's items and guards.
- **System backdrop:** uses `var(--scrim)` + blur (same as the dialog system) instead of a hardcoded dark overlay; barely-there search hairline.
- **Clear button:** replaced the native `type=search` clear affordance with a system square icon button (`IconCrossSmall`, `--r-sm`), shown only when there's a query.
- No-results echoes the query; dropped the keyboard-hint footer.
- **Keyboard:** active row scrolls into view on arrow-nav only; Tab focus reuses the hover highlight (no separate focus ring); **Escape closes from anywhere** via a window listener — the prompt has no focus trap, so this guarantees you can't get stuck in it.

**Scroll fades (design system):**
- New `useScrollFade` hook (`src/lib/use-scroll-fade.ts`) + `.scroll-fade` (contained overlays, WKWebView-safe for popovers) / `.scroll-fade-mask` (`mask-image`, for large panels) utilities, replacing **7 hand-rolled copies** across the composer, both model pickers, suggestion lists, dictation history, note chat, and agent workspace. `spec/scroll-fade.md` documents the rule.

**Docs:** captured the radius-tier convention (square icon buttons use `--r-sm`, not the `--r-xs` keycap tier) in `docs/design/conventions.md`.

## Validation

- `pnpm typecheck` clean, `pnpm check` at baseline (0 new issues), `pnpm test` — 2183 passed / 2 skipped, 0 failures. Added a `use-scroll-fade` unit suite and an Escape-from-focused-row regression test.

- [x] Tested visually where it matters — iterated live in the browser across several rounds of feedback (hover tint, positioning, backdrop, clear button, footer removal). Reviewer: please glance at the prompt in both light and dark.
- [ ] Needs a June API (backend) deploy — **no**, frontend + docs only, no Rust touched.

## Out of scope

- No "start a new recording" command — the existing `onOpenRecording` handler opens the *current* recording note, so the item is labeled "Open recording" and only shows while a recording is live. Wiring a true start-recording action is a separate change.
- The radius-tier guidance is a conventions-doc note, not an enforceable `spec/` rule (tier selection is a judgment call CI can't lint).

## Followups

- Possible: an "Ask June about '<query>'" escape-hatch row in the no-results state instead of a dead end.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] User-facing copy follows the repo UI conventions (sentence case, no dashes, central-icons only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786125940&installation_id=144203540&pr_number=664&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F664&signature=e8c4d196dc90a16a78e815d6023ebc89b1270e74df9f76ee8c23d7c221f8b71d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<img width="2360" height="1560" alt="CleanShot 2026-07-08 at 12 14 21@2x" src="https://github.com/user-attachments/assets/2565fb1f-a330-484f-ac7c-dfb9a1ad6e21" />

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->