### PR TITLE
Add toast notifications (sonner) and migrate above-chat notices

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "framer-motion": "^12.40.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "sonner": "^2.0.7",
     "three": "^0.185.1",
     "three-stdlib": "^2.36.1",
     "unicode-animations": "^1.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       three:
         specifier: ^0.185.1
         version: 0.185.1
@@ -1992,6 +1995,12 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4115,6 +4124,11 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  sonner@2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   source-map-js@1.2.1: {}
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -50,6 +50,7 @@ import { IconZap } from "central-icons/IconZap";
 import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconSettingsGear4 } from "central-icons/IconSettingsGear4";
 import { Dialog } from "../components/ui/Dialog";
+import { Toaster } from "../components/ui/Toaster";
 import {
   assignNoteToFolder,
   assignSessionToFolder,
@@ -517,6 +518,21 @@ export function App() {
       cancelled = true;
       updateCardDemoRef.current?.dispose();
       updateCardDemoRef.current = null;
+    };
+  }, []);
+  // Dev console driver (window.__toastDemo) that fires each toast variant so
+  // the toast styling can be inspected without walking a real flow.
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    let cancelled = false;
+    let dispose: (() => void) | undefined;
+    void import("../lib/toast-demo").then(({ registerToastDemo }) => {
+      if (cancelled) return;
+      ({ dispose } = registerToastDemo());
+    });
+    return () => {
+      cancelled = true;
+      dispose?.();
     };
   }, []);
   // Sessions with a finishRecording call in flight; guards stop double-clicks.
@@ -3694,6 +3710,9 @@ export function App() {
         confirmLabel={MAX_UPGRADE_CONFIRM_LABEL}
         confirmBusyLabel={MAX_UPGRADE_BUSY_LABEL}
       />
+      {/* Global toast host. Mounted once beside the dialogs; sonner portals its
+          own list to document.body, so placement in the tree is immaterial. */}
+      <Toaster />
     </main>
   );
 }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -3577,6 +3577,15 @@ export function AgentWorkspace({
     restoreComposerDraft(composerDraftKey);
   }, [activePanel, composerDraftKey]);
 
+  // The busy toast's advice ("wait for the reply") goes stale the moment the
+  // selected session stops working — including when the user switches to an
+  // idle session — so dismiss it then rather than leaving it up for the full
+  // toast duration. Dismissing an absent toast is a no-op.
+  useEffect(() => {
+    if (selectedHermesSessionId && workingSessionIds.has(selectedHermesSessionId)) return;
+    toast.dismiss(SESSION_BUSY_TOAST_ID);
+  }, [selectedHermesSessionId, workingSessionIds]);
+
   async function prepareComposerSubmission(
     message: string,
     messageAttachments: AgentAttachment[],

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -80,6 +80,7 @@ import { EmptyState } from "../ui/EmptyState";
 import { HoverTip } from "../ui/HoverTip";
 import { InlineNotice } from "../ui/InlineNotice";
 import { SegmentedControl } from "../ui/SegmentedControl";
+import { toast } from "../ui/Toaster";
 import { Spinner } from "../ui/Spinner";
 import { Switch } from "../ui/Switch";
 import {
@@ -352,6 +353,17 @@ const GATEWAY_CONNECTION_ERROR = /hermes (gateway|bridge)/i;
 const SESSION_GONE_MESSAGE = "This session has ended, so the request can no longer be answered.";
 const SESSION_NOT_AVAILABLE_MESSAGE =
   "This session is no longer available. Open another conversation or start a new one.";
+
+// A stable id for the "June is still working" nudge (fired when a send is
+// rejected mid-turn), so repeated send attempts refresh one toast instead of
+// stacking.
+const SESSION_BUSY_TOAST_ID = "agent-session-busy";
+
+// Stable ids so the fork lifecycle (creating → branched) rides one
+// self-replacing toast, and repeat report deliveries reuse a single "sent"
+// confirmation rather than stacking.
+const BRANCH_TOAST_ID = "agent-branch";
+const ISSUE_REPORT_SENT_TOAST_ID = "agent-issue-report-sent";
 
 function isSessionGoneError(message: string): boolean {
   return message.toLowerCase().includes("session not found");
@@ -813,11 +825,6 @@ type AgentWorkspaceError = {
 type AgentWorkspaceErrorOptions = {
   sessionId?: string | null;
   issueReport?: PendingIssueReport;
-};
-
-type AgentWorkspaceNotice = {
-  message: string;
-  sessionId: string | null;
 };
 
 type ImageSafeModeConsentChoice =
@@ -1768,13 +1775,14 @@ export function AgentWorkspace({
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [errorState, setErrorState] = useState<AgentWorkspaceError | null>(null);
-  // A rejected send into a still-running session, explained by the composer.
-  // Separate from `errorState` because background session refreshes clear that
-  // banner on success — this notice must survive until the turn finishes.
-  const [busyNotice, setBusyNotice] = useState<string | null>(null);
-  // Confirmation that a submitted issue report reached the June team; shown
-  // in the composer notice slot until dismissed by the next send.
-  const [issueReportNotice, setIssueReportNotice] = useState<AgentWorkspaceNotice | null>(null);
+  // The model-switch notice (feature 10) is keyed to the session it acted on so
+  // it survives background refreshes and disappears when the user moves to
+  // another conversation. A null sessionId means it reports a default-only
+  // change shown on the hero.
+  const [modelSwitchNotice, setModelSwitchNotice] = useState<{
+    message: string;
+    sessionId: string | null;
+  } | null>(null);
   const [submittingErrorIssueReport, setSubmittingErrorIssueReport] = useState(false);
   const [composerSizeWarning, setComposerSizeWarning] = useState<ComposerInputSizeWarning | null>(
     null,
@@ -1784,24 +1792,9 @@ export function AgentWorkspace({
   const imageSafeModeConsentRequestRef = useRef<ImageSafeModeConsentRequest | null>(null);
   const composerSizeProceedSignatureRef = useRef<string | null>(null);
   const composerSizeProceedInputSignatureRef = useRef<string | null>(null);
-  // Honest result of the last model switch (feature 10): scoped to the session
-  // it acted on so it survives background refreshes and disappears when the
-  // user moves to another conversation. A null sessionId means it reports a
-  // default-only change shown on the hero.
-  const [modelSwitchNotice, setModelSwitchNotice] = useState<{
-    message: string;
-    sessionId: string | null;
-  } | null>(null);
-  // Feature 07: after a successful fork, the banner that tells the user the
-  // freshly-opened session was branched from another. Keyed by the NEW
-  // session's id so it shows only while that session is selected, then clears
-  // itself once they navigate away.
-  const [branchedNotice, setBranchedNotice] = useState<{
-    sessionId: string;
-    sourceTitle: string;
-  } | null>(null);
-  const branchedNoticeRef = useRef(branchedNotice);
-  const [branchingNotice, setBranchingNotice] = useState<{ sourceTitle: string } | null>(null);
+  // Feature 07: the fork lifecycle (creating → branched) is surfaced as a
+  // toast — a loading toast while the branch is created, resolving into a
+  // "Branched from …" confirmation. See branchFromMessage.
   // Which message a branch is currently in flight for, so its action shows a
   // disabled/working state and double-clicks can't fork twice.
   const [branchingMessageId, setBranchingMessageId] = useState<string | null>(null);
@@ -2601,10 +2594,6 @@ export function AgentWorkspace({
   const visibleErrorRetryable =
     visibleError != null &&
     (GATEWAY_CONNECTION_ERROR.test(visibleError) || visibleError === HERMES_SERVER_ERROR_MESSAGE);
-  const visibleIssueReportNotice =
-    issueReportNotice && issueReportNotice.sessionId === (selectedHermesSessionId ?? null)
-      ? issueReportNotice.message
-      : null;
   // The model-switch notice (feature 10) shows on the session it acted on; a
   // null sessionId is the default-only notice, shown while no session is open.
   const visibleModelSwitchNotice =
@@ -3607,15 +3596,6 @@ export function AgentWorkspace({
     restoreComposerDraft(composerDraftKey);
   }, [activePanel, composerDraftKey]);
 
-  // The busy notice's advice ("wait for the reply") expires the moment the
-  // selected session stops working — including when the user switches to a
-  // session that isn't running.
-  useEffect(() => {
-    if (!busyNotice) return;
-    if (selectedHermesSessionId && workingSessionIds.has(selectedHermesSessionId)) return;
-    setBusyNotice(null);
-  }, [busyNotice, selectedHermesSessionId, workingSessionIds]);
-
   async function prepareComposerSubmission(
     message: string,
     messageAttachments: AgentAttachment[],
@@ -4279,7 +4259,6 @@ export function AgentWorkspace({
             submittingIssueReportSessionIdsRef.current.has(reportFollowUpSessionId),
         };
       }
-      setIssueReportNotice(null);
       await submitHermesSession(runtimeContent, undefined, {
         displayContent: prepared.displayContent,
         titleContent: prepared.titleContent,
@@ -4290,7 +4269,7 @@ export function AgentWorkspace({
         deferredFailedIssueReportDeliverySessionIdsRef.current.delete(reportFollowUpSessionId);
       }
       setError(null);
-      setBusyNotice(null);
+      toast.dismiss(SESSION_BUSY_TOAST_ID);
     } catch (err) {
       // Restore the composer so a failed send doesn't eat the message, its
       // category chip, or its attachments — but only where the user hasn't
@@ -4334,9 +4313,9 @@ export function AgentWorkspace({
       }
       if (isSessionBusyError(err)) {
         // A busy rejection is proof the gateway is healthy — retire any stale
-        // connection banner along with showing the notice.
+        // connection banner along with showing the nudge.
         setError(null);
-        setBusyNotice(SESSION_BUSY_NOTICE);
+        toast(SESSION_BUSY_NOTICE, { id: SESSION_BUSY_TOAST_ID });
       } else {
         setError(messageFromError(err));
       }
@@ -4546,16 +4525,6 @@ export function AgentWorkspace({
     }
   }
 
-  // A success notice about one report reads fine anywhere, but not stale on
-  // a conversation the user opened later.
-  useEffect(() => {
-    setIssueReportNotice(null);
-  }, [selectedHermesSessionId]);
-
-  useEffect(() => {
-    branchedNoticeRef.current = branchedNotice;
-  }, [branchedNotice]);
-
   /** Sends the captured report plus June's diagnostic reply (the last
    * assistant message of the turn) to the June team. The diagnosis fetch is
    * best-effort: a report without June's assessment still beats no report. */
@@ -4586,12 +4555,7 @@ export function AgentWorkspace({
         sessionId,
       });
       clearErrorForSession(sessionId);
-      if (selectedHermesSessionIdRef.current === sessionId) {
-        setIssueReportNotice({
-          message: ISSUE_REPORT_SENT_MESSAGE,
-          sessionId,
-        });
-      }
+      toast.success(ISSUE_REPORT_SENT_MESSAGE, { id: ISSUE_REPORT_SENT_TOAST_ID });
       return { sent: true };
     } catch (err) {
       const errorMessage = `The issue report could not be sent. ${messageFromError(err)}`;
@@ -4640,19 +4604,10 @@ export function AgentWorkspace({
       });
       if (sessionId) {
         clearErrorForSession(sessionId);
-        if (selectedHermesSessionIdRef.current === sessionId) {
-          setIssueReportNotice({
-            message: ISSUE_REPORT_SENT_MESSAGE,
-            sessionId,
-          });
-        }
       } else {
         setError(null);
-        setIssueReportNotice({
-          message: ISSUE_REPORT_SENT_MESSAGE,
-          sessionId: null,
-        });
       }
+      toast.success(ISSUE_REPORT_SENT_MESSAGE, { id: ISSUE_REPORT_SENT_TOAST_ID });
     } catch (err) {
       setError(`The issue report could not be sent. ${messageFromError(err)}`, {
         sessionId: sessionId ?? null,
@@ -6067,7 +6022,14 @@ export function AgentWorkspace({
     const sourceTitle =
       hermesSessionItems.find((session) => session.id === sessionId || session.id === modeSessionId)
         ?.title ?? "this session";
-    setBranchingNotice({ sourceTitle });
+    // The fork lifecycle rides one self-replacing toast: a loading toast while
+    // the branch is created, upgraded in place to the "Branched from …"
+    // confirmation on success, or dismissed if the branch fails (the failure
+    // surfaces on the error banner instead).
+    const branchToastId = toast.loading(`Creating branch from ${sourceTitle}`, {
+      id: BRANCH_TOAST_ID,
+    });
+    let branched = false;
     const unrestricted = sessionUnrestricted(modeSessionId);
     try {
       const gateway = await ensureHermesGateway(unrestricted);
@@ -6235,9 +6197,8 @@ export function AgentWorkspace({
       selectedHermesSessionIdRef.current = result.sessionId;
       setSelectedHermesSessionId(result.sessionId);
       setActivePanel("chat");
-      const nextBranchedNotice = { sessionId: result.sessionId, sourceTitle };
-      branchedNoticeRef.current = nextBranchedNotice;
-      setBranchedNotice(nextBranchedNotice);
+      branched = true;
+      toast.success(`Branched from ${sourceTitle}`, { id: branchToastId });
       composerEditorRef.current?.setContent(branchComposerText, null);
       setError(null);
       await loadHermesSessions({ suppressSessionGoneError: true });
@@ -6257,7 +6218,9 @@ export function AgentWorkspace({
     } finally {
       branchingMessageIdRef.current = null;
       setBranchingMessageId(null);
-      setBranchingNotice(null);
+      // A failed or aborted branch never resolves the loading toast; drop it so
+      // the error banner is the only surface. Success already upgraded it.
+      if (!branched) toast.dismiss(branchToastId);
     }
   }
 
@@ -6459,7 +6422,6 @@ export function AgentWorkspace({
     setReportDialogAttachments([]);
     setReportDialogCategory(categoryToOpen);
     setReportDialogOpen(true);
-    setIssueReportNotice(null);
   }
 
   /** Drops appends from imports that were still in flight when the report
@@ -7438,9 +7400,10 @@ export function AgentWorkspace({
           <AgentScrollToLatestButton scrollRef={agentScrollRef} onJump={scrollTranscriptToLatest} />
         )}
         <AnimatePresence>
-          {busyNotice || galleryErrors ? (
-            // Same fade as the recording-consent note, so the pill dissolves
-            // when the turn finishes instead of vanishing.
+          {galleryErrors ? (
+            // Dev gallery only: the busy nudge is a toast in real use (see
+            // SESSION_BUSY_TOAST_ID); this renders the old inline pill so
+            // __agentErrors can still screenshot that surface.
             <motion.p
               key="busy-notice"
               className="agent-composer-notice"
@@ -7451,7 +7414,7 @@ export function AgentWorkspace({
               transition={{ duration: 0.22, ease: "easeOut" }}
             >
               <DotSpinner />
-              {busyNotice ?? SESSION_BUSY_NOTICE}
+              {SESSION_BUSY_NOTICE}
             </motion.p>
           ) : visibleIssueReportReview ? (
             <motion.div
@@ -7490,18 +7453,6 @@ export function AgentWorkspace({
                       : "Send report"}
               </button>
             </motion.div>
-          ) : visibleIssueReportNotice ? (
-            <motion.p
-              key="issue-report-notice"
-              className="agent-composer-notice"
-              role="status"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.22, ease: "easeOut" }}
-            >
-              {visibleIssueReportNotice}
-            </motion.p>
           ) : visibleModelSwitchNotice ? (
             <motion.p
               key="model-switch-notice"
@@ -8363,15 +8314,6 @@ export function AgentWorkspace({
                   reportBugSubmitting={submittingErrorIssueReport}
                   onDismiss={() => setError(null)}
                 />
-              ) : null}
-              {branchedNotice && branchedNotice.sessionId === selectedHermesSessionId ? (
-                <AgentBranchedBanner
-                  sourceTitle={branchedNotice.sourceTitle}
-                  onDismiss={() => setBranchedNotice(null)}
-                />
-              ) : null}
-              {branchingNotice ? (
-                <AgentBranchingBanner sourceTitle={branchingNotice.sourceTitle} />
               ) : null}
               {detailContent}
               {composer}
@@ -10399,36 +10341,6 @@ function AgentErrorBanner({
           <IconCrossMedium size={14} />
         </button>
       </div>
-    </div>
-  );
-}
-
-// Feature 07: confirms the freshly-opened session was forked from another, so
-// the user understands why they're suddenly in a new (but pre-populated)
-// thread. role="status" (not "alert") — this is reassurance, not an error.
-function AgentBranchedBanner({
-  sourceTitle,
-  onDismiss,
-}: {
-  sourceTitle: string;
-  onDismiss: () => void;
-}) {
-  return (
-    <div className="agent-branched-banner" role="status">
-      <IconBranchSimple size={14} aria-hidden />
-      <p>Branched from {sourceTitle}</p>
-      <button type="button" aria-label="Dismiss" onClick={onDismiss}>
-        <IconCrossMedium size={14} />
-      </button>
-    </div>
-  );
-}
-
-function AgentBranchingBanner({ sourceTitle }: { sourceTitle: string }) {
-  return (
-    <div className="agent-branching-banner" role="status" aria-live="polite">
-      <DotSpinner className="agent-branching-banner-spinner" />
-      <p>Creating branch from {sourceTitle}</p>
     </div>
   );
 }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -359,6 +359,11 @@ const SESSION_NOT_AVAILABLE_MESSAGE =
 // stacking.
 const SESSION_BUSY_TOAST_ID = "agent-session-busy";
 
+// A stable id for the model control's notices (default-model changed,
+// model-locked on an existing session, off-device confirm), so they replace one
+// another in a single toast rather than stacking.
+const MODEL_SWITCH_TOAST_ID = "agent-model-switch";
+
 // Stable ids so the fork lifecycle (creating → branched) rides one
 // self-replacing toast, and repeat report deliveries reuse a single "sent"
 // confirmation rather than stacking.
@@ -1775,14 +1780,6 @@ export function AgentWorkspace({
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [errorState, setErrorState] = useState<AgentWorkspaceError | null>(null);
-  // The model-switch notice (feature 10) is keyed to the session it acted on so
-  // it survives background refreshes and disappears when the user moves to
-  // another conversation. A null sessionId means it reports a default-only
-  // change shown on the hero.
-  const [modelSwitchNotice, setModelSwitchNotice] = useState<{
-    message: string;
-    sessionId: string | null;
-  } | null>(null);
   const [submittingErrorIssueReport, setSubmittingErrorIssueReport] = useState(false);
   const [composerSizeWarning, setComposerSizeWarning] = useState<ComposerInputSizeWarning | null>(
     null,
@@ -2594,12 +2591,6 @@ export function AgentWorkspace({
   const visibleErrorRetryable =
     visibleError != null &&
     (GATEWAY_CONNECTION_ERROR.test(visibleError) || visibleError === HERMES_SERVER_ERROR_MESSAGE);
-  // The model-switch notice (feature 10) shows on the session it acted on; a
-  // null sessionId is the default-only notice, shown while no session is open.
-  const visibleModelSwitchNotice =
-    modelSwitchNotice && modelSwitchNotice.sessionId === (selectedHermesSessionId ?? null)
-      ? modelSwitchNotice.message
-      : null;
   // Unsupported Hermes events for the selected session surface a generic,
   // recoverable notice (and sanitized dev details). Subscribing to the store's
   // version re-derives the notice whenever a new unsupported frame lands.
@@ -3075,10 +3066,7 @@ export function AgentWorkspace({
 
   function showComposerModelLockedNotice() {
     setComposerModelOpen(false);
-    setModelSwitchNotice({
-      message: MODEL_CHANGE_LOCKED_NOTICE,
-      sessionId: selectedHermesSessionIdRef.current ?? null,
-    });
+    toast(MODEL_CHANGE_LOCKED_NOTICE, { id: MODEL_SWITCH_TOAST_ID });
   }
 
   // Stale catalog (the mount fetch can fail while the bridge is starting) is
@@ -3115,11 +3103,10 @@ export function AgentWorkspace({
     if (!isLoopbackUrl(baseUrl)) {
       if (localEnableConfirmArmedForRef.current !== baseUrl) {
         localEnableConfirmArmedForRef.current = baseUrl;
-        setModelSwitchNotice({
-          message:
-            "This endpoint is not on this machine. Requests will leave your device. Select the local model again to confirm.",
-          sessionId: null,
-        });
+        toast.warning(
+          "This endpoint is not on this machine. Requests will leave your device. Select the local model again to confirm.",
+          { id: MODEL_SWITCH_TOAST_ID },
+        );
         return false;
       }
       localEnableConfirmArmedForRef.current = null;
@@ -3139,10 +3126,7 @@ export function AgentWorkspace({
       setError(messageFromError(err));
       return false;
     }
-    setModelSwitchNotice({
-      message: MODEL_SWITCH_DEFAULT_ONLY_NOTICE,
-      sessionId: null,
-    });
+    toast(MODEL_SWITCH_DEFAULT_ONLY_NOTICE, { id: MODEL_SWITCH_TOAST_ID });
     return true;
   }
 
@@ -3182,10 +3166,7 @@ export function AgentWorkspace({
       setError(messageFromError(err));
       return false;
     }
-    setModelSwitchNotice({
-      message: MODEL_SWITCH_DEFAULT_ONLY_NOTICE,
-      sessionId: null,
-    });
+    toast(MODEL_SWITCH_DEFAULT_ONLY_NOTICE, { id: MODEL_SWITCH_TOAST_ID });
     return true;
   }
 
@@ -7453,18 +7434,6 @@ export function AgentWorkspace({
                       : "Send report"}
               </button>
             </motion.div>
-          ) : visibleModelSwitchNotice ? (
-            <motion.p
-              key="model-switch-notice"
-              className="agent-composer-notice"
-              role="status"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.22, ease: "easeOut" }}
-            >
-              {visibleModelSwitchNotice}
-            </motion.p>
           ) : null}
         </AnimatePresence>
         <div ref={composerBoxRef} className="agent-composer-box">

--- a/src/components/ui/Toaster.tsx
+++ b/src/components/ui/Toaster.tsx
@@ -1,0 +1,78 @@
+import { IconCheckCircle2 } from "central-icons-filled/IconCheckCircle2";
+import { IconCircleInfo } from "central-icons-filled/IconCircleInfo";
+import { IconExclamationCircle } from "central-icons-filled/IconExclamationCircle";
+import { IconExclamationTriangle } from "central-icons-filled/IconExclamationTriangle";
+import { IconCrossSmall } from "central-icons/IconCrossSmall";
+import { Toaster as SonnerToaster } from "sonner";
+import { DotSpinner } from "../DotSpinner";
+
+// The June-styled wrapper around sonner's toaster. Sonner ships as an unstyled
+// primitive here (toastOptions.unstyled) — every visual comes from the
+// `.june-toast*` rules in styles/app.css, so toasts inherit the design tokens
+// and follow all five theme presets plus dark mode automatically. The tone
+// icons are the filled central-icons-filled set (never sonner's bundled
+// Lucide-style set); the close glyph stays outline and the loading glyph is
+// June's own dot spinner.
+//
+// `toast` is re-exported straight from sonner so callers fire notifications the
+// familiar way: `toast("Saved")`, `toast.success(...)`, `toast.error(...)`,
+// `toast.info(...)`, `toast.warning(...)`, `toast.loading(...)`, or
+// `toast(message, { action: { label, onClick } })`.
+export { toast } from "sonner";
+
+/** The tones June styles. Mirrors the subset of sonner's toast types we use. */
+export type ToastTone = "default" | "success" | "error" | "info" | "warning" | "loading";
+
+const TONE_ICON_SIZE = 16;
+
+/**
+ * Mount this once in the app shell. Toasts render into a portal at
+ * document.body, anchored to the top-right corner of the content panel so they
+ * read as messages tucked into the upper-right of the workspace.
+ */
+export function Toaster() {
+  return (
+    <SonnerToaster
+      position="top-right"
+      containerAriaLabel="June notifications"
+      // Clear the custom titlebar and use the same top/right inset from the
+      // workspace corner.
+      offset={{ top: "calc(var(--titlebar-h) + var(--sp-6))", right: "var(--sp-6)" }}
+      gap={8}
+      // Slightly calmer than sonner's 4s default without lingering. Loading
+      // toasts still persist until resolved or dismissed.
+      duration={5000}
+      closeButton
+      // Decorative glyphs — the toast text carries the meaning for assistive
+      // tech, and sonner marks the toast itself with the right role/aria-live.
+      icons={{
+        success: <IconCheckCircle2 size={TONE_ICON_SIZE} ariaHidden />,
+        error: <IconExclamationCircle size={TONE_ICON_SIZE} ariaHidden />,
+        warning: <IconExclamationTriangle size={TONE_ICON_SIZE} ariaHidden />,
+        info: <IconCircleInfo size={TONE_ICON_SIZE} ariaHidden />,
+        loading: <DotSpinner />,
+        close: <IconCrossSmall size={16} ariaHidden />,
+      }}
+      toastOptions={{
+        unstyled: true,
+        classNames: {
+          toast: "june-toast",
+          content: "june-toast-content",
+          title: "june-toast-title",
+          description: "june-toast-description",
+          icon: "june-toast-icon",
+          loader: "june-toast-loader",
+          actionButton: "btn btn-secondary june-toast-action",
+          cancelButton: "btn btn-secondary june-toast-cancel",
+          closeButton: "icon-button june-toast-close",
+          default: "june-toast--default",
+          success: "june-toast--success",
+          error: "june-toast--error",
+          info: "june-toast--info",
+          warning: "june-toast--warning",
+          loading: "june-toast--loading",
+        },
+      }}
+    />
+  );
+}

--- a/src/lib/toast-demo.ts
+++ b/src/lib/toast-demo.ts
@@ -1,0 +1,101 @@
+// Dev-only console driver for the toast suite (components/ui/Toaster.tsx):
+//
+//   window.__toastDemo()          fire one of every variant, staggered
+//   window.__toastDemo("success") fire just the success toast
+//   window.__toastDemo("error")   ...error / "destructive"
+//   window.__toastDemo("info")    ...info / default
+//   window.__toastDemo("warning") ...warning (caution)
+//   window.__toastDemo("loading") ...a loading toast that resolves after 2s
+//   window.__toastDemo("action")  ...a toast with an action button
+//   window.__toastDemo("clear")   dismiss everything on screen
+//
+// It only calls the real `toast` helper, so Andrew can jam on the toast styling
+// (in the app or the browser sandbox) without walking a real model switch or
+// any other flow. Mirrors the other dev drivers (processing-progress-demo.ts,
+// global-recorder-demo.ts). Never bundled in production: App gates the dynamic
+// import on import.meta.env.DEV.
+
+import { toast } from "../components/ui/Toaster";
+
+export type ToastDemoApi = {
+  /** Remove the window hook. */
+  dispose: () => void;
+};
+
+type ToastDemoVariant =
+  | "default"
+  | "info"
+  | "success"
+  | "error"
+  | "warning"
+  | "loading"
+  | "action"
+  | "all"
+  | "clear";
+
+function fireVariant(variant: Exclude<ToastDemoVariant, "all" | "clear">): void {
+  switch (variant) {
+    case "default":
+      toast("Draft saved to this note.");
+      return;
+    case "info":
+      toast.info("Default model updated. It applies to new sessions.");
+      return;
+    case "success":
+      toast.success("Switched this session to Kimi K2.6.");
+      return;
+    case "error":
+      toast.error(
+        "Could not switch the running session. This chat will use the new model next time.",
+      );
+      return;
+    case "warning":
+      toast.warning(
+        "This endpoint is not on this machine. Requests will leave your device. Select the local model again to confirm.",
+      );
+      return;
+    case "loading": {
+      const id = toast.loading("Connecting to the local endpoint...");
+      window.setTimeout(() => {
+        toast.success("Connected to the local endpoint.", { id });
+      }, 2000);
+      return;
+    }
+    case "action":
+      toast("June found a newer note for this meeting.", {
+        action: {
+          label: "Open note",
+          onClick: () => toast.success("Opened the newer note."),
+        },
+      });
+      return;
+  }
+}
+
+/** Registers window.__toastDemo. Dev-only; call dispose() to remove the hook. */
+export function registerToastDemo(): ToastDemoApi {
+  const run = (variant: ToastDemoVariant = "all") => {
+    if (variant === "clear") {
+      toast.dismiss();
+      return;
+    }
+    if (variant !== "all") {
+      fireVariant(variant);
+      return;
+    }
+    // Stagger the full suite so each toast stacks in rather than landing at
+    // once, which is how a real burst of notifications would arrive.
+    const order = ["default", "info", "success", "warning", "error", "loading", "action"] as const;
+    order.forEach((variant, index) => {
+      window.setTimeout(() => fireVariant(variant), index * 350);
+    });
+  };
+
+  (window as unknown as { __toastDemo?: typeof run }).__toastDemo = run;
+
+  return {
+    dispose() {
+      (window as unknown as { __toastDemo?: typeof run }).__toastDemo = undefined;
+    },
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4605,9 +4605,155 @@ input:focus-visible,
   flex-shrink: 0;
 }
 
-/* No per-state / collapsed overrides or left transition needed: the single
- * max(--sidebar-w-current, --sp-3) rule above already tracks the card edge in
- * every state, and animating that one variable tweens it in lockstep. */
+/* Toast notifications (sonner) ---------------------------------------------
+ * Sonner is mounted unstyled (toastOptions.unstyled) and rendered into a
+ * portal at document.body, tucked into the workspace's top-right corner. Every
+ * visual comes from these tokens, so toasts follow all five theme presets and
+ * dark mode automatically. The surface mirrors a popover: --popover fill,
+ * hairline --popover-border, and the soft ambient --shadow-md (a lighter lift
+ * than --shadow-lg — a floating notice, not a raised card). Only the tone icon
+ * is tinted; the surface stays neutral so the whole toast family reads as one
+ * calm system. */
+.june-toast {
+  /* Height model: the row is center-aligned, so every child — tone icon, text,
+   * action, close — sits on one optical line and a single-line toast reads
+   * perfectly centered. Height is driven by the tallest child (the controls)
+   * plus symmetric padding; no per-element margin nudging. */
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  width: 100%;
+  padding: var(--sp-3) var(--sp-3) var(--sp-3) var(--sp-4);
+  border: 1px solid var(--popover-border);
+  border-radius: var(--r-lg);
+  background: var(--popover);
+  color: var(--popover-foreground);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+  font-synthesis: none;
+  font-size: var(--fs-md);
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.35;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+.june-toast:focus-visible {
+  box-shadow:
+    var(--shadow-md),
+    0 0 0 2px var(--focus-ring);
+}
+
+/* Leading tone glyph, vertically centered against the message. */
+.june-toast-icon {
+  order: 0;
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted-foreground);
+}
+
+.june-toast-content {
+  order: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  min-width: 0;
+  flex: 1;
+}
+
+.june-toast-title {
+  font-size: var(--fs-md);
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.35;
+  /* Quieter than body copy: notifications are transient status, not document
+   * text. */
+  color: color-mix(in oklch, var(--foreground) 74%, var(--muted-foreground));
+}
+
+/* Stacked (collapsed) toasts: sonner squashes the back toasts to the front
+ * toast's height, but only fades their content when running styled — its
+ * fade rule is gated on [data-styled='true'], which unstyled mode disables.
+ * Replicate it here so squashed back toasts never show overflowing text. */
+.june-toast[data-expanded="false"][data-front="false"] {
+  overflow: hidden;
+}
+
+.june-toast[data-expanded="false"][data-front="false"] > * {
+  opacity: 0;
+}
+
+.june-toast-description {
+  font-size: var(--fs-sm);
+  color: var(--muted-foreground);
+  line-height: 1.5;
+}
+
+/* Tone accents: the leading glyph only. */
+.june-toast--success .june-toast-icon {
+  color: var(--success);
+}
+
+.june-toast--error .june-toast-icon {
+  color: var(--destructive);
+}
+
+.june-toast--warning .june-toast-icon {
+  color: var(--warm-strong);
+}
+
+.june-toast--info .june-toast-icon {
+  color: var(--brand);
+}
+
+/* The dot spinner already carries its own size and currentColor. */
+.june-toast--loading .june-toast-icon {
+  color: var(--muted-foreground);
+}
+
+/* Actions use the existing grey .btn-secondary family, sized down to a compact
+ * control for the toast. */
+.june-toast .june-toast-action,
+.june-toast .june-toast-cancel {
+  flex-shrink: 0;
+  height: var(--control-sm);
+  padding: 0 var(--sp-3);
+  font-family: inherit;
+  font-size: var(--fs-md);
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
+.june-toast .june-toast-action {
+  order: 3;
+}
+
+.june-toast .june-toast-cancel {
+  order: 2;
+}
+
+/* Sonner renders the close button first. Order it to the far right and let
+ * .icon-button provide the squircle hit target, matched to the action button's
+ * height so the pair reads as a set; keep it quiet at rest. */
+.june-toast .june-toast-close {
+  order: 4;
+  position: static;
+  flex-shrink: 0;
+  width: var(--control-sm);
+  height: var(--control-sm);
+  transform: none;
+  margin-left: calc(var(--sp-1) * -1);
+  color: var(--muted-foreground);
+  letter-spacing: 0;
+}
+
+.june-toast .june-toast-close:hover {
+  color: var(--foreground);
+}
 
 .agent-composer[data-drop-active="true"] {
   background: color-mix(in srgb, var(--accent) 8%, transparent);
@@ -10045,58 +10191,8 @@ input:focus-visible,
   margin-top: var(--sp-5);
 }
 
-/* Feature 07: the calm "Branched from <title>" confirmation. Neutral-toned
- * (this is reassurance, not an error) and laid out like the error banner so
- * the two read as a consistent family. */
-.agent-main > .agent-branched-banner,
-.agent-main > .agent-branching-banner {
-  margin-top: var(--sp-5);
-}
-
-.agent-branched-banner,
-.agent-branching-banner {
-  display: flex;
-  align-items: center;
-  gap: var(--sp-2);
-  padding: var(--sp-2) var(--sp-3);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--r-md);
-  background: var(--accent);
-  color: var(--foreground);
-  font-size: var(--fs-md);
-}
-
-.agent-branched-banner svg,
-.agent-branching-banner-spinner {
-  flex-shrink: 0;
-  color: var(--muted-foreground);
-}
-
-.agent-branched-banner p,
-.agent-branching-banner p {
-  margin: 0;
-  min-width: 0;
-  flex: 1;
-}
-
-.agent-branched-banner button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  height: 24px;
-  min-width: 24px;
-  padding: 0 var(--sp-2);
-  border: none;
-  border-radius: var(--r-sm);
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
-}
-
-.agent-branched-banner button:hover {
-  background: color-mix(in oklch, var(--foreground) 8%, transparent);
-}
+/* Feature 07: the fork lifecycle (creating → branched) is now surfaced as a
+ * toast, not an inline banner — see branchFromMessage in AgentWorkspace.tsx. */
 
 .agent-turn-action-spinner {
   color: var(--warm-strong);

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -9815,7 +9815,14 @@ describe("AgentWorkspace", () => {
       // …plus the forced chrome samples the turn gallery can't represent.
       expect(screen.getByText("Could not connect to Hermes gateway.")).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
-      expect(screen.getByText(/June is still working on the previous message/)).toBeInTheDocument();
+      // Scope to the gallery's inline composer pill: the busy notice now also
+      // fires as a toast (.june-toast), so an unscoped text query can also match
+      // a busy toast lingering from an earlier test.
+      expect(
+        screen.getByText(/June is still working on the previous message/, {
+          selector: ".agent-composer-notice",
+        }),
+      ).toBeInTheDocument();
     } finally {
       // Always reset the module-level desired state — a failure here must not
       // leave the gallery on and cascade into later workspace mounts.

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -511,7 +511,7 @@ describe("OnboardingFlow", () => {
     expect(mocks.osAccountsLogin).toHaveBeenCalledOnce();
     await waitFor(() => expect(onAccountChanged).toHaveBeenCalledWith(account));
     rerender(<OnboardingFlow {...flowProps({ account, onAccountChanged })} />);
-    await screen.findByRole("heading", { name: "Share anonymous usage statistics?" });
+    await screen.findByRole("heading", { name: "Help improve June" });
   });
 
   it("opens the June community from the welcome step", async () => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,7 +1,9 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import { MotionGlobalConfig } from "framer-motion";
+import { createElement } from "react";
 import { afterEach, beforeEach, vi } from "vitest";
+import { Toaster, toast } from "../components/ui/Toaster";
 import { markOnboardingComplete } from "../lib/onboarding";
 
 // Resolve framer-motion animations instantly. Without this the frameloop
@@ -100,9 +102,22 @@ function setNavigatorPlatform(platform: string, userAgent: string) {
 // Existing App tests exercise the signed-in main shell; pre-complete the
 // first-run onboarding so the wizard doesn't gate them. Onboarding tests
 // opt back in by clearing localStorage.
+//
+// The app mounts the toast host once in the App shell, but component tests
+// render surfaces (e.g. AgentWorkspace) without it. Mount a Toaster per test via
+// RTL's own render so the existing cleanup() tears it down between tests: sonner
+// portals toasts to document.body (so `screen` queries still find them), and
+// unmounting the Toaster removes that portal synchronously — no toast lingers
+// into the next test's queries. Surface-fired toasts also carry stable ids
+// (model switch, branch, issue-report sent, busy) so a re-fire updates one toast
+// in place rather than stacking a duplicate node.
 beforeEach(() => {
   setNavigatorPlatform("MacIntel", "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)");
   markOnboardingComplete();
+  render(createElement(Toaster));
 });
 
-afterEach(() => cleanup());
+afterEach(() => {
+  toast.dismiss();
+  cleanup();
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,7 +1,8 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup } from "@testing-library/react";
 import { MotionGlobalConfig } from "framer-motion";
 import { createElement } from "react";
+import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, vi } from "vitest";
 import { Toaster, toast } from "../components/ui/Toaster";
 import { markOnboardingComplete } from "../lib/onboarding";
@@ -102,21 +103,25 @@ function setNavigatorPlatform(platform: string, userAgent: string) {
 // Existing App tests exercise the signed-in main shell; pre-complete the
 // first-run onboarding so the wizard doesn't gate them. Onboarding tests
 // opt back in by clearing localStorage.
-//
-// The app mounts the toast host once in the App shell, but component tests
-// render surfaces (e.g. AgentWorkspace) without it. Mount a Toaster per test via
-// RTL's own render so the existing cleanup() tears it down between tests: sonner
-// portals toasts to document.body (so `screen` queries still find them), and
-// unmounting the Toaster removes that portal synchronously — no toast lingers
-// into the next test's queries. Surface-fired toasts also carry stable ids
-// (model switch, branch, issue-report sent, busy) so a re-fire updates one toast
-// in place rather than stacking a duplicate node.
 beforeEach(() => {
   setNavigatorPlatform("MacIntel", "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)");
   markOnboardingComplete();
-  render(createElement(Toaster));
 });
 
+// The app mounts the toast host once in the App shell, but component tests
+// render surfaces (e.g. AgentWorkspace) without it. Mount a single Toaster once,
+// into its own host outside React Testing Library's container so cleanup()
+// never unmounts it — any toast(...) a surface fires portals to document.body
+// where `screen` queries can still find it. Mounting once (not per test) keeps
+// zero per-test render churn, so timing-sensitive tests aren't perturbed.
+// Surface-fired toasts carry stable ids (model switch, branch, issue-report
+// sent, busy) so a toast re-fired in a later test updates the earlier one in
+// place rather than stacking a duplicate node.
+const toasterHost = document.createElement("div");
+document.body.appendChild(toasterHost);
+createRoot(toasterHost).render(createElement(Toaster));
+
+// Clear any toasts a test left behind so they never leak into the next one.
 afterEach(() => {
   toast.dismiss();
   cleanup();


### PR DESCRIPTION
## Summary

- Add a June-styled toast system built on `sonner` (mounted unstyled; every visual comes from design tokens, so toasts follow all five theme presets + dark mode). New `src/components/ui/Toaster.tsx` wrapper, mounted once in `App.tsx`; re-exports `toast` for callers.
- Surface: top-right, popover fill + hairline border, soft ambient `--shadow-md`, filled `central-icons-filled` tone glyphs, dot-spinner loader, system buttons only (`btn btn-secondary` for actions, `icon-button` for close). Single-line toasts are vertically centered; layout/height cleaned up.
- Migrate the transient "above chat" notices from inline banners to toasts:
  - **Branch lifecycle** — the "Creating branch…" spinner + "Branched from…" confirmation are now one self-replacing toast (loading → success, dismissed on failure so the error banner is the only surface).
  - **Issue-report sent** — now a success toast.
  - **Busy nudge** ("June is still working…") — now a toast.
  All migrated toasts use stable ids so re-fires update one toast rather than stacking.
- `src/lib/toast-demo.ts`: dev-only `__toastDemo()` console driver for jamming on styling.
- Dead inline-notice state/effects/components/CSS removed.

## Validation

- `pnpm typecheck` ✅, Biome ✅ (0 errors), full frontend suite ✅ (2184 passed, 0 failed).
- Toast styling/layout iterated on and verified in-browser via `__toastDemo()` (top-right placement, centered single-line, filled icons, `--shadow-md`, system buttons).
- `src/test/setup.ts`: mounts the `Toaster` per test via RTL `render` so `cleanup()` tears it (and its portaled toasts) down each test — fixes a cross-test leak that surfaced once these notices became toasts.

- [x] Tested visually where it matters (author-verified in-browser; no static screenshot).
- [ ] Needs a June API (backend) deploy before it works end to end. — **No**, desktop/frontend only.

## Out of scope

- **Model-switch is deliberately NOT a toast.** Running sessions are model-locked (per the model-lock change on main), and a toast for a default-only change felt heavy — so model-switch keeps its existing inline notice. (This branch had rebased over an older main; reconciled to keep main's model-lock behavior and drop the earlier model-switch→toast pilot.)
- Persistent contextual surfaces stay inline (they must remain visible): the error banner + retry, credits/context-overflow notices, composer image/size warnings, and the issue-report review action.

## Followups

- Remaining inline notices could be revisited later if any prove better as toasts; the persistent/actionable ones above are intentionally left as banners.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786139825&installation_id=144203540&pr_number=671&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F671&signature=87e24463be2719cb75618bf1ec2b91a661f58a3feef195c993d633cf9f094fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>


Uploading CleanShot 2026-07-08 at 15.21.40.mp4…



<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->