### PR TITLE
Make P3A ingest token optional (JUN-231)

### DIFF
--- a/june-api/.env.example
+++ b/june-api/.env.example
@@ -26,8 +26,9 @@ JUNE__OS_ACCOUNTS__API_URL=
 # Never embed in the desktop binary or the root .env file.
 JUNE__OS_ACCOUNTS__APP_API_KEY=
 
-# Service token used only for anonymous P3A aggregate ingestion into OS
-# Accounts. Server-side only; OS Accounts stores the SHA-256 hash.
+# Optional service token used only for anonymous P3A aggregate ingestion into
+# OS Accounts. Server-side only; OS Accounts stores the SHA-256 hash. When
+# unset, P3A ingest is disabled and reports are logged only.
 JUNE__OS_ACCOUNTS__P3A_INGEST_TOKEN=
 
 # Flat credit Hold authorized for every metered action (transcribe, generate,

--- a/june-api/crates/app/src/main.rs
+++ b/june-api/crates/app/src/main.rs
@@ -425,7 +425,9 @@ fn build_p3a_sink(config: &AppConfig, http: &reqwest::Client) -> Arc<dyn june_do
         tracing::info!("P3A reports will be forwarded to OS Accounts");
         Arc::new(sink)
     } else {
-        tracing::warn!("P3A ingest token is missing; reports will be logged only");
+        tracing::warn!(
+            "P3A ingest disabled: JUNE__OS_ACCOUNTS__P3A_INGEST_TOKEN not set; reports will be logged only"
+        );
         Arc::new(LogP3aSink)
     }
 }

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -396,6 +396,10 @@ impl Debug for LocalDevConfig {
 pub struct OsAccountsConfig {
     pub api_url: String,
     pub app_api_key: String,
+    /// Optional service token for anonymous P3A aggregate ingestion into OS
+    /// Accounts. When unset (empty), P3A ingest is disabled: reports fall back
+    /// to the log-only sink while startup and all other ingest proceed
+    /// normally.
     #[serde(default)]
     pub p3a_ingest_token: String,
     pub iss: String,
@@ -442,7 +446,14 @@ impl Debug for OsAccountsConfig {
             .debug_struct("OsAccountsConfig")
             .field("api_url", &self.api_url)
             .field("app_api_key", &REDACTED)
-            .field("p3a_ingest_token", &REDACTED)
+            .field(
+                "p3a_ingest_token",
+                if self.p3a_ingest_token.is_empty() {
+                    &"<unset>"
+                } else {
+                    &REDACTED
+                },
+            )
             .field("iss", &self.iss)
             .field("aud", &self.aud)
             .field("jwks_refresh_secs", &self.jwks_refresh_secs)
@@ -977,11 +988,9 @@ fn validate(config: &AppConfig) -> Result<(), ConfigError> {
             &config.os_accounts.app_api_key,
             OS_ACCOUNTS_APP_API_KEY_PLACEHOLDERS,
         )?;
-        validate_required_secret(
-            "os_accounts.p3a_ingest_token",
-            &config.os_accounts.p3a_ingest_token,
-            &[],
-        )?;
+        // os_accounts.p3a_ingest_token is deliberately not validated here:
+        // the token is optional, and when unset the P3A sink degrades to
+        // log-only instead of failing startup (JUN-231).
     }
     validate_request_limits(config)?;
     validate_issue_report_diagnosis(config)?;
@@ -1924,18 +1933,16 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_missing_p3a_ingest_token() {
+    fn validate_accepts_missing_p3a_ingest_token() {
         let mut config = valid_config();
         config.os_accounts.p3a_ingest_token = String::new();
 
         let result = validate(&config);
 
-        assert!(matches!(
-            result,
-            Err(ConfigError::MissingRequired {
-                field: "os_accounts.p3a_ingest_token"
-            })
-        ));
+        assert!(
+            result.is_ok(),
+            "missing P3A ingest token must not fail validation: {result:?}"
+        );
     }
 
     #[test]

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -448,7 +448,7 @@ impl Debug for OsAccountsConfig {
             .field("app_api_key", &REDACTED)
             .field(
                 "p3a_ingest_token",
-                if self.p3a_ingest_token.is_empty() {
+                if self.p3a_ingest_token.trim().is_empty() {
                     &"<unset>"
                 } else {
                     &REDACTED

--- a/june-api/crates/providers/src/os_accounts.rs
+++ b/june-api/crates/providers/src/os_accounts.rs
@@ -508,6 +508,26 @@ mod tests {
         .expect("P3A submit succeeds");
     }
 
+    #[test]
+    fn p3a_sink_from_config_is_disabled_without_token() {
+        let mut config = june_config::AppConfig::default().os_accounts;
+        config.p3a_ingest_token = String::new();
+
+        assert!(OsAccountsP3aSink::from_config(http::default_client(), &config).is_none());
+
+        config.p3a_ingest_token = "   ".to_string();
+
+        assert!(OsAccountsP3aSink::from_config(http::default_client(), &config).is_none());
+    }
+
+    #[test]
+    fn p3a_sink_from_config_is_enabled_with_token() {
+        let mut config = june_config::AppConfig::default().os_accounts;
+        config.p3a_ingest_token = "p3a-token".to_string();
+
+        assert!(OsAccountsP3aSink::from_config(http::default_client(), &config).is_some());
+    }
+
     #[tokio::test]
     async fn authorize_maps_insufficient_credits_to_denied() {
         let server = MockServer::start().await;


### PR DESCRIPTION
Closes JUN-231

## Summary

- Makes `JUNE__OS_ACCOUNTS__P3A_INGEST_TOKEN` optional. The token cannot be provided in some deployments, and its absence previously failed config validation and broke startup.
- `validate()` in `june-config` no longer requires `os_accounts.p3a_ingest_token`. The field keeps its `#[serde(default)]`, so config deserializes and validates without the env var.
- When the token is unset, `build_p3a_sink` falls back to the log-only sink (as it already did) and now logs the explicit line: `P3A ingest disabled: JUNE__OS_ACCOUNTS__P3A_INGEST_TOKEN not set; reports will be logged only`. Startup and all unrelated ingest proceed normally.
- Config debug output shows `<unset>` vs redacted for the token (matching the `local_dev.bearer_token` idiom), and `.env.example` documents the token as optional.

## Root cause

The P3A telemetry rollout added `validate_required_secret("os_accounts.p3a_ingest_token", ...)` to `june-config`'s startup validation, so a missing token aborted boot even though the runtime sink wiring (`OsAccountsP3aSink::from_config` returning `None` -> `LogP3aSink`) already degraded gracefully. The validation requirement was the only breakage.

## Validation

- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path june-api/Cargo.toml --all-targets --all-features --locked`: all suites pass, 0 failures.
- New/updated tests: `validate_accepts_missing_p3a_ingest_token` (config validates without the token, proving boot no longer breaks), `p3a_sink_from_config_is_disabled_without_token` (empty and whitespace-only tokens disable the sink), `p3a_sink_from_config_is_enabled_with_token`.
- `cargo fmt --check` and `cargo clippy --all-targets --all-features --locked` clean on the pinned toolchain.
- No live app walkthrough: this is a backend config-load path with no user-visible surface; the config-load unit test covers the boot behavior without standing up external services.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). N/A, backend only.
- [x] Needs a June API (backend) deploy before it works end to end (the deployment that lacks the token keeps failing until this ships).

## Out of scope

- No change to the P3A report endpoint, question catalog, or OS Accounts ingest contract; reports simply route to the log-only sink when the token is absent.
- No removal of the token from deploy compose files; they still pass the env var through when present.

## Followups

- None planned. Note for history readers: this commit briefly landed directly on main by accident (`d398669b`, reverted in `6e6d689b`); this PR reapplies it through review.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary (relaxes a startup requirement for an optional telemetry credential; ingest auth itself is unchanged).
- [ ] Workflow action references are pinned to full-length commit SHAs. N/A, no workflow changes.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. N/A.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (Logging line changed; flagged for owner review.)
- [ ] User-facing copy follows the repo UI conventions. N/A, no UI copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786287504&installation_id=144203540&pr_number=695&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F695&signature=45312454138f596ce83587cffe1ea4b8edc5ef245d8907c3952408e3b2ba4a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->