### PR TITLE
Borderless command prompt search, model picker private filter, hover scrollbars

### DIFF
--- a/src/components/agent/composer/ModelPicker.tsx
+++ b/src/components/agent/composer/ModelPicker.tsx
@@ -558,8 +558,10 @@ export function ComposerModelPopover({
                   ))
                 ) : (
                   <p className="agent-composer-model-empty">
-                    {privateOnly && !query
-                      ? "No private models available."
+                    {privateOnly
+                      ? query
+                        ? "No private models match your search."
+                        : "No private models available."
                       : "No models match your search."}
                   </p>
                 )}

--- a/src/components/agent/composer/ModelPicker.tsx
+++ b/src/components/agent/composer/ModelPicker.tsx
@@ -1,13 +1,16 @@
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
 import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
 import { IconChevronRightSmall } from "central-icons/IconChevronRightSmall";
-import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconShieldCrossed } from "central-icons/IconShieldCrossed";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { RefObject } from "react";
 import { createPortal } from "react-dom";
 
-import { modelSupportsTools, type ModelPrivacyBadge } from "../../../lib/model-privacy";
+import {
+  modelIsPrivate,
+  modelSupportsTools,
+  type ModelPrivacyBadge,
+} from "../../../lib/model-privacy";
 import { suggestedModelsForMode } from "../../../lib/suggested-models";
 import type { VeniceModelDto } from "../../../lib/tauri";
 import { useScrollFade } from "../../../lib/use-scroll-fade";
@@ -15,6 +18,7 @@ import { rectFromElement, type HoverBridgeRect } from "../../ui/hoverBridge";
 import { useCatalogHoverBridge, useModelDetailHoverBridge } from "../../ui/useModelHoverBridge";
 import { HoverTip } from "../../ui/HoverTip";
 import { ModelPrivacyChip, ModelRowPrivacyBadge } from "../../ui/ModelPrivacyChip";
+import { Switch } from "../../ui/Switch";
 import { ModelPickerCardContent } from "../../settings/ModelPickerPopover";
 
 /** The composer's model picker: the trigger pill and its two-layer popover
@@ -101,6 +105,10 @@ export function ComposerModelPopover({
 }) {
   const flyoutRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
+  // "Private" catalog filter. Local to the popover on purpose: it resets when
+  // the picker closes, so a stale filter can never silently hide models on the
+  // next open.
+  const [privateOnly, setPrivateOnly] = useState(false);
   // Styled hover card for catalog rows (replaces the native title tooltip):
   // fixed-positioned next to the hovered row, on the panel's outer side.
   const [catalogHover, setCatalogHover] = useState<{
@@ -255,16 +263,17 @@ export function ComposerModelPopover({
   }, [detailPos]);
 
   // Re-measure the fades whenever the list's content or cap changes: panel
-  // open (after the max-height effect above), and every search keystroke.
+  // open (after the max-height effect above), every search keystroke, and the
+  // privacy filter.
   useLayoutEffect(() => {
     fade.update();
-  }, [flyout, search, options, fade.update]);
+  }, [flyout, search, privateOnly, options, fade.update]);
 
   // Row positions shift under the pointer on filter/reflow, so a lingering
   // card would point at the wrong row.
   useEffect(() => {
     setCatalogHover(null);
-  }, [flyout, search]);
+  }, [flyout, search, privateOnly]);
 
   const suggested = suggestedModelsForMode("generation", options);
   const query = search.trim().toLowerCase();
@@ -272,9 +281,10 @@ export function ComposerModelPopover({
   // be picked — leave them out of the quick-switch list entirely instead of
   // showing dead rows. (Settings still lists them, greyed, for context.)
   const selectable = options.filter((option) => !option.provider || modelSupportsTools(option));
+  const privacyFiltered = privateOnly ? selectable.filter(modelIsPrivate) : selectable;
   const filteredOptions = query
-    ? selectable.filter((option) => modelMatchesQuery(option, query))
-    : selectable;
+    ? privacyFiltered.filter((option) => modelMatchesQuery(option, query))
+    : privacyFiltered;
   const detail =
     flyout?.kind === "model" ? suggested.find((item) => item.model.id === flyout.id) : undefined;
 
@@ -376,7 +386,7 @@ export function ComposerModelPopover({
         setBridging(false);
       }}
     >
-      <p className="agent-composer-model-title">Model</p>
+      <p className="agent-composer-model-title">Suggested</p>
       <div className="agent-composer-model-menu" role="listbox" aria-label="Suggested text models">
         {suggested.length ? (
           suggested.map(({ model: option }) => (
@@ -496,7 +506,6 @@ export function ComposerModelPopover({
         >
           <div className="agent-composer-model-surface">
             <label className="agent-composer-model-search">
-              <IconMagnifyingGlass size={14} aria-hidden />
               <input
                 ref={searchRef}
                 value={search}
@@ -505,6 +514,14 @@ export function ComposerModelPopover({
                 aria-label="Search models"
               />
             </label>
+            <div className="agent-composer-model-filter">
+              <span>Private</span>
+              <Switch
+                checked={privateOnly}
+                onCheckedChange={setPrivateOnly}
+                aria-label="Only show private models"
+              />
+            </div>
             <div className="agent-composer-model-list-wrap scroll-fade" {...fade.props}>
               <div
                 ref={listRef}
@@ -540,7 +557,11 @@ export function ComposerModelPopover({
                     />
                   ))
                 ) : (
-                  <p className="agent-composer-model-empty">No models match your search.</p>
+                  <p className="agent-composer-model-empty">
+                    {privateOnly && !query
+                      ? "No private models available."
+                      : "No models match your search."}
+                  </p>
                 )}
               </div>
             </div>

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -1,5 +1,4 @@
 import { IconChevronRightSmall } from "central-icons/IconChevronRightSmall";
-import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconCheckmark2Small } from "central-icons-filled/IconCheckmark2Small";
 import {
   Fragment,
@@ -12,13 +11,14 @@ import {
 } from "react";
 import type { RefObject } from "react";
 import { createPortal } from "react-dom";
-import { modelAvailableForMode, modelPrivacyBadge } from "../../lib/model-privacy";
+import { modelAvailableForMode, modelIsPrivate, modelPrivacyBadge } from "../../lib/model-privacy";
 import { suggestedModelsForMode } from "../../lib/suggested-models";
 import type { ProviderModelMode, VeniceModelDto } from "../../lib/tauri";
 import { useScrollFade } from "../../lib/use-scroll-fade";
 import { rectFromElement, type HoverBridgeRect } from "../ui/hoverBridge";
 import { useCatalogHoverBridge, useModelDetailHoverBridge } from "../ui/useModelHoverBridge";
 import { ModelPrivacyChip, ModelRowPrivacyBadge } from "../ui/ModelPrivacyChip";
+import { Switch } from "../ui/Switch";
 import { modelSpecEntries } from "./ModelPickerDialog";
 import { ProviderLogo } from "./ProviderLogo";
 
@@ -41,7 +41,7 @@ export function ModelPickerPopover({
   popoverRef,
   searchRef,
   className,
-  title = "Model",
+  title = "Suggested",
   ariaLabel = `Choose ${modelModeLabel(mode)} model`,
   suggestedListLabel = `Suggested ${modelModeLabel(mode)} models`,
   allModelsLabel = `All ${modelModeLabel(mode)} models`,
@@ -68,6 +68,10 @@ export function ModelPickerPopover({
   const flyoutRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
   const hovercardRef = useRef<HTMLDivElement | null>(null);
+  // "Private" catalog filter. Local to the popover on purpose: it resets when
+  // the picker closes, so a stale filter can never silently hide models on the
+  // next open.
+  const [privateOnly, setPrivateOnly] = useState(false);
   // The suggested-row detail card is portaled to document.body (so a scroll
   // container or panel can't clip or cover it) and positioned in viewport
   // coordinates beside the popover — the same mechanism as the catalog
@@ -217,11 +221,11 @@ export function ModelPickerPopover({
 
   useLayoutEffect(() => {
     fade.update();
-  }, [flyout, options, search, fade.update]);
+  }, [flyout, options, search, privateOnly, fade.update]);
 
   useEffect(() => {
     setCatalogHover(null);
-  }, [flyout, search]);
+  }, [flyout, search, privateOnly]);
 
   // Keep the row's fixed-positioned hover card inside the viewport vertically:
   // the card is anchored to the hovered row's top, but the settings picker
@@ -248,9 +252,10 @@ export function ModelPickerPopover({
     [mode, options],
   );
   const suggested = useMemo(() => suggestedModelsForMode(mode, selectable), [mode, selectable]);
+  const privacyFiltered = privateOnly ? selectable.filter(modelIsPrivate) : selectable;
   const filteredOptions = query
-    ? selectable.filter((option) => modelMatchesQuery(option, query))
-    : selectable;
+    ? privacyFiltered.filter((option) => modelMatchesQuery(option, query))
+    : privacyFiltered;
   const detail =
     flyout?.kind === "model" ? suggested.find((item) => item.model.id === flyout.id) : undefined;
 
@@ -339,7 +344,6 @@ export function ModelPickerPopover({
     return (
       <>
         <label className="agent-composer-model-search">
-          <IconMagnifyingGlass size={14} aria-hidden />
           <input
             ref={searchRef}
             value={search}
@@ -348,6 +352,14 @@ export function ModelPickerPopover({
             aria-label="Search models"
           />
         </label>
+        <div className="agent-composer-model-filter">
+          <span>Private</span>
+          <Switch
+            checked={privateOnly}
+            onCheckedChange={setPrivateOnly}
+            aria-label="Only show private models"
+          />
+        </div>
         <div className="agent-composer-model-list-wrap scroll-fade" {...fade.props}>
           <div
             ref={listRef}
@@ -383,7 +395,11 @@ export function ModelPickerPopover({
                 />
               ))
             ) : (
-              <p className="agent-composer-model-empty">No models match your search.</p>
+              <p className="agent-composer-model-empty">
+                {privateOnly && !query
+                  ? "No private models available."
+                  : "No models match your search."}
+              </p>
             )}
           </div>
         </div>

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -396,8 +396,10 @@ export function ModelPickerPopover({
               ))
             ) : (
               <p className="agent-composer-model-empty">
-                {privateOnly && !query
-                  ? "No private models available."
+                {privateOnly
+                  ? query
+                    ? "No private models match your search."
+                    : "No private models available."
                   : "No models match your search."}
               </p>
             )}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -75,6 +75,7 @@ import {
 import { errorCode, messageFromError } from "../../lib/errors";
 import { NOTE_DND_MIME } from "../../lib/dnd";
 import { useDismiss } from "../../lib/use-dismiss";
+import { attachScrollThumbFade } from "../../lib/scroll-thumb-fade";
 import { useScrollFade } from "../../lib/use-scroll-fade";
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
 import { useRecordingPresenceBounds } from "../../lib/recording-presence-bounds";
@@ -1653,6 +1654,14 @@ function CommandPrompt({
 }) {
   const resultsRef = useRef<HTMLDivElement>(null);
   const fade = useScrollFade(resultsRef);
+  // Native-overlay scrollbar feel, same as the main content areas: the custom
+  // webkit thumb fades in on scroll/hover and back out when idle (see
+  // scroll-thumb-fade.ts and the --thumb-alpha rules in app.css).
+  useEffect(() => {
+    const el = resultsRef.current;
+    if (!el) return;
+    return attachScrollThumbFade(el);
+  }, []);
   // Re-measure the edge fades when the query or result groups change.
   useEffect(() => {
     fade.update();
@@ -1722,7 +1731,6 @@ function CommandPrompt({
     >
       <div className="command-prompt" role="dialog" aria-modal="true" aria-label="Search">
         <label className="command-prompt-search">
-          <IconMagnifyingGlass size={16} />
           <input
             ref={inputRef}
             type="text"

--- a/src/lib/model-privacy.ts
+++ b/src/lib/model-privacy.ts
@@ -120,8 +120,11 @@ export function modelPrivacyBadge(
 
 /** What the catalog's "Private" filter keeps: zero-retention or stronger.
  * E2EE models are also private, so they pass; anonymized models (prompts may
- * be retained) do not. */
+ * be retained) do not. A loopback local model never leaves the machine —
+ * stronger than any zero-retention claim — so it passes too (a non-loopback
+ * custom endpoint reports "external" and makes no claim). */
 export function modelIsPrivate(model: ModelPrivacySignals) {
+  if ((model.privacy ?? "").toLowerCase() === "local") return true;
   const flags = modelPrivacyFlags(model);
   return flags.e2ee || flags.private;
 }

--- a/src/lib/model-privacy.ts
+++ b/src/lib/model-privacy.ts
@@ -118,6 +118,14 @@ export function modelPrivacyBadge(
   return undefined;
 }
 
+/** What the catalog's "Private" filter keeps: zero-retention or stronger.
+ * E2EE models are also private, so they pass; anonymized models (prompts may
+ * be retained) do not. */
+export function modelIsPrivate(model: ModelPrivacySignals) {
+  const flags = modelPrivacyFlags(model);
+  return flags.e2ee || flags.private;
+}
+
 export function modelPrivacyFlags(model: ModelPrivacySignals): ModelPrivacyFlags {
   const privacy = (model.privacy ?? "").toLowerCase();
   const traits = model.traits.map((trait) => trait.toLowerCase());

--- a/src/lib/scroll-thumb-fade.ts
+++ b/src/lib/scroll-thumb-fade.ts
@@ -2,25 +2,35 @@
  * Recreates the native overlay scrollbar's show-while-scrolling behavior for
  * the custom webkit scrollbars on detail views (see the --thumb-alpha rules
  * in app.css). Scrollbar parts ignore CSS transitions, so the fade is driven
- * by stepping the --thumb-alpha custom property each frame. The helper also
- * toggles data-scrollbar-active so WebKit repaints the scrollbar part when the
- * pointer is over content rather than directly over the scrollbar gutter.
+ * by stepping the --thumb-alpha custom property each frame, and the paint is
+ * gated on data-scrollbar-active so WebKit reliably repaints the part.
  */
 
 /** Thumb opacity while scrolling, in color-mix percent of muted-foreground. */
 const VISIBLE_ALPHA = 30;
 /** Fade-in duration — quick, so the thumb tracks the first scroll tick. */
 const SHOW_MS = 100;
-/** Fade-out duration — a softer dissolve, like the native overlay. */
-const HIDE_MS = 450;
+/** Fade-out duration — quick, so the thumb gets out of the way. */
+const HIDE_MS = 200;
 /** How long after the last scroll event the thumb starts fading out. */
-const IDLE_MS = 800;
+const IDLE_MS = 400;
+
+export type ScrollThumbFadeOptions = {
+  /** Fade-out duration; defaults to the shared 200ms dissolve. */
+  hideMs?: number;
+  /** Idle delay before the fade-out starts; defaults to 400ms. */
+  idleMs?: number;
+};
 
 /**
  * Fade `el`'s scrollbar thumb in on scroll or pointer activity and back out
- * after a beat of idleness. Returns a cleanup function.
+ * after a beat of idleness. Returns a cleanup function. Callers with special
+ * pacing needs can override the fade-out timings.
  */
-export function attachScrollThumbFade(el: HTMLElement): () => void {
+export function attachScrollThumbFade(
+  el: HTMLElement,
+  { hideMs = HIDE_MS, idleMs = IDLE_MS }: ScrollThumbFadeOptions = {},
+): () => void {
   let alpha = 0;
   let target = 0;
   let rate = 0; // alpha units per ms
@@ -55,15 +65,33 @@ export function attachScrollThumbFade(el: HTMLElement): () => void {
     }
   };
 
+  // While the pointer rests over the scroller the thumb holds steady —
+  // arming the idle fade-out under a hovering pointer would blink the thumb
+  // in and out on every stray hand movement. The idle timer only runs for
+  // non-hover activity (keyboard-driven scrolls, focus moves).
+  let hovering = false;
+
   const show = () => {
     animateTo(VISIBLE_ALPHA, SHOW_MS);
     window.clearTimeout(idleTimer);
-    idleTimer = window.setTimeout(() => animateTo(0, HIDE_MS), IDLE_MS);
+    if (!hovering) {
+      idleTimer = window.setTimeout(() => animateTo(0, hideMs), idleMs);
+    }
   };
 
   const hide = () => {
     window.clearTimeout(idleTimer);
-    animateTo(0, HIDE_MS);
+    animateTo(0, hideMs);
+  };
+
+  const enter = () => {
+    hovering = true;
+    show();
+  };
+
+  const leave = () => {
+    hovering = false;
+    hide();
   };
 
   const activityOptions = { passive: true, capture: true };
@@ -71,24 +99,20 @@ export function attachScrollThumbFade(el: HTMLElement): () => void {
   el.addEventListener("scroll", show, { passive: true });
   el.addEventListener("wheel", show, activityOptions);
   el.addEventListener("touchmove", show, activityOptions);
-  el.addEventListener("pointerenter", show, { passive: true });
-  el.addEventListener("pointermove", show, activityOptions);
-  el.addEventListener("mouseenter", show, { passive: true });
-  el.addEventListener("mousemove", show, activityOptions);
-  el.addEventListener("pointerleave", hide, { passive: true });
-  el.addEventListener("mouseleave", hide, { passive: true });
+  el.addEventListener("pointerenter", enter, { passive: true });
+  el.addEventListener("mouseenter", enter, { passive: true });
+  el.addEventListener("pointerleave", leave, { passive: true });
+  el.addEventListener("mouseleave", leave, { passive: true });
   el.addEventListener("focusin", show);
   el.addEventListener("focusout", hide);
   return () => {
     el.removeEventListener("scroll", show);
     el.removeEventListener("wheel", show, activityOptions);
     el.removeEventListener("touchmove", show, activityOptions);
-    el.removeEventListener("pointerenter", show);
-    el.removeEventListener("pointermove", show, activityOptions);
-    el.removeEventListener("mouseenter", show);
-    el.removeEventListener("mousemove", show, activityOptions);
-    el.removeEventListener("pointerleave", hide);
-    el.removeEventListener("mouseleave", hide);
+    el.removeEventListener("pointerenter", enter);
+    el.removeEventListener("mouseenter", enter);
+    el.removeEventListener("pointerleave", leave);
+    el.removeEventListener("mouseleave", leave);
     el.removeEventListener("focusin", show);
     el.removeEventListener("focusout", hide);
     window.clearTimeout(idleTimer);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5951,40 +5951,23 @@ input:focus-visible,
 }
 
 .agent-composer-model-all-panel .agent-composer-model-surface {
-  /* Tight: rows fade out right under the search field, no blank band. */
-  gap: var(--sp-2);
+  /* Tight: the search and filter rows sit flush; the filter's full-bleed
+   * hairline (below) does the separating, not whitespace. */
+  gap: 0;
   width: min(280px, calc(100vw - 48px));
   max-height: inherit;
   padding: var(--sp-1);
 }
 
 .agent-composer-model-search {
-  display: grid;
-  grid-template-columns: 14px minmax(0, 1fr);
+  display: flex;
   align-items: center;
-  gap: var(--sp-2);
   flex: 0 0 auto;
-  height: var(--control-lg);
-  /* Inset the field from the popover edges so the focus ring has breathing
-   * room (sp-2 margin clears the 4px ring off the edge), and keep the
-   * icon+placeholder gutter aligned with the row names below (row content
-   * starts at the row's own sp-2 padding). */
-  margin: var(--sp-1) var(--sp-2) 0;
-  padding: 0 calc(var(--sp-2) - 2px);
-  border-radius: var(--r-md);
-  background: var(--card);
+  height: var(--control-md);
+  /* Bare inline input, matching the command prompt: no icon, no boxed
+   * container — sp-2 padding lines the caret up with the rows below. */
+  padding: 0 var(--sp-2);
   color: var(--muted-foreground);
-  box-shadow: inset 0 0 0 1px var(--popover-border);
-  transition:
-    box-shadow var(--t-fast) var(--ease-out),
-    background-color var(--t-fast) var(--ease-out);
-}
-
-.agent-composer-model-search:focus-within {
-  background: var(--popover);
-  box-shadow:
-    0 0 0 1px var(--ring),
-    0 0 0 4px var(--focus-ring);
 }
 
 .agent-composer-model-search input {
@@ -6001,6 +5984,27 @@ input:focus-visible,
   color: var(--muted-foreground);
 }
 
+/* The "Private" catalog filter: a quiet label + switch row between the search
+ * input and the list, on the rows' own padding so everything lines up. The
+ * barely-there hairline under it splits the search + filter block from the
+ * model list (Cursor-style). */
+.agent-composer-model-filter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  flex: 0 0 auto;
+  min-height: var(--control-md);
+  /* Bleed past the surface padding so the hairline runs the panel's full
+   * width; the widened padding keeps the label on the shared content gutter. */
+  margin: 0 calc(-1 * var(--sp-1));
+  padding: 0 calc(var(--sp-1) + var(--sp-2));
+  border-bottom: 1px solid color-mix(in oklch, var(--border-subtle) 50%, transparent);
+  color: var(--popover-foreground);
+  font-size: var(--fs-md);
+  line-height: 1.3;
+}
+
 /* Catalog list scroller. Fades come from the shared `.scroll-fade` primitive
  * (contained overlays, WKWebView-safe for this popover); only the fade size is
  * tuned here so rows melt into the popover surface at the boundary. */
@@ -6012,6 +6016,12 @@ input:focus-visible,
   min-height: 0;
   overflow: hidden;
   contain: paint;
+}
+
+/* In the all-models panel the surface stacks with no gap (the filter hairline
+ * separates instead), so the list carries its own breathing room. */
+.agent-composer-model-all-panel .agent-composer-model-list-wrap {
+  margin-top: var(--sp-1);
 }
 
 .agent-composer-model-list {
@@ -7553,14 +7563,14 @@ input:focus-visible,
 
 .command-prompt-search {
   display: grid;
-  grid-template-columns: 18px minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--sp-2);
   height: 44px;
-  padding: 0 14px;
-  /* Barely-there hairline: half the strength of --border-subtle, just enough
-   * to seat the search row without drawing a visible divider. */
-  border-bottom: 1px solid color-mix(in oklch, var(--border-subtle) 50%, transparent);
+  /* Bare input, Linear-style: no icon, no divider — the results' top
+   * scroll-fade melts rows out underneath this row instead. 17px lines the
+   * caret up with the group titles below (8px results + 9px title padding). */
+  padding: 0 17px;
   color: var(--muted-foreground);
 }
 
@@ -7615,7 +7625,13 @@ input:focus-visible,
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
-  padding: 8px;
+  /* Top edge tucks the first group up under the search row (the group title's
+   * own 5px top padding provides the rest of the gap). */
+  padding: 2px 8px 8px;
+  /* Opt out of the global standard scrollbar props so the app's quiet 4px
+   * hover-reveal webkit scrollbar engages here (same move as .agent-scroll). */
+  scrollbar-width: auto;
+  scrollbar-color: auto;
 }
 
 .command-prompt-group + .command-prompt-group {
@@ -7625,7 +7641,7 @@ input:focus-visible,
 .command-prompt-group-title {
   padding: 5px 9px 7px;
   color: var(--muted-foreground);
-  font-size: var(--fs-xs);
+  font-size: var(--fs-sm);
   font-weight: var(--fw-medium);
 }
 
@@ -16626,6 +16642,7 @@ input:focus-visible,
  * inset 2px from the card edge and the content alike. */
 .agent-scroll::-webkit-scrollbar,
 .note-detail-scroll::-webkit-scrollbar,
+.command-prompt-results::-webkit-scrollbar,
 .main-panel-body[data-detail-scroller="true"]::-webkit-scrollbar {
   width: var(--scrollbar-w);
   background: transparent;
@@ -16633,6 +16650,7 @@ input:focus-visible,
 
 .agent-scroll::-webkit-scrollbar-thumb,
 .note-detail-scroll::-webkit-scrollbar-thumb,
+.command-prompt-results::-webkit-scrollbar-thumb,
 .main-panel-body[data-detail-scroller="true"]::-webkit-scrollbar-thumb {
   border: 2px solid transparent;
   background: transparent;
@@ -16641,6 +16659,7 @@ input:focus-visible,
 
 .agent-scroll[data-scrollbar-active="true"]::-webkit-scrollbar-thumb,
 .note-detail-scroll[data-scrollbar-active="true"]::-webkit-scrollbar-thumb,
+.command-prompt-results[data-scrollbar-active="true"]::-webkit-scrollbar-thumb,
 .main-panel-body[data-detail-scroller="true"][data-scrollbar-active="true"]::-webkit-scrollbar-thumb {
   background: color-mix(
     in oklch,
@@ -16652,6 +16671,7 @@ input:focus-visible,
 
 .agent-scroll::-webkit-scrollbar-thumb:hover,
 .note-detail-scroll::-webkit-scrollbar-thumb:hover,
+.command-prompt-results::-webkit-scrollbar-thumb:hover,
 .main-panel-body[data-detail-scroller="true"]::-webkit-scrollbar-thumb:hover {
   background: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
   background-clip: padding-box;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5967,7 +5967,15 @@ input:focus-visible,
   /* Bare inline input, matching the command prompt: no icon, no boxed
    * container — sp-2 padding lines the caret up with the rows below. */
   padding: 0 var(--sp-2);
+  border-radius: var(--r-sm);
   color: var(--muted-foreground);
+}
+
+/* The input suppresses the default outline, so the row itself must carry a
+ * visible focus state for keyboard users: the same quiet wash the app's menus
+ * use for their active row, rather than boxing the field back in. */
+.agent-composer-model-search:focus-within {
+  background: color-mix(in oklch, var(--muted) 50%, transparent);
 }
 
 .agent-composer-model-search input {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5973,9 +5973,14 @@ input:focus-visible,
 
 /* The input suppresses the default outline, so the row itself must carry a
  * visible focus state for keyboard users: the same quiet wash the app's menus
- * use for their active row, rather than boxing the field back in. */
+ * use for their active row, rather than boxing the field back in. The outline
+ * is transparent in normal themes but forced-colors mode repaints outline
+ * colors, so high-contrast users still get a drawn ring where the background
+ * wash would be flattened away. */
 .agent-composer-model-search:focus-within {
   background: color-mix(in oklch, var(--muted) 50%, transparent);
+  outline: 2px solid transparent;
+  outline-offset: -2px;
 }
 
 .agent-composer-model-search input {

--- a/src/test/model-privacy.test.ts
+++ b/src/test/model-privacy.test.ts
@@ -3,6 +3,7 @@ import {
   ANONYMOUS_MODEL_DESCRIPTION,
   E2EE_MODEL_DESCRIPTION,
   PRIVATE_MODEL_DESCRIPTION,
+  modelIsPrivate,
   modelPrivacyBadge,
   modelSupportsImageInput,
 } from "../lib/model-privacy";
@@ -53,6 +54,23 @@ describe("model privacy labels", () => {
 
   it("does not label models without a privacy signal", () => {
     expect(modelPrivacyBadge({ privacy: "OpenAI", traits: ["prompt"] })).toBe(undefined);
+  });
+});
+
+describe("private catalog filter", () => {
+  it("keeps zero-retention-or-stronger models: private, e2ee, and loopback local", () => {
+    expect(modelIsPrivate({ privacy: "private", traits: [] })).toBe(true);
+    expect(modelIsPrivate({ privacy: "", traits: ["e2ee"] })).toBe(true);
+    // A loopback local model never leaves the machine — stronger than any
+    // provider retention claim, so the filter must not hide it.
+    expect(modelIsPrivate({ privacy: "local", traits: [] })).toBe(true);
+  });
+
+  it("drops anonymized models and custom endpoints that make no claim", () => {
+    expect(modelIsPrivate({ privacy: "anonymized", traits: [] })).toBe(false);
+    // A non-loopback custom endpoint reports "external" — no privacy claim.
+    expect(modelIsPrivate({ privacy: "external", traits: [] })).toBe(false);
+    expect(modelIsPrivate({ privacy: "", traits: [] })).toBe(false);
   });
 });
 

--- a/src/test/scroll-thumb-fade.test.ts
+++ b/src/test/scroll-thumb-fade.test.ts
@@ -77,23 +77,39 @@ describe("attachScrollThumbFade", () => {
     expect(alpha()).toBe(0);
   });
 
-  it("fades the thumb in on pointer movement and back out after idle", () => {
+  it("reveals the thumb on hover and holds it until the pointer leaves", () => {
     detach = attachScrollThumbFade(el);
 
-    el.dispatchEvent(new Event("pointermove"));
+    el.dispatchEvent(new Event("pointerenter"));
     expect(isActive()).toBe(true);
-    frame(50);
-    expect(alpha()).toBeGreaterThan(0);
-    expect(alpha()).toBeLessThan(30);
     while (frame(200));
     expect(alpha()).toBe(30);
 
-    vi.advanceTimersByTime(800);
-    while (frame(2000));
+    vi.advanceTimersByTime(5000); // no idle fade-out while the pointer rests
+    while (frame(6000));
+    expect(alpha()).toBe(30);
+
+    el.dispatchEvent(new Event("pointerleave"));
+    while (frame(10000));
     expect(alpha()).toBe(0);
+    expect(isActive()).toBe(false);
   });
 
-  it("treats wheel and mouse movement as scrollbar activity", () => {
+  it("does not re-arm the idle fade when scrolling while hovering", () => {
+    detach = attachScrollThumbFade(el);
+
+    el.dispatchEvent(new Event("pointerenter"));
+    el.dispatchEvent(new Event("scroll"));
+    while (frame(200));
+    expect(alpha()).toBe(30);
+
+    vi.advanceTimersByTime(5000);
+    while (frame(6000));
+    expect(alpha()).toBe(30);
+    expect(isActive()).toBe(true);
+  });
+
+  it("treats wheel as scrollbar activity", () => {
     detach = attachScrollThumbFade(el);
 
     el.dispatchEvent(new WheelEvent("wheel"));
@@ -101,13 +117,29 @@ describe("attachScrollThumbFade", () => {
     while (frame(200));
     expect(alpha()).toBe(30);
 
-    vi.advanceTimersByTime(500);
-    el.dispatchEvent(new MouseEvent("mousemove"));
-    vi.advanceTimersByTime(500);
+    vi.advanceTimersByTime(300);
+    el.dispatchEvent(new WheelEvent("wheel"));
+    vi.advanceTimersByTime(300);
     expect(isActive()).toBe(true);
     expect(alpha()).toBe(30);
 
     vi.advanceTimersByTime(300);
+    while (frame(5000));
+    expect(alpha()).toBe(0);
+    expect(isActive()).toBe(false);
+  });
+
+  it("honors custom idle and hide timings", () => {
+    detach = attachScrollThumbFade(el, { idleMs: 1000, hideMs: 500 });
+
+    el.dispatchEvent(new Event("scroll"));
+    while (frame(200));
+    expect(alpha()).toBe(30);
+
+    vi.advanceTimersByTime(999); // default 400ms idle would already have fired
+    frame(1500); // pump a frame: nothing should be animating yet
+    expect(alpha()).toBe(30);
+    vi.advanceTimersByTime(1); // custom idle delay elapses → fade-out starts
     while (frame(5000));
     expect(alpha()).toBe(0);
     expect(isActive()).toBe(false);


### PR DESCRIPTION
## Summary

- Command prompt: search input sits bare at the top (no icon, no divider); results scroll up under it through the shared scroll fade. Group titles bumped to `--fs-sm`, results padding tightened, and the results scroller now uses the app's hover scrollbar.
- Model pickers (composer and settings share these classes, so text/image/video all get it): catalog search is a bare inline input, plus a new **Private** filter row using the app `Switch` that narrows the list to zero-retention-or-stronger models (new `modelIsPrivate` helper - E2EE qualifies, anonymized does not). A full-width hairline under the filter separates the search block from the list. Filter state is popover-local on purpose so a stale filter can't silently hide models on the next open. Suggested-models title now reads "Suggested".
- Scroll thumb fade (shared helper, app-wide): faster timings (400ms idle, 200ms dissolve, per-caller overridable), and hovering a scroller now reveals the thumb and holds it steady until the pointer leaves.

## Root cause

The scrollbar "double flash" on hover: the fade helper treated pointer enter/move as scroll activity, so it armed the idle fade-out under a resting pointer - the thumb blinked in, faded out at the idle deadline, then re-flashed on the next tiny hand movement. Hover now pins the thumb visible; the idle fade only arms for non-hover activity (keyboard-driven scrolls, focus moves).

## Validation

- `pnpm typecheck`, Biome (no new diagnostics), and the related vitest suites (agent-workspace, app-settings, folders-workspace, scroll-thumb-fade) all pass; added tests for the custom fade timings, hover-hold behavior, and hover-scroll interaction.

- [x] Tested visually where it matters (verified in the running app by @andrewwashuta).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Persisting the Private filter across picker opens (deliberately session-transient).
- The settings pickers' greyed-out listing of non-selectable models (unchanged).

## Followups

- None planned; the fade reveal triggers are one listener block in `scroll-thumb-fade.ts` if pacing needs another tuning round.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. <!-- none -->
- [x] Workflow action references are pinned to full-length commit SHAs. <!-- no workflow changes -->
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. <!-- none -->
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. <!-- none -->
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786238660&installation_id=144203540&pr_number=686&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F686&signature=bc100b4f5a60c2d52bba3b5cc1e4f44395162fd2445aeae1413d4fca2f47cbb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->