### PR TITLE
Chunk long dictation cleanup so punctuation survives (JUN-212)

### DIFF
--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -2603,70 +2603,137 @@ async fn cleanup_dictation_text(
     if text.is_empty() {
         return Ok(String::new());
     }
-    match tokio::time::timeout(
-        dictation_cleanup_timeout(text.len()),
-        cleanup_dictation_chunks(
-            text,
-            dictionary_context,
-            app_context,
-            style,
-            session_id,
-            utterance_id,
-        ),
+    let chunks = split_dictation_cleanup_chunks(text, DICTATION_CLEANUP_CHUNK_TARGET_BYTES);
+    if chunks.len() == 1 {
+        return match tokio::time::timeout(
+            dictation_cleanup_timeout(text.len()),
+            cleanup_dictation_call(
+                text,
+                dictionary_context,
+                app_context,
+                style,
+                session_id,
+                utterance_id,
+            ),
+        )
+        .await
+        {
+            Ok(result) => Ok(trim_cleaned_dictation(&result?)),
+            Err(_) => Err(AppError::new(
+                "dictation_cleanup_timeout",
+                "Dictation cleanup timed out.",
+            )),
+        };
+    }
+    cleanup_dictation_chunks(
+        &chunks,
+        dictionary_context,
+        app_context,
+        style,
+        session_id,
+        utterance_id,
     )
     .await
-    {
-        Ok(result) => result,
-        Err(_) => Err(AppError::new(
-            "dictation_cleanup_timeout",
-            "Dictation cleanup timed out.",
-        )),
-    }
 }
 
-/// Clean the transcript through `/v1/dictate/cleanup`, splitting long
-/// dictations into word-boundary chunks first. The cleanup model reliably
+/// Clean a long transcript through `/v1/dictate/cleanup` a word-boundary
+/// chunk at a time and rejoin the results. The cleanup model reliably
 /// punctuates short passages but degrades into an unpunctuated verbatim echo
-/// on long run-on speech (JUN-212), so long transcripts are cleaned a chunk at
-/// a time and rejoined. Each chunk gets its own utterance id suffix so the
-/// per-utterance idempotent metering treats it as its own unit of work.
+/// on long run-on speech (JUN-212). Each chunk gets its own utterance id
+/// suffix so metering treats it as its own unit of work.
+///
+/// The whole batch shares one scaled deadline, but hitting it never discards
+/// chunks that already cleaned up: the chunk that ran out of time and any
+/// chunks after it degrade to their raw text instead.
 async fn cleanup_dictation_chunks(
-    text: &str,
+    chunks: &[&str],
     dictionary_context: Option<&str>,
     app_context: Option<String>,
     style: DictationStyle,
     session_id: String,
     utterance_id: String,
 ) -> Result<String, AppError> {
-    let chunks = split_dictation_cleanup_chunks(text, DICTATION_CLEANUP_CHUNK_TARGET_BYTES);
-    if chunks.len() == 1 {
-        return cleanup_dictation_call(
-            text,
-            dictionary_context,
-            app_context,
-            style,
-            session_id,
-            utterance_id,
-        )
-        .await;
-    }
+    let total_bytes: usize = chunks.iter().map(|chunk| chunk.len()).sum();
+    let deadline = Instant::now() + dictation_cleanup_timeout(total_bytes);
     let chunk_count = chunks.len();
     let mut cleaned_chunks: Vec<String> = Vec::with_capacity(chunk_count);
+    let mut raw_chunks = 0usize;
     for (index, chunk) in chunks.iter().enumerate() {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            raw_chunks += 1;
+            cleaned_chunks.push((*chunk).to_string());
+            continue;
+        }
         let chunk_utterance_id = format!("{utterance_id}-c{index}");
-        let cleaned = cleanup_dictation_chunk_with_retry(
-            chunk,
-            dictionary_context,
-            app_context.clone(),
-            style,
-            session_id.clone(),
-            chunk_utterance_id,
+        match tokio::time::timeout(
+            remaining,
+            cleanup_dictation_chunk_with_retry(
+                chunk,
+                dictionary_context,
+                app_context.clone(),
+                style,
+                session_id.clone(),
+                chunk_utterance_id,
+            ),
         )
-        .await?;
-        cleaned_chunks.push(cleaned);
+        .await
+        {
+            Ok(cleaned) => cleaned_chunks.push(trim_cleaned_dictation_chunk(&cleaned?)),
+            Err(_) => {
+                // Out of overall budget mid-chunk: keep this chunk raw and
+                // let the loop degrade the rest the same way, preserving
+                // every chunk that already cleaned up.
+                tracing::warn!(
+                    chunk_index = index,
+                    chunk_bytes = chunk.len(),
+                    "dictation cleanup chunk timed out; keeping raw chunk",
+                );
+                raw_chunks += 1;
+                cleaned_chunks.push((*chunk).to_string());
+            }
+        }
     }
-    tracing::info!(chunk_count, "dictation cleanup ran chunked");
-    Ok(cleaned_chunks.join(" "))
+    if raw_chunks > 0 {
+        tracing::warn!(
+            chunk_count,
+            raw_chunks,
+            "dictation cleanup ran out of time; some chunks pasted raw",
+        );
+    }
+    tracing::info!(chunk_count, raw_chunks, "dictation cleanup ran chunked");
+    Ok(join_cleaned_dictation_chunks(&cleaned_chunks))
+}
+
+/// Trim a single-call cleanup result (the historical behavior).
+fn trim_cleaned_dictation(cleaned: &str) -> String {
+    cleaned.trim().to_string()
+}
+
+/// Trim a cleaned chunk for joining: drop surrounding spaces but keep a
+/// trailing newline, so a line or paragraph break the model placed at a chunk
+/// boundary survives the join.
+fn trim_cleaned_dictation_chunk(cleaned: &str) -> String {
+    cleaned
+        .trim_start()
+        .trim_end_matches([' ', '\t'])
+        .to_string()
+}
+
+/// Join cleaned chunks with a single space, except after a chunk that ends in
+/// a line break, where inserting a space would indent the next line.
+fn join_cleaned_dictation_chunks(chunks: &[String]) -> String {
+    let mut joined = String::new();
+    for chunk in chunks {
+        if chunk.is_empty() {
+            continue;
+        }
+        if !joined.is_empty() && !joined.ends_with('\n') {
+            joined.push(' ');
+        }
+        joined.push_str(chunk);
+    }
+    joined
 }
 
 /// One chunk of a chunked cleanup. Transport errors abort the whole cleanup
@@ -2692,26 +2759,35 @@ async fn cleanup_dictation_chunk_with_retry(
         chunk_utterance_id.clone(),
     )
     .await;
+    // A distinct utterance id: the retry wants a fresh model completion, so
+    // it must not share the first attempt's idempotency identity.
+    let retry_utterance_id = format!("{chunk_utterance_id}r");
     match first {
         Ok(cleaned) if !cleaned_chunk_lacks_sentence_punctuation(chunk, &cleaned) => Ok(cleaned),
         Ok(unpunctuated) => {
-            // Same utterance id on purpose: this is a retry of the same
-            // logical unit of work, so metering replays idempotently.
             match cleanup_dictation_call(
                 chunk,
                 dictionary_context,
                 app_context,
                 style,
                 session_id,
-                chunk_utterance_id,
+                retry_utterance_id,
             )
             .await
             {
                 Ok(retried) if !cleaned_chunk_lacks_sentence_punctuation(chunk, &retried) => {
                     Ok(retried)
                 }
-                // Keep the first attempt: unpunctuated but still cleaned.
-                _ => Ok(unpunctuated),
+                // Keep the first attempt: unpunctuated but still cleaned
+                // (fillers stripped) beats both raw text and failing the
+                // whole dictation's cleanup over one stubborn chunk.
+                _ => {
+                    tracing::warn!(
+                        chunk_bytes = chunk.len(),
+                        "dictation cleanup chunk still unpunctuated after retry",
+                    );
+                    Ok(unpunctuated)
+                }
             }
         }
         Err(error)
@@ -2724,7 +2800,7 @@ async fn cleanup_dictation_chunk_with_retry(
                 app_context,
                 style,
                 session_id,
-                chunk_utterance_id,
+                retry_utterance_id,
             )
             .await
             {
@@ -2770,19 +2846,21 @@ async fn cleanup_dictation_call(
         utterance_id,
     })
     .await?;
-    let cleaned = cleaned.trim().to_string();
-    if cleaned.is_empty() {
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
         return Err(AppError::new(
             "provider_response_invalid",
             "Dictation cleanup response did not contain text output.",
         ));
     }
-    if looks_like_instruction_response(&cleaned) {
+    if looks_like_instruction_response(trimmed) {
         return Err(AppError::new(
             "dictation_cleanup_invalid",
             "Dictation cleanup returned an instruction response.",
         ));
     }
+    // Callers trim for their context: fully for a single-call cleanup,
+    // newline-preserving for chunks about to be joined.
     Ok(cleaned)
 }
 
@@ -5568,6 +5646,29 @@ mod tests {
             "add milk to the shopping list",
             "add milk to the shopping list"
         ));
+    }
+
+    #[test]
+    fn joining_cleaned_chunks_preserves_boundary_line_breaks() {
+        let chunks = vec![
+            "First topic wrapped up.\n\n".to_string(),
+            "Second topic starts here.".to_string(),
+            String::new(),
+            "And a closing thought.".to_string(),
+        ];
+        assert_eq!(
+            join_cleaned_dictation_chunks(&chunks),
+            "First topic wrapped up.\n\nSecond topic starts here. And a closing thought."
+        );
+    }
+
+    #[test]
+    fn chunk_trim_keeps_trailing_line_breaks_but_drops_spaces() {
+        assert_eq!(
+            trim_cleaned_dictation_chunk("  New paragraph next.\n\n \t"),
+            "New paragraph next.\n\n"
+        );
+        assert_eq!(trim_cleaned_dictation_chunk(" plain text "), "plain text");
     }
 
     #[test]

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -38,6 +38,12 @@ const DICTATION_CLEANUP_BASE_TIMEOUT_MS: u64 = 15_000;
 /// conservative floor of ~50 tokens/s for the cleanup model.
 const DICTATION_CLEANUP_TIMEOUT_MS_PER_BYTE: u64 = 5;
 const DICTATION_CLEANUP_MAX_TIMEOUT_MS: u64 = 60_000;
+/// No single cleanup request may wait longer than June API's cleanup billing
+/// hold (`cleanup_hold_ttl_seconds`, 30s): a response that arrives after its
+/// hold expired could paste text whose charge no longer settles. The overall
+/// budget above spans multiple sequential chunk requests; this cap bounds
+/// each one. Keep in sync with the june-api config default.
+const DICTATION_CLEANUP_REQUEST_MAX_TIMEOUT_MS: u64 = 30_000;
 /// Above this size, cleanup runs chunked. Measured against the production
 /// prompt (JUN-212): the cleanup model punctuates ~800-byte passages of
 /// filler-heavy run-on speech reliably, while at 2 KB and beyond it degrades
@@ -2606,7 +2612,9 @@ async fn cleanup_dictation_text(
     let chunks = split_dictation_cleanup_chunks(text, DICTATION_CLEANUP_CHUNK_TARGET_BYTES);
     if chunks.len() == 1 {
         return match tokio::time::timeout(
-            dictation_cleanup_timeout(text.len()),
+            dictation_cleanup_timeout(text.len()).min(Duration::from_millis(
+                DICTATION_CLEANUP_REQUEST_MAX_TIMEOUT_MS,
+            )),
             cleanup_dictation_call(
                 text,
                 dictionary_context,
@@ -2642,9 +2650,11 @@ async fn cleanup_dictation_text(
 /// on long run-on speech (JUN-212). Each chunk gets its own utterance id
 /// suffix so metering treats it as its own unit of work.
 ///
-/// The whole batch shares one scaled deadline, but hitting it never discards
-/// chunks that already cleaned up: the chunk that ran out of time and any
-/// chunks after it degrade to their raw text instead.
+/// Chunks that already cleaned up are never discarded: they were billed, so
+/// their output must reach the paste. Running out of the shared deadline or
+/// hitting a transport error mid-batch degrades the affected chunk and the
+/// rest to their raw text. Only an error before any chunk succeeds fails the
+/// whole cleanup (the caller's raw-transcript fallback, as before).
 async fn cleanup_dictation_chunks(
     chunks: &[&str],
     dictionary_context: Option<&str>,
@@ -2658,6 +2668,7 @@ async fn cleanup_dictation_chunks(
     let chunk_count = chunks.len();
     let mut cleaned_chunks: Vec<String> = Vec::with_capacity(chunk_count);
     let mut raw_chunks = 0usize;
+    let mut any_cleaned = false;
     for (index, chunk) in chunks.iter().enumerate() {
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
@@ -2666,8 +2677,13 @@ async fn cleanup_dictation_chunks(
             continue;
         }
         let chunk_utterance_id = format!("{utterance_id}-c{index}");
+        // Bounded by both the batch deadline and the per-request billing
+        // hold cap (the chunk budget covers at most two small requests).
+        let chunk_budget = remaining.min(Duration::from_millis(
+            DICTATION_CLEANUP_REQUEST_MAX_TIMEOUT_MS,
+        ));
         match tokio::time::timeout(
-            remaining,
+            chunk_budget,
             cleanup_dictation_chunk_with_retry(
                 chunk,
                 dictionary_context,
@@ -2679,11 +2695,36 @@ async fn cleanup_dictation_chunks(
         )
         .await
         {
-            Ok(cleaned) => cleaned_chunks.push(trim_cleaned_dictation_chunk(&cleaned?)),
+            Ok(Ok(cleaned)) => {
+                any_cleaned = true;
+                cleaned_chunks.push(trim_cleaned_dictation_chunk(&cleaned));
+            }
+            Ok(Err(error)) => {
+                // Nothing cleaned yet: fail the whole cleanup so the caller
+                // emits the skip event and pastes the raw transcript.
+                if !any_cleaned {
+                    return Err(error);
+                }
+                // Mid-batch failure after billed successes: keep the cleaned
+                // chunks and degrade this one and the rest to raw. Retrying
+                // the remainder against a failing backend would only burn
+                // the deadline.
+                tracing::warn!(
+                    code = %error.code,
+                    chunk_index = index,
+                    "dictation cleanup chunk failed mid-batch; keeping raw for the rest",
+                );
+                for rest in &chunks[index..] {
+                    raw_chunks += 1;
+                    cleaned_chunks.push((*rest).to_string());
+                }
+                break;
+            }
             Err(_) => {
-                // Out of overall budget mid-chunk: keep this chunk raw and
-                // let the loop degrade the rest the same way, preserving
-                // every chunk that already cleaned up.
+                // This chunk ran out of its budget (the batch deadline or the
+                // per-request cap): keep it raw and move on. Chunks that
+                // already cleaned up are preserved; later chunks still get
+                // whatever batch budget is left.
                 tracing::warn!(
                     chunk_index = index,
                     chunk_bytes = chunk.len(),
@@ -2698,7 +2739,7 @@ async fn cleanup_dictation_chunks(
         tracing::warn!(
             chunk_count,
             raw_chunks,
-            "dictation cleanup ran out of time; some chunks pasted raw",
+            "dictation cleanup degraded; some chunks pasted raw",
         );
     }
     tracing::info!(chunk_count, raw_chunks, "dictation cleanup ran chunked");
@@ -2710,25 +2751,32 @@ fn trim_cleaned_dictation(cleaned: &str) -> String {
     cleaned.trim().to_string()
 }
 
-/// Trim a cleaned chunk for joining: drop surrounding spaces but keep a
-/// trailing newline, so a line or paragraph break the model placed at a chunk
-/// boundary survives the join.
+/// Trim a cleaned chunk for joining: drop surrounding spaces but keep
+/// newlines on either edge, so a line or paragraph break the model placed at
+/// a chunk boundary survives the join whether it landed at the end of one
+/// chunk or the start of the next.
 fn trim_cleaned_dictation_chunk(cleaned: &str) -> String {
     cleaned
-        .trim_start()
+        .trim_start_matches([' ', '\t'])
         .trim_end_matches([' ', '\t'])
         .to_string()
 }
 
-/// Join cleaned chunks with a single space, except after a chunk that ends in
-/// a line break, where inserting a space would indent the next line.
+/// Join cleaned chunks with a single space, except across a boundary that
+/// already carries a line break (a space would indent the line) or where the
+/// next chunk starts with punctuation that attaches to the previous word
+/// (a spoken "comma" or "period" right after the split point).
 fn join_cleaned_dictation_chunks(chunks: &[String]) -> String {
     let mut joined = String::new();
     for chunk in chunks {
         if chunk.is_empty() {
             continue;
         }
-        if !joined.is_empty() && !joined.ends_with('\n') {
+        if !joined.is_empty()
+            && !joined.ends_with('\n')
+            && !chunk.starts_with('\n')
+            && !chunk.starts_with([',', '.', '!', '?', ':', ';', ')', ']'])
+        {
             joined.push(' ');
         }
         joined.push_str(chunk);
@@ -2736,12 +2784,12 @@ fn join_cleaned_dictation_chunks(chunks: &[String]) -> String {
     joined
 }
 
-/// One chunk of a chunked cleanup. Transport errors abort the whole cleanup
-/// (the caller falls back to the raw transcript, as before). Content-quality
-/// failures get one retry — the provider is not deterministic even at
-/// temperature 0, and a retry usually punctuates a chunk the first attempt
-/// echoed — then degrade to the raw chunk so one bad chunk never costs the
-/// rest of the dictation its cleanup.
+/// One chunk of a chunked cleanup. Transport errors propagate to the caller,
+/// which keeps any already-cleaned chunks and degrades the rest to raw.
+/// Content-quality failures get one retry — the provider is not deterministic
+/// even at temperature 0, and a retry usually punctuates a chunk the first
+/// attempt echoed — then degrade to the raw chunk so one bad chunk never
+/// costs the rest of the dictation its cleanup.
 async fn cleanup_dictation_chunk_with_retry(
     chunk: &str,
     dictionary_context: Option<&str>,
@@ -5660,13 +5708,43 @@ mod tests {
             join_cleaned_dictation_chunks(&chunks),
             "First topic wrapped up.\n\nSecond topic starts here. And a closing thought."
         );
+
+        // A break the model emitted at the START of the next chunk survives
+        // too, without picking up a stray space before it.
+        let leading_break = vec![
+            "First topic wrapped up.".to_string(),
+            "\n\nSecond topic starts here.".to_string(),
+        ];
+        assert_eq!(
+            join_cleaned_dictation_chunks(&leading_break),
+            "First topic wrapped up.\n\nSecond topic starts here."
+        );
     }
 
     #[test]
-    fn chunk_trim_keeps_trailing_line_breaks_but_drops_spaces() {
+    fn joining_cleaned_chunks_attaches_leading_punctuation() {
+        // A spoken "comma" or "period" right after the split point makes the
+        // next cleaned chunk start with the mark; it must attach to the
+        // previous word instead of floating after a space.
+        let chunks = vec![
+            "we shipped the fix".to_string(),
+            ", and the tests are green.".to_string(),
+        ];
+        assert_eq!(
+            join_cleaned_dictation_chunks(&chunks),
+            "we shipped the fix, and the tests are green."
+        );
+    }
+
+    #[test]
+    fn chunk_trim_keeps_edge_line_breaks_but_drops_spaces() {
         assert_eq!(
             trim_cleaned_dictation_chunk("  New paragraph next.\n\n \t"),
             "New paragraph next.\n\n"
+        );
+        assert_eq!(
+            trim_cleaned_dictation_chunk("\n\nStarts on a new paragraph."),
+            "\n\nStarts on a new paragraph."
         );
         assert_eq!(trim_cleaned_dictation_chunk(" plain text "), "plain text");
     }

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -26,7 +26,26 @@ use tauri::{
 };
 
 const DICTATION_TRANSCRIPTION_CONTEXT: &str = "Transcribe this as clean hands-free dictation for direct insertion into the active app. Preserve the speaker's intended words, language, and meaning. Remove filler sounds and accidental false starts when they are not meaningful, especially um, uh, ah, er, and a... stutters. Do not remove intentional articles such as a or an when they are grammatically needed. Convert spoken punctuation and formatting into text punctuation, including comma, period, question mark, exclamation point, colon, semicolon, dash, newline, and new paragraph. Convert quote/unquote, open quote/close quote, and start quote/end quote into actual quotation marks around the quoted words. Output only the dictated text.";
-const DICTATION_CLEANUP_TIMEOUT_MS: u64 = 15_000;
+/// Cleanup regenerates the whole transcript through the LLM, so its latency
+/// grows with dictation length. A flat budget silently degraded long
+/// dictations: the call timed out, cleanup was skipped, and the raw ASR text
+/// (capitalized but unpunctuated) was pasted (JUN-212). Scale the budget with
+/// the transcript instead: the base covers short dictations plus network
+/// overhead, each byte of transcript buys generation time, and the cap keeps
+/// a hung request from wedging finalization for minutes.
+const DICTATION_CLEANUP_BASE_TIMEOUT_MS: u64 = 15_000;
+/// ~5 ms per input byte ≈ 20 ms per regenerated token (≈4 bytes/token), a
+/// conservative floor of ~50 tokens/s for the cleanup model.
+const DICTATION_CLEANUP_TIMEOUT_MS_PER_BYTE: u64 = 5;
+const DICTATION_CLEANUP_MAX_TIMEOUT_MS: u64 = 60_000;
+/// Above this size, cleanup runs chunked. Measured against the production
+/// prompt (JUN-212): the cleanup model punctuates ~800-byte passages of
+/// filler-heavy run-on speech reliably, while at 2 KB and beyond it degrades
+/// into echoing the transcript back with no punctuation at all.
+const DICTATION_CLEANUP_CHUNK_TARGET_BYTES: usize = 800;
+/// Below this input size a chunk plausibly is a single sentence, so a cleaned
+/// result without sentence punctuation is not evidence of the echo failure.
+const DICTATION_CLEANUP_RETRY_MIN_CHUNK_BYTES: usize = 300;
 /// App-context slug sent with dictation cleanup when the paste target is a
 /// known kind of app, so the cleaned text is laid out for that surface.
 /// Email is the only recognized context today.
@@ -2519,12 +2538,16 @@ async fn maybe_cleanup_dictation_result(
         Ok(transcript) => transcript,
         Err(error) => return Err(error),
     };
+    let transcript_bytes = transcript.text.trim().len();
     tracing::info!(
         provider,
         style = ?style,
         app_context = app_context.as_deref(),
+        transcript_bytes,
+        timeout_ms = dictation_cleanup_timeout(transcript_bytes).as_millis() as u64,
         "dictation cleanup starting",
     );
+    let started_at = Instant::now();
     match cleanup_dictation_text(
         &transcript.text,
         dictionary_context.as_deref(),
@@ -2538,14 +2561,34 @@ async fn maybe_cleanup_dictation_result(
         Ok(cleaned) => {
             if !cleaned.trim().is_empty() {
                 transcript.text = cleaned;
-                tracing::info!(provider, "dictation cleanup applied");
+                tracing::info!(
+                    provider,
+                    elapsed_ms = started_at.elapsed().as_millis() as u64,
+                    "dictation cleanup applied",
+                );
             }
         }
         Err(error) => {
-            emit_dictation_cleanup_skipped(app, provider, &error);
+            emit_dictation_cleanup_skipped(
+                app,
+                provider,
+                &error,
+                transcript_bytes,
+                started_at.elapsed(),
+            );
         }
     }
     Ok(transcript)
+}
+
+/// Budget for one cleanup round-trip, scaled to the transcript so long
+/// dictations get the generation time they need instead of silently falling
+/// back to raw ASR text. Byte length is a fine proxy: multibyte scripts also
+/// cost more tokens to regenerate.
+fn dictation_cleanup_timeout(text_bytes: usize) -> Duration {
+    let scaled = DICTATION_CLEANUP_BASE_TIMEOUT_MS
+        .saturating_add((text_bytes as u64).saturating_mul(DICTATION_CLEANUP_TIMEOUT_MS_PER_BYTE));
+    Duration::from_millis(scaled.min(DICTATION_CLEANUP_MAX_TIMEOUT_MS))
 }
 
 async fn cleanup_dictation_text(
@@ -2560,27 +2603,173 @@ async fn cleanup_dictation_text(
     if text.is_empty() {
         return Ok(String::new());
     }
-    let cleaned = match tokio::time::timeout(
-        Duration::from_millis(DICTATION_CLEANUP_TIMEOUT_MS),
-        cleanup_text(DictateCleanupRequestParams {
-            text: text.to_string(),
-            dictionary_context: dictionary_context.map(str::to_string),
+    match tokio::time::timeout(
+        dictation_cleanup_timeout(text.len()),
+        cleanup_dictation_chunks(
+            text,
+            dictionary_context,
             app_context,
-            style: style.instruction().to_string(),
+            style,
             session_id,
             utterance_id,
-        }),
+        ),
     )
     .await
     {
-        Ok(result) => result?,
-        Err(_) => {
-            return Err(AppError::new(
-                "dictation_cleanup_timeout",
-                "Dictation cleanup timed out.",
-            ));
+        Ok(result) => result,
+        Err(_) => Err(AppError::new(
+            "dictation_cleanup_timeout",
+            "Dictation cleanup timed out.",
+        )),
+    }
+}
+
+/// Clean the transcript through `/v1/dictate/cleanup`, splitting long
+/// dictations into word-boundary chunks first. The cleanup model reliably
+/// punctuates short passages but degrades into an unpunctuated verbatim echo
+/// on long run-on speech (JUN-212), so long transcripts are cleaned a chunk at
+/// a time and rejoined. Each chunk gets its own utterance id suffix so the
+/// per-utterance idempotent metering treats it as its own unit of work.
+async fn cleanup_dictation_chunks(
+    text: &str,
+    dictionary_context: Option<&str>,
+    app_context: Option<String>,
+    style: DictationStyle,
+    session_id: String,
+    utterance_id: String,
+) -> Result<String, AppError> {
+    let chunks = split_dictation_cleanup_chunks(text, DICTATION_CLEANUP_CHUNK_TARGET_BYTES);
+    if chunks.len() == 1 {
+        return cleanup_dictation_call(
+            text,
+            dictionary_context,
+            app_context,
+            style,
+            session_id,
+            utterance_id,
+        )
+        .await;
+    }
+    let chunk_count = chunks.len();
+    let mut cleaned_chunks: Vec<String> = Vec::with_capacity(chunk_count);
+    for (index, chunk) in chunks.iter().enumerate() {
+        let chunk_utterance_id = format!("{utterance_id}-c{index}");
+        let cleaned = cleanup_dictation_chunk_with_retry(
+            chunk,
+            dictionary_context,
+            app_context.clone(),
+            style,
+            session_id.clone(),
+            chunk_utterance_id,
+        )
+        .await?;
+        cleaned_chunks.push(cleaned);
+    }
+    tracing::info!(chunk_count, "dictation cleanup ran chunked");
+    Ok(cleaned_chunks.join(" "))
+}
+
+/// One chunk of a chunked cleanup. Transport errors abort the whole cleanup
+/// (the caller falls back to the raw transcript, as before). Content-quality
+/// failures get one retry — the provider is not deterministic even at
+/// temperature 0, and a retry usually punctuates a chunk the first attempt
+/// echoed — then degrade to the raw chunk so one bad chunk never costs the
+/// rest of the dictation its cleanup.
+async fn cleanup_dictation_chunk_with_retry(
+    chunk: &str,
+    dictionary_context: Option<&str>,
+    app_context: Option<String>,
+    style: DictationStyle,
+    session_id: String,
+    chunk_utterance_id: String,
+) -> Result<String, AppError> {
+    let first = cleanup_dictation_call(
+        chunk,
+        dictionary_context,
+        app_context.clone(),
+        style,
+        session_id.clone(),
+        chunk_utterance_id.clone(),
+    )
+    .await;
+    match first {
+        Ok(cleaned) if !cleaned_chunk_lacks_sentence_punctuation(chunk, &cleaned) => Ok(cleaned),
+        Ok(unpunctuated) => {
+            // Same utterance id on purpose: this is a retry of the same
+            // logical unit of work, so metering replays idempotently.
+            match cleanup_dictation_call(
+                chunk,
+                dictionary_context,
+                app_context,
+                style,
+                session_id,
+                chunk_utterance_id,
+            )
+            .await
+            {
+                Ok(retried) if !cleaned_chunk_lacks_sentence_punctuation(chunk, &retried) => {
+                    Ok(retried)
+                }
+                // Keep the first attempt: unpunctuated but still cleaned.
+                _ => Ok(unpunctuated),
+            }
         }
-    };
+        Err(error)
+            if error.code == "provider_response_invalid"
+                || error.code == "dictation_cleanup_invalid" =>
+        {
+            match cleanup_dictation_call(
+                chunk,
+                dictionary_context,
+                app_context,
+                style,
+                session_id,
+                chunk_utterance_id,
+            )
+            .await
+            {
+                Ok(retried) => Ok(retried),
+                Err(retry_error) => {
+                    if retry_error.code == "provider_response_invalid"
+                        || retry_error.code == "dictation_cleanup_invalid"
+                    {
+                        // The model refused this chunk twice; keep the
+                        // speaker's words raw rather than dropping them or
+                        // failing the whole dictation's cleanup.
+                        tracing::warn!(
+                            code = %retry_error.code,
+                            chunk_bytes = chunk.len(),
+                            "dictation cleanup chunk kept raw after retry",
+                        );
+                        Ok(chunk.to_string())
+                    } else {
+                        Err(retry_error)
+                    }
+                }
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// One `/v1/dictate/cleanup` round-trip plus content-quality checks.
+async fn cleanup_dictation_call(
+    text: &str,
+    dictionary_context: Option<&str>,
+    app_context: Option<String>,
+    style: DictationStyle,
+    session_id: String,
+    utterance_id: String,
+) -> Result<String, AppError> {
+    let cleaned = cleanup_text(DictateCleanupRequestParams {
+        text: text.to_string(),
+        dictionary_context: dictionary_context.map(str::to_string),
+        app_context,
+        style: style.instruction().to_string(),
+        session_id,
+        utterance_id,
+    })
+    .await?;
     let cleaned = cleaned.trim().to_string();
     if cleaned.is_empty() {
         return Err(AppError::new(
@@ -2597,12 +2786,72 @@ async fn cleanup_dictation_text(
     Ok(cleaned)
 }
 
-fn emit_dictation_cleanup_skipped(app: &AppHandle, provider: &str, error: &AppError) {
+/// Split a transcript into cleanup-sized chunks at whitespace boundaries.
+/// Short transcripts come back as a single borrowed chunk (the exact input),
+/// keeping the single-call path byte-identical to the unchunked behavior.
+/// A chunk may run past the target until the next whitespace; text with no
+/// whitespace at all (e.g. unsegmented CJK) stays one chunk.
+fn split_dictation_cleanup_chunks(text: &str, target_bytes: usize) -> Vec<&str> {
+    if text.len() <= target_bytes {
+        return vec![text];
+    }
+    let mut chunks = Vec::new();
+    let mut chunk_start = 0;
+    let mut last_whitespace: Option<usize> = None;
+    for (index, character) in text.char_indices() {
+        if character.is_whitespace() {
+            last_whitespace = Some(index);
+        }
+        if index - chunk_start >= target_bytes {
+            if let Some(cut) = last_whitespace.filter(|cut| *cut > chunk_start) {
+                chunks.push(text[chunk_start..cut].trim());
+                chunk_start = cut + character_width_at(text, cut);
+                last_whitespace = None;
+            }
+        }
+    }
+    if chunk_start < text.len() {
+        let tail = text[chunk_start..].trim();
+        if !tail.is_empty() {
+            chunks.push(tail);
+        }
+    }
+    if chunks.is_empty() {
+        vec![text]
+    } else {
+        chunks
+    }
+}
+
+fn character_width_at(text: &str, index: usize) -> usize {
+    text[index..].chars().next().map_or(1, char::len_utf8)
+}
+
+/// Whether a cleaned chunk came back without any sentence punctuation at a
+/// size where some is clearly expected — the JUN-212 failure shape, where the
+/// model echoes long run-on speech verbatim instead of punctuating it.
+fn cleaned_chunk_lacks_sentence_punctuation(chunk_input: &str, cleaned: &str) -> bool {
+    chunk_input.len() >= DICTATION_CLEANUP_RETRY_MIN_CHUNK_BYTES
+        && !cleaned.contains(['.', '!', '?', ':', ';', '\n', '。', '！', '？'])
+}
+
+/// The paste falls back to the raw ASR transcript when cleanup fails, so this
+/// warn line (with the transcript size and how long the attempt ran) is the
+/// only trace that the pasted text skipped punctuation and filler cleanup.
+fn emit_dictation_cleanup_skipped(
+    app: &AppHandle,
+    provider: &str,
+    error: &AppError,
+    transcript_bytes: usize,
+    elapsed: Duration,
+) {
     tracing::warn!(
         provider,
         code = %error.code,
         message = %error.message,
-        "dictation cleanup skipped",
+        transcript_bytes,
+        elapsed_ms = elapsed.as_millis() as u64,
+        "dictation cleanup skipped; pasting raw transcript",
     );
     emit_dictation_event_value(
         app,
@@ -5212,6 +5461,127 @@ mod tests {
         assert!(!looks_like_instruction_response(
             "User reported the bug to support."
         ));
+    }
+
+    #[test]
+    fn cleanup_timeout_keeps_base_budget_for_short_dictations() {
+        // A quick one-liner should not wait longer than the historical 15s.
+        assert_eq!(
+            dictation_cleanup_timeout("Send the doc to Sarah today".len()),
+            Duration::from_millis(DICTATION_CLEANUP_BASE_TIMEOUT_MS + 27 * 5),
+        );
+        assert_eq!(
+            dictation_cleanup_timeout(0),
+            Duration::from_millis(DICTATION_CLEANUP_BASE_TIMEOUT_MS),
+        );
+    }
+
+    #[test]
+    fn cleanup_timeout_scales_with_long_rambling_dictations() {
+        // JUN-212: a long rambling dictation timed out of the flat 15s cleanup
+        // budget and pasted raw, unpunctuated ASR text. Model the reported
+        // transcript: minutes of continuous filler-heavy speech, several
+        // thousand bytes long.
+        let reported_fragment = "side nav and everything Like it looks really sharp you \
+             know meeting should kind of be or medium should kind of be used like sparingly ";
+        let long_rambling_transcript = reported_fragment.repeat(40);
+        let budget = dictation_cleanup_timeout(long_rambling_transcript.len());
+
+        assert!(
+            budget > Duration::from_millis(DICTATION_CLEANUP_BASE_TIMEOUT_MS),
+            "a long dictation must get more than the base cleanup budget"
+        );
+        assert!(
+            budget <= Duration::from_millis(DICTATION_CLEANUP_MAX_TIMEOUT_MS),
+            "the cleanup budget must stay bounded"
+        );
+    }
+
+    /// The JUN-212 transcript shape: minutes of unpunctuated, filler-heavy,
+    /// run-on speech, with stray mid-text capitals from the ASR pass.
+    fn jun_212_style_transcript() -> String {
+        "side nav and everything Like it looks really sharp you know meeting \
+         should kind of be or medium should kind of be used like sparingly \
+         because when everything is bold nothing is bold right and then I was \
+         thinking about the onboarding flow because we still have that drop \
+         off on the second step "
+            .repeat(12)
+            .trim()
+            .to_string()
+    }
+
+    #[test]
+    fn short_dictations_stay_one_cleanup_chunk() {
+        let text = "just a quick note about the design review tomorrow";
+        assert_eq!(
+            split_dictation_cleanup_chunks(text, DICTATION_CLEANUP_CHUNK_TARGET_BYTES),
+            vec![text]
+        );
+    }
+
+    #[test]
+    fn long_rambling_dictations_split_at_word_boundaries_and_keep_every_word() {
+        let transcript = jun_212_style_transcript();
+        let chunks =
+            split_dictation_cleanup_chunks(&transcript, DICTATION_CLEANUP_CHUNK_TARGET_BYTES);
+
+        assert!(chunks.len() > 1, "a long dictation must be chunked");
+        for chunk in &chunks {
+            // A chunk may overrun the target only until the next whitespace.
+            assert!(
+                chunk.len() <= DICTATION_CLEANUP_CHUNK_TARGET_BYTES + 40,
+                "chunk of {} bytes overruns the target too far",
+                chunk.len()
+            );
+            assert!(!chunk.is_empty());
+            assert!(!chunk.starts_with(char::is_whitespace));
+            assert!(!chunk.ends_with(char::is_whitespace));
+        }
+        // Chunking must never cost the speaker a single word.
+        assert_eq!(chunks.join(" "), transcript);
+    }
+
+    #[test]
+    fn whitespace_free_text_stays_one_cleanup_chunk() {
+        // Unsegmented text (e.g. CJK with no spaces) has no safe cut points.
+        let text = "x".repeat(2_000);
+        assert_eq!(
+            split_dictation_cleanup_chunks(&text, DICTATION_CLEANUP_CHUNK_TARGET_BYTES),
+            vec![text.as_str()]
+        );
+    }
+
+    #[test]
+    fn unpunctuated_echo_of_a_long_chunk_triggers_a_retry() {
+        let input = jun_212_style_transcript();
+        let chunk = &input[..500];
+
+        // The echo failure: same run-on words back, zero punctuation.
+        assert!(cleaned_chunk_lacks_sentence_punctuation(chunk, chunk));
+        // A punctuated cleaning passes.
+        assert!(!cleaned_chunk_lacks_sentence_punctuation(
+            chunk,
+            "The side nav looks really sharp. Meeting should be used sparingly."
+        ));
+        // A short chunk may legitimately be one unterminated sentence.
+        assert!(!cleaned_chunk_lacks_sentence_punctuation(
+            "add milk to the shopping list",
+            "add milk to the shopping list"
+        ));
+    }
+
+    #[test]
+    fn cleanup_timeout_is_capped_at_the_maximum() {
+        // MAX_DICTATION_TEXT_CHARS upstream is 20k; even that never waits
+        // longer than the cap, and absurd lengths cannot overflow.
+        assert_eq!(
+            dictation_cleanup_timeout(20_000),
+            Duration::from_millis(DICTATION_CLEANUP_MAX_TIMEOUT_MS),
+        );
+        assert_eq!(
+            dictation_cleanup_timeout(usize::MAX),
+            Duration::from_millis(DICTATION_CLEANUP_MAX_TIMEOUT_MS),
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes JUN-212

## Summary

- Dictation cleanup now splits long transcripts into ~800 byte word-boundary chunks, cleans each chunk through `/v1/dictate/cleanup`, retries a chunk once when it comes back without any sentence punctuation, and rejoins the results. Short dictations keep the exact single-call path they had before (same request, same utterance id).
- The cleanup timeout now scales with transcript length (15s floor, 5 ms per byte, 60s cap) instead of a flat 15s that guaranteed a timeout for very long dictations.
- The silent fallback to raw ASR text is now observable: the skip log carries the transcript size and elapsed time, and per-chunk raw fallbacks log a warning.

## Root cause

Two stacked causes, both verified against the live cleanup provider with the production prompt and message format:

1. Primary: the cleanup model (`nvidia-nemotron-3-nano-30b-a3b`, temperature 0) reliably punctuates short passages but degrades into echoing the transcript back verbatim with zero punctuation once filler-heavy run-on speech grows past roughly 2 KB. Reproduced repeatedly with a transcript modeled on the session in the issue: 2,049 bytes in, 2,049 bytes out, `finish_reason: stop`, 0 periods. The prompt already mandates punctuation ("Returning raw unpunctuated text is a failure") and the trailing output contract repeats it; the model ignores both at this length, and prompt-only strengthening tested as unreliable (1 of 3 identical requests still came back unpunctuated) or caused paraphrasing that violates word preservation.
2. Secondary: `cleanup_dictation_text` wrapped the call in a flat 15s timeout. Measured generation speed (~115 tokens/s on a good day) means any transcript past roughly 7 KB could never finish in time, so cleanup timed out and the raw ASR text was pasted with no user-visible signal (nothing consumes the `dictation_cleanup_skipped` event).

Either path produces exactly the report: raw or echoed ASR text with stray sentence-initial capitals ("...everything Like it looks...") and no terminal punctuation.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --locked`: all suites green (556 lib tests, 7 new: chunk splitting, word preservation, whitespace-free fallback, retry detection, timeout scaling and cap).
- `cargo clippy --locked --all-targets` and `cargo fmt --check` on src-tauri: clean.
- `cargo +1.95.0 test --manifest-path june-api/Cargo.toml --all-targets --all-features --locked`: green (june-api is untouched; run as a sanity check).
- Live provider simulation of the exact shipped algorithm (same splitter, production system prompt and output contract, retry rule) on a 3.1 KB rambling transcript modeled on the issue: unchunked baseline returned 0 sentence marks; chunked runs returned 10 to 13 periods with vocabulary preservation 0.997, in 7 to 8 seconds total. Chunk-size calibration (400/800/1200 bytes, 3+ reps each) showed reliable punctuation at ~800 bytes and the echo failure from ~2 KB.
- No live microphone walkthrough: a real dictation QA run needs microphone audio, which agent QA must not record. Covered instead by the unit tests plus the direct provider calls above (input/output documented here).

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end.

Client-only change; no June API deploy needed. Not a UI change, so no screenshot.

## Out of scope

- The broader dictate_cleanup prompt overhaul (in flight separately); this PR deliberately does not touch the prompt or june-api.
- Swapping or upsizing the cleanup model, which would be the deeper fix for the echo failure.
- Surfacing cleanup fallbacks in the UI (the `dictation_cleanup_skipped` event still has no frontend consumer).
- Unsegmented scripts (for example CJK without spaces) have no safe word-boundary cut points and stay single-call.

## Followups

- Even chunked, an adversarial chunk can rarely stay unpunctuated after its retry (observed about 1 in 10 chunk cleanups on the hardest fixture); a stronger cleanup model or a server-side pass would close the gap.
- `FINALIZING_SUPPRESSION_EXPIRY` (30s) can now expire while a very long chunked cleanup is legitimately still finalizing; pre-existing for long transcriptions, worth revisiting.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786288562&installation_id=144203540&pr_number=697&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F697&signature=a286de8feca9fa002b93b09c43c06d122a4fc54f6e33de384dd88b427c05e519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->