### PR TITLE
Add text-size preference, Appearance settings tab, and external-link opener

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,15 @@
             "--brand-wash",
             accent[1],
           );
+          // Pre-paint text-size multiplier. Keep the id->multiplier map in sync
+          // with src/lib/font-scale.ts so a non-default size doesn't flash the
+          // base scale before the bundle runs.
+          var scale = localStorage.getItem("os-june:font-scale");
+          var scales = { default: 1, large: 1.1, larger: 1.2 };
+          document.documentElement.style.setProperty(
+            "--font-scale",
+            String(scales[scale] || 1),
+          );
         } catch (e) {}
       })();
     </script>

--- a/spec/type-scale.md
+++ b/spec/type-scale.md
@@ -13,5 +13,17 @@ fixed scale keeps headings aligned across surfaces and themeable.
 element's role in the mapping table. If a design asks for a size between two
 tokens, resolve it to one of them rather than inventing an off-scale value.
 
+Every `--fs-*` token is `base * var(--font-scale)`, and the Appearance "Text
+size" preference (`src/lib/font-scale.ts`) overrides `--font-scale` on `<html>`.
+So any element that reads a token scales with that preference for free; a
+hand-coded `px` size silently opts out and reads wrong at the non-default sizes.
+Keep sizes relative to the surrounding token where it makes sense — inline code
+using `font-size: 0.9em` scales with its parent, which is fine.
+
+Non-text elements that *represent* text — the sidebar wordmark is the one case
+today — multiply their dimension by `var(--font-scale)` directly
+(`height: calc(14px * var(--font-scale))`). Glyph icons, control heights, and
+spacing deliberately do NOT scale; they're fixed chrome.
+
 **Exceptions.** None beyond the mapping table. Display and marketing sizes are
 already in the scale (`--fs-2xl`, `--fs-display`).

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -783,6 +783,27 @@ pub fn june_open_community_page() -> Result<(), AppError> {
     crate::os_accounts::open_in_browser(JUNE_COMMUNITY_URL)
 }
 
+/// Opens an arbitrary external link in the default browser. This is the
+/// generic sibling of the fixed-URL commands above: the frontend's global
+/// anchor interceptor (src/lib/external-links.ts) routes every external
+/// `target="_blank"` click here, since the webview drops them otherwise.
+/// Scheme-checked to http/https so a crafted href can't reach other URL
+/// handlers (file:, tel:, custom schemes) through the OS opener.
+#[tauri::command]
+pub fn june_open_external_url(url: String) -> Result<(), AppError> {
+    let scheme_ok = {
+        let lower = url.trim_start().to_ascii_lowercase();
+        lower.starts_with("https://") || lower.starts_with("http://")
+    };
+    if !scheme_ok {
+        return Err(AppError::new(
+            "external_url_rejected",
+            "Only http(s) links can be opened externally.",
+        ));
+    }
+    crate::os_accounts::open_in_browser(url.trim())
+}
+
 #[tauri::command]
 pub async fn open_privacy_settings(request: OpenPrivacySettingsRequest) -> Result<(), AppError> {
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -221,6 +221,7 @@ pub fn run() {
             commands::reveal_path,
             commands::june_open_verify_page,
             commands::june_open_community_page,
+            commands::june_open_external_url,
             commands::start_recording,
             commands::pause_recording,
             commands::resume_recording,

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -70,6 +70,12 @@ import type { ReportCategory } from "../agent/composer/reportCategory";
 import { getStoredTheme, setStoredTheme, type ThemePreference } from "../../lib/theme";
 import { BRAND_PRESETS, getStoredBrand, setStoredBrand, type BrandId } from "../../lib/brand";
 import {
+  FONT_SCALE_PRESETS,
+  getStoredFontScale,
+  setStoredFontScale,
+  type FontScaleId,
+} from "../../lib/font-scale";
+import {
   getReleaseChannel,
   reconcileToStable,
   setReleaseChannel,
@@ -155,6 +161,16 @@ const THEME_OPTIONS: readonly {
   },
 ];
 
+const FONT_SCALE_OPTIONS: readonly {
+  value: FontScaleId;
+  label: ReactNode;
+  ariaLabel: string;
+}[] = FONT_SCALE_PRESETS.map((preset) => ({
+  value: preset.id,
+  label: preset.label,
+  ariaLabel: `${preset.label} text size`,
+}));
+
 const RELEASE_CHANNEL_OPTIONS: readonly {
   value: ReleaseChannel;
   label: ReactNode;
@@ -231,6 +247,7 @@ const MIC_TEST_DURATION_SECONDS = 5;
 
 export type SettingsTab =
   | "general"
+  | "appearance"
   | "billing"
   | "shortcuts"
   | "dictation"
@@ -255,6 +272,7 @@ export type SettingsTab =
 
 export const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
   { id: "general", label: "General" },
+  { id: "appearance", label: "Appearance" },
   { id: "billing", label: "Billing" },
   { id: "shortcuts", label: "Shortcuts" },
   { id: "dictation", label: "Dictation" },
@@ -410,6 +428,7 @@ export function AppSettings({
   const [micOpen, setMicOpen] = useState(false);
   const [theme, setTheme] = useState<ThemePreference>(() => getStoredTheme());
   const [brand, setBrand] = useState<BrandId>(() => getStoredBrand());
+  const [fontScale, setFontScale] = useState<FontScaleId>(() => getStoredFontScale());
   const [releaseChannel, setReleaseChannelValue] = useState<ReleaseChannel>("stable");
   // Set only when a leave-rc switch turns up an installable stable, so the
   // bespoke in-context confirm below the toggle can name the exact version.
@@ -1355,7 +1374,7 @@ export function AppSettings({
           <>
             <SettingsPageHeader
               title="General"
-              blurb="Your account, appearance, and everyday June preferences."
+              blurb="Your account and everyday June preferences."
             />
             <AccountSettingsSection
               account={account}
@@ -1363,63 +1382,6 @@ export function AppSettings({
               onAccountChanged={onAccountChanged}
               onRefresh={onAccountRefresh}
             />
-
-            <section className="settings-group" aria-labelledby="appearance-heading">
-              <h2 id="appearance-heading" className="settings-group-heading">
-                Appearance
-              </h2>
-              <div className="settings-card">
-                <div className="settings-rows">
-                  <div className="settings-row">
-                    <div className="settings-row-info">
-                      <h3 className="settings-row-title">Theme</h3>
-                      <p className="settings-row-description">
-                        Match the system or force light or dark mode.
-                      </p>
-                    </div>
-                    <div className="settings-row-control">
-                      <SegmentedControl<ThemePreference>
-                        aria-label="App theme"
-                        value={theme}
-                        options={THEME_OPTIONS}
-                        onValueChange={(next) => {
-                          setTheme(next);
-                          setStoredTheme(next);
-                        }}
-                      />
-                    </div>
-                  </div>
-                  <div className="settings-row">
-                    <div className="settings-row-info">
-                      <h3 className="settings-row-title">Accent</h3>
-                      <p className="settings-row-description">
-                        The brand color used across buttons, highlights, and the recorder.
-                      </p>
-                    </div>
-                    <div className="settings-row-control">
-                      <Select
-                        className="accent-select"
-                        value={brand}
-                        options={BRAND_PRESETS.map((preset) => ({
-                          value: preset.id,
-                          label: preset.label,
-                          color: preset.value,
-                        }))}
-                        placeholder="Clay"
-                        ariaLabel={`Accent color: ${
-                          BRAND_PRESETS.find((preset) => preset.id === brand)?.label ??
-                          BRAND_PRESETS[0].label
-                        }`}
-                        onChange={(id) => {
-                          setBrand(id as BrandId);
-                          setStoredBrand(id as BrandId);
-                        }}
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </section>
 
             <PermissionsSettingsSection
               microphonePermissionStatus={microphonePermissionStatus}
@@ -1433,6 +1395,86 @@ export function AppSettings({
 
             <PrivacySettingsSection />
           </>
+        ) : null}
+
+        {activeTab === "appearance" ? (
+          <section className="settings-group" aria-labelledby="appearance-heading">
+            <SettingsPageHeader
+              id="appearance-heading"
+              title="Appearance"
+              blurb="Choose the theme, accent color, and text size June uses."
+            />
+            <div className="settings-card">
+              <div className="settings-rows">
+                <div className="settings-row">
+                  <div className="settings-row-info">
+                    <h3 className="settings-row-title">Theme</h3>
+                    <p className="settings-row-description">
+                      Match the system or force light or dark mode.
+                    </p>
+                  </div>
+                  <div className="settings-row-control">
+                    <SegmentedControl<ThemePreference>
+                      aria-label="App theme"
+                      value={theme}
+                      options={THEME_OPTIONS}
+                      onValueChange={(next) => {
+                        setTheme(next);
+                        setStoredTheme(next);
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="settings-row">
+                  <div className="settings-row-info">
+                    <h3 className="settings-row-title">Text size</h3>
+                    <p className="settings-row-description">
+                      Make text across the app larger. Affects every label, note, and conversation.
+                    </p>
+                  </div>
+                  <div className="settings-row-control">
+                    <SegmentedControl<FontScaleId>
+                      aria-label="Text size"
+                      value={fontScale}
+                      options={FONT_SCALE_OPTIONS}
+                      onValueChange={(next) => {
+                        setFontScale(next);
+                        setStoredFontScale(next);
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="settings-row">
+                  <div className="settings-row-info">
+                    <h3 className="settings-row-title">Accent</h3>
+                    <p className="settings-row-description">
+                      The brand color used across buttons, highlights, and the recorder.
+                    </p>
+                  </div>
+                  <div className="settings-row-control">
+                    <Select
+                      className="accent-select"
+                      value={brand}
+                      options={BRAND_PRESETS.map((preset) => ({
+                        value: preset.id,
+                        label: preset.label,
+                        color: preset.value,
+                      }))}
+                      placeholder="Clay"
+                      ariaLabel={`Accent color: ${
+                        BRAND_PRESETS.find((preset) => preset.id === brand)?.label ??
+                        BRAND_PRESETS[0].label
+                      }`}
+                      onChange={(id) => {
+                        setBrand(id as BrandId);
+                        setStoredBrand(id as BrandId);
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
         ) : null}
 
         {activeTab === "billing" && !account.localDev ? (

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -13,6 +13,7 @@ import { IconBuildingBlocks } from "central-icons/IconBuildingBlocks";
 import { IconElements } from "central-icons/IconElements";
 import { IconModelcontextprotocol } from "central-icons/IconModelcontextprotocol";
 import { IconCircleInfo } from "central-icons/IconCircleInfo";
+import { IconColorPalette } from "central-icons/IconColorPalette";
 import { IconCreditCard1 } from "central-icons/IconCreditCard1";
 import { IconDotGrid1x3Vertical } from "central-icons/IconDotGrid1x3Vertical";
 import { IconFolderAddRight } from "central-icons/IconFolderAddRight";
@@ -210,6 +211,11 @@ const SETTINGS_SIDEBAR_GROUPS: {
         id: "general",
         label: "General",
         icon: <IconSettingsGear4 size={16} />,
+      },
+      {
+        id: "appearance",
+        label: "Appearance",
+        icon: <IconColorPalette size={16} />,
       },
       {
         id: "billing",
@@ -618,8 +624,9 @@ export function Sidebar({
         action: () => onChangeView("settings"),
       },
       // Per-tab settings jumps surface only once a query is typed so ten
-      // rows don't flood the default Quick actions list. The general tab
-      // hosts Appearance, so its search text carries those terms too.
+      // rows don't flood the default Quick actions list. General and
+      // Appearance carry their row-level terms so "theme" or "account"
+      // still finds the right tab.
       ...(normalized
         ? SETTINGS_TABS.filter(
             (tab) =>
@@ -631,8 +638,10 @@ export function Sidebar({
               icon: <IconSettingsGear4 size={15} />,
               searchText: normalizeCommandQuery(
                 tab.id === "general"
-                  ? "settings general appearance theme accent account"
-                  : `settings ${tab.label}`,
+                  ? "settings general account permissions privacy"
+                  : tab.id === "appearance"
+                    ? "settings appearance theme accent text size dark light mode"
+                    : `settings ${tab.label}`,
               ),
               action: () => {
                 onSettingsTabChange?.(tab.id);

--- a/src/components/ui/HoverTip.tsx
+++ b/src/components/ui/HoverTip.tsx
@@ -12,6 +12,18 @@ import { createPortal } from "react-dom";
 
 const DEFAULT_TIP_WIDTH = 300;
 const TIP_GAP = 6;
+
+// Width caps (the `width` prop and the default above) are hand-tuned at the
+// base text size. Text width grows linearly with the text-size preference, so
+// the cap multiplies by the live --font-scale — otherwise a tip tuned to fit
+// one line at the base size wraps at Large/Larger. Falls back to 1 where the
+// token can't be read (jsdom).
+function currentFontScale(): number {
+  if (typeof document === "undefined") return 1;
+  const raw = getComputedStyle(document.documentElement).getPropertyValue("--font-scale");
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
 const VIEWPORT_MARGIN = 8;
 // Fallback flip threshold used only before the tip's real height is known (it
 // never is, since the side is decided in the measure pass from the measured
@@ -457,7 +469,9 @@ export function HoverTip({
               style={{
                 top: coords?.top ?? anchor.bottom,
                 left: coords?.left ?? 0,
-                maxWidth: width,
+                // Scale-adjusted at mount time; tips are ephemeral, so a
+                // text-size change is picked up on the next open.
+                maxWidth: width * currentFontScale(),
                 // Applied only after the tighten pass; while measuring the tip
                 // renders at its natural capped width so the wrap is real.
                 width: coords?.width,

--- a/src/lib/external-links.ts
+++ b/src/lib/external-links.ts
@@ -1,0 +1,46 @@
+// External-link rescue for the Tauri webview. The webview installs no
+// new-window handler, so `target="_blank"` anchors — the natural way to write
+// an external link, used across settings, onboarding, and agent markdown —
+// are silently dropped in the native shell while working fine in browser dev.
+// Rather than teaching each component to call a command, this installs ONE
+// document-level click interceptor that routes external http(s) anchor clicks
+// through `june_open_external_url` (which opens the default browser).
+//
+// Only installed when running inside Tauri; in a plain browser the anchors'
+// native behavior already works. Handlers that preventDefault (e.g. a future
+// command-backed link) are respected and skipped.
+
+import { invoke } from "@tauri-apps/api/core";
+
+function inTauri() {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+export function installExternalLinkOpener() {
+  if (!inTauri()) return;
+
+  document.addEventListener("click", (event) => {
+    if (event.defaultPrevented) return;
+    const anchor = (event.target as Element | null)?.closest?.("a[href]");
+    if (!(anchor instanceof HTMLAnchorElement)) return;
+    // Links inside an editable surface (the TipTap note editor / composer) are
+    // being edited, not followed — clicking one places the caret.
+    if (anchor.isContentEditable) return;
+
+    let url: URL;
+    try {
+      url = new URL(anchor.href, window.location.href);
+    } catch {
+      return;
+    }
+    if (url.protocol !== "https:" && url.protocol !== "http:") return;
+    // In-app navigation (same origin, no _blank) stays with the router.
+    const external = anchor.target === "_blank" || url.origin !== window.location.origin;
+    if (!external) return;
+
+    event.preventDefault();
+    void invoke("june_open_external_url", { url: url.href }).catch(() => {
+      // Best-effort: a failed open leaves the click a no-op, same as before.
+    });
+  });
+}

--- a/src/lib/font-scale.ts
+++ b/src/lib/font-scale.ts
@@ -1,0 +1,65 @@
+// Text-size preference. The whole app's type derives from the --fs-* tokens
+// (src/styles/tokens.css), and each of those is `base * var(--font-scale)`, so
+// overriding that one custom property at runtime rescales every label, body,
+// and heading in one shot — the same override-one-var trick the brand accent
+// uses. Line-heights are unitless and spacing/control heights stay fixed, so
+// text grows within the existing chrome instead of reflowing the shell.
+//
+// Persisted like the theme/brand preferences: localStorage only, plus a
+// pre-paint bootstrap in index.html that sets --font-scale before the bundle
+// runs so a non-default size doesn't flash the base scale first. Keep the
+// storage key and the id->multiplier map in sync with that bootstrap.
+
+export type FontScaleId = "default" | "large" | "larger";
+
+// Up-only ladder: June is a reading app, so there's no "denser" step — the two
+// larger stops cover "comfortable" and "big" without crowding the fixed chrome
+// (spacing, control heights, and icon sizes stay put at these deltas).
+export const FONT_SCALE_PRESETS: {
+  id: FontScaleId;
+  label: string;
+  value: number;
+}[] = [
+  { id: "default", label: "Default", value: 1 },
+  { id: "large", label: "Large", value: 1.1 },
+  { id: "larger", label: "Larger", value: 1.2 },
+];
+
+const STORAGE_KEY = "os-june:font-scale";
+export const DEFAULT_FONT_SCALE: FontScaleId = "default";
+
+function presetFor(id: string | null) {
+  // Unknown ids (including a stored "small" from the dropped preset) resolve
+  // to the default scale.
+  return (
+    FONT_SCALE_PRESETS.find((preset) => preset.id === id) ??
+    FONT_SCALE_PRESETS.find((preset) => preset.id === DEFAULT_FONT_SCALE) ??
+    FONT_SCALE_PRESETS[0]
+  );
+}
+
+export function getStoredFontScale(): FontScaleId {
+  try {
+    return presetFor(localStorage.getItem(STORAGE_KEY)).id;
+  } catch {
+    // localStorage can throw in sandboxed contexts.
+    return DEFAULT_FONT_SCALE;
+  }
+}
+
+export function applyFontScale(id: FontScaleId) {
+  document.documentElement.style.setProperty("--font-scale", String(presetFor(id).value));
+}
+
+export function setStoredFontScale(id: FontScaleId) {
+  try {
+    localStorage.setItem(STORAGE_KEY, id);
+  } catch {
+    // Apply still works for this session.
+  }
+  applyFontScale(id);
+}
+
+export function initFontScale() {
+  applyFontScale(getStoredFontScale());
+}

--- a/src/lib/p3a.ts
+++ b/src/lib/p3a.ts
@@ -1,8 +1,10 @@
-import { APP_COMMIT_HASH } from "../app/build-info";
 import type { P3aSettingsDto } from "./tauri";
 
-const TELEMETRY_DOCS_REF =
-  APP_COMMIT_HASH && APP_COMMIT_HASH !== "unknown" ? APP_COMMIT_HASH : "main";
+// The telemetry docs link to main, not the build's commit: a pinned commit
+// only resolves on GitHub if that exact commit was pushed, so dev and
+// squash-merged builds served 404s. main always resolves, at the cost of the
+// doc occasionally running ahead of an older installed build.
+const TELEMETRY_DOCS_REF = "main";
 
 export const P3A_SETTINGS_CHANGED_EVENT = "june:p3a";
 export const TELEMETRY_INFO_URL = `https://github.com/open-software-network/os-june/blob/${TELEMETRY_DOCS_REF}/docs/telemetry.md`;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,8 @@ import { installNativeContextMenuGuard } from "./lib/native-context-menu";
 import { replayOnboarding } from "./lib/onboarding";
 import { initTheme } from "./lib/theme";
 import { initBrand } from "./lib/brand";
+import { initFontScale } from "./lib/font-scale";
+import { installExternalLinkOpener } from "./lib/external-links";
 import "./styles/app.css";
 
 declare global {
@@ -23,6 +25,8 @@ if (import.meta.env.DEV) {
 
 initTheme();
 initBrand();
+initFontScale();
+installExternalLinkOpener();
 installNativeContextMenuGuard();
 
 // Console driver for the agent HUD overlay window: __agentHud("demo") etc.

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2831,7 +2831,7 @@ input:focus-visible,
 .agent-tool-icon-minimize {
   opacity: 0;
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 15px;
+  font-size: var(--fs-lg);
   line-height: 1;
 }
 
@@ -7289,7 +7289,9 @@ input:focus-visible,
 .sidebar-brand {
   display: inline-flex;
   align-items: center;
-  height: 14px;
+  /* Matches .sidebar-brand-mark: the wordmark scales with the text-size
+   * preference, so its wrapper must grow with it. */
+  height: calc(14px * var(--font-scale));
   color: var(--foreground);
   text-decoration: none;
   flex: 0 1 auto;
@@ -7381,7 +7383,9 @@ input:focus-visible,
  * accent. Replaces the old light/dark <img> swap. */
 .sidebar-brand-mark {
   display: block;
-  height: 14px;
+  /* The wordmark is brand *text*, so it rides the text-size preference like
+   * the nav labels beside it — unlike glyph icons, which stay fixed chrome. */
+  height: calc(14px * var(--font-scale));
   width: auto;
   color: var(--foreground);
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -46,6 +46,54 @@
   initial-value: #976851;
 }
 
+/* The --fs-* type tokens are registered as lengths so their computed value
+ * resolves to concrete px instead of an unevaluated calc() token stream —
+ * JS readers (the styleguide's resolveToken) get "13px", not
+ * "calc(13px * 1)", and a bad --font-scale falls back to the base size
+ * rather than unsetting the token. @property initial-value must be a
+ * literal, so each mirrors its base size in :root below — keep them in
+ * sync (same drill as --sidebar-w-current / --sidebar-w). */
+@property --fs-2xs {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 10px;
+}
+@property --fs-xs {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 11px;
+}
+@property --fs-sm {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 12px;
+}
+@property --fs-md {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 13px;
+}
+@property --fs-lg {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 14px;
+}
+@property --fs-xl {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 16px;
+}
+@property --fs-2xl {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 20px;
+}
+@property --fs-display {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 30px;
+}
+
 :root {
   /* Type ------------------------------------------------------------- */
   --font-sans:
@@ -54,14 +102,23 @@
   --font-serif: "Martina Plantijn", "Iowan Old Style", Georgia, serif;
   --font-mono: "Berkeley Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
 
-  --fs-2xs: 10px;
-  --fs-xs: 11px;
-  --fs-sm: 12px;
-  --fs-md: 13px;
-  --fs-lg: 14px;
-  --fs-xl: 16px;
-  --fs-2xl: 20px;
-  --fs-display: 30px;
+  /* Global text-size multiplier. Every --fs-* token below is `base *
+   * --font-scale`, so the Appearance "Text size" preference recolors the whole
+   * app's type by overriding this one value on <html> (see src/lib/font-scale.ts
+   * and the pre-paint bootstrap in index.html). Default 1 = the base scale.
+   * Line-heights are unitless and spacing/control heights stay fixed, so text
+   * grows within the existing chrome rather than reflowing the shell. Separate
+   * HUD webviews don't read the preference, so they stay at 1 on purpose. */
+  --font-scale: 1;
+
+  --fs-2xs: calc(10px * var(--font-scale));
+  --fs-xs: calc(11px * var(--font-scale));
+  --fs-sm: calc(12px * var(--font-scale));
+  --fs-md: calc(13px * var(--font-scale));
+  --fs-lg: calc(14px * var(--font-scale));
+  --fs-xl: calc(16px * var(--font-scale));
+  --fs-2xl: calc(20px * var(--font-scale));
+  --fs-display: calc(30px * var(--font-scale));
 
   /* Diatype ships Regular (400) and Medium (600) only, and font-synthesis is
    * off — intermediate weights silently resolve to Regular. "Medium" anywhere

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -653,6 +653,9 @@ describe("AppSettings", () => {
         />,
       );
 
+      // Theme, accent, and text size live on their own Appearance tab.
+      fireEvent.click(screen.getByRole("tab", { name: "Appearance" }));
+
       // The accessible name carries the current selection so screen readers
       // announce the active accent, not just the static "Accent color" label.
       const trigger = (label: string) =>

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -764,7 +764,7 @@ describe("App shortcuts", () => {
 
     mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
 
-    expect(await screen.findByRole("heading", { name: "Appearance" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "General" })).toBeInTheDocument();
   });
 
   it("refreshes Accessibility after requesting access without opening settings over the native prompt", async () => {
@@ -929,7 +929,7 @@ describe("App shortcuts", () => {
         mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
       });
 
-      expect(await screen.findByRole("heading", { name: "Appearance" })).toBeInTheDocument();
+      expect(await screen.findByRole("heading", { name: "General" })).toBeInTheDocument();
       const blockedRow = screen.getByText("System audio").closest(".settings-row");
       expect(blockedRow).not.toBeNull();
       expect(within(blockedRow as HTMLElement).getByLabelText("Blocked")).toBeInTheDocument();
@@ -975,7 +975,7 @@ describe("App shortcuts", () => {
         mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
       });
 
-      expect(await screen.findByRole("heading", { name: "Appearance" })).toBeInTheDocument();
+      expect(await screen.findByRole("heading", { name: "General" })).toBeInTheDocument();
       const blockedRow = screen.getByText("System audio").closest(".settings-row");
       expect(blockedRow).not.toBeNull();
 
@@ -1051,7 +1051,7 @@ describe("App shortcuts", () => {
         mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
       });
 
-      expect(await screen.findByRole("heading", { name: "Appearance" })).toBeInTheDocument();
+      expect(await screen.findByRole("heading", { name: "General" })).toBeInTheDocument();
       const blockedRow = screen.getByText("System audio").closest(".settings-row");
       expect(blockedRow).not.toBeNull();
 


### PR DESCRIPTION
## Summary

- **Text size preference** — every `--fs-*` token is now `base * var(--font-scale)`; three presets (Default 1 / Large 1.1 / Larger 1.2) persist via localStorage with a pre-paint bootstrap, mirroring the theme/brand pattern. Tokens are registered `@property <length>`s so computed values resolve to concrete px (styleguide catalog stays clean) and a corrupted stored scale falls back to the base size.
- **What scales vs what holds**: all type, the sidebar wordmark (brand text), and `HoverTip` width caps (multiplied by the live scale so tips tuned at base size keep one line at Large/Larger). Glyph icons, control heights, spacing, and the titlebar/tab band stay fixed chrome; separate HUD webviews deliberately stay at base scale.
- **Appearance settings tab** — Theme, Text size, and Accent promoted out of General into their own tab (settings sidebar Personal group, quick-actions search terms moved with it).
- **External links actually open** — a global click interceptor routes external http(s) anchors through the new scheme-checked `june_open_external_url` command; fixes dead `target="_blank"` links in nine components at once.
- **Telemetry doc links point at `main`** instead of the build commit.
- Consistency sweep: one stray raw `font-size: 15px` → `var(--fs-lg)`; `spec/type-scale.md` documents the multiplier and the scale/hold dividing line.

## Root cause

- Dead links: the webview installs no new-window handler, so `target="_blank"` anchors were silently dropped in the native shell (only two hardcoded links had per-URL rescue commands).
- Telemetry 404s: the doc URL pinned to `APP_COMMIT_HASH`, which only resolves on GitHub if that exact commit was pushed — dev and squash-merged builds linked to nothing.

## Validation

- `pnpm typecheck`, Biome clean on touched files (remaining warnings pre-exist, verified against stash), `cargo fmt`/`clippy` quiet.
- Affected vitest suites green: app-settings, app-shortcut, hover-tip, tab-bar, tabs, onboarding, sidebar (all updated assertions reflect the new Appearance tab IA).
- Token resolution verified in a real engine (headless Chromium against tokens.css): default → `13px`, scale 1.14 → `14.82px`, garbage scale → falls back to `13px`.

- [x] Tested visually where it matters (owner clicked through text-size stops, Appearance tab, and tooltips at Larger).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Scaling glyph icons/controls with the text size (revisit only if a true accessibility scale ≥1.35 is added).
- A free numeric base-px input (quantized presets keep the ladder ratios and QA surface bounded).
- The big glass mark on sign-in/onboarding (hero display object, not text-adjacent).

## Followups

- Titlebar/tab-strip breathing room (reference screenshot from a similar product noted in review) — separate story.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary (`june_open_external_url` is scheme-checked to http/https so crafted hrefs can't reach other URL handlers).
- [x] Workflow action references are pinned to full-length commit SHAs. (No workflow changes.)
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. (None touched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786224600&installation_id=144203540&pr_number=684&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F684&signature=d7ad96ab09f778bdd89412d49f7c7bdbda6448c532ccba19c52fc4ad912ce332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->