### PR TITLE
Session titles stick and stay readable (JUN-249)

### DIFF
--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -1868,7 +1868,7 @@ fn clean_agent_session_title(value: &str) -> Option<String> {
         } else {
             truncated.rfind(char::is_whitespace)
         };
-        let boundary = boundary?;
+        let boundary = boundary.unwrap_or(truncated.len());
         title = truncated[..boundary]
             .trim_end()
             .trim_end_matches(|ch: char| ch.is_ascii_punctuation() || matches!(ch, '–' | '—' | '…'))
@@ -2673,7 +2673,11 @@ data: \"data\":{\"content\":\"Joined\",\"titleSuggestion\":null,\"provider\":\"v
         );
         assert_eq!(
             clean_agent_session_title(&"a".repeat(AGENT_TITLE_MAX_CHARS + 1)),
-            None
+            Some("a".repeat(AGENT_TITLE_MAX_CHARS))
+        );
+        assert_eq!(
+            clean_agent_session_title(&"界".repeat(AGENT_TITLE_MAX_CHARS + 1)),
+            Some("界".repeat(AGENT_TITLE_MAX_CHARS))
         );
         assert_eq!(clean_agent_session_title("   "), None);
     }

--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -1858,10 +1858,24 @@ fn clean_agent_session_title(value: &str) -> Option<String> {
         return None;
     }
     if title.chars().count() > AGENT_TITLE_MAX_CHARS {
-        title = title.chars().take(AGENT_TITLE_MAX_CHARS).collect();
-        title = title.trim_end().to_string();
+        let truncated: String = title.chars().take(AGENT_TITLE_MAX_CHARS).collect();
+        let boundary = if title
+            .chars()
+            .nth(AGENT_TITLE_MAX_CHARS)
+            .is_some_and(char::is_whitespace)
+        {
+            Some(truncated.len())
+        } else {
+            truncated.rfind(char::is_whitespace)
+        };
+        let boundary = boundary?;
+        title = truncated[..boundary]
+            .trim_end()
+            .trim_end_matches(|ch: char| ch.is_ascii_punctuation() || matches!(ch, '–' | '—' | '…'))
+            .trim_end()
+            .to_string();
     }
-    Some(title)
+    (!title.is_empty()).then_some(title)
 }
 
 async fn post_json<T, B>(path: &str, body: &B, send_venice_api_key: bool) -> Result<T, AppError>
@@ -2648,7 +2662,18 @@ data: \"data\":{\"content\":\"Joined\",\"titleSuggestion\":null,\"provider\":\"v
                 "Create a quarterly planning briefing with follow-up action items",
             )
             .as_deref(),
-            Some("Create a quarterly planning briefing with follow")
+            Some("Create a quarterly planning briefing with")
+        );
+        assert_eq!(
+            clean_agent_session_title(
+                "Create a quarterly planning briefing, extraordinary follow-up actions",
+            )
+            .as_deref(),
+            Some("Create a quarterly planning briefing")
+        );
+        assert_eq!(
+            clean_agent_session_title(&"a".repeat(AGENT_TITLE_MAX_CHARS + 1)),
+            None
         );
         assert_eq!(clean_agent_session_title("   "), None);
     }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2208,12 +2208,6 @@ export function App() {
     }
     pendingSessionProjectRef.current = null;
     setAgentOrigin(undefined);
-    // The agent view resolves the conversation by this id, so switch straight
-    // in. Backfill the bridge session-list registration in the background (best
-    // effort) so the session also shows in the agent history sidebar even if
-    // the note chat's own registration hadn't landed yet — never blocks the
-    // handoff, so a slow or failed registration can't stall or dead-end it.
-    void ensureHermesBridgeSession({ sessionId }).catch(() => undefined);
     setActiveAgentSession({ id: sessionId, title: noteRef.title.trim() || undefined });
     setActiveView("agent");
   }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2213,10 +2213,7 @@ export function App() {
     // effort) so the session also shows in the agent history sidebar even if
     // the note chat's own registration hadn't landed yet — never blocks the
     // handoff, so a slow or failed registration can't stall or dead-end it.
-    void ensureHermesBridgeSession({
-      sessionId,
-      title: noteRef.title.trim() || "Note chat",
-    }).catch(() => undefined);
+    void ensureHermesBridgeSession({ sessionId }).catch(() => undefined);
     setActiveAgentSession({ id: sessionId, title: noteRef.title.trim() || undefined });
     setActiveView("agent");
   }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5835,6 +5835,21 @@ export function AgentWorkspace({
   ): Promise<string | undefined> {
     const displayContent = options?.displayContent ?? content;
     const titleContent = options?.titleContent ?? displayContent;
+    let attachmentOnlyTitle: string | undefined;
+    if (!titleContent.trim() && options?.attachments?.length) {
+      const firstName = options.attachments[0].name.trim();
+      const extensionIndex = firstName.lastIndexOf(".");
+      const firstDisplayName = (
+        extensionIndex > 0 ? firstName.slice(0, extensionIndex) : firstName
+      ).trim();
+      const title =
+        options.attachments.length === 1
+          ? firstDisplayName
+          : `${firstDisplayName} +${options.attachments.length - 1} more`;
+      attachmentOnlyTitle = title
+        .replace(/[–—]/g, "-")
+        .replace(/^([a-z])/, (match) => match.toUpperCase());
+    }
     const targetSessionId = explicitSession?.id
       ? explicitSession.id
       : newSessionModeRef.current
@@ -5911,7 +5926,9 @@ export function AgentWorkspace({
     const titlePromise =
       targetSessionId || options?.issueReport
         ? undefined
-        : agentSessionTitleForPrompt(titleContent).then((suggestion) => suggestion.title);
+        : attachmentOnlyTitle
+          ? Promise.resolve(attachmentOnlyTitle)
+          : agentSessionTitleForPrompt(titleContent).then((suggestion) => suggestion.title);
     const fallbackSessionTitle = targetSessionId
       ? explicitSession?.title?.trim() ||
         hermesSessionItemsRef.current
@@ -5920,7 +5937,7 @@ export function AgentWorkspace({
         "Untitled session"
       : options?.issueReport
         ? "Issue report"
-        : titleFromPrompt(titleContent);
+        : attachmentOnlyTitle || titleFromPrompt(titleContent);
     const optimisticSession =
       targetSessionId || options?.skipPrompt
         ? undefined

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5846,7 +5846,9 @@ export function AgentWorkspace({
         options.attachments.length === 1
           ? firstDisplayName
           : `${firstDisplayName} +${options.attachments.length - 1} more`;
-      attachmentOnlyTitle = title
+      attachmentOnlyTitle = Array.from(title.replace(/\s+/g, " "))
+        .slice(0, AGENT_TITLE_MAX_CHARS)
+        .join("")
         .replace(/[–—]/g, "-")
         .replace(/^([a-z])/, (match) => match.toUpperCase());
     }
@@ -5937,7 +5939,7 @@ export function AgentWorkspace({
         explicitSession?.preview?.trim() ||
         listedTargetSession?.title?.trim() ||
         listedTargetSession?.preview?.trim() ||
-        "Untitled session"
+        titleFromPrompt(titleContent)
       : options?.issueReport
         ? "Issue report"
         : attachmentOnlyTitle || titleFromPrompt(titleContent);
@@ -9485,6 +9487,8 @@ function AgentSessionBar({
     </div>
   );
 }
+
+const AGENT_TITLE_MAX_CHARS = 48;
 
 async function agentSessionTitleForPrompt(prompt: string, response?: string) {
   try {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5846,6 +5846,8 @@ export function AgentWorkspace({
         options.attachments.length === 1
           ? firstDisplayName
           : `${firstDisplayName} +${options.attachments.length - 1} more`;
+      // Array.from splits on Unicode code points, so the cap cannot cut an
+      // emoji or surrogate pair in half the way String.slice would.
       attachmentOnlyTitle = Array.from(title.replace(/\s+/g, " "))
         .slice(0, AGENT_TITLE_MAX_CHARS)
         .join("")

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5929,11 +5929,14 @@ export function AgentWorkspace({
         : attachmentOnlyTitle
           ? Promise.resolve(attachmentOnlyTitle)
           : agentSessionTitleForPrompt(titleContent).then((suggestion) => suggestion.title);
+    const listedTargetSession = targetSessionId
+      ? hermesSessionItemsRef.current.find((session) => session.id === targetSessionId)
+      : undefined;
     const fallbackSessionTitle = targetSessionId
       ? explicitSession?.title?.trim() ||
-        hermesSessionItemsRef.current
-          .find((session) => session.id === targetSessionId)
-          ?.title?.trim() ||
+        explicitSession?.preview?.trim() ||
+        listedTargetSession?.title?.trim() ||
+        listedTargetSession?.preview?.trim() ||
         "Untitled session"
       : options?.issueReport
         ? "Issue report"

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5912,11 +5912,15 @@ export function AgentWorkspace({
       targetSessionId || options?.issueReport
         ? undefined
         : agentSessionTitleForPrompt(titleContent).then((suggestion) => suggestion.title);
-    const fallbackSessionTitle = options?.issueReport
-      ? "Issue report"
-      : explicitSession?.title?.trim() ||
-        explicitSession?.preview?.trim() ||
-        titleFromPrompt(titleContent);
+    const fallbackSessionTitle = targetSessionId
+      ? explicitSession?.title?.trim() ||
+        hermesSessionItemsRef.current
+          .find((session) => session.id === targetSessionId)
+          ?.title?.trim() ||
+        "Untitled session"
+      : options?.issueReport
+        ? "Issue report"
+        : titleFromPrompt(titleContent);
     const optimisticSession =
       targetSessionId || options?.skipPrompt
         ? undefined
@@ -5986,7 +5990,7 @@ export function AgentWorkspace({
     const ensureStoredHermesSession = () =>
       ensureHermesBridgeSession({
         sessionId: storedSessionId,
-        title: sessionDisplayTitle,
+        ...(!targetSessionId ? { title: sessionDisplayTitle } : {}),
         ...(targetSessionModelId ? { model: targetSessionModelId } : {}),
       });
     if (optimisticSession) {

--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -14,7 +14,6 @@ import {
   type HermesAttachmentState,
 } from "../../lib/hermes-image-attach";
 import {
-  ensureHermesBridgeSession,
   hermesBridgeImageDataUrl,
   hermesBridgeSessionMessages,
   hermesBridgeStatus,
@@ -186,12 +185,6 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
   // double send (double-click, or Enter racing the send button) could both
   // pass the state-based check and each create a session / append a turn.
   const submittingRef = useRef(false);
-  // Whether this session is registered in the bridge's session LIST. The
-  // conversation itself always loads by session id (the agent view reads
-  // messages by id, and this ensure is best-effort — mirroring the workspace's
-  // own swallowed ensure), so registration only affects the history sidebar.
-  // Retried on later sends and backfilled at the open-in-agent handoff.
-  const bridgeEnsuredRef = useRef(false);
   const liveEventsRef = useRef<JuneHermesEvent[]>([]);
   const pendingUserTurnsRef = useRef<AgentChatTurn[]>([]);
   liveEventsRef.current = liveEvents;
@@ -205,7 +198,6 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
     pendingModelIdRef.current = undefined;
     appliedModelIdRef.current = undefined;
     submittingRef.current = false;
-    bridgeEnsuredRef.current = false;
     setStoredSessionId(sessionId);
     setMessages([]);
     setLiveEvents([]);
@@ -332,8 +324,6 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
           storedSessionIdRef.current = sessionId;
           setStoredSessionId(sessionId);
           rememberNoteChatSession(noteId, sessionId);
-          // Registration in the bridge list happens at the single ensure point
-          // below (which retries a swallowed attempt on later sends).
         }
         if (!runtimeSessionId) {
           const resumed = await gateway.request<HermesRuntimeSessionResponse>("session.resume", {
@@ -355,23 +345,6 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
             model: modelId,
           });
           appliedModelIdRef.current = modelId;
-          bridgeEnsuredRef.current = await ensureHermesBridgeSession({
-            sessionId,
-            model: modelId,
-          })
-            .then(() => true)
-            .catch(() => bridgeEnsuredRef.current);
-        }
-        // Best-effort registration in the bridge's session list (for the
-        // history sidebar), retrying a swallowed earlier attempt. The chat and
-        // the open-in-agent handoff both work by session id regardless.
-        if (!bridgeEnsuredRef.current) {
-          bridgeEnsuredRef.current = await ensureHermesBridgeSession({
-            sessionId,
-            ...(appliedModelIdRef.current ? { model: appliedModelIdRef.current } : {}),
-          })
-            .then(() => true)
-            .catch(() => false);
         }
         // Images go to the model as first-class inputs before the prompt,
         // like the workspace's feature-19 flow. A failed attach throws so the

--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -357,7 +357,6 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
           appliedModelIdRef.current = modelId;
           bridgeEnsuredRef.current = await ensureHermesBridgeSession({
             sessionId,
-            title: noteTitle.trim() || "Note chat",
             model: modelId,
           })
             .then(() => true)
@@ -369,7 +368,6 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
         if (!bridgeEnsuredRef.current) {
           bridgeEnsuredRef.current = await ensureHermesBridgeSession({
             sessionId,
-            title: noteTitle.trim() || "Note chat",
             ...(appliedModelIdRef.current ? { model: appliedModelIdRef.current } : {}),
           })
             .then(() => true)

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -7541,6 +7541,39 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("titles an attachments-only new session from the attachment name", async () => {
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
+    });
+    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.listen).toHaveBeenCalledWith("tauri://drag-drop", expect.any(Function)),
+    );
+
+    mocks.eventHandlers.get("tauri://drag-drop")?.({
+      payload: {
+        paths: ["/Users/alex/Desktop/quarterly—planning.PDF"],
+      },
+    });
+
+    expect(await screen.findByText("quarterly—planning.PDF")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith(
+        "session.create",
+        expect.objectContaining({ title: "Quarterly-planning" }),
+      ),
+    );
+    expect(mocks.suggestAgentSessionTitle).not.toHaveBeenCalled();
+    expect(await screen.findByText("Quarterly-planning")).toBeInTheDocument();
+    expect(screen.queryByText("Untitled session")).toBeNull();
+  });
+
   it("imports typed file paths from the /file slash command", async () => {
     const user = userEvent.setup();
     render(<AgentWorkspace />);

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3427,6 +3427,47 @@ describe("AgentWorkspace", () => {
     }
   });
 
+  it("uses the prompt as the display title for a cold-start follow-up", async () => {
+    const statusDetails: AgentSessionStatusDetail[] = [];
+    const handleStatus = (event: Event) => {
+      statusDetails.push((event as CustomEvent<AgentSessionStatusDetail>).detail);
+    };
+    window.addEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
+    mocks.listHermesSessions.mockResolvedValue([]);
+    const user = userEvent.setup();
+    const prompt = "Check the signing step too";
+
+    try {
+      render(<AgentWorkspace initialSessionId="session-cold-start" />);
+
+      await user.type(await screen.findByRole("textbox", { name: "Message June" }), prompt);
+      await user.click(screen.getByRole("button", { name: "Send message" }));
+
+      await waitFor(() =>
+        expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+          session_id: "runtime-session-1",
+          text: prompt,
+        }),
+      );
+      expect(mocks.titleFromPrompt).toHaveBeenCalledWith(prompt);
+      expect(statusDetails).toContainEqual(
+        expect.objectContaining({
+          sessionId: "session-cold-start",
+          status: "running",
+          title: prompt,
+        }),
+      );
+      expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: "session-cold-start",
+          title: expect.any(String),
+        }),
+      );
+    } finally {
+      window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
+    }
+  });
+
   it("skips the durable exchange marker when title persistence fails", async () => {
     const rawTitle = "I need you to inspect the flaky tests";
     mocks.listHermesSessions.mockResolvedValue([
@@ -7590,7 +7631,23 @@ describe("AgentWorkspace", () => {
     );
   });
 
-  it("titles an attachments-only new session from the attachment name", async () => {
+  it.each([
+    {
+      name: "titles an attachments-only new session from the attachment name",
+      path: "/Users/alex/Desktop/quarterly—planning.PDF",
+      title: "Quarterly-planning",
+    },
+    {
+      name: "caps an attachments-only session title derived from a long filename",
+      path: "/Users/alex/Desktop/this-is-a-very-long-attachment-name-that-exceeds-the-forty-eight-character-title-limit.pdf",
+      title: "This-is-a-very-long-attachment-name-that-exceeds",
+    },
+    {
+      name: "collapses filename whitespace in an attachments-only session title",
+      path: "/Users/alex/Desktop/quarterly\n\tplanning\t notes.PDF",
+      title: "Quarterly planning notes",
+    },
+  ])("$name", async ({ path, title }) => {
     const user = userEvent.setup();
     render(<AgentWorkspace />);
 
@@ -7605,21 +7662,22 @@ describe("AgentWorkspace", () => {
 
     mocks.eventHandlers.get("tauri://drag-drop")?.({
       payload: {
-        paths: ["/Users/alex/Desktop/quarterly—planning.PDF"],
+        paths: [path],
       },
     });
 
-    expect(await screen.findByText("quarterly—planning.PDF")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Start session" }));
+    const startButton = screen.getByRole("button", { name: "Start session" });
+    await waitFor(() => expect(startButton).not.toBeDisabled());
+    await user.click(startButton);
 
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith(
         "session.create",
-        expect.objectContaining({ title: "Quarterly-planning" }),
+        expect.objectContaining({ title }),
       ),
     );
     expect(mocks.suggestAgentSessionTitle).not.toHaveBeenCalled();
-    expect(await screen.findByText("Quarterly-planning")).toBeInTheDocument();
+    expect(await screen.findByText(title)).toBeInTheDocument();
     expect(screen.queryByText("Untitled session")).toBeNull();
   });
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -74,6 +74,7 @@ const mocks = vi.hoisted(() => ({
   startHermesBridge: vi.fn(),
   submitIssueReport: vi.fn(),
   suggestAgentSessionTitle: vi.fn(),
+  titleFromPrompt: vi.fn((prompt: string) => prompt.trim() || "Untitled session"),
   explainAgentApproval: vi.fn(),
   toggleHermesBridgeSkill: vi.fn(),
   toggleHermesBridgeToolset: vi.fn(),
@@ -168,7 +169,7 @@ vi.mock("../lib/hermes-adapter", async (importOriginal) => ({
   listHermesSessions: mocks.listHermesSessions,
   sessionTimestamp: (session: { last_active?: string; started_at?: string }) =>
     session.last_active ?? session.started_at ?? "",
-  titleFromPrompt: (prompt: string) => prompt.trim() || "Untitled session",
+  titleFromPrompt: mocks.titleFromPrompt,
 }));
 
 vi.mock("../lib/hermes-gateway", async (importOriginal) => ({
@@ -3176,6 +3177,205 @@ describe("AgentWorkspace", () => {
         JSON.stringify({ "session-exchange": "exchange" }),
       ),
     );
+  });
+
+  it("keeps the persisted first-exchange title after a follow-up and restart", async () => {
+    const user = userEvent.setup();
+    const rawTitle = "I need you to inspect the flaky tests";
+    let persistedTitle = rawTitle;
+    mocks.listHermesSessions.mockImplementation(async () => [
+      {
+        id: "session-follow-up-restart",
+        title: persistedTitle,
+        preview: rawTitle,
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "u1",
+        role: "user",
+        content: "inspect the flaky tests",
+        timestamp: "2026-06-04T12:00:00Z",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "I traced the failure to stale timers and updated the regression test.",
+        timestamp: "2026-06-04T12:00:01Z",
+      },
+    ]);
+    mocks.suggestAgentSessionTitle.mockResolvedValue({ title: "Flaky Timer Fix" });
+    mocks.ensureHermesBridgeSession.mockImplementation(
+      async (input: { sessionId: string; title?: string }) => {
+        if (input.title) persistedTitle = input.title;
+        return {};
+      },
+    );
+
+    const first = render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Flaky Timer Fix")).toBeInTheDocument();
+    await waitFor(() => expect(persistedTitle).toBe("Flaky Timer Fix"));
+    await waitFor(() =>
+      expect(window.localStorage.getItem("june.agent.manuallyTitledSessions")).toBe(
+        JSON.stringify({ "session-follow-up-restart": "exchange" }),
+      ),
+    );
+
+    await user.type(screen.getByRole("textbox"), "Does this also fail in CI?");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "Does this also fail in CI?",
+      }),
+    );
+
+    first.unmount();
+    resetAgentSessionContinuity();
+    mocks.gatewayEventHandlers.clear();
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Flaky Timer Fix")).toBeInTheDocument();
+    expect(screen.queryByText("Does this also fail in CI?")).toBeNull();
+  });
+
+  it("does not write a follow-up title while the first-exchange title is pending", async () => {
+    const user = userEvent.setup();
+    const rawTitle = "I need you to inspect the flaky tests";
+    let persistedTitle = rawTitle;
+    let resolveTitleSuggestion: ((value: { title: string }) => void) | undefined;
+    mocks.listHermesSessions.mockImplementation(async () => [
+      {
+        id: "session-follow-up-pending-title",
+        title: persistedTitle,
+        preview: rawTitle,
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "u1",
+        role: "user",
+        content: "inspect the flaky tests",
+        timestamp: "2026-06-04T12:00:00Z",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "I traced the failure to stale timers and updated the regression test.",
+        timestamp: "2026-06-04T12:00:01Z",
+      },
+    ]);
+    mocks.suggestAgentSessionTitle.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveTitleSuggestion = resolve;
+        }),
+    );
+    mocks.ensureHermesBridgeSession.mockImplementation(
+      async (input: { sessionId: string; title?: string }) => {
+        if (input.title) persistedTitle = input.title;
+        return {};
+      },
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText(rawTitle)).toBeInTheDocument();
+    await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(1));
+    const titleDerivationsBeforeFollowUp = mocks.titleFromPrompt.mock.calls.length;
+
+    await user.type(screen.getByRole("textbox"), "Does this also fail in CI?");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "Does this also fail in CI?",
+      }),
+    );
+
+    expect(persistedTitle).toBe(rawTitle);
+    expect(mocks.titleFromPrompt).toHaveBeenCalledTimes(titleDerivationsBeforeFollowUp);
+
+    await act(async () => {
+      resolveTitleSuggestion?.({ title: "Flaky Timer Fix" });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(persistedTitle).toBe("Flaky Timer Fix"));
+    expect(await screen.findByText("Flaky Timer Fix")).toBeInTheDocument();
+  });
+
+  it("keeps a manual title after a follow-up and restart", async () => {
+    const user = userEvent.setup();
+    let persistedTitle = "Flaky Timer Fix";
+    window.localStorage.setItem(
+      "june.agent.manuallyTitledSessions",
+      JSON.stringify({ "session-manual-follow-up": "exchange" }),
+    );
+    mocks.listHermesSessions.mockImplementation(async () => [
+      {
+        id: "session-manual-follow-up",
+        title: persistedTitle,
+        preview: "inspect the flaky tests",
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "u1",
+        role: "user",
+        content: "inspect the flaky tests",
+        timestamp: "2026-06-04T12:00:00Z",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "I traced the failure to stale timers and updated the regression test.",
+        timestamp: "2026-06-04T12:00:01Z",
+      },
+    ]);
+    mocks.ensureHermesBridgeSession.mockImplementation(
+      async (input: { sessionId: string; title?: string }) => {
+        if (input.title) persistedTitle = input.title;
+        return {};
+      },
+    );
+
+    const first = render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Flaky Timer Fix")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Session actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Rename" }));
+    const input = screen.getByRole("textbox", { name: "Session name" });
+    await user.clear(input);
+    await user.type(input, "Manual CI investigation{Enter}");
+    await waitFor(() => expect(persistedTitle).toBe("Manual CI investigation"));
+    expect(window.localStorage.getItem("june.agent.manuallyTitledSessions")).toBe(
+      JSON.stringify({ "session-manual-follow-up": "manual" }),
+    );
+    const titleDerivationsBeforeFollowUp = mocks.titleFromPrompt.mock.calls.length;
+
+    await user.type(screen.getByRole("textbox"), "Check the Windows runner too");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "Check the Windows runner too",
+      }),
+    );
+
+    expect(persistedTitle).toBe("Manual CI investigation");
+    expect(mocks.titleFromPrompt).toHaveBeenCalledTimes(titleDerivationsBeforeFollowUp);
+
+    first.unmount();
+    resetAgentSessionContinuity();
+    mocks.gatewayEventHandlers.clear();
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Manual CI investigation")).toBeInTheDocument();
   });
 
   it("skips the durable exchange marker when title persistence fails", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3378,6 +3378,55 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("Manual CI investigation")).toBeInTheDocument();
   });
 
+  it("uses the preview as the display title for a titleless existing-session follow-up", async () => {
+    const statusDetails: AgentSessionStatusDetail[] = [];
+    const handleStatus = (event: Event) => {
+      statusDetails.push((event as CustomEvent<AgentSessionStatusDetail>).detail);
+    };
+    window.addEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
+    const preview = "Investigate the desktop release failure";
+    const titlelessSession = {
+      id: "session-preview-fallback",
+      title: "",
+      preview,
+      last_active: "2026-06-04T12:00:00Z",
+    };
+    mocks.listHermesSessions.mockResolvedValue([titlelessSession]);
+    const user = userEvent.setup();
+
+    try {
+      render(<AgentWorkspace initialSession={titlelessSession} />);
+
+      await user.type(
+        await screen.findByRole("textbox", { name: "Message June" }),
+        "Check the signing step too",
+      );
+      await user.click(screen.getByRole("button", { name: "Send message" }));
+
+      await waitFor(() =>
+        expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+          session_id: "runtime-session-1",
+          text: "Check the signing step too",
+        }),
+      );
+      expect(statusDetails).toContainEqual(
+        expect.objectContaining({
+          sessionId: "session-preview-fallback",
+          status: "running",
+          title: preview,
+        }),
+      );
+      expect(statusDetails).not.toContainEqual(
+        expect.objectContaining({
+          sessionId: "session-preview-fallback",
+          title: "Untitled session",
+        }),
+      );
+    } finally {
+      window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
+    }
+  });
+
   it("skips the durable exchange marker when title persistence fails", async () => {
     const rawTitle = "I need you to inspect the flaky tests";
     mocks.listHermesSessions.mockResolvedValue([

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -8,7 +8,6 @@ import {
 import { useNoteChat } from "../components/note-chat/useNoteChat";
 
 const mocks = vi.hoisted(() => ({
-  ensureHermesBridgeSession: vi.fn(),
   gatewayRequest: vi.fn(),
   hermesBridgeImageDataUrl: vi.fn(),
   hermesBridgeSessionMessages: vi.fn(),
@@ -17,7 +16,6 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../lib/tauri", () => ({
-  ensureHermesBridgeSession: mocks.ensureHermesBridgeSession,
   hermesBridgeImageDataUrl: mocks.hermesBridgeImageDataUrl,
   hermesBridgeSessionMessages: mocks.hermesBridgeSessionMessages,
   hermesBridgeStatus: mocks.hermesBridgeStatus,
@@ -99,18 +97,8 @@ describe("note chat session map", () => {
     expect(noteChatSessionIdFor("note-1")).toBe("sess-a");
   });
 
-  it("keeps a manual stored-session title through reopen, model change, and registration retry", async () => {
+  it("switches models on a reopened note chat", async () => {
     rememberNoteChatSession("note-1", "stored-note-chat");
-    let persistedTitle = "Manual launch blockers";
-    let registrationAttempt = 0;
-    mocks.ensureHermesBridgeSession.mockImplementation(
-      async (input: { sessionId: string; title?: string; model?: string }) => {
-        registrationAttempt += 1;
-        if (registrationAttempt === 1) throw new Error("registration unavailable");
-        if (input.title) persistedTitle = input.title;
-        return {};
-      },
-    );
 
     const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
 
@@ -131,10 +119,5 @@ describe("note chat session map", () => {
       session_id: "runtime-note-chat",
       command: "/model kimi-k2-6",
     });
-    expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledTimes(2);
-    expect(persistedTitle).toBe("Manual launch blockers");
-    for (const [input] of mocks.ensureHermesBridgeSession.mock.calls) {
-      expect(input).not.toHaveProperty("title");
-    }
   });
 });

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -1,15 +1,61 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   forgetNoteChatSession,
   noteChatSessionIdFor,
   rememberNoteChatSession,
 } from "../components/note-chat/noteChatSessions";
+import { useNoteChat } from "../components/note-chat/useNoteChat";
+
+const mocks = vi.hoisted(() => ({
+  ensureHermesBridgeSession: vi.fn(),
+  gatewayRequest: vi.fn(),
+  hermesBridgeImageDataUrl: vi.fn(),
+  hermesBridgeSessionMessages: vi.fn(),
+  hermesBridgeStatus: vi.fn(),
+  startHermesBridge: vi.fn(),
+}));
+
+vi.mock("../lib/tauri", () => ({
+  ensureHermesBridgeSession: mocks.ensureHermesBridgeSession,
+  hermesBridgeImageDataUrl: mocks.hermesBridgeImageDataUrl,
+  hermesBridgeSessionMessages: mocks.hermesBridgeSessionMessages,
+  hermesBridgeStatus: mocks.hermesBridgeStatus,
+  startHermesBridge: mocks.startHermesBridge,
+}));
+
+vi.mock("../lib/hermes-gateway", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/hermes-gateway")>()),
+  HermesGatewayClient: class {
+    connect = vi.fn();
+    close = vi.fn();
+    onEvent = vi.fn();
+    onClose = vi.fn();
+    request = mocks.gatewayRequest;
+  },
+}));
 
 const STORAGE_KEY = "june.noteChat.sessionsByNote.v1";
 
 describe("note chat session map", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     window.localStorage.clear();
+    mocks.hermesBridgeStatus.mockResolvedValue({
+      running: true,
+      connection: { port: 61234, wsUrl: "ws://127.0.0.1:61234" },
+    });
+    mocks.hermesBridgeSessionMessages.mockResolvedValue({ messages: [] });
+    mocks.startHermesBridge.mockResolvedValue({
+      running: true,
+      connection: { port: 61234, wsUrl: "ws://127.0.0.1:61234" },
+    });
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-note-chat" });
+      }
+      return Promise.resolve({});
+    });
   });
 
   it("remembers and recalls the session for a note", () => {
@@ -51,5 +97,44 @@ describe("note chat session map", () => {
     // A write over corrupt storage heals it.
     rememberNoteChatSession("note-1", "sess-a");
     expect(noteChatSessionIdFor("note-1")).toBe("sess-a");
+  });
+
+  it("keeps a manual stored-session title through reopen, model change, and registration retry", async () => {
+    rememberNoteChatSession("note-1", "stored-note-chat");
+    let persistedTitle = "Manual launch blockers";
+    let registrationAttempt = 0;
+    mocks.ensureHermesBridgeSession.mockImplementation(
+      async (input: { sessionId: string; title?: string; model?: string }) => {
+        registrationAttempt += 1;
+        if (registrationAttempt === 1) throw new Error("registration unavailable");
+        if (input.title) persistedTitle = input.title;
+        return {};
+      },
+    );
+
+    const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
+
+    await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
+    act(() => result.current.setSessionModel("kimi-k2-6"));
+
+    let accepted = false;
+    await act(async () => {
+      accepted = await result.current.submit("What remains blocked?");
+    });
+
+    expect(accepted).toBe(true);
+    expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.resume", {
+      session_id: "stored-note-chat",
+      cols: 96,
+    });
+    expect(mocks.gatewayRequest).toHaveBeenCalledWith("command.dispatch", {
+      session_id: "runtime-note-chat",
+      command: "/model kimi-k2-6",
+    });
+    expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledTimes(2);
+    expect(persistedTitle).toBe("Manual launch blockers");
+    for (const [input] of mocks.ensureHermesBridgeSession.mock.calls) {
+      expect(input).not.toHaveProperty("title");
+    }
   });
 });


### PR DESCRIPTION
Closes JUN-249.

## What changed
- **Follow-up submissions no longer clobber persisted session titles** (the root cause of "names still suck"): existing sessions never derive or PATCH a title from the latest prompt; a session title is written only by creation, successful first-exchange persistence, or manual rename. Note-chat paths (handoff, model change, registration retry) included.
- Rust title cleaner truncates at word boundaries (no more mid-word cuts), strips dangling punctuation, and hard-truncates boundary-less titles (long URLs/identifiers, unspaced scripts like CJK) instead of discarding them.
- Attachments-only sessions get a deterministic filename-derived title (whitespace-collapsed, 48-char cap) instead of leaking "Untitled session".
- Cold-start follow-ups show a prompt-derived display title (display-only, never persisted) instead of "Untitled session" in the HUD and completion notifications.
- Removed provably inert title-less ensure calls + retry machinery in note-chat (dead code with misleading comments).

## Root cause
Not the generation prompt: every ordinary follow-up overwrote the good first-exchange title with a 6-word heuristic of the LATEST message via an unconditional PATCH (masked in-session by an in-memory override; visible after restart, when the durable exchange marker blocked repair). The issue's own triage had investigated a different product's stack entirely.

## Validation
- Diagnosis chunk with file:line evidence preceded any code; every fix chunk shipped a red-first regression (restart clobber, note-chat manual-rename survival, boundary-less truncation, long/whitespace filenames, cold-start display).
- Full `make tauri-test` green; focused vitest suites green across chunks (agent-workspace, note-chat, sessions-list, HUD, rename).
- Two adversarial review rounds on alternating harnesses; all 6 findings fixed.
- Known flake: one unrelated model-locking toast test can fail under full-suite load; passes in isolation with and without this diff.

## Tested visually
No - the change is behavioral (titles stop changing); deterministic restart-simulation fixtures cover the repro. Can add a walkthrough if reviewers want one.

## Needs June API deploy
No.

## Out of scope / followups
- Title generation model choice (currently the configured generation model) - possible fast-model follow-up.
- `/image` and `/video` prompt-only titles never upgrade to exchange titles (diagnosed, deferred).
- Preview-as-title rendering fallback in session lists (pre-existing, unchanged).

🤖 Generated with Claude Code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786275513&installation_id=144203540&pr_number=693&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F693&signature=d1e8b49d07b4ebeeeed9d7b5d73d90beb91fa420e6444e8eae79fdfc21403925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->