### PR TITLE
Add configurable session dates and rename dialog

### DIFF
--- a/src/components/agent/AgentSessionsList.tsx
+++ b/src/components/agent/AgentSessionsList.tsx
@@ -194,7 +194,8 @@ export const AgentSessionsList = forwardRef<AgentSessionsListHandle, AgentSessio
     useEffect(() => {
       if (selectedCount === 0 || confirmBulkDelete) return;
       function onKey(event: KeyboardEvent) {
-        if (event.key === "Escape") resetSelection();
+        const target = event.target instanceof Element ? event.target : null;
+        if (event.key === "Escape" && !target?.closest('[role="dialog"]')) resetSelection();
       }
       window.addEventListener("keydown", onKey);
       return () => window.removeEventListener("keydown", onKey);

--- a/src/components/agent/AgentSessionsList.tsx
+++ b/src/components/agent/AgentSessionsList.tsx
@@ -31,6 +31,7 @@ import { primaryShortcutLabel } from "../../lib/platform";
 import type { FolderDto, HermesSessionInfo } from "../../lib/tauri";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { EmptyState } from "../ui/EmptyState";
+import { RenameSessionDialog } from "./RenameSessionDialog";
 
 type AgentSessionsListProps = {
   sessions: HermesSessionInfo[];
@@ -445,22 +446,7 @@ function AgentSessionListRow({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
-  const [editingTitle, setEditingTitle] = useState(false);
-  const [titleDraft, setTitleDraft] = useState(title);
-  const titleInputRef = useRef<HTMLInputElement | null>(null);
-  const titleEditFinalizedRef = useRef(false);
-
-  useEffect(() => {
-    if (editingTitle && titleInputRef.current) {
-      titleEditFinalizedRef.current = false;
-      titleInputRef.current.focus();
-      titleInputRef.current.select();
-    }
-  }, [editingTitle]);
-
-  useEffect(() => {
-    if (!editingTitle) setTitleDraft(title);
-  }, [editingTitle, title]);
+  const [renameDialogOpen, setRenameDialogOpen] = useState(false);
 
   useEffect(() => {
     if (!menu) return;
@@ -499,24 +485,6 @@ function AgentSessionListRow({
     }
   }
 
-  function commitRename(value: string) {
-    if (titleEditFinalizedRef.current) return;
-    titleEditFinalizedRef.current = true;
-    setEditingTitle(false);
-    const next = value.trim();
-    if (!next || next === title) {
-      setTitleDraft(title);
-      return;
-    }
-    onRename(next);
-  }
-
-  function cancelRename() {
-    titleEditFinalizedRef.current = true;
-    setTitleDraft(title);
-    setEditingTitle(false);
-  }
-
   const rowMain = (
     <>
       <span className="folder-note-icon" aria-hidden>
@@ -527,31 +495,7 @@ function AgentSessionListRow({
         )}
       </span>
       <span className="folder-note-body">
-        {editingTitle ? (
-          <input
-            ref={titleInputRef}
-            className="folder-note-title-input"
-            aria-label="Session name"
-            value={titleDraft}
-            onChange={(event) => setTitleDraft(event.currentTarget.value)}
-            onClick={(event) => event.stopPropagation()}
-            onMouseDown={(event) => event.stopPropagation()}
-            onBlur={(event) => commitRename(event.currentTarget.value)}
-            onKeyDown={(event) => {
-              event.stopPropagation();
-              if (event.key === "Enter") {
-                event.preventDefault();
-                commitRename(event.currentTarget.value);
-              }
-              if (event.key === "Escape") {
-                event.preventDefault();
-                cancelRename();
-              }
-            }}
-          />
-        ) : (
-          <span className="folder-note-title">{title}</span>
-        )}
+        <span className="folder-note-title">{title}</span>
         <span className="folder-note-subtitle">
           {projectName ? `${projectName} · ${preview}` : preview}
         </span>
@@ -579,13 +523,9 @@ function AgentSessionListRow({
             {checked ? <IconCheckmark2Medium size={10} /> : null}
           </span>
         </label>
-        {editingTitle ? (
-          <div className="folder-note-main">{rowMain}</div>
-        ) : (
-          <button type="button" className="folder-note-main" onClick={onSelect}>
-            {rowMain}
-          </button>
-        )}
+        <button type="button" className="folder-note-main" onClick={onSelect}>
+          {rowMain}
+        </button>
         {status ? (
           <span
             className="agent-session-list-status"
@@ -635,9 +575,7 @@ function AgentSessionListRow({
               role="menuitem"
               onClick={() => {
                 setMenu(null);
-                setTitleDraft(title);
-                titleEditFinalizedRef.current = false;
-                setEditingTitle(true);
+                setRenameDialogOpen(true);
               }}
             >
               <IconPencil size={14} />
@@ -684,6 +622,12 @@ function AgentSessionListRow({
           </div>
         ) : null}
       </div>
+      <RenameSessionDialog
+        open={renameDialogOpen}
+        currentName={title}
+        onClose={() => setRenameDialogOpen(false)}
+        onRename={onRename}
+      />
       <ConfirmDialog
         open={confirmDelete}
         onClose={() => {

--- a/src/components/agent/RenameSessionDialog.tsx
+++ b/src/components/agent/RenameSessionDialog.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useId, useState } from "react";
+import { Dialog, DialogField } from "../ui/Dialog";
+
+type RenameSessionDialogProps = {
+  open: boolean;
+  currentName: string;
+  onClose: () => void;
+  onRename: (name: string) => void;
+};
+
+export function RenameSessionDialog({
+  open,
+  currentName,
+  onClose,
+  onRename,
+}: RenameSessionDialogProps) {
+  const [name, setName] = useState(currentName);
+  const formId = useId();
+  const inputId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    setName(currentName);
+  }, [currentName, open]);
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    if (trimmed !== currentName) onRename(trimmed);
+    onClose();
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Rename session"
+      initialFocusSelector="[data-rename-session-input]"
+      footer={
+        <>
+          <button type="button" className="primary-action" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="submit"
+            form={formId}
+            className="primary-action primary-solid"
+            disabled={name.trim().length === 0}
+          >
+            Rename
+          </button>
+        </>
+      }
+    >
+      <form id={formId} className="dialog-body" onSubmit={handleSubmit}>
+        <DialogField label="Name" htmlFor={inputId}>
+          <input
+            id={inputId}
+            data-rename-session-input=""
+            className="dialog-input"
+            aria-label="Session name"
+            autoComplete="off"
+            value={name}
+            maxLength={120}
+            onChange={(event) => setName(event.currentTarget.value)}
+            onFocus={(event) => event.currentTarget.select()}
+          />
+        </DialogField>
+      </form>
+    </Dialog>
+  );
+}

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -117,6 +117,11 @@ import { DictionarySettingsSection } from "./DictionarySettingsSection";
 import { MicTestControl, type MicTestState } from "./MicTestControl";
 import { StyleSettingsSection } from "./StyleSettingsSection";
 import { PrivacySettingsSection } from "./PrivacySettingsSection";
+import {
+  getStoredDateFormat,
+  setStoredDateFormat,
+  type DateFormatPreference,
+} from "../../lib/date-format";
 
 const THEME_OPTIONS: readonly {
   value: ThemePreference;
@@ -154,6 +159,12 @@ const THEME_OPTIONS: readonly {
     ariaLabel: "Use dark theme",
   },
 ];
+
+const DATE_FORMAT_OPTIONS = [
+  { value: "system", label: "System" },
+  { value: "month-first", label: "Jul 9" },
+  { value: "day-first", label: "9 Jul" },
+] satisfies { value: DateFormatPreference; label: string }[];
 
 const RELEASE_CHANNEL_OPTIONS: readonly {
   value: ReleaseChannel;
@@ -410,6 +421,7 @@ export function AppSettings({
   const [micOpen, setMicOpen] = useState(false);
   const [theme, setTheme] = useState<ThemePreference>(() => getStoredTheme());
   const [brand, setBrand] = useState<BrandId>(() => getStoredBrand());
+  const [dateFormat, setDateFormat] = useState<DateFormatPreference>(() => getStoredDateFormat());
   const [releaseChannel, setReleaseChannelValue] = useState<ReleaseChannel>("stable");
   // Set only when a leave-rc switch turns up an installable stable, so the
   // bespoke in-context confirm below the toggle can name the exact version.
@@ -1413,6 +1425,30 @@ export function AppSettings({
                         onChange={(id) => {
                           setBrand(id as BrandId);
                           setStoredBrand(id as BrandId);
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <div className="settings-row">
+                    <div className="settings-row-info">
+                      <h3 className="settings-row-title">Date format</h3>
+                      <p className="settings-row-description">
+                        Choose how older session dates appear in the sidebar.
+                      </p>
+                    </div>
+                    <div className="settings-row-control">
+                      <Select
+                        value={dateFormat}
+                        options={DATE_FORMAT_OPTIONS}
+                        placeholder="System"
+                        ariaLabel={`Date format: ${
+                          DATE_FORMAT_OPTIONS.find((option) => option.value === dateFormat)
+                            ?.label ?? "System"
+                        }`}
+                        onChange={(value) => {
+                          const next = value as DateFormatPreference;
+                          setDateFormat(next);
+                          setStoredDateFormat(next);
                         }}
                       />
                     </div>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -98,6 +98,7 @@ import {
   DATE_FORMAT_CHANGED_EVENT,
   formatCalendarDate,
   getStoredDateFormat,
+  normalizeDateFormatPreference,
   type DateFormatChangedDetail,
   type DateFormatPreference,
 } from "../../lib/date-format";
@@ -439,7 +440,8 @@ export function Sidebar({
 
   useEffect(() => {
     const handleDateFormatChanged = (event: Event) => {
-      setDateFormat((event as CustomEvent<DateFormatChangedDetail>).detail.preference);
+      const detail = (event as CustomEvent<Partial<DateFormatChangedDetail>>).detail;
+      setDateFormat(normalizeDateFormatPreference(detail?.preference));
     };
     window.addEventListener(DATE_FORMAT_CHANGED_EVENT, handleDateFormatChanged);
     return () => window.removeEventListener(DATE_FORMAT_CHANGED_EVENT, handleDateFormatChanged);

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -93,6 +93,14 @@ import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { Dialog } from "../ui/Dialog";
 import { DotSpinner } from "../DotSpinner";
 import { combineSourceAudioLevels, Waveform } from "../recorder/Waveform";
+import { RenameSessionDialog } from "../agent/RenameSessionDialog";
+import {
+  DATE_FORMAT_CHANGED_EVENT,
+  formatCalendarDate,
+  getStoredDateFormat,
+  type DateFormatChangedDetail,
+  type DateFormatPreference,
+} from "../../lib/date-format";
 
 const NO_AGENT_SESSIONS: HermesSessionInfo[] = [];
 
@@ -396,6 +404,7 @@ export function Sidebar({
   const [agentSessionToDelete, setAgentSessionToDelete] = useState<HermesSessionInfo | null>(null);
   const [agentSessionDeleteError, setAgentSessionDeleteError] = useState<string | null>(null);
   const [renamingAgentSessionId, setRenamingAgentSessionId] = useState<string | null>(null);
+  const [dateFormat, setDateFormat] = useState<DateFormatPreference>(() => getStoredDateFormat());
   const [deletingAgentSessionIds, setDeletingAgentSessionIds] = useState<Set<string>>(
     () => new Set(),
   );
@@ -427,6 +436,14 @@ export function Sidebar({
   useEffect(() => {
     writePinnedAgentSessionIds(pinnedAgentSessionIds);
   }, [pinnedAgentSessionIds]);
+
+  useEffect(() => {
+    const handleDateFormatChanged = (event: Event) => {
+      setDateFormat((event as CustomEvent<DateFormatChangedDetail>).detail.preference);
+    };
+    window.addEventListener(DATE_FORMAT_CHANGED_EVENT, handleDateFormatChanged);
+    return () => window.removeEventListener(DATE_FORMAT_CHANGED_EVENT, handleDateFormatChanged);
+  }, []);
 
   useEffect(() => {
     const openId = activeView === "agent" ? selectedAgentSessionId : undefined;
@@ -1173,6 +1190,7 @@ export function Sidebar({
                     unread={unreadAgentSessionIds.has(session.id)}
                     deleting={deletingAgentSessionIds.has(session.id)}
                     renaming={renamingAgentSessionId === session.id}
+                    dateFormat={dateFormat}
                     menuOpen={menu?.kind === "agent-session" && menu.sessionId === session.id}
                     onSelect={() => {
                       setSelectedAgentSessionId(session.id);
@@ -1223,6 +1241,7 @@ export function Sidebar({
                       unread={unreadAgentSessionIds.has(session.id)}
                       deleting={deletingAgentSessionIds.has(session.id)}
                       renaming={renamingAgentSessionId === session.id}
+                      dateFormat={dateFormat}
                       menuOpen={menu?.kind === "agent-session" && menu.sessionId === session.id}
                       onSelect={() => {
                         setSelectedAgentSessionId(session.id);
@@ -2032,6 +2051,7 @@ function AgentSessionRow({
   unread,
   deleting,
   renaming,
+  dateFormat,
   menuOpen,
   onSelect,
   onRename,
@@ -2045,6 +2065,7 @@ function AgentSessionRow({
   unread: boolean;
   deleting: boolean;
   renaming: boolean;
+  dateFormat: DateFormatPreference;
   menuOpen: boolean;
   onSelect: () => void;
   onRename: (title: string) => void;
@@ -2053,42 +2074,8 @@ function AgentSessionRow({
 }) {
   const title = session.title || session.preview || "Untitled session";
   const status = waiting ? "waitingForUser" : working ? "running" : undefined;
-  const time = formatSessionTime(sessionTimestamp(session));
+  const time = formatSessionTime(sessionTimestamp(session), dateFormat);
   const menuRef = useRef<HTMLButtonElement>(null);
-  const titleInputRef = useRef<HTMLInputElement | null>(null);
-  const titleEditFinalizedRef = useRef(false);
-  const [titleDraft, setTitleDraft] = useState(title);
-
-  useEffect(() => {
-    if (renaming && titleInputRef.current) {
-      titleEditFinalizedRef.current = false;
-      setTitleDraft(title);
-      titleInputRef.current.focus();
-      titleInputRef.current.select();
-    }
-  }, [renaming, title]);
-
-  useEffect(() => {
-    if (!renaming) setTitleDraft(title);
-  }, [renaming, title]);
-
-  function commitRename(value: string) {
-    if (titleEditFinalizedRef.current) return;
-    titleEditFinalizedRef.current = true;
-    onRenameEnd();
-    const next = value.trim();
-    if (!next || next === title) {
-      setTitleDraft(title);
-      return;
-    }
-    onRename(next);
-  }
-
-  function cancelRename() {
-    titleEditFinalizedRef.current = true;
-    setTitleDraft(title);
-    onRenameEnd();
-  }
 
   return (
     <article
@@ -2105,46 +2092,18 @@ function AgentSessionRow({
     >
       <div
         className="note-row-main"
-        role={renaming ? undefined : "button"}
-        tabIndex={renaming ? undefined : 0}
-        onClick={renaming ? undefined : onSelect}
-        onKeyDown={
-          renaming
-            ? undefined
-            : (event) => {
-                if (event.key === "Enter" || event.key === " ") {
-                  event.preventDefault();
-                  onSelect();
-                }
-              }
-        }
+        role="button"
+        tabIndex={0}
+        onClick={onSelect}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onSelect();
+          }
+        }}
       >
         <span className="note-row-title">
-          {renaming ? (
-            <input
-              ref={titleInputRef}
-              className="folder-note-title-input"
-              aria-label="Session name"
-              value={titleDraft}
-              onChange={(event) => setTitleDraft(event.currentTarget.value)}
-              onClick={(event) => event.stopPropagation()}
-              onMouseDown={(event) => event.stopPropagation()}
-              onBlur={(event) => commitRename(event.currentTarget.value)}
-              onKeyDown={(event) => {
-                event.stopPropagation();
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  commitRename(event.currentTarget.value);
-                }
-                if (event.key === "Escape") {
-                  event.preventDefault();
-                  cancelRename();
-                }
-              }}
-            />
-          ) : (
-            <span className="note-row-title-text">{title}</span>
-          )}
+          <span className="note-row-title-text">{title}</span>
         </span>
       </div>
       {waiting ? (
@@ -2192,6 +2151,12 @@ function AgentSessionRow({
           <IconDotGrid1x3Vertical size={14} />
         </button>
       </span>
+      <RenameSessionDialog
+        open={renaming}
+        currentName={title}
+        onClose={onRenameEnd}
+        onRename={onRename}
+      />
     </article>
   );
 }
@@ -2265,7 +2230,7 @@ function AgentSessionContextMenu({
 // Compact trailing timestamp for agent session rows: "now", "5m", "3h", "2d"
 // while recent, then "May 2". sessionTimestamp falls back to the epoch when a
 // session has no dates at all, which we render as nothing rather than 1970.
-function formatSessionTime(iso: string): string {
+function formatSessionTime(iso: string, dateFormat: DateFormatPreference): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime()) || date.getTime() === 0) return "";
   const diffMs = Date.now() - date.getTime();
@@ -2276,10 +2241,7 @@ function formatSessionTime(iso: string): string {
   if (hours < 24) return `${hours}h`;
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d`;
-  return date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
+  return formatCalendarDate(date, dateFormat);
 }
 
 function NoteContextMenu({

--- a/src/lib/date-format.ts
+++ b/src/lib/date-format.ts
@@ -1,0 +1,53 @@
+export const DATE_FORMAT_STORAGE_KEY = "june:date-format";
+export const DATE_FORMAT_CHANGED_EVENT = "june:date-format-changed";
+
+export type DateFormatPreference = "system" | "month-first" | "day-first";
+
+export type DateFormatChangedDetail = {
+  preference: DateFormatPreference;
+};
+
+export function getStoredDateFormat(): DateFormatPreference {
+  if (typeof window === "undefined") return "system";
+  try {
+    return parseDateFormat(window.localStorage.getItem(DATE_FORMAT_STORAGE_KEY));
+  } catch {
+    return "system";
+  }
+}
+
+export function setStoredDateFormat(preference: DateFormatPreference) {
+  try {
+    window.localStorage.setItem(DATE_FORMAT_STORAGE_KEY, preference);
+  } catch {
+    // Locked-down WebViews may reject storage writes. Keep the live choice.
+  }
+  window.dispatchEvent(
+    new CustomEvent<DateFormatChangedDetail>(DATE_FORMAT_CHANGED_EVENT, {
+      detail: { preference },
+    }),
+  );
+}
+
+export function formatCalendarDate(
+  date: Date,
+  preference: DateFormatPreference,
+  locales?: Intl.LocalesArgument,
+) {
+  const formatter = new Intl.DateTimeFormat(locales, {
+    month: "short",
+    day: "numeric",
+  });
+  if (preference === "system") return formatter.format(date);
+
+  const parts = formatter.formatToParts(date);
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+  if (!month || !day) return formatter.format(date);
+  return preference === "month-first" ? `${month} ${day}` : `${day} ${month}`;
+}
+
+function parseDateFormat(value: string | null): DateFormatPreference {
+  if (value === "month-first" || value === "day-first") return value;
+  return "system";
+}

--- a/src/lib/date-format.ts
+++ b/src/lib/date-format.ts
@@ -41,10 +41,10 @@ export function formatCalendarDate(
   });
   if (normalizedPreference === "system") return formatter.format(date);
 
-  const parts = formatter.formatToParts(date);
-  const month = parts.find((part) => part.type === "month")?.value;
-  const day = parts.find((part) => part.type === "day")?.value;
-  if (!month || !day) return formatter.format(date);
+  // Format each component on its own so locale-specific units stay attached
+  // when their order is forced (for example, Japanese `7月` and `9日`).
+  const month = new Intl.DateTimeFormat(locales, { month: "short" }).format(date);
+  const day = new Intl.DateTimeFormat(locales, { day: "numeric" }).format(date);
   return normalizedPreference === "month-first" ? `${month} ${day}` : `${day} ${month}`;
 }
 

--- a/src/lib/date-format.ts
+++ b/src/lib/date-format.ts
@@ -10,7 +10,7 @@ export type DateFormatChangedDetail = {
 export function getStoredDateFormat(): DateFormatPreference {
   if (typeof window === "undefined") return "system";
   try {
-    return parseDateFormat(window.localStorage.getItem(DATE_FORMAT_STORAGE_KEY));
+    return normalizeDateFormatPreference(window.localStorage.getItem(DATE_FORMAT_STORAGE_KEY));
   } catch {
     return "system";
   }
@@ -34,20 +34,21 @@ export function formatCalendarDate(
   preference: DateFormatPreference,
   locales?: Intl.LocalesArgument,
 ) {
+  const normalizedPreference = normalizeDateFormatPreference(preference);
   const formatter = new Intl.DateTimeFormat(locales, {
     month: "short",
     day: "numeric",
   });
-  if (preference === "system") return formatter.format(date);
+  if (normalizedPreference === "system") return formatter.format(date);
 
   const parts = formatter.formatToParts(date);
   const month = parts.find((part) => part.type === "month")?.value;
   const day = parts.find((part) => part.type === "day")?.value;
   if (!month || !day) return formatter.format(date);
-  return preference === "month-first" ? `${month} ${day}` : `${day} ${month}`;
+  return normalizedPreference === "month-first" ? `${month} ${day}` : `${day} ${month}`;
 }
 
-function parseDateFormat(value: string | null): DateFormatPreference {
+export function normalizeDateFormatPreference(value: unknown): DateFormatPreference {
   if (value === "month-first" || value === "day-first") return value;
   return "system";
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8281,10 +8281,7 @@ input:focus-visible,
 .agent-session-time {
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
-  /* Ticking value: the sidebar re-renders on a 60s clock so this relative time
-   * advances (5m to 10m to 1h). Tabular figures keep the width stable across
-   * ticks per the spec/no-tabular-numerals.md live-value exception. */
-  font-variant-numeric: tabular-nums;
+  text-align: right;
   white-space: nowrap;
 }
 
@@ -18872,27 +18869,6 @@ input:focus-visible,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.folder-note-title-input {
-  width: 100%;
-  min-width: 0;
-  border: 0;
-  border-radius: var(--r-xs);
-  padding: 0 var(--sp-1);
-  outline: 0;
-  background: var(--surface-subtle);
-  color: var(--foreground);
-  font-family: var(--font-sans);
-  font-size: var(--fs-md);
-  font-weight: 400;
-  line-height: 1.2;
-}
-
-.folder-note-title-input:focus,
-.folder-note-title-input:focus-visible {
-  outline: none;
-  box-shadow: none;
 }
 
 .folder-note-subtitle {

--- a/src/test/agent-sessions-list.test.tsx
+++ b/src/test/agent-sessions-list.test.tsx
@@ -197,6 +197,7 @@ describe("AgentSessionsList", () => {
 
     await user.click(screen.getByRole("button", { name: "Actions for Idle session" }));
     await user.click(screen.getByRole("menuitem", { name: "Rename" }));
+    expect(screen.getByRole("dialog", { name: "Rename session" })).toBeInTheDocument();
     const input = screen.getByRole("textbox", { name: "Session name" });
 
     await user.clear(input);
@@ -227,6 +228,7 @@ describe("AgentSessionsList", () => {
     await user.type(screen.getByRole("textbox", { name: "Session name" }), "{Escape}");
 
     expect(onRenameSession).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog", { name: "Rename session" })).not.toBeInTheDocument();
     expect(screen.getByText("Idle session")).toBeInTheDocument();
   });
 
@@ -267,9 +269,11 @@ describe("AgentSessionsList", () => {
     await user.click(screen.getByRole("button", { name: "Actions for Idle session" }));
     await user.click(screen.getByRole("menuitem", { name: "Rename" }));
     await user.clear(screen.getByRole("textbox", { name: "Session name" }));
+    expect(screen.getByRole("button", { name: "Rename" })).toBeDisabled();
     await user.type(screen.getByRole("textbox", { name: "Session name" }), "{Enter}");
 
     expect(onRenameSession).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog", { name: "Rename session" })).toBeInTheDocument();
   });
 });
 

--- a/src/test/agent-sessions-list.test.tsx
+++ b/src/test/agent-sessions-list.test.tsx
@@ -223,12 +223,14 @@ describe("AgentSessionsList", () => {
       />,
     );
 
+    await user.click(screen.getByLabelText("Select Idle session"));
     await user.click(screen.getByRole("button", { name: "Actions for Idle session" }));
     await user.click(screen.getByRole("menuitem", { name: "Rename" }));
     await user.type(screen.getByRole("textbox", { name: "Session name" }), "{Escape}");
 
     expect(onRenameSession).not.toHaveBeenCalled();
     expect(screen.queryByRole("dialog", { name: "Rename session" })).not.toBeInTheDocument();
+    expect(screen.getByRole("toolbar", { name: "Selection" })).toHaveTextContent("1 selected");
     expect(screen.getByText("Idle session")).toBeInTheDocument();
   });
 

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -8,6 +8,7 @@ import { AGENT_HUD_ENABLED_KEY } from "../lib/agent-hud-settings";
 import { MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS } from "../lib/hermes-messaging";
 import { PROVIDER_MODEL_SETTINGS_CHANGED_EVENT } from "../lib/model-privacy";
 import { TELEMETRY_INFO_URL } from "../lib/p3a";
+import { DATE_FORMAT_STORAGE_KEY } from "../lib/date-format";
 
 const mocks = vi.hoisted(() => ({
   dictationSettings: vi.fn(),
@@ -682,6 +683,28 @@ describe("AppSettings", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("changes the sidebar date format through the appearance picker", () => {
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Date format: System" });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("option", { name: "9 Jul" }));
+
+    expect(localStorage.getItem(DATE_FORMAT_STORAGE_KEY)).toBe("day-first");
+    expect(screen.getByRole("button", { name: "Date format: 9 Jul" })).toBeInTheDocument();
   });
 
   it("falls back to subscription plan credits when balance has no usage percentage", async () => {

--- a/src/test/date-format.test.ts
+++ b/src/test/date-format.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   DATE_FORMAT_STORAGE_KEY,
+  type DateFormatPreference,
   formatCalendarDate,
   getStoredDateFormat,
   setStoredDateFormat,
@@ -23,5 +24,10 @@ describe("date format preference", () => {
     const date = new Date("2026-07-09T12:00:00Z");
     expect(formatCalendarDate(date, "month-first", "en-US")).toBe("Jul 9");
     expect(formatCalendarDate(date, "day-first", "en-US")).toBe("9 Jul");
+  });
+
+  it("falls back to the system format for an invalid runtime preference", () => {
+    const date = new Date("2026-07-09T12:00:00Z");
+    expect(formatCalendarDate(date, "unknown" as DateFormatPreference, "en-US")).toBe("Jul 9");
   });
 });

--- a/src/test/date-format.test.ts
+++ b/src/test/date-format.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DATE_FORMAT_STORAGE_KEY,
+  formatCalendarDate,
+  getStoredDateFormat,
+  setStoredDateFormat,
+} from "../lib/date-format";
+
+describe("date format preference", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("defaults invalid stored values to the system format", () => {
+    localStorage.setItem(DATE_FORMAT_STORAGE_KEY, "unknown");
+    expect(getStoredDateFormat()).toBe("system");
+  });
+
+  it("persists a date order preference", () => {
+    setStoredDateFormat("day-first");
+    expect(getStoredDateFormat()).toBe("day-first");
+  });
+
+  it("formats month-first and day-first dates without changing the locale", () => {
+    const date = new Date("2026-07-09T12:00:00Z");
+    expect(formatCalendarDate(date, "month-first", "en-US")).toBe("Jul 9");
+    expect(formatCalendarDate(date, "day-first", "en-US")).toBe("9 Jul");
+  });
+});

--- a/src/test/date-format.test.ts
+++ b/src/test/date-format.test.ts
@@ -24,6 +24,8 @@ describe("date format preference", () => {
     const date = new Date("2026-07-09T12:00:00Z");
     expect(formatCalendarDate(date, "month-first", "en-US")).toBe("Jul 9");
     expect(formatCalendarDate(date, "day-first", "en-US")).toBe("9 Jul");
+    expect(formatCalendarDate(date, "month-first", "ja-JP")).toBe("7月 9日");
+    expect(formatCalendarDate(date, "day-first", "ja-JP")).toBe("9日 7月");
   });
 
   it("falls back to the system format for an invalid runtime preference", () => {

--- a/src/test/sidebar-agent-session-rename.test.tsx
+++ b/src/test/sidebar-agent-session-rename.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "../components/agent/AgentWorkspace";
 import { Sidebar } from "../components/sidebar/Sidebar";
 import type { HermesSessionInfo, NoteListItemDto } from "../lib/tauri";
+import { setStoredDateFormat } from "../lib/date-format";
 
 vi.mock("../lib/hermes-adapter", () => ({
   deleteHermesSession: vi.fn(),
@@ -74,6 +75,7 @@ describe("Sidebar agent session rename", () => {
 
     await user.click(await screen.findByRole("button", { name: "Actions for Recent session" }));
     await user.click(screen.getByRole("menuitem", { name: "Rename session" }));
+    expect(screen.getByRole("dialog", { name: "Rename session" })).toBeInTheDocument();
     const input = screen.getByRole("textbox", { name: "Session name" });
 
     await user.clear(input);
@@ -116,6 +118,17 @@ describe("Sidebar agent session rename", () => {
     await user.type(screen.getByRole("textbox", { name: "Session name" }), "{Escape}");
 
     expect(onRenameAgentSession).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog", { name: "Rename session" })).not.toBeInTheDocument();
     expect(screen.getByText("Pinned session")).toBeInTheDocument();
+  });
+
+  it("updates older session dates when the date format preference changes", async () => {
+    renderSidebar();
+
+    act(() => setStoredDateFormat("day-first"));
+    expect(await screen.findAllByText("4 Jun")).toHaveLength(2);
+
+    act(() => setStoredDateFormat("month-first"));
+    expect(await screen.findAllByText("Jun 4")).toHaveLength(2);
   });
 });

--- a/src/test/sidebar-agent-session-rename.test.tsx
+++ b/src/test/sidebar-agent-session-rename.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "../components/agent/AgentWorkspace";
 import { Sidebar } from "../components/sidebar/Sidebar";
 import type { HermesSessionInfo, NoteListItemDto } from "../lib/tauri";
-import { setStoredDateFormat } from "../lib/date-format";
+import { DATE_FORMAT_CHANGED_EVENT, setStoredDateFormat } from "../lib/date-format";
 
 vi.mock("../lib/hermes-adapter", () => ({
   deleteHermesSession: vi.fn(),
@@ -128,7 +128,13 @@ describe("Sidebar agent session rename", () => {
     act(() => setStoredDateFormat("day-first"));
     expect(await screen.findAllByText("4 Jun")).toHaveLength(2);
 
-    act(() => setStoredDateFormat("month-first"));
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(DATE_FORMAT_CHANGED_EVENT, {
+          detail: { preference: "invalid" },
+        }),
+      );
+    });
     expect(await screen.findAllByText("Jun 4")).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

- Add a General > Appearance preference for system, month-first, or day-first session dates.
- Keep older sidebar session dates visually right-aligned with proportional numerals.
- Replace inline session renaming with the shared neutral dialog across the sidebar and Sessions view.

## Root cause

Calendar dates inherited tabular numerals intended for ticking relative timestamps, which changed the trailing digit's optical edge and made dates appear offset. Session renaming also relied on text selection inside a borderless inline input, so the editing state was difficult to recognize.

## Validation

- `node_modules/.bin/biome check src scripts`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/vitest run` (2,233 passed, 2 skipped)
- Focused date-format, settings, session-list, and sidebar rename tests (78 passed)
- Visually verified by Andrew in June: date preferences, timestamp alignment, and the rename dialog.

- [x] Tested visually where it matters.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Changing date formats outside older sidebar session timestamps.
- Changing the existing relative-time thresholds.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. No security-sensitive behavior changed.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. None changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. None changed.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786219105&installation_id=144203540&pr_number=683&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F683&signature=502eac49679d2ef4ceb0aa5385e6fc3ad6533f461c6a5f495bcc32e31ae736d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->