### PR TITLE
Pin the dictation paste target so long dictations reach the app you dictated into (JUN-226)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -131,8 +131,9 @@ _Avoid_: dictation app, keyboard helper.
 The app the dictation helper types a finished transcript into, pinned at the
 instant the recording stops and never re-resolved afterwards (see
 [ADR-0014](docs/adr/0014-pinned-dictation-paste-target.md)). Pinning matters
-because the transcription round trip can outlast the user's attention: the
-frontmost app at paste time is often no longer the one they dictated into.
+because the dictation round trip (capture, then dictation transcription, then
+cleanup) can outlast the user's attention: the frontmost app at paste time is
+often no longer the one they dictated into.
 _Avoid_: foreground app, frontmost app (both name a live value, not the pin);
 focus target.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -123,9 +123,18 @@ _Avoid_: system driver, in-process capture.
 
 **Dictation helper**:
 The native macOS helper (`mac-dictation-helper`) that owns push-to-talk
-**dictation** capture and text insertion into the foreground app, and is the
+**dictation** capture and text insertion into the **paste target**, and is the
 authoritative source for microphone + accessibility permission state.
 _Avoid_: dictation app, keyboard helper.
+
+**Paste target**:
+The app the dictation helper types a finished transcript into, pinned at the
+instant the recording stops and never re-resolved afterwards (see
+[ADR-0014](docs/adr/0014-pinned-dictation-paste-target.md)). Pinning matters
+because the transcription round trip can outlast the user's attention: the
+frontmost app at paste time is often no longer the one they dictated into.
+_Avoid_: foreground app, frontmost app (both name a live value, not the pin);
+focus target.
 
 ### Agent runtime (Hermes)
 
@@ -235,10 +244,12 @@ _Avoid_: admin panel, Hermes UI (June presents as June).
 ### AI work & billing
 
 **Dictation**:
-A latency-critical June mode where the user pushes-to-talk, speaks a short
-phrase, releases, and expects cleaned-up text inserted into the foreground
-app within a few hundred milliseconds. Distinct from **note transcription**.
-Goes through June API in v1, so the binary holds no upstream provider key.
+A latency-critical June mode where the user pushes-to-talk, speaks, releases,
+and expects cleaned-up text inserted into the **paste target**. A short phrase
+round-trips in a few hundred milliseconds; a sustained block of speech can take
+many seconds, and everything on the paste path must stay correct across that
+whole window. Distinct from **note transcription**. Goes through June API in
+v1, so the binary holds no upstream provider key.
 _Avoid_: speech-to-text (too generic — covers both dictation and note
 transcription).
 

--- a/docs/adr/0014-pinned-dictation-paste-target.md
+++ b/docs/adr/0014-pinned-dictation-paste-target.md
@@ -1,0 +1,91 @@
+---
+status: accepted
+date: 2026-07-09
+---
+
+# The dictation paste target is pinned when the recording stops
+
+The **dictation helper** delivers a transcript by writing it to the clipboard
+and posting a synthetic Cmd+V. It chooses the app that receives that keystroke
+by **pinning** the frontmost app at the instant the recording stops
+(`FocusTargetController.pinCurrentTarget()`, called from
+`emitRecordingReady()`), and it pastes into that pinned app and no other.
+
+If the pinned app has quit by the time the transcript comes back, June does not
+paste at all: it leaves the transcript on the clipboard and tells the user to
+paste it themselves, the same way it behaves when Accessibility trust is
+missing.
+
+The helper also waits for the pinned app to actually become frontmost before
+posting Cmd+V (bounded, then it posts anyway), and it measures the
+clipboard-restore delay from the keystroke rather than from the start of the
+paste.
+
+## Why
+
+Dictation is not a single instant. The user releases push-to-talk, and only
+then does June upload the audio, transcribe it upstream, and optionally run a
+cleanup pass over the text. That round trip is fast for a short phrase and slow
+for a long one: **the wait scales with how long the user spoke.**
+
+The helper used to resolve the paste destination at paste time, reading
+`lastExternalApp` — a field that a global `didActivateApplicationNotification`
+observer rewrites on *every* app activation. Those two facts compose into a
+time-of-check/time-of-use bug:
+
+- Short dictation: the gap is under a second, nothing else activates, the
+  paste lands where the user was typing. It looks like it always works.
+- Long dictation: the gap is many seconds. Anything that activates an app in
+  that window silently repoints the target, and the transcript is typed into
+  whatever app now happens to be frontmost.
+
+Because the transcript is written to dictation history regardless of where the
+paste went, the failure presents as "dictation didn't work, but the text is in
+the dictation tab" (JUN-226) rather than as an error.
+
+Pinning removes the drift window entirely. It also makes the target a single
+source of truth: Rust already snapshots `targetBundleIdentifier` at
+`recording_ready` to decide cleanup context, and the helper now pastes into
+that same app instead of into a value that has since moved.
+
+Two smaller assumptions on the same path were wrong for the same reason:
+`NSRunningApplication.activate(options:)` is asynchronous, so posting Cmd+V a
+fixed 180 ms later could deliver the keystroke to the app that was *still*
+frontmost; and scheduling the clipboard restore from the start of the paste
+left the target only ~520 ms to read a clipboard that was about to be yanked
+back.
+
+## Alternatives considered
+
+- **Insert into June's own composer directly, and keep clipboard+Cmd+V only for
+  external apps.** Rejected for now: it splits dictation delivery into two
+  code paths with different failure modes, and it fixes the bug only when the
+  target is June. Dictation into any other app would keep drifting. Pinning
+  fixes every target with one mechanism.
+- **Pass the pinned target from Rust in the `paste_text` command.** Rust holds
+  the bundle id already, and this would make the choice unit-testable in Rust.
+  Rejected because a bundle id cannot distinguish two running instances, while
+  the helper can hold the exact `NSRunningApplication`. Correctness beat
+  testability; the helper ships in the same binary, so there is no wire
+  contract to keep compatible.
+- **Fall back to the frontmost app when the pinned app is gone.** Rejected: it
+  reintroduces the failure this ADR exists to prevent, and typing a long
+  transcript into an unintended app is worse than asking the user to press
+  Cmd+V.
+- **Pin when the recording starts rather than when it stops.** Equivalent in
+  practice (the frontmost app rarely changes while the user is holding
+  push-to-talk and speaking), and stop-time pinning matches the instant Rust
+  already snapshots the bundle id.
+
+## Consequences
+
+- If the user deliberately switches apps while a long dictation is
+  transcribing, the text lands in the app they dictated from, not the one they
+  moved to. This is intended, and is what "paste into the chat I had active"
+  means.
+- A new `paste_target_unavailable` error can reach the HUD. It is not in the
+  silent-error allowlist, so it renders as a real error rather than being
+  swallowed as "nothing recorded".
+- The helper's paste path is now the only place that decides the target.
+  `activateLastExternalApp()` is gone; `lastExternalApp` remains only as the
+  live source that `pinCurrentTarget()` samples.

--- a/docs/adr/0014-pinned-dictation-paste-target.md
+++ b/docs/adr/0014-pinned-dictation-paste-target.md
@@ -24,9 +24,10 @@ paste.
 ## Why
 
 Dictation is not a single instant. The user releases push-to-talk, and only
-then does June upload the audio, transcribe it upstream, and optionally run a
-cleanup pass over the text. That round trip is fast for a short phrase and slow
-for a long one: **the wait scales with how long the user spoke.**
+then does June upload the audio, run dictation transcription upstream, and
+optionally run a cleanup pass over the text. That round trip is fast for a
+short phrase and slow for a long one: **the wait scales with how long the user
+spoke.**
 
 The helper used to resolve the paste destination at paste time, reading
 `lastExternalApp` — a field that a global `didActivateApplicationNotification`

--- a/docs/adr/0014-pinned-dictation-paste-target.md
+++ b/docs/adr/0014-pinned-dictation-paste-target.md
@@ -16,10 +16,11 @@ paste at all: it leaves the transcript on the clipboard and tells the user to
 paste it themselves, the same way it behaves when Accessibility trust is
 missing.
 
-The helper also waits for the pinned app to actually become frontmost before
-posting Cmd+V (bounded, then it posts anyway), and it measures the
-clipboard-restore delay from the keystroke rather than from the start of the
-paste.
+The helper also waits (bounded) for the pinned app to actually become
+frontmost, and posts Cmd+V **only** if it is frontmost at that moment. If the
+app never comes forward, the paste is abandoned to the clipboard rather than
+typed somewhere else. The clipboard-restore delay is measured from the
+keystroke rather than from the start of the paste.
 
 ## Why
 
@@ -90,3 +91,16 @@ back.
 - The helper's paste path is now the only place that decides the target.
   `activateLastExternalApp()` is gone; `lastExternalApp` remains only as the
   live source that `pinCurrentTarget()` samples.
+- A pinned app that refuses to come forward (a modal, another full-screen
+  space, a refused cooperative activation) now yields `paste_target_unavailable`
+  instead of a paste. That is the intended trade: activation is a request, not
+  a command, and typing a private transcript into the wrong window is worse
+  than asking for a manual Cmd+V.
+- The guarantee is "frontmost when we posted the keystroke", not "frontmost
+  when the keystroke was delivered". The remaining window is the time to post a
+  CGEvent, versus the multi-second window this ADR removes. It cannot be closed
+  from outside the window server.
+- `paste_text` carries no state guard, so if the helper crashes and respawns
+  while Rust is still transcribing, the replacement process has no pin and
+  reports `paste_target_unavailable`. The transcript is still on the clipboard
+  and in dictation history, so nothing is lost.

--- a/docs/adr/0014-pinned-dictation-paste-target.md
+++ b/docs/adr/0014-pinned-dictation-paste-target.md
@@ -8,8 +8,10 @@ date: 2026-07-09
 The **dictation helper** delivers a transcript by writing it to the clipboard
 and posting a synthetic Cmd+V. It chooses the app that receives that keystroke
 by **pinning** the frontmost app at the instant the recording stops
-(`FocusTargetController.pinCurrentTarget()`, called from
-`emitRecordingReady()`), and it pastes into that pinned app and no other.
+(`FocusTargetController.pinCurrentTarget()`, called from `stopActiveRecording()`
+before the recorder is torn down), and it pastes into that pinned app and no
+other. The pin must precede teardown: the selected-microphone recorder stops
+asynchronously, so pinning after it would reopen the drift window.
 
 If the pinned app has quit by the time the transcript comes back, June does not
 paste at all: it leaves the transcript on the clipboard and tells the user to

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ decision. See "When to add an ADR" in [AGENTS.md](../AGENTS.md).
 - [adr/0011](adr/0011-bundled-hermes-skills.md) — selected Hermes skills ship as read-only app resources when the runtime pin cannot move
 - [adr/0012](adr/0012-direct-issue-report-submission.md) — issue reports submit directly (no client model turn, nothing to charge); June API generates the team-facing diagnosis
 - [adr/0013](adr/0013-stream-inference-responses-through-june-api.md) — inference responses stream through June API (SSE pass-through + keep-alive heartbeats); charges settle after the stream ends
+- [adr/0014](adr/0014-pinned-dictation-paste-target.md) — the dictation paste target is pinned when the recording stops, never re-resolved at paste time
 
 ## Enforceable rules (spec/)
 

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -952,6 +952,7 @@ final class FocusTargetController {
     static let shared = FocusTargetController()
 
     private var lastExternalApp: NSRunningApplication?
+    private var pinnedTarget: NSRunningApplication?
     private let ignoredBundleIdentifiers: Set<String> = [
         "co.opensoftware.june.dictation-helper",
     ]
@@ -971,11 +972,19 @@ final class FocusTargetController {
         }
     }
 
-    func activateLastExternalApp() -> Bool {
-        guard let app = lastExternalApp, !app.isTerminated else {
-            return false
+    func pinCurrentTarget() {
+        pinnedTarget = lastExternalApp
+    }
+
+    func clearPinnedTarget() {
+        pinnedTarget = nil
+    }
+
+    func pasteTarget() -> NSRunningApplication? {
+        guard let app = pinnedTarget, !app.isTerminated else {
+            return nil
         }
-        return app.activate(options: [])
+        return app
     }
 
     func targetDescription() -> String {
@@ -985,9 +994,22 @@ final class FocusTargetController {
         return app.localizedName ?? app.bundleIdentifier ?? "\(app.processIdentifier)"
     }
 
-    /// Bundle id of the app `activateLastExternalApp()` will paste into, so
-    /// the main process can shape cleanup for the same target it pastes to.
+    func pasteTargetDescription() -> String {
+        guard let app = pasteTarget() else {
+            return "unknown"
+        }
+        return app.localizedName ?? app.bundleIdentifier ?? "\(app.processIdentifier)"
+    }
+
+    /// Rust cleanup needs the same target that paste will use, so a pinned
+    /// dictation target must win over later activation drift.
     func targetBundleIdentifier() -> String? {
+        if let app = pinnedTarget {
+            guard !app.isTerminated else {
+                return nil
+            }
+            return app.bundleIdentifier
+        }
         guard let app = lastExternalApp, !app.isTerminated else {
             return nil
         }
@@ -1708,6 +1730,7 @@ final class DictationController {
             return
         }
 
+        FocusTargetController.shared.pinCurrentTarget()
         emit("recording_ready", [
             "path": recordingURL.path,
             "observedAudioLevel": String(format: "%.4f", maxObservedAudioLevel),
@@ -1909,6 +1932,7 @@ final class DictationController {
     }
 
     private func resetRecordingState(keepRecordingFile: Bool = false) {
+        FocusTargetController.shared.clearPinnedTarget()
         isListening = false
         isFinalizing = false
         startPending = false
@@ -1942,6 +1966,19 @@ struct PasteboardSnapshot {
 }
 
 enum PasteboardInserter {
+    /// The activation observer is cheap, and 20 ms keeps long dictation paste
+    /// handoff responsive without blocking the main run loop.
+    private static let activationPollInterval: TimeInterval = 0.02
+    /// Activation is asynchronous; after one second we still post Cmd+V so a
+    /// transient false or delayed state update does not silently drop text.
+    private static let activationTimeout: TimeInterval = 1.0
+    /// Frontmost app activation and key-window focus do not land at the same
+    /// instant, so a short settle delay protects the synthetic Cmd+V target.
+    private static let activationSettleDelay: TimeInterval = 0.18
+    /// Restore is measured from the keystroke so the target gets a full window
+    /// to read the transcript from the pasteboard.
+    private static let pasteboardRestoreDelay: TimeInterval = 0.7
+
     static func paste(_ text: String) {
         let pasteboard = NSPasteboard.general
         let snapshot = capture(pasteboard)
@@ -1971,21 +2008,54 @@ enum PasteboardInserter {
             return
         }
 
-        let targetActivated = FocusTargetController.shared.activateLastExternalApp()
+        guard let target = FocusTargetController.shared.pasteTarget() else {
+            emit("error", [
+                "code": "paste_target_unavailable",
+                "message": "June couldn't paste automatically. Your transcript is on the clipboard, so you can paste it with Cmd+V.",
+            ])
+            return
+        }
+
+        let targetActivated = target.isActive ? true : target.activate(options: [])
         emit("paste_target", [
-            "app": FocusTargetController.shared.targetDescription(),
+            "app": FocusTargetController.shared.pasteTargetDescription(),
             "activated": boolStatus(targetActivated),
         ])
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+        waitForActivation(
+            of: target,
+            deadline: DispatchTime.now() + activationTimeout
+        ) {
             postPasteShortcut()
             emit("paste_completed")
+
+            DispatchQueue.global().asyncAfter(deadline: .now() + pasteboardRestoreDelay) {
+                if pasteboard.string(forType: .string) == text {
+                    restore(snapshot, to: pasteboard)
+                }
+            }
+        }
+    }
+
+    private static func waitForActivation(
+        of target: NSRunningApplication,
+        deadline: DispatchTime,
+        completion: @escaping () -> Void
+    ) {
+        if target.isActive {
+            DispatchQueue.main.asyncAfter(deadline: .now() + activationSettleDelay) {
+                completion()
+            }
+            return
         }
 
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.7) {
-            if pasteboard.string(forType: .string) == text {
-                restore(snapshot, to: pasteboard)
-            }
+        guard DispatchTime.now().uptimeNanoseconds < deadline.uptimeNanoseconds else {
+            completion()
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + activationPollInterval) {
+            waitForActivation(of: target, deadline: deadline, completion: completion)
         }
     }
 

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -1730,7 +1730,6 @@ final class DictationController {
             return
         }
 
-        FocusTargetController.shared.pinCurrentTarget()
         emit("recording_ready", [
             "path": recordingURL.path,
             "observedAudioLevel": String(format: "%.4f", maxObservedAudioLevel),
@@ -1773,6 +1772,11 @@ final class DictationController {
 
     private func stopActiveRecording() {
         let purpose = recordingPurpose
+        if purpose == .dictation {
+            // Selected-device recorder teardown is asynchronous, so the paste
+            // target must be pinned before focus can drift during finalization.
+            FocusTargetController.shared.pinCurrentTarget()
+        }
         isListening = false
         isFinalizing = true
         micTestStopWorkItem?.cancel()
@@ -1979,6 +1983,13 @@ enum PasteboardInserter {
     /// to read the transcript from the pasteboard.
     private static let pasteboardRestoreDelay: TimeInterval = 0.7
 
+    private static func emitPasteTargetUnavailable() {
+        emit("error", [
+            "code": "paste_target_unavailable",
+            "message": "June couldn't paste automatically. Your transcript is on the clipboard, so you can paste it with Cmd+V.",
+        ])
+    }
+
     static func paste(_ text: String) {
         let pasteboard = NSPasteboard.general
         let snapshot = capture(pasteboard)
@@ -2009,10 +2020,7 @@ enum PasteboardInserter {
         }
 
         guard let target = FocusTargetController.shared.pasteTarget() else {
-            emit("error", [
-                "code": "paste_target_unavailable",
-                "message": "June couldn't paste automatically. Your transcript is on the clipboard, so you can paste it with Cmd+V.",
-            ])
+            emitPasteTargetUnavailable()
             return
         }
 
@@ -2025,7 +2033,12 @@ enum PasteboardInserter {
         waitForActivation(
             of: target,
             deadline: DispatchTime.now() + activationTimeout
-        ) {
+        ) { targetAvailable in
+            guard targetAvailable, !target.isTerminated else {
+                emitPasteTargetUnavailable()
+                return
+            }
+
             postPasteShortcut()
             emit("paste_completed")
 
@@ -2040,17 +2053,22 @@ enum PasteboardInserter {
     private static func waitForActivation(
         of target: NSRunningApplication,
         deadline: DispatchTime,
-        completion: @escaping () -> Void
+        completion: @escaping (_ targetAvailable: Bool) -> Void
     ) {
+        guard !target.isTerminated else {
+            completion(false)
+            return
+        }
+
         if target.isActive {
             DispatchQueue.main.asyncAfter(deadline: .now() + activationSettleDelay) {
-                completion()
+                completion(!target.isTerminated)
             }
             return
         }
 
         guard DispatchTime.now().uptimeNanoseconds < deadline.uptimeNanoseconds else {
-            completion()
+            completion(!target.isTerminated)
             return
         }
 

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -2033,8 +2033,13 @@ enum PasteboardInserter {
         waitForActivation(
             of: target,
             deadline: DispatchTime.now() + activationTimeout
-        ) { targetAvailable in
-            guard targetAvailable, !target.isTerminated else {
+        ) { targetIsFrontmost in
+            // Cmd+V goes wherever the window server thinks focus is, so posting
+            // it while the pinned app is not frontmost types the transcript
+            // into somebody else's window. If the activation never landed,
+            // abandon the paste rather than guess: the transcript is already on
+            // the clipboard, and a manual Cmd+V beats text in the wrong app.
+            guard targetIsFrontmost else {
                 emitPasteTargetUnavailable()
                 return
             }
@@ -2050,10 +2055,15 @@ enum PasteboardInserter {
         }
     }
 
+    /// Calls `completion(true)` only when `target` is alive and frontmost at
+    /// that moment. `NSRunningApplication.isActive` means "currently
+    /// frontmost", so a read taken right before the keystroke is the strongest
+    /// guarantee available: it shrinks the gap between deciding and typing to
+    /// the time it takes to post the event, rather than closing it outright.
     private static func waitForActivation(
         of target: NSRunningApplication,
         deadline: DispatchTime,
-        completion: @escaping (_ targetAvailable: Bool) -> Void
+        completion: @escaping (_ targetIsFrontmost: Bool) -> Void
     ) {
         guard !target.isTerminated else {
             completion(false)
@@ -2062,13 +2072,16 @@ enum PasteboardInserter {
 
         if target.isActive {
             DispatchQueue.main.asyncAfter(deadline: .now() + activationSettleDelay) {
-                completion(!target.isTerminated)
+                completion(!target.isTerminated && target.isActive)
             }
             return
         }
 
+        // The app never came forward. Activation is a request, not a command:
+        // a modal, a full-screen space, or a refused cooperative activation can
+        // all outlast the deadline.
         guard DispatchTime.now().uptimeNanoseconds < deadline.uptimeNanoseconds else {
-            completion(!target.isTerminated)
+            completion(false)
             return
         }
 

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -1973,8 +1973,9 @@ enum PasteboardInserter {
     /// The activation observer is cheap, and 20 ms keeps long dictation paste
     /// handoff responsive without blocking the main run loop.
     private static let activationPollInterval: TimeInterval = 0.02
-    /// Activation is asynchronous; after one second we still post Cmd+V so a
-    /// transient false or delayed state update does not silently drop text.
+    /// Activation is asynchronous. If the pinned app has not come forward
+    /// within a second, abandon the automatic paste rather than post Cmd+V into
+    /// whichever app is frontmost instead.
     private static let activationTimeout: TimeInterval = 1.0
     /// Frontmost app activation and key-window focus do not land at the same
     /// instant, so a short settle delay protects the synthetic Cmd+V target.

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -5053,6 +5053,24 @@ mod tests {
     }
 
     #[test]
+    fn paste_target_unavailable_error_is_visible() {
+        // The dictation helper emits this when the app that was frontmost as
+        // the recording stopped has since quit, so there is nowhere safe to
+        // send the synthetic Cmd+V. Like the Accessibility case, the
+        // transcript is left on the clipboard and the user must be told.
+        let mut event = serde_json::json!({
+            "type": "error",
+            "payload": {
+                "code": "paste_target_unavailable",
+                "message": "June couldn't paste automatically. Your transcript is on the clipboard, so you can paste it with Cmd+V.",
+            }
+        });
+        assert!(!is_silent_transcription_error(&event));
+        annotate_silent_error(&mut event);
+        assert_eq!(event["payload"]["silent"], false);
+    }
+
+    #[test]
     fn dictation_event_log_redacts_transcript_text() {
         let event = serde_json::json!({
             "type": "final_transcript",

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -2359,10 +2359,11 @@ fn handle_helper_event_line(app: &AppHandle, line: String) {
 
 async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInfo) {
     // Resolve the paste target before the first await. Prefer the bundle id
-    // the helper captured with the recording: its FocusTargetController is
-    // the same authority that activateLastExternalApp() pastes into, so
-    // layout and paste share one source of truth. Fall back to the frontmost
-    // app for helper builds that predate the field.
+    // the helper captured with the recording: the helper pins that same app
+    // when the recording stops and pastes into it once we return, so layout
+    // and paste share one source of truth even though the awaits below can
+    // take many seconds. Fall back to the frontmost app for helper builds
+    // that predate the field.
     let app_context = recording
         .target_bundle_id
         .as_deref()

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -2726,9 +2726,9 @@ struct DictationTranscriptionOutcome {
 struct RecordingReadyInfo {
     audio_path: PathBuf,
     observed_audio_level: Option<f32>,
-    /// Bundle id of the paste target as tracked by the helper's
-    /// FocusTargetController: the same app activateLastExternalApp() will
-    /// paste into. None with older helper builds that predate the field.
+    /// Bundle id of the paste target the helper pinned when the recording
+    /// stopped: the same app it will paste into once we hand back a
+    /// transcript. None with older helper builds that predate the field.
     target_bundle_id: Option<String>,
 }
 

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -95,7 +95,7 @@ if (meetingStartIcon) {
 
 let hideTimer: number | undefined;
 let meetingPromptTimer: number | undefined;
-let longTranscribeTimer: number | undefined;
+let longDictationNoticeTimer: number | undefined;
 let brailleTimer: number | undefined;
 let brailleFrame = 0;
 let meetingPromptSuppressed = false;
@@ -124,7 +124,7 @@ const ERROR_LAYER_GAP = 8;
 const MEETING_PROMPT_TIMEOUT_MS = 30_000;
 // A short dictation round-trips in well under a second. Past this, the
 // user is watching a spinner wondering whether June hung, so say so.
-const LONG_TRANSCRIBE_NOTICE_MS = 6_000;
+const LONG_DICTATION_NOTICE_MS = 6_000;
 
 function invokeBestEffort(command: string, args?: Record<string, unknown>) {
   try {
@@ -227,7 +227,7 @@ function setHud(state: string, status: string): HudTransition {
     hud.classList.remove("hud-reveal-collapsed");
   }
   if (state !== "transcribing") {
-    clearLongTranscribeTimer();
+    clearLongDictationNotice();
   }
   if (state === "transcribing" || state === "pasting") {
     startBraille();
@@ -649,21 +649,21 @@ function startMeetingPromptTimer() {
   }, MEETING_PROMPT_TIMEOUT_MS);
 }
 
-function clearLongTranscribeTimer() {
-  if (longTranscribeTimer) {
-    window.clearTimeout(longTranscribeTimer);
-    longTranscribeTimer = undefined;
+function clearLongDictationNotice() {
+  if (longDictationNoticeTimer) {
+    window.clearTimeout(longDictationNoticeTimer);
+    longDictationNoticeTimer = undefined;
   }
 }
 
-function startLongTranscribeTimer() {
-  if (longTranscribeTimer !== undefined) return;
-  longTranscribeTimer = window.setTimeout(() => {
-    longTranscribeTimer = undefined;
+function startLongDictationNotice() {
+  if (longDictationNoticeTimer !== undefined) return;
+  longDictationNoticeTimer = window.setTimeout(() => {
+    longDictationNoticeTimer = undefined;
     if (hud?.dataset.state !== "transcribing") return;
     const transition = setHud("transcribing", "Still transcribing");
     void showHud(showOptionsForTransition(transition));
-  }, LONG_TRANSCRIBE_NOTICE_MS);
+  }, LONG_DICTATION_NOTICE_MS);
 }
 
 async function hideHud() {
@@ -884,7 +884,7 @@ async function handleDictationEventPayload(payload: unknown) {
     cancelPendingAudioLevel();
     const transition = setHud("transcribing", "Transcribing");
     await showHud(showOptionsForTransition(transition));
-    startLongTranscribeTimer();
+    startLongDictationNotice();
     return;
   }
 

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -95,6 +95,7 @@ if (meetingStartIcon) {
 
 let hideTimer: number | undefined;
 let meetingPromptTimer: number | undefined;
+let longTranscribeTimer: number | undefined;
 let brailleTimer: number | undefined;
 let brailleFrame = 0;
 let meetingPromptSuppressed = false;
@@ -121,6 +122,9 @@ const WINDOW_GUTTER = 18;
 // — must match the .hud-error-layer margin in hud.css.
 const ERROR_LAYER_GAP = 8;
 const MEETING_PROMPT_TIMEOUT_MS = 30_000;
+// A short dictation round-trips in well under a second. Past this, the
+// user is watching a spinner wondering whether June hung, so say so.
+const LONG_TRANSCRIBE_NOTICE_MS = 6_000;
 
 function invokeBestEffort(command: string, args?: Record<string, unknown>) {
   try {
@@ -221,6 +225,9 @@ function setHud(state: string, status: string): HudTransition {
   // sizing, and error exits clear it before fading the expanded HUD in place.
   if (state !== "error" && state !== "exiting") {
     hud.classList.remove("hud-reveal-collapsed");
+  }
+  if (state !== "transcribing") {
+    clearLongTranscribeTimer();
   }
   if (state === "transcribing" || state === "pasting") {
     startBraille();
@@ -642,6 +649,23 @@ function startMeetingPromptTimer() {
   }, MEETING_PROMPT_TIMEOUT_MS);
 }
 
+function clearLongTranscribeTimer() {
+  if (longTranscribeTimer) {
+    window.clearTimeout(longTranscribeTimer);
+    longTranscribeTimer = undefined;
+  }
+}
+
+function startLongTranscribeTimer() {
+  if (longTranscribeTimer !== undefined) return;
+  longTranscribeTimer = window.setTimeout(() => {
+    longTranscribeTimer = undefined;
+    if (hud?.dataset.state !== "transcribing") return;
+    const transition = setHud("transcribing", "Still transcribing");
+    void showHud(showOptionsForTransition(transition));
+  }, LONG_TRANSCRIBE_NOTICE_MS);
+}
+
 async function hideHud() {
   const requestId = ++hideRequestId;
   showRequestId += 1;
@@ -860,6 +884,7 @@ async function handleDictationEventPayload(payload: unknown) {
     cancelPendingAudioLevel();
     const transition = setHud("transcribing", "Transcribing");
     await showHud(showOptionsForTransition(transition));
+    startLongTranscribeTimer();
     return;
   }
 

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -650,7 +650,7 @@ function startMeetingPromptTimer() {
 }
 
 function clearLongDictationNotice() {
-  if (longDictationNoticeTimer) {
+  if (longDictationNoticeTimer !== undefined) {
     window.clearTimeout(longDictationNoticeTimer);
     longDictationNoticeTimer = undefined;
   }

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -324,7 +324,7 @@ describe("meeting detection HUD", () => {
     expect(hudShowCalls()).toBe(0);
   });
 
-  it("surfaces a long transcription notice", async () => {
+  it("surfaces a long dictation notice", async () => {
     vi.useFakeTimers();
     await loadHud();
 
@@ -339,7 +339,7 @@ describe("meeting detection HUD", () => {
     expect(document.querySelector("#hud-status")).toHaveTextContent("Still transcribing");
   });
 
-  it("re-arms the long transcription notice on the next dictation's clock", async () => {
+  it("re-arms the long dictation notice on the next dictation's clock", async () => {
     vi.useFakeTimers();
     await loadHud();
 

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -324,6 +324,51 @@ describe("meeting detection HUD", () => {
     expect(hudShowCalls()).toBe(0);
   });
 
+  it("surfaces a long transcription notice", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+
+    await emit("dictation-event", { type: "finalizing_transcript" });
+
+    expect(hudElement().dataset.state).toBe("transcribing");
+    expect(document.querySelector("#hud-status")).toHaveTextContent("Transcribing");
+
+    await vi.advanceTimersByTimeAsync(6_000);
+
+    expect(hudElement().dataset.state).toBe("transcribing");
+    expect(document.querySelector("#hud-status")).toHaveTextContent("Still transcribing");
+  });
+
+  it("re-arms the long transcription notice on the next dictation's clock", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+
+    // A quick dictation: it leaves the notice window long before 6s.
+    await emit("dictation-event", { type: "finalizing_transcript" });
+    await vi.advanceTimersByTimeAsync(1_000);
+    await emit("dictation-event", {
+      type: "final_transcript",
+      payload: { text: "hi" },
+    });
+    expect(document.querySelector("#hud-status")).not.toHaveTextContent("Still transcribing");
+    await emit("dictation-event", { type: "paste_completed" });
+
+    // A second dictation starts 2s after the first armed its timer. If the
+    // first timer leaked, it fires 4s from here and mislabels this dictation
+    // as slow, and this dictation never arms a timer of its own.
+    await vi.advanceTimersByTimeAsync(1_000);
+    await emit("dictation-event", { type: "finalizing_transcript" });
+
+    await vi.advanceTimersByTimeAsync(4_500);
+    expect(hudElement().dataset.state).toBe("transcribing");
+    expect(document.querySelector("#hud-status")).toHaveTextContent("Transcribing");
+    expect(document.querySelector("#hud-status")).not.toHaveTextContent("Still transcribing");
+
+    // 6s after *this* dictation began, the notice appears.
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(document.querySelector("#hud-status")).toHaveTextContent("Still transcribing");
+  });
+
   it("silently dismisses the HUD when nothing was recorded", async () => {
     vi.useFakeTimers();
     await loadHud();


### PR DESCRIPTION
Closes JUN-226

## Summary

- Pin the dictation paste target when the recording stops, and paste into exactly that app. It used to be re-resolved at paste time from a live field, so long dictations landed in whatever app happened to be frontmost by the time the transcript came back.
- Post Cmd+V only while the pinned app is actually frontmost. If it never comes forward, or it quit, leave the transcript on the clipboard and tell the user to press Cmd+V, rather than typing it into someone else's window.
- Measure the clipboard restore from the keystroke instead of from the start of the paste, so the target gets its full window to read the clipboard.
- Tell the user a long dictation is still working: after six seconds the HUD label becomes "Still transcribing" instead of sitting on a static spinner that reads as a hang.
- Record the decision in [ADR-0014](docs/adr/0014-pinned-dictation-paste-target.md) and correct the glossary, which described dictation as "a short phrase" pasted into "the foreground app". That assumption is where the bug hid.

## Root cause

Not truncation, and not the transcript itself. The dictation helper resolved the paste destination **at paste time** from `FocusTargetController.lastExternalApp` (`main.swift`), a field rewritten by a global `NSWorkspace.didActivateApplicationNotification` observer on every app activation.

Between the user releasing push-to-talk and the `paste_text` command arriving, Rust runs auth, audio upload, upstream dictation transcription, and an optional cleanup pass (up to 15s). **That wall-clock gap scales with how long the user spoke.** Any app activation inside the gap silently repointed the target:

- Short dictation: sub-second gap, nothing else activates, always works.
- Long dictation: multi-second gap, the target drifts, Cmd+V goes elsewhere.

The transcript is written to dictation history regardless of where the paste went (`dictation.rs`), which is exactly why the reporter found it in the dictation tab. Classic time-of-check/time-of-use.

Two more assumptions on the same path were wrong for the same reason. `NSRunningApplication.activate(options:)` is asynchronous, so posting Cmd+V a fixed 180ms later could deliver the keystroke to the app that was *still* frontmost; and scheduling the clipboard restore from the start of the paste left the target only ~520ms to read a clipboard about to be yanked back.

## Validation

- `make verify` passes (exit 0, unpiped): Biome, typecheck, web tests, and fmt/clippy/test for both Rust crates. `build.rs` compiles the Swift helper during `cargo`, so the helper is compile-gated by this run.
- New Rust test `paste_target_unavailable_error_is_visible` locks in that the new error code is not swallowed by the silent-error allowlist (an unknown code renders as a real HUD error; the sibling `accessibility_permission_missing` test asserts the same).
- Two new frontend tests for the HUD notice. The second one spans two dictations and was **mutation-checked**: with the central `clearLongDictationNotice()` removed from `setHud`, it fails; with it, it passes. Without that shape it would have passed either way, because the callback's state guard alone masks the leak.
- Pre-publish review battery (high-stakes sizing: an implementer harness wrote the diff, and it types text into arbitrary apps). Standards, Spec, and adversarial on Codex; a second adversarial on Claude, the harness that did not write the code. Findings and dispositions below.

**No live walkthrough.** Long dictation needs a real microphone, Accessibility trust, and the native build, so an agent cannot drive it. It is compile-gated and unit-tested here; the end-to-end repro is manual (see below). This is a deliberate gap, not an oversight.

- [ ] Tested visually where it matters. **Not done — needs the manual repro below.**
- [ ] Needs a June API (backend) deploy. **No.** Desktop-only; no `/v1/*` contract touched.

### Manual repro to confirm before merge

1. `pnpm tauri:dev`, grant Accessibility to the helper.
2. Focus the agent chat composer, hold push-to-talk, and dictate a sustained block (roughly a minute, several hundred words).
3. Release. The HUD should show "Transcribing", then "Still transcribing" after six seconds, then "Pasting into June".
4. The transcript should land in the composer. Before this change it would reach the dictation tab only.
5. Worth also checking: dictate a long block into an external app (Notes), and dictate with a specific microphone selected in settings rather than auto-detect — that path stops the recorder asynchronously and was a distinct hole (see below).

## Review findings and dispositions

Four confirmed defects were found and fixed, three of them in the first implementation of this very fix:

- **Pin taken too late (fixed).** `pinCurrentTarget()` sat in `emitRecordingReady()`, which on the selected-microphone path runs inside the async `selectedDeviceRecorder.stop { … }` callback. The drift window reopened between stop and callback, so the fix only worked for the default recorder. Now pinned synchronously at the top of `stopActiveRecording()`.
- **Target could quit mid-wait (fixed).** `waitForActivation` only checked `isActive`, never `isTerminated`, so an app that quit during the bounded wait still got a Cmd+V. Now checked at every poll entry, after the settle delay, and once more immediately before the keystroke.
- **Keystroke posted on timeout regardless (fixed).** The activation wait posted Cmd+V even when the app never came forward. That reproduced the original bug. Now it aborts to the clipboard.
- **Stale comment / naming (fixed).** A doc comment still named the deleted `activateLastExternalApp()`; HUD identifiers and test names now use the dictation vocabulary from `CONTEXT.md`.

One finding was **refuted with evidence**: that an impatient second push-to-talk during a long dictation clears the first dictation's pin via `resetRecordingState()`. It cannot. `start()` guards on `!listening`, and `listening` is `isListening || isFinalizing || startPending`; `isFinalizing` stays true for the whole transcription. Both callers of `startRecording()` sit behind that guard, so it is unreachable while a dictation is finalizing.

## Out of scope

- Direct insertion into June's own ProseMirror composer. Rejected in ADR-0014: it splits delivery into two paths with different failure modes and fixes only the case where June is the target. Pinning fixes every target with one mechanism.
- The `agent_session_prompt_from_dictation` "hey june" path, which also writes history without pasting, but is gated on a wake phrase rather than on length.
- Any June API change.

## Known gaps

- The guarantee is "frontmost when we posted the keystroke", not "frontmost when the keystroke was delivered". The residual window is the time to post a CGEvent, against the multi-second window this removes. It cannot be closed from outside the window server.
- A pinned app that refuses to come forward (a modal, another full-screen space, a refused cooperative activation) now yields `paste_target_unavailable` instead of a paste. That is the intended trade.
- `paste_text` carries no state guard, so if the helper crashes and respawns mid-transcription the replacement has no pin and reports `paste_target_unavailable`. Nothing is lost: the transcript is on the clipboard and in history.
- The Swift helper has no test target in this repo, so its behavior is compile-gated only. Moving targeting into Rust would make it unit-testable, but a bundle id cannot distinguish two running instances of an app, so correctness won over testability. Recorded in ADR-0014.

## Followups

- Pressing push-to-talk while a dictation is finalizing surfaces a visible "Dictation is already listening" HUD error, which now replaces the new "Still transcribing" notice. That is pre-existing behavior, not introduced here, but it is exactly the impatient-user moment this PR otherwise improves. Worth a dedicated issue.
- **ADR number collision:** PR #627 (video generation, still draft) also adds `docs/adr/0014-`. Both branched off a `main` whose highest ADR is `0013`, so both picked `0014` per the AGENTS.md rule. Whichever merges second must renumber to `0015` and update `docs/index.md`. This PR is ready and #627 is draft, so the expectation is that this one keeps `0014`.
- `docs/adr/` already has two `0013-` ADRs (`agent-recorder-tool-via-frontend-event` and `stream-inference-responses-through-june-api`), and only the latter is listed in `docs/index.md` — the same collision, already merged. Worth a convention fix (renumber at merge, not at branch). Not touched here.
