### PR TITLE
Redesign agent action cards: quiet cards, collapsed receipts, honest color

### DIFF
--- a/docs/design/taste.md
+++ b/docs/design/taste.md
@@ -41,6 +41,11 @@ for free.
   takes the wash.
 - **Earthy over electric.** The preset family (rose, clay, sage, ocean, plum)
   is dusty and warm; a new accent should feel like it belongs at that table.
+- **Semantic colors stay in the earthy chroma register.** Danger/success/
+  warning live near the palette's saturation (`--brand` ~0.13, `--success`
+  0.12), not above it. `--destructive` was dechromatized from 0.22 to a brick
+  0.15 because a neon red was the one element that fought the low-chroma
+  surfaces around it; keep new status colors in that band.
 
 ## Motion and feedback
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -10497,6 +10497,7 @@ function CollapsibleActionCard({
   title,
   description,
   headerMeta,
+  command,
   hasDetails,
   expanded,
   onToggleExpanded,
@@ -10509,14 +10510,19 @@ function CollapsibleActionCard({
   /** A short signal pinned to the header row that must stay visible while
    * collapsed (e.g. the sudo blast-radius mode tag). */
   headerMeta?: ReactNode;
-  /** Whether there is extra body content worth a "Details" disclosure (a
-   * command, or the sudo mode notice). When false, no disclosure is rendered. */
+  /** SECURITY: the concrete command being authorized. Rendered ALWAYS (never
+   * behind the disclosure) so the exact command is visible at the decision
+   * point — the Approve button is live while the card is collapsed, so a user
+   * must be able to see what they are approving without expanding anything. */
+  command?: ReactNode;
+  /** Whether there is supplementary body content worth a "Details" disclosure
+   * (e.g. the sudo mode notice). The command is NOT gated on this. */
   hasDetails: boolean;
   expanded: boolean;
   onToggleExpanded: () => void;
   /** The actions row (or the in-flight result line), always visible. */
   footer: ReactNode;
-  /** The full body revealed on expand. */
+  /** Supplementary body revealed on expand (never the command). */
   children: ReactNode;
 }) {
   return (
@@ -10529,9 +10535,16 @@ function CollapsibleActionCard({
         <span className="agent-action-card-title">{title}</span>
         {headerMeta}
       </div>
-      <p className="agent-action-card-description" data-clamped={!expanded || undefined}>
+      {/* Only clamp when a Details expander exists to reveal the rest; otherwise
+       * a long description-only request would be truncated with no way to read
+       * it before choosing. */}
+      <p
+        className="agent-action-card-description"
+        data-clamped={(hasDetails && !expanded) || undefined}
+      >
         {description}
       </p>
+      {command}
       {hasDetails ? (
         <button
           type="button"
@@ -10980,19 +10993,18 @@ export function ApprovalPart({
     <CollapsibleActionCard
       title="Approval required"
       description={part.description}
-      hasDetails={Boolean(part.command)}
+      command={part.command ? <pre>{part.command}</pre> : null}
+      // The command is always shown; the only expandable body is the optional
+      // explanation, which its own "Explain first" button toggles.
+      hasDetails={false}
       expanded={expanded}
       onToggleExpanded={() => {
         const next = !expanded;
         setExpanded(next);
-        // Collapsing the card unmounts the explanation body, so resync the
-        // "Explain first" toggle rather than leave it stuck on "Hide
-        // explanation" with nothing shown.
         if (!next) setExplainOpen(false);
       }}
       footer={footer}
     >
-      {part.command ? <pre>{part.command}</pre> : null}
       {explainOpen ? (
         <div className="agent-approval-explanation" id={explanationId}>
           {explainState === "loading" ? (
@@ -11285,12 +11297,14 @@ export function SudoPart({
       title="Privilege escalation requested"
       description={reason}
       headerMeta={modeBadge}
+      command={part.command ? <pre>{part.command}</pre> : null}
+      // Command is always visible; Details reveals the fuller mode notice (the
+      // blast-radius badge already shows collapsed).
       hasDetails={true}
       expanded={expanded}
       onToggleExpanded={() => setExpanded((value) => !value)}
       footer={footer}
     >
-      {part.command ? <pre>{part.command}</pre> : null}
       {modeNotice}
     </CollapsibleActionCard>
   );

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -11,7 +11,7 @@ import { IconBubble3 } from "central-icons/IconBubble3";
 import { IconBubbleWide } from "central-icons/IconBubbleWide";
 import { IconCheckmark1Medium } from "central-icons/IconCheckmark1Medium";
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
-import { IconCircleQuestionmark } from "central-icons/IconCircleQuestionmark";
+import { IconCheckmark2Small } from "central-icons/IconCheckmark2Small";
 import { IconClipboard } from "central-icons/IconClipboard";
 import { IconCrossMedium } from "central-icons/IconCrossMedium";
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
@@ -19,6 +19,7 @@ import { IconExclamationTriangle } from "central-icons/IconExclamationTriangle";
 import { IconFinder } from "central-icons/IconFinder";
 import { IconFolder1 } from "central-icons/IconFolder1";
 import { IconFolders } from "central-icons/IconFolders";
+import { IconLightBulbSimple } from "central-icons/IconLightBulbSimple";
 import { IconConsole } from "central-icons/IconConsole";
 import { IconShieldCheck } from "central-icons/IconShieldCheck";
 import { IconStopCircle } from "central-icons/IconStopCircle";
@@ -33,7 +34,6 @@ import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
 import { IconChevronLeftSmall } from "central-icons/IconChevronLeftSmall";
 import { IconChevronRightSmall } from "central-icons/IconChevronRightSmall";
 import { IconConsoleSimple } from "central-icons/IconConsoleSimple";
-import { IconWallet3 } from "central-icons/IconWallet3";
 import { IconDeepSearch } from "central-icons/IconDeepSearch";
 import { IconCheckCircle2 } from "central-icons/IconCheckCircle2";
 import { IconConcise } from "central-icons/IconConcise";
@@ -44,7 +44,6 @@ import { IconFileText } from "central-icons/IconFileText";
 import { IconEmail1Sparkle } from "central-icons/IconEmail1Sparkle";
 import { IconGauge } from "central-icons/IconGauge";
 import { IconHeartBeat } from "central-icons/IconHeartBeat";
-import { IconLock } from "central-icons/IconLock";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconNoteText } from "central-icons/IconNoteText";
@@ -61,6 +60,7 @@ import {
   type ClipboardEvent,
   type DragEvent,
   type FormEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
   type RefObject,
@@ -9753,6 +9753,7 @@ function AgentChatTurnRow({
     (part): part is Extract<AgentChatPart, { type: "context" }> => part.type === "context",
   );
   const nonTextParts = turn.parts.filter((part) => part.type !== "text");
+  const concreteResponse = turnIsConcreteResponse(turn);
   const copyText = copyableTextForTurn(turn);
 
   async function copyTurn() {
@@ -9830,7 +9831,7 @@ function AgentChatTurnRow({
     </HoverTip>
   ) : null;
   const turnActions =
-    copyAction || branchAction || timestampAction ? (
+    concreteResponse && (copyAction || branchAction || timestampAction) ? (
       <div className="agent-turn-actions" data-branching={branchSubmitting ? "true" : undefined}>
         <div className="agent-turn-actions-inner">
           {/* The timestamp sits on the outer/far side of the row: before the
@@ -9848,11 +9849,7 @@ function AgentChatTurnRow({
     return (
       <>
         {contextParts.map((part, index) => (
-          <ContextCompactionPart
-            key={`${turn.id}:context:${index}`}
-            createdAt={turn.createdAt}
-            part={part}
-          />
+          <ContextCompactionPart key={`${turn.id}:context:${index}`} part={part} />
         ))}
       </>
     );
@@ -9921,11 +9918,7 @@ function AgentChatTurnRow({
               </div>
             )
           ) : part.type === "context" ? (
-            <ContextCompactionPart
-              key={`${turn.id}:context:${index}`}
-              createdAt={turn.createdAt}
-              part={part}
-            />
+            <ContextCompactionPart key={`${turn.id}:context:${index}`} part={part} />
           ) : part.type === "approval" ? (
             <ApprovalPart
               key={`${turn.id}:approval:${part.id}`}
@@ -9965,11 +9958,7 @@ function AgentChatTurnRow({
               />
             )
           ) : part.type === "steering" ? (
-            <SteeringPart
-              key={`${turn.id}:steering:${index}`}
-              createdAt={turn.createdAt}
-              part={part}
-            />
+            <SteeringPart key={`${turn.id}:steering:${index}`} part={part} />
           ) : part.type === "image" ? (
             <AgentGeneratedImage
               key={`${turn.id}:image:${index}`}
@@ -10019,26 +10008,20 @@ function userPromptTextForTurn(turn: AgentChatTurn): string {
     .trim();
 }
 
-function ContextCompactionPart({
-  createdAt,
-  part,
-}: {
-  createdAt: string;
-  part: Extract<AgentChatPart, { type: "context" }>;
-}) {
+function ContextCompactionPart({ part }: { part: Extract<AgentChatPart, { type: "context" }> }) {
   return (
     <details className="agent-context-summary">
       <summary>
         {/* Same hover affordance as the tool rows: the glyph cross-fades to a
          * plain-text "+"/"−" so the row reads as one quiet, expandable line.
-         * IconConcise (thinned via CSS) marks the squeeze of compaction. */}
+         * IconConcise (thinned via CSS) marks the squeeze of compaction. No
+         * timestamp: this is a system marker, not a concrete message. */}
         <span className="agent-tool-icon">
           <IconConcise size={15} className="agent-context-icon-glyph" />
           <span className="agent-tool-icon-expand">+</span>
           <span className="agent-tool-icon-minimize">−</span>
         </span>
         <span className="agent-context-label">Context compacted</span>
-        <time>{relativeDate(createdAt)}</time>
       </summary>
       <MarkdownContent markdown={part.text} />
     </details>
@@ -10302,7 +10285,7 @@ function CreditsNoticePart({
       className="agent-credits-notice"
       tone="destructive"
       role="alert"
-      icon={<IconWallet3 size={14} aria-hidden />}
+      icon={<IconExclamationTriangle size={14} aria-hidden />}
       body="June stopped because your balance ran out."
       actions={
         onTopUp ? (
@@ -10337,13 +10320,7 @@ function ContextOverflowNoticePart() {
  * June toward mid-run, recorded quietly in the transcript so the conversation
  * shows what changed course. Mirrors {@link ContextCompactionPart}'s quiet,
  * timestamped system-row styling. */
-function SteeringPart({
-  createdAt,
-  part,
-}: {
-  createdAt: string;
-  part: Extract<AgentChatPart, { type: "steering" }>;
-}) {
+function SteeringPart({ part }: { part: Extract<AgentChatPart, { type: "steering" }> }) {
   return (
     <div className="agent-steering-item">
       <span className="agent-steering-icon" aria-hidden>
@@ -10351,7 +10328,6 @@ function SteeringPart({
       </span>
       <span className="agent-steering-label">Steering</span>
       <span className="agent-steering-text">{part.text}</span>
-      <time>{relativeDate(createdAt)}</time>
     </div>
   );
 }
@@ -10461,7 +10437,250 @@ function AgentGeneratedImage({
   );
 }
 
-function ClarifyPart({
+/** A resolved action card renders as a quiet, expandable one-line row instead
+ * of a full card — a receipt in the transcript rather than a prompt. The row
+ * mirrors {@link ContextCompactionPart}: an outcome glyph (checkmark / cross)
+ * that cross-fades to a plain-text "+"/"−" on hover (pure opacity — no layout
+ * shift, a WKWebView compositing constraint), a short outcome label, and a
+ * truncated one-line detail. Expanding reveals the full detail body (the
+ * `children`) minus the action buttons. */
+function ResolvedActionRow({
+  denied = false,
+  label,
+  detail,
+  children,
+}: {
+  /** Renders the cross glyph and destructive tint instead of the checkmark. */
+  denied?: boolean;
+  /** Short outcome word(s), e.g. "Approved once" / "Answered" / "Denied". */
+  label: string;
+  /** One-line truncated detail shown inline on the collapsed row. */
+  detail?: ReactNode;
+  /** The full detail body revealed on expand. */
+  children?: ReactNode;
+}) {
+  return (
+    <details
+      className="agent-tool-disclosure agent-resolved-row"
+      data-choice={denied ? "deny" : "done"}
+    >
+      <summary>
+        <span className="agent-tool-icon">
+          {denied ? (
+            <IconCrossSmall size={15} className="agent-tool-icon-glyph agent-resolved-icon-glyph" />
+          ) : (
+            <IconCheckmark2Small
+              size={15}
+              className="agent-tool-icon-glyph agent-resolved-icon-glyph"
+            />
+          )}
+          <span className="agent-tool-icon-expand">+</span>
+          <span className="agent-tool-icon-minimize">−</span>
+        </span>
+        <span className="agent-tool-name agent-resolved-label">{label}</span>
+        {detail !== undefined ? <span className="agent-resolved-detail">{detail}</span> : null}
+      </summary>
+      {children !== undefined ? <div className="agent-resolved-body">{children}</div> : null}
+    </details>
+  );
+}
+
+/** The condensed chrome shared by the pending approval and sudo cards. The
+ * header is a plain row (title + optional inline mode tag + waiting status) —
+ * not a toggle. Below it the prose `description` reads at all times, clamped to
+ * two lines while collapsed. When there is more to show (`hasDetails` — a
+ * command, or the sudo mode notice) a quiet "Details" disclosure sits under the
+ * description and reveals the full body (`children`: the full command `pre` and
+ * any extra detail). The actions row (`footer`) is always visible. Collapsed by
+ * default so a long command never dominates the card before a decision. */
+function CollapsibleActionCard({
+  title,
+  description,
+  headerMeta,
+  hasDetails,
+  expanded,
+  onToggleExpanded,
+  footer,
+  children,
+}: {
+  title: string;
+  /** The prose description (part.description / sudo reason), always visible. */
+  description: ReactNode;
+  /** A short signal pinned to the header row that must stay visible while
+   * collapsed (e.g. the sudo blast-radius mode tag). */
+  headerMeta?: ReactNode;
+  /** Whether there is extra body content worth a "Details" disclosure (a
+   * command, or the sudo mode notice). When false, no disclosure is rendered. */
+  hasDetails: boolean;
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  /** The actions row (or the in-flight result line), always visible. */
+  footer: ReactNode;
+  /** The full body revealed on expand. */
+  children: ReactNode;
+}) {
+  return (
+    <article
+      className="agent-approval-card agent-action-card"
+      data-status="pending"
+      data-expanded={expanded || undefined}
+    >
+      <div className="agent-action-card-header">
+        <span className="agent-action-card-title">{title}</span>
+        {headerMeta}
+      </div>
+      <p className="agent-action-card-description" data-clamped={!expanded || undefined}>
+        {description}
+      </p>
+      {hasDetails ? (
+        <button
+          type="button"
+          className="agent-action-card-details"
+          aria-expanded={expanded}
+          onClick={onToggleExpanded}
+        >
+          Details
+          <IconChevronDownSmall size={14} className="agent-disclosure-chevron" aria-hidden />
+        </button>
+      ) : null}
+      {expanded ? <div className="agent-action-card-body">{children}</div> : null}
+      {footer}
+    </article>
+  );
+}
+
+/** The approval footer's primary control: a split button. "Approve" approves
+ * "once"; the attached caret opens a small scope menu ("Approve once" /
+ * "Approve for this session" / "Always approve", the last hidden when
+ * `allowPermanent` is false). Dismisses on outside click or Escape and supports
+ * arrow-key navigation, mirroring the repo's other hand-rolled menus. */
+function ApproveSplitButton({
+  disabled,
+  allowPermanent,
+  onChoice,
+}: {
+  disabled: boolean;
+  allowPermanent?: boolean;
+  onChoice: (choice: AgentApprovalChoice) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const scopeRef = useRef<HTMLButtonElement | null>(null);
+
+  // Close on a click outside the split wrapper or on Escape.
+  useEffect(() => {
+    if (!open) return;
+    function onPointer(event: MouseEvent) {
+      if (wrapRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+        // Escape is a keyboard dismissal — return focus to the caret trigger so
+        // it doesn't drop to <body> when the focused menu item unmounts.
+        scopeRef.current?.focus();
+      }
+    }
+    window.addEventListener("mousedown", onPointer);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onPointer);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // Move focus into the menu when it opens so arrow keys land immediately.
+  useEffect(() => {
+    if (!open) return;
+    menuRef.current?.querySelector<HTMLButtonElement>('[role="menuitem"]')?.focus();
+  }, [open]);
+
+  const items: { choice: AgentApprovalChoice; label: string }[] = [
+    { choice: "once", label: "Approve once" },
+    { choice: "session", label: "Approve for this session" },
+    ...(allowPermanent
+      ? [{ choice: "always" as AgentApprovalChoice, label: "Always approve" }]
+      : []),
+  ];
+
+  function choose(choice: AgentApprovalChoice) {
+    setOpen(false);
+    onChoice(choice);
+  }
+
+  function onMenuKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
+    const buttons = Array.from(
+      menuRef.current?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') ?? [],
+    );
+    if (!buttons.length) return;
+    const current = buttons.indexOf(document.activeElement as HTMLButtonElement);
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      buttons[(current + 1 + buttons.length) % buttons.length]?.focus();
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      buttons[(current - 1 + buttons.length) % buttons.length]?.focus();
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      buttons[0]?.focus();
+    } else if (event.key === "End") {
+      event.preventDefault();
+      buttons[buttons.length - 1]?.focus();
+    }
+  }
+
+  return (
+    <div className="agent-approval-split" ref={wrapRef}>
+      <button
+        type="button"
+        className="agent-approval-approve"
+        disabled={disabled}
+        onClick={() => onChoice("once")}
+      >
+        Approve
+      </button>
+      <button
+        ref={scopeRef}
+        type="button"
+        className="agent-approval-scope"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Approve options"
+        disabled={disabled}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <IconChevronDownSmall size={14} aria-hidden />
+      </button>
+      {open ? (
+        <div
+          ref={menuRef}
+          className="agent-approval-scope-menu"
+          role="menu"
+          aria-label="Approve scope"
+          onKeyDown={onMenuKeyDown}
+        >
+          {items.map((item) => (
+            <button
+              key={item.choice}
+              type="button"
+              role="menuitem"
+              className="agent-approval-scope-item"
+              disabled={disabled}
+              onClick={() => choose(item.choice)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function ClarifyPart({
   onClarify,
   part,
   submitting,
@@ -10474,25 +10693,25 @@ function ClarifyPart({
   const [draft, setDraft] = useState("");
   const disabled = part.status !== "pending" || submitting !== undefined;
 
+  // Resolved clarify collapses to a quiet receipt row: "Answered" (or "Skipped")
+  // plus the question, expandable to the full question and answer.
+  if (part.status !== "pending") {
+    const answered = Boolean(part.answer?.trim());
+    return (
+      <ResolvedActionRow label={answered ? "Answered" : "Skipped"} detail={part.question}>
+        <p>{part.question}</p>
+        {answered ? <p className="agent-clarify-answer">{part.answer}</p> : null}
+      </ResolvedActionRow>
+    );
+  }
+
   return (
     <article className="agent-clarify-card" data-status={part.status}>
-      <span className="agent-tool-icon">
-        <IconBubbleWide size={14} />
-      </span>
       <div>
         <div className="agent-tool-title">
           <span>Clarify</span>
-          <span
-            className="agent-tool-live-status"
-            data-status={part.status === "pending" ? "running" : "complete"}
-          >
-            {part.status === "pending" ? "Waiting" : "Answered"}
-          </span>
         </div>
-        <p>{part.question}</p>
-        {part.answer !== undefined ? (
-          <p className="agent-clarify-answer">{part.answer.trim() ? part.answer : "Skipped"}</p>
-        ) : null}
+        <p className="agent-clarify-question">{part.question}</p>
         {part.status === "pending" ? (
           <>
             {!typing && part.choices.length ? (
@@ -10528,6 +10747,7 @@ function ClarifyPart({
                 }}
               >
                 <textarea
+                  className="dialog-textarea agent-clarify-textarea"
                   value={draft}
                   disabled={disabled}
                   rows={3}
@@ -10587,60 +10807,61 @@ type AgentCliAccessCardProps = {
  * live setting rather than stored per message: a revisited transcript shows
  * "Enabled" once the grant is on, and re-offers the choice while it is off.
  * Mirrors the approval card chrome. */
-function AgentCliAccessCard({ cliAccess }: { cliAccess?: AgentCliAccessCardProps }) {
+export function AgentCliAccessCard({ cliAccess }: { cliAccess?: AgentCliAccessCardProps }) {
   const [dismissed, setDismissed] = useState(false);
   const enabled = cliAccess?.enabled === true;
   const resolved = enabled || dismissed;
   const busy = Boolean(cliAccess?.submitting);
+
+  const description = (
+    <p>
+      June wants write access to the state folders of your coding CLIs (Claude Code, Codex, Gemini,
+      opencode) so they stay logged in and can save their work in sandboxed sessions. Those folders
+      configure software that also runs outside June's sandbox. Enabling turns on "Agent CLI access"
+      in Settings and restarts the sandboxed runtime.
+    </p>
+  );
+
+  // Resolved collapses to a quiet receipt row, expandable to the description.
+  if (resolved) {
+    return (
+      <ResolvedActionRow denied={!enabled} label={enabled ? "Agent CLI access enabled" : "Not now"}>
+        {description}
+      </ResolvedActionRow>
+    );
+  }
+
   return (
-    <article className="agent-approval-card" data-status={resolved ? "resolved" : "pending"}>
-      <span className="agent-tool-icon">
-        <IconConsole size={14} />
-      </span>
+    <article className="agent-approval-card" data-status="pending">
       <div>
         <div className="agent-tool-title">
           <span>Agent CLI access requested</span>
-          <span className="agent-tool-live-status" data-status={resolved ? "complete" : "running"}>
-            {resolved ? "Resolved" : "Waiting"}
-          </span>
         </div>
-        <p>
-          June wants write access to the state folders of your coding CLIs (Claude Code, Codex,
-          Gemini, opencode) so they stay logged in and can save their work in sandboxed sessions.
-          Those folders configure software that also runs outside June's sandbox. Enabling turns on
-          "Agent CLI access" in Settings and restarts the sandboxed runtime.
-        </p>
-        {resolved ? (
-          <p className="agent-approval-result" data-choice={enabled ? "once" : "deny"}>
-            {enabled ? <IconCheckmark1Small size={14} /> : <IconCrossMedium size={14} />}
-            {enabled ? "Agent CLI access enabled" : "Not now"}
-          </p>
-        ) : (
-          <div className="agent-approval-actions">
-            <button
-              type="button"
-              className="btn btn-secondary"
-              disabled={busy || !cliAccess || cliAccess.enabled === undefined}
-              onClick={() => cliAccess?.onEnable()}
-            >
-              {busy ? "Enabling…" : "Enable Agent CLI access"}
-            </button>
-            <button
-              type="button"
-              className="btn btn-ghost agent-approval-deny"
-              disabled={busy}
-              onClick={() => setDismissed(true)}
-            >
-              Not now
-            </button>
-          </div>
-        )}
+        {description}
+        <div className="agent-approval-actions">
+          <button
+            type="button"
+            className="btn btn-secondary"
+            disabled={busy || !cliAccess || cliAccess.enabled === undefined}
+            onClick={() => cliAccess?.onEnable()}
+          >
+            {busy ? "Enabling…" : "Enable Agent CLI access"}
+          </button>
+          <button
+            type="button"
+            className="btn btn-ghost agent-approval-deny"
+            disabled={busy}
+            onClick={() => setDismissed(true)}
+          >
+            Not now
+          </button>
+        </div>
       </div>
     </article>
   );
 }
 
-function ApprovalPart({
+export function ApprovalPart({
   onApproval,
   part,
   submitting,
@@ -10654,7 +10875,13 @@ function ApprovalPart({
 }) {
   const disabled = Boolean(submitting) || part.status !== "pending";
   const activeChoice = part.choice ?? submitting;
-  const resolved = part.status !== "pending" || activeChoice !== undefined;
+  // A card that has actually resolved collapses to a receipt row. A submission
+  // still in flight (submitting set, status pending) keeps the card so the
+  // in-progress line ("Approving once") stays visible until it resolves.
+  const resolved = part.status !== "pending";
+  const showResult = resolved || activeChoice !== undefined;
+  // The whole card is compact by default; expanding reveals the full body.
+  const [expanded, setExpanded] = useState(false);
   const [explainOpen, setExplainOpen] = useState(false);
   // "Explain first" asks the generation model what this specific request
   // would do — the request stays parked, nothing is approved by asking.
@@ -10667,6 +10894,8 @@ function ApprovalPart({
   function toggleExplain() {
     const nextOpen = !explainOpen;
     setExplainOpen(nextOpen);
+    // Opening the explanation auto-expands the card so the panel has room.
+    if (nextOpen) setExpanded(true);
     if (!nextOpen || explainState === "loading" || explainState === "ready") {
       return;
     }
@@ -10684,117 +10913,116 @@ function ApprovalPart({
       });
   }
 
-  return (
-    <article className="agent-approval-card" data-status={part.status}>
-      <span className="agent-tool-icon">
-        <IconShieldCheck size={14} />
-      </span>
-      <div>
-        <div className="agent-tool-title">
-          <span>Approval required</span>
-          <span
-            className="agent-tool-live-status"
-            data-status={part.status === "pending" ? "running" : "complete"}
-          >
-            {part.status === "pending" ? "Waiting" : "Resolved"}
-          </span>
-        </div>
+  // Resolved collapses to a quiet receipt row: the outcome label plus the
+  // command (or description) truncated to one line, expandable to the full
+  // description and command — no action buttons.
+  if (resolved) {
+    return (
+      <ResolvedActionRow
+        denied={activeChoice === "deny"}
+        label={approvalChoiceLabel(activeChoice)}
+        detail={
+          part.command ? (
+            <span className="agent-resolved-mono">{part.command}</span>
+          ) : (
+            part.description
+          )
+        }
+      >
         <p>{part.description}</p>
         {part.command ? <pre>{part.command}</pre> : null}
-        {!resolved && explainOpen ? (
-          <div className="agent-approval-explanation" id={explanationId}>
-            {explainState === "loading" ? (
-              <p className="agent-approval-explanation-loading" role="status" aria-live="polite">
-                <Spinner aria-hidden />
-                <span>Working out what this request does…</span>
-              </p>
-            ) : explainState === "ready" && explanation ? (
-              explanation
-                .split(/\n{2,}/)
-                .map((paragraph) => paragraph.trim())
-                .filter(Boolean)
-                .map((paragraph, index) => <p key={index}>{paragraph}</p>)
-            ) : (
-              // Generation unavailable (offline, signed out): keep the
-              // static framing rather than an empty panel.
-              <p>
-                June is paused because this request needs your explicit permission before it can
-                continue.
-              </p>
-            )}
-            <p>
-              Approve once allows only this request. This session allows matching requests until the
-              session ends.{" "}
-              {part.allowPermanent ? "Always allows matching requests in future sessions. " : null}
-              Deny blocks the request.
+      </ResolvedActionRow>
+    );
+  }
+
+  const footer = showResult ? (
+    // Submission in flight (status still pending): the in-progress line stays
+    // in the card until the request actually resolves.
+    <p className="agent-approval-result" data-choice={activeChoice}>
+      {activeChoice === "deny" ? <IconCrossMedium size={14} /> : <IconCheckmark1Small size={14} />}
+      {approvalChoiceLabel(activeChoice, submitting !== undefined)}
+    </p>
+  ) : (
+    // Compact footer: a split "Approve" (approves once, caret opens the scope
+    // menu) and a quiet "Deny" anchor the row; "Explain first" demotes to a
+    // plain text-level button pushed to the right edge.
+    <div className="agent-approval-actions">
+      <ApproveSplitButton
+        disabled={disabled}
+        allowPermanent={part.allowPermanent}
+        onChoice={(choice) => onApproval(part, choice)}
+      />
+      <button
+        type="button"
+        className="btn btn-ghost agent-approval-deny"
+        disabled={disabled}
+        onClick={() => onApproval(part, "deny")}
+      >
+        Deny
+      </button>
+      <button
+        type="button"
+        className="btn btn-ghost agent-approval-explain"
+        aria-expanded={explainOpen}
+        // Only advertise the panel while it's actually in the DOM (the body
+        // renders only when the card is expanded and the explanation is open).
+        aria-controls={explainOpen ? explanationId : undefined}
+        disabled={disabled}
+        onClick={toggleExplain}
+      >
+        <IconLightBulbSimple size={14} aria-hidden />
+        {explainOpen ? "Hide explanation" : "Explain first"}
+      </button>
+    </div>
+  );
+
+  return (
+    <CollapsibleActionCard
+      title="Approval required"
+      description={part.description}
+      hasDetails={Boolean(part.command)}
+      expanded={expanded}
+      onToggleExpanded={() => {
+        const next = !expanded;
+        setExpanded(next);
+        // Collapsing the card unmounts the explanation body, so resync the
+        // "Explain first" toggle rather than leave it stuck on "Hide
+        // explanation" with nothing shown.
+        if (!next) setExplainOpen(false);
+      }}
+      footer={footer}
+    >
+      {part.command ? <pre>{part.command}</pre> : null}
+      {explainOpen ? (
+        <div className="agent-approval-explanation" id={explanationId}>
+          {explainState === "loading" ? (
+            <p className="agent-approval-explanation-loading" role="status" aria-live="polite">
+              <Spinner aria-hidden />
+              <span>Working out what this request does…</span>
             </p>
-          </div>
-        ) : null}
-        {resolved ? (
-          <p className="agent-approval-result" data-choice={activeChoice}>
-            {activeChoice === "deny" ? (
-              <IconCrossMedium size={14} />
-            ) : (
-              <IconCheckmark1Small size={14} />
-            )}
-            {approvalChoiceLabel(
-              activeChoice,
-              part.status === "pending" && submitting !== undefined,
-            )}
+          ) : explainState === "ready" && explanation ? (
+            explanation
+              .split(/\n{2,}/)
+              .map((paragraph) => paragraph.trim())
+              .filter(Boolean)
+              .map((paragraph, index) => <p key={index}>{paragraph}</p>)
+          ) : (
+            // Generation unavailable (offline, signed out): keep the
+            // static framing rather than an empty panel.
+            <p>
+              June is paused because this request needs your explicit permission before it can
+              continue.
+            </p>
+          )}
+          <p>
+            Approve once allows only this request. This session allows matching requests until the
+            session ends.{" "}
+            {part.allowPermanent ? "Always allows matching requests in future sessions. " : null}
+            Deny blocks the request.
           </p>
-        ) : (
-          // System buttons (.btn) — quiet soft-fill choices, ghost deny. The
-          // repeated per-button icons read as noise, so labels stand alone.
-          <div className="agent-approval-actions">
-            <button
-              type="button"
-              className="btn btn-secondary agent-approval-explain"
-              aria-expanded={explainOpen}
-              aria-controls={explanationId}
-              disabled={disabled}
-              onClick={toggleExplain}
-            >
-              <IconCircleQuestionmark size={14} />
-              {explainOpen ? "Hide explanation" : "Explain first"}
-            </button>
-            <button
-              type="button"
-              className="btn btn-secondary"
-              disabled={disabled}
-              onClick={() => onApproval(part, "once")}
-            >
-              Approve once
-            </button>
-            <button
-              type="button"
-              className="btn btn-secondary"
-              disabled={disabled}
-              onClick={() => onApproval(part, "session")}
-            >
-              This session
-            </button>
-            {part.allowPermanent ? (
-              <button
-                type="button"
-                className="btn btn-secondary"
-                disabled={disabled}
-                onClick={() => onApproval(part, "always")}
-              >
-                Always
-              </button>
-            ) : null}
-            <button
-              type="button"
-              className="btn btn-ghost agent-approval-deny"
-              disabled={disabled}
-              onClick={() => onApproval(part, "deny")}
-            >
-              Deny
-            </button>
-          </div>
-        )}
-      </div>
-    </article>
+        </div>
+      ) : null}
+    </CollapsibleActionCard>
   );
 }
 
@@ -10814,6 +11042,22 @@ export function branchSourceSessionIdForTurn(turn: Pick<AgentChatTurn, "parts">)
     if (sessionId) return sessionId;
   }
   return undefined;
+}
+
+/** Whether a turn is a concrete message — the only kind that carries per-turn
+ * affordances (copy / branch / timestamp). A user message always qualifies; an
+ * assistant turn qualifies once it has produced a real answer: non-empty text
+ * or a finished image. Everything else is process or interaction — thinking in
+ * progress, tool calls, approval/clarify/sudo/secret cards, context summaries,
+ * in-flight/empty turns — and gets nothing below it. An allowlist (not a
+ * per-type blocklist) so new process/card part types stay quiet by default. */
+export function turnIsConcreteResponse(turn: Pick<AgentChatTurn, "role" | "parts">) {
+  if (turn.role === "user") return true;
+  return turn.parts.some(
+    (part) =>
+      (part.type === "text" && part.text.trim().length > 0) ||
+      (part.type === "image" && part.status === "complete"),
+  );
 }
 
 function previousBranchableMessageIndex(messages: HermesSessionMessage[], beforeIndex: number) {
@@ -10936,75 +11180,119 @@ export function SudoPart({
   submitting?: "approve" | "deny";
 }) {
   const disabled = Boolean(submitting) || part.status !== "pending";
-  const resolved = part.status !== "pending" || submitting !== undefined;
+  // A card that has actually resolved collapses to a receipt row. A submission
+  // still in flight (submitting set, status pending) keeps the card.
+  const resolved = part.status !== "pending";
+  const showResult = resolved || submitting !== undefined;
+  // The whole card is compact by default; expanding reveals the full body.
+  const [expanded, setExpanded] = useState(false);
   // Absent mode defaults to the safe direction (sandboxed) so the card never
   // implies more access than is being granted.
   const mode: HermesMode = part.mode ?? "sandboxed";
   const unrestricted = mode === "unrestricted";
   const decided = part.approved ?? (submitting ? submitting === "approve" : undefined);
 
-  return (
-    <article className="agent-approval-card" data-status={part.status}>
-      <span className="agent-tool-icon">
-        {unrestricted ? <IconShieldCrossed size={14} /> : <IconShieldCheck size={14} />}
-      </span>
-      <div>
-        <div className="agent-tool-title">
-          <span>Privilege escalation requested</span>
-          <span
-            className="agent-tool-live-status"
-            data-status={part.status === "pending" ? "running" : "complete"}
-          >
-            {part.status === "pending" ? "Waiting" : "Resolved"}
-          </span>
-        </div>
+  const modeCopy = unrestricted
+    ? "Will run unrestricted (full write access)"
+    : "Will run sandboxed (limited write access)";
+
+  // Pending: the blast radius shows as an InlineNotice — warning chrome for
+  // unrestricted, neutral for sandboxed.
+  const modeNotice = (
+    <InlineNotice
+      className="agent-sudo-mode-notice"
+      tone={unrestricted ? "warning" : "info"}
+      icon={
+        unrestricted ? (
+          <IconShieldCrossed size={14} aria-hidden />
+        ) : (
+          <IconShieldCheck size={14} aria-hidden />
+        )
+      }
+      body={modeCopy}
+    />
+  );
+
+  // Receipt: the same mode line, but as quiet plain text — receipts carry no
+  // notice chrome.
+  const modeReceiptLine = (
+    <p className="agent-sudo-mode-receipt" data-mode={mode}>
+      {modeCopy}
+    </p>
+  );
+
+  // Collapsed pending: the full InlineNotice lives behind Details, so the header
+  // still has to carry the blast radius at the moment of decision — but only for
+  // the unrestricted (elevated) case. A small warning badge pinned in the header
+  // row does it. Sandboxed is the safe default and shows no collapsed badge (the
+  // full mode line still appears in Details for both).
+  const modeBadge = unrestricted ? (
+    <span className="agent-sudo-mode-badge">
+      <IconExclamationTriangle size={12} aria-hidden />
+      Unrestricted
+    </span>
+  ) : null;
+
+  // Resolved collapses to a quiet receipt row: "Approved"/"Denied" plus the
+  // command, expandable to the reason, command, and execution mode.
+  if (resolved) {
+    return (
+      <ResolvedActionRow
+        denied={!decided}
+        label={decided ? "Approved" : "Denied"}
+        detail={
+          part.command ? <span className="agent-resolved-mono">{part.command}</span> : undefined
+        }
+      >
         <p>{part.reason ?? "June needs elevated permissions before it can continue."}</p>
         {part.command ? <pre>{part.command}</pre> : null}
-        <p
-          className="agent-sudo-mode"
-          data-mode={mode}
-          title={
-            unrestricted
-              ? "Runs with full write access, outside June's sandbox."
-              : "Runs inside June's write sandbox."
-          }
-        >
-          {unrestricted ? (
-            <IconShieldCrossed size={12} aria-hidden />
-          ) : (
-            <IconShieldCheck size={12} aria-hidden />
-          )}
-          {unrestricted
-            ? "Will run unrestricted (full write access)"
-            : "Will run sandboxed (limited write access)"}
-        </p>
-        {resolved ? (
-          <p className="agent-approval-result" data-choice={decided ? "once" : "deny"}>
-            {decided ? <IconCheckmark1Small size={14} /> : <IconCrossMedium size={14} />}
-            {decided ? (submitting ? "Approving" : "Approved") : submitting ? "Denying" : "Denied"}
-          </p>
-        ) : (
-          <div className="agent-approval-actions">
-            <button
-              type="button"
-              className="btn btn-secondary"
-              disabled={disabled}
-              onClick={() => onSudo(part, true)}
-            >
-              Approve
-            </button>
-            <button
-              type="button"
-              className="btn btn-ghost agent-approval-deny"
-              disabled={disabled}
-              onClick={() => onSudo(part, false)}
-            >
-              Deny
-            </button>
-          </div>
-        )}
-      </div>
-    </article>
+        {modeReceiptLine}
+      </ResolvedActionRow>
+    );
+  }
+
+  const reason = part.reason ?? "June needs elevated permissions before it can continue.";
+
+  const footer = showResult ? (
+    <p className="agent-approval-result" data-choice={decided ? "once" : "deny"}>
+      {decided ? <IconCheckmark1Small size={14} /> : <IconCrossMedium size={14} />}
+      {decided ? (submitting ? "Approving" : "Approved") : submitting ? "Denying" : "Denied"}
+    </p>
+  ) : (
+    // Sudo keeps a simple Approve/Deny pair.
+    <div className="agent-approval-actions">
+      <button
+        type="button"
+        className="btn btn-secondary"
+        disabled={disabled}
+        onClick={() => onSudo(part, true)}
+      >
+        Approve
+      </button>
+      <button
+        type="button"
+        className="btn btn-ghost agent-approval-deny"
+        disabled={disabled}
+        onClick={() => onSudo(part, false)}
+      >
+        Deny
+      </button>
+    </div>
+  );
+
+  return (
+    <CollapsibleActionCard
+      title="Privilege escalation requested"
+      description={reason}
+      headerMeta={modeBadge}
+      hasDetails={true}
+      expanded={expanded}
+      onToggleExpanded={() => setExpanded((value) => !value)}
+      footer={footer}
+    >
+      {part.command ? <pre>{part.command}</pre> : null}
+      {modeNotice}
+    </CollapsibleActionCard>
   );
 }
 
@@ -11050,78 +11338,80 @@ export function SecretPart({
     onCancel?.(part);
   }
 
+  const keyLine = label ? (
+    <p className="agent-secret-key">
+      <span>Key</span>
+      <code>{label}</code>
+    </p>
+  ) : null;
+
+  // Resolved collapses to a quiet receipt row: "Secret provided" plus the
+  // redacted key name (never the value), expandable to the reason and key.
+  // SECURITY: no secret value is ever rendered here — only the reason and the
+  // already-redacted key label.
+  if (part.status !== "pending") {
+    return (
+      <ResolvedActionRow
+        label="Secret provided"
+        detail={label ? <span className="agent-resolved-mono">{label}</span> : undefined}
+      >
+        <p>{part.reason ?? "June needs a secret value before it can continue."}</p>
+        {keyLine}
+      </ResolvedActionRow>
+    );
+  }
+
   return (
     <article className="agent-approval-card" data-status={part.status}>
-      <span className="agent-tool-icon">
-        <IconLock size={14} />
-      </span>
       <div>
         <div className="agent-tool-title">
           <span>Secret requested</span>
-          <span
-            className="agent-tool-live-status"
-            data-status={part.status === "pending" ? "running" : "complete"}
-          >
-            {part.status === "pending" ? "Waiting" : "Provided"}
-          </span>
         </div>
         <p>{part.reason ?? "June needs a secret value before it can continue."}</p>
-        {label ? (
-          <p className="agent-secret-key">
-            <span>Key</span>
-            <code>{label}</code>
+        {keyLine}
+        <form
+          className="agent-secret-form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            submit();
+          }}
+        >
+          <label htmlFor={inputId} className="agent-secret-label">
+            Secret value
+          </label>
+          <input
+            id={inputId}
+            type="password"
+            className="dialog-input agent-secret-input"
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            // The browser must never store or suggest this value.
+            data-1p-ignore
+            data-lpignore="true"
+            disabled={disabled}
+            value={value}
+            placeholder="Paste the value"
+            onChange={(event) => setValue(event.currentTarget.value)}
+          />
+          <p className="agent-secret-note">
+            Sent straight to the agent and never saved, logged, or shown.
           </p>
-        ) : null}
-        {part.status === "pending" ? (
-          <form
-            className="agent-secret-form"
-            onSubmit={(event) => {
-              event.preventDefault();
-              submit();
-            }}
-          >
-            <label htmlFor={inputId} className="agent-secret-label">
-              Secret value
-            </label>
-            <input
-              id={inputId}
-              type="password"
-              className="agent-secret-input"
-              autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="off"
-              spellCheck={false}
-              // The browser must never store or suggest this value.
-              data-1p-ignore
-              data-lpignore="true"
-              disabled={disabled}
-              value={value}
-              placeholder="Paste the value"
-              onChange={(event) => setValue(event.currentTarget.value)}
-            />
-            <p className="agent-secret-note">
-              Sent straight to the agent and never saved, logged, or shown.
-            </p>
-            <div className="agent-approval-actions">
-              <button type="submit" className="btn btn-secondary" disabled={disabled || !value}>
-                {submitting ? "Submitting" : "Submit"}
-              </button>
-              <button
-                type="button"
-                className="btn btn-ghost agent-approval-deny"
-                disabled={submitting !== undefined}
-                onClick={cancel}
-              >
-                Cancel
-              </button>
-            </div>
-          </form>
-        ) : (
-          <p className="agent-approval-result" data-choice="once">
-            <IconCheckmark1Small size={14} />
-            Secret provided
-          </p>
-        )}
+          <div className="agent-approval-actions">
+            <button type="submit" className="btn btn-secondary" disabled={disabled || !value}>
+              {submitting ? "Submitting" : "Submit"}
+            </button>
+            <button
+              type="button"
+              className="btn btn-ghost agent-approval-deny"
+              disabled={submitting !== undefined}
+              onClick={cancel}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
       </div>
     </article>
   );

--- a/src/lib/agent-chat-gallery.ts
+++ b/src/lib/agent-chat-gallery.ts
@@ -301,7 +301,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
     {
       label: "Approval: pending",
       description:
-        "Approval request awaiting a choice. Buttons: Explain first / Approve once / This session / Always / Deny.",
+        "Approval request awaiting a choice. Compact by default: header (title + waiting), the prose description clamped to two lines, a quiet Details disclosure for the full command, and the footer. Footer: split Approve (caret opens once / this session / always), Deny, and a right-aligned Explain first.",
       turns: [
         assistantTurn("approval-pending", [
           {
@@ -317,7 +317,8 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
     },
     {
       label: "Approval: pending (no “Always”)",
-      description: "When allowPermanent is false the “Always” button is hidden.",
+      description:
+        "When allowPermanent is false the “Always approve” item is hidden from the Approve scope menu.",
       turns: [
         assistantTurn("approval-no-permanent", [
           {
@@ -333,14 +334,15 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
     },
     {
       label: "Approval: resolved",
-      description: "Each resolved outcome: approved once / session / always / denied.",
+      description:
+        "Each resolved outcome collapses to a quiet one-line receipt row (outcome label + the command, truncated); expand to see the full description and command. Approved once / session / always / denied.",
       turns: [
         assistantTurn("approval-once", [
           {
             type: "approval",
             id: "approval-once",
             command: "git status",
-            description: "Approved once.",
+            description: "The agent wants to check the working tree status.",
             allowPermanent: true,
             choice: "once",
             status: "resolved",
@@ -351,7 +353,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
             type: "approval",
             id: "approval-session",
             command: "ls -la",
-            description: "Approved for this session.",
+            description: "The agent wants to list the project directory.",
             allowPermanent: true,
             choice: "session",
             status: "resolved",
@@ -362,7 +364,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
             type: "approval",
             id: "approval-always",
             command: "cat package.json",
-            description: "Always approved.",
+            description: "The agent wants to read package.json.",
             allowPermanent: true,
             choice: "always",
             status: "resolved",
@@ -373,7 +375,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
             type: "approval",
             id: "approval-deny",
             command: "rm -rf /",
-            description: "Denied.",
+            description: "The agent wants to delete the entire filesystem.",
             allowPermanent: true,
             choice: "deny",
             status: "resolved",
@@ -413,7 +415,8 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
     },
     {
       label: "Clarify: answered",
-      description: "Resolved clarify showing the chosen answer.",
+      description:
+        'Resolved clarify collapses to a quiet one-line row ("Answered" + the question); expand to see the question and chosen answer.',
       turns: [
         assistantTurn("clarify-answered", [
           {
@@ -429,7 +432,8 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
     },
     {
       label: "Clarify: skipped",
-      description: "Resolved clarify where the person skipped without answering.",
+      description:
+        'Resolved clarify where the person skipped without answering: collapses to a quiet one-line "Skipped" row, expandable to the question.',
       turns: [
         assistantTurn("clarify-skipped", [
           {
@@ -462,7 +466,8 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
     },
     {
       label: "Sudo: approved",
-      description: "Resolved sudo request showing the granted decision.",
+      description:
+        'Resolved sudo request collapses to a quiet one-line row ("Approved"/"Denied" + the command); expand to see the reason, command, and execution mode.',
       turns: [
         assistantTurn("sudo-approved", [
           {
@@ -495,7 +500,8 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
     },
     {
       label: "Secret: provided",
-      description: "Resolved secret request. No value is ever shown.",
+      description:
+        'Resolved secret request collapses to a quiet one-line "Secret provided" row (with the redacted key name); expand to see the reason and key. No value is ever shown.',
       turns: [
         assistantTurn("secret-provided", [
           {

--- a/src/lib/agent-chat-gallery.ts
+++ b/src/lib/agent-chat-gallery.ts
@@ -301,7 +301,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
     {
       label: "Approval: pending",
       description:
-        "Approval request awaiting a choice. Compact by default: header (title + waiting), the prose description clamped to two lines, a quiet Details disclosure for the full command, and the footer. Footer: split Approve (caret opens once / this session / always), Deny, and a right-aligned Explain first.",
+        "Approval request awaiting a choice. Header (title), the prose description, and the exact command (always visible — you must see what you approve, since Approve is live), then the footer: split Approve (caret opens once / this session / always), Deny, and a right-aligned Explain first.",
       turns: [
         assistantTurn("approval-pending", [
           {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1588,9 +1588,7 @@ input:focus-visible,
  * border, soft shadow. */
 .agent-safety-panel,
 .agent-tool-event,
-.agent-hermes-event,
-.agent-approval-card,
-.agent-clarify-card {
+.agent-hermes-event {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   gap: var(--sp-3);
@@ -1601,31 +1599,40 @@ input:focus-visible,
   box-shadow: var(--shadow-sm);
 }
 
-.agent-approval-card > .agent-tool-icon {
-  display: inline-grid;
-  place-items: center;
-  width: 30px;
-  height: 30px;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--r-md);
-  background: var(--card);
-  color: var(--warm-strong);
-}
-
-.agent-approval-card > div {
+/* A pending action card (approval / clarify / sudo / secret / CLI access) is
+ * single-column: no icon tile and no inline title glyph. The title text stands
+ * alone; structure comes from spacing, not decoration. No shadow: the redesign
+ * is quieter, so the border + card surface carry the elevation on their own. */
+.agent-approval-card,
+.agent-clarify-card {
+  display: block;
   min-width: 0;
+  padding: var(--sp-6);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-lg);
+  background: var(--card);
 }
 
-.agent-approval-card .agent-tool-title > span:first-child {
+/* Card title: the shared row-title treatment across all five card types, so
+ * approval / clarify / sudo / secret / CLI titles land on one scale.
+ * `.agent-action-card-title` is the condensed approval/sudo header title. */
+.agent-approval-card .agent-tool-title > span:first-child,
+.agent-clarify-card .agent-tool-title > span:first-child,
+.agent-action-card-title {
   color: var(--foreground);
+  font-size: var(--fs-lg);
   font-weight: var(--fw-medium);
 }
 
+/* Card body/description prose across all five card types (approval, clarify,
+ * sudo, secret, CLI access). One coherent body tier at --fs-md — the meta,
+ * status, note, and mono tiers stay put; the resolved-receipt rows live under
+ * .agent-tool-disclosure, not here, so they're unaffected. */
 .agent-approval-card p,
 .agent-clarify-card p {
   margin: var(--sp-2) 0 0;
   color: var(--muted-foreground);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-md);
   line-height: 1.45;
   white-space: pre-wrap;
 }
@@ -1637,6 +1644,10 @@ input:focus-visible,
 .agent-clarify-card {
   width: min(760px, 100%);
 }
+
+/* The question reads at the shared card body tier (--fs-md / --muted-foreground
+ * via .agent-clarify-card p), matching the approval/sudo description text — no
+ * override needed. */
 
 .agent-clarify-answer {
   border-left: 2px solid var(--border-subtle);
@@ -1650,19 +1661,21 @@ input:focus-visible,
   margin-top: var(--sp-3);
 }
 
-/* Choice rows stay quiet: hairline outline, transparent fill, soft tint on
- * hover. The numeral is a bare muted digit — no keycap chip. */
+/* Choice rows stay quiet: a light neutral fill (no border, so they don't read as
+ * a second border inside the already-bordered card), firming one step on hover.
+ * The numeral is a bare muted digit — no keycap chip. */
 .agent-clarify-choices button {
   display: flex;
   align-items: center;
   gap: var(--sp-3);
   min-height: var(--control-sm);
-  border: 1px solid var(--border-subtle);
+  border: 0;
   border-radius: var(--r-sm);
   padding: 0 var(--sp-3);
-  background: transparent;
+  background: var(--surface-subtle);
   color: var(--foreground);
   font: inherit;
+  font-size: var(--fs-md);
   text-align: left;
   transition: background-color var(--t-fast) var(--ease-out);
 }
@@ -1677,7 +1690,7 @@ input:focus-visible,
 }
 
 .agent-clarify-choices button:hover:not(:disabled) {
-  background: var(--surface-subtle);
+  background: var(--muted);
 }
 
 .agent-clarify-choices button:disabled,
@@ -1693,28 +1706,22 @@ input:focus-visible,
   margin-top: var(--sp-3);
 }
 
-.agent-clarify-form textarea {
-  width: 100%;
+/* The field itself is the canonical dialog-textarea treatment (border + focus
+ * ring); this only adds the clarify deltas: a taller default and vertical
+ * resize. Scoped under .agent-clarify-form so it outranks the later
+ * .dialog-textarea rule that would otherwise reset resize/min-height. */
+.agent-clarify-form .agent-clarify-textarea {
   min-height: 84px;
   resize: vertical;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--r-sm);
-  padding: var(--sp-3);
-  background: var(--surface);
-  color: var(--foreground);
-  font: inherit;
-  line-height: 1.45;
 }
 
-.agent-clarify-form textarea:focus {
-  outline: 2px solid var(--ring);
-  outline-offset: 2px;
-}
-
+/* A little extra air above the actions row so the buttons don't crowd the
+ * textarea (additive to the form's --sp-2 gap). */
 .agent-clarify-form div {
   display: flex;
   justify-content: flex-end;
   gap: var(--sp-2);
+  margin-top: var(--sp-1);
 }
 
 .agent-approval-card pre {
@@ -1731,6 +1738,102 @@ input:focus-visible,
   max-width: 100%;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
+}
+
+/* The condensed pending card (approval / sudo). Compact by default: a plain
+ * header row (title + optional mode tag + waiting status), the prose description
+ * (clamped to two lines while collapsed), a quiet "Details" disclosure for the
+ * full command / notice, and the always-visible actions row. Tighter padding
+ * than the fuller cards, with a touch of extra room below so the always-visible
+ * actions row never crowds the card's bottom edge. */
+.agent-action-card {
+  padding: var(--sp-5);
+  padding-bottom: var(--sp-6);
+}
+
+/* The header is a plain row: the title stands alone; the mode tag and the
+ * waiting status pin to its right. */
+.agent-action-card-header {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  width: 100%;
+}
+
+.agent-action-card-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The description reads at all times; collapsed it clamps to two lines so a long
+ * reason never pushes the actions down. Expanding (via Details) restores the
+ * full prose. */
+.agent-action-card-description[data-clamped] {
+  display: -webkit-box;
+  overflow: hidden;
+  white-space: normal;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+/* A quiet text-level disclosure under the description: reveals the full command
+ * pre (and, for sudo, the mode notice). Color-only hover; the chevron rotates
+ * when open. */
+.agent-action-card-details {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  margin-top: var(--sp-3);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  transition: color var(--t-fast) var(--ease-out);
+}
+
+.agent-action-card-details:hover {
+  color: var(--foreground);
+}
+
+.agent-action-card-details .agent-disclosure-chevron {
+  flex: 0 0 auto;
+  transition: transform var(--t-fast) var(--ease-out);
+}
+
+.agent-action-card-details[aria-expanded="true"] .agent-disclosure-chevron {
+  transform: rotate(180deg);
+}
+
+/* Collapsed unrestricted signal: only the unrestricted (elevated blast radius)
+ * mode earns a header badge so the wider access registers at the decision point
+ * before the card is expanded. Sandboxed is the safe default and shows no
+ * collapsed badge (the full mode line still lives in Details for both).
+ * Unrestricted is a CAUTION, not an error, so it wears the system warning
+ * treatment (the warm palette — the same recipe as .status-pill[data-tone=
+ * "warning"] and InlineNotice's warning tone: --warm-soft bg + --warm-strong
+ * text) rather than the error-reserved destructive red. A leading warning glyph,
+ * --fs-xs, --r-sm. Weight matches the sibling "Waiting" status pill (400) — the
+ * warm caution color carries the emphasis, not the weight. */
+.agent-sudo-mode-badge {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: 2px var(--sp-2);
+  border-radius: var(--r-sm);
+  /* Quiet neutral pill; the leading caution glyph + "Unrestricted" label carry
+   * the meaning without a pop of color. */
+  background: var(--surface-subtle);
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  font-weight: 400;
+  line-height: 1.4;
+  white-space: nowrap;
 }
 
 .agent-approval-explanation {
@@ -1753,30 +1856,189 @@ input:focus-visible,
   gap: var(--sp-2);
 }
 
-/* Buttons come from the .btn system (secondary fills, ghost deny) — this
- * block only lays them out and adds the deny accent. */
+/* Buttons come from the .btn system, but at the small control height and
+ * smaller type so the row reads quiet. On the approval card, a split "Approve"
+ * (with a scope caret) and a quiet "Deny" anchor the row, and "Explain first"
+ * demotes to a plain text button pushed to the right edge. */
 .agent-approval-actions {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: var(--sp-2);
   margin-top: var(--sp-4);
+}
+
+.agent-approval-actions .btn {
+  height: var(--control-md);
+  padding: 0 var(--sp-3);
+  font-size: var(--fs-md);
 }
 
 .agent-approval-actions button:disabled {
   opacity: 0.55;
 }
 
-.agent-approval-explain[aria-expanded="true"] {
-  color: var(--warm-strong);
+/* "Explain first" and "Deny" are plain neutral ghost buttons: only Approve
+ * carries color (green). The system .btn-ghost:hover fills --muted (a mid grey)
+ * which jumps starkly from transparent on the near-white card, so the footer's
+ * ghost buttons rest on the softer --surface-subtle instead. Denying is the
+ * safe choice, so it wears no alarm color — red stays reserved for genuinely
+ * destructive states. */
+.agent-approval-actions .btn-ghost:hover:not(:disabled) {
+  background: var(--surface-subtle);
 }
 
+/* Explain sits at the right edge of the footer, past the anchor actions. `auto`
+ * still wraps cleanly when the row runs out of room. */
+.agent-approval-actions .agent-approval-explain {
+  margin-left: auto;
+}
+
+/* Deny is quieter than the Approve/Explain labels at rest (it is the secondary
+ * choice), firming to the shared subtle-gray hover. */
 .agent-approval-deny {
   color: var(--muted-foreground);
 }
 
-.agent-approval-deny:hover:not(:disabled) {
-  background: var(--destructive-soft);
-  color: var(--destructive);
+/* Approve is a split button in the Cursor mold: a compact secondary rail
+ * (--surface-subtle) holds two distinct inset segments with a 2px gutter on
+ * every side and between them, so the rail reads as the tray and each segment as
+ * its own button. "Approve" is the primary segment — transparent until hovered,
+ * when it fills a contained rounded shape (never edge-to-edge). The scope caret
+ * is a square segment on a darker fill, deepening on hover (background only). */
+/* Outlined split button: a hairline border reads as a clear affordance on the
+ * near-white card (a filled --surface-subtle pill did not). Approve and the
+ * caret sit inset with a 2px gutter, so a strip of negative space divides them
+ * (no seam line). No overflow:hidden — the scope menu is positioned outside the
+ * rail and must not be clipped. */
+.agent-approval-split {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  height: var(--control-md);
+  padding: 2px;
+  /* The container is just a hairline outline that binds Approve + caret into
+   * one control; the gray fill lives on the segments themselves. */
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  background: transparent;
+}
+
+/* Both segments disable together; dim the whole control so it reads inert. */
+.agent-approval-split:has(:disabled) {
+  opacity: 0.55;
+}
+
+.agent-approval-approve {
+  height: 100%;
+  padding: 0 var(--sp-3);
+  border: 0;
+  /* Concentric with the rail: inset by the 1px border + 2px gutter. */
+  border-radius: calc(var(--r-md) - 3px);
+  /* Solid gray fill (the system secondary surface); firms to --muted on hover.
+   * Approve reads as primary by being filled, against the ghost Deny/Explain. */
+  background: var(--surface-subtle);
+  color: var(--secondary-foreground);
+  font-size: var(--fs-md);
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+/* Approve is the confirm action, so its hover reveals an explicit green wash
+ * (--success, a fixed hue-150 green — the same recipe as the "ok" status pill,
+ * theme-stable, not the brand accent) — the universal go signal opposite Deny's
+ * red. */
+.agent-approval-approve:hover:not(:disabled) {
+  background: var(--muted);
+}
+
+/* The caret sits inset in the rail with a 2px gutter from Approve — the strip
+ * of negative space divides them, no seam line. A subtle resting fill marks it
+ * as the secondary; its corners are concentric with the rail. */
+.agent-approval-scope {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(var(--control-md) - 4px);
+  height: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: calc(var(--r-md) - 3px);
+  /* Same gray fill as Approve so the split reads as one control; the 2px gap
+   * (not a seam line) divides them. Firms to --muted on hover. */
+  background: var(--surface-subtle);
+  color: var(--secondary-foreground);
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+/* On hover the caret joins Approve's green wash so the whole control reads as
+ * one confirm affordance on interaction, transparent at rest. */
+.agent-approval-scope:hover:not(:disabled) {
+  background: var(--muted);
+}
+
+/* The scope menu opens upward from the caret (the actions sit near the card
+ * floor). Popover tokens + one ambient shadow, per the popover conventions. */
+.agent-approval-scope-menu {
+  position: absolute;
+  bottom: calc(100% + var(--sp-1));
+  left: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 208px;
+  padding: var(--sp-1);
+  border: 1px solid var(--popover-border);
+  border-radius: var(--r-lg);
+  background: var(--popover);
+  box-shadow: var(--shadow-lg);
+}
+
+.agent-approval-scope-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: var(--control-sm);
+  padding: 0 var(--sp-2);
+  border: 0;
+  border-radius: var(--r-md);
+  background: transparent;
+  color: var(--foreground);
+  font: inherit;
+  font-size: var(--fs-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+/* Focus mirrors hover exactly: the menu autofocuses its first item on open and
+ * moves focus with the arrow keys, so the focused item just wears the hover
+ * background. */
+.agent-approval-scope-item:hover:not(:disabled),
+.agent-approval-scope-item:focus:not(:disabled) {
+  background: var(--surface-subtle);
+}
+
+/* Focus is always visible via that background, so drop the default ring (which
+ * otherwise reads as an ugly outline the moment the menu autofocuses). */
+.agent-approval-scope-item:focus {
+  outline: none;
+}
+
+/* Prevent a double highlight: once the mouse is in the menu, only the hovered
+ * item stays lit — the keyboard-focused-but-not-hovered item drops its
+ * background so hover and focus never light two rows at once. With the mouse
+ * outside the menu (keyboard only), the focused item keeps its background. */
+.agent-approval-scope-menu:hover .agent-approval-scope-item:focus:not(:hover) {
+  background: transparent;
+}
+
+.agent-approval-scope-item:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 
 /* The resolved record is a quiet line of text, not a chip. */
@@ -1794,20 +2056,21 @@ input:focus-visible,
   color: var(--destructive) !important;
 }
 
-/* Sudo execution-mode line: a quiet inline note under the command, tinted by
- * blast radius. Sandboxed stays neutral; unrestricted picks up the warm accent
- * so the wider access reads at a glance. */
-.agent-sudo-mode {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--sp-2);
-  width: fit-content;
+/* Pending sudo shows the blast radius as an InlineNotice under the command. */
+.agent-sudo-mode-notice {
+  margin-top: var(--sp-3);
+}
+
+/* Receipt sudo shows the same mode line as quiet plain text — no notice chrome
+ * in a receipt. Unrestricted picks up the warm accent so the wider access
+ * reads at a glance. */
+.agent-sudo-mode-receipt {
   margin-top: var(--sp-3) !important;
   color: var(--muted-foreground) !important;
   font-size: var(--fs-xs) !important;
 }
 
-.agent-sudo-mode[data-mode="unrestricted"] {
+.agent-sudo-mode-receipt[data-mode="unrestricted"] {
   color: var(--warm-strong) !important;
 }
 
@@ -1838,27 +2101,29 @@ input:focus-visible,
   margin-top: var(--sp-3);
 }
 
+/* Matches the system field-label recipe (.dialog-field-label), the canonical
+ * partner of the .dialog-input the secret field already uses: --fs-md,
+ * full-strength foreground, weight 400. The reassurance .agent-secret-note stays
+ * quieter (--fs-sm muted) so the label reads as the field's title above it. */
 .agent-secret-label {
-  color: var(--muted-foreground);
-  font-size: var(--fs-xs);
-}
-
-.agent-secret-input {
-  width: 100%;
-  min-height: var(--control-md, 36px);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--r-sm);
-  padding: 0 var(--sp-3);
-  background: var(--surface);
   color: var(--foreground);
-  font: inherit;
-  /* Mono so the (masked) length reads consistently. */
-  font-family: var(--font-mono);
+  font-size: var(--fs-md);
+  font-weight: 400;
 }
 
-.agent-secret-input:focus {
-  outline: 2px solid var(--ring);
-  outline-offset: 2px;
+/* The field itself is the canonical dialog-input treatment (border + focus
+ * ring); this adds the secret deltas, all scoped under .agent-secret-form (0,2,0)
+ * so they outrank the later single-class .dialog-input base (0,1,0) regardless
+ * of order: mono so the (masked) length reads consistently, and a tighter fit so
+ * the field sits proportionate to the --control-sm footer buttons rather than
+ * looming over them. Down from the dialog default (--control-lg / --sp-3 pad /
+ * --fs-md): --control-md height, --sp-2 vertical padding, --fs-sm mono so the
+ * masked dots don't read chunky. Border + focus ring stay from the base. */
+.agent-secret-form .agent-secret-input {
+  min-height: var(--control-md);
+  padding: var(--sp-2) var(--sp-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
 }
 
 .agent-secret-input:disabled {
@@ -1866,11 +2131,13 @@ input:focus-visible,
   opacity: 0.55;
 }
 
-/* The reassurance line under the input — smaller and quieter than the body. */
+/* The reassurance line under the input — quieter than the body, but not the
+ * micro --fs-xs (which read tiny once the body prose moved up to --fs-md). One
+ * step down at --fs-sm, still muted so the label above it reads as the title. */
 .agent-secret-note {
   margin-top: 0 !important;
   color: var(--muted-foreground) !important;
-  font-size: var(--fs-xs) !important;
+  font-size: var(--fs-sm) !important;
 }
 
 .agent-safety-panel h3 {
@@ -1979,6 +2246,18 @@ input:focus-visible,
 
 .agent-assistant-turn-body {
   position: relative;
+}
+
+/* An action card (approval / clarify / sudo / secret / CLI access) sits flush at
+ * the turn's bottom edge, and the timestamp/actions row is absolutely positioned
+ * at the turn body's floor (inset-block-start: 100%) with only 1px of padding —
+ * so under a bordered card the timestamp nearly touches the card's bottom border.
+ * Reserve clearance below a card-bearing turn (padding grows the padding box, so
+ * the 100%-anchored row drops clear of the border). Scoped via :has() so text
+ * turns keep their tight 1px timestamp spacing. */
+.agent-assistant-turn-body:has(.agent-approval-card),
+.agent-assistant-turn-body:has(.agent-clarify-card) {
+  padding-bottom: var(--sp-2);
 }
 
 .agent-user-turn:hover .agent-turn-actions,
@@ -2255,13 +2534,6 @@ input:focus-visible,
   font-weight: 400;
 }
 
-/* Timestamp pins to the right edge and matches the row's body size. */
-.agent-context-summary time {
-  margin-left: auto;
-  color: var(--muted-foreground);
-  font-size: var(--fs-lg);
-}
-
 /* Feature 06: the "Steering" system item recording a mid-run instruction. Quiet
  * one-line row in the same muted register as the context-compaction summary, so
  * a redirect reads as a beat in the transcript rather than a message bubble —
@@ -2298,13 +2570,6 @@ input:focus-visible,
   white-space: nowrap;
 }
 
-.agent-steering-item time {
-  margin-left: auto;
-  flex: 0 0 auto;
-  color: var(--muted-foreground);
-  font-size: var(--fs-lg);
-}
-
 /* Expanded summary reads at body size, same as the row above it. */
 .agent-context-summary > .agent-markdown {
   overflow: auto;
@@ -2316,6 +2581,86 @@ input:focus-visible,
 
 .agent-context-summary:not([open]) > .agent-markdown {
   display: none;
+}
+
+/* Resolved action card (approval / clarify / sudo / secret / CLI access) — a
+ * quiet one-line receipt row. It reuses the .agent-tool-disclosure row treatment
+ * VERBATIM (body size, 15px flat icon cell, gap, padding, hover firms to
+ * --foreground, instant opacity glyph→+/− swap) so a receipt is exactly the
+ * same size as the "Run Command"/"Fetch Url" tool rows above it in a turn — one
+ * source of truth. This modifier only carries the receipt-specific bits: the
+ * denied tint and the collapsed-body layout. No card border/shadow; it's a
+ * receipt, not a prompt. */
+
+/* The outcome label anchors the row and never shrinks; the detail truncates.
+ * Color is inherited from the row so it firms to --foreground on hover exactly
+ * like the tool-row name. A denied outcome stays quiet too — it reads via its
+ * cross glyph and "Denied" label, not a color, since denying is a safe choice
+ * (not destructive). */
+.agent-resolved-label {
+  flex: 0 0 auto;
+}
+
+/* One-line detail: truncated with an ellipsis so the receipt stays a single
+ * quiet line no matter how long the command or question is. */
+.agent-resolved-detail {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-resolved-detail .agent-resolved-mono {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+}
+
+/* Expanded body reads quiet, indented under the row to line up under the 15px
+ * icon cell, like the context summary. */
+.agent-resolved-body {
+  margin: var(--sp-2) 0 0 calc(15px + var(--sp-2));
+  color: var(--muted-foreground);
+}
+
+.agent-resolved-row:not([open]) > .agent-resolved-body {
+  display: none;
+}
+
+.agent-resolved-body p {
+  margin: var(--sp-2) 0 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.agent-resolved-body p:first-child {
+  margin-top: 0;
+}
+
+/* Reuse the approval card's pre/mode/key treatments inside the expanded body. */
+.agent-resolved-body pre {
+  overflow: auto;
+  max-height: 220px;
+  margin: var(--sp-3) 0 0;
+  border-radius: var(--r-md);
+  padding: var(--sp-3) var(--sp-4);
+  background: color-mix(in oklch, var(--muted) 45%, transparent);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: 1.45;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.agent-resolved-body .agent-clarify-answer {
+  margin-top: var(--sp-3);
+  border-left: 2px solid var(--border-subtle);
+  padding-left: var(--sp-3);
+  color: var(--foreground);
 }
 
 /* Context-compaction dialog (feature 08). Confirmation copy, then a success or
@@ -10137,6 +10482,15 @@ input:focus-visible,
  * pieces out as wrapping flex items, so long text drops wholesale onto its
  * own line the moment it can't fit — inline flow wraps mid-sentence like a
  * paragraph instead. */
+/* Single-line body + action: vertically center the icon/content in the row
+ * rather than top-aligning against a one-line message. The base inline-notice
+ * rule (align-items flex-start) sits LATER in this flat stylesheet, so at equal
+ * specificity it would win and re-impose flex-start; pairing the base class
+ * here bumps specificity (two classes) so the center override holds. */
+.inline-notice.agent-credits-notice {
+  align-items: center;
+}
+
 .agent-credits-notice .inline-notice-message {
   display: block;
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -198,8 +198,11 @@
   --muted-foreground: oklch(55.8% 0.0015 84.59);
   --accent: color-mix(in oklch, oklch(97.03% 0 none), var(--brand-wash) 3%);
   --accent-foreground: oklch(20.44% 0 none);
-  --destructive: oklch(57% 0.22 27);
-  --destructive-soft: oklch(95% 0.025 27);
+  /* An earthy brick red: chroma pulled down from 0.22 to 0.15 (into the same
+   * register as --brand ~0.13 and --success 0.12) and hue nudged 27 to 30 so it
+   * reads as danger without the neon pop that fought the low-chroma palette. */
+  --destructive: oklch(57% 0.15 30);
+  --destructive-soft: oklch(95% 0.025 30);
   --success: oklch(48% 0.12 150);
   --border: color-mix(in oklch, oklch(86.91% 0.0015 84.59), var(--brand-wash) 5%);
   --input: color-mix(in oklch, oklch(86.91% 0.0015 84.59), var(--brand-wash) 5%);
@@ -357,8 +360,10 @@
   --muted-foreground: oklch(0.709 0.0015 84.59);
   --accent: color-mix(in oklch, oklch(0.268 0.0015 84.59), var(--brand-wash) 7%);
   --accent-foreground: oklch(0.985 0.0015 84.59);
-  --destructive: oklch(0.704 0.191 22.216);
-  --destructive-soft: oklch(0.3 0.08 22 / 40%);
+  /* Earthy brick red, matching the light theme's dechromatized destructive:
+   * chroma 0.191 to 0.14, hue aligned to 30. */
+  --destructive: oklch(0.704 0.14 30);
+  --destructive-soft: oklch(0.3 0.08 30 / 40%);
   --success: oklch(0.72 0.14 150);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3157,8 +3157,10 @@ describe("AgentWorkspace", () => {
 
     render(<AgentWorkspace initialSession={existingSession} />);
 
-    expect(await screen.findByText("Agent CLI access requested")).toBeInTheDocument();
+    // Already granted resolves to the quiet collapsed receipt row — the full
+    // "requested" prompt title is not shown, only the enabled outcome.
     expect(await screen.findByText("Agent CLI access enabled")).toBeInTheDocument();
+    expect(screen.queryByText("Agent CLI access requested")).toBeNull();
     expect(screen.queryByRole("button", { name: "Enable Agent CLI access" })).toBeNull();
   });
 
@@ -4901,8 +4903,12 @@ describe("AgentWorkspace", () => {
       screen.getByText(/Always allows matching requests in future sessions/),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Hide explanation" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Approve once" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Always" })).toBeEnabled();
+    // The top-level Approve (approves once) and the scope menu's permanent
+    // option are both live while the explanation is open.
+    expect(screen.getByRole("button", { name: "Approve" })).toBeEnabled();
+    await user.click(screen.getByRole("button", { name: /approve options/i }));
+    expect(screen.getByRole("menuitem", { name: "Always approve" })).toBeEnabled();
+    await user.keyboard("{Escape}");
     // Asking for an explanation never answers the approval.
     expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("approval.respond", expect.anything());
 
@@ -4964,7 +4970,7 @@ describe("AgentWorkspace", () => {
     expect(projection.waitingSessionIds.has("session-2")).toBe(true);
     expect(projection.waitingSessionIds.has("runtime-session-2")).toBe(false);
 
-    await user.click(screen.getByRole("button", { name: "Approve once" }));
+    await user.click(screen.getByRole("button", { name: "Approve" }));
 
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("approval.respond", {
@@ -5193,7 +5199,7 @@ describe("AgentWorkspace", () => {
       pendingActionStore.openRecords().some((record) => record.requestId === "approval-gone"),
     ).toBe(true);
 
-    await user.click(screen.getByRole("button", { name: "Approve once" }));
+    await user.click(screen.getByRole("button", { name: "Approve" }));
 
     // The request can never be answered now, so June retires the dead-end card
     // (the "Needs you" row and the inline prompt) instead of leaving a "Respond"

--- a/src/test/approval-card-css.test.ts
+++ b/src/test/approval-card-css.test.ts
@@ -77,7 +77,7 @@ describe("pending action card styles", () => {
     );
   });
 
-  it("shows the description collapsed (clamped) and hides the command behind a Details disclosure", () => {
+  it("clamps the collapsed description and keeps the Details disclosure chrome (sudo mode notice)", () => {
     // The collapsed card shows the prose description clamped to two lines...
     const description = cssRuleFor(".agent-action-card-description[data-clamped]");
     expect(description).toContain("display: -webkit-box;");

--- a/src/test/approval-card-css.test.ts
+++ b/src/test/approval-card-css.test.ts
@@ -17,11 +17,255 @@ function cssRuleFor(selector: string) {
   throw new Error(`Unclosed CSS rule for ${selector}`);
 }
 
-describe("approval card styles", () => {
+describe("pending action card styles", () => {
   it("keeps long links inside approval cards", () => {
-    expect(cssRuleFor(".agent-approval-card > div")).toContain("min-width: 0;");
     expect(cssRuleFor(".agent-approval-card p")).toContain("overflow-wrap: anywhere;");
     expect(cssRuleFor(".agent-approval-card pre")).toContain("max-width: 100%;");
     expect(cssRuleFor(".agent-approval-card pre")).toContain("overflow-wrap: anywhere;");
+  });
+
+  it("sets card body/description prose one step up at --fs-md (shared across all card types)", () => {
+    // The shared body-prose rule that every card type's <p> flows through — bumped
+    // from --fs-sm to --fs-md so the description reads at the body tier. The
+    // pre/mono block stays at the smaller --fs-xs.
+    const body = cssRuleFor(".agent-approval-card p,\n.agent-clarify-card p");
+    expect(body).toContain("font-size: var(--fs-md);");
+    expect(cssRuleFor(".agent-approval-card pre")).toContain("font-size: var(--fs-xs);");
+  });
+
+  it("gives the secret label the system field-label treatment", () => {
+    // Matches .dialog-field-label (the canonical partner of the .dialog-input the
+    // field already uses): --fs-md, full-strength foreground, weight 400 — no
+    // longer the quieter --fs-xs muted eyebrow. The note stays quieter one step
+    // down at --fs-sm (bumped up from --fs-xs, which read tiny once the body
+    // prose moved to --fs-md).
+    const label = cssRuleFor(".agent-secret-label");
+    expect(label).toContain("font-size: var(--fs-md);");
+    expect(label).toContain("color: var(--foreground);");
+    expect(label).toContain("font-weight: 400;");
+    const note = cssRuleFor(".agent-secret-note");
+    expect(note).toContain("font-size: var(--fs-sm) !important");
+    expect(note).toContain("color: var(--muted-foreground)");
+  });
+
+  it("is single-column with no icon tile and no inline title glyph", () => {
+    const card = cssRuleFor(".agent-approval-card,\n.agent-clarify-card");
+    // The card is a plain block, not the old two-column grid.
+    expect(card).toContain("display: block;");
+    expect(card).not.toContain("grid-template-columns");
+    // The round-1 inline title glyph is gone entirely — no CSS rule for it.
+    expect(() =>
+      cssRuleFor(
+        ".agent-approval-card > .agent-tool-icon,\n.agent-clarify-card > .agent-tool-icon",
+      ),
+    ).toThrow();
+    // Titles across all five card types land on the shared row-title scale
+    // (including the condensed approval/sudo header title).
+    const title = cssRuleFor(
+      ".agent-approval-card .agent-tool-title > span:first-child,\n.agent-clarify-card .agent-tool-title > span:first-child,\n.agent-action-card-title",
+    );
+    expect(title).toContain("font-size: var(--fs-lg);");
+    expect(title).toContain("font-weight: var(--fw-medium);");
+  });
+
+  it("drops the shadow on the approval and clarify cards but keeps it on the other surfaces", () => {
+    // The approval/clarify cards go shadowless in the quieter redesign.
+    expect(cssRuleFor(".agent-approval-card,\n.agent-clarify-card")).not.toContain("box-shadow");
+    // The other three system surfaces keep their soft elevation.
+    expect(cssRuleFor(".agent-safety-panel,\n.agent-tool-event,\n.agent-hermes-event")).toContain(
+      "box-shadow: var(--shadow-sm);",
+    );
+  });
+
+  it("shows the description collapsed (clamped) and hides the command behind a Details disclosure", () => {
+    // The collapsed card shows the prose description clamped to two lines...
+    const description = cssRuleFor(".agent-action-card-description[data-clamped]");
+    expect(description).toContain("display: -webkit-box;");
+    expect(description).toContain("-webkit-line-clamp: 2;");
+    // ...the old truncated mono summary line is gone entirely (no CSS rule for it).
+    expect(() => cssRuleFor(".agent-action-card-summary-line")).toThrow();
+    expect(() => cssRuleFor(".agent-action-card-summary")).toThrow();
+    expect(() => cssRuleFor(".agent-action-card-command")).toThrow();
+    // The unrestricted mode survives collapsed as a small caution badge (the
+    // blast radius must read before expanding). It is a quiet neutral-gray pill
+    // — the leading caution glyph + "Unrestricted" label carry the meaning
+    // without a pop of color (neither the error-reserved destructive red nor a
+    // brand/warm accent).
+    const modeBadge = cssRuleFor(".agent-sudo-mode-badge");
+    expect(modeBadge).toContain("flex: 0 0 auto;");
+    expect(modeBadge).toContain("background: var(--surface-subtle);");
+    expect(modeBadge).toContain("color: var(--muted-foreground);");
+    expect(modeBadge).toContain("font-weight: 400;");
+    expect(modeBadge).not.toContain("var(--destructive");
+    expect(modeBadge).not.toContain("var(--warm");
+    // ...and the old bare-text lowercase tag is gone entirely.
+    expect(() => cssRuleFor(".agent-sudo-mode-tag")).toThrow();
+    // ...and the Details disclosure chevron rotates when the card is expanded.
+    expect(
+      cssRuleFor('.agent-action-card-details[aria-expanded="true"] .agent-disclosure-chevron'),
+    ).toContain("transform: rotate(180deg);");
+  });
+
+  it("frames the split button as an outlined container with gray-filled segments", () => {
+    // The container is just a hairline outline (transparent bg) binding the two
+    // segments; the gray fill lives on the buttons themselves. Approve reads as
+    // primary by being filled, against the ghost Deny/Explain — no dark or
+    // colored weight. The risk lives in the request, not the button.
+    const split = cssRuleFor(".agent-approval-split");
+    expect(split).toContain("background: transparent;");
+    expect(split).toContain("border: 1px solid var(--border-subtle);");
+    expect(split).toContain("border-radius: var(--r-md);");
+    expect(split).toContain("padding: 2px;");
+    expect(split).toContain("gap: 2px;");
+    // Disabled dims the whole control.
+    expect(cssRuleFor(".agent-approval-split:has(:disabled)")).toContain("opacity: 0.55;");
+    // Approve carries the solid gray fill (--surface-subtle), firming to --muted
+    // on hover — no green, no dark primary fill.
+    const approve = cssRuleFor(".agent-approval-approve");
+    expect(approve).toContain("border-radius: calc(var(--r-md) - 3px);");
+    expect(approve).toContain("background: var(--surface-subtle);");
+    expect(approve).toContain("color: var(--secondary-foreground);");
+    expect(approve).not.toContain("var(--success)");
+    expect(cssRuleFor(".agent-approval-approve:hover:not(:disabled)")).toContain(
+      "background: var(--muted);",
+    );
+    // The caret shares Approve's gray fill so the split reads as one control,
+    // divided only by the 2px gap (no seam/border).
+    const scope = cssRuleFor(".agent-approval-scope");
+    expect(scope).not.toContain("border-left");
+    expect(scope).toContain("border-radius: calc(var(--r-md) - 3px);");
+    expect(scope).toContain("background: var(--surface-subtle);");
+    expect(cssRuleFor(".agent-approval-scope:hover:not(:disabled)")).toContain(
+      "background: var(--muted);",
+    );
+  });
+
+  it("styles scope-menu item focus exactly like hover, with no default ring", () => {
+    // Focus shares the hover background...
+    const focusHover = cssRuleFor(
+      ".agent-approval-scope-item:hover:not(:disabled),\n.agent-approval-scope-item:focus:not(:disabled)",
+    );
+    expect(focusHover).toContain("background: var(--surface-subtle);");
+    // ...and the default outline is dropped (focus stays visible via the background).
+    expect(cssRuleFor(".agent-approval-scope-item:focus")).toContain("outline: none;");
+    // With the mouse in the menu, a focused-but-not-hovered item drops its
+    // background so hover and focus never light two rows at once.
+    expect(
+      cssRuleFor(".agent-approval-scope-menu:hover .agent-approval-scope-item:focus:not(:hover)"),
+    ).toContain("background: transparent;");
+  });
+
+  it("gives clarify choices a light fill and no border (no border-within-border)", () => {
+    // The card already carries a border, so the choice rows drop theirs and read
+    // as a light neutral fill instead, firming one step on hover.
+    const choice = cssRuleFor(".agent-clarify-choices button");
+    expect(choice).toContain("border: 0;");
+    expect(choice).not.toContain("border: 1px solid var(--border-subtle);");
+    expect(choice).toContain("background: var(--surface-subtle);");
+    expect(cssRuleFor(".agent-clarify-choices button:hover:not(:disabled)")).toContain(
+      "background: var(--muted);",
+    );
+    // A little extra air separates the textarea from the actions row.
+    expect(cssRuleFor(".agent-clarify-form div")).toContain("margin-top: var(--sp-1);");
+  });
+
+  it("keeps Explain and Deny as plain neutral ghost buttons (only Approve is colored)", () => {
+    // Explain is no longer brand-themed — no svg brand rule, no open-state brand.
+    expect(() => cssRuleFor(".agent-approval-explain svg")).toThrow();
+    expect(() => cssRuleFor('.agent-approval-explain[aria-expanded="true"]')).toThrow();
+    // Both footer ghost buttons share a soft neutral gray hover (no exclusion
+    // for Deny, which is no longer red).
+    const ghostHover = cssRuleFor(".agent-approval-actions .btn-ghost:hover:not(:disabled)");
+    expect(ghostHover).toContain("background: var(--surface-subtle);");
+    // Deny wears no alarm color: its old destructive-soft hover rule is gone
+    // (denying is the safe choice; red is reserved for destructive states).
+    expect(() => cssRuleFor(".agent-approval-deny:hover:not(:disabled)")).toThrow();
+    // Deny stays quiet at rest (muted, the secondary choice).
+    expect(cssRuleFor(".agent-approval-deny")).toContain("color: var(--muted-foreground);");
+  });
+
+  it("drops the redundant header status rule, leaving the tool-row pill intact", () => {
+    // The pending-card "Waiting" status is gone (redundant with the title and
+    // the visible action buttons), so its header-scoped override no longer
+    // exists.
+    expect(() =>
+      cssRuleFor(".agent-action-card-header .agent-tool-live-status[data-status]"),
+    ).toThrow();
+    // The shared base .agent-tool-live-status (tool-disclosure running/failed
+    // rows) is untouched — it keeps its pill fill.
+    expect(cssRuleFor(".agent-tool-live-status")).toContain("background: var(--surface-subtle);");
+  });
+
+  it("sizes the secret input proportionate to the compact footer buttons", () => {
+    // Scoped under .agent-secret-form (0,2,0) so it outranks the later
+    // .dialog-input base (0,1,0): shorter --control-md height, tighter --sp-2
+    // vertical padding, and --fs-sm mono so the masked dots don't read chunky.
+    const secret = cssRuleFor(".agent-secret-form .agent-secret-input");
+    expect(secret).toContain("min-height: var(--control-md);");
+    expect(secret).toContain("padding: var(--sp-2) var(--sp-3);");
+    expect(secret).toContain("font-family: var(--font-mono);");
+    expect(secret).toContain("font-size: var(--fs-sm);");
+    // The dialog-input base still owns the larger default the scope overrides.
+    expect(cssRuleFor(".dialog-input,\n.dialog-textarea")).toContain(
+      "min-height: var(--control-lg);",
+    );
+  });
+
+  it("reserves timestamp clearance below a card-bearing turn only", () => {
+    // A turn that holds an action card gets padding-bottom so the absolutely
+    // positioned timestamp row (anchored at the turn body floor) clears the
+    // card's bottom border. Scoped via :has() so text turns are untouched.
+    const cleared = cssRuleFor(
+      ".agent-assistant-turn-body:has(.agent-approval-card),\n.agent-assistant-turn-body:has(.agent-clarify-card)",
+    );
+    expect(cleared).toContain("padding-bottom: var(--sp-2);");
+    // The base turn body carries no such padding (text turns stay tight).
+    expect(cssRuleFor(".agent-turn-actions-inner")).toContain("padding-top: var(--sp-px);");
+  });
+});
+
+describe("credits notice centering", () => {
+  it("centers the single-line credits notice via an override that outranks the base rule", () => {
+    // The base rule top-aligns every inline notice.
+    expect(cssRuleFor(".inline-notice")).toContain("align-items: flex-start;");
+    // The credits override centers it — and because the base rule sits LATER in
+    // this flat stylesheet, the override must carry higher specificity (a
+    // two-class compound, 0,2,0) to beat the single-class base (0,1,0).
+    expect(cssRuleFor(".inline-notice.agent-credits-notice")).toContain("align-items: center;");
+    const baseIndex = appCss.indexOf(".inline-notice {");
+    const overrideIndex = appCss.indexOf(".inline-notice.agent-credits-notice {");
+    expect(overrideIndex).toBeGreaterThan(-1);
+    // Guard the diagnosis: the base really is later in the file, so equal
+    // specificity would lose — the compound override is what makes it hold.
+    expect(baseIndex).toBeGreaterThan(overrideIndex);
+  });
+});
+
+describe("resolved action row styles", () => {
+  it("reuses the tool-disclosure row treatment so the receipt matches the tool rows", () => {
+    // The receipt carries .agent-tool-disclosure (verified in the DOM tests), so
+    // its sizing/hover/icon-swap come from that shared block — no duplicated
+    // numbers here. This modifier only owns the receipt-specific bits.
+    // The expanded body is hidden while collapsed — the row is one line.
+    expect(cssRuleFor(".agent-resolved-row:not([open]) > .agent-resolved-body")).toContain(
+      "display: none;",
+    );
+    // The detail truncates to a single line with an ellipsis.
+    const detail = cssRuleFor(".agent-resolved-detail");
+    expect(detail).toContain("text-overflow: ellipsis;");
+    expect(detail).toContain("white-space: nowrap;");
+    // The body indents under the 15px tool-row icon cell.
+    expect(cssRuleFor(".agent-resolved-body")).toContain("calc(15px + var(--sp-2))");
+  });
+
+  it("keeps a denied outcome quiet (no destructive tint) — read via glyph and label", () => {
+    // Denying is a safe choice, not a destructive one, so the receipt carries no
+    // red: the deny-tint rules for the glyph and label are gone entirely.
+    expect(() =>
+      cssRuleFor('.agent-resolved-row[data-choice="deny"] .agent-resolved-icon-glyph'),
+    ).toThrow();
+    expect(() =>
+      cssRuleFor('.agent-resolved-row[data-choice="deny"] .agent-resolved-label'),
+    ).toThrow();
   });
 });

--- a/src/test/hermes-sudo-secret-actions.test.tsx
+++ b/src/test/hermes-sudo-secret-actions.test.tsx
@@ -48,21 +48,23 @@ describe("SudoPart card", () => {
   it("blocks the session with an explicit approve/deny card showing the reason and mode", async () => {
     render(<SudoPart part={sudoPart()} onSudo={() => {}} />);
 
-    // Compact by default: the prose reason shows, the command is hidden behind
-    // Details, and the approve/deny actions are always visible.
+    // The prose reason and the exact command both show by default — SECURITY:
+    // the command must be visible at the decision point, since Approve is live
+    // while the card is collapsed.
     expect(
       screen.getByText(/ripgrep is required to search the dependency tree/),
     ).toBeInTheDocument();
-    expect(screen.queryByText("apt-get install ripgrep")).not.toBeInTheDocument();
+    expect(screen.getByText("apt-get install ripgrep")).toBeInTheDocument();
     // The unrestricted mode badge stays visible while collapsed so the blast
     // radius reads before expanding.
     expect(document.querySelector(".agent-sudo-mode-badge")?.textContent).toMatch(/unrestricted/i);
     expect(screen.getByRole("button", { name: /approve/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /deny/i })).toBeInTheDocument();
 
-    // Expanding Details reveals the full command pre and the execution-mode notice.
+    // Details reveals only the fuller execution-mode notice (the command is
+    // already shown above).
+    expect(document.querySelector(".agent-sudo-mode-notice")).toBeNull();
     await userEvent.click(screen.getByRole("button", { name: /details/i }));
-    expect(screen.getByText("apt-get install ripgrep")).toBeInTheDocument();
     expect(document.querySelector(".agent-sudo-mode-notice")?.textContent).toMatch(/unrestricted/i);
   });
 
@@ -474,31 +476,26 @@ describe("action card refinements", () => {
     );
   });
 
-  it("the pending approval card shows the description and hides the command behind Details", async () => {
+  it("the pending approval card shows the description and the command together", () => {
     render(<ApprovalPart part={approvalPart()} onApproval={() => {}} />);
     // The header is a plain row now, not a toggle button.
     expect(screen.queryByRole("button", { name: /approval required/i })).toBeNull();
-    // Collapsed by default — the description shows, the command is not in the DOM
-    // yet, and the Details disclosure owns aria-expanded.
+    // SECURITY: the description AND the exact command are both visible by
+    // default — Approve is live while collapsed, so the user must see what they
+    // are authorizing without expanding anything. No Details disclosure to hide
+    // it behind.
     expect(screen.getByText("The agent wants to run a shell command.")).toBeInTheDocument();
-    expect(document.querySelector(".agent-approval-card pre")).toBeNull();
-    expect(screen.queryByText("rm -rf ./build && npm run build")).not.toBeInTheDocument();
-    const details = screen.getByRole("button", { name: /details/i });
-    expect(details.getAttribute("aria-expanded")).toBe("false");
-
-    // Expanding Details reveals the full command in a pre.
-    await userEvent.click(details);
-    expect(details.getAttribute("aria-expanded")).toBe("true");
     expect(document.querySelector(".agent-approval-card pre")?.textContent).toBe(
       "rm -rf ./build && npm run build",
     );
+    expect(screen.queryByRole("button", { name: /details/i })).toBeNull();
   });
 
-  it("omits the Details disclosure on an approval whose only content is the description", () => {
+  it("shows the description alone when an approval has no command", () => {
     render(<ApprovalPart part={approvalPart({ command: undefined })} onApproval={() => {}} />);
-    // No command and no notice, so there is nothing to disclose.
+    // No command to show; the description still reads and there is no Details.
+    expect(document.querySelector(".agent-approval-card pre")).toBeNull();
     expect(screen.queryByRole("button", { name: /details/i })).toBeNull();
-    // The description still reads.
     expect(screen.getByText("The agent wants to run a shell command.")).toBeInTheDocument();
   });
 

--- a/src/test/hermes-sudo-secret-actions.test.tsx
+++ b/src/test/hermes-sudo-secret-actions.test.tsx
@@ -1,8 +1,15 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { SudoPart, SecretPart } from "../components/agent/AgentWorkspace";
-import type { AgentChatPart } from "../lib/agent-chat-runtime";
+import {
+  AgentCliAccessCard,
+  ApprovalPart,
+  ClarifyPart,
+  SudoPart,
+  SecretPart,
+  turnIsConcreteResponse,
+} from "../components/agent/AgentWorkspace";
+import type { AgentChatPart, AgentChatTurn } from "../lib/agent-chat-runtime";
 import { createHermesMethods } from "../lib/hermes-control-plane";
 import secretFixture from "../lib/hermes-control-plane/fixtures/secret-request-response.json";
 
@@ -38,17 +45,25 @@ function secretPart(
 }
 
 describe("SudoPart card", () => {
-  it("blocks the session with an explicit approve/deny card showing the command and mode", () => {
+  it("blocks the session with an explicit approve/deny card showing the reason and mode", async () => {
     render(<SudoPart part={sudoPart()} onSudo={() => {}} />);
 
-    expect(screen.getByText("apt-get install ripgrep")).toBeInTheDocument();
+    // Compact by default: the prose reason shows, the command is hidden behind
+    // Details, and the approve/deny actions are always visible.
     expect(
       screen.getByText(/ripgrep is required to search the dependency tree/),
     ).toBeInTheDocument();
-    // The execution mode is shown explicitly so the user knows the blast radius.
-    expect(screen.getByText(/unrestricted/i)).toBeInTheDocument();
+    expect(screen.queryByText("apt-get install ripgrep")).not.toBeInTheDocument();
+    // The unrestricted mode badge stays visible while collapsed so the blast
+    // radius reads before expanding.
+    expect(document.querySelector(".agent-sudo-mode-badge")?.textContent).toMatch(/unrestricted/i);
     expect(screen.getByRole("button", { name: /approve/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /deny/i })).toBeInTheDocument();
+
+    // Expanding Details reveals the full command pre and the execution-mode notice.
+    await userEvent.click(screen.getByRole("button", { name: /details/i }));
+    expect(screen.getByText("apt-get install ripgrep")).toBeInTheDocument();
+    expect(document.querySelector(".agent-sudo-mode-notice")?.textContent).toMatch(/unrestricted/i);
   });
 
   it("invokes respondToSudo with approved=true and the mode when approved", async () => {
@@ -203,5 +218,444 @@ describe("SecretPart card", () => {
     render(<SecretPart part={secretPart({ keyName: "DATABASE_PASSWORD" })} onSecret={() => {}} />);
     expect(screen.queryByText("DATABASE_PASSWORD")).not.toBeInTheDocument();
     expect(screen.getByText(/\[redacted\]/i)).toBeInTheDocument();
+  });
+});
+
+function approvalPart(
+  overrides: Partial<Extract<AgentChatPart, { type: "approval" }>> = {},
+): Extract<AgentChatPart, { type: "approval" }> {
+  return {
+    type: "approval",
+    id: "ap-1",
+    sessionId: "sess-approval",
+    command: "rm -rf ./build && npm run build",
+    description: "The agent wants to run a shell command.",
+    allowPermanent: true,
+    status: "pending",
+    ...overrides,
+  };
+}
+
+function clarifyPart(
+  overrides: Partial<Extract<AgentChatPart, { type: "clarify" }>> = {},
+): Extract<AgentChatPart, { type: "clarify" }> {
+  return {
+    type: "clarify",
+    id: "cl-1",
+    sessionId: "sess-clarify",
+    question: "Which format should the recap use?",
+    choices: ["Bulleted list", "Numbered steps"],
+    status: "pending",
+    ...overrides,
+  };
+}
+
+/** The collapsed resolved receipt is a <details> row (role "group"). */
+function resolvedRow() {
+  return document.querySelector(".agent-resolved-row") as HTMLDetailsElement | null;
+}
+
+describe("ApprovalPart", () => {
+  it("pending renders a compact card with a split Approve, Deny, and a scope menu", async () => {
+    render(<ApprovalPart part={approvalPart()} onApproval={() => {}} />);
+
+    expect(resolvedRow()).toBeNull();
+    expect(document.querySelector(".agent-approval-card")).toBeInTheDocument();
+    // Two anchor actions (Approve / Deny) plus the scope caret and Explain first.
+    expect(screen.getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /deny/i })).toBeInTheDocument();
+    const scope = screen.getByRole("button", { name: /approve options/i });
+    // The scope choices live behind the caret — hidden until it opens.
+    expect(screen.queryByRole("menuitem", { name: /approve once/i })).not.toBeInTheDocument();
+
+    await userEvent.click(scope);
+    expect(screen.getByRole("menuitem", { name: "Approve once" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Approve for this session" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Always approve" })).toBeInTheDocument();
+  });
+
+  it("the scope menu fires the matching choice for each item", async () => {
+    for (const [name, choice] of [
+      ["Approve once", "once"],
+      ["Approve for this session", "session"],
+      ["Always approve", "always"],
+    ] as const) {
+      const onApproval = vi.fn();
+      const { unmount } = render(<ApprovalPart part={approvalPart()} onApproval={onApproval} />);
+      await userEvent.click(screen.getByRole("button", { name: /approve options/i }));
+      await userEvent.click(screen.getByRole("menuitem", { name }));
+      expect(onApproval).toHaveBeenCalledWith(expect.objectContaining({ id: "ap-1" }), choice);
+      unmount();
+    }
+  });
+
+  it("the top-level Approve approves once, and hides Always approve when not permitted", async () => {
+    const onApproval = vi.fn();
+    const { unmount } = render(<ApprovalPart part={approvalPart()} onApproval={onApproval} />);
+    await userEvent.click(screen.getByRole("button", { name: "Approve" }));
+    expect(onApproval).toHaveBeenCalledWith(expect.objectContaining({ id: "ap-1" }), "once");
+    unmount();
+
+    render(<ApprovalPart part={approvalPart({ allowPermanent: false })} onApproval={() => {}} />);
+    await userEvent.click(screen.getByRole("button", { name: /approve options/i }));
+    expect(screen.getByRole("menuitem", { name: "Approve once" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Always approve" })).not.toBeInTheDocument();
+  });
+
+  it("moves focus into the scope menu on open and returns it to the caret on Escape", async () => {
+    render(<ApprovalPart part={approvalPart()} onApproval={() => {}} />);
+    const scope = screen.getByRole("button", { name: /approve options/i });
+    await userEvent.click(scope);
+    // Focus lands on the first menu item so arrow keys work immediately.
+    expect(screen.getByRole("menuitem", { name: "Approve once" })).toHaveFocus();
+    // Escape dismisses and returns focus to the caret (not to <body>).
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByRole("menuitem", { name: "Approve once" })).not.toBeInTheDocument();
+    expect(scope).toHaveFocus();
+  });
+
+  it("keeps the expanded card with an in-progress line while a submission is in flight", () => {
+    // status still pending, submitting set — the card must not collapse yet.
+    render(<ApprovalPart part={approvalPart()} onApproval={() => {}} submitting="once" />);
+
+    expect(resolvedRow()).toBeNull();
+    expect(document.querySelector(".agent-approval-card")).toBeInTheDocument();
+    expect(screen.getByText("Approving once")).toBeInTheDocument();
+  });
+
+  it("resolved collapses to a one-line receipt row (no action buttons) that expands to the detail", async () => {
+    render(
+      <ApprovalPart
+        part={approvalPart({ status: "resolved", choice: "session" })}
+        onApproval={() => {}}
+      />,
+    );
+
+    const row = resolvedRow();
+    expect(row).not.toBeNull();
+    // Collapsed: the outcome label shows and no buttons render.
+    expect(within(row as HTMLElement).getByText("Approved for this session")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /approve once/i })).not.toBeInTheDocument();
+    // The command shows in the collapsed detail and again in the expandable body.
+    expect(
+      within(row as HTMLElement).getAllByText("rm -rf ./build && npm run build").length,
+    ).toBeGreaterThan(0);
+
+    // The row is keyboard-operable via native <details>: opening reveals the body.
+    (row as HTMLDetailsElement).open = true;
+    expect((row as HTMLDetailsElement).open).toBe(true);
+  });
+
+  it("resolved denial tints the row as a denied outcome", () => {
+    render(
+      <ApprovalPart
+        part={approvalPart({ status: "resolved", choice: "deny" })}
+        onApproval={() => {}}
+      />,
+    );
+    const row = resolvedRow();
+    expect(row?.dataset.choice).toBe("deny");
+    expect(within(row as HTMLElement).getByText("Denied")).toBeInTheDocument();
+  });
+});
+
+describe("ClarifyPart", () => {
+  it("pending renders the choice buttons", () => {
+    render(<ClarifyPart part={clarifyPart()} onClarify={() => {}} />);
+    expect(resolvedRow()).toBeNull();
+    expect(screen.getByRole("button", { name: /bulleted list/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /numbered steps/i })).toBeInTheDocument();
+  });
+
+  it("resolved+answered collapses to an 'Answered' receipt showing the answer on expand", () => {
+    render(
+      <ClarifyPart
+        part={clarifyPart({ status: "resolved", answer: "Bulleted list" })}
+        onClarify={() => {}}
+      />,
+    );
+    const row = resolvedRow();
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getByText("Answered")).toBeInTheDocument();
+    // The question and answer live in the expandable body; no buttons.
+    expect(within(row as HTMLElement).getByText("Bulleted list")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /bulleted list/i })).not.toBeInTheDocument();
+  });
+
+  it("resolved+skipped collapses to a 'Skipped' receipt", () => {
+    render(
+      <ClarifyPart part={clarifyPart({ status: "resolved", answer: "" })} onClarify={() => {}} />,
+    );
+    const row = resolvedRow();
+    expect(within(row as HTMLElement).getByText("Skipped")).toBeInTheDocument();
+  });
+});
+
+describe("SudoPart resolved", () => {
+  it("collapses to a one-line receipt row that expands to the command and mode", () => {
+    render(<SudoPart part={sudoPart({ status: "resolved", approved: true })} onSudo={() => {}} />);
+    const row = resolvedRow();
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getByText("Approved")).toBeInTheDocument();
+    // No action buttons on a resolved receipt.
+    expect(screen.queryByRole("button", { name: /^approve$/i })).not.toBeInTheDocument();
+    // Command and mode line live in the expandable body.
+    expect(
+      within(row as HTMLElement).getAllByText("apt-get install ripgrep").length,
+    ).toBeGreaterThan(0);
+    expect(within(row as HTMLElement).getByText(/unrestricted/i)).toBeInTheDocument();
+  });
+});
+
+describe("SecretPart resolved", () => {
+  it("collapses to a 'Secret provided' receipt and never shows the input", () => {
+    render(
+      <SecretPart
+        part={secretPart({ status: "resolved", keyName: "GITHUB_USERNAME" })}
+        onSecret={() => {}}
+      />,
+    );
+    const row = resolvedRow();
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getByText("Secret provided")).toBeInTheDocument();
+    // No secure input on the receipt.
+    expect(screen.queryByLabelText(/secret value/i)).not.toBeInTheDocument();
+    // Benign key names surface (in the collapsed detail and expanded body).
+    expect(within(row as HTMLElement).getAllByText("GITHUB_USERNAME").length).toBeGreaterThan(0);
+  });
+});
+
+describe("AgentCliAccessCard", () => {
+  it("pending renders the enable/not-now choice", () => {
+    render(
+      <AgentCliAccessCard cliAccess={{ enabled: false, submitting: false, onEnable: () => {} }} />,
+    );
+    expect(resolvedRow()).toBeNull();
+    expect(screen.getByRole("button", { name: /enable agent cli access/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /not now/i })).toBeInTheDocument();
+  });
+
+  it("enabled collapses to an 'Agent CLI access enabled' receipt", () => {
+    render(
+      <AgentCliAccessCard cliAccess={{ enabled: true, submitting: false, onEnable: () => {} }} />,
+    );
+    const row = resolvedRow();
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getByText("Agent CLI access enabled")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /enable agent cli access/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("action card refinements", () => {
+  it("pending cards carry no title glyph (title text stands alone)", () => {
+    const { unmount: u1 } = render(<ApprovalPart part={approvalPart()} onApproval={() => {}} />);
+    expect(document.querySelector(".agent-approval-card .agent-tool-title .agent-tool-icon")).toBe(
+      null,
+    );
+    u1();
+
+    const { unmount: u2 } = render(<SudoPart part={sudoPart()} onSudo={() => {}} />);
+    expect(document.querySelector(".agent-approval-card .agent-tool-title .agent-tool-icon")).toBe(
+      null,
+    );
+    u2();
+
+    const { unmount: u3 } = render(<SecretPart part={secretPart()} onSecret={() => {}} />);
+    expect(document.querySelector(".agent-approval-card .agent-tool-title .agent-tool-icon")).toBe(
+      null,
+    );
+    u3();
+
+    render(<ClarifyPart part={clarifyPart()} onClarify={() => {}} />);
+    expect(document.querySelector(".agent-clarify-card .agent-tool-title .agent-tool-icon")).toBe(
+      null,
+    );
+  });
+
+  it("the pending approval card shows the description and hides the command behind Details", async () => {
+    render(<ApprovalPart part={approvalPart()} onApproval={() => {}} />);
+    // The header is a plain row now, not a toggle button.
+    expect(screen.queryByRole("button", { name: /approval required/i })).toBeNull();
+    // Collapsed by default — the description shows, the command is not in the DOM
+    // yet, and the Details disclosure owns aria-expanded.
+    expect(screen.getByText("The agent wants to run a shell command.")).toBeInTheDocument();
+    expect(document.querySelector(".agent-approval-card pre")).toBeNull();
+    expect(screen.queryByText("rm -rf ./build && npm run build")).not.toBeInTheDocument();
+    const details = screen.getByRole("button", { name: /details/i });
+    expect(details.getAttribute("aria-expanded")).toBe("false");
+
+    // Expanding Details reveals the full command in a pre.
+    await userEvent.click(details);
+    expect(details.getAttribute("aria-expanded")).toBe("true");
+    expect(document.querySelector(".agent-approval-card pre")?.textContent).toBe(
+      "rm -rf ./build && npm run build",
+    );
+  });
+
+  it("omits the Details disclosure on an approval whose only content is the description", () => {
+    render(<ApprovalPart part={approvalPart({ command: undefined })} onApproval={() => {}} />);
+    // No command and no notice, so there is nothing to disclose.
+    expect(screen.queryByRole("button", { name: /details/i })).toBeNull();
+    // The description still reads.
+    expect(screen.getByText("The agent wants to run a shell command.")).toBeInTheDocument();
+  });
+
+  it("renders Explain first as a system ghost button", () => {
+    render(<ApprovalPart part={approvalPart()} onApproval={() => {}} />);
+    const explain = screen.getByRole("button", { name: "Explain first" });
+    expect(explain.classList.contains("btn")).toBe(true);
+    expect(explain.classList.contains("btn-ghost")).toBe(true);
+    // A leading lightbulb glyph precedes the label (aria-hidden, so the
+    // accessible name stays "Explain first").
+    expect(explain.querySelector("svg")).not.toBeNull();
+  });
+
+  it("the resolved receipt reuses the tool-disclosure row treatment", () => {
+    render(
+      <ApprovalPart
+        part={approvalPart({ status: "resolved", choice: "once" })}
+        onApproval={() => {}}
+      />,
+    );
+    const row = resolvedRow();
+    // Same class the tool rows use, so the receipt is sized identically.
+    expect(row?.classList.contains("agent-tool-disclosure")).toBe(true);
+  });
+
+  it("the resolved receipt body does not restate the outcome", () => {
+    render(
+      <ApprovalPart
+        part={approvalPart({ status: "resolved", choice: "session" })}
+        onApproval={() => {}}
+      />,
+    );
+    const row = resolvedRow();
+    // No .agent-approval-result-style outcome line inside the receipt body — the
+    // summary already carries the outcome label.
+    expect(row?.querySelector(".agent-approval-result")).toBe(null);
+    expect(within(row as HTMLElement).queryByText("Approved once")).not.toBeInTheDocument();
+  });
+
+  it("surfaces the sudo execution mode on the COLLAPSED card, before the full notice is expanded", () => {
+    // Blast radius must read at the decision point: the collapsed unrestricted
+    // card carries a warning badge even though the full InlineNotice lives in the
+    // body.
+    const { unmount } = render(
+      <SudoPart part={sudoPart({ mode: "unrestricted" })} onSudo={() => {}} />,
+    );
+    // The header is a plain row; the Details disclosure owns the collapsed state.
+    expect(screen.queryByRole("button", { name: /privilege escalation requested/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /details/i }).getAttribute("aria-expanded")).toBe(
+      "false",
+    );
+    // No expanded body yet, so the full InlineNotice is absent...
+    expect(document.querySelector(".agent-sudo-mode-notice")).toBeNull();
+    // ...but the unrestricted badge is visible in the collapsed header and the
+    // Approve button is already live.
+    const badge = document.querySelector(".agent-sudo-mode-badge");
+    expect(badge?.textContent).toMatch(/unrestricted/i);
+    // A leading warning glyph precedes the label so the badge reads as negative.
+    expect(badge?.querySelector("svg")).not.toBeNull();
+    expect(screen.getByRole("button", { name: /^approve$/i })).toBeEnabled();
+    unmount();
+
+    // Sandboxed is the safe default: no collapsed badge (the full mode line still
+    // appears in Details).
+    render(<SudoPart part={sudoPart({ mode: "sandboxed" })} onSudo={() => {}} />);
+    expect(document.querySelector(".agent-sudo-mode-badge")).toBeNull();
+  });
+
+  it("pending sudo shows the execution mode as a tone-aware InlineNotice in the expanded body", async () => {
+    const { unmount } = render(
+      <SudoPart part={sudoPart({ mode: "unrestricted" })} onSudo={() => {}} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /details/i }));
+    const warnNotice = document.querySelector(".agent-sudo-mode-notice");
+    expect(warnNotice?.getAttribute("data-tone")).toBe("warning");
+    expect(warnNotice?.textContent).toMatch(/unrestricted/i);
+    unmount();
+
+    render(<SudoPart part={sudoPart({ mode: "sandboxed" })} onSudo={() => {}} />);
+    await userEvent.click(screen.getByRole("button", { name: /details/i }));
+    const infoNotice = document.querySelector(".agent-sudo-mode-notice");
+    expect(infoNotice?.getAttribute("data-tone")).toBe("info");
+    expect(infoNotice?.textContent).toMatch(/sandboxed/i);
+  });
+
+  it("the resolved sudo receipt shows the mode as plain text (no notice chrome)", () => {
+    render(<SudoPart part={sudoPart({ status: "resolved", approved: true })} onSudo={() => {}} />);
+    const row = resolvedRow();
+    // Receipts stay quiet: plain text mode line, never an InlineNotice.
+    expect(row?.querySelector(".agent-sudo-mode-notice")).toBe(null);
+    expect(row?.querySelector(".agent-sudo-mode-receipt")).not.toBeNull();
+  });
+});
+
+describe("turnIsConcreteResponse", () => {
+  const assistant = (parts: AgentChatPart[]): Pick<AgentChatTurn, "role" | "parts"> => ({
+    role: "assistant",
+    parts,
+  });
+
+  it("is true for a user message (always concrete) and an assistant text answer", () => {
+    expect(
+      turnIsConcreteResponse({
+        role: "user",
+        parts: [{ type: "text", text: "hi", status: "complete" }],
+      }),
+    ).toBe(true);
+    expect(
+      turnIsConcreteResponse(
+        assistant([{ type: "text", text: "Here you go.", status: "complete" }]),
+      ),
+    ).toBe(true);
+  });
+
+  it("is true for a finished image but not one still generating", () => {
+    expect(
+      turnIsConcreteResponse(
+        assistant([{ type: "image", status: "complete", prompt: "a fox" } as AgentChatPart]),
+      ),
+    ).toBe(true);
+    expect(
+      turnIsConcreteResponse(
+        assistant([{ type: "image", status: "running", prompt: "a fox" } as AgentChatPart]),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for process and interaction turns (thinking, tools, cards, empty)", () => {
+    // The screenshot case: a running tool row gets no timestamp below it.
+    expect(
+      turnIsConcreteResponse(
+        assistant([{ type: "tool", id: "t", name: "Read File", text: "", status: "running" }]),
+      ),
+    ).toBe(false);
+    expect(
+      turnIsConcreteResponse(
+        assistant([{ type: "reasoning", text: "thinking...", status: "running" }]),
+      ),
+    ).toBe(false);
+    for (const type of ["approval", "clarify", "sudo", "secret"] as const) {
+      expect(turnIsConcreteResponse(assistant([{ type, id: type } as AgentChatPart]))).toBe(false);
+    }
+    expect(turnIsConcreteResponse(assistant([]))).toBe(false);
+    // Whitespace-only text is not a concrete answer.
+    expect(
+      turnIsConcreteResponse(assistant([{ type: "text", text: "   ", status: "complete" }])),
+    ).toBe(false);
+  });
+
+  it("is true when an assistant turn mixes a tool call with a real text answer", () => {
+    expect(
+      turnIsConcreteResponse(
+        assistant([
+          { type: "tool", id: "t", name: "Read File", text: "", status: "complete" },
+          { type: "text", text: "Done.", status: "complete" },
+        ]),
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Redesigned the agent chat action surfaces (approval, clarify, sudo, secret, CLI-access) into a calmer, consistent system: pending cards are condensed with a "Details" disclosure, resolved actions collapse to one-line tool-row receipts, and the heavy icon tiles and title glyphs are gone.
- Reworked the footer to a quiet gray split-button Approve (outlined container, gray-filled Approve + inset caret scope menu) with neutral ghost Deny and Explain — no go-green or stop-red on the choice; risk is signaled by the request and a gray "Unrestricted" caution badge on sudo.
- Dechromatized the global `--destructive` token (0.22 → 0.15 chroma, an earthier brick) so red stops fighting the low-chroma palette and is reserved strictly for errors; recorded the principle in `taste.md`.
- Made per-turn copy/branch/timestamp appear only on concrete responses (user messages, assistant text or finished-image answers) via an allowlist, dropping them from process, interaction, and system rows — including the context-compacted and steering rows.
- Also fixed the scope-menu double-highlight, credits-notice tone and centering, field focus, and type-scale drift; the behavior of the underlying flows is unchanged.

## Validation

- `pnpm typecheck`, `pnpm check` (0 errors), and the touched vitest suites (agent-workspace, approval-card-css, hermes-sudo-secret-actions — 260 pass) are green.

- [x] Tested visually where it matters — verified live in the dev response gallery (`window.__agentGallery`), which renders every state through the real components.
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- no: frontend-only change -->

## Out of scope

- The "Not now" (CLI) and "Cancel" (secret) buttons still share the deny class, so they carry the same neutral ghost hover. No functional change to any approval/clarify/sudo/secret flow.

## Followups

- Optional: give "Not now" / "Cancel" a hover treatment distinct from Deny.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. Secret value handling is unchanged (value stays in local state, wiped on submit/cancel/unmount, never rendered); the sudo "Unrestricted" blast-radius signal stays visible while Approve is live.
- [x] Workflow action references are pinned to full-length commit SHAs. <!-- no workflow changes -->
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. <!-- none -->
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. <!-- none -->
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786142559&installation_id=144203540&pr_number=672&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F672&signature=30a212a45405df02afe926cb49cf713e12f112d9da1f5d99cc48b7bff535b97f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->