### PR TITLE
Keep system audio readiness honest on macOS 14.0/14.1 (JUN-223)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1490,19 +1490,21 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
         );
     }
 
-    assemble_recording_source_readiness(microphone, Some(system), source_mode)
+    assemble_recording_source_readiness(microphone, system, source_mode)
 }
 
+/// Readiness describes the machine, not the request: the system source is
+/// always reported so callers can explain why it is unavailable. Only
+/// `required` follows the requested mode, keeping the `start_recording` gate
+/// from blocking a microphone-only take on a Mac that cannot capture system
+/// audio at all.
 fn assemble_recording_source_readiness(
     microphone: SourceReadinessDto,
-    system: Option<SourceReadinessDto>,
+    mut system: SourceReadinessDto,
     source_mode: RecordingSourceMode,
 ) -> RecordingSourceReadinessDto {
-    let mut sources = vec![microphone];
-    if let Some(mut system) = system {
-        system.required = source_mode == RecordingSourceMode::MicrophonePlusSystem;
-        sources.push(system);
-    }
+    system.required = source_mode == RecordingSourceMode::MicrophonePlusSystem;
+    let sources = vec![microphone, system];
     let ready = sources
         .iter()
         .all(|source| !source.required || source.ready);
@@ -2258,7 +2260,7 @@ mod tests {
     fn microphone_only_readiness_still_reports_the_system_source() {
         let readiness = assemble_recording_source_readiness(
             microphone_readiness(),
-            Some(unsupported_system_readiness()),
+            unsupported_system_readiness(),
             RecordingSourceMode::MicrophoneOnly,
         );
         let system = readiness
@@ -2275,7 +2277,7 @@ mod tests {
     fn microphone_only_readiness_stays_ready_when_system_is_unsupported() {
         let readiness = assemble_recording_source_readiness(
             microphone_readiness(),
-            Some(unsupported_system_readiness()),
+            unsupported_system_readiness(),
             RecordingSourceMode::MicrophoneOnly,
         );
 
@@ -2286,7 +2288,7 @@ mod tests {
     fn microphone_plus_system_keeps_the_system_source_required() {
         let readiness = assemble_recording_source_readiness(
             microphone_readiness(),
-            Some(unsupported_system_readiness()),
+            unsupported_system_readiness(),
             RecordingSourceMode::MicrophonePlusSystem,
         );
         let system = readiness

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1471,7 +1471,7 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
     } else {
         None
     };
-    let mut sources = vec![SourceReadinessDto {
+    let microphone = SourceReadinessDto {
         source: RecordingSource::Microphone,
         required: true,
         ready: microphone_ready,
@@ -1481,15 +1481,26 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
         recovery_action: microphone_permission_blocked
             .then(|| "openMicrophoneSettings".to_string()),
         message: microphone_message,
-    }];
-    if source_mode == RecordingSourceMode::MicrophonePlusSystem {
-        let mut system = crate::audio::system_macos::system_audio_readiness();
-        if should_probe_system_audio_permission(system.ready, is_capture_active()) {
-            system = apply_system_audio_permission_probe_result(
-                system,
-                crate::audio::system_macos::helper_permission_check(),
-            );
-        }
+    };
+    let mut system = crate::audio::system_macos::system_audio_readiness();
+    if should_probe_system_audio_permission(source_mode, system.ready, is_capture_active()) {
+        system = apply_system_audio_permission_probe_result(
+            system,
+            crate::audio::system_macos::helper_permission_check(),
+        );
+    }
+
+    assemble_recording_source_readiness(microphone, Some(system), source_mode)
+}
+
+fn assemble_recording_source_readiness(
+    microphone: SourceReadinessDto,
+    system: Option<SourceReadinessDto>,
+    source_mode: RecordingSourceMode,
+) -> RecordingSourceReadinessDto {
+    let mut sources = vec![microphone];
+    if let Some(mut system) = system {
+        system.required = source_mode == RecordingSourceMode::MicrophonePlusSystem;
         sources.push(system);
     }
     let ready = sources
@@ -1503,8 +1514,12 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
     }
 }
 
-fn should_probe_system_audio_permission(system_ready: bool, capture_active: bool) -> bool {
-    system_ready && !capture_active
+fn should_probe_system_audio_permission(
+    source_mode: RecordingSourceMode,
+    system_ready: bool,
+    capture_active: bool,
+) -> bool {
+    source_mode == RecordingSourceMode::MicrophonePlusSystem && system_ready && !capture_active
 }
 
 fn apply_system_audio_permission_probe_result(
@@ -2187,9 +2202,9 @@ fn app_paths(app: &AppHandle) -> Result<AppPaths, AppError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_system_audio_permission_probe_result, capture_start_timeout_error,
-        recovery_validation_expected_duration_ms, should_probe_system_audio_permission,
-        start_capture_with_timeout_and_cleanup,
+        apply_system_audio_permission_probe_result, assemble_recording_source_readiness,
+        capture_start_timeout_error, recovery_validation_expected_duration_ms,
+        should_probe_system_audio_permission, start_capture_with_timeout_and_cleanup,
     };
     use crate::{
         audio::capture::{is_capture_active, CaptureStartState, StartedRecording, StartedSource},
@@ -2209,13 +2224,79 @@ mod tests {
 
     #[test]
     fn skips_system_audio_permission_probe_while_capture_is_active() {
-        assert!(!should_probe_system_audio_permission(true, true));
+        assert!(!should_probe_system_audio_permission(
+            RecordingSourceMode::MicrophonePlusSystem,
+            true,
+            true
+        ));
     }
 
     #[test]
     fn probes_system_audio_permission_only_when_available_and_idle() {
-        assert!(should_probe_system_audio_permission(true, false));
-        assert!(!should_probe_system_audio_permission(false, false));
+        assert!(should_probe_system_audio_permission(
+            RecordingSourceMode::MicrophonePlusSystem,
+            true,
+            false
+        ));
+        assert!(!should_probe_system_audio_permission(
+            RecordingSourceMode::MicrophonePlusSystem,
+            false,
+            false
+        ));
+    }
+
+    #[test]
+    fn system_audio_permission_probe_is_skipped_for_microphone_only() {
+        assert!(!should_probe_system_audio_permission(
+            RecordingSourceMode::MicrophoneOnly,
+            true,
+            false
+        ));
+    }
+
+    #[test]
+    fn microphone_only_readiness_still_reports_the_system_source() {
+        let readiness = assemble_recording_source_readiness(
+            microphone_readiness(),
+            Some(unsupported_system_readiness()),
+            RecordingSourceMode::MicrophoneOnly,
+        );
+        let system = readiness
+            .sources
+            .iter()
+            .find(|source| source.source == RecordingSource::System)
+            .expect("system readiness");
+
+        assert_eq!(system.permission_state, "unsupported");
+        assert!(!system.required);
+    }
+
+    #[test]
+    fn microphone_only_readiness_stays_ready_when_system_is_unsupported() {
+        let readiness = assemble_recording_source_readiness(
+            microphone_readiness(),
+            Some(unsupported_system_readiness()),
+            RecordingSourceMode::MicrophoneOnly,
+        );
+
+        assert!(readiness.ready);
+    }
+
+    #[test]
+    fn microphone_plus_system_keeps_the_system_source_required() {
+        let readiness = assemble_recording_source_readiness(
+            microphone_readiness(),
+            Some(unsupported_system_readiness()),
+            RecordingSourceMode::MicrophonePlusSystem,
+        );
+        let system = readiness
+            .sources
+            .iter()
+            .find(|source| source.source == RecordingSource::System)
+            .expect("system readiness");
+
+        assert!(system.required);
+        assert!(!readiness.ready);
     }
 
     #[test]
@@ -2385,6 +2466,32 @@ mod tests {
             device_available: true,
             capture_available: true,
             recovery_action: Some("openSystemAudioSettings".to_string()),
+            message: None,
+        }
+    }
+
+    fn unsupported_system_readiness() -> SourceReadinessDto {
+        SourceReadinessDto {
+            source: RecordingSource::System,
+            required: true,
+            ready: false,
+            permission_state: "unsupported".to_string(),
+            device_available: false,
+            capture_available: false,
+            recovery_action: Some("upgradeMacos".to_string()),
+            message: Some("System audio capture requires macOS 14.2 or later.".to_string()),
+        }
+    }
+
+    fn microphone_readiness() -> SourceReadinessDto {
+        SourceReadinessDto {
+            source: RecordingSource::Microphone,
+            required: true,
+            ready: true,
+            permission_state: "granted".to_string(),
+            device_available: true,
+            capture_available: true,
+            recovery_action: None,
             message: None,
         }
     }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -87,6 +87,7 @@ import {
 } from "../lib/tauri";
 import { playRecordingSound, preloadRecordingSounds } from "../lib/recording-sounds";
 import { isMacLikePlatform, isPrimaryShortcut } from "../lib/platform";
+import { mergeSourceReadiness } from "../lib/source-readiness";
 import { AGENT_RECORDER_REQUEST_EVENT, MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
 import {
   AGENT_GALLERY_EVENT,
@@ -2433,7 +2434,7 @@ export function App() {
       try {
         setCheckingSourceReadiness(true);
         const readiness = await checkRecordingSourceReadiness(requestedSourceMode);
-        setSourceReadiness(readiness);
+        setSourceReadiness((previous) => mergeSourceReadiness(previous, readiness));
 
         const micSource = readiness.sources.find((source) => source.source === "microphone");
         if (!micSource?.ready) {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -416,8 +416,13 @@ export function App() {
   const [preparingUpdate, setPreparingUpdate] = useState(false);
   const [relaunchingUpdate, setRelaunchingUpdate] = useState(false);
   const [updateProgress, setUpdateProgress] = useState<UpdateInstallProgress | null>(null);
-  const systemGranted = !!sourceReadiness?.sources.find((source) => source.source === "system")
-    ?.ready;
+  // `ready` only says this Mac is capable of system capture; the grant is the
+  // permission state, which only a microphone-plus-system probe establishes.
+  const systemSourceReadiness = sourceReadiness?.sources.find(
+    (source) => source.source === "system",
+  );
+  const systemGranted =
+    systemSourceReadiness?.ready === true && systemSourceReadiness.permissionState === "granted";
   const recordingState = state.recordingStatus?.state;
   const captureActive =
     recordingState === "recording" ||

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -191,7 +191,10 @@ export function NoteEditor({
   const systemSource = sourceReadiness?.sources.find((source) => source.source === "system");
   const systemDenied =
     systemSource?.permissionState === "denied" || systemSource?.permissionState === "restricted";
-  const systemUnsupported = systemSource?.permissionState === "unsupported";
+  // A readiness payload that omits the system source means the backend could
+  // not offer it; an absent payload only means the probe has not answered yet.
+  const systemUnsupported =
+    !!sourceReadiness && (!systemSource || systemSource.permissionState === "unsupported");
   const showRecordingOptions = isMacLikePlatform();
   // Mic denial is sourced from App via the dictation helper, not from
   // sourceReadiness — the Rust cpal-based check can't see TCC denials.

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -191,8 +191,8 @@ export function NoteEditor({
   const systemSource = sourceReadiness?.sources.find((source) => source.source === "system");
   const systemDenied =
     systemSource?.permissionState === "denied" || systemSource?.permissionState === "restricted";
-  // A readiness payload that omits the system source means the backend could
-  // not offer it; an absent payload only means the probe has not answered yet.
+  // A readiness payload that omits the system source cannot offer it; an
+  // absent payload only means the probe has not answered yet.
   const systemUnsupported =
     !!sourceReadiness && (!systemSource || systemSource.permissionState === "unsupported");
   const showRecordingOptions = isMacLikePlatform();

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -28,6 +28,7 @@ import { SegmentedControl } from "../ui/SegmentedControl";
 import { RecorderBar } from "../recorder/RecorderBar";
 import { NoteRecoveryPrompt } from "../recorder/NoteRecoveryPrompt";
 import { isMacLikePlatform } from "../../lib/platform";
+import { systemAudioAvailability } from "../../lib/source-readiness";
 import {
   isInvalidJuneResponseMessage,
   NoteFailureBanner,
@@ -188,13 +189,11 @@ export function NoteEditor({
     return transcriptTurns.filter((turn) => sourceKey(turn.source) === sourceFilter);
   }, [transcriptTurns, hasBothSources, sourceFilter]);
   const systemOn = sourceMode === "microphonePlusSystem";
-  const systemSource = sourceReadiness?.sources.find((source) => source.source === "system");
-  const systemDenied =
-    systemSource?.permissionState === "denied" || systemSource?.permissionState === "restricted";
-  // A readiness payload that omits the system source cannot offer it; an
-  // absent payload only means the probe has not answered yet.
-  const systemUnsupported =
-    !!sourceReadiness && (!systemSource || systemSource.permissionState === "unsupported");
+  const systemAvailability = systemAudioAvailability(sourceReadiness);
+  const systemUnsupported = systemAvailability === "unsupported";
+  // Denied and granted-but-uncapturable both mean the switch must not be
+  // offered; only the recovery copy differs.
+  const systemLocked = systemAvailability === "denied" || systemAvailability === "unavailable";
   const showRecordingOptions = isMacLikePlatform();
   // Mic denial is sourced from App via the dictation helper, not from
   // sourceReadiness — the Rust cpal-based check can't see TCC denials.
@@ -516,10 +515,10 @@ export function NoteEditor({
                         System audio requires macOS 14.2 or later.
                       </p>
                     ) : (
-                      <div className="record-options-row" data-locked={systemDenied || undefined}>
+                      <div className="record-options-row" data-locked={systemLocked || undefined}>
                         <Switch
                           checked={systemOn}
-                          disabled={systemDenied}
+                          disabled={systemLocked}
                           aria-labelledby="record-options-system"
                           onCheckedChange={(next) =>
                             onSourceModeChange(next ? "microphonePlusSystem" : "microphoneOnly")
@@ -528,7 +527,7 @@ export function NoteEditor({
                         <span id="record-options-system" className="record-options-label">
                           Capture system audio
                         </span>
-                        {systemDenied ? (
+                        {systemAvailability === "denied" ? (
                           <button
                             type="button"
                             className="btn btn-ghost record-options-enable"

--- a/src/components/onboarding/steps/PermissionSteps.tsx
+++ b/src/components/onboarding/steps/PermissionSteps.tsx
@@ -79,6 +79,11 @@ export function PermissionsStep({
   // macOS < 14.2 (or a missing capture helper) can never grant; the row
   // explains itself and stays out of the Continue gate.
   const systemAudioUnsupported = systemAudioStatus === "unsupported";
+  // Granted, but the helper cannot capture until June restarts. Onboarding has
+  // nothing left to ask for, so the row explains itself and clears the gate
+  // too. It is not marked granted: the source does not work yet.
+  const systemAudioUnavailable = systemAudioStatus === "unavailable";
+  const systemAudioSettled = systemAudioGranted || systemAudioUnsupported || systemAudioUnavailable;
   const showPermissionRows = statuses.checked || showUnknownStatuses;
   const macLikePlatform = isMacLikePlatform();
 
@@ -169,9 +174,11 @@ export function PermissionsStep({
                   ? "Turned off in System Settings. Flip the toggle and June will notice."
                   : systemAudioUnsupported
                     ? "Needs macOS 14.2 or later."
-                    : systemAudioStatus === "probing"
-                      ? "Waiting for macOS. Approve the prompt when it appears."
-                      : "Hears your calls and meetings, only while you record."
+                    : systemAudioUnavailable
+                      ? "Allowed. Restart June to finish turning it on."
+                      : systemAudioStatus === "probing"
+                        ? "Waiting for macOS. Approve the prompt when it appears."
+                        : "Hears your calls and meetings, only while you record."
               }
               onAllow={
                 showPermissionRows
@@ -191,8 +198,7 @@ export function PermissionsStep({
         continueDisabled={
           !showPermissionRows ||
           !micGranted ||
-          (macLikePlatform &&
-            (!accessibilityGranted || !(systemAudioGranted || systemAudioUnsupported)))
+          (macLikePlatform && (!accessibilityGranted || !systemAudioSettled))
         }
         onSkip={onContinue}
       />

--- a/src/components/onboarding/use-permission-status.ts
+++ b/src/components/onboarding/use-permission-status.ts
@@ -68,6 +68,9 @@ export function useSystemAudioStatus(active: boolean): {
     checkRecordingSourceReadiness("microphonePlusSystem")
       .then((readiness) => {
         const system = readiness.sources.find((source) => source.source === "system");
+        // This row reports the *grant*, not whether capture works right now: a
+        // granted-but-uncapturable helper recovers on restart and must not send
+        // the user back to System Settings, nor hold the Continue gate open.
         if (!system || system.permissionState === "unsupported") {
           setStatus("unsupported");
         } else if (system.permissionState === "granted") {

--- a/src/components/onboarding/use-permission-status.ts
+++ b/src/components/onboarding/use-permission-status.ts
@@ -75,7 +75,9 @@ export function useSystemAudioStatus(active: boolean): {
         } else if (system.permissionState === "denied" || system.permissionState === "restricted") {
           setStatus("denied");
         } else {
-          setStatus(system.ready ? "granted" : "unknown");
+          // `ready` only says this Mac is capable; an unprobed source carries
+          // no grant, so it stays unknown rather than reading as allowed.
+          setStatus("unknown");
         }
       })
       .catch(() => {

--- a/src/components/onboarding/use-permission-status.ts
+++ b/src/components/onboarding/use-permission-status.ts
@@ -35,7 +35,20 @@ export function isAccessibilityGranted(statuses: PermissionStatuses) {
  * screen the whole time, so the usual focus-refresh in App.tsx isn't
  * running yet.
  */
-export type SystemAudioStatus = "unknown" | "probing" | "granted" | "denied" | "unsupported";
+/**
+ * `unavailable` is granted-but-uncapturable: the user allowed system audio,
+ * yet the capture helper cannot open the tap and recovers on restart. It is a
+ * settled state with nothing left to ask for, so it neither holds the Continue
+ * gate nor sends the user to System Settings. It is deliberately not `granted`,
+ * because the source does not work.
+ */
+export type SystemAudioStatus =
+  | "unknown"
+  | "probing"
+  | "granted"
+  | "unavailable"
+  | "denied"
+  | "unsupported";
 
 /**
  * System-audio permission state for the onboarding wizard.
@@ -68,13 +81,15 @@ export function useSystemAudioStatus(active: boolean): {
     checkRecordingSourceReadiness("microphonePlusSystem")
       .then((readiness) => {
         const system = readiness.sources.find((source) => source.source === "system");
-        // This row reports the *grant*, not whether capture works right now: a
-        // granted-but-uncapturable helper recovers on restart and must not send
-        // the user back to System Settings, nor hold the Continue gate open.
+        // This row reports the *grant*, so it cannot reuse `systemAudioAvailability`:
+        // that predicate calls a capable-but-unprobed source usable, which is right
+        // for a recording switch (flipping it fires the prompt) and wrong here,
+        // where the grant is still the open question.
         if (!system || system.permissionState === "unsupported") {
           setStatus("unsupported");
         } else if (system.permissionState === "granted") {
-          setStatus("granted");
+          // Granted, but `ready` says the helper cannot open the tap.
+          setStatus(system.ready ? "granted" : "unavailable");
         } else if (system.permissionState === "denied" || system.permissionState === "restricted") {
           setStatus("denied");
         } else {

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -472,8 +472,8 @@ export function AppSettings({
   );
   const systemState = systemReadiness?.permissionState;
   const systemDenied = systemState === "denied" || systemState === "restricted";
-  // A readiness payload that omits the system source means the backend could
-  // not offer it; an absent payload only means the probe has not answered yet.
+  // A readiness payload that omits the system source cannot offer it; an
+  // absent payload only means the probe has not answered yet.
   const systemUnavailable =
     !macLikePlatform || (!!sourceReadiness && !systemReadiness) || systemState === "unsupported";
 

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -2329,10 +2329,14 @@ function sourcePermissionStatus(
   source?: RecordingSourceReadinessDto["sources"][number],
 ): PermissionStatusView {
   if (!source) return { label: "Checking", tone: "unknown" };
-  // `ready` only says this Mac is capable of the capture; the grant lives in
-  // permissionState, and a microphone-only check never asks for it.
-  if (source.ready && source.permissionState === "granted") {
-    return { label: "Allowed", tone: "allowed" };
+  // The two halves are independent: permissionState is the grant, `ready` is
+  // whether this Mac can actually capture. A microphone-only check never asks
+  // for the grant, and a granted source can still be uncapturable (the helper
+  // reports `system_audio_capture_unavailable`, recoverable by restarting).
+  if (source.permissionState === "granted") {
+    return source.ready
+      ? { label: "Allowed", tone: "allowed" }
+      : { label: "Unavailable", tone: "attention" };
   }
   return permissionStatus(source.permissionState);
 }

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -76,6 +76,7 @@ import {
   type ReleaseChannel,
 } from "../../lib/updater";
 import { isMacLikePlatform } from "../../lib/platform";
+import { systemAudioAvailability } from "../../lib/source-readiness";
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
 import { dispatchProviderModelSettingsChanged } from "../../lib/model-privacy";
 import {
@@ -470,12 +471,11 @@ export function AppSettings({
   const microphoneReadiness = sourceReadiness?.sources.find(
     (source) => source.source === "microphone",
   );
-  const systemState = systemReadiness?.permissionState;
-  const systemDenied = systemState === "denied" || systemState === "restricted";
-  // A readiness payload that omits the system source cannot offer it; an
-  // absent payload only means the probe has not answered yet.
-  const systemUnavailable =
-    !macLikePlatform || (!!sourceReadiness && !systemReadiness) || systemState === "unsupported";
+  const systemAvailability = systemAudioAvailability(sourceReadiness);
+  // Denied and granted-but-uncapturable both mean the switch must not be
+  // offered; the status label below tells the two apart.
+  const systemDenied = systemAvailability === "denied" || systemAvailability === "unavailable";
+  const systemUnavailable = !macLikePlatform || systemAvailability === "unsupported";
 
   useEffect(() => {
     capturingShortcutRef.current = capturingShortcut;

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -472,7 +472,10 @@ export function AppSettings({
   );
   const systemState = systemReadiness?.permissionState;
   const systemDenied = systemState === "denied" || systemState === "restricted";
-  const systemUnavailable = !macLikePlatform || systemState === "unsupported";
+  // A readiness payload that omits the system source means the backend could
+  // not offer it; an absent payload only means the probe has not answered yet.
+  const systemUnavailable =
+    !macLikePlatform || (!!sourceReadiness && !systemReadiness) || systemState === "unsupported";
 
   useEffect(() => {
     capturingShortcutRef.current = capturingShortcut;

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -472,9 +472,12 @@ export function AppSettings({
     (source) => source.source === "microphone",
   );
   const systemAvailability = systemAudioAvailability(sourceReadiness);
-  // Denied and granted-but-uncapturable both mean the switch must not be
-  // offered; the status label below tells the two apart.
-  const systemDenied = systemAvailability === "denied" || systemAvailability === "unavailable";
+  // Denied and granted-but-uncapturable both lock the switch, but only a real
+  // denial is fixable in System Settings: the uncapturable helper recovers on
+  // restart, so sending the user to grant an already-granted permission would
+  // be a dead end. The status label tells the two apart.
+  const systemDenied = systemAvailability === "denied";
+  const systemLocked = systemDenied || systemAvailability === "unavailable";
   const systemUnavailable = !macLikePlatform || systemAvailability === "unsupported";
 
   useEffect(() => {
@@ -1666,7 +1669,7 @@ export function AppSettings({
                       ) : null}
                       <Switch
                         checked={systemOn}
-                        disabled={checkingSourceReadiness || systemDenied}
+                        disabled={checkingSourceReadiness || systemLocked}
                         aria-label="Capture system audio for notes"
                         onCheckedChange={(next) =>
                           onSourceModeChange(next ? "microphonePlusSystem" : "microphoneOnly")

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -2329,7 +2329,11 @@ function sourcePermissionStatus(
   source?: RecordingSourceReadinessDto["sources"][number],
 ): PermissionStatusView {
   if (!source) return { label: "Checking", tone: "unknown" };
-  if (source.ready) return { label: "Allowed", tone: "allowed" };
+  // `ready` only says this Mac is capable of the capture; the grant lives in
+  // permissionState, and a microphone-only check never asks for it.
+  if (source.ready && source.permissionState === "granted") {
+    return { label: "Allowed", tone: "allowed" };
+  }
   return permissionStatus(source.permissionState);
 }
 

--- a/src/lib/source-readiness.ts
+++ b/src/lib/source-readiness.ts
@@ -1,0 +1,23 @@
+import type { RecordingSourceReadinessDto } from "./tauri";
+
+/**
+ * A microphone-only readiness check never assesses system audio: it skips the
+ * capture helper's permission preflight, so its system source reports whether
+ * this Mac is *capable* rather than whether the permission was granted. Keep
+ * the source last assessed by a microphone-plus-system check instead of
+ * overwriting it with that weaker signal.
+ */
+export function mergeSourceReadiness(
+  previous: RecordingSourceReadinessDto | undefined,
+  next: RecordingSourceReadinessDto,
+): RecordingSourceReadinessDto {
+  if (next.sourceMode === "microphonePlusSystem") return next;
+  const assessed = previous?.sources.find((source) => source.source === "system");
+  if (!assessed) return next;
+  return {
+    ...next,
+    sources: next.sources.map((source) =>
+      source.source === "system" ? { ...assessed, required: source.required } : source,
+    ),
+  };
+}

--- a/src/lib/source-readiness.ts
+++ b/src/lib/source-readiness.ts
@@ -1,5 +1,35 @@
 import type { RecordingSourceReadinessDto } from "./tauri";
 
+export type SystemAudioAvailability =
+  /** The readiness probe has not answered yet. */
+  | "unknown"
+  /** This Mac cannot capture system audio at all (macOS below 14.2). */
+  | "unsupported"
+  /** The user declined the permission. */
+  | "denied"
+  /** The permission is granted, but the capture helper cannot capture now. */
+  | "unavailable"
+  | "usable";
+
+/**
+ * The single question every system-audio surface asks. `permissionState` is the
+ * grant and `ready` is whether this Mac can actually capture; neither answers
+ * on its own, and a granted source can still be uncapturable. Offering the user
+ * a control June cannot honor is the bug this collapses.
+ */
+export function systemAudioAvailability(
+  readiness: RecordingSourceReadinessDto | undefined,
+): SystemAudioAvailability {
+  if (!readiness) return "unknown";
+  const system = readiness.sources.find((source) => source.source === "system");
+  if (!system || system.permissionState === "unsupported") return "unsupported";
+  if (system.permissionState === "denied" || system.permissionState === "restricted") {
+    return "denied";
+  }
+  if (!system.ready) return "unavailable";
+  return "usable";
+}
+
 /**
  * A microphone-only readiness check never assesses system audio: it skips the
  * capture helper's permission preflight, so its system source reports whether

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -185,7 +185,7 @@ describe("meeting start transcription event", () => {
       sourceMode: "microphonePlusSystem",
       sources: [
         { source: "microphone", ready: true },
-        { source: "system", ready: true },
+        { source: "system", ready: true, permissionState: "granted" },
       ],
     });
     mocks.startRecording.mockResolvedValue(recording());
@@ -352,7 +352,7 @@ describe("agent recorder request event", () => {
       sourceMode: "microphonePlusSystem",
       sources: [
         { source: "microphone", ready: true },
-        { source: "system", ready: true },
+        { source: "system", ready: true, permissionState: "granted" },
       ],
     });
     mocks.startRecording.mockResolvedValue(recording({ id: "rec-agent", noteId: "note-agent" }));

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -239,7 +239,7 @@ describe("notes recording reliability", () => {
       sourceMode: "microphonePlusSystem",
       sources: [
         { source: "microphone", ready: true },
-        { source: "system", ready: true },
+        { source: "system", ready: true, permissionState: "granted" },
       ],
     });
     mocks.startRecording.mockResolvedValue(recording());
@@ -549,7 +549,7 @@ describe("notes recording reliability", () => {
           ready: false,
           message: "Microphone is not ready.",
         },
-        { source: "system", ready: true },
+        { source: "system", ready: true, permissionState: "granted" },
       ],
     });
 

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1497,6 +1497,64 @@ describe("AppSettings", () => {
     expect(onEnableSystemAudio).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    {
+      name: "capable but never probed",
+      system: { ready: true, permissionState: "unknown" as const, captureAvailable: true },
+      status: "Unknown",
+    },
+    {
+      name: "granted but the capture is unavailable",
+      system: { ready: false, permissionState: "granted" as const, captureAvailable: false },
+      status: "Unavailable",
+    },
+  ])("does not label system audio allowed when it is $name", async ({ system, status }) => {
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        sourceReadiness={{
+          sourceMode: "microphonePlusSystem",
+          ready: false,
+          checkedAt: "2026-06-08T12:00:00Z",
+          sources: [
+            {
+              source: "microphone",
+              required: true,
+              ready: true,
+              permissionState: "granted",
+              deviceAvailable: true,
+              captureAvailable: true,
+            },
+            {
+              source: "system",
+              required: true,
+              deviceAvailable: true,
+              ...system,
+            },
+          ],
+        }}
+        checkingSourceReadiness={false}
+        microphonePermissionStatus="granted"
+        accessibilityPermissionStatus="granted"
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableMicrophone={vi.fn()}
+        onEnableAccessibility={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    const systemAudioRow = screen.getByText("System audio").closest(".settings-row");
+
+    expect(within(systemAudioRow as HTMLElement).getByLabelText(status)).toBeInTheDocument();
+    expect(
+      within(systemAudioRow as HTMLElement).queryByLabelText("Allowed"),
+    ).not.toBeInTheDocument();
+  });
+
   it("only lists microphone permissions on Windows", async () => {
     const restoreNavigator = stubNavigatorPlatform(
       "Win32",

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1555,6 +1555,71 @@ describe("AppSettings", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("locks the system audio switch without offering Enable when a restart is what it needs", async () => {
+    const user = userEvent.setup();
+    const restoreNavigator = stubNavigatorPlatform(
+      "MacIntel",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    );
+    try {
+      render(
+        <AppSettings
+          account={signedInAccount}
+          accountLoading={false}
+          sourceMode="microphoneOnly"
+          sourceReadiness={{
+            sourceMode: "microphonePlusSystem",
+            ready: false,
+            checkedAt: "2026-06-08T12:00:00Z",
+            sources: [
+              {
+                source: "microphone",
+                required: true,
+                ready: true,
+                permissionState: "granted",
+                deviceAvailable: true,
+                captureAvailable: true,
+              },
+              {
+                source: "system",
+                required: true,
+                ready: false,
+                permissionState: "granted",
+                deviceAvailable: true,
+                captureAvailable: false,
+                recoveryAction: "restartApp",
+              },
+            ],
+          }}
+          checkingSourceReadiness={false}
+          microphonePermissionStatus="granted"
+          accessibilityPermissionStatus="granted"
+          onAccountChanged={vi.fn()}
+          onAccountRefresh={vi.fn()}
+          onSourceModeChange={vi.fn()}
+          onEnableMicrophone={vi.fn()}
+          onEnableAccessibility={vi.fn()}
+          onEnableSystemAudio={vi.fn()}
+        />,
+      );
+
+      await user.click(screen.getByRole("tab", { name: "Audio" }));
+
+      const sourceRow = screen
+        .getByText("Capture audio from other apps along with your microphone.")
+        .closest(".settings-row") as HTMLElement;
+
+      // The grant already exists, so "Enable" would send the user to System
+      // Settings to allow something they have already allowed.
+      expect(within(sourceRow).queryByRole("button", { name: "Enable" })).not.toBeInTheDocument();
+      expect(
+        within(sourceRow).getByRole("switch", { name: "Capture system audio for notes" }),
+      ).toBeDisabled();
+    } finally {
+      restoreNavigator();
+    }
+  });
+
   it("only lists microphone permissions on Windows", async () => {
     const restoreNavigator = stubNavigatorPlatform(
       "Win32",

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -305,7 +305,7 @@ describe("App shortcuts", () => {
     mocks.checkRecordingSourceReadiness.mockResolvedValue({
       sources: [
         { source: "microphone", ready: true },
-        { source: "system", ready: true },
+        { source: "system", ready: true, permissionState: "granted" },
       ],
     });
     mocks.dictationHelperCommand.mockResolvedValue(undefined);

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -888,6 +888,48 @@ describe("NoteEditor", () => {
     expect(screen.queryByRole("switch", { name: "Capture system audio" })).not.toBeInTheDocument();
   });
 
+  it("does not offer the system audio switch when the grant exists but capture is unavailable", async () => {
+    const user = userEvent.setup();
+    const onSourceModeChange = vi.fn();
+    render(
+      <NoteEditor
+        {...props}
+        note={note()}
+        sourceMode="microphoneOnly"
+        onSourceModeChange={onSourceModeChange}
+        sourceReadiness={{
+          sourceMode: "microphonePlusSystem",
+          ready: false,
+          checkedAt: now,
+          sources: [
+            {
+              source: "microphone",
+              required: true,
+              ready: true,
+              permissionState: "granted",
+              deviceAvailable: true,
+              captureAvailable: true,
+            },
+            {
+              source: "system",
+              required: true,
+              ready: false,
+              permissionState: "granted",
+              deviceAvailable: true,
+              captureAvailable: false,
+              recoveryAction: "restartApp",
+            },
+          ],
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Recording options" }));
+
+    expect(screen.getByRole("switch", { name: "Capture system audio" })).toBeDisabled();
+    expect(onSourceModeChange).not.toHaveBeenCalled();
+  });
+
   it("does not claim system audio is unsupported before readiness is known", async () => {
     const user = userEvent.setup();
     render(<NoteEditor {...props} note={note()} sourceMode="microphoneOnly" />);

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -857,6 +857,49 @@ describe("NoteEditor", () => {
     expect(onEnableSystemAudio).toHaveBeenCalledOnce();
   });
 
+  it("treats a missing system readiness entry as unsupported in recording options", async () => {
+    const user = userEvent.setup();
+    render(
+      <NoteEditor
+        {...props}
+        note={note()}
+        sourceMode="microphoneOnly"
+        sourceReadiness={{
+          sourceMode: "microphoneOnly",
+          ready: true,
+          checkedAt: now,
+          sources: [
+            {
+              source: "microphone",
+              required: true,
+              ready: true,
+              permissionState: "granted",
+              deviceAvailable: true,
+              captureAvailable: true,
+            },
+          ],
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Recording options" }));
+
+    expect(screen.getByText("System audio requires macOS 14.2 or later.")).toBeInTheDocument();
+    expect(screen.queryByRole("switch", { name: "Capture system audio" })).not.toBeInTheDocument();
+  });
+
+  it("does not claim system audio is unsupported before readiness is known", async () => {
+    const user = userEvent.setup();
+    render(<NoteEditor {...props} note={note()} sourceMode="microphoneOnly" />);
+
+    await user.click(screen.getByRole("button", { name: "Recording options" }));
+
+    expect(
+      screen.queryByText("System audio requires macOS 14.2 or later."),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Capture system audio" })).toBeInTheDocument();
+  });
+
   it("hides system audio recording options on Windows", () => {
     const restoreNavigator = stubNavigatorPlatform(
       "Win32",

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -743,6 +743,25 @@ describe("OnboardingFlow", () => {
       restoreNavigator();
     }
   });
+
+  it("says system audio needs a restart rather than calling it allowed", async () => {
+    const restoreNavigator = stubMacNavigatorPlatform();
+    mocks.checkRecordingSourceReadiness.mockResolvedValue(systemAudioCaptureUnavailableReadiness());
+    try {
+      await renderFlow();
+      grantPermissions();
+
+      // The grant exists, so there is nothing left to allow, but the source
+      // does not work yet and the row must not claim otherwise.
+      await screen.findByText("Allowed. Restart June to finish turning it on.");
+      expect(
+        screen.queryByText("Hears your calls and meetings, only while you record."),
+      ).not.toBeInTheDocument();
+      expect(mocks.openPrivacySettings).not.toHaveBeenCalled();
+    } finally {
+      restoreNavigator();
+    }
+  });
 });
 
 describe("subscribeToOnboardingComplete", () => {

--- a/src/test/source-readiness.test.ts
+++ b/src/test/source-readiness.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mergeSourceReadiness } from "../lib/source-readiness";
+import { mergeSourceReadiness, systemAudioAvailability } from "../lib/source-readiness";
 import type { RecordingSourceReadinessDto, SourceReadinessDto } from "../lib/tauri";
 
 function microphone(): SourceReadinessDto {
@@ -31,6 +31,57 @@ function readiness(
 ): RecordingSourceReadinessDto {
   return { sourceMode, ready: true, sources };
 }
+
+describe("systemAudioAvailability", () => {
+  it("is unknown until the probe answers", () => {
+    expect(systemAudioAvailability(undefined)).toBe("unknown");
+  });
+
+  it("is unsupported when the payload omits the system source", () => {
+    expect(systemAudioAvailability(readiness("microphoneOnly", [microphone()]))).toBe(
+      "unsupported",
+    );
+  });
+
+  it.each([
+    {
+      name: "below macOS 14.2",
+      overrides: { permissionState: "unsupported" as const },
+      expected: "unsupported",
+    },
+    {
+      name: "the user declined",
+      overrides: { permissionState: "denied" as const },
+      expected: "denied",
+    },
+    {
+      name: "policy restricts it",
+      overrides: { permissionState: "restricted" as const },
+      expected: "denied",
+    },
+    {
+      name: "granted but the capture is unavailable",
+      overrides: { permissionState: "granted" as const, ready: false },
+      expected: "unavailable",
+    },
+    {
+      name: "granted and capturable",
+      overrides: { permissionState: "granted" as const, ready: true },
+      expected: "usable",
+    },
+    {
+      // Capable but unprobed stays offerable, so turning the switch on can fire
+      // the permission probe.
+      name: "capable but never probed",
+      overrides: { permissionState: "unknown" as const, ready: true },
+      expected: "usable",
+    },
+  ])("is $expected when $name", ({ overrides, expected }) => {
+    const payload = readiness("microphonePlusSystem", [microphone(), system(overrides)]);
+
+    expect(systemAudioAvailability(payload)).toBe(expected);
+  });
+});
 
 describe("mergeSourceReadiness", () => {
   it("keeps a denied verdict when a microphone-only check reports the Mac as capable", () => {

--- a/src/test/source-readiness.test.ts
+++ b/src/test/source-readiness.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { mergeSourceReadiness } from "../lib/source-readiness";
+import type { RecordingSourceReadinessDto, SourceReadinessDto } from "../lib/tauri";
+
+function microphone(): SourceReadinessDto {
+  return {
+    source: "microphone",
+    required: true,
+    ready: true,
+    permissionState: "granted",
+    deviceAvailable: true,
+    captureAvailable: true,
+  };
+}
+
+function system(overrides: Partial<SourceReadinessDto>): SourceReadinessDto {
+  return {
+    source: "system",
+    required: false,
+    ready: false,
+    permissionState: "unknown",
+    deviceAvailable: false,
+    captureAvailable: false,
+    ...overrides,
+  };
+}
+
+function readiness(
+  sourceMode: RecordingSourceReadinessDto["sourceMode"],
+  sources: SourceReadinessDto[],
+): RecordingSourceReadinessDto {
+  return { sourceMode, ready: true, sources };
+}
+
+describe("mergeSourceReadiness", () => {
+  it("keeps a denied verdict when a microphone-only check reports the Mac as capable", () => {
+    const previous = readiness("microphonePlusSystem", [
+      microphone(),
+      system({ required: true, permissionState: "denied" }),
+    ]);
+    // A microphone-only probe skips the helper preflight, so `ready` here means
+    // "this Mac is capable", never "the permission was granted".
+    const next = readiness("microphoneOnly", [
+      microphone(),
+      system({ ready: true, captureAvailable: true, deviceAvailable: true }),
+    ]);
+
+    const merged = mergeSourceReadiness(previous, next);
+    const merged_system = merged.sources.find((source) => source.source === "system");
+
+    expect(merged_system?.permissionState).toBe("denied");
+    expect(merged_system?.ready).toBe(false);
+    expect(merged_system?.required).toBe(false);
+  });
+
+  it("takes a microphone-plus-system payload verbatim", () => {
+    const previous = readiness("microphonePlusSystem", [
+      microphone(),
+      system({ required: true, ready: true, permissionState: "granted" }),
+    ]);
+    const next = readiness("microphonePlusSystem", [
+      microphone(),
+      system({ required: true, permissionState: "denied" }),
+    ]);
+
+    const merged = mergeSourceReadiness(previous, next);
+
+    expect(merged.sources.find((source) => source.source === "system")?.permissionState).toBe(
+      "denied",
+    );
+  });
+
+  it("falls back to the microphone-only payload when nothing was assessed yet", () => {
+    const next = readiness("microphoneOnly", [
+      microphone(),
+      system({ permissionState: "unsupported" }),
+    ]);
+
+    const merged = mergeSourceReadiness(undefined, next);
+
+    expect(merged.sources.find((source) => source.source === "system")?.permissionState).toBe(
+      "unsupported",
+    );
+  });
+});

--- a/src/test/source-readiness.test.ts
+++ b/src/test/source-readiness.test.ts
@@ -82,4 +82,19 @@ describe("mergeSourceReadiness", () => {
       "unsupported",
     );
   });
+
+  it("never reports a grant from an unassessed capable Mac", () => {
+    // Recording can start before the mount-time probe answers, so nothing has
+    // been assessed yet and the payload carries capability, not a verdict.
+    const next = readiness("microphoneOnly", [
+      microphone(),
+      system({ ready: true, captureAvailable: true, deviceAvailable: true }),
+    ]);
+
+    const merged = mergeSourceReadiness(undefined, next);
+    const mergedSystem = merged.sources.find((source) => source.source === "system");
+
+    expect(mergedSystem?.ready).toBe(true);
+    expect(mergedSystem?.permissionState).not.toBe("granted");
+  });
 });


### PR DESCRIPTION
Closes JUN-223.

## Summary

On macOS 14.0 and 14.1, June showed a system audio permission control that could never work. The note editor rendered an **enabled** "Capture system audio" switch, and settings rendered a **live** system audio permission row, on Macs where system audio capture is impossible. That is what "on older Mac the permissions are broken" looks like from the user's side.

This restores the honest state ("System audio requires macOS 14.2 or later.") and, along the way, stops three surfaces from treating *capability* as *permission*.

## Root cause

June's floor is macOS 14.0; system audio capture uses Core Audio process taps and needs **14.2+**, so 14.0/14.1 fall back to microphone-only (`docs/release-macos.md`).

`system_audio_readiness()` reports this correctly: `permission_state: "unsupported"`, `recovery_action: "upgradeMacos"`, plus the explanatory message.

The defect was one layer up. `recording_source_readiness()` only put the **system** source into the readiness payload when the requested mode was `microphonePlusSystem`:

```rust
if source_mode == RecordingSourceMode::MicrophonePlusSystem {
    sources.push(system);
}
```

Readiness describes **the machine**, not the request. But `App.tsx` calls it with the *requested* mode at recording start and then unconditionally replaces its whole `sourceReadiness` state. On 14.0/14.1 the derived mode is `microphoneOnly`, so the reply carried **no system entry**, `systemState` became `undefined` — which is not `"unsupported"` — and both consumers fell through to their "available" branch. The mount-time probe got it right; the first recording destroyed it.

Fixing that exposed a second, sharper bug, found by the pre-publish adversarial review and confirmed independently on both harnesses. `system_audio_readiness()` sets `ready: capture_available` with `permission_state: "unknown"`: **`ready` means "this Mac is capable", not "TCC granted"** — only the capture-helper preflight produces a verdict, and that preflight is deliberately skipped for mic-only checks (it can block for tens of seconds). So simply always emitting the system source made a mic-only check on a capable-but-**denied** Mac return `ready: true`, and `App.tsx` derived `systemGranted` straight from `ready`. Starting a mic-only recording would flip the toggle back on and make settings display **"Allowed"** for a source the user had denied.

So the change has two halves:

1. **Readiness always reports the system source.** `required` follows the requested mode, which keeps the `start_recording` gate (`!readiness.ready -> source_not_ready`) exactly as it was, so mic-only recording on 14.0/14.1 still starts, and the slow helper preflight still never runs for mic-only takes.
2. **Capability is no longer read as a grant.** `systemGranted`, the settings "Allowed" badge, and the onboarding system-audio row now all require `permissionState === "granted"`. A new `mergeSourceReadiness` keeps a mic-only payload from overwriting the verdict that the last `microphonePlusSystem` probe established.

## Validation

- `make check`, `make typecheck` — clean.
- `make test-web` — 138 files, **2234 passed**, 0 failed. (CI's first run hit a known flake in `agent-workspace.test.tsx`, a file this PR does not touch; a rerun of the same commit is green.)
- `make tauri-test` — **527 passed**, 0 failed (plus the integration suites).
- New regression tests: 4 in `src-tauri/src/commands.rs` (system source always present; `required` mode-derived; mic-only stays startable; preflight skipped for mic-only) and 8 across `src/test/source-readiness.test.ts`, `src/test/note-editor.test.tsx`, and `src/test/app-settings.test.tsx`.
- Pre-publish review battery (`repo-review`), sized **high-stakes** because an implementer harness wrote the diff: Standards / Spec / Adversarial, three rounds, adversarial run on **both** harnesses each round. Round 3 ends with standards clean and no unaddressed introduced defect. Two defects the green test suite did not catch were found and fixed this way — the `ready`-as-grant conflation above, and an earlier guard that made a capable Mac claim "requires macOS 14.2 or later" during the (slow) startup probe window.
- Bot review: Octopus 0 findings. Codex no major issues. Greptile raised one P1 — a source with `permissionState: "granted"` and `ready: false` (the helper's `system_audio_capture_unavailable` branch) still rendered "Allowed". Pre-existing on `main`, but squarely this PR's thesis, so fixed in `f84113cb` and covered by two new settings tests. Adopted Greptile's structure with tone `attention` rather than `blocked`, since that branch's recovery is `restartApp`, not a TCC denial.

**Fixture note for reviewers:** `app-meeting-start`, `app-notes-reliability`, and `app-shortcut` had system fixtures shaped `{ source: "system", ready: true }` with no `permissionState`. The real command never returns that for a granted Mac. Those tests were passing *because of* the conflation this PR removes, so the fixtures now carry `permissionState: "granted"`.

- [ ] Tested visually where it matters.

  **Not done, deliberately.** The defect only manifests where system audio is unsupported (macOS 14.0/14.1); no such machine is available here, and no CI runner has one. The three user-visible states are instead asserted at component level against the real `NoteEditor` — unknown readiness renders the switch, a payload missing the system source renders the explanation, and `"unsupported"` renders the explanation.

  A reviewer on any Mac can reproduce the original bug deterministically: set `src-tauri/system-audio-min-macos-version.txt` to `99.0`, `pnpm tauri:dev`, open recording options (correct: the macOS 14.2 copy), start a recording, reopen recording options. On `main` the copy is replaced by an enabled toggle; on this branch it is not.

- [ ] Needs a June API (backend) deploy. **No.** Desktop-only; no `/v1/*` contract touched.

## Out of scope

- **The bug the reporter most likely hit is already fixed.** JUN-223 was filed against **v0.0.29**. PR #650 (JUN-190/191) shipped in **v0.0.31** the next day and fixed a genuine TCC microphone bug: `microphone_permission_state()` checked *device presence* instead of `AVCaptureDevice.authorizationStatus`, and the main app never requested its own bundle-scoped mic grant. This PR does not claim to be the whole of JUN-223 — the reporter should be asked to confirm against 0.0.31+.
- The dictation helper, Accessibility, and dictation paste.
- `build.rs`, entitlements, signing, CI workflows.

## Followups

Found while diagnosing, not fixed here:

1. **No Intel Mac ever executes the Swift helpers.** Every macOS runner in every workflow is Apple Silicon, and the only x86_64 validation is `lipo -archs` — presence, not execution. An x86_64-only defect in the Accessibility or audio-capture paths would ship undetected. Directly relevant, since "older Mac" may mean Intel.
2. **`staging-desktop-dmg.yml` caches `src-tauri/target`.** The RC and promote workflows deliberately do not, because a restored target skips `build.rs` and leaves the nested Swift helpers ad-hoc-signed. Ad-hoc signatures give a helper an unstable TCC identity, so Accessibility and microphone grants reset on every update.
3. **`build.rs` fails open.** If `swiftc`/`lipo` fails it prints `cargo:warning` and returns *after* the `.app` directory shell exists, so a build can ship a helper bundle with no executable and no `Info.plist`, making that helper's permission silently unobtainable.
4. **Stale-grant race at record start (pre-existing, not introduced).** If system audio is denied, the user grants it in System Settings, and then starts recording before the focus-triggered re-probe lands, the take is mic-only. `main` behaves identically. The obvious fix (probe `microphonePlusSystem` at every record start) would reintroduce the multi-second preflight this PR keeps gated, so it needs its own design pass.

## Assumptions flagged for review

- That the reporter's "permissions" means the recording/system-audio surface. The issue names no permission. If they meant Accessibility or the dictation paste, this PR does not address it.
