### PR TITLE
Forward-port model picker hover polish from #669 onto main

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2789,6 +2789,9 @@ export function AgentWorkspace({
       const target = event.target as Node;
       if (composerModelPopoverRef.current?.contains(target)) return;
       if (composerModelTriggerRef.current?.contains(target)) return;
+      // The hover detail cards are portaled to document.body, so a click inside
+      // one (its "Show more" toggle) lands outside the popover — treat it as in.
+      if (target instanceof Element && target.closest(".agent-composer-model-hovercard")) return;
       setComposerModelOpen(false);
     }
     function onKey(event: KeyboardEvent) {

--- a/src/components/agent/composer/ModelPicker.tsx
+++ b/src/components/agent/composer/ModelPicker.tsx
@@ -5,18 +5,17 @@ import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconShieldCrossed } from "central-icons/IconShieldCrossed";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { RefObject } from "react";
+import { createPortal } from "react-dom";
 
-import {
-  modelPrivacyBadge,
-  modelSupportsTools,
-  type ModelPrivacyBadge,
-} from "../../../lib/model-privacy";
+import { modelSupportsTools, type ModelPrivacyBadge } from "../../../lib/model-privacy";
 import { suggestedModelsForMode } from "../../../lib/suggested-models";
 import type { VeniceModelDto } from "../../../lib/tauri";
 import { useScrollFade } from "../../../lib/use-scroll-fade";
+import { rectFromElement, type HoverBridgeRect } from "../../ui/hoverBridge";
+import { useCatalogHoverBridge, useModelDetailHoverBridge } from "../../ui/useModelHoverBridge";
 import { HoverTip } from "../../ui/HoverTip";
-import { ModelPrivacyChip } from "../../ui/ModelPrivacyChip";
-import { contextLabel, pricingLabel } from "../../settings/ModelPickerDialog";
+import { ModelPrivacyChip, ModelRowPrivacyBadge } from "../../ui/ModelPrivacyChip";
+import { ModelPickerCardContent } from "../../settings/ModelPickerPopover";
 
 /** The composer's model picker: the trigger pill and its two-layer popover
  * (suggested rows + an "All models" flyout with search). Extracted from
@@ -70,11 +69,12 @@ export function ComposerModelPicker({
 // full catalog behind the "All models" row.
 export type ComposerModelFlyout = { kind: "model"; id: string } | { kind: "all" } | null;
 
-// Hover-intent delay before a hover opens a flyout or card — a pointer
-// sweeping across rows (or rows scrolling under a resting pointer) should
-// not flash panels open. Click and keyboard focus stay immediate.
-const MODEL_HOVER_INTENT_MS = 150;
-const MODEL_HOVERCARD_W = 220;
+// Row hovers should feel quick while moving through models, but still keep a
+// tiny intent delay so a pointer sweep does not flash every card open. Click
+// and keyboard focus stay immediate.
+const MODEL_HOVER_OPEN_INTENT_MS = 45;
+const MODEL_HOVER_CLOSE_INTENT_MS = 150;
+const MODEL_HOVERCARD_W = 248;
 const MODEL_HOVERCARD_GAP = 4;
 const MODEL_HOVERCARD_VIEWPORT_MARGIN = 12;
 
@@ -105,6 +105,17 @@ export function ComposerModelPopover({
   // fixed-positioned next to the hovered row, on the panel's outer side.
   const [catalogHover, setCatalogHover] = useState<{
     model: VeniceModelDto;
+    rowRect: HoverBridgeRect;
+    top: number;
+    x: number;
+    side: "left" | "right";
+  } | null>(null);
+  const hovercardRef = useRef<HTMLDivElement | null>(null);
+  // The suggested-row detail card is portaled to document.body (so the note
+  // chat panel's overflow/z-index can't clip or cover it) and positioned in
+  // viewport coordinates beside the popover — the same mechanism as the catalog
+  // hovercard below.
+  const [detailPos, setDetailPos] = useState<{
     top: number;
     x: number;
     side: "left" | "right";
@@ -120,16 +131,15 @@ export function ComposerModelPopover({
   const hoverIntent = useCallback(
     (action: () => void) => {
       cancelHoverIntent();
-      hoverTimerRef.current = window.setTimeout(action, MODEL_HOVER_INTENT_MS);
+      hoverTimerRef.current = window.setTimeout(action, MODEL_HOVER_OPEN_INTENT_MS);
     },
     [cancelHoverIntent],
   );
   useEffect(() => cancelHoverIntent, [cancelHoverIntent]);
-  // The catalog hover card is interactive (its description carries its own
-  // hover tip for the full, untruncated text), so it cannot vanish the instant
-  // the pointer leaves a row — it has to survive the trip across the gap onto
-  // the card. A short close debounce bridges that gap; entering the card or a
-  // fresh row cancels it.
+  // The catalog hover card is interactive (the pointer can move onto it to
+  // read), so it cannot vanish the instant the pointer leaves a row — it has
+  // to survive the trip across the gap onto the card. A short close debounce
+  // bridges that gap; entering the card or a fresh row cancels it.
   const closeTimerRef = useRef<number | null>(null);
   const cancelCatalogClose = useCallback(() => {
     if (closeTimerRef.current !== null) {
@@ -139,47 +149,110 @@ export function ComposerModelPopover({
   }, []);
   const scheduleCatalogClose = useCallback(() => {
     cancelCatalogClose();
-    closeTimerRef.current = window.setTimeout(() => setCatalogHover(null), MODEL_HOVER_INTENT_MS);
+    closeTimerRef.current = window.setTimeout(
+      () => setCatalogHover(null),
+      MODEL_HOVER_CLOSE_INTENT_MS,
+    );
   }, [cancelCatalogClose]);
   useEffect(() => cancelCatalogClose, [cancelCatalogClose]);
-  // Position-aware scroll fades on the catalog list, same treatment as the
-  // artifact panel body: only when it overflows, only on edges with hidden
-  // content.
+
+  // While a safe-polygon traversal is in flight, a `data-hover-bridging` marker
+  // on the popover suppresses the CSS `:hover` highlight on every non-active row
+  // so only one row ever reads as active (see app.css). Toggled imperatively to
+  // avoid a re-render on every pointermove.
+  const setBridging = useCallback(
+    (on: boolean) => {
+      const el = popoverRef.current;
+      if (!el) return;
+      if (on) el.setAttribute("data-hover-bridging", "true");
+      else el.removeAttribute("data-hover-bridging");
+    },
+    [popoverRef],
+  );
+
+  const portalTarget = typeof document === "undefined" ? null : document.body;
+  // Position-aware scroll fades on the catalog list, via the shared primitive.
   const fade = useScrollFade(listRef);
 
-  // The flyout always opens on the composer side (left of the menu), where
-  // there is reliably room — flipping with the window edge made the card
-  // jump sides between otherwise-identical hovers. The right side is only a
-  // fallback for the degenerate case of the menu hugging the left edge.
-  //
-  // The hover detail card pins to the hovered row, submenu-style, so it
-  // shows up next to the pointer. The all-models panel stays anchored to
-  // the menu's bottom edge and grows upward, so its height is capped to the
-  // room above — clearing the titlebar strip, which would otherwise cover
-  // the search field — and to a fixed ceiling so it doesn't tower on tall
-  // windows.
+  // The all-models panel stays anchored to the menu's bottom edge and grows
+  // upward, so its height is capped to the room above — clearing the titlebar
+  // strip, which would otherwise cover the search field — and to a fixed
+  // ceiling so it doesn't tower on tall windows. (The suggested-model detail
+  // card is positioned separately, below, since it's portaled to the body.)
   useLayoutEffect(() => {
+    if (flyout?.kind !== "all") return;
     const el = flyoutRef.current;
     if (!el) return;
     el.dataset.side = "left";
-    if (flyout?.kind === "model") {
-      const row = el.parentElement?.querySelector<HTMLElement>(
-        '.agent-composer-model-row[data-active="true"]',
-      );
-      el.style.top = row ? `${row.offsetTop}px` : "";
-      el.style.bottom = row ? "auto" : "";
-      el.style.maxHeight = "";
-    } else {
-      el.style.top = "";
-      el.style.bottom = "";
-      const titlebar = parseFloat(getComputedStyle(el).getPropertyValue("--titlebar-h")) || 0;
-      const room = el.getBoundingClientRect().bottom - titlebar - 16;
-      el.style.maxHeight = `${Math.max(160, Math.min(room, 400))}px`;
-    }
+    el.style.top = "";
+    el.style.bottom = "";
+    const titlebar = parseFloat(getComputedStyle(el).getPropertyValue("--titlebar-h")) || 0;
+    const room = el.getBoundingClientRect().bottom - titlebar - 16;
+    el.style.maxHeight = `${Math.max(160, Math.min(room, 400))}px`;
     if (el.getBoundingClientRect().left < 12) {
       el.dataset.side = "right";
     }
   }, [flyout]);
+
+  // The detail card opens beside the popover, its top pinned to the active
+  // row's top. It's portaled to the body (see render), so `offsetTop` is
+  // meaningless — compute viewport-fixed coords here, the same math as
+  // `showCatalogHover`. Prefer the composer side (left of the menu, where there
+  // is reliably room); flip right only when the card wouldn't fit on the left.
+  useLayoutEffect(() => {
+    if (flyout?.kind !== "model") {
+      setDetailPos(null);
+      return;
+    }
+    const popover = popoverRef.current;
+    const row = popover?.querySelector<HTMLElement>(
+      '.agent-composer-model-row[data-active="true"]',
+    );
+    if (!popover || !row) {
+      setDetailPos(null);
+      return;
+    }
+    const rowRect = row.getBoundingClientRect();
+    const popoverRect = popover.getBoundingClientRect();
+    const canOpenLeft =
+      popoverRect.left -
+        MODEL_HOVERCARD_GAP -
+        MODEL_HOVERCARD_W -
+        MODEL_HOVERCARD_VIEWPORT_MARGIN >=
+      0;
+    const canOpenRight =
+      popoverRect.right +
+        MODEL_HOVERCARD_GAP +
+        MODEL_HOVERCARD_W +
+        MODEL_HOVERCARD_VIEWPORT_MARGIN <=
+      window.innerWidth;
+    const side = canOpenLeft ? "left" : canOpenRight ? "right" : "left";
+    setDetailPos({
+      top: rowRect.top,
+      x:
+        side === "right"
+          ? popoverRect.right + MODEL_HOVERCARD_GAP
+          : popoverRect.left - MODEL_HOVERCARD_GAP,
+      side,
+    });
+  }, [flyout, popoverRef]);
+
+  // Keep the detail card on-screen: it's anchored to the active row's top, but
+  // an expanded description near the viewport floor would run off the bottom.
+  // Measure the real height and pull it up so its bottom stays visible.
+  useLayoutEffect(() => {
+    if (!detailPos) return;
+    const card = flyoutRef.current;
+    if (!card) return;
+    const height = card.getBoundingClientRect().height;
+    if (height <= 0) return;
+    const maxTop = window.innerHeight - height - MODEL_HOVERCARD_VIEWPORT_MARGIN;
+    setDetailPos((prev) => {
+      if (!prev) return prev;
+      const clampedTop = Math.max(MODEL_HOVERCARD_VIEWPORT_MARGIN, Math.min(prev.top, maxTop));
+      return Math.abs(clampedTop - prev.top) > 0.5 ? { ...prev, top: clampedTop } : prev;
+    });
+  }, [detailPos]);
 
   // Re-measure the fades whenever the list's content or cap changes: panel
   // open (after the max-height effect above), and every search keystroke.
@@ -193,7 +266,6 @@ export function ComposerModelPopover({
     setCatalogHover(null);
   }, [flyout, search]);
 
-  if (!model) return null;
   const suggested = suggestedModelsForMode("generation", options);
   const query = search.trim().toLowerCase();
   // June's agent needs tool calls, so models without tool support can never
@@ -206,45 +278,88 @@ export function ComposerModelPopover({
   const detail =
     flyout?.kind === "model" ? suggested.find((item) => item.model.id === flyout.id) : undefined;
 
-  function showCatalogHover(option: VeniceModelDto, row: HTMLElement) {
-    cancelCatalogClose();
-    const panel = flyoutRef.current;
-    if (!panel) return;
-    const rowRect = row.getBoundingClientRect();
-    const panelRect = panel.getBoundingClientRect();
-    const preferred = panel.dataset.side === "right" ? "right" : "left";
-    const canOpenLeft =
-      panelRect.left - MODEL_HOVERCARD_GAP - MODEL_HOVERCARD_W - MODEL_HOVERCARD_VIEWPORT_MARGIN >=
-      0;
-    const canOpenRight =
-      panelRect.right + MODEL_HOVERCARD_GAP + MODEL_HOVERCARD_W + MODEL_HOVERCARD_VIEWPORT_MARGIN <=
-      window.innerWidth;
-    const side =
-      preferred === "left"
-        ? canOpenLeft
-          ? "left"
+  // Latest filtered rows, read by the hand-off closure without re-subscribing
+  // the pointer listener on every keystroke.
+  const filteredOptionsRef = useRef(filteredOptions);
+  filteredOptionsRef.current = filteredOptions;
+
+  const showCatalogHover = useCallback(
+    (option: VeniceModelDto, row: HTMLElement) => {
+      cancelCatalogClose();
+      const panel = flyoutRef.current;
+      if (!panel) return;
+      const rowRect = row.getBoundingClientRect();
+      const panelRect = panel.getBoundingClientRect();
+      const preferred = panel.dataset.side === "right" ? "right" : "left";
+      const canOpenLeft =
+        panelRect.left -
+          MODEL_HOVERCARD_GAP -
+          MODEL_HOVERCARD_W -
+          MODEL_HOVERCARD_VIEWPORT_MARGIN >=
+        0;
+      const canOpenRight =
+        panelRect.right +
+          MODEL_HOVERCARD_GAP +
+          MODEL_HOVERCARD_W +
+          MODEL_HOVERCARD_VIEWPORT_MARGIN <=
+        window.innerWidth;
+      const side =
+        preferred === "left"
+          ? canOpenLeft
+            ? "left"
+            : canOpenRight
+              ? "right"
+              : null
           : canOpenRight
             ? "right"
-            : null
-        : canOpenRight
-          ? "right"
-          : canOpenLeft
-            ? "left"
-            : null;
-    if (!side) {
-      setCatalogHover(null);
-      return;
-    }
-    setCatalogHover({
-      model: option,
-      top: rowRect.top,
-      x:
-        side === "right"
-          ? panelRect.right + MODEL_HOVERCARD_GAP
-          : panelRect.left - MODEL_HOVERCARD_GAP,
-      side,
-    });
-  }
+            : canOpenLeft
+              ? "left"
+              : null;
+      if (!side) {
+        setCatalogHover(null);
+        return;
+      }
+      setCatalogHover({
+        model: option,
+        rowRect: rectFromElement(row),
+        top: rowRect.top,
+        x:
+          side === "right"
+            ? panelRect.right + MODEL_HOVERCARD_GAP
+            : panelRect.left - MODEL_HOVERCARD_GAP,
+        side,
+      });
+    },
+    [cancelCatalogClose],
+  );
+
+  const resolveFilteredOption = useCallback(
+    (id: string) => filteredOptionsRef.current.find((item) => item.id === id),
+    [],
+  );
+
+  const modelBridge = useModelDetailHoverBridge({
+    flyout,
+    popoverRef,
+    cardRef: flyoutRef,
+    cancelHoverIntent,
+    setBridging,
+    onFlyoutChange,
+  });
+
+  const catalogBridge = useCatalogHoverBridge({
+    catalogHover,
+    cardRef: hovercardRef,
+    listRef,
+    resolveOption: resolveFilteredOption,
+    showCatalogHover,
+    cancelHoverIntent,
+    cancelCatalogClose,
+    scheduleCatalogClose,
+    setBridging,
+  });
+
+  if (!model) return null;
 
   return (
     <div
@@ -252,11 +367,13 @@ export function ComposerModelPopover({
       className="agent-composer-model-popover"
       role="dialog"
       aria-label="Choose text model"
-      onMouseLeave={() => {
-        // Hover details follow the pointer out; the all-models panel stays
-        // pinned so a search in progress doesn't vanish mid-keystroke.
+      // Opening/closing the detail flyout is owned by the safe-polygon listener;
+      // leaving the popover drops a not-yet-fired open intent and lifts any
+      // bridging suppression left by an abandoned re-target, so row hover
+      // feedback can never stay dead.
+      onPointerLeave={() => {
         cancelHoverIntent();
-        if (flyout?.kind === "model") onFlyoutChange(null);
+        setBridging(false);
       }}
     >
       <p className="agent-composer-model-title">Model</p>
@@ -269,17 +386,27 @@ export function ComposerModelPopover({
               className="agent-composer-model-row"
               role="option"
               aria-selected={option.id === model.id}
+              data-model-id={option.id}
               data-active={(flyout?.kind === "model" && flyout.id === option.id) || undefined}
-              onMouseEnter={() =>
-                hoverIntent(() => onFlyoutChange({ kind: "model", id: option.id }))
-              }
+              onMouseEnter={() => {
+                if (modelBridge.isActive()) {
+                  return;
+                }
+                const open = () => onFlyoutChange({ kind: "model", id: option.id });
+                if (flyout) {
+                  cancelHoverIntent();
+                  open();
+                } else {
+                  hoverIntent(open);
+                }
+              }}
               onFocus={() => {
                 cancelHoverIntent();
                 onFlyoutChange({ kind: "model", id: option.id });
               }}
               onClick={() => onSelect(option.id)}
             >
-              <span className="agent-composer-model-row-name">{option.name}</span>
+              <ComposerModelOptionText model={option} />
               {option.id === model.id ? (
                 <IconCheckmark1Small
                   size={14}
@@ -287,6 +414,7 @@ export function ComposerModelPopover({
                   className="agent-composer-model-row-check"
                 />
               ) : null}
+              <ModelRowPrivacyBadge model={option} />
             </button>
           ))
         ) : (
@@ -299,7 +427,18 @@ export function ComposerModelPopover({
         aria-haspopup="true"
         aria-expanded={flyout?.kind === "all"}
         data-active={flyout?.kind === "all" || undefined}
-        onMouseEnter={() => hoverIntent(() => onFlyoutChange({ kind: "all" }))}
+        onMouseEnter={() => {
+          if (modelBridge.isActive()) {
+            return;
+          }
+          const open = () => onFlyoutChange({ kind: "all" });
+          if (flyout) {
+            cancelHoverIntent();
+            open();
+          } else {
+            hoverIntent(open);
+          }
+        }}
         onFocus={() => {
           cancelHoverIntent();
           onFlyoutChange({ kind: "all" });
@@ -313,21 +452,46 @@ export function ComposerModelPopover({
         <span className="agent-composer-model-row-name">All models</span>
         <IconChevronRightSmall size={12} aria-hidden className="agent-composer-model-row-chevron" />
       </button>
-      {detail ? (
-        <div ref={flyoutRef} className="agent-composer-model-flyout agent-composer-model-detail">
-          <div className="agent-composer-model-surface">
-            <ComposerModelCardContent model={detail.model} />
-          </div>
-        </div>
-      ) : flyout?.kind === "all" ? (
+      {detail && portalTarget
+        ? createPortal(
+            // Portaled to the body and fixed-positioned so the note-chat panel's
+            // overflow/z-index can't clip it or paint the resize divider over it.
+            // Rendered as a .hovercard (position: fixed + z 140 + the slide
+            // animation) rather than the absolute .flyout, but keeps
+            // .agent-composer-model-detail for the card's own surface styles.
+            <div
+              ref={flyoutRef}
+              className="agent-composer-model-hovercard agent-composer-model-detail"
+              data-side={detailPos?.side ?? "left"}
+              onPointerEnter={cancelHoverIntent}
+              // Hidden for the one commit before the layout effect measures the
+              // active row (which runs before paint, so no flash reaches screen).
+              style={
+                detailPos
+                  ? detailPos.side === "right"
+                    ? { top: detailPos.top, left: detailPos.x }
+                    : { top: detailPos.top, right: window.innerWidth - detailPos.x }
+                  : { visibility: "hidden" }
+              }
+            >
+              <div className="agent-composer-model-surface">
+                <ModelPickerCardContent model={detail.model} withDescription animateChange />
+              </div>
+            </div>,
+            portalTarget,
+          )
+        : null}
+      {flyout?.kind === "all" ? (
         <div
           ref={flyoutRef}
           className="agent-composer-model-flyout agent-composer-model-all-panel"
           role="group"
           aria-label="All text models"
-          onMouseLeave={() => {
+          // Leaving the catalog panel abandons any pending re-target hover, so
+          // also lift the bridging suppression here to keep row hover alive.
+          onPointerLeave={() => {
             cancelHoverIntent();
-            scheduleCatalogClose();
+            setBridging(false);
           }}
         >
           <div className="agent-composer-model-surface">
@@ -359,10 +523,14 @@ export function ComposerModelPopover({
                       key={option.id}
                       model={option}
                       selected={option.id === model.id}
+                      active={catalogHover?.model.id === option.id}
                       onSelect={onSelect}
                       onHover={(hoverModel, row, immediate) => {
+                        if (!immediate && catalogBridge.isActive()) {
+                          return;
+                        }
                         cancelCatalogClose();
-                        if (immediate) {
+                        if (immediate || catalogHover) {
                           cancelHoverIntent();
                           showCatalogHover(hoverModel, row);
                         } else {
@@ -379,26 +547,32 @@ export function ComposerModelPopover({
           </div>
         </div>
       ) : null}
-      {flyout?.kind === "all" && catalogHover ? (
-        <div
-          className="agent-composer-model-hovercard agent-composer-model-detail"
-          data-side={catalogHover.side}
-          onMouseEnter={cancelCatalogClose}
-          onMouseLeave={scheduleCatalogClose}
-          style={
-            catalogHover.side === "right"
-              ? { top: catalogHover.top, left: catalogHover.x }
-              : {
-                  top: catalogHover.top,
-                  right: window.innerWidth - catalogHover.x,
-                }
-          }
-        >
-          <div className="agent-composer-model-surface">
-            <ComposerModelCardContent model={catalogHover.model} withDescription />
-          </div>
-        </div>
-      ) : null}
+      {flyout?.kind === "all" && catalogHover && portalTarget
+        ? createPortal(
+            // Portaled alongside the detail card for the same reason: it's a DOM
+            // descendant of the note-chat panel otherwise, trapped below the
+            // resize handle even though it's already position: fixed.
+            <div
+              ref={hovercardRef}
+              className="agent-composer-model-hovercard agent-composer-model-detail"
+              data-side={catalogHover.side}
+              onPointerEnter={cancelCatalogClose}
+              style={
+                catalogHover.side === "right"
+                  ? { top: catalogHover.top, left: catalogHover.x }
+                  : {
+                      top: catalogHover.top,
+                      right: window.innerWidth - catalogHover.x,
+                    }
+              }
+            >
+              <div className="agent-composer-model-surface">
+                <ModelPickerCardContent model={catalogHover.model} withDescription animateChange />
+              </div>
+            </div>,
+            portalTarget,
+          )
+        : null}
     </div>
   );
 }
@@ -425,75 +599,18 @@ export function heroPrivacyFootnote(
   }
 }
 
-// Shared content of the model hover cards: name with the privacy chip
-// alongside, then the value line (pricing, context window). The catalog
-// card also carries the model's description, standing in for the native
-// title tooltip it replaces.
-function ComposerModelCardContent({
-  model,
-  withDescription,
-}: {
-  model: VeniceModelDto;
-  withDescription?: boolean;
-}) {
-  const badge = modelPrivacyBadge(model);
-  const values = [pricingLabel(model), contextLabel(model)].filter(Boolean).join(" · ");
-  return (
-    <>
-      <p className="agent-composer-model-detail-name">
-        <span>{model.name}</span>
-        {badge ? (
-          <ModelPrivacyChip
-            badge={badge}
-            withTip={false}
-            label={badge.label.replace(" mode", "")}
-          />
-        ) : null}
-      </p>
-      {values ? <p className="agent-composer-model-detail-values">{values}</p> : null}
-      {withDescription && model.description ? (
-        <ComposerModelDescription text={model.description} />
-      ) : null}
-    </>
-  );
-}
-
-// The catalog card clamps the description to two lines so it stays compact.
-// When that clamp actually hides text, the row becomes its own hover tip
-// carrying the full copy — hover the truncated blurb to read the rest. The tip
-// only attaches when the text is clipped, so short descriptions don't get a
-// redundant repeat of what's already fully visible.
-function ComposerModelDescription({ text }: { text: string }) {
-  const ref = useRef<HTMLSpanElement | null>(null);
-  const [clamped, setClamped] = useState(false);
-  useLayoutEffect(() => {
-    const el = ref.current;
-    if (el) setClamped(el.scrollHeight - el.clientHeight > 1);
-  }, [text]);
-  const body = (
-    <span ref={ref} className="agent-composer-model-detail-desc">
-      {text}
-    </span>
-  );
-  return clamped ? (
-    <HoverTip tip={text} className="agent-composer-model-detail-desc-tip">
-      {body}
-    </HoverTip>
-  ) : (
-    body
-  );
-}
-
 // Name-only rows: the composer popover is for quick switching, so pricing,
 // context, and privacy detail live in the hover card beside the row.
 function ComposerModelOption({
   model,
   selected,
+  active,
   onSelect,
   onHover,
 }: {
   model: VeniceModelDto;
   selected: boolean;
+  active?: boolean;
   onSelect: (modelId: string) => void;
   onHover: (model: VeniceModelDto, row: HTMLElement, immediate: boolean) => void;
 }) {
@@ -503,15 +620,26 @@ function ComposerModelOption({
       className="agent-composer-model-row"
       role="option"
       aria-selected={selected}
+      data-model-id={model.id}
+      data-active={active || undefined}
       onMouseEnter={(event) => onHover(model, event.currentTarget, false)}
       onFocus={(event) => onHover(model, event.currentTarget, true)}
       onClick={() => onSelect(model.id)}
     >
-      <span className="agent-composer-model-row-name">{model.name}</span>
+      <ComposerModelOptionText model={model} />
       {selected ? (
         <IconCheckmark1Small size={14} aria-hidden className="agent-composer-model-row-check" />
       ) : null}
+      <ModelRowPrivacyBadge model={model} />
     </button>
+  );
+}
+
+function ComposerModelOptionText({ model }: { model: VeniceModelDto }) {
+  return (
+    <span className="agent-composer-model-row-copy">
+      <span className="agent-composer-model-row-name">{model.name}</span>
+    </span>
   );
 }
 

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -252,6 +252,9 @@ export function NoteChatPanel({
       const target = event.target as Node;
       if (modelPopoverRef.current?.contains(target)) return;
       if (modelTriggerRef.current?.contains(target)) return;
+      // The hover detail cards are portaled to document.body, so a click inside
+      // one (its "Show more" toggle) lands outside the popover — treat it as in.
+      if (target instanceof Element && target.closest(".agent-composer-model-hovercard")) return;
       setModelOpen(false);
     }
     window.addEventListener("mousedown", handlePointerDown);

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1193,6 +1193,9 @@ export function AppSettings({
       const target = event.target as Node;
       if (modelPickerPopoverRef.current?.contains(target)) return;
       if (modelPickerTriggerRef.current?.contains(target)) return;
+      // The hover detail cards are portaled to document.body, so a click inside
+      // one (its "Show more" toggle) lands outside the popover — treat it as in.
+      if (target instanceof Element && target.closest(".agent-composer-model-hovercard")) return;
       closeModelPicker();
     }
     function onKey(event: KeyboardEvent) {
@@ -1718,6 +1721,7 @@ export function AppSettings({
                     onFlyoutChange={setModelPickerFlyout}
                     onSearchChange={setModelSearch}
                     onSelect={(modelId) => selectModelFromPicker("transcription", modelId)}
+                    summarySuppressed={pickerMode !== undefined}
                   />
                   <ModelRow
                     mode="generation"
@@ -1739,6 +1743,7 @@ export function AppSettings({
                     onFlyoutChange={setModelPickerFlyout}
                     onSearchChange={setModelSearch}
                     onSelect={(modelId) => selectModelFromPicker("generation", modelId)}
+                    summarySuppressed={pickerMode !== undefined}
                   />
                   {IMAGE_GENERATION_ENABLED ? (
                     <ModelRow
@@ -1759,6 +1764,7 @@ export function AppSettings({
                       onFlyoutChange={setModelPickerFlyout}
                       onSearchChange={setModelSearch}
                       onSelect={(modelId) => selectModelFromPicker("image", modelId)}
+                      summarySuppressed={pickerMode !== undefined}
                     />
                   ) : null}
                   <button
@@ -2375,6 +2381,7 @@ function ModelRow({
   onFlyoutChange,
   onSearchChange,
   onSelect,
+  summarySuppressed,
 }: {
   mode: ProviderModelMode;
   title: string;
@@ -2391,6 +2398,7 @@ function ModelRow({
   onFlyoutChange: (flyout: ModelPickerFlyout) => void;
   onSearchChange: (value: string) => void;
   onSelect: (modelId: string) => void;
+  summarySuppressed?: boolean;
 }) {
   const model = selectedModel(options, value);
   const modelLabel = `${title.toLowerCase()} model`;
@@ -2406,7 +2414,7 @@ function ModelRow({
           className="model-summary-tip-anchor"
           width={280}
           delay={280}
-          suppressed={open}
+          suppressed={summarySuppressed || open}
         >
           <button
             ref={open ? triggerRef : undefined}

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1927,44 +1927,68 @@ export function AppSettings({
               </div>
             </section>
 
-            {IMAGE_GENERATION_ENABLED ? (
+            {IMAGE_GENERATION_ENABLED || VIDEO_GENERATION_ENABLED ? (
               <section
                 className="settings-group settings-models-group"
-                aria-labelledby="image-generation-heading"
+                aria-labelledby="media-generation-heading"
               >
-                <h2 id="image-generation-heading" className="settings-group-heading">
-                  Image generation
+                <h2 id="media-generation-heading" className="settings-group-heading">
+                  Image and video
                 </h2>
                 <p className="settings-group-description">
-                  Choose the model June uses when you ask it to generate an image.
+                  Choose the models June uses when you ask it to generate an image or video.
                 </p>
                 <div className="settings-card settings-models-card">
                   <div className="settings-rows">
-                    <ModelRow
-                      mode="image"
-                      title="Image"
-                      description="Used when you generate an image from chat."
-                      value={providerSettings.imageModel}
-                      options={imageOptions}
-                      open={pickerMode === "image"}
-                      summarySuppressed={pickerMode !== undefined}
-                      flyout={modelPickerFlyout}
-                      search={modelSearch}
-                      triggerRef={modelPickerTriggerRef}
-                      popoverRef={modelPickerPopoverRef}
-                      searchRef={modelPickerSearchRef}
-                      onToggle={() =>
-                        pickerMode === "image" ? closeModelPicker() : openModelPicker("image")
-                      }
-                      onFlyoutChange={setModelPickerFlyout}
-                      onSearchChange={setModelSearch}
-                      onSelect={(modelId) => selectModelFromPicker("image", modelId)}
-                    />
+                    {IMAGE_GENERATION_ENABLED ? (
+                      <ModelRow
+                        mode="image"
+                        title="Image"
+                        description="Used when you generate an image from chat."
+                        value={providerSettings.imageModel}
+                        options={imageOptions}
+                        open={pickerMode === "image"}
+                        summarySuppressed={pickerMode !== undefined}
+                        flyout={modelPickerFlyout}
+                        search={modelSearch}
+                        triggerRef={modelPickerTriggerRef}
+                        popoverRef={modelPickerPopoverRef}
+                        searchRef={modelPickerSearchRef}
+                        onToggle={() =>
+                          pickerMode === "image" ? closeModelPicker() : openModelPicker("image")
+                        }
+                        onFlyoutChange={setModelPickerFlyout}
+                        onSearchChange={setModelSearch}
+                        onSelect={(modelId) => selectModelFromPicker("image", modelId)}
+                      />
+                    ) : null}
+                    {VIDEO_GENERATION_ENABLED ? (
+                      <ModelRow
+                        mode="video"
+                        title="Video"
+                        description="Used when you generate a video from chat."
+                        value={providerSettings.videoModel}
+                        options={videoOptions}
+                        open={pickerMode === "video"}
+                        summarySuppressed={pickerMode !== undefined}
+                        flyout={modelPickerFlyout}
+                        search={modelSearch}
+                        triggerRef={modelPickerTriggerRef}
+                        popoverRef={modelPickerPopoverRef}
+                        searchRef={modelPickerSearchRef}
+                        onToggle={() =>
+                          pickerMode === "video" ? closeModelPicker() : openModelPicker("video")
+                        }
+                        onFlyoutChange={setModelPickerFlyout}
+                        onSearchChange={setModelSearch}
+                        onSelect={(modelId) => selectModelFromPicker("video", modelId)}
+                      />
+                    ) : null}
                     <div className="settings-row-divider" aria-hidden />
                     <button
                       type="button"
                       className="settings-more-options-trigger settings-more-options-row"
-                      aria-label="More options for image generation"
+                      aria-label="More options for image and video"
                       aria-expanded={showMoreImageOptions}
                       aria-controls="image-more-options-panel"
                       onClick={() => setShowMoreImageOptions((open) => !open)}
@@ -1972,7 +1996,7 @@ export function AppSettings({
                       <span className="settings-row-info">
                         <span className="settings-row-title">More options</span>
                         <span className="settings-row-description">
-                          Advanced image generation settings
+                          Advanced image and video settings
                         </span>
                       </span>
                       <IconChevronDownSmall
@@ -2002,44 +2026,6 @@ export function AppSettings({
                         </div>
                       </div>
                     ) : null}
-                  </div>
-                </div>
-              </section>
-            ) : null}
-
-            {VIDEO_GENERATION_ENABLED ? (
-              <section
-                className="settings-group settings-models-group"
-                aria-labelledby="video-generation-heading"
-              >
-                <h2 id="video-generation-heading" className="settings-group-heading">
-                  Video generation
-                </h2>
-                <p className="settings-group-description">
-                  Choose the model June uses when you ask it to generate a video.
-                </p>
-                <div className="settings-card settings-models-card">
-                  <div className="settings-rows">
-                    <ModelRow
-                      mode="video"
-                      title="Video"
-                      description="Used when you generate a video from chat."
-                      value={providerSettings.videoModel}
-                      options={videoOptions}
-                      open={pickerMode === "video"}
-                      summarySuppressed={pickerMode !== undefined}
-                      flyout={modelPickerFlyout}
-                      search={modelSearch}
-                      triggerRef={modelPickerTriggerRef}
-                      popoverRef={modelPickerPopoverRef}
-                      searchRef={modelPickerSearchRef}
-                      onToggle={() =>
-                        pickerMode === "video" ? closeModelPicker() : openModelPicker("video")
-                      }
-                      onFlyoutChange={setModelPickerFlyout}
-                      onSearchChange={setModelSearch}
-                      onSelect={(modelId) => selectModelFromPicker("video", modelId)}
-                    />
                   </div>
                 </div>
               </section>

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -417,6 +417,7 @@ export function AppSettings({
   const modelPickerSearchRef = useRef<HTMLInputElement>(null);
   const [veniceApiKeyDraft, setVeniceApiKeyDraft] = useState("");
   const [showMoreModelOptions, setShowMoreModelOptions] = useState(false);
+  const [showMoreImageOptions, setShowMoreImageOptions] = useState(false);
   const [localModelSetupVisible, setLocalModelSetupVisible] = useState(false);
   const [localModelStatus, setLocalModelStatus] = useState<string>();
   const [internalTab, setInternalTab] = useState<SettingsTab>("general");
@@ -992,18 +993,18 @@ export function AppSettings({
   // The model picker's local option enables from the SAVED settings (never
   // the draft), but it must honor the same off-device invariant as the
   // toggle: a non-loopback endpoint is never enabled silently. Instead of
-  // enabling, it reveals the confirm affordance in the Local model section
+  // enabling, it reveals the confirm affordance in More options
   // and says so; a loopback endpoint enables in one step.
   function enableLocalGenerationFromPicker() {
     const baseUrl = providerSettings.localGeneration.baseUrl.trim();
     if (!isLoopbackUrl(baseUrl)) {
       setLocalEnableConfirm(true);
       setLocalModelSetupVisible(true);
-      // The confirm affordance lives in the Local model section behind "More
-      // options"; reveal it so the status message's instruction is reachable.
+      // The confirm affordance lives behind More options; reveal it so the
+      // status message's instruction is reachable.
       setShowMoreModelOptions(true);
       setLocalModelStatus(
-        "This endpoint is not on this machine. Requests will leave your device. Confirm in the Local model section to enable it.",
+        "This endpoint is not on this machine. Requests will leave your device. Confirm in More options to enable it.",
       );
       return;
     }
@@ -1708,6 +1709,7 @@ export function AppSettings({
                     value={providerSettings.transcriptionModel}
                     options={transcriptionOptions}
                     open={pickerMode === "transcription"}
+                    summarySuppressed={pickerMode !== undefined}
                     flyout={modelPickerFlyout}
                     search={modelSearch}
                     triggerRef={modelPickerTriggerRef}
@@ -1721,7 +1723,6 @@ export function AppSettings({
                     onFlyoutChange={setModelPickerFlyout}
                     onSearchChange={setModelSearch}
                     onSelect={(modelId) => selectModelFromPicker("transcription", modelId)}
-                    summarySuppressed={pickerMode !== undefined}
                   />
                   <ModelRow
                     mode="generation"
@@ -1730,6 +1731,7 @@ export function AppSettings({
                     value={modelValueForMode("generation")}
                     options={generationOptions}
                     open={pickerMode === "generation"}
+                    summarySuppressed={pickerMode !== undefined}
                     flyout={modelPickerFlyout}
                     search={modelSearch}
                     triggerRef={modelPickerTriggerRef}
@@ -1743,9 +1745,188 @@ export function AppSettings({
                     onFlyoutChange={setModelPickerFlyout}
                     onSearchChange={setModelSearch}
                     onSelect={(modelId) => selectModelFromPicker("generation", modelId)}
-                    summarySuppressed={pickerMode !== undefined}
                   />
-                  {IMAGE_GENERATION_ENABLED ? (
+                  <div className="settings-row-divider" aria-hidden />
+                  <button
+                    type="button"
+                    className="settings-more-options-trigger settings-more-options-row"
+                    aria-label="More options for AI models"
+                    aria-expanded={showMoreModelOptions}
+                    aria-controls="models-more-options-panel"
+                    onClick={() => setShowMoreModelOptions((open) => !open)}
+                  >
+                    <span className="settings-row-info">
+                      <span className="settings-row-title">More options</span>
+                      <span className="settings-row-description">Advanced model settings</span>
+                    </span>
+                    <IconChevronDownSmall
+                      className="settings-more-options-chevron"
+                      size={14}
+                      aria-hidden
+                    />
+                  </button>
+                  {showMoreModelOptions ? (
+                    <div id="models-more-options-panel" className="settings-more-options-panel">
+                      <VeniceApiKeyRow
+                        configured={providerSettings.veniceApiKeyConfigured}
+                        value={veniceApiKeyDraft}
+                        onValueChange={setVeniceApiKeyDraft}
+                        onSave={() => void saveVeniceApiKey()}
+                        onRemove={() => void removeVeniceApiKey()}
+                      />
+                      <div className="settings-row settings-local-model-toggle-row">
+                        <div className="settings-row-info">
+                          <h3 className="settings-row-title">Use local model</h3>
+                          <p className="settings-row-description">
+                            Route generated notes and agent responses through your own
+                            OpenAI-compatible endpoint.
+                          </p>
+                        </div>
+                        <div className="settings-row-control">
+                          <Switch
+                            checked={localModelEnabled}
+                            aria-label="Use local text model"
+                            onCheckedChange={handleLocalToggle}
+                          />
+                        </div>
+                      </div>
+
+                      {showLocalModelFields ? (
+                        <div className="settings-row settings-row-stack settings-local-model-fields-row">
+                          <div className="settings-row-info">
+                            <h3 className="settings-row-title">Endpoint</h3>
+                            <p className="settings-row-description">
+                              Add the base URL, model ID, and optional API key for your local text
+                              model.
+                            </p>
+                          </div>
+                          <div className="settings-row-control settings-local-model-fields">
+                            <label className="settings-field">
+                              <span>Base URL</span>
+                              <input
+                                value={localGenerationDraft.baseUrl}
+                                onChange={(event) => {
+                                  const baseUrl = event.currentTarget.value;
+                                  setLocalGenerationDraft((draft) => ({
+                                    ...draft,
+                                    baseUrl,
+                                  }));
+                                  setLocalEnableConfirm(false);
+                                  setLocalModelStatus(undefined);
+                                }}
+                                placeholder="http://localhost:11434/v1"
+                                autoCapitalize="none"
+                                autoCorrect="off"
+                                spellCheck={false}
+                              />
+                            </label>
+                            <label className="settings-field">
+                              <span>Model ID</span>
+                              <input
+                                value={localGenerationDraft.modelId}
+                                onChange={(event) => {
+                                  const modelId = event.currentTarget.value;
+                                  setLocalGenerationDraft((draft) => ({
+                                    ...draft,
+                                    modelId,
+                                  }));
+                                  setLocalModelStatus(undefined);
+                                }}
+                                placeholder="llama3.1:8b"
+                                list="local-generation-models"
+                                autoCapitalize="none"
+                                autoCorrect="off"
+                                spellCheck={false}
+                              />
+                              <datalist id="local-generation-models">
+                                {localProbeModels.map((id) => (
+                                  <option key={id} value={id} />
+                                ))}
+                              </datalist>
+                            </label>
+                            <label className="settings-field">
+                              <span>Local API key</span>
+                              <input
+                                type="password"
+                                value={localGenerationDraft.apiKey}
+                                onChange={(event) => {
+                                  const apiKey = event.currentTarget.value;
+                                  setLocalGenerationDraft((draft) => ({
+                                    ...draft,
+                                    apiKey,
+                                  }));
+                                  setLocalModelStatus(undefined);
+                                }}
+                                placeholder="Optional"
+                                autoCapitalize="none"
+                                autoCorrect="off"
+                                spellCheck={false}
+                              />
+                            </label>
+                            {localNonLoopback ? (
+                              <p className="settings-local-model-warning" role="note">
+                                This endpoint is not on this machine. Requests will leave your
+                                device.
+                              </p>
+                            ) : null}
+                            <div className="settings-local-model-actions">
+                              <button
+                                type="button"
+                                className="btn btn-secondary"
+                                onClick={() => void testLocalConnection()}
+                              >
+                                Test connection
+                              </button>
+                              <button
+                                type="button"
+                                className="btn btn-secondary"
+                                onClick={() => void handleSaveLocalModel()}
+                              >
+                                Save local model
+                              </button>
+                            </div>
+                            {localModelStatus ? (
+                              <p className="settings-local-model-status" role="status">
+                                {localModelStatus}
+                              </p>
+                            ) : null}
+                            {localEnableConfirm ? (
+                              <div className="settings-local-model-confirm" role="alert">
+                                <p className="settings-row-error">
+                                  This endpoint is not on this machine. Requests will leave your
+                                  device.
+                                </p>
+                                <button
+                                  type="button"
+                                  className="btn btn-secondary"
+                                  onClick={() => void enableLocalGeneration()}
+                                >
+                                  Enable anyway
+                                </button>
+                              </div>
+                            ) : null}
+                          </div>
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            </section>
+
+            {IMAGE_GENERATION_ENABLED ? (
+              <section
+                className="settings-group settings-models-group"
+                aria-labelledby="image-generation-heading"
+              >
+                <h2 id="image-generation-heading" className="settings-group-heading">
+                  Image generation
+                </h2>
+                <p className="settings-group-description">
+                  Choose the model June uses when you ask it to generate an image.
+                </p>
+                <div className="settings-card settings-models-card">
+                  <div className="settings-rows">
                     <ModelRow
                       mode="image"
                       title="Image"
@@ -1753,6 +1934,7 @@ export function AppSettings({
                       value={providerSettings.imageModel}
                       options={imageOptions}
                       open={pickerMode === "image"}
+                      summarySuppressed={pickerMode !== undefined}
                       flyout={modelPickerFlyout}
                       search={modelSearch}
                       triggerRef={modelPickerTriggerRef}
@@ -1764,37 +1946,30 @@ export function AppSettings({
                       onFlyoutChange={setModelPickerFlyout}
                       onSearchChange={setModelSearch}
                       onSelect={(modelId) => selectModelFromPicker("image", modelId)}
-                      summarySuppressed={pickerMode !== undefined}
                     />
-                  ) : null}
-                  <button
-                    type="button"
-                    className="settings-row settings-more-options-trigger"
-                    aria-expanded={showMoreModelOptions}
-                    aria-controls="models-more-options local-model-section"
-                    onClick={() => setShowMoreModelOptions((open) => !open)}
-                  >
-                    <span className="settings-row-info">
-                      <span className="settings-row-title">More options</span>
-                      <span className="settings-row-description">Advanced model settings.</span>
-                    </span>
-                    <IconChevronDownSmall
-                      className="settings-more-options-chevron"
-                      size={14}
-                      aria-hidden
-                    />
-                  </button>
-                  {showMoreModelOptions ? (
-                    <>
-                      <VeniceApiKeyRow
-                        id="models-more-options"
-                        configured={providerSettings.veniceApiKeyConfigured}
-                        value={veniceApiKeyDraft}
-                        onValueChange={setVeniceApiKeyDraft}
-                        onSave={() => void saveVeniceApiKey()}
-                        onRemove={() => void removeVeniceApiKey()}
+                    <div className="settings-row-divider" aria-hidden />
+                    <button
+                      type="button"
+                      className="settings-more-options-trigger settings-more-options-row"
+                      aria-label="More options for image generation"
+                      aria-expanded={showMoreImageOptions}
+                      aria-controls="image-more-options-panel"
+                      onClick={() => setShowMoreImageOptions((open) => !open)}
+                    >
+                      <span className="settings-row-info">
+                        <span className="settings-row-title">More options</span>
+                        <span className="settings-row-description">
+                          Advanced image generation settings
+                        </span>
+                      </span>
+                      <IconChevronDownSmall
+                        className="settings-more-options-chevron"
+                        size={14}
+                        aria-hidden
                       />
-                      {IMAGE_GENERATION_ENABLED ? (
+                    </button>
+                    {showMoreImageOptions ? (
+                      <div id="image-more-options-panel" className="settings-more-options-panel">
                         <div className="settings-row">
                           <div className="settings-row-info">
                             <h3 className="settings-row-title">Safe mode</h3>
@@ -1810,158 +1985,6 @@ export function AppSettings({
                               onCheckedChange={toggleImageSafeMode}
                             />
                           </div>
-                        </div>
-                      ) : null}
-                    </>
-                  ) : null}
-                </div>
-              </div>
-            </section>
-
-            {showMoreModelOptions ? (
-              <section
-                id="local-model-section"
-                className="settings-group settings-models-group settings-local-model-group"
-                aria-labelledby="local-model-heading"
-              >
-                <h2 id="local-model-heading" className="settings-group-heading">
-                  Local model
-                </h2>
-                <p className="settings-group-description">
-                  Advanced text generation through your own OpenAI-compatible endpoint.
-                </p>
-                <div className="settings-card settings-models-card">
-                  <div className="settings-rows">
-                    <div className="settings-row settings-local-model-toggle-row">
-                      <div className="settings-row-info">
-                        <h3 className="settings-row-title">Use local model</h3>
-                        <p className="settings-row-description">
-                          Route generated notes and agent responses through your own
-                          OpenAI-compatible endpoint.
-                        </p>
-                      </div>
-                      <div className="settings-row-control">
-                        <Switch
-                          checked={localModelEnabled}
-                          aria-label="Use local text model"
-                          onCheckedChange={handleLocalToggle}
-                        />
-                      </div>
-                    </div>
-
-                    {showLocalModelFields ? (
-                      <div className="settings-row settings-row-stack settings-local-model-fields-row">
-                        <div className="settings-row-info">
-                          <h3 className="settings-row-title">Endpoint</h3>
-                          <p className="settings-row-description">
-                            Add the base URL, model ID, and optional API key for your local text
-                            model.
-                          </p>
-                        </div>
-                        <div className="settings-row-control settings-local-model-fields">
-                          <label className="settings-field">
-                            <span>Base URL</span>
-                            <input
-                              value={localGenerationDraft.baseUrl}
-                              onChange={(event) => {
-                                const baseUrl = event.currentTarget.value;
-                                setLocalGenerationDraft((draft) => ({
-                                  ...draft,
-                                  baseUrl,
-                                }));
-                                setLocalEnableConfirm(false);
-                                setLocalModelStatus(undefined);
-                              }}
-                              placeholder="http://localhost:11434/v1"
-                              autoCapitalize="none"
-                              autoCorrect="off"
-                              spellCheck={false}
-                            />
-                          </label>
-                          <label className="settings-field">
-                            <span>Model ID</span>
-                            <input
-                              value={localGenerationDraft.modelId}
-                              onChange={(event) => {
-                                const modelId = event.currentTarget.value;
-                                setLocalGenerationDraft((draft) => ({
-                                  ...draft,
-                                  modelId,
-                                }));
-                                setLocalModelStatus(undefined);
-                              }}
-                              placeholder="llama3.1:8b"
-                              list="local-generation-models"
-                              autoCapitalize="none"
-                              autoCorrect="off"
-                              spellCheck={false}
-                            />
-                            <datalist id="local-generation-models">
-                              {localProbeModels.map((id) => (
-                                <option key={id} value={id} />
-                              ))}
-                            </datalist>
-                          </label>
-                          <label className="settings-field">
-                            <span>Local API key</span>
-                            <input
-                              type="password"
-                              value={localGenerationDraft.apiKey}
-                              onChange={(event) => {
-                                const apiKey = event.currentTarget.value;
-                                setLocalGenerationDraft((draft) => ({
-                                  ...draft,
-                                  apiKey,
-                                }));
-                                setLocalModelStatus(undefined);
-                              }}
-                              placeholder="Optional"
-                              autoCapitalize="none"
-                              autoCorrect="off"
-                              spellCheck={false}
-                            />
-                          </label>
-                          {localNonLoopback ? (
-                            <p className="settings-local-model-warning" role="note">
-                              This endpoint is not on this machine. Requests will leave your device.
-                            </p>
-                          ) : null}
-                          <div className="settings-local-model-actions">
-                            <button
-                              type="button"
-                              className="btn btn-secondary"
-                              onClick={() => void testLocalConnection()}
-                            >
-                              Test connection
-                            </button>
-                            <button
-                              type="button"
-                              className="btn btn-secondary"
-                              onClick={() => void handleSaveLocalModel()}
-                            >
-                              Save local model
-                            </button>
-                          </div>
-                          {localModelStatus ? (
-                            <p className="settings-local-model-status" role="status">
-                              {localModelStatus}
-                            </p>
-                          ) : null}
-                          {localEnableConfirm ? (
-                            <div className="settings-local-model-confirm" role="alert">
-                              <p className="settings-row-error">
-                                This endpoint is not on this machine. Requests will leave your
-                                device.
-                              </p>
-                              <button
-                                type="button"
-                                className="btn btn-secondary"
-                                onClick={() => void enableLocalGeneration()}
-                              >
-                                Enable anyway
-                              </button>
-                            </div>
-                          ) : null}
                         </div>
                       </div>
                     ) : null}
@@ -2415,6 +2438,7 @@ function ModelRow({
           width={280}
           delay={280}
           suppressed={summarySuppressed || open}
+          interactive
         >
           <button
             ref={open ? triggerRef : undefined}
@@ -2455,12 +2479,12 @@ function ModelRow({
 }
 
 function ModelSummaryHoverDetails({ model }: { model: VeniceModelDto }) {
-  // Reuse the popover's model hovercard surface (name line + muted metadata line
-  // + description) so the summary tip reads exactly like the picker hovercard.
   return (
-    <span className="agent-composer-model-detail model-summary-hovercard">
+    <div className="agent-composer-model-detail model-summary-hovercard">
+      {/* Read-only summary card: full description in one hover (the card shows
+          it in a capped scroll box; there is no "Show more" toggle anywhere). */}
       <ModelPickerCardContent model={model} withDescription />
-    </span>
+    </div>
   );
 }
 

--- a/src/components/settings/ModelPickerDialog.tsx
+++ b/src/components/settings/ModelPickerDialog.tsx
@@ -326,6 +326,47 @@ function trimNumber(value: number) {
   return Number.isInteger(value) ? String(value) : value.toFixed(1);
 }
 
+// The hover card's spec list: the pricing/context facts split into label/value
+// pairs so the card renders a compact spec table instead of a prose sentence.
+// Falls back to a single "Pricing" row when there is no clean input/output
+// credit split.
+export function modelSpecEntries(model: VeniceModelDto): { label: string; value: string }[] {
+  const entries: { label: string; value: string }[] = [];
+  // Use June's billed credit price (with margin) for the input/output split.
+  // The raw `pricing.*.usd` on the DTO is upstream provider metadata the backend
+  // keeps for reference only — the user-facing price must come from the credit
+  // price (see june-api handlers/models.rs), so it is never shown as the price
+  // here. Anything without the credit split defers to `pricingLabel`, which
+  // resolves the price the same way the rest of the app does.
+  if (
+    model.priceUnit === "tokens" &&
+    typeof model.inputCreditsPerMillionTokens === "number" &&
+    typeof model.outputCreditsPerMillionTokens === "number"
+  ) {
+    entries.push({
+      label: "Input",
+      value: `${formatCreditsAsUsd(model.inputCreditsPerMillionTokens)} /1M`,
+    });
+    entries.push({
+      label: "Output",
+      value: `${formatCreditsAsUsd(model.outputCreditsPerMillionTokens)} /1M`,
+    });
+  } else {
+    const price = pricingLabel(model);
+    if (price) entries.push({ label: "Pricing", value: price });
+  }
+  if (model.contextTokens) {
+    const context =
+      model.contextTokens >= 1_000_000
+        ? `${trimNumber(model.contextTokens / 1_000_000)}M tokens`
+        : model.contextTokens >= 1_000
+          ? `${trimNumber(model.contextTokens / 1_000)}K tokens`
+          : `${model.contextTokens} tokens`;
+    entries.push({ label: "Context", value: context });
+  }
+  return entries;
+}
+
 export function modelOptions(models: VeniceModelDto[], selectedModel: string) {
   const modelId = selectedModel.trim();
   if (!modelId || models.some((model) => model.id === modelId)) {

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -1,23 +1,34 @@
 import { IconChevronRightSmall } from "central-icons/IconChevronRightSmall";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconCheckmark2Small } from "central-icons-filled/IconCheckmark2Small";
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { RefObject } from "react";
+import { createPortal } from "react-dom";
 import { modelAvailableForMode, modelPrivacyBadge } from "../../lib/model-privacy";
 import { suggestedModelsForMode } from "../../lib/suggested-models";
-import { useScrollFade } from "../../lib/use-scroll-fade";
 import type { ProviderModelMode, VeniceModelDto } from "../../lib/tauri";
-import { HoverTip } from "../ui/HoverTip";
-import { ModelPrivacyChip } from "../ui/ModelPrivacyChip";
-import { contextLabel, pricingLabel } from "./ModelPickerDialog";
+import { useScrollFade } from "../../lib/use-scroll-fade";
+import { rectFromElement, type HoverBridgeRect } from "../ui/hoverBridge";
+import { useCatalogHoverBridge, useModelDetailHoverBridge } from "../ui/useModelHoverBridge";
+import { ModelPrivacyChip, ModelRowPrivacyBadge } from "../ui/ModelPrivacyChip";
+import { modelSpecEntries } from "./ModelPickerDialog";
 import { ProviderLogo } from "./ProviderLogo";
 
 export type ModelPickerFlyout = { kind: "model"; id: string } | { kind: "all" } | null;
 
-// Deliberate hover-intent delay before a row's detail card opens, so a pointer
-// sweeping across rows doesn't flash the card on pass-over.
-const MODEL_HOVER_INTENT_MS = 260;
-const MODEL_HOVERCARD_W = 232;
+// Row hovers should feel quick while moving through models, but still keep a
+// tiny intent delay so a pointer sweep does not flash every card open.
+const MODEL_HOVER_OPEN_INTENT_MS = 45;
+const MODEL_HOVER_CLOSE_INTENT_MS = 150;
+const MODEL_HOVERCARD_W = 248;
 const MODEL_HOVERCARD_GAP = 4;
 const MODEL_HOVERCARD_VIEWPORT_MARGIN = 12;
 
@@ -57,8 +68,18 @@ export function ModelPickerPopover({
   const flyoutRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
   const hovercardRef = useRef<HTMLDivElement | null>(null);
+  // The suggested-row detail card is portaled to document.body (so a scroll
+  // container or panel can't clip or cover it) and positioned in viewport
+  // coordinates beside the popover — the same mechanism as the catalog
+  // hovercard below.
+  const [detailPos, setDetailPos] = useState<{
+    top: number;
+    x: number;
+    side: "left" | "right";
+  } | null>(null);
   const [catalogHover, setCatalogHover] = useState<{
     model: VeniceModelDto;
+    rowRect: HoverBridgeRect;
     top: number;
     x: number;
     side: "left" | "right";
@@ -73,7 +94,7 @@ export function ModelPickerPopover({
   const hoverIntent = useCallback(
     (action: () => void) => {
       cancelHoverIntent();
-      hoverTimerRef.current = window.setTimeout(action, MODEL_HOVER_INTENT_MS);
+      hoverTimerRef.current = window.setTimeout(action, MODEL_HOVER_OPEN_INTENT_MS);
     },
     [cancelHoverIntent],
   );
@@ -88,34 +109,111 @@ export function ModelPickerPopover({
   }, []);
   const scheduleCatalogClose = useCallback(() => {
     cancelCatalogClose();
-    closeTimerRef.current = window.setTimeout(() => setCatalogHover(null), MODEL_HOVER_INTENT_MS);
+    closeTimerRef.current = window.setTimeout(
+      () => setCatalogHover(null),
+      MODEL_HOVER_CLOSE_INTENT_MS,
+    );
   }, [cancelCatalogClose]);
   useEffect(() => cancelCatalogClose, [cancelCatalogClose]);
 
+  // While a safe-polygon traversal is in flight, a `data-hover-bridging` marker
+  // on the popover suppresses the CSS `:hover` highlight on every non-active row
+  // so only one row ever reads as active (see app.css). Toggled imperatively to
+  // avoid a re-render on every pointermove.
+  const setBridging = useCallback(
+    (on: boolean) => {
+      const el = popoverRef.current;
+      if (!el) return;
+      if (on) el.setAttribute("data-hover-bridging", "true");
+      else el.removeAttribute("data-hover-bridging");
+    },
+    [popoverRef],
+  );
+
+  const portalTarget = typeof document === "undefined" ? null : document.body;
+
   const fade = useScrollFade(listRef);
 
+  // The all-models panel stays anchored to the menu's bottom edge and grows
+  // upward; cap its height to the room above (clearing the titlebar strip that
+  // would otherwise cover the search field) and a fixed ceiling. (The
+  // suggested-model detail card is positioned separately, below, since it's
+  // portaled to the body.)
   useLayoutEffect(() => {
+    if (flyout?.kind !== "all") return;
     const el = flyoutRef.current;
     if (!el) return;
     el.dataset.side = "left";
-    if (flyout?.kind === "model") {
-      const row = el.parentElement?.querySelector<HTMLElement>(
-        '.agent-composer-model-row[data-active="true"]',
-      );
-      el.style.top = row ? `${row.offsetTop}px` : "";
-      el.style.bottom = row ? "auto" : "";
-      el.style.maxHeight = "";
-    } else {
-      el.style.top = "";
-      el.style.bottom = "";
-      const titlebar = parseFloat(getComputedStyle(el).getPropertyValue("--titlebar-h")) || 0;
-      const room = el.getBoundingClientRect().bottom - titlebar - 16;
-      el.style.maxHeight = `${Math.max(160, Math.min(room, 400))}px`;
-    }
+    el.style.top = "";
+    el.style.bottom = "";
+    const titlebar = parseFloat(getComputedStyle(el).getPropertyValue("--titlebar-h")) || 0;
+    const room = el.getBoundingClientRect().bottom - titlebar - 16;
+    el.style.maxHeight = `${Math.max(160, Math.min(room, 400))}px`;
     if (el.getBoundingClientRect().left < 12) {
       el.dataset.side = "right";
     }
   }, [flyout]);
+
+  // The detail card opens beside the popover, its top pinned to the active
+  // row's top. It's portaled to the body (see render), so `offsetTop` is
+  // meaningless — compute viewport-fixed coords here, the same math as
+  // `showCatalogHover`. Prefer the left side; flip right only when the card
+  // wouldn't fit on the left.
+  useLayoutEffect(() => {
+    if (flyout?.kind !== "model") {
+      setDetailPos(null);
+      return;
+    }
+    const popover = popoverRef.current;
+    const row = popover?.querySelector<HTMLElement>(
+      '.agent-composer-model-row[data-active="true"]',
+    );
+    if (!popover || !row) {
+      setDetailPos(null);
+      return;
+    }
+    const rowRect = row.getBoundingClientRect();
+    const popoverRect = popover.getBoundingClientRect();
+    const canOpenLeft =
+      popoverRect.left -
+        MODEL_HOVERCARD_GAP -
+        MODEL_HOVERCARD_W -
+        MODEL_HOVERCARD_VIEWPORT_MARGIN >=
+      0;
+    const canOpenRight =
+      popoverRect.right +
+        MODEL_HOVERCARD_GAP +
+        MODEL_HOVERCARD_W +
+        MODEL_HOVERCARD_VIEWPORT_MARGIN <=
+      window.innerWidth;
+    const side = canOpenLeft ? "left" : canOpenRight ? "right" : "left";
+    setDetailPos({
+      top: rowRect.top,
+      x:
+        side === "right"
+          ? popoverRect.right + MODEL_HOVERCARD_GAP
+          : popoverRect.left - MODEL_HOVERCARD_GAP,
+      side,
+    });
+  }, [flyout, popoverRef]);
+
+  // Keep the detail card on-screen: it's anchored to the active row's top, but
+  // the picker opens downward, so a row near the viewport floor (or an expanded
+  // description) would push the card off the bottom. Measure the real height
+  // and pull it up so its bottom stays visible.
+  useLayoutEffect(() => {
+    if (!detailPos) return;
+    const card = flyoutRef.current;
+    if (!card) return;
+    const height = card.getBoundingClientRect().height;
+    if (height <= 0) return;
+    const maxTop = window.innerHeight - height - MODEL_HOVERCARD_VIEWPORT_MARGIN;
+    setDetailPos((prev) => {
+      if (!prev) return prev;
+      const clampedTop = Math.max(MODEL_HOVERCARD_VIEWPORT_MARGIN, Math.min(prev.top, maxTop));
+      return Math.abs(clampedTop - prev.top) > 0.5 ? { ...prev, top: clampedTop } : prev;
+    });
+  }, [detailPos]);
 
   useLayoutEffect(() => {
     fade.update();
@@ -137,13 +235,11 @@ export function ModelPickerPopover({
     const height = card.getBoundingClientRect().height;
     if (height <= 0) return;
     const maxTop = window.innerHeight - height - MODEL_HOVERCARD_VIEWPORT_MARGIN;
-    const clampedTop = Math.max(
-      MODEL_HOVERCARD_VIEWPORT_MARGIN,
-      Math.min(catalogHover.top, maxTop),
-    );
-    if (Math.abs(clampedTop - catalogHover.top) > 0.5) {
-      setCatalogHover((prev) => (prev ? { ...prev, top: clampedTop } : prev));
-    }
+    setCatalogHover((prev) => {
+      if (!prev) return prev;
+      const clampedTop = Math.max(MODEL_HOVERCARD_VIEWPORT_MARGIN, Math.min(prev.top, maxTop));
+      return Math.abs(clampedTop - prev.top) > 0.5 ? { ...prev, top: clampedTop } : prev;
+    });
   }, [catalogHover]);
 
   const query = search.trim().toLowerCase();
@@ -158,45 +254,86 @@ export function ModelPickerPopover({
   const detail =
     flyout?.kind === "model" ? suggested.find((item) => item.model.id === flyout.id) : undefined;
 
-  function showCatalogHover(option: VeniceModelDto, row: HTMLElement) {
-    cancelCatalogClose();
-    const panel = flyoutRef.current ?? popoverRef.current;
-    if (!panel) return;
-    const rowRect = row.getBoundingClientRect();
-    const panelRect = panel.getBoundingClientRect();
-    const preferred = panel.dataset.side === "right" ? "right" : "left";
-    const canOpenLeft =
-      panelRect.left - MODEL_HOVERCARD_GAP - MODEL_HOVERCARD_W - MODEL_HOVERCARD_VIEWPORT_MARGIN >=
-      0;
-    const canOpenRight =
-      panelRect.right + MODEL_HOVERCARD_GAP + MODEL_HOVERCARD_W + MODEL_HOVERCARD_VIEWPORT_MARGIN <=
-      window.innerWidth;
-    const side =
-      preferred === "left"
-        ? canOpenLeft
-          ? "left"
+  // Latest filtered rows, read by the hand-off closure without re-subscribing
+  // the pointer listener on every keystroke.
+  const filteredOptionsRef = useRef(filteredOptions);
+  filteredOptionsRef.current = filteredOptions;
+
+  const showCatalogHover = useCallback(
+    (option: VeniceModelDto, row: HTMLElement) => {
+      cancelCatalogClose();
+      const panel = flyoutRef.current ?? popoverRef.current;
+      if (!panel) return;
+      const rowRect = row.getBoundingClientRect();
+      const panelRect = panel.getBoundingClientRect();
+      const preferred = panel.dataset.side === "right" ? "right" : "left";
+      const canOpenLeft =
+        panelRect.left -
+          MODEL_HOVERCARD_GAP -
+          MODEL_HOVERCARD_W -
+          MODEL_HOVERCARD_VIEWPORT_MARGIN >=
+        0;
+      const canOpenRight =
+        panelRect.right +
+          MODEL_HOVERCARD_GAP +
+          MODEL_HOVERCARD_W +
+          MODEL_HOVERCARD_VIEWPORT_MARGIN <=
+        window.innerWidth;
+      const side =
+        preferred === "left"
+          ? canOpenLeft
+            ? "left"
+            : canOpenRight
+              ? "right"
+              : null
           : canOpenRight
             ? "right"
-            : null
-        : canOpenRight
-          ? "right"
-          : canOpenLeft
-            ? "left"
-            : null;
-    if (!side) {
-      setCatalogHover(null);
-      return;
-    }
-    setCatalogHover({
-      model: option,
-      top: rowRect.top,
-      x:
-        side === "right"
-          ? panelRect.right + MODEL_HOVERCARD_GAP
-          : panelRect.left - MODEL_HOVERCARD_GAP,
-      side,
-    });
-  }
+            : canOpenLeft
+              ? "left"
+              : null;
+      if (!side) {
+        setCatalogHover(null);
+        return;
+      }
+      setCatalogHover({
+        model: option,
+        rowRect: rectFromElement(row),
+        top: rowRect.top,
+        x:
+          side === "right"
+            ? panelRect.right + MODEL_HOVERCARD_GAP
+            : panelRect.left - MODEL_HOVERCARD_GAP,
+        side,
+      });
+    },
+    [cancelCatalogClose, popoverRef],
+  );
+
+  const resolveFilteredOption = useCallback(
+    (id: string) => filteredOptionsRef.current.find((item) => item.id === id),
+    [],
+  );
+
+  const modelBridge = useModelDetailHoverBridge({
+    flyout,
+    popoverRef,
+    cardRef: flyoutRef,
+    cancelHoverIntent,
+    setBridging,
+    onFlyoutChange,
+  });
+
+  const catalogBridge = useCatalogHoverBridge({
+    catalogHover,
+    cardRef: hovercardRef,
+    listRef,
+    resolveOption: resolveFilteredOption,
+    showCatalogHover,
+    cancelHoverIntent,
+    cancelCatalogClose,
+    scheduleCatalogClose,
+    setBridging,
+  });
 
   function catalogList(label: string) {
     return (
@@ -229,10 +366,14 @@ export function ModelPickerPopover({
                   key={option.id}
                   model={option}
                   selected={option.id === model?.id}
+                  active={catalogHover?.model.id === option.id}
                   onSelect={onSelect}
                   onHover={(hoverModel, row, immediate) => {
+                    if (!immediate && catalogBridge.isActive()) {
+                      return;
+                    }
                     cancelCatalogClose();
-                    if (immediate) {
+                    if (immediate || catalogHover) {
                       cancelHoverIntent();
                       showCatalogHover(hoverModel, row);
                     } else {
@@ -257,9 +398,13 @@ export function ModelPickerPopover({
       className={["agent-composer-model-popover", className].filter(Boolean).join(" ")}
       role="dialog"
       aria-label={ariaLabel}
-      onMouseLeave={() => {
+      // Opening/closing the detail flyout is owned by the safe-polygon listener;
+      // leaving the popover drops a not-yet-fired open intent and lifts any
+      // bridging suppression left by an abandoned re-target, so row hover
+      // feedback can never stay dead.
+      onPointerLeave={() => {
         cancelHoverIntent();
-        if (flyout?.kind === "model") onFlyoutChange(null);
+        setBridging(false);
       }}
     >
       <p className="agent-composer-model-title">{title}</p>
@@ -272,10 +417,20 @@ export function ModelPickerPopover({
               className="agent-composer-model-row"
               role="option"
               aria-selected={option.id === model.id}
+              data-model-id={option.id}
               data-active={(flyout?.kind === "model" && flyout.id === option.id) || undefined}
-              onMouseEnter={() =>
-                hoverIntent(() => onFlyoutChange({ kind: "model", id: option.id }))
-              }
+              onMouseEnter={() => {
+                if (modelBridge.isActive()) {
+                  return;
+                }
+                const open = () => onFlyoutChange({ kind: "model", id: option.id });
+                if (flyout) {
+                  cancelHoverIntent();
+                  open();
+                } else {
+                  hoverIntent(open);
+                }
+              }}
               onFocus={() => {
                 cancelHoverIntent();
                 onFlyoutChange({ kind: "model", id: option.id });
@@ -290,6 +445,7 @@ export function ModelPickerPopover({
                   className="agent-composer-model-row-check"
                 />
               ) : null}
+              <ModelRowPrivacyBadge model={option} />
             </button>
           ))
         ) : (
@@ -302,7 +458,18 @@ export function ModelPickerPopover({
         aria-haspopup="true"
         aria-expanded={flyout?.kind === "all"}
         data-active={flyout?.kind === "all" || undefined}
-        onMouseEnter={() => hoverIntent(() => onFlyoutChange({ kind: "all" }))}
+        onMouseEnter={() => {
+          if (modelBridge.isActive()) {
+            return;
+          }
+          const open = () => onFlyoutChange({ kind: "all" });
+          if (flyout) {
+            cancelHoverIntent();
+            open();
+          } else {
+            hoverIntent(open);
+          }
+        }}
         onFocus={() => {
           cancelHoverIntent();
           onFlyoutChange({ kind: "all" });
@@ -316,109 +483,156 @@ export function ModelPickerPopover({
         <span className="agent-composer-model-row-name">All models</span>
         <IconChevronRightSmall size={16} aria-hidden className="agent-composer-model-row-chevron" />
       </button>
-      {detail ? (
-        <div ref={flyoutRef} className="agent-composer-model-flyout agent-composer-model-detail">
-          <div className="agent-composer-model-surface">
-            <ModelPickerCardContent model={detail.model} />
-          </div>
-        </div>
-      ) : flyout?.kind === "all" ? (
+      {detail && portalTarget
+        ? createPortal(
+            // Portaled to the body and fixed-positioned so no scroll container
+            // or panel (e.g. the note-chat panel) can clip it or paint over it.
+            // Rendered as a .hovercard (position: fixed + z 140 + the slide
+            // animation) rather than the absolute .flyout, but keeps
+            // .agent-composer-model-detail for the card's own surface styles.
+            <div
+              ref={flyoutRef}
+              className="agent-composer-model-hovercard agent-composer-model-detail"
+              data-side={detailPos?.side ?? "left"}
+              onPointerEnter={cancelHoverIntent}
+              // Hidden for the one commit before the layout effect measures the
+              // active row (which runs before paint, so no flash reaches screen).
+              style={
+                detailPos
+                  ? detailPos.side === "right"
+                    ? { top: detailPos.top, left: detailPos.x }
+                    : { top: detailPos.top, right: window.innerWidth - detailPos.x }
+                  : { visibility: "hidden" }
+              }
+            >
+              <div className="agent-composer-model-surface">
+                <ModelPickerCardContent model={detail.model} withDescription animateChange />
+              </div>
+            </div>,
+            portalTarget,
+          )
+        : null}
+      {flyout?.kind === "all" ? (
         <div
           ref={flyoutRef}
           className="agent-composer-model-flyout agent-composer-model-all-panel"
           role="group"
           aria-label={allModelsLabel}
-          onMouseLeave={() => {
+          // Leaving the catalog panel abandons any pending re-target hover, so
+          // also lift the bridging suppression here to keep row hover alive.
+          onPointerLeave={() => {
             cancelHoverIntent();
-            scheduleCatalogClose();
+            setBridging(false);
           }}
         >
           <div className="agent-composer-model-surface">{catalogList(allModelsLabel)}</div>
         </div>
       ) : null}
-      {flyout?.kind === "all" && catalogHover ? (
-        <div
-          ref={hovercardRef}
-          className="agent-composer-model-hovercard agent-composer-model-detail"
-          data-side={catalogHover.side}
-          onMouseEnter={cancelCatalogClose}
-          onMouseLeave={scheduleCatalogClose}
-          style={
-            catalogHover.side === "right"
-              ? { top: catalogHover.top, left: catalogHover.x }
-              : {
-                  top: catalogHover.top,
-                  right: window.innerWidth - catalogHover.x,
-                }
-          }
-        >
-          <div className="agent-composer-model-surface">
-            <ModelPickerCardContent model={catalogHover.model} withDescription />
-          </div>
-        </div>
-      ) : null}
+      {flyout?.kind === "all" && catalogHover && portalTarget
+        ? createPortal(
+            // Portaled alongside the detail card, for the same reason.
+            <div
+              ref={hovercardRef}
+              className="agent-composer-model-hovercard agent-composer-model-detail"
+              data-side={catalogHover.side}
+              onPointerEnter={cancelCatalogClose}
+              style={
+                catalogHover.side === "right"
+                  ? { top: catalogHover.top, left: catalogHover.x }
+                  : {
+                      top: catalogHover.top,
+                      right: window.innerWidth - catalogHover.x,
+                    }
+              }
+            >
+              <div className="agent-composer-model-surface">
+                <ModelPickerCardContent model={catalogHover.model} withDescription animateChange />
+              </div>
+            </div>,
+            portalTarget,
+          )
+        : null}
     </div>
   );
 }
 
+// The card: name + privacy chip, the full description in a capped scroll box,
+// then the pricing/context facts as a compact spec list. The description never
+// grows the card after it opens (no "Show more" toggle), so the open-time
+// viewport clamp stays correct and there is no focusable control stranded
+// inside the portaled subtree.
 export function ModelPickerCardContent({
   model,
   withDescription,
+  animateChange = false,
 }: {
   model: VeniceModelDto;
   withDescription?: boolean;
+  animateChange?: boolean;
 }) {
   const badge = modelPrivacyBadge(model);
-  const values = [pricingLabel(model), contextLabel(model)].filter(Boolean).join(" · ");
+  const specs = modelSpecEntries(model);
   return (
-    <>
+    <div
+      key={animateChange ? model.id : undefined}
+      className="agent-composer-model-detail-content"
+      data-animate-change={animateChange || undefined}
+    >
       <p className="agent-composer-model-detail-name">
         <span>{model.name}</span>
         {badge ? (
           <ModelPrivacyChip
             badge={badge}
             withTip={false}
+            variant="themed"
+            size="sm"
             label={badge.label.replace(" mode", "")}
           />
         ) : null}
       </p>
-      {values ? <p className="agent-composer-model-detail-values">{values}</p> : null}
       {withDescription && model.description ? (
-        <ModelPickerDescription text={model.description} />
+        // Keyed by model so switching rows re-measures the fade from the top.
+        <ModelCardDescription key={model.id} text={model.description} />
       ) : null}
-    </>
+      {specs.length ? (
+        <dl className="agent-composer-model-detail-specs">
+          {specs.map((spec) => (
+            <Fragment key={spec.label}>
+              <dt>{spec.label}</dt>
+              <dd>{spec.value}</dd>
+            </Fragment>
+          ))}
+        </dl>
+      ) : null}
+    </div>
   );
 }
 
-function ModelPickerDescription({ text }: { text: string }) {
-  const ref = useRef<HTMLSpanElement | null>(null);
-  const [clamped, setClamped] = useState(false);
-  useLayoutEffect(() => {
-    const el = ref.current;
-    if (el) setClamped(el.scrollHeight - el.clientHeight > 1);
-  }, [text]);
-  const body = (
-    <span ref={ref} className="agent-composer-model-detail-desc">
-      {text}
-    </span>
-  );
-  return clamped ? (
-    <HoverTip tip={text} className="agent-composer-model-detail-desc-tip">
-      {body}
-    </HoverTip>
-  ) : (
-    body
+// Full description in a short capped box that scrolls when it overflows, with
+// contained top/bottom scroll fades from the shared `useScrollFade` primitive
+// (WKWebView-safe overlay flavor — never a mask on the scroller itself).
+function ModelCardDescription({ text }: { text: string }) {
+  const ref = useRef<HTMLParagraphElement | null>(null);
+  const fade = useScrollFade(ref);
+  return (
+    <div className="agent-composer-model-detail-desc-wrap scroll-fade" {...fade.props}>
+      <p ref={ref} className="agent-composer-model-detail-desc">
+        {text}
+      </p>
+    </div>
   );
 }
 
 function ModelPickerOption({
   model,
   selected,
+  active,
   onSelect,
   onHover,
 }: {
   model: VeniceModelDto;
   selected: boolean;
+  active?: boolean;
   onSelect: (modelId: string) => void;
   onHover: (model: VeniceModelDto, row: HTMLElement, immediate: boolean) => void;
 }) {
@@ -428,6 +642,8 @@ function ModelPickerOption({
       className="agent-composer-model-row"
       role="option"
       aria-selected={selected}
+      data-model-id={model.id}
+      data-active={active || undefined}
       onMouseEnter={(event) => onHover(model, event.currentTarget, false)}
       onFocus={(event) => onHover(model, event.currentTarget, true)}
       onClick={() => onSelect(model.id)}
@@ -436,6 +652,7 @@ function ModelPickerOption({
       {selected ? (
         <IconCheckmark2Small size={14} aria-hidden className="agent-composer-model-row-check" />
       ) : null}
+      <ModelRowPrivacyBadge model={model} />
     </button>
   );
 }

--- a/src/components/ui/HoverTip.tsx
+++ b/src/components/ui/HoverTip.tsx
@@ -94,6 +94,9 @@ type HoverTipProps = HTMLAttributes<HTMLSpanElement> & {
    * trigger's own picker popover is open, so the hover callout never fights the
    * popover for the same anchor. */
   suppressed?: boolean;
+  /** Keeps the callout alive while the pointer moves onto it. Use only for
+   * rich, card-like tips with controls inside. */
+  interactive?: boolean;
   children: ReactNode;
 };
 
@@ -114,6 +117,7 @@ export function HoverTip({
   compact = false,
   delay = HOVER_INTENT_MS,
   suppressed = false,
+  interactive = false,
   children,
   ...spanProps
 }: HoverTipProps) {
@@ -121,14 +125,16 @@ export function HoverTip({
     "aria-describedby": ariaDescribedBy,
     onBlur,
     onFocus,
+    onKeyDown,
     onMouseEnter,
     onMouseLeave,
     ...restSpanProps
   } = spanProps;
   const anchorRef = useRef<HTMLSpanElement | null>(null);
-  const tipRef = useRef<HTMLSpanElement | null>(null);
+  const tipRef = useRef<HTMLDivElement | null>(null);
   const hoverTimerRef = useRef<number | null>(null);
   const closeTimerRef = useRef<number | null>(null);
+  const resizeFrameRef = useRef<number | null>(null);
   // The side committed by the first measure pass, held for the tip's whole
   // mounted lifetime: a re-hover or a content swap (e.g. "Copy message" →
   // "Copied") re-measures, and re-deciding the side then would visibly
@@ -139,10 +145,12 @@ export function HoverTip({
   const [anchor, setAnchor] = useState<TipAnchor>();
   // The final clamped coordinates, set after measuring the rendered tip.
   const [coords, setCoords] = useState<TipCoords>();
+  const [measureVersion, setMeasureVersion] = useState(0);
   // "open" once revealed (enter animation runs), "closing" during the exit
   // fade. Absent while measuring or unmounted.
   const [phase, setPhase] = useState<"open" | "closing">();
   const mounted = anchor !== undefined;
+  const portalTarget = typeof document === "undefined" ? null : document.body;
   const describedBy = [ariaDescribedBy, mounted ? tooltipId : null].filter(Boolean).join(" ");
 
   const cancelHoverIntent = useCallback(() => {
@@ -197,6 +205,34 @@ export function HoverTip({
     cancelClose();
     closeTimerRef.current = window.setTimeout(unmount, EXIT_MS);
   }
+
+  function hideAfterInteractiveGrace() {
+    cancelHoverIntent();
+    if (!mounted) return;
+    cancelClose();
+    closeTimerRef.current = window.setTimeout(hide, HOVER_INTENT_MS);
+  }
+
+  function elementInsideHoverTipSurface(element: EventTarget | null) {
+    return element instanceof Node && Boolean(tipRef.current?.contains(element));
+  }
+
+  function elementInsideAnchor(element: EventTarget | null) {
+    return element instanceof Node && Boolean(anchorRef.current?.contains(element));
+  }
+
+  function firstTipFocusable() {
+    return tipRef.current?.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+  }
+
+  const cancelResizeMeasure = useCallback(() => {
+    if (resizeFrameRef.current !== null) {
+      window.cancelAnimationFrame(resizeFrameRef.current);
+      resizeFrameRef.current = null;
+    }
+  }, []);
 
   // Measure the rendered tip and clamp its centered position to the viewport,
   // all before paint, so the reveal never jumps. jsdom reports a zero-width
@@ -262,15 +298,47 @@ export function HoverTip({
       Math.max(anchor.centerX - boxWidth / 2, VIEWPORT_MARGIN),
       Math.max(window.innerWidth - boxWidth - VIEWPORT_MARGIN, VIEWPORT_MARGIN),
     );
-    setCoords({ side, top: side === "bottom" ? anchor.bottom : anchor.top, left, width });
-  }, [anchor, tip]);
+    const rawTop = side === "bottom" ? anchor.bottom : anchor.top;
+    let top = rawTop;
+    // Vertical viewport clamp is scoped to interactive tips only: those carry
+    // tall, card-like content (the model summary card) that can run off a
+    // window edge. Plain tooltips keep their exact prior top so this change has
+    // no blast radius on the many small tips across the app.
+    if (interactive && tipHeight > 0) {
+      top =
+        side === "bottom"
+          ? Math.min(rawTop, window.innerHeight - tipHeight - VIEWPORT_MARGIN)
+          : Math.max(rawTop, tipHeight + VIEWPORT_MARGIN);
+      top = Math.max(VIEWPORT_MARGIN, Math.min(top, window.innerHeight - VIEWPORT_MARGIN));
+    }
+    setCoords({ side, top, left, width });
+  }, [anchor, tip, measureVersion, interactive]);
+
+  useLayoutEffect(() => {
+    if (!interactive || !mounted || typeof ResizeObserver === "undefined") return;
+    const node = tipRef.current;
+    if (!node) return;
+    const observer = new ResizeObserver(() => {
+      cancelResizeMeasure();
+      resizeFrameRef.current = window.requestAnimationFrame(() => {
+        resizeFrameRef.current = null;
+        setMeasureVersion((version) => version + 1);
+      });
+    });
+    observer.observe(node);
+    return () => {
+      observer.disconnect();
+      cancelResizeMeasure();
+    };
+  }, [interactive, mounted, cancelResizeMeasure]);
 
   useEffect(
     () => () => {
       cancelHoverIntent();
       cancelClose();
+      cancelResizeMeasure();
     },
-    [cancelHoverIntent, cancelClose],
+    [cancelHoverIntent, cancelClose, cancelResizeMeasure],
   );
 
   // Force-close the moment suppression turns on (the picker popover opened over
@@ -285,14 +353,22 @@ export function HoverTip({
   useEffect(() => {
     if (!mounted) return;
     // Scroll/resize would drift the tip off its anchor; cut it immediately
-    // rather than fading in place.
-    window.addEventListener("scroll", unmount, true);
+    // rather than fading in place. An interactive tip can itself hold a scroll
+    // region (e.g. a capped description), so a scroll that originates inside the
+    // tip must not dismiss it — only outside scrolls do.
+    const onScroll = (event: Event) => {
+      if (interactive && event.target instanceof Node && tipRef.current?.contains(event.target)) {
+        return;
+      }
+      unmount();
+    };
+    window.addEventListener("scroll", onScroll, true);
     window.addEventListener("resize", unmount);
     return () => {
-      window.removeEventListener("scroll", unmount, true);
+      window.removeEventListener("scroll", onScroll, true);
       window.removeEventListener("resize", unmount);
     };
-  }, [mounted, unmount]);
+  }, [mounted, unmount, interactive]);
 
   return (
     <span
@@ -305,7 +381,8 @@ export function HoverTip({
       }}
       onMouseLeave={(event) => {
         onMouseLeave?.(event);
-        hide();
+        if (interactive) hideAfterInteractiveGrace();
+        else hide();
       }}
       onFocus={(event) => {
         onFocus?.(event);
@@ -313,17 +390,41 @@ export function HoverTip({
       }}
       onBlur={(event) => {
         onBlur?.(event);
+        if (
+          interactive &&
+          (elementInsideAnchor(event.relatedTarget) ||
+            elementInsideHoverTipSurface(event.relatedTarget))
+        ) {
+          return;
+        }
         hide();
+      }}
+      onKeyDown={(event) => {
+        onKeyDown?.(event);
+        if (
+          event.defaultPrevented ||
+          !interactive ||
+          event.key !== "Tab" ||
+          event.shiftKey ||
+          !mounted
+        ) {
+          return;
+        }
+        const focusTarget = firstTipFocusable();
+        if (!focusTarget) return;
+        event.preventDefault();
+        focusTarget.focus();
       }}
     >
       {children}
-      {mounted
+      {mounted && portalTarget
         ? createPortal(
-            <span
+            <div
               ref={tipRef}
               id={tooltipId}
               className={compact ? "hover-tip hover-tip-compact" : "hover-tip"}
               role="tooltip"
+              data-interactive={interactive || undefined}
               data-side={coords?.side ?? "bottom"}
               // Hidden until measured: the enter animation runs only once the
               // final position is revealed, never while offscreen.
@@ -331,6 +432,28 @@ export function HoverTip({
               onTransitionEnd={(event) => {
                 if (event.propertyName === "opacity" && phase === "closing") unmount();
               }}
+              onMouseEnter={
+                interactive
+                  ? () => {
+                      cancelClose();
+                      setPhase("open");
+                    }
+                  : undefined
+              }
+              onMouseLeave={interactive ? hide : undefined}
+              onBlur={
+                interactive
+                  ? (event) => {
+                      if (
+                        elementInsideAnchor(event.relatedTarget) ||
+                        elementInsideHoverTipSurface(event.relatedTarget)
+                      ) {
+                        return;
+                      }
+                      hide();
+                    }
+                  : undefined
+              }
               style={{
                 top: coords?.top ?? anchor.bottom,
                 left: coords?.left ?? 0,
@@ -341,8 +464,8 @@ export function HoverTip({
               }}
             >
               {tip}
-            </span>,
-            document.body,
+            </div>,
+            portalTarget,
           )
         : null}
     </span>

--- a/src/components/ui/ModelPrivacyChip.tsx
+++ b/src/components/ui/ModelPrivacyChip.tsx
@@ -1,13 +1,23 @@
 import { IconAnonymous } from "central-icons/IconAnonymous";
 import { IconGhost2 } from "central-icons/IconGhost2";
 import { IconLock } from "central-icons/IconLock";
-import type { ModelPrivacyBadge } from "../../lib/model-privacy";
+import { modelPrivacyBadge, type ModelPrivacyBadge } from "../../lib/model-privacy";
+import type { VeniceModelDto } from "../../lib/tauri";
 import { HoverTip } from "./HoverTip";
+
+/** The privacy mode's mascot: the lock for E2EE, the ghost for private, the
+ * anonymized figure otherwise. Shared so every surface draws the same glyph
+ * for a given mode. */
+function privacyModeIcon(mode: ModelPrivacyBadge["mode"], size: number) {
+  if (mode === "e2ee") return <IconLock size={size} aria-hidden />;
+  if (mode === "private") return <IconGhost2 size={size} aria-hidden />;
+  return <IconAnonymous size={size} aria-hidden />;
+}
 
 /**
  * The single chip for a model's privacy badge — the icon-by-mode (lock / ghost /
  * anonymous) plus its label. Shared by the model picker (`ModelMeta`), the chat
- * model hover cards (`ComposerModelCardContent`), the chat session bar
+ * model hover cards (`ModelPickerCardContent`), the chat session bar
  * (`PrivacyModeBadge`), and the session usage panel so the surfaces stay
  * identical.
  *
@@ -52,14 +62,7 @@ export function ModelPrivacyChip({
   // its shorter height; every other placement keeps the 13/14px icon.
   const iconSize = size === "sm" ? 12 : variant === "themed" ? 13 : 14;
 
-  const icon =
-    badge.mode === "e2ee" ? (
-      <IconLock size={iconSize} aria-hidden />
-    ) : badge.mode === "private" ? (
-      <IconGhost2 size={iconSize} aria-hidden />
-    ) : (
-      <IconAnonymous size={iconSize} aria-hidden />
-    );
+  const icon = privacyModeIcon(badge.mode, iconSize);
 
   if (!withTip) {
     return (
@@ -80,6 +83,26 @@ export function ModelPrivacyChip({
     >
       {icon}
       <span>{label}</span>
+    </HoverTip>
+  );
+}
+
+/**
+ * The compact private marker for model-picker rows. It stays icon-only because
+ * row details live in the hover card. Anonymous/E2EE models keep their privacy
+ * detail in the hover card instead of adding a trailing row icon.
+ */
+export function ModelRowPrivacyBadge({ model }: { model: VeniceModelDto }) {
+  const badge = modelPrivacyBadge(model);
+  if (badge?.mode !== "private") return null;
+  return (
+    <HoverTip
+      tip={badge.description}
+      className="model-row-privacy"
+      data-mode={badge.mode}
+      aria-label={`${badge.label}: ${badge.description}`}
+    >
+      {privacyModeIcon("private", 14)}
     </HoverTip>
   );
 }

--- a/src/components/ui/hoverBridge.ts
+++ b/src/components/ui/hoverBridge.ts
@@ -1,0 +1,218 @@
+export type HoverBridgeSide = "left" | "right";
+
+export type HoverBridgePoint = {
+  x: number;
+  y: number;
+};
+
+export type HoverBridgeRect = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+export function rectFromElement(element: Element): HoverBridgeRect {
+  const rect = element.getBoundingClientRect();
+  return {
+    top: rect.top,
+    right: rect.right,
+    bottom: rect.bottom,
+    left: rect.left,
+  };
+}
+
+export function pointInRect(point: HoverBridgePoint, rect: HoverBridgeRect, padding = 0): boolean {
+  return (
+    point.x >= rect.left - padding &&
+    point.x <= rect.right + padding &&
+    point.y >= rect.top - padding &&
+    point.y <= rect.bottom + padding
+  );
+}
+
+function pointInPolygon(point: HoverBridgePoint, polygon: HoverBridgePoint[]): boolean {
+  let inside = false;
+  for (let index = 0, previous = polygon.length - 1; index < polygon.length; previous = index++) {
+    const currentPoint = polygon[index];
+    const previousPoint = polygon[previous];
+    const crossesY = currentPoint.y > point.y !== previousPoint.y > point.y;
+    if (!crossesY) continue;
+    const slopeX =
+      ((previousPoint.x - currentPoint.x) * (point.y - currentPoint.y)) /
+        (previousPoint.y - currentPoint.y) +
+      currentPoint.x;
+    if (point.x < slopeX) inside = !inside;
+  }
+  return inside;
+}
+
+// Half-height of the row-edge slice that forms the polygon's apex. The safe
+// area is anchored at the pointer's exit position (not the whole row), so it is
+// a narrow wedge at the row edge that fans out to the card's near edge — a true
+// safe triangle/trapezoid rather than a slab covering the menu.
+const SAFE_APEX_HALF = 8;
+
+function buildSafePolygon(
+  exit: HoverBridgePoint,
+  trigger: HoverBridgeRect,
+  floating: HoverBridgeRect,
+  side: HoverBridgeSide,
+  padding: number,
+): HoverBridgePoint[] {
+  const top = floating.top - padding;
+  const bottom = floating.bottom + padding;
+  const apexHigh = exit.y - SAFE_APEX_HALF;
+  const apexLow = exit.y + SAFE_APEX_HALF;
+  if (side === "right") {
+    // Card sits to the right of the row: apex on the row's right edge, base on
+    // the card's left edge.
+    const nearX = trigger.right;
+    const farX = floating.left;
+    return [
+      { x: nearX, y: apexHigh },
+      { x: farX, y: top },
+      { x: farX, y: bottom },
+      { x: nearX, y: apexLow },
+    ];
+  }
+  // Card sits to the left of the row: apex on the row's left edge, base on the
+  // card's right edge.
+  const nearX = trigger.left;
+  const farX = floating.right;
+  return [
+    { x: farX, y: top },
+    { x: nearX, y: apexHigh },
+    { x: nearX, y: apexLow },
+    { x: farX, y: bottom },
+  ];
+}
+
+export type HoverBridgeTracker = {
+  /** Anchor a fresh safe polygon at the pointer's exit from the trigger row. */
+  begin(
+    exit: HoverBridgePoint,
+    trigger: HoverBridgeRect,
+    floating: HoverBridgeRect,
+    side: HoverBridgeSide,
+  ): void;
+  /** Feed a pointer position; returns false once the bridge should be dropped. */
+  update(point: HoverBridgePoint): boolean;
+  /** True while a bridge is anchored. */
+  isActive(): boolean;
+  /** Tear the bridge down and cancel any pending stall expiry. */
+  stop(): void;
+};
+
+/**
+ * A floating-ui `safePolygon`-style tracker. Once the pointer leaves the
+ * trigger row heading for the card it consumes pointermove points and answers
+ * "still bridging?":
+ *
+ * - the safe area is a wedge anchored at the exit point, widening to the card's
+ *   near edge, so it never covers unrelated rows;
+ * - progress toward the card (its near edge getting closer) restarts a stall
+ *   clock; a point outside the wedge drops the bridge immediately;
+ * - if the pointer stalls inside the wedge without making progress for
+ *   `stallMs`, `onExpire` fires with the last point so the caller can hand hover
+ *   to whatever row now sits under the pointer.
+ */
+export function createHoverBridgeTracker(options?: {
+  stallMs?: number;
+  padding?: number;
+  onExpire?: (lastPoint: HoverBridgePoint) => void;
+}): HoverBridgeTracker {
+  const stallMs = options?.stallMs ?? 280;
+  const padding = options?.padding ?? 6;
+  const onExpire = options?.onExpire;
+  // A point must close this many px on the card's near edge to count as
+  // meaningful progress; anything less is treated as a stall.
+  const progressEpsilon = 1;
+
+  let polygon: HoverBridgePoint[] | null = null;
+  let floating: HoverBridgeRect | null = null;
+  let trigger: HoverBridgeRect | null = null;
+  let side: HoverBridgeSide = "right";
+  let bestGap = Number.POSITIVE_INFINITY;
+  let lastPoint: HoverBridgePoint | null = null;
+  let stallTimer: number | null = null;
+
+  function clearStall() {
+    if (stallTimer !== null) {
+      window.clearTimeout(stallTimer);
+      stallTimer = null;
+    }
+  }
+
+  function armStall() {
+    clearStall();
+    stallTimer = window.setTimeout(() => {
+      stallTimer = null;
+      const at = lastPoint;
+      stop();
+      if (at) onExpire?.(at);
+    }, stallMs);
+  }
+
+  function stop() {
+    clearStall();
+    polygon = null;
+    floating = null;
+    trigger = null;
+    bestGap = Number.POSITIVE_INFINITY;
+    lastPoint = null;
+  }
+
+  // Horizontal distance from the pointer to the card's near edge; shrinking
+  // means the pointer is closing on the card.
+  function gapTo(point: HoverBridgePoint): number {
+    if (!floating) return Number.POSITIVE_INFINITY;
+    return side === "right" ? floating.left - point.x : point.x - floating.right;
+  }
+
+  function begin(
+    exit: HoverBridgePoint,
+    triggerRect: HoverBridgeRect,
+    floatingRect: HoverBridgeRect,
+    nextSide: HoverBridgeSide,
+  ) {
+    trigger = triggerRect;
+    floating = floatingRect;
+    side = nextSide;
+    polygon = buildSafePolygon(exit, triggerRect, floatingRect, nextSide, padding);
+    lastPoint = exit;
+    bestGap = gapTo(exit);
+    armStall();
+  }
+
+  function update(point: HoverBridgePoint): boolean {
+    if (!polygon || !floating || !trigger) return false;
+    lastPoint = point;
+    // Back over the card or the trigger row: unambiguously safe, so hold the
+    // bridge open and let progress restart from here.
+    if (pointInRect(point, floating, padding) || pointInRect(point, trigger, padding)) {
+      clearStall();
+      bestGap = Math.min(bestGap, gapTo(point));
+      return true;
+    }
+    if (!pointInPolygon(point, polygon)) {
+      stop();
+      return false;
+    }
+    const gap = gapTo(point);
+    if (gap <= bestGap - progressEpsilon) {
+      bestGap = gap;
+      armStall();
+    } else if (stallTimer === null) {
+      armStall();
+    }
+    return true;
+  }
+
+  return {
+    begin,
+    update,
+    isActive: () => polygon !== null,
+    stop,
+  };
+}

--- a/src/components/ui/useModelHoverBridge.ts
+++ b/src/components/ui/useModelHoverBridge.ts
@@ -1,0 +1,242 @@
+import { type RefObject, useEffect, useRef, useState } from "react";
+
+import type { VeniceModelDto } from "../../lib/tauri";
+import {
+  createHoverBridgeTracker,
+  type HoverBridgePoint,
+  type HoverBridgeRect,
+  pointInRect,
+  rectFromElement,
+} from "./hoverBridge";
+
+// The picker flyout state, shared verbatim by the composer and settings pickers
+// (both declare a structurally identical alias). A row's detail card is open
+// when `kind === "model"`; the searchable catalog when `kind === "all"`.
+export type ModelHoverFlyout = { kind: "model"; id: string } | { kind: "all" } | null;
+
+// Reports whether a safe-polygon traversal is currently anchored, so the rows
+// can suppress their own hover-intent while the pointer is bridging to a card.
+export type HoverBridgeHandle = { isActive: () => boolean };
+
+/**
+ * Suggested-row detail flyout bridge. A single window listener drives the whole
+ * safe polygon: leaving the active row anchors a fresh wedge toward the card;
+ * while the wedge holds, the card stays put and other rows' hover is
+ * suppressed (via `setBridging`). When the wedge is dropped (pointer left it or
+ * stalled), hover is handed to the row now under the pointer, which re-opens
+ * its own card. Extracted so the composer and settings pickers share one copy.
+ */
+export function useModelDetailHoverBridge({
+  flyout,
+  popoverRef,
+  cardRef,
+  cancelHoverIntent,
+  setBridging,
+  onFlyoutChange,
+}: {
+  flyout: ModelHoverFlyout;
+  popoverRef: RefObject<HTMLElement | null>;
+  cardRef: RefObject<HTMLElement | null>;
+  cancelHoverIntent: () => void;
+  setBridging: (on: boolean) => void;
+  onFlyoutChange: (flyout: ModelHoverFlyout) => void;
+}): HoverBridgeHandle {
+  // `onExpire` (pointer stalled inside the wedge) routes through a ref so it
+  // always runs the latest hand-off closure.
+  const handoffRef = useRef<(point: HoverBridgePoint) => void>(() => {});
+  const [tracker] = useState(() =>
+    createHoverBridgeTracker({ onExpire: (point) => handoffRef.current(point) }),
+  );
+  const anchorRef = useRef(false);
+
+  useEffect(() => {
+    if (flyout?.kind !== "model") return;
+    // The flyout just opened because the pointer (or focus) is on a row.
+    anchorRef.current = true;
+
+    const activeRow = () =>
+      popoverRef.current?.querySelector<HTMLElement>(
+        '.agent-composer-model-row[data-active="true"]',
+      );
+
+    function handoff(point: HoverBridgePoint) {
+      const target = document
+        .elementFromPoint(point.x, point.y)
+        ?.closest<HTMLElement>(".agent-composer-model-row");
+      if (target && popoverRef.current?.contains(target)) {
+        // Re-targeting another row: keep the bridging marker suppressing the new
+        // row's raw :hover through the hover-intent delay, and lift it only as
+        // the new card opens (when data-active transfers). Otherwise the still-
+        // open card's row and the freshly hovered row both read as highlighted
+        // during the delay.
+        if (target.classList.contains("agent-composer-model-all")) {
+          cancelHoverIntent();
+          onFlyoutChange({ kind: "all" });
+          setBridging(false);
+          return;
+        }
+        const id = target.getAttribute("data-model-id");
+        if (id) {
+          cancelHoverIntent();
+          onFlyoutChange({ kind: "model", id });
+          setBridging(false);
+          return;
+        }
+      }
+      // No re-target (pointer left the list): lift the suppression immediately.
+      setBridging(false);
+      onFlyoutChange(null);
+    }
+    handoffRef.current = handoff;
+
+    function handlePointerMove(event: PointerEvent) {
+      const point = { x: event.clientX, y: event.clientY };
+      const card = cardRef.current;
+      const row = activeRow();
+      if (!card || !row) return;
+      if (pointInRect(point, rectFromElement(card)) || pointInRect(point, rectFromElement(row))) {
+        anchorRef.current = true;
+        cancelHoverIntent();
+        tracker.stop();
+        setBridging(false);
+        return;
+      }
+      if (tracker.isActive()) {
+        if (tracker.update(point)) setBridging(true);
+        else handoff(point);
+        return;
+      }
+      if (anchorRef.current) {
+        anchorRef.current = false;
+        const rowRect = rectFromElement(row);
+        const cardRect = rectFromElement(card);
+        const side = cardRect.left >= rowRect.right ? "right" : "left";
+        tracker.begin(point, rowRect, cardRect, side);
+        setBridging(true);
+      }
+    }
+    window.addEventListener("pointermove", handlePointerMove, true);
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove, true);
+      tracker.stop();
+      setBridging(false);
+    };
+  }, [flyout, tracker, onFlyoutChange, popoverRef, cardRef, cancelHoverIntent, setBridging]);
+
+  return { isActive: tracker.isActive };
+}
+
+// The catalog hovercard's anchoring: the hovered row's rect and the card's
+// preferred side, computed by the caller's `showCatalogHover`.
+export type CatalogHoverAnchor = {
+  model: VeniceModelDto;
+  rowRect: HoverBridgeRect;
+  side: "left" | "right";
+};
+
+/**
+ * Catalog hovercard bridge — the same safe-polygon machine, anchored on the
+ * hovered catalog row and its card. Works for both the "All models" panel and
+ * the direct-catalog popover (the list lives under `listRef` either way).
+ */
+export function useCatalogHoverBridge({
+  catalogHover,
+  cardRef,
+  listRef,
+  resolveOption,
+  showCatalogHover,
+  cancelHoverIntent,
+  cancelCatalogClose,
+  scheduleCatalogClose,
+  setBridging,
+}: {
+  catalogHover: CatalogHoverAnchor | null;
+  cardRef: RefObject<HTMLElement | null>;
+  listRef: RefObject<HTMLElement | null>;
+  resolveOption: (id: string) => VeniceModelDto | undefined;
+  showCatalogHover: (option: VeniceModelDto, row: HTMLElement) => void;
+  cancelHoverIntent: () => void;
+  cancelCatalogClose: () => void;
+  scheduleCatalogClose: () => void;
+  setBridging: (on: boolean) => void;
+}): HoverBridgeHandle {
+  const handoffRef = useRef<(point: HoverBridgePoint) => void>(() => {});
+  const [tracker] = useState(() =>
+    createHoverBridgeTracker({ onExpire: (point) => handoffRef.current(point) }),
+  );
+  const anchorRef = useRef(false);
+
+  useEffect(() => {
+    if (!catalogHover) return;
+    anchorRef.current = true;
+    const { rowRect, side } = catalogHover;
+
+    function handoff(point: HoverBridgePoint) {
+      const target = document
+        .elementFromPoint(point.x, point.y)
+        ?.closest<HTMLElement>(".agent-composer-model-row");
+      if (target && listRef.current?.contains(target)) {
+        const id = target.getAttribute("data-model-id");
+        const option = id ? resolveOption(id) : undefined;
+        if (option) {
+          cancelHoverIntent();
+          showCatalogHover(option, target);
+          setBridging(false);
+          return;
+        }
+      }
+      // No re-target: lift the suppression immediately.
+      setBridging(false);
+      scheduleCatalogClose();
+    }
+    handoffRef.current = handoff;
+
+    function handlePointerMove(event: PointerEvent) {
+      const point = { x: event.clientX, y: event.clientY };
+      const card = cardRef.current;
+      if (!card) return;
+      if (pointInRect(point, rectFromElement(card)) || pointInRect(point, rowRect)) {
+        anchorRef.current = true;
+        cancelHoverIntent();
+        cancelCatalogClose();
+        tracker.stop();
+        setBridging(false);
+        return;
+      }
+      if (tracker.isActive()) {
+        if (tracker.update(point)) {
+          setBridging(true);
+          cancelCatalogClose();
+        } else {
+          handoff(point);
+        }
+        return;
+      }
+      if (anchorRef.current) {
+        anchorRef.current = false;
+        tracker.begin(point, rowRect, rectFromElement(card), side);
+        setBridging(true);
+        cancelCatalogClose();
+      }
+    }
+    window.addEventListener("pointermove", handlePointerMove, true);
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove, true);
+      tracker.stop();
+      setBridging(false);
+    };
+  }, [
+    catalogHover,
+    tracker,
+    cardRef,
+    listRef,
+    resolveOption,
+    showCatalogHover,
+    cancelHoverIntent,
+    cancelCatalogClose,
+    scheduleCatalogClose,
+    setBridging,
+  ]);
+
+  return { isActive: tracker.isActive };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11740,6 +11740,13 @@ input:focus-visible,
   margin: var(--sp-2) calc(var(--sp-3) * -1);
 }
 
+/* When "More options" is collapsed it sits last in the card, so its sp-2 bottom
+ * margin stacks on the card's own bottom padding and reads as a dead gap. Drop
+ * it there; when expanded the options panel follows, so the row isn't last. */
+.settings-more-options-row:last-child {
+  margin-block-end: 0;
+}
+
 .settings-row-divider {
   height: 1px;
   margin: 0;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5543,6 +5543,16 @@ input:focus-visible,
   background: var(--secondary);
 }
 
+/* While a safe-polygon hover traversal is in flight the popover carries
+   data-hover-bridging: only the active row (the one whose card is open) may
+   read as highlighted, so a row the pointer merely crosses on its diagonal
+   path to the card does not also light up. Higher specificity than the :hover
+   rule above so it wins regardless of source order in this flat stylesheet. */
+.agent-composer-model-popover[data-hover-bridging]
+.agent-composer-model-row:hover:not([data-active="true"]) {
+  background: transparent;
+}
+
 .agent-composer-model-row[aria-selected="true"] {
   color: var(--foreground);
 }
@@ -5575,16 +5585,48 @@ input:focus-visible,
 .agent-composer-model-row-check,
 .agent-composer-model-row-chevron {
   flex: 0 0 auto;
-  margin-left: auto;
 }
 
 .agent-composer-model-row-check {
   width: 16px;
+  margin-left: auto;
   color: var(--foreground);
 }
 
 .agent-composer-model-row-chevron {
+  margin-left: auto;
   color: var(--muted-foreground);
+}
+
+/* Trailing private marker: a compact mode icon in the same clay-tinted family
+ * as .agent-safety-badge. It claims the auto gap on private rows; if the row is
+ * also selected, the selected checkmark sits immediately to its left. */
+.model-row-privacy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  margin-left: auto;
+  padding: 0;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--brand) 14%, transparent);
+  color: var(--warm-strong);
+  line-height: 0;
+}
+
+/* Center the glyph on whole pixels: a 14px icon in the 20px box leaves a 3px
+ * ring on every side (an odd 13px icon rounded to 3.5px and read off-center). */
+.model-row-privacy svg {
+  display: block;
+  color: var(--warm-strong);
+}
+
+/* When the selected checkmark precedes the private marker, the check already
+ * claimed the auto gap, so the icon just trails it and stays flush right. */
+.agent-composer-model-row-check ~ .model-row-privacy {
+  margin-left: 0;
 }
 
 /* Sits below the suggested rows with the same breathing room, so its hover
@@ -5593,10 +5635,10 @@ input:focus-visible,
   margin-top: var(--sp-1);
 }
 
-/* Second layer: a side panel hanging off the root menu — the hover detail
- * card for a suggested model, or the searchable full catalog. The bottom
- * anchor here is the panel's; the detail card gets repositioned to its
- * hovered row from JS (see the flyout measure effect). */
+/* Second layer: the searchable full-catalog panel hanging off the root menu,
+ * anchored to the panel's bottom edge. (The suggested-model detail card renders
+ * as a body-portaled .agent-composer-model-hovercard so the note-chat panel
+ * can't clip or cover it — see the model pickers.) */
 .agent-composer-model-flyout {
   position: absolute;
   bottom: -1px;
@@ -5647,14 +5689,34 @@ input:focus-visible,
 }
 
 .agent-composer-model-detail .agent-composer-model-surface {
-  gap: var(--sp-1);
-  width: 232px;
+  gap: var(--sp-2);
+  width: 248px;
   padding: var(--sp-3);
+}
+
+.agent-composer-model-detail-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.agent-composer-model-detail-content[data-animate-change="true"] {
+  animation: agent-composer-model-detail-content-in var(--t-fast) var(--ease-out);
+}
+
+@keyframes agent-composer-model-detail-content-in {
+  from {
+    opacity: 0.72;
+    filter: blur(4px);
+    transform: translateY(1px);
+  }
 }
 
 .agent-composer-model-detail-name {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--sp-2);
   margin: 0;
   font-size: var(--fs-md);
@@ -5662,63 +5724,184 @@ input:focus-visible,
 }
 
 .agent-composer-model-detail-name > span:first-child {
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.agent-composer-model-detail-name .model-trait-icon {
+/* The privacy chip uses the themed (brand-tinted clay) pill so it reads as the
+ * same family as the trailing row marker. Pin it so it never shrinks against a
+ * long model name. */
+.agent-composer-model-detail-name .agent-safety-badge {
   flex: 0 0 auto;
-  font-weight: 400;
 }
 
-.agent-composer-model-detail-values {
-  margin: 0;
-  color: var(--muted-foreground);
-  font-size: var(--fs-xs);
+/* ============================================================================
+ * Scroll fades (design system)
+ *
+ * A scroller melts its clipped edge when content is hidden above or below the
+ * viewport. Driven by the `useScrollFade` hook, which sets `data-fade-top` /
+ * `data-fade-bottom` only on the edge(s) with hidden content (so a fade never
+ * shows when everything fits). Two flavors, one contract:
+ *
+ *  - `.scroll-fade`      — contained overlays: `::before`/`::after` gradients
+ *    pinned to the wrapper's edges. WKWebView-safe for popovers (a mask on the
+ *    scroller rides the scrolled content in WebKit and bleeds past the bounds).
+ *    Put the class + data attributes on a non-scrolling wrapper; the scroller
+ *    is its child. Tunables: `--scroll-fade-size`, `--scroll-fade-color`,
+ *    `--scroll-fade-inset-right`.
+ *  - `.scroll-fade-mask` — mask-image gradient on the scroller itself. Reveals
+ *    the real content at the edge (clean in light + dark) for large panel
+ *    scrollers. Put the class + data attributes on the scroller. Tunable:
+ *    `--scroll-fade-size`.
+ * ============================================================================ */
+.scroll-fade {
+  position: relative;
+}
+
+.scroll-fade::before,
+.scroll-fade::after {
+  content: "";
+  position: absolute;
+  right: var(--scroll-fade-inset-right, 0);
+  left: 0;
+  z-index: 1;
+  height: var(--scroll-fade-size, 24px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--t-fast) var(--ease-out);
+}
+
+.scroll-fade::before {
+  top: 0;
+  background: linear-gradient(to bottom, var(--scroll-fade-color, var(--popover)), transparent);
+}
+
+.scroll-fade::after {
+  bottom: 0;
+  background: linear-gradient(to top, var(--scroll-fade-color, var(--popover)), transparent);
+}
+
+.scroll-fade[data-fade-top]::before,
+.scroll-fade[data-fade-bottom]::after {
+  opacity: 1;
+}
+
+.scroll-fade-mask[data-fade-top][data-fade-bottom] {
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    #000 var(--scroll-fade-size, 28px),
+    #000 calc(100% - var(--scroll-fade-size, 28px)),
+    transparent
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    #000 var(--scroll-fade-size, 28px),
+    #000 calc(100% - var(--scroll-fade-size, 28px)),
+    transparent
+  );
+}
+
+.scroll-fade-mask[data-fade-top]:not([data-fade-bottom]) {
+  -webkit-mask-image: linear-gradient(to bottom, transparent, #000 var(--scroll-fade-size, 28px));
+  mask-image: linear-gradient(to bottom, transparent, #000 var(--scroll-fade-size, 28px));
+}
+
+.scroll-fade-mask:not([data-fade-top])[data-fade-bottom] {
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    #000 calc(100% - var(--scroll-fade-size, 28px)),
+    transparent
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    #000 calc(100% - var(--scroll-fade-size, 28px)),
+    transparent
+  );
+}
+
+/* The card always shows the full description (no "Show more" toggle): a capped,
+ * scrollable box so the card can never grow after it opens, which keeps the
+ * open-time viewport clamp correct and the expansion keyboard-neutral. It rides
+ * the shared `.scroll-fade` primitive with a tighter fade sized for the short
+ * box. */
+.agent-composer-model-detail-desc-wrap {
+  --scroll-fade-size: 14px;
+  overflow: hidden;
+  contain: paint;
 }
 
 .agent-composer-model-detail-desc {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
   margin: 0;
-  overflow: hidden;
+  max-height: 104px;
+  overflow-y: auto;
   color: var(--muted-foreground);
-  font-size: var(--fs-xs);
-  line-height: 1.4;
+  font-size: var(--fs-sm);
+  line-height: 1.5;
 }
 
-/* When the description is clamped it's wrapped in a HoverTip; the wrapper span
- * must stretch so the clamped text keeps the card's full width (an inline span
- * would shrink-wrap and throw off the two-line measurement). */
-.agent-composer-model-detail-desc-tip {
-  display: block;
+/* The card's spec table: pricing and context as label/value rows, set on a
+ * subtle inset panel (rather than a divider) so it reads as its own group.
+ * Muted labels on the left, values hugging the right edge. */
+.agent-composer-model-detail-specs {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: var(--sp-1) var(--sp-3);
+  margin: 0;
+  padding: var(--sp-2);
+  border-radius: var(--r-sm);
+  background: var(--secondary);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+}
+
+.agent-composer-model-detail-specs dt {
+  color: var(--muted-foreground);
+}
+
+.agent-composer-model-detail-specs dd {
+  margin: 0;
+  color: var(--popover-foreground);
+  text-align: right;
 }
 
 /* The catalog rows' hover card — same body as the suggested-model detail
  * card, but fixed-positioned beside the hovered row (set from JS) so it can
  * escape the panel's clipping and tracks the pointer like Codex's item
- * tooltips. Interactive so the pointer can reach its (clamped) description and
- * its hover tip; a close debounce keeps it alive across the gap from the row. */
+ * tooltips. Interactive so the pointer can move onto and read the card; a
+ * close debounce keeps it alive across the gap from the row. */
 .agent-composer-model-hovercard {
   position: fixed;
-  z-index: 3;
+  /* Portaled to document.body, so it must clear every panel it can open over —
+   * notably the note-chat panel (z-index 6) and its resize handle (z-index 71).
+   * Shares the top transient layer with .hover-tip (also z-index 140). */
+  z-index: 140;
   display: block;
   pointer-events: auto;
   color: var(--popover-foreground);
-  /* Keep the hover card above the panel so the panel shadow/fade cannot wash
-   * over the card. Clip only the side facing the panel; the other three sides
-   * keep the same elevation, and the clipped side cannot bleed back into the
-   * panel. */
-  clip-path: inset(-48px 0 -48px -48px);
+  transition:
+    top var(--t-med) var(--ease-spring),
+    right var(--t-med) var(--ease-spring),
+    left var(--t-med) var(--ease-spring);
   animation: agent-composer-model-flyout-left var(--t-med) var(--ease-out);
 }
 
 .agent-composer-model-hovercard[data-side="right"] {
-  clip-path: inset(-48px -48px -48px 0);
   animation-name: agent-composer-model-flyout-right;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-composer-model-hovercard {
+    transition: none;
+  }
+
+  .agent-composer-model-detail-content[data-animate-change="true"] {
+    animation: none;
+  }
 }
 
 .agent-composer-model-all-panel {
@@ -5776,18 +5959,17 @@ input:focus-visible,
   color: var(--muted-foreground);
 }
 
-/* The list's scroll viewport plus its edge fades. The wrap exists so the
- * overlays can sit at top: 0 / bottom: 0 of the exact scroll area — no
- * hand-computed offsets to drift out of place. */
+/* Catalog list scroller. Fades come from the shared `.scroll-fade` primitive
+ * (contained overlays, WKWebView-safe for this popover); only the fade size is
+ * tuned here so rows melt into the popover surface at the boundary. */
 .agent-composer-model-list-wrap {
-  position: relative;
+  --scroll-fade-size: 16px;
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
   contain: paint;
-  --scroll-fade-size: 16px;
 }
 
 .agent-composer-model-list {
@@ -8608,6 +8790,23 @@ input:focus-visible,
   padding: 0 var(--sp-8) var(--sp-5);
 }
 
+.main-panel-body[data-active-view="settings"] {
+  scrollbar-width: auto;
+  scrollbar-color: auto;
+  padding-bottom: calc(var(--sp-5) + 96px);
+}
+
+.main-panel-body[data-active-view="settings"]::-webkit-scrollbar {
+  width: var(--scrollbar-w);
+  background: transparent;
+}
+
+.main-panel-body[data-active-view="settings"]::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  background: color-mix(in oklch, var(--muted-foreground) 30%, transparent);
+  background-clip: padding-box;
+}
+
 /* Top + bottom fades for the main card. Top is short (28px) since no
  * sticky header sits there; bottom is taller (96px) so content dissolves
  * cleanly behind the record button. Same scroll-timeline trick as the
@@ -8634,6 +8833,7 @@ input:focus-visible,
   bottom: 0;
   height: 96px;
   background: linear-gradient(to bottom, transparent, var(--card) 78%);
+  opacity: 0;
   /* Soften any static opacity flip (e.g. leaving the agent view, where the
    * :has() rule below holds the dissolve at 0) so the veil never pops in a
    * single frame over content. Matches the warm wash's 280ms fade. Lives
@@ -10933,6 +11133,10 @@ input:focus-visible,
   letter-spacing: 0;
 }
 
+.settings-group-heading + .settings-group-description {
+  margin-top: calc(-1 * var(--sp-1));
+}
+
 /* The platforms group heading carries a quiet muted count beside it (the count
  * that used to live on the in-list h3). */
 .agent-messaging-heading {
@@ -11513,12 +11717,13 @@ input:focus-visible,
  * the external-dir summary hover), not a full-bleed edge-to-edge band. Content
  * stays left-aligned; the bottom border is dropped so the rounded fill reads as
  * a single rectangle. */
-.settings-rows .settings-more-options-trigger,
 .settings-more-options-trigger {
-  width: auto;
-  /* Top inset so the rounded hover fill has clear separation from the row/border
-   * directly above it. */
-  margin: var(--sp-3) calc(var(--sp-3) * -1) 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--sp-6);
+  width: 100%;
+  margin: 0;
   padding: var(--sp-3);
   border: 0;
   border-radius: var(--r-md);
@@ -11528,6 +11733,26 @@ input:focus-visible,
   cursor: pointer;
   color: inherit;
   transition: background-color var(--t-fast) var(--ease-out);
+}
+
+.settings-more-options-row {
+  width: auto;
+  margin: var(--sp-2) calc(var(--sp-3) * -1);
+}
+
+.settings-row-divider {
+  height: 1px;
+  margin: 0;
+  background: var(--border-subtle);
+}
+
+.settings-row:has(+ .settings-row-divider) {
+  border-bottom: 0;
+}
+
+.settings-more-options-panel {
+  display: flex;
+  flex-direction: column;
 }
 
 .settings-more-options-trigger:hover {
@@ -15945,18 +16170,21 @@ input:focus-visible,
 .model-summary-hovercard {
   display: flex;
   flex-direction: column;
-  gap: var(--sp-1);
-  width: 232px;
+  gap: var(--sp-2);
+  width: 248px;
   max-width: 100%;
 }
 
 /* Hover callout card (HoverTip) — the Venice-style explainer behind privacy
  * pills. Body-portaled at a fixed position, so it must sit above dialogs
- * (backdrop is z-index 112). data-side="top" anchors the card's bottom edge
- * to the coordinate instead of its top. */
+ * (backdrop is z-index 112) and above the model picker popover (130), which
+ * hosts a privacy-ghost tip inside its own rows. As the topmost transient
+ * layer the tip clears every overlay it can be triggered from over.
+ * data-side="top" anchors the card's bottom edge to the coordinate instead of
+ * its top. */
 .hover-tip {
   position: fixed;
-  z-index: 120;
+  z-index: 140;
   padding: var(--sp-3) var(--sp-4);
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-md);
@@ -15973,6 +16201,10 @@ input:focus-visible,
    * box width to hug the widest line, so the box edges match the text edges. */
   text-wrap: balance;
   pointer-events: none;
+}
+
+.hover-tip[data-interactive="true"] {
+  pointer-events: auto;
 }
 
 /* First frame: rendered hidden so its content width can be measured before the

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -2832,22 +2832,26 @@ describe("AppSettings", () => {
 
     await user.click(await screen.findByRole("tab", { name: "Models" }));
 
-    // Image generation is its own section with the model row up top; Safe mode
-    // lives behind that section's own "More options" disclosure (defaults on).
-    const imageSection = screen
-      .getByRole("heading", { name: "Image generation" })
+    // Image and video share one section, each with its own model row; the Safe
+    // mode toggle (which governs both) lives behind that section's shared "More
+    // options" disclosure and defaults on.
+    const mediaSection = screen
+      .getByRole("heading", { name: "Image and video" })
       .closest("section");
-    expect(imageSection).not.toBeNull();
+    expect(mediaSection).not.toBeNull();
     expect(
-      within(imageSection as HTMLElement).getByRole("button", { name: "Change image model" }),
+      within(mediaSection as HTMLElement).getByRole("button", { name: "Change image model" }),
     ).toBeInTheDocument();
-    expect(within(imageSection as HTMLElement).getByText("Venice SD3.5")).toBeInTheDocument();
     expect(
-      within(imageSection as HTMLElement).queryByRole("switch", {
+      within(mediaSection as HTMLElement).getByRole("button", { name: "Change video model" }),
+    ).toBeInTheDocument();
+    expect(within(mediaSection as HTMLElement).getByText("Venice SD3.5")).toBeInTheDocument();
+    expect(
+      within(mediaSection as HTMLElement).queryByRole("switch", {
         name: "Blur adult content in images",
       }),
     ).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "More options for image generation" }));
+    await user.click(screen.getByRole("button", { name: "More options for image and video" }));
     expect(screen.getByRole("switch", { name: "Blur adult content in images" })).toBeChecked();
 
     // The picker opens with the curated image options (no backend fetch) and,

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -2255,7 +2255,7 @@ describe("AppSettings", () => {
 
     // The primary pickers are visible, but advanced local controls are hidden
     // behind a collapsed "More options" disclosure by default.
-    const trigger = await screen.findByRole("button", { name: /More options/ });
+    const trigger = await screen.findByRole("button", { name: "More options for AI models" });
     expect(trigger).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("switch", { name: "Use local text model" })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Base URL")).not.toBeInTheDocument();
@@ -2317,7 +2317,7 @@ describe("AppSettings", () => {
     expect(await screen.findByRole("switch", { name: "Use local text model" })).toBeInTheDocument();
     expect(screen.getByLabelText("Base URL")).toBeInTheDocument();
     expect(screen.getByLabelText("Model ID")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /More options/ })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "More options for AI models" })).toHaveAttribute(
       "aria-expanded",
       "true",
     );
@@ -2344,7 +2344,7 @@ describe("AppSettings", () => {
 
       await user.click(await screen.findByRole("tab", { name: "Models" }));
       // The local model config lives behind the "More options" disclosure.
-      await user.click(await screen.findByRole("button", { name: /More options/ }));
+      await user.click(await screen.findByRole("button", { name: "More options for AI models" }));
       await user.click(await screen.findByRole("switch", { name: "Use local text model" }));
       await user.type(await screen.findByLabelText("Base URL"), "http://localhost:11434/v1");
       await user.type(screen.getByLabelText("Model ID"), "llama3.1:8b");
@@ -2633,7 +2633,7 @@ describe("AppSettings", () => {
     expect(mocks.setLocalGenerationEnabled).not.toHaveBeenCalled();
     expect(
       await screen.findByText(
-        "This endpoint is not on this machine. Requests will leave your device. Confirm in the Local model section to enable it.",
+        "This endpoint is not on this machine. Requests will leave your device. Confirm in More options to enable it.",
       ),
     ).toBeInTheDocument();
     const confirm = await screen.findByRole("button", {
@@ -2667,7 +2667,7 @@ describe("AppSettings", () => {
 
     await user.click(await screen.findByRole("tab", { name: "Models" }));
     // The local model config lives behind the "More options" disclosure.
-    await user.click(await screen.findByRole("button", { name: /More options/ }));
+    await user.click(await screen.findByRole("button", { name: "More options for AI models" }));
     await user.click(await screen.findByRole("switch", { name: "Use local text model" }));
     await user.type(await screen.findByLabelText("Base URL"), "http://localhost:11434/v1");
     await user.click(screen.getByRole("button", { name: "Test connection" }));
@@ -2702,7 +2702,7 @@ describe("AppSettings", () => {
 
     await user.click(await screen.findByRole("tab", { name: "Models" }));
     // The local model config lives behind the "More options" disclosure.
-    await user.click(await screen.findByRole("button", { name: /More options/ }));
+    await user.click(await screen.findByRole("button", { name: "More options for AI models" }));
     await user.click(await screen.findByRole("switch", { name: "Use local text model" }));
     await user.type(await screen.findByLabelText("Base URL"), "https://models.example.com/v1");
     await user.type(screen.getByLabelText("Model ID"), "llama3.1:8b");
@@ -2756,7 +2756,7 @@ describe("AppSettings", () => {
     // The Venice API key lives behind "More options" so the average user never
     // has to reason about it. It should be hidden until the row is expanded.
     expect(screen.queryByLabelText("Venice API key")).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /More options/ }));
+    await user.click(screen.getByRole("button", { name: "More options for AI models" }));
 
     const input = await screen.findByLabelText("Venice API key");
     await user.type(input, "  vc_test_key  ");
@@ -2829,21 +2829,22 @@ describe("AppSettings", () => {
 
     await user.click(await screen.findByRole("tab", { name: "Models" }));
 
-    // #640 placement (restored, JUN-209): the image model lives inside the
-    // shared "AI models" card, not a standalone "Image generation" section.
-    expect(screen.queryByRole("heading", { name: "Image generation" })).toBeNull();
-    const modelsSection = screen.getByRole("heading", { name: "AI models" }).closest("section");
-    expect(modelsSection).not.toBeNull();
+    // Image generation is its own section with the model row up top; Safe mode
+    // lives behind that section's own "More options" disclosure (defaults on).
+    const imageSection = screen
+      .getByRole("heading", { name: "Image generation" })
+      .closest("section");
+    expect(imageSection).not.toBeNull();
     expect(
-      within(modelsSection as HTMLElement).getByRole("button", { name: "Change image model" }),
+      within(imageSection as HTMLElement).getByRole("button", { name: "Change image model" }),
     ).toBeInTheDocument();
-    expect(within(modelsSection as HTMLElement).getByText("Venice SD3.5")).toBeInTheDocument();
-    // Safe mode moved into the advanced "More options" disclosure (collapsed by
-    // default) and still defaults on (JUN-209).
+    expect(within(imageSection as HTMLElement).getByText("Venice SD3.5")).toBeInTheDocument();
     expect(
-      screen.queryByRole("switch", { name: "Blur adult content in images" }),
+      within(imageSection as HTMLElement).queryByRole("switch", {
+        name: "Blur adult content in images",
+      }),
     ).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /More options/ }));
+    await user.click(screen.getByRole("button", { name: "More options for image generation" }));
     expect(screen.getByRole("switch", { name: "Blur adult content in images" })).toBeChecked();
 
     // The picker opens with the curated image options (no backend fetch) and,

--- a/src/test/hover-bridge.test.ts
+++ b/src/test/hover-bridge.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createHoverBridgeTracker,
+  type HoverBridgeRect,
+  pointInRect,
+  rectFromElement,
+} from "../components/ui/hoverBridge";
+
+// A trigger row on the left and its card to the right, with a wide gap between
+// them — the canonical "safe triangle" layout the tracker guards.
+const TRIGGER: HoverBridgeRect = { top: 100, bottom: 120, left: 0, right: 100 };
+const FLOATING: HoverBridgeRect = { top: 80, bottom: 200, left: 200, right: 400 };
+// Pointer leaving the row's right edge, mid-height.
+const EXIT = { x: 100, y: 110 };
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("pointInRect", () => {
+  it("treats the edges as inside and honours padding", () => {
+    expect(pointInRect({ x: 0, y: 100 }, TRIGGER)).toBe(true);
+    expect(pointInRect({ x: 100, y: 120 }, TRIGGER)).toBe(true);
+    expect(pointInRect({ x: 105, y: 110 }, TRIGGER)).toBe(false);
+    expect(pointInRect({ x: 105, y: 110 }, TRIGGER, 6)).toBe(true);
+  });
+});
+
+describe("rectFromElement", () => {
+  it("copies the four edges off getBoundingClientRect", () => {
+    const element = {
+      getBoundingClientRect: () => ({ top: 1, right: 2, bottom: 3, left: 4 }),
+    } as unknown as Element;
+    expect(rectFromElement(element)).toEqual({ top: 1, right: 2, bottom: 3, left: 4 });
+  });
+});
+
+describe("createHoverBridgeTracker", () => {
+  it("is inactive until begin and inactive again after stop", () => {
+    const tracker = createHoverBridgeTracker();
+    expect(tracker.isActive()).toBe(false);
+    tracker.begin(EXIT, TRIGGER, FLOATING, "right");
+    expect(tracker.isActive()).toBe(true);
+    tracker.stop();
+    expect(tracker.isActive()).toBe(false);
+  });
+
+  it("holds the bridge for a point inside the wedge that closes on the card", () => {
+    const tracker = createHoverBridgeTracker();
+    tracker.begin(EXIT, TRIGGER, FLOATING, "right");
+    // Halfway to the card, still within the fanning wedge.
+    expect(tracker.update({ x: 150, y: 110 })).toBe(true);
+    expect(tracker.isActive()).toBe(true);
+  });
+
+  it("drops the bridge for a point outside the wedge", () => {
+    const tracker = createHoverBridgeTracker();
+    tracker.begin(EXIT, TRIGGER, FLOATING, "right");
+    // Well above the wedge's upper edge at that x.
+    expect(tracker.update({ x: 150, y: 40 })).toBe(false);
+    expect(tracker.isActive()).toBe(false);
+  });
+
+  it("holds the bridge when the pointer lands back on the card", () => {
+    const tracker = createHoverBridgeTracker();
+    tracker.begin(EXIT, TRIGGER, FLOATING, "right");
+    expect(tracker.update({ x: 300, y: 150 })).toBe(true);
+    expect(tracker.isActive()).toBe(true);
+  });
+
+  it("fires onExpire with the last point when the pointer stalls in the wedge", () => {
+    vi.useFakeTimers();
+    const onExpire = vi.fn();
+    const tracker = createHoverBridgeTracker({ stallMs: 200, onExpire });
+    tracker.begin(EXIT, TRIGGER, FLOATING, "right");
+    // No further movement: the stall clock runs out and hands hover back.
+    vi.advanceTimersByTime(200);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+    expect(onExpire).toHaveBeenCalledWith(EXIT);
+    expect(tracker.isActive()).toBe(false);
+  });
+
+  it("restarts the stall clock while the pointer keeps closing on the card", () => {
+    vi.useFakeTimers();
+    const onExpire = vi.fn();
+    const tracker = createHoverBridgeTracker({ stallMs: 200, onExpire });
+    tracker.begin(EXIT, TRIGGER, FLOATING, "right");
+    vi.advanceTimersByTime(150);
+    // Progress toward the card re-arms the clock, so the original expiry is cancelled.
+    expect(tracker.update({ x: 160, y: 110 })).toBe(true);
+    vi.advanceTimersByTime(150);
+    expect(onExpire).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(60);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a pending stall expiry on stop", () => {
+    vi.useFakeTimers();
+    const onExpire = vi.fn();
+    const tracker = createHoverBridgeTracker({ stallMs: 200, onExpire });
+    tracker.begin(EXIT, TRIGGER, FLOATING, "right");
+    tracker.stop();
+    vi.advanceTimersByTime(500);
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/hover-tip.test.tsx
+++ b/src/test/hover-tip.test.tsx
@@ -82,6 +82,98 @@ describe("HoverTip", () => {
     }
   });
 
+  it("lets keyboard users tab from an interactive anchor into the portaled tip", () => {
+    render(
+      <HoverTip
+        tip={
+          <div>
+            Details
+            <button type="button">Show more</button>
+          </div>
+        }
+        interactive
+      >
+        <button type="button">Change model</button>
+      </HoverTip>,
+    );
+
+    const anchorButton = screen.getByRole("button", { name: "Change model" });
+    fireEvent.focus(anchorButton);
+    const tooltip = screen.getByRole("tooltip");
+
+    fireEvent.keyDown(anchorButton, { key: "Tab" });
+
+    expect(screen.getByRole("button", { name: "Show more" })).toHaveFocus();
+    expect(tooltip).toHaveAttribute("data-state", "open");
+  });
+
+  it("remeasures interactive tips when portaled content resizes", () => {
+    window.innerHeight = 240;
+    window.innerWidth = 1000;
+    let tooltipHeight = 40;
+    let resizeCallback: ResizeObserverCallback | undefined;
+    const originalResizeObserver = globalThis.ResizeObserver;
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        if (this.getAttribute("role") === "tooltip") {
+          return {
+            top: 0,
+            left: 0,
+            right: 120,
+            bottom: tooltipHeight,
+            width: 120,
+            height: tooltipHeight,
+          } as DOMRect;
+        }
+        return { top: 100, left: 100, right: 132, bottom: 116, width: 32, height: 16 } as DOMRect;
+      });
+    const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+    const cancelRafSpy = vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    try {
+      render(
+        <HoverTip
+          tip={
+            <div>
+              Description
+              <button type="button">Show more</button>
+            </div>
+          }
+          interactive
+        >
+          <button type="button">Change model</button>
+        </HoverTip>,
+      );
+
+      fireEvent.focus(screen.getByRole("button", { name: "Change model" }));
+      const tooltip = screen.getByRole("tooltip");
+      expect(tooltip.style.top).toBe("122px");
+
+      tooltipHeight = 180;
+      act(() => {
+        resizeCallback?.([], {} as ResizeObserver);
+      });
+
+      expect(tooltip.style.top).toBe("52px");
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+      rectSpy.mockRestore();
+      rafSpy.mockRestore();
+      cancelRafSpy.mockRestore();
+    }
+  });
+
   it("keeps a compact tip below the anchor near the viewport bottom when it fits", () => {
     // jsdom has no layout, so feed the geometry the measure pass reads: a short
     // anchor low in a tall-enough viewport, and a one-line tip that fits below.

--- a/src/test/model-spec-entries.test.ts
+++ b/src/test/model-spec-entries.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { modelSpecEntries } from "../components/settings/ModelPickerDialog";
+import type { VeniceModelDto } from "../lib/tauri";
+
+function model(overrides: Partial<VeniceModelDto>): VeniceModelDto {
+  return {
+    provider: "venice",
+    id: "test-model",
+    name: "Test model",
+    modelType: "text",
+    traits: [],
+    capabilities: [],
+    ...overrides,
+  } as VeniceModelDto;
+}
+
+describe("modelSpecEntries", () => {
+  it("shows June's billed credit price, never the raw upstream pricing", () => {
+    // Raw upstream pricing ($2/$6) is present but must be ignored: the backend
+    // keeps `pricing` as reference metadata and bills from the credit price
+    // (with margin), which here formats to $30 / $60.
+    const entries = modelSpecEntries(
+      model({
+        priceUnit: "tokens",
+        pricing: { input: { usd: 2 }, output: { usd: 6 } },
+        inputCreditsPerMillionTokens: 30_000,
+        outputCreditsPerMillionTokens: 60_000,
+      }),
+    );
+    expect(entries).toContainEqual({ label: "Input", value: "$30.00 /1M" });
+    expect(entries).toContainEqual({ label: "Output", value: "$60.00 /1M" });
+    const joined = entries.map((entry) => entry.value).join(" ");
+    expect(joined).not.toContain("$2.00");
+    expect(joined).not.toContain("$6.00");
+  });
+
+  it("falls back to the shared pricing label when there is no credit split", () => {
+    const entries = modelSpecEntries(
+      model({ priceUnit: "images", priceDescription: "$0.01 per image" }),
+    );
+    expect(entries).toContainEqual({ label: "Pricing", value: "$0.01 per image" });
+  });
+
+  it("appends a formatted context window", () => {
+    const entries = modelSpecEntries(model({ contextTokens: 128_000 }));
+    expect(entries).toContainEqual({ label: "Context", value: "128K tokens" });
+  });
+});


### PR DESCRIPTION
## What & why

[#669](https://github.com/open-software-network/os-june/pull/669) ("Polish model picker hover cards") was **merged into a feature branch** (`claude/model-selector-private-icon-am1f86`), not `main` — and that branch was abandoned one hop short of `main`, so none of its work ever shipped. This PR **forward-ports #669's model-picker + AI-models-settings work** onto current `main`, reconciled with everything that landed since (including #627 video generation).

## Root cause (why it went missing)
An agent opened #669 with its base set to another agent's feature branch instead of `main`, merged it there, and that branch never landed. This workspace branches off `main`, so it correctly showed none of it.

## The model picker overlay
- **Safe-polygon hover bridge** (`hoverBridge.ts` + `useModelHoverBridge.ts`) — the pointer can travel diagonally toward a detail/catalog card without it closing; a `data-hover-bridging` marker suppresses every non-active row's `:hover` during a traversal so only one row reads active.
- **Portaled fixed-position hovercard** (`.agent-composer-model-hovercard`), replacing the old inline flyout so no scroll container can clip it.
- **Per-row privacy squircle** (`ModelRowPrivacyBadge`) and **HoverTip** motion/visual polish (incl. `interactive` tips you can move into — this is also what lets the settings summary card scroll long descriptions).

## The AI models settings page
Media generation is broken into its own settings area, separate from the "AI models" card:
- **"AI models" section**: Transcription + Text rows → its own **"More options for AI models"** disclosure (Venice API key + local-model setup).
- **"Image and video" section**: Image row + Video row → a shared **"More options"** holding the **Safe mode** toggle. Safe mode governs both (blurs images, holds back NSFW video prompts), so it lives with both; the section shows whenever image **or** video is enabled, keeping the toggle reachable.
- ModelRow summary tip is `interactive` with a full-description-in-one-hover card matching the picker hovercard.
- Trimmed a dead gap under the collapsed "More options" row.

> ⚠️ **Reverses JUN-209 (#657)** on image placement: #657 had *restored* the image model into the shared "AI models" card; this moves media out into a dedicated section. Done deliberately at the requester's direction.

## Merged `main` incl. #627 (video generation)
Merged current `main`; only `AppSettings.tsx` needed hand-resolution. #627 added a **Video** model to settings inside the shared card — reconciled into this PR's structure (the "Image and video" section above). All of #627's video wiring (state, options, picker mode, chat plumbing, `chat-video-generation`, `video-models`) is preserved.

## Testing
- ✅ `tsc --noEmit`
- ✅ Biome (no new errors)
- ✅ Full vitest: **2281 passed, 2 skipped, 0 failures** (incl. `chat-video-generation` + AppSettings tests for the combined media section)
- ⏳ **Visual verification pending** — hover/motion + settings-layout change; needs a click-through in the running app.

## Deploy
Frontend only for the picker/settings work — **no June API deploy needed** for this PR itself. (Video generation end-to-end depends on #627's June API side, inherited from `main`.)

## Out of scope / deferred
- The original stranded branches (`andrewwashuta/model-selector-options`, `claude/model-selector-private-icon-am1f86`) can be deleted once this lands.