### PR TITLE
Extend os-platform skill with issue write commands, UA override, full bodies (JUN-250)

### DIFF
--- a/.agents/skills/os-platform/SKILL.md
+++ b/.agents/skills/os-platform/SKILL.md
@@ -22,7 +22,7 @@ python3 scripts/os_platform.py issues assign open-software 123
 python3 scripts/os_platform.py issues status open-software 123 in_review
 python3 scripts/os_platform.py issues take open-software 123 --yes
 python3 scripts/os_platform.py files upload ./evidence.mp4 --purpose attachment
-python3 scripts/os_platform.py issues attach open-software 123 --path ./evidence.mp4
+python3 scripts/os_platform.py issues attach open-software 123 --path ./evidence.mp4 --public
 python3 scripts/os_platform.py comments add open-software 123 --body "Opened PR #456."
 ```
 
@@ -52,7 +52,7 @@ Use the user prompt first, then `os-platform.json`, then ask the user for missin
 - Keeping an owned Issue current: use `issues status <org> <number> <status>` with `proposed`, `todo`, `in_progress`, `in_review`, `completed`, or `cancelled`. It refuses another user's Issue unless `--force` is deliberate; terminal `completed` and `cancelled` transitions require `--yes`.
 - Taking a todo Issue: after the user confirms they want to work on it, use `issues take <org> <number>`; use `--yes` only when confirmation already happened in chat or another trusted workflow.
 - Uploading a file: use `files upload <path>` for a private attachment, add `--public` only when public download access is intended, and use `--purpose attachment|avatar` when the default `attachment` is not appropriate.
-- Attaching a file to an Issue: use `issues attach <org> <number> --file-id <fil_xxx>`, or `--path <path>` to upload it privately as an attachment first. The command preserves all existing attachments.
+- Attaching a file to an Issue: the platform only attaches PUBLIC files (error 2015 otherwise, verified live). Use `issues attach <org> <number> --file-id <fil_xxx>` with a public upload, or `--path <path> --public` to upload-then-attach; `--public` is required with `--path` and acknowledges that anyone with the URL can download the file. The command preserves all existing attachments.
 - Adding an Issue comment: use `comments add <org> <number> --body <body>`.
 - Reading Issue submissions, activity, or comments: use the scoped command with `<org>` and `<issue-number>`.
 - Contributors: use `contributors list <org>` or `contributors show <org> <user-handle>`.

--- a/.agents/skills/os-platform/SKILL.md
+++ b/.agents/skills/os-platform/SKILL.md
@@ -17,11 +17,11 @@ python3 scripts/os_platform.py issues list open-software --q "wallet" --limit 10
 python3 scripts/os_platform.py issues list open-software --assignee me --status todo,in_progress
 python3 scripts/os_platform.py issues search open-software "wallet bug" --status todo
 python3 scripts/os_platform.py issues show open-software 123
-python3 scripts/os_platform.py issues create open-software --title "Fix wallet sync" --body "Issue details" --type bug --priority high
+python3 scripts/os_platform.py issues create open-software --title "Fix wallet sync" --body "Issue details" --type bug --priority urgent --idempotency-key issue-wallet-sync
 python3 scripts/os_platform.py issues assign open-software 123
 python3 scripts/os_platform.py issues status open-software 123 in_review
 python3 scripts/os_platform.py issues take open-software 123 --yes
-python3 scripts/os_platform.py comments add open-software 123 --body "Opened PR #456."
+python3 scripts/os_platform.py comments add open-software 123 --body "Opened PR #456." --idempotency-key issue-123-pr-comment
 ```
 
 Configuration:
@@ -45,11 +45,11 @@ Use the user prompt first, then `os-platform.json`, then ask the user for missin
 - Issue lists, filters, or work queues: use `issues list <org>` with the narrowest filters.
 - Issue searches by rough user phrasing: use `issues search <org> "<query>"` with narrow filters when useful.
 - A specific Issue/Bounty by number: use `issues show <org> <number>`.
-- Creating an Issue for new work: use `issues create <org> --title <title> --body <body>` with `--type` and `--priority` when known.
-- Assigning yourself after taking ownership: use `issues assign <org> <number>`; `--to me` is accepted but optional.
+- Creating an Issue for new work: use `issues create <org> --title <title> --body <body>` with `--type` and `--priority` when known. Known examples include types `feature`, `bug`, and `other`, and priorities `low`, `med`, `high`, and `urgent`; these are examples, not exhaustive enums, and the platform validates them.
+- Assigning yourself after taking ownership: use `issues assign <org> <number>`; `--to me` is accepted but optional. The command refuses to replace another assignee unless `--force` is passed deliberately.
 - Keeping an owned Issue current: use `issues status <org> <number> <status>` with `todo`, `in_progress`, `in_review`, `completed`, or `cancelled`.
 - Taking a todo Issue: after the user confirms they want to work on it, use `issues take <org> <number>`; use `--yes` only when confirmation already happened in chat or another trusted workflow.
-- Adding an Issue comment: use `comments add <org> <number> --body <body>`.
+- Adding an Issue comment: use `comments add <org> <number> --body <body>`; use the optional `--idempotency-key <key>` when a stable key is available before the first attempt.
 - Reading Issue submissions, activity, or comments: use the scoped command with `<org>` and `<issue-number>`.
 - Contributors: use `contributors list <org>` or `contributors show <org> <user-handle>`.
 
@@ -120,10 +120,11 @@ Common flags:
 
 Other writes:
 
-- `issues create` creates an Org-scoped Issue with a required title and body plus optional type and priority.
-- `issues assign` resolves the authenticated user through `GET /v1/users/me`, then assigns that user.
+- `issues create` creates an Org-scoped Issue with a required title and body plus optional type and priority. The metadata values pass through to platform validation; documented values are known examples, not exhaustive enums.
+- `issues assign` fetches the Issue and resolves the authenticated user before assigning. It is a no-op when already self-assigned, refuses another current assignee, and accepts `--force` for a deliberate replacement.
 - `issues status` accepts only `todo`, `in_progress`, `in_review`, `completed`, or `cancelled`.
 - `comments add` adds a Markdown comment to an Issue.
+- `issues create` and `comments add` accept `--idempotency-key <key>` and send it as the `Idempotency-Key` header. The script never generates a key.
 
 `scripts/install.sh` installs this skill into a local agent skills directory. It defaults to `~/.codex/skills`, supports `--dest`, `--source`, `--repo`, `--ref`, `--path`, and `--force`, and never stores credentials.
 
@@ -145,6 +146,7 @@ Other writes:
 ## Safety
 
 - Run write commands only when the user or a trusted workflow has established the intended platform mutation. Verify each write with a read before any fan-out.
+- The script does not retry writes internally. Re-running `issues create` or `comments add` after a timeout or other ambiguous failure can duplicate the write. A caller-provided idempotency key may prevent that only if the platform honors `Idempotency-Key`; platform support is unverified, so read before retrying instead of assuming the key was enforced.
 - Issue body edits remain append-only: fetch the full current body first, append, and never overwrite existing content. The script does not expose body editing.
 - Do not print or persist `OS_PLATFORM_API_KEY`.
 - Do not infer private data from missing public data. A 404 on private/member-only resources can mean hidden, missing, or inaccessible.

--- a/.agents/skills/os-platform/SKILL.md
+++ b/.agents/skills/os-platform/SKILL.md
@@ -17,11 +17,13 @@ python3 scripts/os_platform.py issues list open-software --q "wallet" --limit 10
 python3 scripts/os_platform.py issues list open-software --assignee me --status todo,in_progress
 python3 scripts/os_platform.py issues search open-software "wallet bug" --status todo
 python3 scripts/os_platform.py issues show open-software 123
-python3 scripts/os_platform.py issues create open-software --title "Fix wallet sync" --body "Issue details" --type bug --priority urgent --idempotency-key issue-wallet-sync
+python3 scripts/os_platform.py issues create open-software --title "Fix wallet sync" --body "Issue details" --type bug --priority urgent
 python3 scripts/os_platform.py issues assign open-software 123
 python3 scripts/os_platform.py issues status open-software 123 in_review
 python3 scripts/os_platform.py issues take open-software 123 --yes
-python3 scripts/os_platform.py comments add open-software 123 --body "Opened PR #456." --idempotency-key issue-123-pr-comment
+python3 scripts/os_platform.py files upload ./evidence.mp4 --purpose attachment
+python3 scripts/os_platform.py issues attach open-software 123 --path ./evidence.mp4
+python3 scripts/os_platform.py comments add open-software 123 --body "Opened PR #456."
 ```
 
 Configuration:
@@ -36,7 +38,7 @@ Configuration:
 
 ## Routing Rules
 
-The script is deterministic. Read commands do not mutate platform state. Write commands create Issues, assign the authenticated user, update status, or add comments. `issues take` remains the confirmed shortcut that moves a `todo` Issue to `in_progress`; if the Issue has no assignee, it first assigns it to the authenticated API user. Do not rely on the script to decide user intent. Route the request before calling it, and verify writes with a read.
+The script is deterministic. Read commands do not mutate platform state. Write commands create Issues, assign the authenticated user, update status, add comments, upload files, or attach uploaded files. `issues take` remains the confirmed shortcut that moves a `todo` Issue to `in_progress`; if the Issue has no assignee, it first assigns it to the authenticated API user. Do not rely on the script to decide user intent. Route the request before calling it, and verify writes with a read.
 
 Use the user prompt first, then `os-platform.json`, then ask the user for missing required parameters. Do not guess an org, issue number, project, or contributor when the prompt and config do not provide one.
 
@@ -45,11 +47,13 @@ Use the user prompt first, then `os-platform.json`, then ask the user for missin
 - Issue lists, filters, or work queues: use `issues list <org>` with the narrowest filters.
 - Issue searches by rough user phrasing: use `issues search <org> "<query>"` with narrow filters when useful.
 - A specific Issue/Bounty by number: use `issues show <org> <number>`.
-- Creating an Issue for new work: use `issues create <org> --title <title> --body <body>` with `--type` and `--priority` when known. Known examples include types `feature`, `bug`, and `other`, and priorities `low`, `med`, `high`, and `urgent`; these are examples, not exhaustive enums, and the platform validates them.
-- Assigning yourself after taking ownership: use `issues assign <org> <number>`; `--to me` is accepted but optional. The command refuses to replace another assignee unless `--force` is passed deliberately.
-- Keeping an owned Issue current: use `issues status <org> <number> <status>` with `todo`, `in_progress`, `in_review`, `completed`, or `cancelled`.
+- Creating an Issue for new work: use `issues create <org> --title <title> --body <body>` with `--type` and `--priority` when known. Contract types are `feature`, `bug`, `improvement`, `design`, `docs`, `refactor`, and `other`; priorities are `none`, `low`, `med`, `high`, and `urgent`. The CLI passes both values through for platform validation.
+- Assigning yourself on an Issue you already own: use `issues assign <org> <number>`; `--to me` is accepted but optional. The command refuses to replace another assignee unless `--force` is passed deliberately, then re-reads the Issue to catch a concurrent assignment race.
+- Keeping an owned Issue current: use `issues status <org> <number> <status>` with `proposed`, `todo`, `in_progress`, `in_review`, `completed`, or `cancelled`. It refuses another user's Issue unless `--force` is deliberate; terminal `completed` and `cancelled` transitions require `--yes`.
 - Taking a todo Issue: after the user confirms they want to work on it, use `issues take <org> <number>`; use `--yes` only when confirmation already happened in chat or another trusted workflow.
-- Adding an Issue comment: use `comments add <org> <number> --body <body>`; use the optional `--idempotency-key <key>` when a stable key is available before the first attempt.
+- Uploading a file: use `files upload <path>` for a private attachment, add `--public` only when public download access is intended, and use `--purpose attachment|avatar` when the default `attachment` is not appropriate.
+- Attaching a file to an Issue: use `issues attach <org> <number> --file-id <fil_xxx>`, or `--path <path>` to upload it privately as an attachment first. The command preserves all existing attachments.
+- Adding an Issue comment: use `comments add <org> <number> --body <body>`.
 - Reading Issue submissions, activity, or comments: use the scoped command with `<org>` and `<issue-number>`.
 - Contributors: use `contributors list <org>` or `contributors show <org> <user-handle>`.
 
@@ -63,7 +67,9 @@ Use the platform as the source of truth for tracked work whenever it is availabl
 
 - For a pre-existing Issue, read it before starting, assign yourself when you take ownership, and move it to `in_progress`.
 - For an ad hoc request with no Issue, create one first, then assign yourself and move it to `in_progress`.
+- Route taking ownership through `issues take`; its `todo` check and confirmation discipline are authoritative. Use separate `issues assign` and `issues status` commands only for Issues you already own.
 - Keep the Issue current while work advances: use `in_review` when the PR opens, `completed` after it merges, and `cancelled` when the work is deliberately abandoned or will not be done.
+- Reference the Issue id in the PR, for example `JUN-123` or a `Closes JUN-123` line. The Org's GitHub `pr-links` webhook integration creates the platform PR link automatically; there is no CLI PR-link write command. If the integration does not link it, add the PR URL with `comments add`.
 - Add comments for durable progress or handoff context when useful. Do not replace or rewrite the Issue body to record progress.
 - Read the Issue after each write to verify the platform applied it. A write response alone is not durable evidence.
 
@@ -79,7 +85,7 @@ When the user asks about a specific issue, fetch the live issue first, then insp
 
 ## Available Script
 
-`scripts/os_platform.py` is an API helper for platform reads and controlled Issue workflow writes. It uses only Python standard library modules.
+`scripts/os_platform.py` is an API helper for platform reads and controlled Issue workflow writes. It uses only Python standard library modules; file uploads invoke `curl` for streaming multipart transfer.
 
 Core commands:
 
@@ -94,7 +100,9 @@ python3 scripts/os_platform.py issues show <org> <number>
 python3 scripts/os_platform.py issues create <org> --title <title> --body <body>
 python3 scripts/os_platform.py issues assign <org> <number>
 python3 scripts/os_platform.py issues status <org> <number> <status>
+python3 scripts/os_platform.py issues attach <org> <number> --file-id <fil_xxx>
 python3 scripts/os_platform.py issues take <org> <number>
+python3 scripts/os_platform.py files upload <path>
 python3 scripts/os_platform.py submissions list <org> <issue-number>
 python3 scripts/os_platform.py activity list <org> <issue-number>
 python3 scripts/os_platform.py comments list issue <org> <issue-number>
@@ -120,11 +128,12 @@ Common flags:
 
 Other writes:
 
-- `issues create` creates an Org-scoped Issue with a required title and body plus optional type and priority. The metadata values pass through to platform validation; documented values are known examples, not exhaustive enums.
-- `issues assign` fetches the Issue and resolves the authenticated user before assigning. It is a no-op when already self-assigned, refuses another current assignee, and accepts `--force` for a deliberate replacement.
-- `issues status` accepts only `todo`, `in_progress`, `in_review`, `completed`, or `cancelled`.
+- `issues create` creates an Org-scoped Issue with a required title and body plus optional contract type and priority values. The metadata flags remain pass-through values and do not use client-side choices.
+- `issues assign` fetches the Issue and resolves the authenticated user before assigning. `assignee_user_id` is the authoritative identity: a missing or empty value is unassigned, even if a sparse `assignee` display object exists. It is a no-op when already self-assigned, refuses another current assignee, and accepts `--force` for a deliberate replacement. After a PATCH, it re-reads and fails if another writer won the assignment race.
+- `issues status` fetches the Issue and authenticated user first, prints its external id, title, and current status, and accepts `proposed`, `todo`, `in_progress`, `in_review`, `completed`, or `cancelled`. It refuses another user's Issue unless `--force` is passed. `completed` and `cancelled` require `--yes`; without it, the command prints what would change and exits without writing.
+- `files upload` sends multipart `file`, `is_public`, and `purpose` fields to `POST /v1/files`; purpose is `attachment` or `avatar` and defaults to `attachment`.
+- `issues attach` reads the Issue's existing `files[].id` values and sends the complete list plus the new id as `file_ids` through the Issue PATCH. `--path` uploads first with private attachment defaults.
 - `comments add` adds a Markdown comment to an Issue.
-- `issues create` and `comments add` accept `--idempotency-key <key>` and send it as the `Idempotency-Key` header. The script never generates a key.
 
 `scripts/install.sh` installs this skill into a local agent skills directory. It defaults to `~/.codex/skills`, supports `--dest`, `--source`, `--repo`, `--ref`, `--path`, and `--force`, and never stores credentials.
 
@@ -146,7 +155,7 @@ Other writes:
 ## Safety
 
 - Run write commands only when the user or a trusted workflow has established the intended platform mutation. Verify each write with a read before any fan-out.
-- The script does not retry writes internally. Re-running `issues create` or `comments add` after a timeout or other ambiguous failure can duplicate the write. A caller-provided idempotency key may prevent that only if the platform honors `Idempotency-Key`; platform support is unverified, so read before retrying instead of assuming the key was enforced.
+- The script does not retry writes internally. The platform contract has no idempotency support, so re-running `issues create` or `comments add` after a timeout or other ambiguous failure can duplicate the write. Read before retrying.
 - Issue body edits remain append-only: fetch the full current body first, append, and never overwrite existing content. The script does not expose body editing.
 - Do not print or persist `OS_PLATFORM_API_KEY`.
 - Do not infer private data from missing public data. A 404 on private/member-only resources can mean hidden, missing, or inaccessible.

--- a/.agents/skills/os-platform/SKILL.md
+++ b/.agents/skills/os-platform/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: os-platform
-description: Query live Open Software os-platform production data through the platform API. Use when an agent needs current Issues/Bounties, Orgs, Projects, Submissions, Comments, Activity, Contributors, or API status instead of inspecting repo files, fixtures, screenshots, or stale docs.
+description: Query and update live Open Software os-platform production data through the platform API. Use when an agent needs current Issues/Bounties, Orgs, Projects, Submissions, Comments, Activity, Contributors, or API status, or needs to create, assign, move, or comment on tracked work.
 ---
 
 # os-platform
 
-Use this skill when the user asks about current Open Software / os-platform state: Issues, Bounties, Projects, Orgs, Submissions, Comments, Activity, Contributors, or whether API endpoints are real-backed. Prefer the bundled script over reading code, seed data, frontend fixtures, or docs when the question is about production data.
+Use this skill when the user asks about current Open Software / os-platform state or an agent needs to keep tracked work current: Issues, Bounties, Projects, Orgs, Submissions, Comments, Activity, Contributors, or whether API endpoints are real-backed. Prefer the bundled script over reading code, seed data, frontend fixtures, or docs when the question is about production data.
 
 ## Quick Start
 
@@ -17,7 +17,11 @@ python3 scripts/os_platform.py issues list open-software --q "wallet" --limit 10
 python3 scripts/os_platform.py issues list open-software --assignee me --status todo,in_progress
 python3 scripts/os_platform.py issues search open-software "wallet bug" --status todo
 python3 scripts/os_platform.py issues show open-software 123
+python3 scripts/os_platform.py issues create open-software --title "Fix wallet sync" --body "Issue details" --type bug --priority high
+python3 scripts/os_platform.py issues assign open-software 123
+python3 scripts/os_platform.py issues status open-software 123 in_review
 python3 scripts/os_platform.py issues take open-software 123 --yes
+python3 scripts/os_platform.py comments add open-software 123 --body "Opened PR #456."
 ```
 
 Configuration:
@@ -25,13 +29,14 @@ Configuration:
 - The default API base URL is `https://app.opensoftware.co/api`.
 - `OS_PLATFORM_API_BASE_URL` can override the default unless `--base-url` is passed.
 - `OS_PLATFORM_API_KEY` is required unless `--api-key` is passed. The script sends it as `Authorization: Bearer ...`.
+- `OS_PLATFORM_USER_AGENT` can override the default `os-platform-cli/2.0 (+https://opensoftware.co)` User-Agent.
 - Optional project defaults can be stored in `os-platform.json` in the workspace root or a parent directory. Supported fields are `org` and `limit`; both are optional.
 - Never ask the user to paste an API key into chat. Ask them to set the environment variable in their shell or agent runtime.
 - The installer does not prompt for or write environment values. If the API key is missing, tell the user to set it first.
 
 ## Routing Rules
 
-The script is deterministic. Most commands are read-only; `issues take` is the only controlled write command and moves a `todo` Issue to `in_progress` after confirmation or `--yes`. If the Issue has no assignee, `issues take` first assigns it to the authenticated API user. Do not rely on the script to decide user intent. Route the request before calling it.
+The script is deterministic. Read commands do not mutate platform state. Write commands create Issues, assign the authenticated user, update status, or add comments. `issues take` remains the confirmed shortcut that moves a `todo` Issue to `in_progress`; if the Issue has no assignee, it first assigns it to the authenticated API user. Do not rely on the script to decide user intent. Route the request before calling it, and verify writes with a read.
 
 Use the user prompt first, then `os-platform.json`, then ask the user for missing required parameters. Do not guess an org, issue number, project, or contributor when the prompt and config do not provide one.
 
@@ -40,13 +45,27 @@ Use the user prompt first, then `os-platform.json`, then ask the user for missin
 - Issue lists, filters, or work queues: use `issues list <org>` with the narrowest filters.
 - Issue searches by rough user phrasing: use `issues search <org> "<query>"` with narrow filters when useful.
 - A specific Issue/Bounty by number: use `issues show <org> <number>`.
+- Creating an Issue for new work: use `issues create <org> --title <title> --body <body>` with `--type` and `--priority` when known.
+- Assigning yourself after taking ownership: use `issues assign <org> <number>`; `--to me` is accepted but optional.
+- Keeping an owned Issue current: use `issues status <org> <number> <status>` with `todo`, `in_progress`, `in_review`, `completed`, or `cancelled`.
 - Taking a todo Issue: after the user confirms they want to work on it, use `issues take <org> <number>`; use `--yes` only when confirmation already happened in chat or another trusted workflow.
-- Issue submissions, activity, or comments: use the scoped command with `<org>` and `<issue-number>`.
+- Adding an Issue comment: use `comments add <org> <number> --body <body>`.
+- Reading Issue submissions, activity, or comments: use the scoped command with `<org>` and `<issue-number>`.
 - Contributors: use `contributors list <org>` or `contributors show <org> <user-handle>`.
 
 If the user asks for issues and omits org, read `os-platform.json`; if it has `org`, use it. If no org is available, ask the user which org to use before running the script.
 
 When the user asks for their own tasks or issues assigned to them, pass `--assignee me` (the script resolves `me`/`@me` to the authenticated API user via `GET /v1/users/me`, so no handle lookup is needed). When the user asks for issues to work on generally, prioritize todo issues assigned to the user or with no assignee before other todo issues. If the user identity is unclear, prefer unassigned todo issues.
+
+## Agent status lifecycle
+
+Use the platform as the source of truth for tracked work whenever it is available.
+
+- For a pre-existing Issue, read it before starting, assign yourself when you take ownership, and move it to `in_progress`.
+- For an ad hoc request with no Issue, create one first, then assign yourself and move it to `in_progress`.
+- Keep the Issue current while work advances: use `in_review` when the PR opens, `completed` after it merges, and `cancelled` when the work is deliberately abandoned or will not be done.
+- Add comments for durable progress or handoff context when useful. Do not replace or rewrite the Issue body to record progress.
+- Read the Issue after each write to verify the platform applied it. A write response alone is not durable evidence.
 
 ## Specific Issue Triage
 
@@ -60,7 +79,7 @@ When the user asks about a specific issue, fetch the live issue first, then insp
 
 ## Available Script
 
-`scripts/os_platform.py` is primarily a read-only API helper, with one controlled write command for taking an Issue. It uses only Python standard library modules.
+`scripts/os_platform.py` is an API helper for platform reads and controlled Issue workflow writes. It uses only Python standard library modules.
 
 Core commands:
 
@@ -72,10 +91,14 @@ python3 scripts/os_platform.py project get <org> <project>
 python3 scripts/os_platform.py issues list <org>
 python3 scripts/os_platform.py issues search <org> "<query>"
 python3 scripts/os_platform.py issues show <org> <number>
+python3 scripts/os_platform.py issues create <org> --title <title> --body <body>
+python3 scripts/os_platform.py issues assign <org> <number>
+python3 scripts/os_platform.py issues status <org> <number> <status>
 python3 scripts/os_platform.py issues take <org> <number>
 python3 scripts/os_platform.py submissions list <org> <issue-number>
 python3 scripts/os_platform.py activity list <org> <issue-number>
 python3 scripts/os_platform.py comments list issue <org> <issue-number>
+python3 scripts/os_platform.py comments add <org> <issue-number> --body <body>
 python3 scripts/os_platform.py contributors list <org>
 python3 scripts/os_platform.py contributors show <org> <user-handle>
 python3 scripts/os_platform.py raw GET /v1/...
@@ -85,7 +108,7 @@ Common flags:
 
 - `--limit N` caps list output.
 - `--json` prints the unwrapped `data` payload.
-- `--full` prints the full unwrapped data without compact summarization.
+- `--full` prints the full unwrapped data without compact summarization. `issues show` always does this, so its `--full` flag is a backward-compatible no-op.
 - `--base-url URL` overrides `OS_PLATFORM_API_BASE_URL` and the default base URL.
 
 `issues take`:
@@ -95,6 +118,13 @@ Common flags:
 - Assigns the Issue to the authenticated API user first when the Issue has no assignee.
 - Prompts before moving the Issue to `in_progress`, unless `--yes` is passed.
 
+Other writes:
+
+- `issues create` creates an Org-scoped Issue with a required title and body plus optional type and priority.
+- `issues assign` resolves the authenticated user through `GET /v1/users/me`, then assigns that user.
+- `issues status` accepts only `todo`, `in_progress`, `in_review`, `completed`, or `cancelled`.
+- `comments add` adds a Markdown comment to an Issue.
+
 `scripts/install.sh` installs this skill into a local agent skills directory. It defaults to `~/.codex/skills`, supports `--dest`, `--source`, `--repo`, `--ref`, `--path`, and `--force`, and never stores credentials.
 
 ## Workflow
@@ -102,7 +132,7 @@ Common flags:
 1. Decide whether the question is about current production state. If yes, use this skill.
 2. If the target route is unclear, read `references/api-map.md`.
 3. Run the narrowest script command that answers the question.
-4. Use default compact output for summaries. Use `--json` or `--full` only when exact fields matter.
+4. Use default compact output for summaries. `issues show` always returns the full Issue; use `--json` or `--full` on other reads when exact fields matter.
 5. Cite the live API result in your answer, and mention if a route appears fixture-backed or unreachable.
 
 ## Language Rules
@@ -114,7 +144,8 @@ Common flags:
 
 ## Safety
 
-- The bundled API script is read-only except for `issues take`. Do not add more mutation commands unless the user explicitly asks for a new version of the skill.
+- Run write commands only when the user or a trusted workflow has established the intended platform mutation. Verify each write with a read before any fan-out.
+- Issue body edits remain append-only: fetch the full current body first, append, and never overwrite existing content. The script does not expose body editing.
 - Do not print or persist `OS_PLATFORM_API_KEY`.
 - Do not infer private data from missing public data. A 404 on private/member-only resources can mean hidden, missing, or inaccessible.
 - Treat production data as current at request time, not as a durable local fact.

--- a/.agents/skills/os-platform/references/api-map.md
+++ b/.agents/skills/os-platform/references/api-map.md
@@ -2,6 +2,10 @@
 
 Use this map when the command shape is unclear. All routes are prefixed by the configured API base URL. By default, the bundled helper uses `https://app.opensoftware.co/api`; `OS_PLATFORM_API_BASE_URL` and `--base-url` can override it.
 
+## Contract source
+
+The single source of truth for every write method, path, request shape, and enum below is `open-software-network/os-platform/api/openapi.json`. The relevant OpenAPI operations are `create_org_bounty`, `update_bounty`, `set_bounty_status`, `create_bounty_comment`, `upload_file`, and the `pr-links` webhook operations. Live probes are only for current authentication and permission behavior, not for discovering or changing request shapes.
+
 ## Authentication
 
 - All skill API calls require `OS_PLATFORM_API_KEY`, sent as `Authorization: Bearer ...`.
@@ -36,14 +40,16 @@ Use `real_paths` and `fixture_paths` from that response to decide whether a resu
 | `issues list <org>` | `GET /v1/orgs/{org}/bounties` |
 | `issues search <org> "<query>"` | `GET /v1/orgs/{org}/bounties`, then local relevance ranking |
 | `issues show <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}` |
-| `issues create <org> --title <title> --body <body>` | `POST /v1/orgs/{org}/bounties` with `{"title":"...","body_markdown":"..."}` plus optional `type` and `priority`; optional `--idempotency-key` sends `Idempotency-Key` |
-| `issues assign <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}`, then `GET /v1/users/me`; `PATCH /v1/orgs/{org}/bounties/{number}` with `{"assignee_user_id":"usr_xxx"}` only when unassigned or `--force` permits replacement |
-| `issues status <org> <number> <status>` | `POST /v1/orgs/{org}/bounties/{number}/status` with `{"status":"..."}` |
+| `issues create <org> --title <title> --body <body>` | `POST /v1/orgs/{org}/bounties` with `{"title":"...","body_markdown":"..."}` plus optional `type` and `priority` |
+| `issues assign <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}`, then `GET /v1/users/me`; `PATCH /v1/orgs/{org}/bounties/{number}` with `{"assignee_user_id":"usr_xxx"}` only when unassigned or `--force` permits replacement; then a verification GET |
+| `issues status <org> <number> <status>` | `GET /v1/orgs/{org}/bounties/{number}`, `GET /v1/users/me`, then guarded `POST /v1/orgs/{org}/bounties/{number}/status` with `{"status":"..."}` |
+| `issues attach <org> <number> --file-id <id>` | `GET /v1/orgs/{org}/bounties/{number}`, then `PATCH /v1/orgs/{org}/bounties/{number}` with the complete existing-plus-new `{"file_ids":[...]}` list |
 | `issues take <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}`; if unassigned, `GET /v1/users/me` and `PATCH /v1/orgs/{org}/bounties/{number}` with `{"assignee_user_id":"usr_xxx"}`; then `POST /v1/orgs/{org}/bounties/{number}/status` with `{"status":"in_progress"}` |
+| `files upload <path>` | Multipart `POST /v1/files` with `file`, `is_public`, and `purpose` fields |
 | `submissions list <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}/submissions` |
 | `activity list <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}/activity` |
 | `comments list issue <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}/comments` |
-| `comments add <org> <number> --body <body>` | `POST /v1/orgs/{org}/bounties/{number}/comments` with `{"body_markdown":"..."}`; optional `--idempotency-key` sends `Idempotency-Key` |
+| `comments add <org> <number> --body <body>` | `POST /v1/orgs/{org}/bounties/{number}/comments` with `{"body_markdown":"..."}` |
 | `contributors list <org>` | `GET /v1/orgs/{org}/contributors` |
 | `contributors show <org> <user>` | `GET /v1/orgs/{org}/contributors/{user}` |
 | `raw GET /v1/...` | Any read-only GET path |
@@ -73,11 +79,13 @@ python3 scripts/os_platform.py issues list open-software --status todo,in_progre
 python3 scripts/os_platform.py issues list open-software --assignee me --status todo,in_progress
 python3 scripts/os_platform.py issues list open-software --project os-forge --q "wallet"
 python3 scripts/os_platform.py issues search open-software "wallet bug" --status todo --assignee none
-python3 scripts/os_platform.py issues create open-software --title "Fix wallet sync" --body "Issue details" --type bug --priority urgent --idempotency-key issue-wallet-sync
+python3 scripts/os_platform.py issues create open-software --title "Fix wallet sync" --body "Issue details" --type bug --priority urgent
 python3 scripts/os_platform.py issues assign open-software 123
 python3 scripts/os_platform.py issues status open-software 123 in_review
 python3 scripts/os_platform.py issues take open-software 123 --yes
-python3 scripts/os_platform.py comments add open-software 123 --body "Opened PR #456." --idempotency-key issue-123-pr-comment
+python3 scripts/os_platform.py files upload ./evidence.mp4 --public --purpose attachment
+python3 scripts/os_platform.py issues attach open-software 123 --file-id fil_xxx
+python3 scripts/os_platform.py comments add open-software 123 --body "Opened PR #456."
 python3 scripts/os_platform.py issues list open-software --labels good-first-issue --sort status_grouped
 ```
 
@@ -90,7 +98,7 @@ POST /v1/orgs/{org}/bounties
 {"title":"...","body_markdown":"...","type":"bug","priority":"high"}
 ```
 
-`type` and `priority` are omitted when their flags are not provided. Known type examples include `feature`, `bug`, `improvement`, `design`, `docs`, `refactor`, and `other`; known priority examples include `low`, `med`, `high`, and `urgent`. These are examples, not exhaustive enums: create passes the values through and the platform is the validation source of truth.
+`type` and `priority` are omitted when their flags are not provided. The contract type enum is `feature`, `bug`, `improvement`, `design`, `docs`, `refactor`, `other`; the priority enum is `none`, `low`, `med`, `high`, `urgent`. Create keeps these flags as pass-through values without client-side choices, and the platform validates them.
 
 `issues assign <org> <number>` first reads the Issue through:
 
@@ -104,14 +112,16 @@ It then reads the authenticated API user through:
 GET /v1/users/me
 ```
 
-If the Issue is already assigned to that user, the command succeeds without a write. If another assignee owns it, the command refuses and names that assignee unless `--force` was passed. An unassigned Issue, or a deliberate forced replacement, assigns the authenticated user through:
+`IssueDto.assignee_user_id` is the authoritative ownership field. A missing or empty value means unassigned, even when a sparse `assignee` display object is present. If the Issue is already assigned to the current user's `public_id`, the command succeeds without a write. If another assignee owns it, the command refuses and names that assignee unless `--force` was passed. An unassigned Issue, or a deliberate forced replacement, assigns the authenticated user through:
 
 ```text
 PATCH /v1/orgs/{org}/bounties/{number}
 {"assignee_user_id":"usr_xxx"}
 ```
 
-`issues status <org> <number> <status>` accepts `todo`, `in_progress`, `in_review`, `completed`, or `cancelled` and sends:
+After the PATCH, the command re-reads the Issue and fails loudly unless `assignee_user_id` is still the current user's id. This detects a read-then-write race between concurrent agents.
+
+`issues status <org> <number> <status>` accepts the contract enum `proposed`, `todo`, `in_progress`, `in_review`, `completed`, or `cancelled`. It first reads the Issue, prints its external id, title, and current status to stderr, and resolves the current user through `GET /v1/users/me`. It refuses a foreign assignee unless `--force` is passed. Terminal transitions to `completed` or `cancelled` require `--yes`; otherwise it prints what would change and exits 1 without the POST. Allowed writes send:
 
 ```text
 POST /v1/orgs/{org}/bounties/{number}/status
@@ -125,7 +135,27 @@ POST /v1/orgs/{org}/bounties/{number}/comments
 {"body_markdown":"..."}
 ```
 
-`issues create` and `comments add` accept an optional `--idempotency-key <key>` and send it as an `Idempotency-Key` header. The script does not retry or generate keys. Re-running either command after an ambiguous failure can create a duplicate. Platform support for this header is unverified, so the key prevents duplication only if the platform honors it; read before retrying.
+The contract has no idempotency header or key. The script does not retry writes. Re-running create or comment after an ambiguous failure can create a duplicate, so read before retrying.
+
+`files upload <path> [--public] [--purpose attachment|avatar]` sends multipart form data through:
+
+```text
+POST /v1/files
+file=@<path>
+is_public=false
+purpose=attachment
+```
+
+`purpose` is the contract enum `attachment` or `avatar` and defaults to `attachment`; uploads are private unless `--public` is passed. The response is a `FileDto`; persist its opaque `id`, not its download URL.
+
+The contract has no attach endpoint. `issues attach <org> <number> --file-id <fil_xxx>` reads the Issue's ordered `files[].id` values, appends the new id, and sends the complete replacement list through:
+
+```text
+PATCH /v1/orgs/{org}/bounties/{number}
+{"file_ids":["fil_existing","fil_xxx"]}
+```
+
+It never replaces existing attachments with a bare one-element list. `--path <path>` runs a private `attachment` upload first and uses the returned id.
 
 `issues take <org> <number>` remains the confirmed shortcut for starting todo work. It fetches the Issue first and refuses non-`todo` Issues. When the Issue has no assignee, it reads the authenticated API user through:
 
@@ -146,6 +176,10 @@ Finally, it moves the Issue to `in_progress` through:
 POST /v1/orgs/{org}/bounties/{number}/status
 {"status":"in_progress"}
 ```
+
+## Pull request links
+
+There is no submission or PR-link create command in the contract. The Org's GitHub integration receives `POST /v1/webhooks/pr-links/github` and creates links when a PR references the Issue id, for example `JUN-123` or `Closes JUN-123`. Per-Issue PR-link routes are read/delete only. If the integration does not create the link, record the PR URL with `comments add`.
 
 ## Language
 

--- a/.agents/skills/os-platform/references/api-map.md
+++ b/.agents/skills/os-platform/references/api-map.md
@@ -36,14 +36,14 @@ Use `real_paths` and `fixture_paths` from that response to decide whether a resu
 | `issues list <org>` | `GET /v1/orgs/{org}/bounties` |
 | `issues search <org> "<query>"` | `GET /v1/orgs/{org}/bounties`, then local relevance ranking |
 | `issues show <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}` |
-| `issues create <org> --title <title> --body <body>` | `POST /v1/orgs/{org}/bounties` with `{"title":"...","body_markdown":"..."}` plus optional `type` and `priority` |
-| `issues assign <org> <number>` | `GET /v1/users/me`, then `PATCH /v1/orgs/{org}/bounties/{number}` with `{"assignee_user_id":"usr_xxx"}` |
+| `issues create <org> --title <title> --body <body>` | `POST /v1/orgs/{org}/bounties` with `{"title":"...","body_markdown":"..."}` plus optional `type` and `priority`; optional `--idempotency-key` sends `Idempotency-Key` |
+| `issues assign <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}`, then `GET /v1/users/me`; `PATCH /v1/orgs/{org}/bounties/{number}` with `{"assignee_user_id":"usr_xxx"}` only when unassigned or `--force` permits replacement |
 | `issues status <org> <number> <status>` | `POST /v1/orgs/{org}/bounties/{number}/status` with `{"status":"..."}` |
 | `issues take <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}`; if unassigned, `GET /v1/users/me` and `PATCH /v1/orgs/{org}/bounties/{number}` with `{"assignee_user_id":"usr_xxx"}`; then `POST /v1/orgs/{org}/bounties/{number}/status` with `{"status":"in_progress"}` |
 | `submissions list <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}/submissions` |
 | `activity list <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}/activity` |
 | `comments list issue <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}/comments` |
-| `comments add <org> <number> --body <body>` | `POST /v1/orgs/{org}/bounties/{number}/comments` with `{"body_markdown":"..."}` |
+| `comments add <org> <number> --body <body>` | `POST /v1/orgs/{org}/bounties/{number}/comments` with `{"body_markdown":"..."}`; optional `--idempotency-key` sends `Idempotency-Key` |
 | `contributors list <org>` | `GET /v1/orgs/{org}/contributors` |
 | `contributors show <org> <user>` | `GET /v1/orgs/{org}/contributors/{user}` |
 | `raw GET /v1/...` | Any read-only GET path |
@@ -73,11 +73,11 @@ python3 scripts/os_platform.py issues list open-software --status todo,in_progre
 python3 scripts/os_platform.py issues list open-software --assignee me --status todo,in_progress
 python3 scripts/os_platform.py issues list open-software --project os-forge --q "wallet"
 python3 scripts/os_platform.py issues search open-software "wallet bug" --status todo --assignee none
-python3 scripts/os_platform.py issues create open-software --title "Fix wallet sync" --body "Issue details" --type bug --priority high
+python3 scripts/os_platform.py issues create open-software --title "Fix wallet sync" --body "Issue details" --type bug --priority urgent --idempotency-key issue-wallet-sync
 python3 scripts/os_platform.py issues assign open-software 123
 python3 scripts/os_platform.py issues status open-software 123 in_review
 python3 scripts/os_platform.py issues take open-software 123 --yes
-python3 scripts/os_platform.py comments add open-software 123 --body "Opened PR #456."
+python3 scripts/os_platform.py comments add open-software 123 --body "Opened PR #456." --idempotency-key issue-123-pr-comment
 python3 scripts/os_platform.py issues list open-software --labels good-first-issue --sort status_grouped
 ```
 
@@ -90,15 +90,21 @@ POST /v1/orgs/{org}/bounties
 {"title":"...","body_markdown":"...","type":"bug","priority":"high"}
 ```
 
-`type` and `priority` are omitted when their flags are not provided.
+`type` and `priority` are omitted when their flags are not provided. Known type examples include `feature`, `bug`, `improvement`, `design`, `docs`, `refactor`, and `other`; known priority examples include `low`, `med`, `high`, and `urgent`. These are examples, not exhaustive enums: create passes the values through and the platform is the validation source of truth.
 
-`issues assign <org> <number>` reads the authenticated API user through:
+`issues assign <org> <number>` first reads the Issue through:
+
+```text
+GET /v1/orgs/{org}/bounties/{number}
+```
+
+It then reads the authenticated API user through:
 
 ```text
 GET /v1/users/me
 ```
 
-Then it assigns the Issue to that user through:
+If the Issue is already assigned to that user, the command succeeds without a write. If another assignee owns it, the command refuses and names that assignee unless `--force` was passed. An unassigned Issue, or a deliberate forced replacement, assigns the authenticated user through:
 
 ```text
 PATCH /v1/orgs/{org}/bounties/{number}
@@ -118,6 +124,8 @@ POST /v1/orgs/{org}/bounties/{number}/status
 POST /v1/orgs/{org}/bounties/{number}/comments
 {"body_markdown":"..."}
 ```
+
+`issues create` and `comments add` accept an optional `--idempotency-key <key>` and send it as an `Idempotency-Key` header. The script does not retry or generate keys. Re-running either command after an ambiguous failure can create a duplicate. Platform support for this header is unverified, so the key prevents duplication only if the platform honors it; read before retrying.
 
 `issues take <org> <number>` remains the confirmed shortcut for starting todo work. It fetches the Issue first and refuses non-`todo` Issues. When the Issue has no assignee, it reads the authenticated API user through:
 

--- a/.agents/skills/os-platform/references/api-map.md
+++ b/.agents/skills/os-platform/references/api-map.md
@@ -5,6 +5,7 @@ Use this map when the command shape is unclear. All routes are prefixed by the c
 ## Authentication
 
 - All skill API calls require `OS_PLATFORM_API_KEY`, sent as `Authorization: Bearer ...`.
+- Requests use `os-platform-cli/2.0 (+https://opensoftware.co)` as the default User-Agent. `OS_PLATFORM_USER_AGENT` overrides it.
 - A missing or malformed API key can produce `401`.
 - A `404` can mean missing, private, or inaccessible.
 
@@ -35,10 +36,14 @@ Use `real_paths` and `fixture_paths` from that response to decide whether a resu
 | `issues list <org>` | `GET /v1/orgs/{org}/bounties` |
 | `issues search <org> "<query>"` | `GET /v1/orgs/{org}/bounties`, then local relevance ranking |
 | `issues show <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}` |
+| `issues create <org> --title <title> --body <body>` | `POST /v1/orgs/{org}/bounties` with `{"title":"...","body_markdown":"..."}` plus optional `type` and `priority` |
+| `issues assign <org> <number>` | `GET /v1/users/me`, then `PATCH /v1/orgs/{org}/bounties/{number}` with `{"assignee_user_id":"usr_xxx"}` |
+| `issues status <org> <number> <status>` | `POST /v1/orgs/{org}/bounties/{number}/status` with `{"status":"..."}` |
 | `issues take <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}`; if unassigned, `GET /v1/users/me` and `PATCH /v1/orgs/{org}/bounties/{number}` with `{"assignee_user_id":"usr_xxx"}`; then `POST /v1/orgs/{org}/bounties/{number}/status` with `{"status":"in_progress"}` |
 | `submissions list <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}/submissions` |
 | `activity list <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}/activity` |
 | `comments list issue <org> <number>` | `GET /v1/orgs/{org}/bounties/{number}/comments` |
+| `comments add <org> <number> --body <body>` | `POST /v1/orgs/{org}/bounties/{number}/comments` with `{"body_markdown":"..."}` |
 | `contributors list <org>` | `GET /v1/orgs/{org}/contributors` |
 | `contributors show <org> <user>` | `GET /v1/orgs/{org}/contributors/{user}` |
 | `raw GET /v1/...` | Any read-only GET path |
@@ -68,13 +73,53 @@ python3 scripts/os_platform.py issues list open-software --status todo,in_progre
 python3 scripts/os_platform.py issues list open-software --assignee me --status todo,in_progress
 python3 scripts/os_platform.py issues list open-software --project os-forge --q "wallet"
 python3 scripts/os_platform.py issues search open-software "wallet bug" --status todo --assignee none
+python3 scripts/os_platform.py issues create open-software --title "Fix wallet sync" --body "Issue details" --type bug --priority high
+python3 scripts/os_platform.py issues assign open-software 123
+python3 scripts/os_platform.py issues status open-software 123 in_review
 python3 scripts/os_platform.py issues take open-software 123 --yes
+python3 scripts/os_platform.py comments add open-software 123 --body "Opened PR #456."
 python3 scripts/os_platform.py issues list open-software --labels good-first-issue --sort status_grouped
 ```
 
-## Controlled Issue write
+## Controlled Issue writes
 
-`issues take <org> <number>` is the only write command. It fetches the Issue first and refuses non-`todo` Issues. When the Issue has no assignee, it reads the authenticated API user through:
+`issues create <org> --title <title> --body <body>` creates an Org-scoped Issue through:
+
+```text
+POST /v1/orgs/{org}/bounties
+{"title":"...","body_markdown":"...","type":"bug","priority":"high"}
+```
+
+`type` and `priority` are omitted when their flags are not provided.
+
+`issues assign <org> <number>` reads the authenticated API user through:
+
+```text
+GET /v1/users/me
+```
+
+Then it assigns the Issue to that user through:
+
+```text
+PATCH /v1/orgs/{org}/bounties/{number}
+{"assignee_user_id":"usr_xxx"}
+```
+
+`issues status <org> <number> <status>` accepts `todo`, `in_progress`, `in_review`, `completed`, or `cancelled` and sends:
+
+```text
+POST /v1/orgs/{org}/bounties/{number}/status
+{"status":"in_review"}
+```
+
+`comments add <org> <number> --body <body>` sends:
+
+```text
+POST /v1/orgs/{org}/bounties/{number}/comments
+{"body_markdown":"..."}
+```
+
+`issues take <org> <number>` remains the confirmed shortcut for starting todo work. It fetches the Issue first and refuses non-`todo` Issues. When the Issue has no assignee, it reads the authenticated API user through:
 
 ```text
 GET /v1/users/me

--- a/.agents/skills/os-platform/scripts/os_platform.py
+++ b/.agents/skills/os-platform/scripts/os_platform.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import mimetypes
 import os
 import pathlib
 import re
+import subprocess
 import sys
 import textwrap
 import urllib.error
@@ -28,7 +30,9 @@ USER_AGENT = os.environ.get("OS_PLATFORM_USER_AGENT") or (
 )
 WORD_RE = re.compile(r"[a-z0-9]+")
 ME_TOKENS = {"me", "@me"}
-ISSUE_STATUSES = ("todo", "in_progress", "in_review", "completed", "cancelled")
+ISSUE_STATUSES = ("proposed", "todo", "in_progress", "in_review", "completed", "cancelled")
+TERMINAL_ISSUE_STATUSES = {"completed", "cancelled"}
+FILE_PURPOSES = ("attachment", "avatar")
 
 COMPACT_KEYS = {
     "id",
@@ -570,14 +574,17 @@ def leaf_parser(subparsers: argparse._SubParsersAction, name: str, **kwargs: Any
 
 def add_issue_filters(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--project", help="CSV of project handles/public ids, or none.")
-    parser.add_argument("--status", help="CSV statuses: todo,in_progress,in_review,completed,cancelled.")
+    parser.add_argument(
+        "--status",
+        help="CSV statuses: proposed,todo,in_progress,in_review,completed,cancelled.",
+    )
     parser.add_argument(
         "--type",
-        help="CSV issue types; known examples include feature,bug,improvement,design,docs,refactor,other.",
+        help="CSV issue types: feature,bug,improvement,design,docs,refactor,other.",
     )
     parser.add_argument(
         "--priority",
-        help="CSV priorities; known examples include none,low,med,high,urgent.",
+        help="CSV priorities: none,low,med,high,urgent.",
     )
     parser.add_argument("--assignee", help="CSV user refs, me/@me for yourself, or none.")
     parser.add_argument("--creator", help="CSV user refs, or me/@me for yourself.")
@@ -668,24 +675,8 @@ def current_user_request() -> tuple[str, str, dict[str, Any]]:
 
 
 def issue_has_assignee(issue: Mapping[str, Any]) -> bool:
-    if issue.get("assignee_user_id"):
-        return True
-    return issue.get("assignee") is not None or issue.get("assignee_user") is not None
-
-
-def identity_values(value: Any) -> set[str]:
-    if isinstance(value, Mapping):
-        values = [value.get(key) for key in ("public_id", "id", "user_id", "handle", "username")]
-    else:
-        values = [value]
-    return {str(item).strip().lower() for item in values if item is not None and str(item).strip()}
-
-
-def issue_assignee_identities(issue: Mapping[str, Any]) -> set[str]:
-    identities = identity_values(issue.get("assignee_user_id"))
-    identities.update(identity_values(issue.get("assignee")))
-    identities.update(identity_values(issue.get("assignee_user")))
-    return identities
+    value = issue.get("assignee_user_id")
+    return isinstance(value, str) and bool(value.strip())
 
 
 def issue_assignee_label(issue: Mapping[str, Any]) -> str:
@@ -778,8 +769,9 @@ def assign_issue_to_current_user(
     if not isinstance(user_id, str) or not user_id.strip():
         raise OsPlatformError("current user response did not contain public_id")
 
+    assignee_user_id = issue.get("assignee_user_id")
     if issue_has_assignee(issue):
-        if issue_assignee_identities(issue) & identity_values(user):
+        if assignee_user_id == user_id:
             return issue
         if not force:
             raise OsPlatformError(
@@ -788,16 +780,209 @@ def assign_issue_to_current_user(
             )
 
     method, path, query, body = issue_update_request(org, number, {"assignee_user_id": user_id})
-    payload = request(
-        method,
-        path,
+    unwrap_envelope(
+        request(
+            method,
+            path,
+            base_url=base_url,
+            api_key=api_key,
+            query=query,
+            timeout=timeout,
+            body=body,
+        )
+    )
+
+    verify_payload = request(
+        get_method,
+        get_path,
         base_url=base_url,
         api_key=api_key,
-        query=query,
+        query=get_query,
         timeout=timeout,
-        body=body,
     )
+    verified_issue = unwrap_envelope(verify_payload)
+    if not isinstance(verified_issue, Mapping):
+        raise OsPlatformError("assignment verification response did not contain an issue object")
+    verified_assignee_id = verified_issue.get("assignee_user_id")
+    if verified_assignee_id != user_id:
+        actual = verified_assignee_id or "unassigned"
+        raise OsPlatformError(
+            "assignment verification failed after PATCH: "
+            f"expected {user_id}, found {actual}; another writer may have raced this update"
+        )
+    return verified_issue
+
+
+def print_issue_status_context(issue: Mapping[str, Any]) -> None:
+    label = issue.get("external_id") or issue.get("number_in_org") or "Issue"
+    title = issue.get("title") or ""
+    status = issue.get("status") or "unknown"
+    print(f"{label} {title!r} (current status: {status})", file=sys.stderr)
+
+
+def set_issue_status(
+    org: str,
+    number: str,
+    status: str,
+    *,
+    base_url: str,
+    api_key: str,
+    timeout: int,
+    force: bool = False,
+    assume_yes: bool = False,
+    request: Any = request_json,
+) -> Any:
+    get_method, get_path, get_query = issue_get_request(org, number)
+    issue_payload = request(
+        get_method,
+        get_path,
+        base_url=base_url,
+        api_key=api_key,
+        query=get_query,
+        timeout=timeout,
+    )
+    issue = unwrap_envelope(issue_payload)
+    if not isinstance(issue, Mapping):
+        raise OsPlatformError("issue response did not contain an object")
+    print_issue_status_context(issue)
+
+    user_id = current_user_public_id(
+        base_url=base_url,
+        api_key=api_key,
+        timeout=timeout,
+        request=request,
+    )
+    if issue_has_assignee(issue) and issue.get("assignee_user_id") != user_id and not force:
+        raise OsPlatformError(
+            f"issue is assigned to {issue_assignee_label(issue)}; "
+            "refusing to change its status without --force"
+        )
+
+    if status in TERMINAL_ISSUE_STATUSES and not assume_yes:
+        label = issue.get("external_id") or issue.get("number_in_org") or "Issue"
+        current_status = issue.get("status") or "unknown"
+        print(f"WOULD change {label} from {current_status} to {status}.", file=sys.stderr)
+        raise OsPlatformError("terminal status transitions require --yes")
+
+    return send_write_request(
+        issue_status_request(org, number, status),
+        base_url=base_url,
+        api_key=api_key,
+        timeout=timeout,
+        request=request,
+    )
+
+
+def curl_config_value(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def upload_file(
+    file_path: pathlib.Path | str,
+    *,
+    is_public: bool,
+    purpose: str,
+    base_url: str,
+    api_key: str,
+    timeout: int,
+    run: Any = subprocess.run,
+) -> Any:
+    path = pathlib.Path(file_path).expanduser()
+    if not path.is_file():
+        raise OsPlatformError(f"file does not exist or is not a regular file: {path}")
+    if purpose not in FILE_PURPOSES:
+        raise OsPlatformError(f"file purpose must be one of: {', '.join(FILE_PURPOSES)}")
+
+    endpoint = build_url(base_url, "/v1/files")
+    content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    curl_config = f'header = "Authorization: Bearer {curl_config_value(api_key)}"\n'
+    command = [
+        "curl",
+        "-sS",
+        "-X",
+        "POST",
+        endpoint,
+        "--config",
+        "-",
+        "-H",
+        "Accept: application/json",
+        "-H",
+        f"User-Agent: {USER_AGENT}",
+        "-F",
+        f"file=@{path};type={content_type};filename={path.name}",
+        "-F",
+        f"is_public={'true' if is_public else 'false'}",
+        "-F",
+        f"purpose={purpose}",
+    ]
+    try:
+        result = run(
+            command,
+            input=curl_config,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise OsPlatformError("curl is required for file uploads") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise OsPlatformError(f"file upload timed out after {timeout} seconds") from exc
+
+    if result.returncode != 0:
+        raise OsPlatformError(result.stderr.strip() or "curl file upload failed")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise OsPlatformError(f"non-JSON response from /v1/files: {result.stdout[:800]}") from exc
     return unwrap_envelope(payload)
+
+
+def attach_file_to_issue(
+    org: str,
+    number: str,
+    file_id: str,
+    *,
+    base_url: str,
+    api_key: str,
+    timeout: int,
+    request: Any = request_json,
+) -> Any:
+    attached_file_id = require_text(file_id, "file id")
+    get_method, get_path, get_query = issue_get_request(org, number)
+    issue_payload = request(
+        get_method,
+        get_path,
+        base_url=base_url,
+        api_key=api_key,
+        query=get_query,
+        timeout=timeout,
+    )
+    issue = unwrap_envelope(issue_payload)
+    if not isinstance(issue, Mapping):
+        raise OsPlatformError("issue response did not contain an object")
+
+    files = issue.get("files")
+    if not isinstance(files, list):
+        raise OsPlatformError("issue response did not contain a files array")
+    file_ids: list[str] = []
+    for attached_file in files:
+        if not isinstance(attached_file, Mapping):
+            raise OsPlatformError("issue files array contained a non-object entry")
+        existing_id = attached_file.get("id")
+        if not isinstance(existing_id, str) or not existing_id.strip():
+            raise OsPlatformError("issue files array contained an entry without an id")
+        file_ids.append(existing_id)
+    if attached_file_id not in file_ids:
+        file_ids.append(attached_file_id)
+
+    return send_write_request(
+        issue_update_request(org, number, {"file_ids": file_ids}),
+        base_url=base_url,
+        api_key=api_key,
+        timeout=timeout,
+        request=request,
+    )
 
 
 def send_write_request(
@@ -985,7 +1170,6 @@ def build_parser() -> argparse.ArgumentParser:
     issues_create.add_argument("--body", required=True)
     issues_create.add_argument("--type", help="Issue type passed through to the platform.")
     issues_create.add_argument("--priority", help="Priority passed through to the platform.")
-    issues_create.add_argument("--idempotency-key", help="Optional Idempotency-Key header value.")
     issues_assign = leaf_parser(issues_sub, "assign", help="Assign an Issue to the current user.")
     issues_assign.add_argument("refs", nargs="*", metavar="ref")
     issues_assign.add_argument("--to", choices=["me"], default="me")
@@ -993,6 +1177,17 @@ def build_parser() -> argparse.ArgumentParser:
     issues_status = leaf_parser(issues_sub, "status", help="Set an Issue's status.")
     issues_status.add_argument("refs", nargs="*", metavar="ref")
     issues_status.add_argument("status", choices=ISSUE_STATUSES)
+    issues_status.add_argument("--force", action="store_true", help="Change an Issue assigned to another user.")
+    issues_status.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm a terminal completed or cancelled transition.",
+    )
+    issues_attach = leaf_parser(issues_sub, "attach", help="Attach an uploaded file to an Issue.")
+    issues_attach.add_argument("refs", nargs="*", metavar="ref")
+    attach_source = issues_attach.add_mutually_exclusive_group(required=True)
+    attach_source.add_argument("--file-id", help="Opaque fil_xxx id returned by files upload.")
+    attach_source.add_argument("--path", help="Upload this path privately, then attach it.")
     issues_take = leaf_parser(issues_sub, "take", help="Move a todo Issue to in_progress after confirmation.")
     issues_take.add_argument("refs", nargs="*", metavar="ref")
     issues_take.add_argument("--yes", action="store_true", help="Skip confirmation prompt.")
@@ -1022,7 +1217,13 @@ def build_parser() -> argparse.ArgumentParser:
     comments_add = leaf_parser(comments_sub, "add", help="Add a comment to an Issue.")
     comments_add.add_argument("refs", nargs="*", metavar="ref")
     comments_add.add_argument("--body", required=True)
-    comments_add.add_argument("--idempotency-key", help="Optional Idempotency-Key header value.")
+
+    files = subparsers.add_parser("files", help="File uploads.")
+    files_sub = files.add_subparsers(dest="action", required=True)
+    files_upload = leaf_parser(files_sub, "upload", help="Upload a file to os-platform.")
+    files_upload.add_argument("path")
+    files_upload.add_argument("--public", action="store_true", dest="is_public")
+    files_upload.add_argument("--purpose", choices=FILE_PURPOSES, default="attachment")
 
     contributors = subparsers.add_parser("contributors", help="Contributor reads.")
     contributors_sub = contributors.add_subparsers(dest="action", required=True)
@@ -1055,9 +1256,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             resolve_self_refs(args, base_url=base_url, api_key=api_key, timeout=args.timeout)
 
         if args.resource == "issues" and args.action == "take":
+            org = require_arg(args, "org", "org")
+            number = require_arg(args, "number", "issue number")
             data = take_issue(
-                args.org,
-                args.number,
+                org,
+                number,
                 base_url=base_url,
                 api_key=api_key,
                 timeout=args.timeout,
@@ -1067,23 +1270,21 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
         if args.resource == "issues" and args.action == "create":
-            headers = None
-            if args.idempotency_key is not None:
-                headers = {"Idempotency-Key": require_text(args.idempotency_key, "idempotency key")}
             data = send_write_request(
                 issue_create_request(args.org, args.title, args.body, args.type, args.priority),
                 base_url=base_url,
                 api_key=api_key,
                 timeout=args.timeout,
-                headers=headers,
             )
             print_payload(data, args)
             return 0
 
         if args.resource == "issues" and args.action == "assign":
+            org = require_arg(args, "org", "org")
+            number = require_arg(args, "number", "issue number")
             data = assign_issue_to_current_user(
-                args.org,
-                args.number,
+                org,
+                number,
                 base_url=base_url,
                 api_key=api_key,
                 timeout=args.timeout,
@@ -1093,8 +1294,43 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
         if args.resource == "issues" and args.action == "status":
-            data = send_write_request(
-                issue_status_request(args.org, args.number, args.status),
+            org = require_arg(args, "org", "org")
+            number = require_arg(args, "number", "issue number")
+            data = set_issue_status(
+                org,
+                number,
+                args.status,
+                base_url=base_url,
+                api_key=api_key,
+                timeout=args.timeout,
+                force=args.force,
+                assume_yes=args.yes,
+            )
+            print_payload(data, args)
+            return 0
+
+        if args.resource == "issues" and args.action == "attach":
+            org = require_arg(args, "org", "org")
+            number = require_arg(args, "number", "issue number")
+            file_id = args.file_id
+            if args.path is not None:
+                uploaded = upload_file(
+                    args.path,
+                    is_public=False,
+                    purpose="attachment",
+                    base_url=base_url,
+                    api_key=api_key,
+                    timeout=args.timeout,
+                )
+                if not isinstance(uploaded, Mapping):
+                    raise OsPlatformError("file upload response did not contain an object")
+                file_id = uploaded.get("id")
+                if not isinstance(file_id, str) or not file_id.strip():
+                    raise OsPlatformError("file upload response did not contain an id")
+            data = attach_file_to_issue(
+                org,
+                number,
+                require_text(file_id, "file id"),
                 base_url=base_url,
                 api_key=api_key,
                 timeout=args.timeout,
@@ -1103,17 +1339,27 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
         if args.resource == "comments" and args.action == "add":
-            headers = None
-            if args.idempotency_key is not None:
-                headers = {"Idempotency-Key": require_text(args.idempotency_key, "idempotency key")}
+            org = require_arg(args, "org", "org")
+            number = require_arg(args, "number", "issue number")
             data = send_write_request(
-                comment_create_request(args.org, args.number, args.body),
+                comment_create_request(org, number, args.body),
                 base_url=base_url,
                 api_key=api_key,
                 timeout=args.timeout,
-                headers=headers,
             )
             print_payload(data, args)
+            return 0
+
+        if args.resource == "files" and args.action == "upload":
+            data = upload_file(
+                args.path,
+                is_public=args.is_public,
+                purpose=args.purpose,
+                base_url=base_url,
+                api_key=api_key,
+                timeout=args.timeout,
+            )
+            print(json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False))
             return 0
 
         method, path, query = command_to_request(args)

--- a/.agents/skills/os-platform/scripts/os_platform.py
+++ b/.agents/skills/os-platform/scripts/os_platform.py
@@ -238,12 +238,14 @@ def build_json_request(
     url: str,
     api_key: str,
     body: Mapping[str, Any] | None = None,
+    extra_headers: Mapping[str, str] | None = None,
 ) -> urllib.request.Request:
     headers = {
         "Accept": "application/json",
         "User-Agent": USER_AGENT,
         "Authorization": f"Bearer {api_key}",
     }
+    headers.update(extra_headers or {})
     data = None
     if body is not None:
         headers["Content-Type"] = "application/json"
@@ -259,10 +261,11 @@ def request_json(
     api_key: str,
     query: Mapping[str, Any] | None = None,
     body: Mapping[str, Any] | None = None,
+    headers: Mapping[str, str] | None = None,
     timeout: int = DEFAULT_TIMEOUT_SECONDS,
 ) -> Any:
     url = build_url(base_url, path, query)
-    req = build_json_request(method, url, api_key, body)
+    req = build_json_request(method, url, api_key, body, headers)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as response:
             raw = response.read().decode("utf-8")
@@ -568,8 +571,14 @@ def leaf_parser(subparsers: argparse._SubParsersAction, name: str, **kwargs: Any
 def add_issue_filters(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--project", help="CSV of project handles/public ids, or none.")
     parser.add_argument("--status", help="CSV statuses: todo,in_progress,in_review,completed,cancelled.")
-    parser.add_argument("--type", help="CSV issue types: feature,bug,improvement,design,docs,refactor,other.")
-    parser.add_argument("--priority", help="CSV priorities: none,low,med,high,urgent.")
+    parser.add_argument(
+        "--type",
+        help="CSV issue types; known examples include feature,bug,improvement,design,docs,refactor,other.",
+    )
+    parser.add_argument(
+        "--priority",
+        help="CSV priorities; known examples include none,low,med,high,urgent.",
+    )
     parser.add_argument("--assignee", help="CSV user refs, me/@me for yourself, or none.")
     parser.add_argument("--creator", help="CSV user refs, or me/@me for yourself.")
     parser.add_argument("--labels", help="CSV label slugs.")
@@ -661,17 +670,47 @@ def current_user_request() -> tuple[str, str, dict[str, Any]]:
 def issue_has_assignee(issue: Mapping[str, Any]) -> bool:
     if issue.get("assignee_user_id"):
         return True
-    assignee = issue.get("assignee")
-    return assignee is not None
+    return issue.get("assignee") is not None or issue.get("assignee_user") is not None
 
 
-def current_user_public_id(
+def identity_values(value: Any) -> set[str]:
+    if isinstance(value, Mapping):
+        values = [value.get(key) for key in ("public_id", "id", "user_id", "handle", "username")]
+    else:
+        values = [value]
+    return {str(item).strip().lower() for item in values if item is not None and str(item).strip()}
+
+
+def issue_assignee_identities(issue: Mapping[str, Any]) -> set[str]:
+    identities = identity_values(issue.get("assignee_user_id"))
+    identities.update(identity_values(issue.get("assignee")))
+    identities.update(identity_values(issue.get("assignee_user")))
+    return identities
+
+
+def issue_assignee_label(issue: Mapping[str, Any]) -> str:
+    for field in ("assignee", "assignee_user"):
+        assignee = issue.get(field)
+        if isinstance(assignee, Mapping):
+            for key in ("handle", "display_name", "name", "public_id", "id", "user_id"):
+                value = assignee.get(key)
+                if value is not None and str(value).strip():
+                    return str(value).strip()
+        elif assignee is not None and str(assignee).strip():
+            return str(assignee).strip()
+    value = issue.get("assignee_user_id")
+    if value is not None and str(value).strip():
+        return str(value).strip()
+    return "an unknown assignee"
+
+
+def current_user(
     *,
     base_url: str,
     api_key: str,
     timeout: int,
     request: Any = request_json,
-) -> str:
+) -> Mapping[str, Any]:
     method, path, query = current_user_request()
     payload = request(
         method,
@@ -684,6 +723,22 @@ def current_user_public_id(
     user = unwrap_envelope(payload)
     if not isinstance(user, Mapping):
         raise OsPlatformError("current user response did not contain an object")
+    return user
+
+
+def current_user_public_id(
+    *,
+    base_url: str,
+    api_key: str,
+    timeout: int,
+    request: Any = request_json,
+) -> str:
+    user = current_user(
+        base_url=base_url,
+        api_key=api_key,
+        timeout=timeout,
+        request=request,
+    )
     public_id = user.get("public_id")
     if not isinstance(public_id, str) or not public_id.strip():
         raise OsPlatformError("current user response did not contain public_id")
@@ -697,14 +752,41 @@ def assign_issue_to_current_user(
     base_url: str,
     api_key: str,
     timeout: int,
+    force: bool = False,
     request: Any = request_json,
 ) -> Any:
-    user_id = current_user_public_id(
+    get_method, get_path, get_query = issue_get_request(org, number)
+    issue_payload = request(
+        get_method,
+        get_path,
+        base_url=base_url,
+        api_key=api_key,
+        query=get_query,
+        timeout=timeout,
+    )
+    issue = unwrap_envelope(issue_payload)
+    if not isinstance(issue, Mapping):
+        raise OsPlatformError("issue response did not contain an object")
+
+    user = current_user(
         base_url=base_url,
         api_key=api_key,
         timeout=timeout,
         request=request,
     )
+    user_id = user.get("public_id")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise OsPlatformError("current user response did not contain public_id")
+
+    if issue_has_assignee(issue):
+        if issue_assignee_identities(issue) & identity_values(user):
+            return issue
+        if not force:
+            raise OsPlatformError(
+                f"issue is already assigned to {issue_assignee_label(issue)}; "
+                "refusing to replace the assignee without --force"
+            )
+
     method, path, query, body = issue_update_request(org, number, {"assignee_user_id": user_id})
     payload = request(
         method,
@@ -724,6 +806,7 @@ def send_write_request(
     base_url: str,
     api_key: str,
     timeout: int,
+    headers: Mapping[str, str] | None = None,
     request: Any = request_json,
 ) -> Any:
     method, path, query, body = request_spec
@@ -735,6 +818,7 @@ def send_write_request(
         query=query,
         timeout=timeout,
         body=body,
+        headers=headers,
     )
     return unwrap_envelope(payload)
 
@@ -899,11 +983,13 @@ def build_parser() -> argparse.ArgumentParser:
     issues_create.add_argument("org", nargs="?")
     issues_create.add_argument("--title", required=True)
     issues_create.add_argument("--body", required=True)
-    issues_create.add_argument("--type", choices=["feature", "bug", "other"])
-    issues_create.add_argument("--priority", choices=["low", "med", "high"])
+    issues_create.add_argument("--type", help="Issue type passed through to the platform.")
+    issues_create.add_argument("--priority", help="Priority passed through to the platform.")
+    issues_create.add_argument("--idempotency-key", help="Optional Idempotency-Key header value.")
     issues_assign = leaf_parser(issues_sub, "assign", help="Assign an Issue to the current user.")
     issues_assign.add_argument("refs", nargs="*", metavar="ref")
     issues_assign.add_argument("--to", choices=["me"], default="me")
+    issues_assign.add_argument("--force", action="store_true", help="Replace another current assignee.")
     issues_status = leaf_parser(issues_sub, "status", help="Set an Issue's status.")
     issues_status.add_argument("refs", nargs="*", metavar="ref")
     issues_status.add_argument("status", choices=ISSUE_STATUSES)
@@ -936,6 +1022,7 @@ def build_parser() -> argparse.ArgumentParser:
     comments_add = leaf_parser(comments_sub, "add", help="Add a comment to an Issue.")
     comments_add.add_argument("refs", nargs="*", metavar="ref")
     comments_add.add_argument("--body", required=True)
+    comments_add.add_argument("--idempotency-key", help="Optional Idempotency-Key header value.")
 
     contributors = subparsers.add_parser("contributors", help="Contributor reads.")
     contributors_sub = contributors.add_subparsers(dest="action", required=True)
@@ -980,11 +1067,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
         if args.resource == "issues" and args.action == "create":
+            headers = None
+            if args.idempotency_key is not None:
+                headers = {"Idempotency-Key": require_text(args.idempotency_key, "idempotency key")}
             data = send_write_request(
                 issue_create_request(args.org, args.title, args.body, args.type, args.priority),
                 base_url=base_url,
                 api_key=api_key,
                 timeout=args.timeout,
+                headers=headers,
             )
             print_payload(data, args)
             return 0
@@ -996,6 +1087,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 base_url=base_url,
                 api_key=api_key,
                 timeout=args.timeout,
+                force=args.force,
             )
             print_payload(data, args)
             return 0
@@ -1011,11 +1103,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
         if args.resource == "comments" and args.action == "add":
+            headers = None
+            if args.idempotency_key is not None:
+                headers = {"Idempotency-Key": require_text(args.idempotency_key, "idempotency key")}
             data = send_write_request(
                 comment_create_request(args.org, args.number, args.body),
                 base_url=base_url,
                 api_key=api_key,
                 timeout=args.timeout,
+                headers=headers,
             )
             print_payload(data, args)
             return 0

--- a/.agents/skills/os-platform/scripts/os_platform.py
+++ b/.agents/skills/os-platform/scripts/os_platform.py
@@ -1186,8 +1186,14 @@ def build_parser() -> argparse.ArgumentParser:
     issues_attach = leaf_parser(issues_sub, "attach", help="Attach an uploaded file to an Issue.")
     issues_attach.add_argument("refs", nargs="*", metavar="ref")
     attach_source = issues_attach.add_mutually_exclusive_group(required=True)
-    attach_source.add_argument("--file-id", help="Opaque fil_xxx id returned by files upload.")
-    attach_source.add_argument("--path", help="Upload this path privately, then attach it.")
+    attach_source.add_argument("--file-id", help="Opaque fil_xxx id of a PUBLIC upload (the platform rejects private attachments).")
+    attach_source.add_argument("--path", help="Upload this path, then attach it. Requires --public.")
+    issues_attach.add_argument(
+        "--public",
+        action="store_true",
+        dest="is_public",
+        help="Acknowledge the upload is public: anyone with the URL can download it. Required with --path.",
+    )
     issues_take = leaf_parser(issues_sub, "take", help="Move a todo Issue to in_progress after confirmation.")
     issues_take.add_argument("refs", nargs="*", metavar="ref")
     issues_take.add_argument("--yes", action="store_true", help="Skip confirmation prompt.")
@@ -1314,9 +1320,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             number = require_arg(args, "number", "issue number")
             file_id = args.file_id
             if args.path is not None:
+                if not args.is_public:
+                    raise OsPlatformError(
+                        "the platform only attaches public files (error 2015); "
+                        "re-run with --public to acknowledge anyone with the URL can download it"
+                    )
                 uploaded = upload_file(
                     args.path,
-                    is_public=False,
+                    is_public=True,
                     purpose="attachment",
                     base_url=base_url,
                     api_key=api_key,

--- a/.agents/skills/os-platform/scripts/os_platform.py
+++ b/.agents/skills/os-platform/scripts/os_platform.py
@@ -25,7 +25,7 @@ DEFAULT_BASE_URL = "https://app.opensoftware.co/api"
 CONFIG_FILE_NAME = "os-platform.json"
 API_KEY_ENV = "OS_PLATFORM_API_KEY"
 BASE_URL_ENV = "OS_PLATFORM_API_BASE_URL"
-USER_AGENT = os.environ.get("OS_PLATFORM_USER_AGENT") or (
+USER_AGENT = (os.environ.get("OS_PLATFORM_USER_AGENT") or "").strip() or (
     "os-platform-cli/2.0 (+https://opensoftware.co)"
 )
 WORD_RE = re.compile(r"[a-z0-9]+")

--- a/.agents/skills/os-platform/scripts/os_platform.py
+++ b/.agents/skills/os-platform/scripts/os_platform.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Read-only os-platform production API helper for agents."""
+"""os-platform production API helper for agents."""
 
 from __future__ import annotations
 
@@ -23,8 +23,12 @@ DEFAULT_BASE_URL = "https://app.opensoftware.co/api"
 CONFIG_FILE_NAME = "os-platform.json"
 API_KEY_ENV = "OS_PLATFORM_API_KEY"
 BASE_URL_ENV = "OS_PLATFORM_API_BASE_URL"
+USER_AGENT = os.environ.get("OS_PLATFORM_USER_AGENT") or (
+    "os-platform-cli/2.0 (+https://opensoftware.co)"
+)
 WORD_RE = re.compile(r"[a-z0-9]+")
 ME_TOKENS = {"me", "@me"}
+ISSUE_STATUSES = ("todo", "in_progress", "in_review", "completed", "cancelled")
 
 COMPACT_KEYS = {
     "id",
@@ -237,7 +241,7 @@ def build_json_request(
 ) -> urllib.request.Request:
     headers = {
         "Accept": "application/json",
-        "User-Agent": "os-platform-agent-skill/1.0",
+        "User-Agent": USER_AGENT,
         "Authorization": f"Bearer {api_key}",
     }
     data = None
@@ -523,7 +527,10 @@ def take_issue(
 
 def print_payload(data: Any, args: argparse.Namespace) -> None:
     data = output_data_for_args(data, args)
-    if args.full or args.json:
+    issue_show = (
+        getattr(args, "resource", None) == "issues" and getattr(args, "action", None) == "show"
+    )
+    if args.full or args.json or issue_show:
         output = data
     else:
         output = compact_value(data, limit=args.limit)
@@ -601,6 +608,25 @@ def issue_get_request(org: str, number: str) -> tuple[str, str, dict[str, Any]]:
     return "GET", f"/v1/orgs/{org_ref}/bounties/{number_ref}", {}
 
 
+def issue_create_request(
+    org: str,
+    title: str,
+    body_markdown: str,
+    issue_type: str | None,
+    priority: str | None,
+) -> tuple[str, str, dict[str, Any], dict[str, str]]:
+    org_ref = urllib.parse.quote(require_text(org, "org"))
+    body = {
+        "title": require_text(title, "title"),
+        "body_markdown": require_text(body_markdown, "body"),
+    }
+    if issue_type is not None:
+        body["type"] = issue_type
+    if priority is not None:
+        body["priority"] = priority
+    return "POST", f"/v1/orgs/{org_ref}/bounties", {}, body
+
+
 def issue_status_request(org: str, number: str, status: str) -> tuple[str, str, dict[str, Any], dict[str, str]]:
     org_ref = urllib.parse.quote(require_text(org, "org"))
     number_ref = urllib.parse.quote(require_text(number, "issue number"))
@@ -615,6 +641,17 @@ def issue_update_request(
     org_ref = urllib.parse.quote(require_text(org, "org"))
     number_ref = urllib.parse.quote(require_text(number, "issue number"))
     return "PATCH", f"/v1/orgs/{org_ref}/bounties/{number_ref}", {}, dict(body)
+
+
+def comment_create_request(
+    org: str,
+    number: str,
+    body_markdown: str,
+) -> tuple[str, str, dict[str, Any], dict[str, str]]:
+    org_ref = urllib.parse.quote(require_text(org, "org"))
+    number_ref = urllib.parse.quote(require_text(number, "issue number"))
+    body = {"body_markdown": require_text(body_markdown, "body")}
+    return "POST", f"/v1/orgs/{org_ref}/bounties/{number_ref}/comments", {}, body
 
 
 def current_user_request() -> tuple[str, str, dict[str, Any]]:
@@ -669,6 +706,27 @@ def assign_issue_to_current_user(
         request=request,
     )
     method, path, query, body = issue_update_request(org, number, {"assignee_user_id": user_id})
+    payload = request(
+        method,
+        path,
+        base_url=base_url,
+        api_key=api_key,
+        query=query,
+        timeout=timeout,
+        body=body,
+    )
+    return unwrap_envelope(payload)
+
+
+def send_write_request(
+    request_spec: tuple[str, str, dict[str, Any], dict[str, Any]],
+    *,
+    base_url: str,
+    api_key: str,
+    timeout: int,
+    request: Any = request_json,
+) -> Any:
+    method, path, query, body = request_spec
     payload = request(
         method,
         path,
@@ -791,14 +849,15 @@ def command_to_request(args: argparse.Namespace) -> tuple[str, str, dict[str, An
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="os_platform.py",
-        description="Read-only helper for querying os-platform production API data.",
+        description="Helper for reading and updating os-platform production API data.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=textwrap.dedent(
             """\
             Examples:
               python3 scripts/os_platform.py status
               python3 scripts/os_platform.py issues list open-software --q wallet --limit 10
-              python3 scripts/os_platform.py issues show open-software 123 --full
+              python3 scripts/os_platform.py issues show open-software 123
+              python3 scripts/os_platform.py issues status open-software 123 in_review
               python3 scripts/os_platform.py raw GET /v1/_status
             """
         ),
@@ -827,7 +886,7 @@ def build_parser() -> argparse.ArgumentParser:
     project_get = leaf_parser(project_sub, "get", help="Get one Project.")
     project_get.add_argument("refs", nargs="*", metavar="ref")
 
-    issues = subparsers.add_parser("issues", help="Issue/Bounty reads.")
+    issues = subparsers.add_parser("issues", help="Issue/Bounty reads and writes.")
     issues_sub = issues.add_subparsers(dest="action", required=True)
     issues_list = leaf_parser(issues_sub, "list", help="List Issues for an Org.")
     issues_list.add_argument("org", nargs="?")
@@ -836,6 +895,18 @@ def build_parser() -> argparse.ArgumentParser:
     issues_search.add_argument("org", nargs="?")
     issues_search.add_argument("search_query")
     add_issue_filters(issues_search)
+    issues_create = leaf_parser(issues_sub, "create", help="Create an Issue in an Org.")
+    issues_create.add_argument("org", nargs="?")
+    issues_create.add_argument("--title", required=True)
+    issues_create.add_argument("--body", required=True)
+    issues_create.add_argument("--type", choices=["feature", "bug", "other"])
+    issues_create.add_argument("--priority", choices=["low", "med", "high"])
+    issues_assign = leaf_parser(issues_sub, "assign", help="Assign an Issue to the current user.")
+    issues_assign.add_argument("refs", nargs="*", metavar="ref")
+    issues_assign.add_argument("--to", choices=["me"], default="me")
+    issues_status = leaf_parser(issues_sub, "status", help="Set an Issue's status.")
+    issues_status.add_argument("refs", nargs="*", metavar="ref")
+    issues_status.add_argument("status", choices=ISSUE_STATUSES)
     issues_take = leaf_parser(issues_sub, "take", help="Move a todo Issue to in_progress after confirmation.")
     issues_take.add_argument("refs", nargs="*", metavar="ref")
     issues_take.add_argument("--yes", action="store_true", help="Skip confirmation prompt.")
@@ -854,7 +925,7 @@ def build_parser() -> argparse.ArgumentParser:
     activity_list.add_argument("--page", type=int)
     activity_list.add_argument("--per-page", type=int, dest="per_page")
 
-    comments = subparsers.add_parser("comments", help="Comment reads.")
+    comments = subparsers.add_parser("comments", help="Comment reads and writes.")
     comments_sub = comments.add_subparsers(dest="action", required=True)
     comments_list = comments_sub.add_parser("list", help="List comments.")
     comments_list_sub = comments_list.add_subparsers(dest="target", required=True)
@@ -862,6 +933,9 @@ def build_parser() -> argparse.ArgumentParser:
     issue_comments.add_argument("refs", nargs="*", metavar="ref")
     issue_comments.add_argument("--page", type=int)
     issue_comments.add_argument("--per-page", type=int, dest="per_page")
+    comments_add = leaf_parser(comments_sub, "add", help="Add a comment to an Issue.")
+    comments_add.add_argument("refs", nargs="*", metavar="ref")
+    comments_add.add_argument("--body", required=True)
 
     contributors = subparsers.add_parser("contributors", help="Contributor reads.")
     contributors_sub = contributors.add_subparsers(dest="action", required=True)
@@ -901,6 +975,47 @@ def main(argv: Sequence[str] | None = None) -> int:
                 api_key=api_key,
                 timeout=args.timeout,
                 assume_yes=args.yes,
+            )
+            print_payload(data, args)
+            return 0
+
+        if args.resource == "issues" and args.action == "create":
+            data = send_write_request(
+                issue_create_request(args.org, args.title, args.body, args.type, args.priority),
+                base_url=base_url,
+                api_key=api_key,
+                timeout=args.timeout,
+            )
+            print_payload(data, args)
+            return 0
+
+        if args.resource == "issues" and args.action == "assign":
+            data = assign_issue_to_current_user(
+                args.org,
+                args.number,
+                base_url=base_url,
+                api_key=api_key,
+                timeout=args.timeout,
+            )
+            print_payload(data, args)
+            return 0
+
+        if args.resource == "issues" and args.action == "status":
+            data = send_write_request(
+                issue_status_request(args.org, args.number, args.status),
+                base_url=base_url,
+                api_key=api_key,
+                timeout=args.timeout,
+            )
+            print_payload(data, args)
+            return 0
+
+        if args.resource == "comments" and args.action == "add":
+            data = send_write_request(
+                comment_create_request(args.org, args.number, args.body),
+                base_url=base_url,
+                api_key=api_key,
+                timeout=args.timeout,
             )
             print_payload(data, args)
             return 0

--- a/.agents/skills/os-platform/scripts/test_os_platform.py
+++ b/.agents/skills/os-platform/scripts/test_os_platform.py
@@ -383,7 +383,7 @@ class RequestShapeTest(unittest.TestCase):
         self.assertIn("Authorization: Bearer secret", captured["input"])
         self.assertNotIn(API_KEY, captured["command"])
 
-    def test_attach_path_uploads_privately_before_attach(self):
+    def test_attach_path_requires_public_acknowledgement(self):
         argv = [
             "issues",
             "attach",
@@ -391,6 +391,25 @@ class RequestShapeTest(unittest.TestCase):
             "250",
             "--path",
             "/tmp/evidence.mp4",
+            "--api-key",
+            API_KEY,
+        ]
+        with mock.patch.object(os_platform, "load_project_config", return_value={}):
+            with mock.patch.object(os_platform, "upload_file") as upload:
+                with contextlib.redirect_stderr(io.StringIO()) as err:
+                    self.assertEqual(os_platform.main(argv), 1)
+        upload.assert_not_called()
+        self.assertIn("--public", err.getvalue())
+
+    def test_attach_path_uploads_publicly_before_attach(self):
+        argv = [
+            "issues",
+            "attach",
+            "june",
+            "250",
+            "--path",
+            "/tmp/evidence.mp4",
+            "--public",
             "--api-key",
             API_KEY,
         ]
@@ -407,7 +426,7 @@ class RequestShapeTest(unittest.TestCase):
                         self.assertEqual(os_platform.main(argv), 0)
 
         self.assertEqual(upload.call_args.args, ("/tmp/evidence.mp4",))
-        self.assertFalse(upload.call_args.kwargs["is_public"])
+        self.assertTrue(upload.call_args.kwargs["is_public"])
         self.assertEqual(upload.call_args.kwargs["purpose"], "attachment")
         self.assertEqual(attach.call_args.args, ("june", "250", "fil_uploaded"))
 

--- a/.agents/skills/os-platform/scripts/test_os_platform.py
+++ b/.agents/skills/os-platform/scripts/test_os_platform.py
@@ -1,10 +1,87 @@
 #!/usr/bin/env python3
-"""Tests for the `me` self-reference resolution in os_platform.py."""
+"""Unit tests for os_platform.py without live API writes."""
 
 import argparse
+import contextlib
+import io
+import json
+import pathlib
+import subprocess
+import tempfile
 import unittest
+from unittest import mock
 
 import os_platform
+
+
+BASE_URL = "https://platform.test/api"
+API_KEY = "secret"
+TIMEOUT = 5
+
+
+def envelope(data):
+    return {"success": True, "data": data}
+
+
+def issue(assignee_user_id=None, **overrides):
+    value = {
+        "external_id": "JUN-250",
+        "title": "Align platform writes",
+        "status": "todo",
+        "assignee_user_id": assignee_user_id,
+        "assignee": None,
+        "files": [],
+    }
+    value.update(overrides)
+    return value
+
+
+def current_user():
+    return {"public_id": "usr_me", "handle": "caller"}
+
+
+class FakeRequest:
+    def __init__(self, *responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def __call__(self, method, path, **kwargs):
+        self.calls.append({"method": method, "path": path, **kwargs})
+        if not self.responses:
+            raise AssertionError(f"unexpected request: {method} {path}")
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def assert_exhausted(self, test_case):
+        test_case.assertEqual(self.responses, [])
+
+
+def assign_with(request, *, force=False):
+    return os_platform.assign_issue_to_current_user(
+        "june",
+        "250",
+        base_url=BASE_URL,
+        api_key=API_KEY,
+        timeout=TIMEOUT,
+        force=force,
+        request=request,
+    )
+
+
+def set_status_with(request, status="in_review", *, force=False, assume_yes=False):
+    return os_platform.set_issue_status(
+        "june",
+        "250",
+        status,
+        base_url=BASE_URL,
+        api_key=API_KEY,
+        timeout=TIMEOUT,
+        force=force,
+        assume_yes=assume_yes,
+        request=request,
+    )
 
 
 class ResolveMeTokensTest(unittest.TestCase):
@@ -27,33 +104,344 @@ class ResolveMeTokensTest(unittest.TestCase):
 
 
 class ResolveSelfRefsTest(unittest.TestCase):
-    def _stub_request(self):
-        calls = []
-
-        def request(method, path, **_kwargs):
-            calls.append((method, path))
-            return {"success": True, "data": {"public_id": "usr_me", "handle": "caller"}}
-
-        return request, calls
-
     def test_resolves_assignee_and_creator_with_single_lookup(self):
         args = argparse.Namespace(assignee="me", creator="@me")
-        request, calls = self._stub_request()
+        request = FakeRequest(envelope(current_user()))
         os_platform.resolve_self_refs(
-            args, base_url="https://x", api_key="k", timeout=5, request=request
+            args, base_url=BASE_URL, api_key=API_KEY, timeout=TIMEOUT, request=request
         )
         self.assertEqual(args.assignee, "usr_me")
         self.assertEqual(args.creator, "usr_me")
-        self.assertEqual(calls, [("GET", "/v1/users/me")])
+        self.assertEqual(
+            [(call["method"], call["path"]) for call in request.calls],
+            [("GET", "/v1/users/me")],
+        )
 
     def test_no_lookup_when_no_me_token(self):
         args = argparse.Namespace(assignee="alice", creator=None)
-        request, calls = self._stub_request()
+        request = FakeRequest()
         os_platform.resolve_self_refs(
-            args, base_url="https://x", api_key="k", timeout=5, request=request
+            args, base_url=BASE_URL, api_key=API_KEY, timeout=TIMEOUT, request=request
         )
         self.assertEqual(args.assignee, "alice")
-        self.assertEqual(calls, [])
+        self.assertEqual(request.calls, [])
+
+
+class AssignIssueTest(unittest.TestCase):
+    def test_assigns_unassigned_issue_and_verifies(self):
+        verified = issue("usr_me", assignee={"id": "usr_me", "handle": "caller"})
+        request = FakeRequest(
+            envelope(issue()),
+            envelope(current_user()),
+            envelope(verified),
+            envelope(verified),
+        )
+
+        result = assign_with(request)
+
+        self.assertEqual(result, verified)
+        self.assertEqual([call["method"] for call in request.calls], ["GET", "GET", "PATCH", "GET"])
+        self.assertEqual(request.calls[2]["body"], {"assignee_user_id": "usr_me"})
+        request.assert_exhausted(self)
+
+    def test_self_assigned_uses_assignee_user_id_and_skips_patch(self):
+        owned = issue("usr_me", assignee={"id": "unrelated_sparse_id"})
+        request = FakeRequest(envelope(owned), envelope(current_user()))
+
+        self.assertEqual(assign_with(request), owned)
+        self.assertEqual([call["method"] for call in request.calls], ["GET", "GET"])
+        request.assert_exhausted(self)
+
+    def test_refuses_issue_assigned_to_another_user(self):
+        foreign = issue("usr_other", assignee={"id": "usr_other", "handle": "alice"})
+        request = FakeRequest(envelope(foreign), envelope(current_user()))
+
+        with self.assertRaisesRegex(os_platform.OsPlatformError, "alice.*--force"):
+            assign_with(request)
+
+        self.assertEqual([call["method"] for call in request.calls], ["GET", "GET"])
+        request.assert_exhausted(self)
+
+    def test_force_replaces_another_assignee_and_verifies(self):
+        foreign = issue("usr_other", assignee={"id": "usr_other", "handle": "alice"})
+        verified = issue("usr_me", assignee={"id": "usr_me", "handle": "caller"})
+        request = FakeRequest(
+            envelope(foreign),
+            envelope(current_user()),
+            envelope(verified),
+            envelope(verified),
+        )
+
+        result = assign_with(request, force=True)
+
+        self.assertEqual(result, verified)
+        self.assertEqual(request.calls[2]["body"], {"assignee_user_id": "usr_me"})
+        request.assert_exhausted(self)
+
+    def test_sparse_assignee_object_without_id_is_unassigned(self):
+        sparse = issue(assignee={"handle": "stale-display-only"})
+        sparse.pop("assignee_user_id")
+        verified = issue("usr_me")
+        request = FakeRequest(
+            envelope(sparse),
+            envelope(current_user()),
+            envelope(verified),
+            envelope(verified),
+        )
+
+        self.assertEqual(assign_with(request), verified)
+        self.assertEqual(request.calls[2]["body"], {"assignee_user_id": "usr_me"})
+        request.assert_exhausted(self)
+
+    def test_fails_when_post_write_verification_observes_race(self):
+        request = FakeRequest(
+            envelope(issue()),
+            envelope(current_user()),
+            envelope(issue("usr_me")),
+            envelope(issue("usr_racer")),
+        )
+
+        with self.assertRaisesRegex(os_platform.OsPlatformError, "verification failed.*raced"):
+            assign_with(request)
+
+        self.assertEqual([call["method"] for call in request.calls], ["GET", "GET", "PATCH", "GET"])
+        request.assert_exhausted(self)
+
+
+class StatusGuardTest(unittest.TestCase):
+    def test_owned_issue_changes_status_and_prints_context(self):
+        updated = issue("usr_me", status="in_review")
+        request = FakeRequest(
+            envelope(issue("usr_me")),
+            envelope(current_user()),
+            envelope(updated),
+        )
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            result = set_status_with(request)
+
+        self.assertEqual(result, updated)
+        self.assertIn("JUN-250", stderr.getvalue())
+        self.assertIn("Align platform writes", stderr.getvalue())
+        self.assertIn("current status: todo", stderr.getvalue())
+        self.assertEqual(request.calls[2]["method"], "POST")
+        self.assertEqual(request.calls[2]["path"], "/v1/orgs/june/bounties/250/status")
+        self.assertEqual(request.calls[2]["body"], {"status": "in_review"})
+        request.assert_exhausted(self)
+
+    def test_refuses_foreign_issue_without_force(self):
+        foreign = issue("usr_other", assignee={"id": "usr_other", "handle": "alice"})
+        request = FakeRequest(envelope(foreign), envelope(current_user()))
+
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaisesRegex(os_platform.OsPlatformError, "alice.*--force"):
+                set_status_with(request)
+
+        self.assertEqual([call["method"] for call in request.calls], ["GET", "GET"])
+        request.assert_exhausted(self)
+
+    def test_force_allows_foreign_issue_status_change(self):
+        foreign = issue("usr_other", assignee={"id": "usr_other", "handle": "alice"})
+        updated = dict(foreign, status="in_review")
+        request = FakeRequest(envelope(foreign), envelope(current_user()), envelope(updated))
+
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(set_status_with(request, force=True), updated)
+
+        self.assertEqual(request.calls[2]["body"], {"status": "in_review"})
+        request.assert_exhausted(self)
+
+    def test_terminal_status_without_yes_prints_would_change_and_refuses(self):
+        request = FakeRequest(envelope(issue("usr_me")), envelope(current_user()))
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            with self.assertRaisesRegex(os_platform.OsPlatformError, "require --yes"):
+                set_status_with(request, "completed")
+
+        self.assertIn("WOULD change JUN-250 from todo to completed", stderr.getvalue())
+        self.assertEqual([call["method"] for call in request.calls], ["GET", "GET"])
+        request.assert_exhausted(self)
+
+    def test_terminal_status_with_yes_posts(self):
+        completed = issue("usr_me", status="completed")
+        request = FakeRequest(
+            envelope(issue("usr_me")),
+            envelope(current_user()),
+            envelope(completed),
+        )
+
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(set_status_with(request, "completed", assume_yes=True), completed)
+
+        self.assertEqual(request.calls[2]["body"], {"status": "completed"})
+        request.assert_exhausted(self)
+
+
+class RequestShapeTest(unittest.TestCase):
+    def test_create_shape_uses_contract_fields(self):
+        request = FakeRequest(envelope(issue()))
+
+        os_platform.send_write_request(
+            os_platform.issue_create_request("june", "Title", "Body", "bug", "urgent"),
+            base_url=BASE_URL,
+            api_key=API_KEY,
+            timeout=TIMEOUT,
+            request=request,
+        )
+
+        self.assertEqual(request.calls[0]["method"], "POST")
+        self.assertEqual(request.calls[0]["path"], "/v1/orgs/june/bounties")
+        self.assertEqual(
+            request.calls[0]["body"],
+            {
+                "title": "Title",
+                "body_markdown": "Body",
+                "type": "bug",
+                "priority": "urgent",
+            },
+        )
+        request.assert_exhausted(self)
+
+    def test_comment_shape_uses_body_markdown(self):
+        request = FakeRequest(envelope({"id": "cmt_1"}))
+
+        os_platform.send_write_request(
+            os_platform.comment_create_request("june", "250", "PR opened"),
+            base_url=BASE_URL,
+            api_key=API_KEY,
+            timeout=TIMEOUT,
+            request=request,
+        )
+
+        self.assertEqual(request.calls[0]["method"], "POST")
+        self.assertEqual(request.calls[0]["path"], "/v1/orgs/june/bounties/250/comments")
+        self.assertEqual(request.calls[0]["body"], {"body_markdown": "PR opened"})
+        request.assert_exhausted(self)
+
+    def test_attach_preserves_existing_file_ids(self):
+        initial = issue(files=[{"id": "fil_old_1"}, {"id": "fil_old_2"}])
+        updated = issue(files=[{"id": "fil_old_1"}, {"id": "fil_old_2"}, {"id": "fil_new"}])
+        request = FakeRequest(envelope(initial), envelope(updated))
+
+        result = os_platform.attach_file_to_issue(
+            "june",
+            "250",
+            "fil_new",
+            base_url=BASE_URL,
+            api_key=API_KEY,
+            timeout=TIMEOUT,
+            request=request,
+        )
+
+        self.assertEqual(result, updated)
+        self.assertEqual([call["method"] for call in request.calls], ["GET", "PATCH"])
+        self.assertEqual(
+            request.calls[1]["body"],
+            {"file_ids": ["fil_old_1", "fil_old_2", "fil_new"]},
+        )
+        request.assert_exhausted(self)
+
+    def test_file_upload_uses_contract_multipart_fields(self):
+        captured = {}
+
+        def run(command, **kwargs):
+            captured["command"] = command
+            captured.update(kwargs)
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(envelope({"id": "fil_new", "purpose": "attachment"})),
+                stderr="",
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "evidence.mp4"
+            path.write_bytes(b"video")
+            result = os_platform.upload_file(
+                path,
+                is_public=True,
+                purpose="attachment",
+                base_url=BASE_URL,
+                api_key=API_KEY,
+                timeout=TIMEOUT,
+                run=run,
+            )
+
+        self.assertEqual(result["id"], "fil_new")
+        self.assertIn("https://platform.test/api/v1/files", captured["command"])
+        forms = [
+            captured["command"][index + 1]
+            for index, value in enumerate(captured["command"])
+            if value == "-F"
+        ]
+        self.assertTrue(forms[0].startswith("file=@"))
+        self.assertIn("type=video/mp4", forms[0])
+        self.assertIn("filename=evidence.mp4", forms[0])
+        self.assertEqual(forms[1:], ["is_public=true", "purpose=attachment"])
+        self.assertIn("Authorization: Bearer secret", captured["input"])
+        self.assertNotIn(API_KEY, captured["command"])
+
+    def test_attach_path_uploads_privately_before_attach(self):
+        argv = [
+            "issues",
+            "attach",
+            "june",
+            "250",
+            "--path",
+            "/tmp/evidence.mp4",
+            "--api-key",
+            API_KEY,
+        ]
+        with mock.patch.object(os_platform, "load_project_config", return_value={}):
+            with mock.patch.object(
+                os_platform, "upload_file", return_value={"id": "fil_uploaded"}
+            ) as upload:
+                with mock.patch.object(
+                    os_platform,
+                    "attach_file_to_issue",
+                    return_value=issue(files=[{"id": "fil_uploaded"}]),
+                ) as attach:
+                    with contextlib.redirect_stdout(io.StringIO()):
+                        self.assertEqual(os_platform.main(argv), 0)
+
+        self.assertEqual(upload.call_args.args, ("/tmp/evidence.mp4",))
+        self.assertFalse(upload.call_args.kwargs["is_public"])
+        self.assertEqual(upload.call_args.kwargs["purpose"], "attachment")
+        self.assertEqual(attach.call_args.args, ("june", "250", "fil_uploaded"))
+
+
+class ParserAndErrorTest(unittest.TestCase):
+    def test_status_accepts_proposed(self):
+        args = os_platform.build_parser().parse_args(["issues", "status", "june", "250", "proposed"])
+        self.assertEqual(args.status, "proposed")
+
+    def test_file_upload_defaults_to_private_attachment(self):
+        args = os_platform.build_parser().parse_args(["files", "upload", "evidence.mp4"])
+        self.assertFalse(args.is_public)
+        self.assertEqual(args.purpose, "attachment")
+
+    def assert_missing_number(self, argv):
+        stderr = io.StringIO()
+        with mock.patch.object(os_platform, "load_project_config", return_value={}):
+            with contextlib.redirect_stderr(stderr):
+                with self.assertRaises(SystemExit) as raised:
+                    os_platform.main([*argv, "--api-key", API_KEY])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("issue number is required", stderr.getvalue())
+        self.assertNotIn("AttributeError", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_assign_missing_number_is_clean_error(self):
+        self.assert_missing_number(["issues", "assign", "june"])
+
+    def test_status_missing_number_is_clean_error(self):
+        self.assert_missing_number(["issues", "status", "june", "in_review"])
+
+    def test_comment_missing_number_is_clean_error(self):
+        self.assert_missing_number(["comments", "add", "june", "--body", "Update"])
 
 
 if __name__ == "__main__":

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -21,27 +21,34 @@ Defaults (org `june`, limit 20) come from `os-platform.json` at the repo root.
   `python3 scripts/os_platform.py issues take june <number>`
   — confirm with the user before passing `--yes`.
 
-## Write conventions (direct API)
+## Write conventions
 
-Writes beyond `issues take` go straight to the platform API
-(`https://app.opensoftware.co/api`, `Authorization: Bearer $OS_PLATFORM_API_KEY`),
-following the precedent set by `os-task-prep/scripts/enrich_issue.py`.
+The `os-platform` script owns routine workflow writes. Run it from
+`.agents/skills/os-platform/` and verify each write with a read before any
+fan-out:
 
-Documented endpoints (safe to use):
+- **Create an issue**:
+  `python3 scripts/os_platform.py issues create june --title "..." --body "..."`
+  (optional: `--type feature|bug|other`, `--priority low|med|high`).
+- **Assign yourself**:
+  `python3 scripts/os_platform.py issues assign june <number>`.
+- **Change status**:
+  `python3 scripts/os_platform.py issues status june <number> <status>` where
+  status is `todo|in_progress|in_review|completed|cancelled`.
+- **Add a comment**:
+  `python3 scripts/os_platform.py comments add june <number> --body "..."`.
 
-- **Update an issue** (body, assignee):
-  `PATCH /v1/orgs/june/bounties/{number}` with e.g.
-  `{"body_markdown": "..."}` or `{"assignee_user_id": "usr_xxx"}`.
-  Body edits are **append-only** — fetch the current body first, append, never
-  overwrite. Prefer `enrich_issue.py` for diagnosis notes.
-- **Change status**: `POST /v1/orgs/june/bounties/{number}/status` with
-  `{"status": "todo|in_progress|in_review|completed|cancelled"}`.
+`issues take` remains the confirmed shortcut that assigns an unassigned todo
+Issue to the authenticated user and moves it to `in_progress`.
 
-Undocumented mutations (issue create, comment create, label set): probe on a
-single Issue first, verify the result with a GET, then proceed. If the
-endpoint 404s/405s or the write doesn't stick, fall back to drafting the
-content for the user to apply in the platform UI. Confirm any fan-out
-mutation on one Issue before applying it to many — this is a shared
+Issue body edits are still **append-only** and are not exposed by
+`os_platform.py`: fetch the full current body first, append, and never
+overwrite. The direct endpoint remains
+`PATCH /v1/orgs/june/bounties/{number}` with the combined body as
+`{"body_markdown": "..."}`. Prefer `os-task-prep/scripts/enrich_issue.py` for
+diagnosis notes. Other mutations not owned by the script, such as body or
+label updates, keep the direct API probe-then-verify discipline. Confirm any
+fan-out mutation on one Issue before applying it to many — this is a shared
 production tracker.
 
 ## Language
@@ -52,8 +59,8 @@ User-facing product language says **Issue** (internal API paths say
 
 ## When a skill says "publish to the issue tracker"
 
-Create the Issue via the API (probe-then-verify, above); fall back to
-drafting it for the user if creation isn't supported.
+Create the Issue with `python3 scripts/os_platform.py issues create ...`, then
+verify it with `issues show`.
 
 ## When a skill says "fetch the relevant ticket"
 


### PR DESCRIPTION
Closes JUN-250.

## What changed
- `os_platform.py` write surface: `issues create` / `assign` (pre-read guard, `--force`) / `status` (guarded: pre-read, echo, `--yes` for terminal transitions, `--force` for foreign assignee) / `attach` (public-file requirement + `--public` acknowledgement) plus `comments add` and `files upload` (multipart `POST /v1/files`).
- Contract alignment with the platform OpenAPI (`api/openapi.json` in os-platform): full status enum (incl. `proposed`), type/priority pass-through with documented contract values, status via `POST .../status`, attach via read-modify-write of the bounty's `file_ids`.
- User-Agent overridable via `OS_PLATFORM_USER_AGENT`; default bumped (old UA blocked writes).
- `issues show` returns full bodies by default (was silently truncated; `--full` kept as no-op).
- Assign post-write verification (concurrent-agent race), clean missing-argument errors, 27 offline stub tests.
- SKILL.md agent status lifecycle (create-if-missing, take-to-own, in_review at PR, terminal via `--yes`), PR auto-link guidance (GitHub pr-links integration; comment fallback), public-attachment rules; api-map.md cites the OpenAPI as source.

## Why
JUN-250: agents should keep work status current on the platform; the skill had one write (`take`), a blocked UA, and truncated reads.

## Validation — live probe-then-verify (production, authorized)
Full lifecycle exercised on test issue **JUN-253** (created for this purpose, now cancelled):
- create → assign → in_progress → in_review → comment → cancelled: all accepted, each verified by independent read-back.
- New UA accepted for every write.
- Guards verified live: terminal status without `--yes` refuses with a WOULD-change echo; attach of a private file surfaces the platform's error 2015; `--path` without `--public` refuses client-side.
- `files upload` + `issues attach --path --public`: file `fil_vfLevUnmLHCj` attached to JUN-253 and read back.
- The probe caught one real defect (attachments must be public) that offline stubs could not — fixed and re-probed green.
- Offline: 27/27 stub tests, py_compile clean.

## Review
Adversarial axis run twice (cross-harness): round 1 (3 findings: assign guard, enum pass-through — both fixed; idempotency claim **refuted by the OpenAPI contract**, flag removed), round 2 on the other harness (5 findings: status guard, identity check via `assignee_user_id`, post-write verify, coverage, argument crashes — all fixed).

## Tested visually
N/A — CLI/skill change.

## Needs June API deploy
No.

## Out of scope / followups
- PR links are created by the platform's GitHub webhook integration, not this CLI (documented; comment fallback available).
- Adoption of the lifecycle by other skills rides in future skill edits.

🤖 Generated with Claude Code