### PR TITLE
Fix bottom gap when the sidebar is collapsed (JUN-237)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -50,7 +50,6 @@ import { IconZap } from "central-icons/IconZap";
 import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconSettingsGear4 } from "central-icons/IconSettingsGear4";
 import { Dialog } from "../components/ui/Dialog";
-import { Toaster } from "../components/ui/Toaster";
 import {
   assignNoteToFolder,
   assignSessionToFolder,
@@ -3714,9 +3713,6 @@ export function App() {
         confirmLabel={MAX_UPGRADE_CONFIRM_LABEL}
         confirmBusyLabel={MAX_UPGRADE_BUSY_LABEL}
       />
-      {/* Global toast host. Mounted once beside the dialogs; sonner portals its
-          own list to document.body, so placement in the tree is immaterial. */}
-      <Toaster />
     </main>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { Agentation } from "agentation";
 import { App } from "./app/App";
+import { Toaster } from "./components/ui/Toaster";
 import { installNativeContextMenuGuard } from "./lib/native-context-menu";
 import { replayOnboarding } from "./lib/onboarding";
 import { initTheme } from "./lib/theme";
@@ -71,6 +72,12 @@ if (import.meta.env.DEV) {
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
+    {/* Global toast host. Sonner mounts a real in-flow <section> (no portal),
+        so it must live outside App's .app-shell grid: an in-flow child there
+        auto-places into an implicit second grid row and steals height from
+        the main column once the sidebar collapses (JUN-237). The toast list
+        itself is position: fixed, so it renders identically from here. */}
+    <Toaster />
     {import.meta.env.DEV ? <Agentation /> : null}
   </React.StrictMode>,
 );

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -103,6 +103,11 @@ input:focus-visible,
 .app-shell {
   display: grid;
   grid-template-columns: var(--sidebar-w-current, var(--sidebar-w)) minmax(0, 1fr);
+  /* One full-height row, always. Without this the row is implicit (auto), and
+   * any stray in-flow child wraps into a second implicit row that steals
+   * height from the main column once the collapsed sidebar stops propping the
+   * first row up to 100vh (JUN-237's bottom gap). */
+  grid-template-rows: minmax(0, 100%);
   position: relative;
   height: 100vh;
   overflow: hidden;

--- a/src/test/app-shell-layout.test.ts
+++ b/src/test/app-shell-layout.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import appSrc from "../app/App.tsx?raw";
+import mainSrc from "../main.tsx?raw";
+import appCss from "../styles/app.css?raw";
+
+// JUN-237: with the sidebar collapsed (display: none), the shell grid lost the
+// 100vh sidebar that propped its single implicit row up to full height. Any
+// stray in-flow child of .app-shell (the sonner toast host <section> at the
+// time) then wrapped into a second implicit row, and the row split left a
+// blank strip under the main panel. Two guards keep that from coming back:
+// the shell pins itself to one full-height row, and the toast host stays
+// mounted outside App's shell grid.
+
+function cssRuleFor(selector: string) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`${escaped}\\s*\\{`).exec(appCss);
+  if (!match) throw new Error(`Missing CSS rule for ${selector}`);
+  const openIndex = match.index + match[0].length - 1;
+  const closeIndex = appCss.indexOf("}", openIndex);
+  return appCss.slice(openIndex + 1, closeIndex);
+}
+
+describe("app shell layout (JUN-237)", () => {
+  it("pins the shell grid to one full-height row", () => {
+    const rule = cssRuleFor(".app-shell");
+    expect(rule).toContain("grid-template-rows: minmax(0, 100%);");
+  });
+
+  it("keeps the toast host out of the app shell grid", () => {
+    // The sonner host renders a real in-flow <section>; inside .app-shell it
+    // becomes a grid item and re-opens the bottom gap. It mounts in main.tsx,
+    // beside <App />, never inside it.
+    expect(appSrc).not.toContain("<Toaster");
+    expect(mainSrc).toContain("<Toaster />");
+  });
+});

--- a/src/test/app-shell-layout.test.ts
+++ b/src/test/app-shell-layout.test.ts
@@ -30,7 +30,7 @@ describe("app shell layout (JUN-237)", () => {
     // The sonner host renders a real in-flow <section>; inside .app-shell it
     // becomes a grid item and re-opens the bottom gap. It mounts in main.tsx,
     // beside <App />, never inside it.
-    expect(appSrc).not.toContain("<Toaster");
-    expect(mainSrc).toContain("<Toaster />");
+    expect(appSrc).not.toMatch(/<Toaster\b/);
+    expect(mainSrc).toMatch(/<Toaster\b/);
   });
 });


### PR DESCRIPTION
Closes JUN-237

## Summary

- With the sidebar hidden, the main content card stopped short of the window bottom, leaving a blank strip under every page (bug report: "There's empty space on bottom of page when disable sidemenu toggle").
- Mount the global toast host beside `<App />` in `main.tsx` instead of inside the `.app-shell` grid, and pin the shell grid to one full-height row.

## Root cause

The sonner toast host (`<Toaster />`) mounts a real in-flow `<section>` (no portal, despite the old comment saying otherwise). Inside `<main class="app-shell">`, that section is a grid item, and auto-placement wraps it into an implicit second grid row. With the sidebar expanded, the sidebar's `height: 100vh` props the first row up to full height and `overflow: hidden` hides the second row. Once the sidebar collapses (`display: none`), nothing holds the first row open anymore; the grid splits its height across the two rows, the main column shrinks to its content, and the leftover second-row space shows as the empty strip at the bottom.

## What changed

- `src/main.tsx`: mount `<Toaster />` beside `<App />`, outside the shell grid (the toast list itself is `position: fixed`, so it renders identically).
- `src/app/App.tsx`: remove the in-shell `<Toaster />` and its now-wrong "sonner portals to document.body" comment.
- `src/styles/app.css`: `.app-shell` gets `grid-template-rows: minmax(0, 100%)` so a stray in-flow child can never steal a row again.
- `src/test/app-shell-layout.test.ts`: regression guards for both (single full-height row rule, toast host mounted in `main.tsx` and not in `App.tsx`).

## Validation

- `pnpm test`: 144 files, 2313 passed, 2 skipped, exit 0 (includes the new `app-shell-layout` suite).
- `pnpm check` (Biome): no errors (`--diagnostic-level=error` clean); `pnpm typecheck`: clean.
- Reproduced in the web preview with a Playwright measurement before the fix: collapsing the sidebar shrank `.main-column` from 824px to 651px against an 824px shell (173px gap; the shell grid computed rows `651.4px 172.6px`). After the fix both states measure 824px with a single `824px` row.
- QA video (before/after): [watch](https://app.opensoftware.co/api/v1/files/fil_qXhdye7A4gl5/download). 0:00-0:21 is the unfixed build: collapsing the sidebar on the agent, Meeting notes, and Projects views leaves the blank strip. 0:21-0:42 is this branch: same walkthrough plus a window resize while collapsed; the panel hugs the window bottom throughout.

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- The intermittent web-preview boot crash seen while recording QA (`Cannot read properties of undefined (reading 'trim')` with a stubbed Tauri bridge); it is a QA-shim artifact, not app behavior.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
