### PR TITLE
Polish telemetry consent wording and Settings placement

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -7,7 +7,7 @@ inference through June API.
 ## Optional usage statistics
 
 June can ask for opt-in anonymous usage statistics during onboarding and in
-Settings > Privacy. The default is off.
+Settings > General > Privacy. The default is off.
 
 When enabled in this release, June stores the choice and local counters on the
 device. It does not send telemetry reports yet. Future reporting is limited to

--- a/onboarding-preview.html
+++ b/onboarding-preview.html
@@ -140,6 +140,10 @@
             }
           : { signedIn: false, configured: true };
 
+        // Anonymous usage statistics consent, flipped by the telemetry step
+        // and the Settings > General > Privacy toggle.
+        let p3aSettings = { enabled: false, consentVersion: 1, consentedAtWeek: null };
+
         window.__JUNE_STUB__ = {
           emitEvent,
           signOut() {
@@ -148,6 +152,15 @@
           },
         };
 
+        // @tauri-apps/api >= 2.11 tears listeners down through this separate
+        // global; without it every unlisten throws in the browser preview.
+        window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+          unregisterListener(event, id) {
+            const set = listeners.get(event);
+            if (set) set.delete(id);
+            callbacks.delete(id);
+          },
+        };
         window.__TAURI_INTERNALS__ = {
           transformCallback(cb) {
             const id = nextId++;
@@ -306,6 +319,19 @@
                 }
                 return null;
               }
+              case "p3a_settings":
+                return { settings: p3aSettings };
+              case "set_p3a_enabled": {
+                const enabled = Boolean(args.request && args.request.enabled);
+                p3aSettings = {
+                  enabled,
+                  consentVersion: 1,
+                  consentedAtWeek: enabled ? "2026-W28" : null,
+                };
+                return { settings: p3aSettings };
+              }
+              case "p3a_record":
+                return null;
               default:
                 return null;
             }

--- a/src/components/onboarding/steps/TelemetryConsentStep.tsx
+++ b/src/components/onboarding/steps/TelemetryConsentStep.tsx
@@ -25,8 +25,8 @@ export function TelemetryConsentStep({ onContinue }: { onContinue: () => void })
 
   return (
     <StepCard
-      title="Share anonymous usage statistics?"
-      subtitle="This is optional and off by default."
+      title="Help improve June"
+      subtitle="Optional and off by default. Change it anytime in Settings."
       wide
       className="onboarding-card-privacy"
     >
@@ -34,8 +34,8 @@ export function TelemetryConsentStep({ onContinue }: { onContinue: () => void })
         <div className="onboarding-privacy-copy">
           <h2>Share anonymous usage statistics</h2>
           <p>
-            Never your recordings, notes, or written content. Only anonymous counts that help us
-            understand feature usage.
+            Anonymous counts of feature usage, like how many dictation sessions happen in a week.
+            Never your recordings, notes, or anything you write, and nothing that can identify you.
           </p>
           <a href={TELEMETRY_INFO_URL} target="_blank" rel="noreferrer">
             Learn how it works

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1341,8 +1341,6 @@ export function AppSettings({
               onRefresh={onAccountRefresh}
             />
 
-            <PrivacySettingsSection />
-
             <section className="settings-group" aria-labelledby="appearance-heading">
               <h2 id="appearance-heading" className="settings-group-heading">
                 Appearance
@@ -1409,6 +1407,8 @@ export function AppSettings({
               onEnableAccessibility={onEnableAccessibility}
               onEnableSystemAudio={onEnableSystemAudio}
             />
+
+            <PrivacySettingsSection />
           </>
         ) : null}
 

--- a/src/components/settings/PrivacySettingsSection.tsx
+++ b/src/components/settings/PrivacySettingsSection.tsx
@@ -38,7 +38,7 @@ export function PrivacySettingsSection() {
       setStatus(
         enabled
           ? "Anonymous usage statistics are on for this device."
-          : "Anonymous usage statistics are off and local counters were deleted.",
+          : "Anonymous usage statistics are off. Usage data stored on this device was deleted.",
       );
     } catch {
       setStatus("Could not update usage statistics. Try again.");
@@ -48,12 +48,12 @@ export function PrivacySettingsSection() {
   }
 
   return (
-    <section className="settings-group" aria-labelledby="general-usage-statistics-heading">
-      <h2 id="general-usage-statistics-heading" className="settings-group-heading">
-        Anonymous usage statistics
+    <section className="settings-group" aria-labelledby="general-privacy-heading">
+      <h2 id="general-privacy-heading" className="settings-group-heading">
+        Privacy
       </h2>
       <p className="settings-group-description">
-        Opt in to anonymous product usage counts that help prioritize June work.
+        Choose whether June shares anonymous usage statistics with Open Software. Off by default.
       </p>
       <div className="settings-card">
         <div className="settings-rows">
@@ -61,8 +61,8 @@ export function PrivacySettingsSection() {
             <div className="settings-row-info">
               <h3 className="settings-row-title">Share anonymous usage statistics</h3>
               <p className="settings-row-description">
-                Never your recordings, notes, or written content. Only anonymous counts that help us
-                understand feature usage.{" "}
+                Anonymous counts of feature usage, like how many dictation sessions happen in a
+                week. Never your recordings, notes, or anything you write.{" "}
                 <a
                   className="settings-inline-link"
                   href={TELEMETRY_INFO_URL}

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -574,7 +574,13 @@ describe("AppSettings", () => {
     );
 
     await screen.findByRole("heading", { name: "General" });
-    expect(screen.getByText(/Only anonymous counts that help us understand/)).toBeInTheDocument();
+    // Privacy is the last group in General, below system permissions.
+    const permissionsHeading = screen.getByRole("heading", { name: "System permissions" });
+    const privacyHeading = screen.getByRole("heading", { name: "Privacy" });
+    expect(
+      permissionsHeading.compareDocumentPosition(privacyHeading) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(screen.getByText(/Anonymous counts of feature usage/)).toBeInTheDocument();
     expect(screen.queryByText("How usage statistics work")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Learn how it works" })).toHaveAttribute(
       "href",

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -181,7 +181,7 @@ describe("OnboardingFlow", () => {
 
   async function renderFlow(onComplete = vi.fn()) {
     render(<OnboardingFlow {...flowProps({ onComplete })} />);
-    await screen.findByRole("heading", { name: "Share anonymous usage statistics?" });
+    await screen.findByRole("heading", { name: "Help improve June" });
     await userEvent.click(screen.getByRole("button", { name: "Continue" }));
     await screen.findByRole("heading", { name: "Let June listen and type" });
     return onComplete;
@@ -250,7 +250,7 @@ describe("OnboardingFlow", () => {
   it("keeps anonymous usage statistics off by default", async () => {
     render(<OnboardingFlow {...flowProps()} />);
 
-    await screen.findByRole("heading", { name: "Share anonymous usage statistics?" });
+    await screen.findByRole("heading", { name: "Help improve June" });
     expect(screen.queryByText("See exactly what is shared")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Learn how it works" })).toHaveAttribute(
       "href",
@@ -270,7 +270,7 @@ describe("OnboardingFlow", () => {
     const user = userEvent.setup();
     render(<OnboardingFlow {...flowProps()} />);
 
-    await screen.findByRole("heading", { name: "Share anonymous usage statistics?" });
+    await screen.findByRole("heading", { name: "Help improve June" });
     await user.click(screen.getByRole("switch", { name: "Share anonymous usage statistics" }));
     await user.click(screen.getByRole("button", { name: "Continue" }));
 
@@ -492,7 +492,7 @@ describe("OnboardingFlow", () => {
   it("does not ask unsubscribed users for a card during onboarding", async () => {
     const user = userEvent.setup();
     render(<OnboardingFlow {...flowProps({ account: unsubscribedAccount })} />);
-    await screen.findByRole("heading", { name: "Share anonymous usage statistics?" });
+    await screen.findByRole("heading", { name: "Help improve June" });
     await user.click(screen.getByRole("button", { name: "Continue" }));
     await screen.findByRole("heading", { name: "Let June listen and type" });
 


### PR DESCRIPTION
Closes JUN-228 (follow-up to #655).

## What changed
- **Onboarding step**: retitled "Share anonymous usage statistics?" to "Help improve June" so the title stops repeating the toggle label beneath it, and matches the short human voice of the neighboring steps ("Talk to June", "Let June listen and type"). Subtitle now says the choice can be changed later in Settings. Body copy is concrete about what gets counted ("like how many dictation sessions happen in a week") instead of abstract.
- **Settings placement**: the Privacy group moves from between Account and Appearance to the end of Settings > General, below System permissions, where privacy-adjacent controls read together. The group is renamed "Privacy" (it previously duplicated its own row title) with a clearer description.
- **Status copy**: the opt-out confirmation drops the "local counters" jargon: "Anonymous usage statistics are off. Usage data stored on this device was deleted."
- **PRIVACY.md**: points at the real location (Settings > General > Privacy).
- **Onboarding preview**: the browser preview bridge now stubs the P3A commands, so the wizard's telemetry step works there again (Continue previously failed on a null response), and defines `__TAURI_EVENT_PLUGIN_INTERNALS__` so listener teardown stops throwing in the preview.

The toggle label "Share anonymous usage statistics" is unchanged; the PRD pins it as the consent control wording.

## Why
JUN-228 flagged the #655 surfaces as needing polish: the wording was stiff and self-repeating, and a telemetry opt-in sat above everyday appearance settings in General.

## Validation
- `pnpm exec vitest run src/test/onboarding.test.tsx src/test/app-settings.test.tsx` (86 tests pass; added a DOM-order assertion that Privacy renders after System permissions)
- `pnpm typecheck`, `pnpm build`, `pnpm exec biome check` on touched files
- Live browser walkthrough (Playwright against the Vite preview with the fake Tauri bridge): onboarding telemetry step renders the new copy, toggles, and saves through Continue; Settings > General shows Account | Appearance | System permissions | Privacy with working on/off status lines. QA video comment to follow.

## Gaps
- Native Tauri run not exercised; the change is React copy/ordering only, covered by the component walkthrough and unit tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786128609&installation_id=144203540&pr_number=668&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F668&signature=9a90456284e52545b65b116208d34c198dd2b5754dea996e605b2f4f6c00b807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->