### PR TITLE
Add onboarding usage intent step

### DIFF
--- a/docs/telemetry-p3a-prd.md
+++ b/docs/telemetry-p3a-prd.md
@@ -154,6 +154,14 @@ platform (`macos` / `windows` / `linux`) and app version series (e.g.
 | `agent.privacy-guard` | Agent privacy guard mode (sampled weekly) | off / structured | Rampart default-on decision |
 | `models.privacy-mode` | Most-selected model privacy mode this week | e2ee / private / anonymous | Model catalog and TEE roadmap |
 | `onboarding.completed` | Onboarding completed | completed | Onboarding funnel health |
+| `onboarding.use-case.work` | Onboarding interest selected: work | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.personal` | Onboarding interest selected: personal | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.school` | Onboarding interest selected: school | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.creative` | Onboarding interest selected: creative projects | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.coding` | Onboarding interest selected: coding | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.meetings` | Onboarding interest selected: meetings | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.other` | Onboarding interest selected: other | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.not-sure` | Onboarding interest selected: not sure yet | selected | New-user intent and activation segmentation |
 
 Explicitly rejected for v1: anything billing-related (balance, top-ups —
 too sensitive next to OS Accounts identity), country/region (population too

--- a/docs/telemetry-questions.md
+++ b/docs/telemetry-questions.md
@@ -32,6 +32,14 @@ Every report is one question per request and carries only:
 | `agent.privacy-guard` | Agent privacy guard mode | off / structured | Rampart default-on decision |
 | `models.privacy-mode` | Most-selected model privacy mode this week | e2ee / private / anonymous | Model catalog and TEE roadmap |
 | `onboarding.completed` | Onboarding completed | completed | Onboarding funnel health |
+| `onboarding.use-case.work` | Onboarding interest selected: work | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.personal` | Onboarding interest selected: personal | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.school` | Onboarding interest selected: school | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.creative` | Onboarding interest selected: creative projects | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.coding` | Onboarding interest selected: coding | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.meetings` | Onboarding interest selected: meetings | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.other` | Onboarding interest selected: other | selected | New-user intent and activation segmentation |
+| `onboarding.use-case.not-sure` | Onboarding interest selected: not sure yet | selected | New-user intent and activation segmentation |
 
 ## Change rules
 

--- a/onboarding-preview.html
+++ b/onboarding-preview.html
@@ -14,6 +14,7 @@
     june.replayOnboarding()            restart the wizard from step 1
     june.replayOnboarding("permissions")
                                        jump to a step (sign-in, permissions,
+                                       telemetry, usage-intent,
                                        dictation-practice)
     __JUNE_STUB__.signOut()            back to the signed-out welcome pitch
     localStorage.setItem("os-june:theme", "dark"); location.reload()
@@ -34,6 +35,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>June onboarding preview</title>
+    <link rel="icon" href="data:," />
     <script>
       // Pre-paint theme bootstrap, same as index.html (plus a ?theme=
       // override so scripted screenshots can pick a theme per URL).
@@ -129,6 +131,12 @@
             language: "",
           };
         }
+        const p3aEvents = [];
+        const p3aSettings = {
+          enabled: false,
+          consentVersion: 1,
+          consentedAtWeek: null,
+        };
 
         let account = step
           ? {
@@ -142,9 +150,18 @@
 
         window.__JUNE_STUB__ = {
           emitEvent,
+          p3aEvents,
           signOut() {
             // The bare URL is the signed-out start.
             location.href = location.pathname;
+          },
+        };
+
+        window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+          unregisterListener(event, eventId) {
+            const ids = listeners.get(event);
+            if (ids) ids.delete(eventId);
+            callbacks.delete(eventId);
           },
         };
 
@@ -170,6 +187,10 @@
                 return args.handler;
               }
               case "plugin:event|unlisten":
+                window.__TAURI_EVENT_PLUGIN_INTERNALS__.unregisterListener(
+                  args.event,
+                  args.eventId,
+                );
                 return null;
               case "os_accounts_status":
                 return account;
@@ -184,6 +205,17 @@
                 return account;
               case "os_accounts_open_portal":
               case "os_accounts_top_up":
+                return null;
+              case "p3a_settings":
+                return { settings: { ...p3aSettings } };
+              case "set_p3a_enabled":
+                p3aSettings.enabled = Boolean(args.request && args.request.enabled);
+                p3aSettings.consentedAtWeek = p3aSettings.enabled ? "2026-W28" : null;
+                return { settings: { ...p3aSettings } };
+              case "p3a_record":
+                if (p3aSettings.enabled && args.request && args.request.questionId) {
+                  p3aEvents.push(args.request.questionId);
+                }
                 return null;
               case "dictation_settings":
                 return { settings: dictationSettings() };

--- a/src-tauri/src/p3a/questions.rs
+++ b/src-tauri/src/p3a/questions.rs
@@ -8,6 +8,14 @@ pub enum Question {
     AgentPrivacyGuard,
     ModelsPrivacyMode,
     OnboardingCompleted,
+    OnboardingUseCaseWork,
+    OnboardingUseCasePersonal,
+    OnboardingUseCaseSchool,
+    OnboardingUseCaseCreative,
+    OnboardingUseCaseCoding,
+    OnboardingUseCaseMeetings,
+    OnboardingUseCaseOther,
+    OnboardingUseCaseNotSure,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -76,6 +84,62 @@ pub const ALL_QUESTIONS: &[QuestionDef] = &[
         buckets: &["completed"],
         decision: "Onboarding funnel health",
     },
+    QuestionDef {
+        question: Question::OnboardingUseCaseWork,
+        id: "onboarding.use-case.work",
+        prompt: "Onboarding interest selected: work",
+        buckets: &["selected"],
+        decision: "New-user intent and activation segmentation",
+    },
+    QuestionDef {
+        question: Question::OnboardingUseCasePersonal,
+        id: "onboarding.use-case.personal",
+        prompt: "Onboarding interest selected: personal",
+        buckets: &["selected"],
+        decision: "New-user intent and activation segmentation",
+    },
+    QuestionDef {
+        question: Question::OnboardingUseCaseSchool,
+        id: "onboarding.use-case.school",
+        prompt: "Onboarding interest selected: school",
+        buckets: &["selected"],
+        decision: "New-user intent and activation segmentation",
+    },
+    QuestionDef {
+        question: Question::OnboardingUseCaseCreative,
+        id: "onboarding.use-case.creative",
+        prompt: "Onboarding interest selected: creative projects",
+        buckets: &["selected"],
+        decision: "New-user intent and activation segmentation",
+    },
+    QuestionDef {
+        question: Question::OnboardingUseCaseCoding,
+        id: "onboarding.use-case.coding",
+        prompt: "Onboarding interest selected: coding",
+        buckets: &["selected"],
+        decision: "New-user intent and activation segmentation",
+    },
+    QuestionDef {
+        question: Question::OnboardingUseCaseMeetings,
+        id: "onboarding.use-case.meetings",
+        prompt: "Onboarding interest selected: meetings",
+        buckets: &["selected"],
+        decision: "New-user intent and activation segmentation",
+    },
+    QuestionDef {
+        question: Question::OnboardingUseCaseOther,
+        id: "onboarding.use-case.other",
+        prompt: "Onboarding interest selected: other",
+        buckets: &["selected"],
+        decision: "New-user intent and activation segmentation",
+    },
+    QuestionDef {
+        question: Question::OnboardingUseCaseNotSure,
+        id: "onboarding.use-case.not-sure",
+        prompt: "Onboarding interest selected: not sure yet",
+        buckets: &["selected"],
+        decision: "New-user intent and activation segmentation",
+    },
 ];
 
 impl Question {
@@ -122,7 +186,15 @@ impl Question {
                 }
             }
             Self::ModelsPrivacyMode => raw.min(2) as u8,
-            Self::OnboardingCompleted => 0,
+            Self::OnboardingCompleted
+            | Self::OnboardingUseCaseWork
+            | Self::OnboardingUseCasePersonal
+            | Self::OnboardingUseCaseSchool
+            | Self::OnboardingUseCaseCreative
+            | Self::OnboardingUseCaseCoding
+            | Self::OnboardingUseCaseMeetings
+            | Self::OnboardingUseCaseOther
+            | Self::OnboardingUseCaseNotSure => 0,
         }
     }
 
@@ -153,6 +225,9 @@ mod tests {
         assert_eq!(Question::DictationSessions.event_bucket(), 0);
         assert_eq!(Question::AgentSessions.event_bucket(), 0);
         assert_eq!(Question::OnboardingCompleted.event_bucket(), 0);
+        assert_eq!(Question::OnboardingUseCaseWork.event_bucket(), 0);
+        assert_eq!(Question::OnboardingUseCaseOther.event_bucket(), 0);
+        assert_eq!(Question::OnboardingUseCaseNotSure.event_bucket(), 0);
     }
 
     #[test]

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -8,9 +8,10 @@ import { PermissionsStep } from "./steps/PermissionSteps";
 import { DictationPracticeStep } from "./steps/PracticeStep";
 import { SignInStep } from "./steps/SignInStep";
 import { TelemetryConsentStep } from "./steps/TelemetryConsentStep";
+import { UsageIntentStep } from "./steps/UsageIntentStep";
 import { usePermissionStatuses, useSystemAudioStatus } from "./use-permission-status";
 
-type StepId = "sign-in" | "telemetry" | "permissions" | "dictation-practice";
+type StepId = "sign-in" | "telemetry" | "usage-intent" | "permissions" | "dictation-practice";
 
 // The product default: bare fn, mirroring DictationShortcutSetting::bare_fn()
 // on the Rust side.
@@ -40,8 +41,14 @@ function isFactoryDefaultShortcut(shortcut: DictationShortcutSetting) {
   );
 }
 
-const MAC_STEPS: StepId[] = ["sign-in", "telemetry", "permissions", "dictation-practice"];
-const NON_MAC_STEPS: StepId[] = ["sign-in", "telemetry", "permissions"];
+const MAC_STEPS: StepId[] = [
+  "sign-in",
+  "telemetry",
+  "usage-intent",
+  "permissions",
+  "dictation-practice",
+];
+const NON_MAC_STEPS: StepId[] = ["sign-in", "telemetry", "usage-intent", "permissions"];
 
 type Props = {
   account: AccountStatus;
@@ -66,6 +73,7 @@ function browserOnboardingDemoStep(): StepId | null {
   const step = new URLSearchParams(window.location.search).get("juneDemoStep");
   return step === "sign-in" ||
     step === "telemetry" ||
+    step === "usage-intent" ||
     step === "permissions" ||
     step === "dictation-practice"
     ? step
@@ -184,6 +192,8 @@ export function OnboardingFlow({ account, onAccountChanged, onComplete }: Props)
           <SignInStep account={account} onAccountChanged={onAccountChanged} onContinue={goNext} />
         ) : stepId === "telemetry" ? (
           <TelemetryConsentStep onContinue={goNext} />
+        ) : stepId === "usage-intent" ? (
+          <UsageIntentStep onContinue={goNext} />
         ) : stepId === "permissions" ? (
           <PermissionsStep
             statuses={permissionStatuses}

--- a/src/components/onboarding/steps/UsageIntentStep.tsx
+++ b/src/components/onboarding/steps/UsageIntentStep.tsx
@@ -1,0 +1,91 @@
+import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
+import { useId, useState } from "react";
+import {
+  onboardingCustomUseCase,
+  onboardingUseCases,
+  saveOnboardingCustomUseCase,
+  saveOnboardingUseCases,
+  type OnboardingUseCase,
+} from "../../../lib/onboarding";
+import { p3aRecord } from "../../../lib/tauri";
+import { StepActions, StepCard } from "../StepChrome";
+
+const USE_CASE_OPTIONS: ReadonlyArray<{
+  id: OnboardingUseCase;
+  label: string;
+  p3aQuestionId: string;
+}> = [
+  { id: "work", label: "Work", p3aQuestionId: "onboarding.use-case.work" },
+  { id: "personal", label: "Personal", p3aQuestionId: "onboarding.use-case.personal" },
+  { id: "school", label: "School", p3aQuestionId: "onboarding.use-case.school" },
+  { id: "creative", label: "Creative projects", p3aQuestionId: "onboarding.use-case.creative" },
+  { id: "coding", label: "Coding", p3aQuestionId: "onboarding.use-case.coding" },
+  { id: "meetings", label: "Meetings", p3aQuestionId: "onboarding.use-case.meetings" },
+  { id: "other", label: "Other", p3aQuestionId: "onboarding.use-case.other" },
+  { id: "not-sure", label: "Not sure yet", p3aQuestionId: "onboarding.use-case.not-sure" },
+];
+
+export function UsageIntentStep({ onContinue }: { onContinue: () => void }) {
+  const otherInputId = useId();
+  const [selected, setSelected] = useState<ReadonlySet<OnboardingUseCase>>(
+    () => new Set(onboardingUseCases()),
+  );
+  const [customUseCase, setCustomUseCase] = useState(() => onboardingCustomUseCase());
+  const otherSelected = selected.has("other");
+  const continueDisabled = selected.size === 0 || (otherSelected && customUseCase.trim() === "");
+
+  function toggle(useCase: OnboardingUseCase) {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (next.has(useCase)) next.delete(useCase);
+      else next.add(useCase);
+      return next;
+    });
+  }
+
+  function continueWithSelection() {
+    const selectedOptions = USE_CASE_OPTIONS.filter(({ id }) => selected.has(id));
+    saveOnboardingUseCases(selectedOptions.map(({ id }) => id));
+    saveOnboardingCustomUseCase(otherSelected ? customUseCase : "");
+    void Promise.allSettled(selectedOptions.map(({ p3aQuestionId }) => p3aRecord(p3aQuestionId)));
+    onContinue();
+  }
+
+  return (
+    <StepCard title="What are you interested in using June for?" subtitle="Pick all that fit." wide>
+      <fieldset className="onboarding-intent-grid" aria-label="June interests">
+        {USE_CASE_OPTIONS.map(({ id, label }) => {
+          const active = selected.has(id);
+          return (
+            <button
+              key={id}
+              type="button"
+              className="onboarding-intent-option"
+              aria-pressed={active}
+              onClick={() => toggle(id)}
+            >
+              <span className="onboarding-intent-check" aria-hidden>
+                {active ? <IconCheckmark1Small size={15} /> : null}
+              </span>
+              <span>{label}</span>
+            </button>
+          );
+        })}
+      </fieldset>
+      {otherSelected ? (
+        <label className="onboarding-intent-other" htmlFor={otherInputId}>
+          <span>What else?</span>
+          <input
+            id={otherInputId}
+            type="text"
+            value={customUseCase}
+            onChange={(event) => setCustomUseCase(event.currentTarget.value)}
+            placeholder="Type your own use case"
+            maxLength={120}
+          />
+        </label>
+      ) : null}
+      <StepActions onContinue={continueWithSelection} continueDisabled={continueDisabled} />
+    </StepCard>
+  );
+}

--- a/src/components/onboarding/steps/UsageIntentStep.tsx
+++ b/src/components/onboarding/steps/UsageIntentStep.tsx
@@ -1,4 +1,4 @@
-import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
+import { IconCheckmark2Small } from "central-icons/IconCheckmark2Small";
 import { useId, useState } from "react";
 import {
   onboardingCustomUseCase,
@@ -65,7 +65,7 @@ export function UsageIntentStep({ onContinue }: { onContinue: () => void }) {
               onClick={() => toggle(id)}
             >
               <span className="onboarding-intent-check" aria-hidden>
-                {active ? <IconCheckmark1Small size={15} /> : null}
+                {active ? <IconCheckmark2Small size={14} /> : null}
               </span>
               <span>{label}</span>
             </button>

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -10,9 +10,25 @@ const ONBOARDING_VERSION = 8;
 const COMPLETED_KEY = "june.onboarding.completedVersion";
 const RESUME_KEY = "june.onboarding.resumeStep";
 const AGENT_ACK_KEY = "june.agent.riskAcknowledged";
+const USE_CASES_KEY = "june.onboarding.useCases";
+const CUSTOM_USE_CASE_KEY = "june.onboarding.customUseCase";
 const ONBOARDING_BROADCAST_CHANNEL = "june.onboarding";
 
 export const ONBOARDING_COMPLETED_EVENT = "june:onboarding-completed";
+export const ONBOARDING_USE_CASES = [
+  "work",
+  "personal",
+  "school",
+  "creative",
+  "coding",
+  "meetings",
+  "other",
+  "not-sure",
+] as const;
+
+export type OnboardingUseCase = (typeof ONBOARDING_USE_CASES)[number];
+
+const ONBOARDING_USE_CASE_SET = new Set<string>(ONBOARDING_USE_CASES);
 
 type OnboardingReplayEnv = {
   readonly DEV?: boolean;
@@ -127,6 +143,62 @@ export function setOnboardingResumeStep(stepId: string) {
   } catch {
     // Ignore; worst case the wizard restarts from the top.
   }
+}
+
+export function onboardingUseCases(): OnboardingUseCase[] {
+  try {
+    const raw = window.localStorage.getItem(USE_CASES_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const deduped = new Set(
+      parsed.filter((value): value is OnboardingUseCase => {
+        return typeof value === "string" && ONBOARDING_USE_CASE_SET.has(value);
+      }),
+    );
+    return ONBOARDING_USE_CASES.filter((useCase) => deduped.has(useCase));
+  } catch {
+    return [];
+  }
+}
+
+export function saveOnboardingUseCases(useCases: readonly OnboardingUseCase[]) {
+  try {
+    const deduped = new Set(
+      useCases.filter((value): value is OnboardingUseCase => {
+        return ONBOARDING_USE_CASE_SET.has(value);
+      }),
+    );
+    const ordered = ONBOARDING_USE_CASES.filter((useCase) => deduped.has(useCase));
+    window.localStorage.setItem(USE_CASES_KEY, JSON.stringify(ordered));
+  } catch {
+    // Ignore; this is product metadata, not a completion gate.
+  }
+}
+
+export function onboardingCustomUseCase(): string {
+  try {
+    return sanitizeCustomUseCase(window.localStorage.getItem(CUSTOM_USE_CASE_KEY) ?? "");
+  } catch {
+    return "";
+  }
+}
+
+export function saveOnboardingCustomUseCase(customUseCase: string) {
+  try {
+    const sanitized = sanitizeCustomUseCase(customUseCase);
+    if (sanitized) {
+      window.localStorage.setItem(CUSTOM_USE_CASE_KEY, sanitized);
+    } else {
+      window.localStorage.removeItem(CUSTOM_USE_CASE_KEY);
+    }
+  } catch {
+    // Ignore; this is product metadata, not a completion gate.
+  }
+}
+
+function sanitizeCustomUseCase(customUseCase: string): string {
+  return customUseCase.trim().replace(/\s+/g, " ").slice(0, 120);
 }
 
 /**

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -20433,6 +20433,113 @@ input:focus-visible,
   color: var(--foreground);
 }
 
+.onboarding-intent-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--sp-2);
+  min-inline-size: 0;
+  margin: var(--sp-2) 0 0;
+  padding: 0;
+  border: 0;
+}
+
+.onboarding-intent-option {
+  display: flex;
+  min-width: 0;
+  min-height: var(--control-xl);
+  align-items: center;
+  gap: var(--sp-3);
+  padding: 0 var(--sp-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-lg);
+  background: var(--card);
+  color: var(--foreground);
+  font: inherit;
+  font-size: var(--fs-md);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--t-fast) var(--ease-out),
+    background-color var(--t-fast) var(--ease-out),
+    box-shadow var(--t-fast) var(--ease-out),
+    transform var(--t-fast) var(--ease-out);
+}
+
+.onboarding-intent-option:nth-last-child(1):nth-child(odd) {
+  grid-column: 1 / -1;
+}
+
+.onboarding-intent-option:hover {
+  border-color: color-mix(in oklch, var(--brand) 24%, var(--border));
+  background: color-mix(in oklch, var(--warm-soft) 20%, var(--card));
+}
+
+.onboarding-intent-option:active {
+  transform: translateY(1px);
+}
+
+.onboarding-intent-option:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.onboarding-intent-option[aria-pressed="true"] {
+  border-color: color-mix(in oklch, var(--warm-strong) 34%, var(--border));
+  background: color-mix(in oklch, var(--warm-soft) 34%, var(--card));
+}
+
+.onboarding-intent-option span:last-child {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.onboarding-intent-check {
+  flex: 0 0 auto;
+  display: inline-grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  color: var(--warm-strong);
+}
+
+.onboarding-intent-option[aria-pressed="true"] .onboarding-intent-check {
+  border-color: color-mix(in oklch, var(--warm-strong) 36%, transparent);
+  background: color-mix(in oklch, var(--warm-soft) 42%, var(--card));
+}
+
+.onboarding-intent-other {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  margin-block-start: var(--sp-3);
+  color: var(--foreground);
+  font-size: var(--fs-sm);
+}
+
+.onboarding-intent-other input {
+  height: var(--control-xl);
+  min-width: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  background: var(--card);
+  color: var(--foreground);
+  font: inherit;
+  font-size: var(--fs-md);
+  padding: 0 var(--sp-3);
+}
+
+.onboarding-intent-other input::placeholder {
+  color: var(--muted-foreground);
+}
+
+.onboarding-intent-other input:focus {
+  outline: none;
+  border-color: color-mix(in oklch, var(--brand) 30%, var(--border));
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
 /* Permissions: one bordered card, one row per permission — icon chip, a
  * line of copy, the grant affordance. A granted row trades its icon for a
  * check and tints terracotta. */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -20458,24 +20458,21 @@ input:focus-visible,
   font-size: var(--fs-md);
   text-align: left;
   cursor: pointer;
+  /* Hover/selection carry on the fill only; the border is static chrome and
+   * never transitions (see docs/design/conventions.md). */
   transition:
-    border-color var(--t-fast) var(--ease-out),
     background-color var(--t-fast) var(--ease-out),
-    box-shadow var(--t-fast) var(--ease-out),
-    transform var(--t-fast) var(--ease-out);
+    box-shadow var(--t-fast) var(--ease-out);
 }
 
 .onboarding-intent-option:nth-last-child(1):nth-child(odd) {
   grid-column: 1 / -1;
 }
 
+/* Warm-soft wash, matching the onboarding surface's own hover idiom
+ * (.onboarding-back:hover). Background only — the border stays put. */
 .onboarding-intent-option:hover {
-  border-color: color-mix(in oklch, var(--brand) 24%, var(--border));
   background: color-mix(in oklch, var(--warm-soft) 20%, var(--card));
-}
-
-.onboarding-intent-option:active {
-  transform: translateY(1px);
 }
 
 .onboarding-intent-option:focus-visible {
@@ -20488,25 +20485,35 @@ input:focus-visible,
   background: color-mix(in oklch, var(--warm-soft) 34%, var(--card));
 }
 
+/* Selected + hover deepens rather than lightens, so the ramp reads
+ * card -> hover -> selected -> selected-hover. */
+.onboarding-intent-option[aria-pressed="true"]:hover {
+  background: color-mix(in oklch, var(--warm-soft) 44%, var(--card));
+}
+
 .onboarding-intent-option span:last-child {
   min-width: 0;
   overflow-wrap: anywhere;
 }
 
+/* A rounded-square checkbox (multiple can be picked), mirroring the
+ * canonical .folder-note-select-box: unchecked outline, filled on select. */
 .onboarding-intent-check {
   flex: 0 0 auto;
   display: inline-grid;
   place-items: center;
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
   border: 1px solid var(--border);
-  border-radius: 50%;
-  color: var(--warm-strong);
+  border-radius: var(--r-xs);
+  background: var(--card);
+  color: var(--on-solid);
+  transition: background-color var(--t-fast) var(--ease-out);
 }
 
 .onboarding-intent-option[aria-pressed="true"] .onboarding-intent-check {
-  border-color: color-mix(in oklch, var(--warm-strong) 36%, transparent);
-  background: color-mix(in oklch, var(--warm-soft) 42%, var(--card));
+  border-color: var(--warm-strong);
+  background: var(--warm-strong);
 }
 
 .onboarding-intent-other {
@@ -20521,22 +20528,30 @@ input:focus-visible,
 .onboarding-intent-other input {
   height: var(--control-xl);
   min-width: 0;
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--border);
   border-radius: var(--r-md);
   background: var(--card);
   color: var(--foreground);
   font: inherit;
   font-size: var(--fs-md);
   padding: 0 var(--sp-3);
+  outline: 0;
+  transition:
+    border-color var(--t-fast) var(--ease-out),
+    box-shadow var(--t-fast) var(--ease-out);
 }
 
 .onboarding-intent-other input::placeholder {
   color: var(--muted-foreground);
 }
 
-.onboarding-intent-other input:focus {
-  outline: none;
-  border-color: color-mix(in oklch, var(--brand) 30%, var(--border));
+.onboarding-intent-other input:hover {
+  border-color: var(--ring);
+}
+
+.onboarding-intent-other input:focus,
+.onboarding-intent-other input:focus-visible {
+  border-color: var(--ring-focus);
   box-shadow: 0 0 0 3px var(--focus-ring);
 }
 

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -8,6 +8,8 @@ import {
   isOnboardingComplete,
   markOnboardingComplete,
   ONBOARDING_COMPLETED_EVENT,
+  onboardingCustomUseCase,
+  onboardingUseCases,
   onboardingResumeStep,
   resetOnboardingForReplay,
   setOnboardingResumeStep,
@@ -183,6 +185,11 @@ describe("OnboardingFlow", () => {
     render(<OnboardingFlow {...flowProps({ onComplete })} />);
     await screen.findByRole("heading", { name: "Share anonymous usage statistics?" });
     await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+    await screen.findByRole("heading", {
+      name: "What are you interested in using June for?",
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Work" }));
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
     await screen.findByRole("heading", { name: "Let June listen and type" });
     return onComplete;
   }
@@ -243,6 +250,7 @@ describe("OnboardingFlow", () => {
 
     expect(onComplete).toHaveBeenCalledOnce();
     expect(mocks.p3aRecord).toHaveBeenCalledWith("onboarding.completed");
+    expect(mocks.p3aRecord).toHaveBeenCalledWith("onboarding.use-case.work");
     // Completion is the caller's job (App marks it), not the flow's.
     expect(isOnboardingComplete()).toBe(false);
   });
@@ -263,7 +271,9 @@ describe("OnboardingFlow", () => {
     await userEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     expect(mocks.setP3aEnabled).toHaveBeenCalledWith(false);
-    await screen.findByRole("heading", { name: "Let June listen and type" });
+    await screen.findByRole("heading", {
+      name: "What are you interested in using June for?",
+    });
   });
 
   it("saves anonymous usage statistics consent when selected", async () => {
@@ -275,6 +285,56 @@ describe("OnboardingFlow", () => {
     await user.click(screen.getByRole("button", { name: "Continue" }));
 
     expect(mocks.setP3aEnabled).toHaveBeenCalledWith(true);
+    await screen.findByRole("heading", {
+      name: "What are you interested in using June for?",
+    });
+  });
+
+  it("asks what the user wants to use June for", async () => {
+    const user = userEvent.setup();
+    setOnboardingResumeStep("usage-intent");
+    render(<OnboardingFlow {...flowProps()} />);
+
+    await screen.findByRole("heading", {
+      name: "What are you interested in using June for?",
+    });
+    const continueButton = screen.getByRole("button", { name: "Continue" });
+    expect(continueButton).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Work" }));
+    await user.click(screen.getByRole("button", { name: "Personal" }));
+    expect(continueButton).toBeEnabled();
+
+    await user.click(continueButton);
+
+    expect(onboardingUseCases()).toEqual(["work", "personal"]);
+    expect(mocks.p3aRecord).toHaveBeenCalledWith("onboarding.use-case.work");
+    expect(mocks.p3aRecord).toHaveBeenCalledWith("onboarding.use-case.personal");
+    await screen.findByRole("heading", { name: "Let June listen and type" });
+  });
+
+  it("saves a custom onboarding use case locally", async () => {
+    const user = userEvent.setup();
+    setOnboardingResumeStep("usage-intent");
+    render(<OnboardingFlow {...flowProps()} />);
+
+    await screen.findByRole("heading", {
+      name: "What are you interested in using June for?",
+    });
+    const continueButton = screen.getByRole("button", { name: "Continue" });
+
+    await user.click(screen.getByRole("button", { name: "Other" }));
+    expect(continueButton).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText("Type your own use case"), "  family admin  ");
+    expect(continueButton).toBeEnabled();
+
+    await user.click(continueButton);
+
+    expect(onboardingUseCases()).toEqual(["other"]);
+    expect(onboardingCustomUseCase()).toBe("family admin");
+    expect(mocks.p3aRecord).toHaveBeenCalledWith("onboarding.use-case.other");
+    expect(mocks.p3aRecord.mock.calls.flat()).not.toContain("family admin");
     await screen.findByRole("heading", { name: "Let June listen and type" });
   });
 
@@ -441,13 +501,17 @@ describe("OnboardingFlow", () => {
     const user = userEvent.setup();
     const onAccountChanged = vi.fn();
     mocks.osAccountsLogin.mockResolvedValue(account);
-    render(<OnboardingFlow {...flowProps({ account: signedOutAccount, onAccountChanged })} />);
+    const { rerender } = render(
+      <OnboardingFlow {...flowProps({ account: signedOutAccount, onAccountChanged })} />,
+    );
 
     await screen.findByRole("heading", { name: "Welcome to June" });
     await user.click(screen.getByRole("button", { name: "Continue with OpenSoftware" }));
 
     expect(mocks.osAccountsLogin).toHaveBeenCalledOnce();
     await waitFor(() => expect(onAccountChanged).toHaveBeenCalledWith(account));
+    rerender(<OnboardingFlow {...flowProps({ account, onAccountChanged })} />);
+    await screen.findByRole("heading", { name: "Share anonymous usage statistics?" });
   });
 
   it("opens the June community from the welcome step", async () => {
@@ -493,6 +557,11 @@ describe("OnboardingFlow", () => {
     const user = userEvent.setup();
     render(<OnboardingFlow {...flowProps({ account: unsubscribedAccount })} />);
     await screen.findByRole("heading", { name: "Share anonymous usage statistics?" });
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await screen.findByRole("heading", {
+      name: "What are you interested in using June for?",
+    });
+    await user.click(screen.getByRole("button", { name: "Work" }));
     await user.click(screen.getByRole("button", { name: "Continue" }));
     await screen.findByRole("heading", { name: "Let June listen and type" });
 


### PR DESCRIPTION
## Summary
- Add a usage-intent onboarding step after telemetry consent for Work, Personal, School, Creative projects, Coding, Meetings, Other, and Not sure yet.
- Persist selected intents locally under `june.onboarding.useCases` with normalized ordering and restore them on replay.
- Let users enter a custom local-only use case when they choose Other, stored under `june.onboarding.customUseCase`.
- Record one coarse P3A question per selected onboarding interest through the existing opt-in telemetry gate. The custom Other text is not sent to telemetry.
- Add the onboarding interest questions to the Rust P3A catalog plus public telemetry docs/PRD, and update the dev onboarding preview telemetry stub.

https://github.com/user-attachments/assets/9d1df17a-aa55-4b94-802a-fa3d69a36e74


## Why
New users should be asked what they are interested in using June for before the permissions and practice steps, and opted-in users should contribute coarse onboarding intent telemetry without sending free-form text.

## Validation
- `pnpm test src/test/onboarding.test.tsx`
- `pnpm run typecheck`
- `pnpm exec biome check src/lib/onboarding.ts src/components/onboarding/OnboardingFlow.tsx src/components/onboarding/steps/UsageIntentStep.tsx src/test/onboarding.test.tsx`
- `cargo test --manifest-path src-tauri/Cargo.toml p3a::questions --locked`
- `git diff --check`

## Live QA
- PASS: Playwright with local Chrome against `http://127.0.0.1:1422/onboarding-preview.html?step=usage-intent&theme=light` before the P3A rebase.
- Verified Continue starts disabled, Work + Personal selections enable Continue, `june.onboarding.useCases` persists as `["work","personal"]`, and the flow advances to permissions with no console or page errors.
- The local Tauri dev app is running from this branch with `--replay-onboarding` for manual testing.
- Local artifacts: `.tmp/qa-recordings/page@123129dc40edf9a16682a25bba9afe34.compressed.mp4`, `.tmp/qa-recordings/onboarding-use-case-selected.png`.

## Backend deploy
- No June API deploy needed. This uses the desktop P3A catalog and existing P3A report endpoint.

## Gaps
- Did not rerun native Tauri permission prompt QA in this PR update. This change is onboarding UI plus P3A event wiring, and the Rust command gates persistence on telemetry opt-in.
- Public QA video upload was blocked because `OS_PLATFORM_API_KEY`/`JUNE__ISSUE_REPORTS__OS_PLATFORM_API_KEY` is not set locally.
