### PR TITLE
Track and manage granted access permissions (JUN-206)

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -204,6 +204,7 @@ import { normalizeSteerText, steeringLiveEvent } from "../../lib/hermes-session-
 import { useScrollFade } from "../../lib/use-scroll-fade";
 import { unsupportedEventStore } from "../../lib/hermes-unsupported-events";
 import { pendingActionStore } from "../../lib/hermes-pending-actions";
+import { accessGrantLog, approvalPatternKeys } from "../../lib/access-grant-log";
 import { hermesActivityStore, type AgentActivityRecord } from "../../lib/hermes-activity-store";
 import {
   hermesArtifactStore,
@@ -6617,6 +6618,30 @@ export function AgentWorkspace({
           payload: { request_id: requestId, choice },
         }),
       );
+      // JUN-206: the user just granted something — record what, with the
+      // scope/duration the choice implies, so the Access grants settings page
+      // can show it. Look the request's details up before resolving it away.
+      if (choice !== "deny") {
+        const pending = pendingActionStore.getRecords().find(
+          (record) =>
+            // The store keys some streams by the live-event key (task id)
+            // rather than the runtime session id — accept either, the same
+            // way the resolve below addresses the record by liveEventKey.
+            (record.sessionId === sessionId || record.sessionId === liveEventKey) &&
+            record.requestId === requestId &&
+            record.action.kind === "approval",
+        );
+        const action = pending?.action.kind === "approval" ? pending.action : undefined;
+        accessGrantLog.record({
+          sessionId,
+          requestId,
+          choice,
+          toolName: action?.toolName,
+          command: action?.command,
+          description: action?.description,
+          patternKeys: approvalPatternKeys(action?.payload),
+        });
+      }
       // Feature 04: the user just answered this approval — clear its global
       // "Needs you" row immediately (the response itself is the resolution).
       pendingActionStore.resolveRequest(liveEventKey, requestId);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -6618,10 +6618,12 @@ export function AgentWorkspace({
           payload: { request_id: requestId, choice },
         }),
       );
-      // JUN-206: the user just granted something — record what, with the
-      // scope/duration the choice implies, so the Access grants settings page
-      // can show it. Look the request's details up before resolving it away.
-      if (choice !== "deny") {
+      // JUN-206: the user just granted something persistent ("Always
+      // approve" is app-wide and ongoing) — record what, so the Access grants
+      // settings page can enrich the allowlist row it creates. One-time and
+      // session approvals expire on their own and are not tracked. Look the
+      // request's details up before resolving it away.
+      if (choice === "always") {
         const pending = pendingActionStore.getRecords().find(
           (record) =>
             // The store keys some streams by the live-event key (task id)
@@ -6635,7 +6637,6 @@ export function AgentWorkspace({
         accessGrantLog.record({
           sessionId,
           requestId,
-          choice,
           toolName: action?.toolName,
           command: action?.command,
           description: action?.description,

--- a/src/components/settings/AccessGrantsSection.tsx
+++ b/src/components/settings/AccessGrantsSection.tsx
@@ -1,9 +1,13 @@
 import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
 import { IconCircleInfo } from "central-icons/IconCircleInfo";
 import { IconExclamationCircle } from "central-icons/IconExclamationCircle";
-import { useCallback, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { accessGrantLog, type AccessGrantLog } from "../../lib/access-grant-log";
-import { forgetSessionMode, unrestrictedSessionIds } from "../../lib/agent-session-modes";
+import {
+  forgetSessionMode,
+  subscribeSessionModes,
+  unrestrictedSessionIds,
+} from "../../lib/agent-session-modes";
 import {
   buildAllowedCommandRows,
   buildSessionGrantRows,
@@ -47,6 +51,12 @@ export function AccessGrantsSection({ mode = "sandboxed" }: AccessGrantsSectionP
   const state = useAccessGrants(mode);
   const log = useAccessGrantLog(accessGrantLog);
   const [unrestricted, setUnrestricted] = useState<string[]>(() => unrestrictedSessionIds());
+
+  // Track opt-ins/revokes made elsewhere in the app (e.g. the session bar)
+  // while this page stays mounted, so the list never goes stale.
+  useEffect(() => {
+    return subscribeSessionModes(() => setUnrestricted(unrestrictedSessionIds()));
+  }, []);
 
   const revokeUnrestricted = useCallback((sessionId: string) => {
     forgetSessionMode(sessionId);

--- a/src/components/settings/AccessGrantsSection.tsx
+++ b/src/components/settings/AccessGrantsSection.tsx
@@ -1,0 +1,362 @@
+import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
+import { IconCircleInfo } from "central-icons/IconCircleInfo";
+import { IconExclamationCircle } from "central-icons/IconExclamationCircle";
+import { useCallback, useState, useSyncExternalStore } from "react";
+import { accessGrantLog, type AccessGrantLog } from "../../lib/access-grant-log";
+import { forgetSessionMode, unrestrictedSessionIds } from "../../lib/agent-session-modes";
+import {
+  buildAllowedCommandRows,
+  buildSessionGrantRows,
+  grantDurationLabel,
+  grantScopeLabel,
+  shortSessionId,
+  useAccessGrants,
+  type AccessGrantsState,
+  type AllowedCommandRow,
+  type HermesAdminMode,
+  type SessionGrantRow,
+} from "../../lib/hermes-admin";
+import { AdminNotifications } from "./AdminNotifications";
+import { InlineNotice } from "../ui/InlineNotice";
+import { SettingsPageHeader } from "./AppSettings";
+
+type AccessGrantsSectionProps = {
+  /** The write-access mode whose runtime the allowlist half targets. Defaults
+   * to the safe sandboxed runtime; the host can point it at Full mode. */
+  mode?: HermesAdminMode;
+};
+
+/**
+ * June's Access grants manager (JUN-206). One page listing everything the user
+ * has granted the agent, with the scope (this session vs app-wide) and duration
+ * (one time vs ongoing) of each grant, and the ability to revoke:
+ *
+ * - "Always allowed commands": the runtime's persisted `command_allowlist`
+ *   (an "Always approve" answer), read and revoked through the same safe REST
+ *   config write the External directories page uses. App-wide, ongoing.
+ * - "Session approvals": June's local log of "Approve once" / "Approve for
+ *   this session" answers. Session-scoped; a session approval expires with its
+ *   session, a one-time approval was consumed by the request that asked.
+ * - "Full access sessions": sessions switched to Unrestricted (no sandbox).
+ *   Revoking returns the session to the sandbox on its next message.
+ *
+ * Remote data lives in {@link useAccessGrants}; the local log and session-mode
+ * store are read synchronously. This component is presentation plus wiring.
+ */
+export function AccessGrantsSection({ mode = "sandboxed" }: AccessGrantsSectionProps) {
+  const state = useAccessGrants(mode);
+  const log = useAccessGrantLog(accessGrantLog);
+  const [unrestricted, setUnrestricted] = useState<string[]>(() => unrestrictedSessionIds());
+
+  const revokeUnrestricted = useCallback((sessionId: string) => {
+    forgetSessionMode(sessionId);
+    setUnrestricted(unrestrictedSessionIds());
+  }, []);
+
+  const grantRows = buildSessionGrantRows(log.entries);
+  // Clear only the records the list shows. "always" log entries are invisible
+  // here (their live representation is the allowlist row) and clearing them
+  // would only strip the granted-when/what enrichment off those rows.
+  const clearAllGrants = useCallback(() => {
+    for (const row of buildSessionGrantRows(accessGrantLog.list())) {
+      accessGrantLog.remove(row.id);
+    }
+  }, []);
+
+  return (
+    <AccessGrantsView
+      state={state}
+      grantRows={grantRows}
+      allowedRows={buildAllowedCommandRows(state.patterns, log.entries)}
+      unrestrictedSessions={unrestricted}
+      onClearGrant={log.remove}
+      onClearAllGrants={clearAllGrants}
+      onRevokeUnrestricted={revokeUnrestricted}
+    />
+  );
+}
+
+/** Binds an {@link AccessGrantLog} to React. Exported for tests. */
+export function useAccessGrantLog(log: AccessGrantLog) {
+  const entries = useSyncExternalStore(log.subscribe, log.list, log.list);
+  const remove = useCallback((id: string) => log.remove(id), [log]);
+  const clear = useCallback(() => log.clear(), [log]);
+  return { entries, remove, clear };
+}
+
+/**
+ * The render-only view, split out so component tests can drive it with stubbed
+ * state (no Tauri, no network) and assert the labels and the revoke wiring.
+ */
+export function AccessGrantsView({
+  state,
+  allowedRows,
+  grantRows,
+  unrestrictedSessions,
+  onClearGrant,
+  onClearAllGrants,
+  onRevokeUnrestricted,
+}: {
+  state: AccessGrantsState;
+  allowedRows: AllowedCommandRow[];
+  grantRows: SessionGrantRow[];
+  unrestrictedSessions: string[];
+  onClearGrant: (id: string) => void;
+  onClearAllGrants: () => void;
+  onRevokeUnrestricted: (sessionId: string) => void;
+}) {
+  const [refreshSpins, setRefreshSpins] = useState(0);
+  const isUnavailable = state.status === "unavailable";
+  const isErrored = state.status === "error";
+  const isLoading = state.status === "loading";
+
+  const handleRefresh = () => {
+    setRefreshSpins((spins) => spins + 1);
+    state.refresh();
+  };
+
+  return (
+    <section className="settings-group access-grants" aria-labelledby="access-grants-heading">
+      <SettingsPageHeader
+        id="access-grants-heading"
+        title="Access grants"
+        blurb="Everything you have granted the agent, with the scope and duration of each grant. Revoke a grant here to take it back."
+      />
+
+      <AdminNotifications
+        notifications={state.notifications}
+        onDismiss={state.dismissNotification}
+      />
+
+      {/* --- Always allowed commands (app-wide, ongoing; lives in the runtime's
+       * config, so this group needs the runtime to be reachable) --- */}
+      <div className="access-grants-group">
+        <div className="access-grants-group-header">
+          <h3 className="settings-group-heading">Always allowed commands</h3>
+          <button
+            type="button"
+            className="icon-button access-grants-refresh"
+            aria-label="Refresh always allowed commands"
+            aria-busy={isLoading || state.busy}
+            title="Refresh always allowed commands"
+            disabled={isUnavailable || isLoading || state.busy}
+            onClick={handleRefresh}
+          >
+            <IconArrowRotateClockwise
+              size={14}
+              ariaHidden
+              className="balance-refresh-icon"
+              style={{ transform: `rotate(${refreshSpins * 360}deg)` }}
+            />
+          </button>
+        </div>
+        <p className="settings-group-description">
+          Commands you chose to always approve. They apply app-wide and stay in effect until
+          revoked. Revoking applies to new sessions; a matching command will ask for approval again.
+        </p>
+        <div className="settings-card">
+          {state.error && !isErrored ? (
+            <p className="settings-row-error access-grants-inline-error">
+              <IconExclamationCircle size={14} ariaHidden />
+              {state.error}
+            </p>
+          ) : null}
+          {isUnavailable ? (
+            <GroupNote text="The agent runtime is not running. Start it to see and revoke always allowed commands." />
+          ) : isErrored ? (
+            <div className="access-grants-note" role="alert">
+              <p>{state.error ?? "Could not load always allowed commands."}</p>
+              {state.retryable ? (
+                <button type="button" className="btn btn-secondary" onClick={state.refresh}>
+                  Try again
+                </button>
+              ) : null}
+            </div>
+          ) : isLoading ? (
+            <GroupNote text="Loading always allowed commands." />
+          ) : allowedRows.length === 0 ? (
+            <GroupNote text="No always allowed commands. When you answer an approval with Always approve, it appears here." />
+          ) : (
+            <ul className="access-grants-list">
+              {allowedRows.map((row) => (
+                <AllowedCommandItem
+                  key={row.pattern}
+                  row={row}
+                  busy={state.busy}
+                  onRevoke={() => state.revoke(row.pattern)}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* --- Session approvals (June's local record) --- */}
+      <div className="access-grants-group">
+        <div className="access-grants-group-header">
+          <h3 className="settings-group-heading">Session approvals</h3>
+          {grantRows.length > 0 ? (
+            <button type="button" className="btn btn-secondary" onClick={onClearAllGrants}>
+              Clear all
+            </button>
+          ) : null}
+        </div>
+        <p className="settings-group-description">
+          Approvals you granted for a single request or for the rest of a session. A session
+          approval expires when its session ends; a one-time approval covered only the request that
+          asked. Clearing a record removes it from this list only.
+        </p>
+        <div className="settings-card">
+          {grantRows.length === 0 ? (
+            <GroupNote text="No recorded session approvals." />
+          ) : (
+            <ul className="access-grants-list">
+              {grantRows.map((row) => (
+                <SessionGrantItem key={row.id} row={row} onClear={() => onClearGrant(row.id)} />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* --- Full access sessions (Unrestricted opt-ins) --- */}
+      <div className="access-grants-group">
+        <h3 className="settings-group-heading">Full access sessions</h3>
+        <p className="settings-group-description">
+          Sessions you switched to full access, which runs without the sandbox. Revoking returns the
+          session to the sandbox the next time you send a message in it.
+        </p>
+        <div className="settings-card">
+          {unrestrictedSessions.length === 0 ? (
+            <GroupNote text="No sessions have full access." />
+          ) : (
+            <ul className="access-grants-list">
+              {unrestrictedSessions.map((sessionId) => (
+                <li key={sessionId} className="settings-row access-grant-row">
+                  <div className="settings-row-info">
+                    <h4 className="settings-row-title">Session {shortSessionId(sessionId)}</h4>
+                    <p className="settings-row-description">
+                      <GrantBadges scope="session" duration="ongoing" />
+                    </p>
+                  </div>
+                  <div className="settings-row-control">
+                    <button
+                      type="button"
+                      className="btn btn-secondary"
+                      onClick={() => onRevokeUnrestricted(sessionId)}
+                    >
+                      Revoke
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      <InlineNotice
+        tone="info"
+        icon={<IconCircleInfo size={15} ariaHidden />}
+        body="System permissions like microphone and accessibility are managed under General. MCP server and connector access is managed under MCP servers."
+      />
+    </section>
+  );
+}
+
+function AllowedCommandItem({
+  row,
+  busy,
+  onRevoke,
+}: {
+  row: AllowedCommandRow;
+  busy: boolean;
+  onRevoke: () => void;
+}) {
+  return (
+    <li className="settings-row access-grant-row">
+      <div className="settings-row-info">
+        <h4 className="settings-row-title">{row.pattern}</h4>
+        {row.command ? (
+          <p className="settings-row-description access-grant-command" title={row.command}>
+            {row.command}
+          </p>
+        ) : null}
+        <p className="settings-row-description">
+          <GrantBadges scope={row.scope} duration={row.duration} />
+          {row.grantedAt ? (
+            <span className="access-grant-when">Granted {formatGrantedAt(row.grantedAt)}</span>
+          ) : null}
+        </p>
+      </div>
+      <div className="settings-row-control">
+        <button type="button" className="btn btn-secondary" disabled={busy} onClick={onRevoke}>
+          Revoke
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function SessionGrantItem({ row, onClear }: { row: SessionGrantRow; onClear: () => void }) {
+  return (
+    <li className="settings-row access-grant-row">
+      <div className="settings-row-info">
+        <h4 className="settings-row-title">{row.title}</h4>
+        {row.command && row.command !== row.title ? (
+          <p className="settings-row-description access-grant-command" title={row.command}>
+            {row.command}
+          </p>
+        ) : null}
+        <p className="settings-row-description">
+          <GrantBadges scope={row.scope} duration={row.duration} />
+          <span className="access-grant-when">
+            Session {shortSessionId(row.sessionId)}, granted {formatGrantedAt(row.grantedAt)}
+          </span>
+        </p>
+      </div>
+      <div className="settings-row-control">
+        <button type="button" className="btn btn-secondary" onClick={onClear}>
+          Clear
+        </button>
+      </div>
+    </li>
+  );
+}
+
+/** The scope + duration pills every row carries, so the two JUN-206 dimensions
+ * read consistently across the groups. */
+function GrantBadges({
+  scope,
+  duration,
+}: {
+  scope: AllowedCommandRow["scope"] | SessionGrantRow["scope"];
+  duration: AllowedCommandRow["duration"] | SessionGrantRow["duration"];
+}) {
+  return (
+    <span className="access-grant-badges">
+      <span className="status-pill">{grantScopeLabel(scope)}</span>
+      <span className="status-pill">{grantDurationLabel(duration)}</span>
+    </span>
+  );
+}
+
+function GroupNote({ text }: { text: string }) {
+  return (
+    <p className="access-grants-note" role="status">
+      {text}
+    </p>
+  );
+}
+
+function formatGrantedAt(grantedAt: number): string {
+  try {
+    return new Date(grantedAt).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return "recently";
+  }
+}

--- a/src/components/settings/AccessGrantsSection.tsx
+++ b/src/components/settings/AccessGrantsSection.tsx
@@ -9,6 +9,7 @@ import {
   unrestrictedSessionIds,
 } from "../../lib/agent-session-modes";
 import { pendingActionStore, type PendingActionStore } from "../../lib/hermes-pending-actions";
+import { hermesAgentCliAccess, setHermesAgentCliAccess } from "../../lib/tauri";
 import {
   buildAllowedCommandRows,
   buildSessionGrantRows,
@@ -64,6 +65,37 @@ export function AccessGrantsSection({ mode = "sandboxed" }: AccessGrantsSectionP
     setUnrestricted(unrestrictedSessionIds());
   }, []);
 
+  // Agent CLI access: an app-wide, ongoing grant persisted as a flag file.
+  // Read here so the inventory really covers everything granted; the toggle in
+  // Agent settings remains the primary control.
+  const [cliAccess, setCliAccess] = useState<boolean | null>(null);
+  const [cliBusy, setCliBusy] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    hermesAgentCliAccess()
+      .then((status) => {
+        if (!cancelled) setCliAccess(status.enabled);
+      })
+      .catch(() => {
+        if (!cancelled) setCliAccess(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  const revokeCliAccess = useCallback(async () => {
+    setCliBusy(true);
+    try {
+      const status = await setHermesAgentCliAccess(false);
+      setCliAccess(status.enabled);
+    } catch {
+      // Leave the shown state unchanged; the Agent settings toggle surfaces
+      // write failures with full error copy.
+    } finally {
+      setCliBusy(false);
+    }
+  }, []);
+
   const grantRows = buildSessionGrantRows(log.entries);
   // Clear only the records the list shows. "always" log entries are invisible
   // here (their live representation is the allowlist row) and clearing them
@@ -80,9 +112,12 @@ export function AccessGrantsSection({ mode = "sandboxed" }: AccessGrantsSectionP
       grantRows={grantRows}
       allowedRows={buildAllowedCommandRows(state.patterns, log.entries)}
       unrestrictedSessions={unrestricted}
+      cliAccess={cliAccess}
+      cliBusy={cliBusy}
       onClearGrant={log.remove}
       onClearAllGrants={clearAllGrants}
       onRevokeUnrestricted={revokeUnrestricted}
+      onRevokeCliAccess={() => void revokeCliAccess()}
     />
   );
 }
@@ -122,17 +157,24 @@ export function AccessGrantsView({
   allowedRows,
   grantRows,
   unrestrictedSessions,
+  cliAccess,
+  cliBusy,
   onClearGrant,
   onClearAllGrants,
   onRevokeUnrestricted,
+  onRevokeCliAccess,
 }: {
   state: AccessGrantsState;
   allowedRows: AllowedCommandRow[];
   grantRows: SessionGrantRow[];
   unrestrictedSessions: string[];
+  /** Whether Agent CLI access is granted; null when the status is unknown. */
+  cliAccess: boolean | null;
+  cliBusy: boolean;
   onClearGrant: (id: string) => void;
   onClearAllGrants: () => void;
   onRevokeUnrestricted: (sessionId: string) => void;
+  onRevokeCliAccess: () => void;
 }) {
   const [refreshSpins, setRefreshSpins] = useState(0);
   const isUnavailable = state.status === "unavailable";
@@ -280,6 +322,45 @@ export function AccessGrantsView({
                 </li>
               ))}
             </ul>
+          )}
+        </div>
+      </div>
+
+      {/* --- Agent CLI access (app-wide flag; the Agent settings toggle is the
+       * primary control, this row keeps the inventory complete) --- */}
+      <div className="access-grants-group">
+        <h3 className="settings-group-heading">Agent CLI access</h3>
+        <p className="settings-group-description">
+          Write access to the settings and session folders of coding CLIs you already use, like
+          Claude Code and Codex. Also managed under Agent settings. Revoking applies to new
+          sessions.
+        </p>
+        <div className="settings-card">
+          {cliAccess === null ? (
+            <GroupNote text="Could not read the current status. Manage this grant under Agent settings." />
+          ) : cliAccess ? (
+            <ul className="access-grants-list">
+              <li className="settings-row access-grant-row">
+                <div className="settings-row-info">
+                  <h4 className="settings-row-title">Coding CLI state folders</h4>
+                  <p className="settings-row-description">
+                    <GrantBadges scope="app-wide" duration="ongoing" />
+                  </p>
+                </div>
+                <div className="settings-row-control">
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    disabled={cliBusy}
+                    onClick={onRevokeCliAccess}
+                  >
+                    Revoke
+                  </button>
+                </div>
+              </li>
+            </ul>
+          ) : (
+            <GroupNote text="Not granted." />
           )}
         </div>
       </div>

--- a/src/components/settings/AccessGrantsSection.tsx
+++ b/src/components/settings/AccessGrantsSection.tsx
@@ -8,6 +8,7 @@ import {
   subscribeSessionModes,
   unrestrictedSessionIds,
 } from "../../lib/agent-session-modes";
+import { pendingActionStore, type PendingActionStore } from "../../lib/hermes-pending-actions";
 import {
   buildAllowedCommandRows,
   buildSessionGrantRows,
@@ -59,7 +60,7 @@ export function AccessGrantsSection({ mode = "sandboxed" }: AccessGrantsSectionP
   }, []);
 
   const revokeUnrestricted = useCallback((sessionId: string) => {
-    forgetSessionMode(sessionId);
+    revokeUnrestrictedSession(sessionId);
     setUnrestricted(unrestrictedSessionIds());
   }, []);
 
@@ -84,6 +85,24 @@ export function AccessGrantsSection({ mode = "sandboxed" }: AccessGrantsSectionP
       onRevokeUnrestricted={revokeUnrestricted}
     />
   );
+}
+
+/**
+ * Revokes a session's full access and retires any of its still-open pending
+ * actions. The retire matters: once the mode flag is gone,
+ * `sessionUnrestricted()` reads false and a later Approve/Deny/answer would be
+ * routed to the sandboxed gateway while the blocked request lives in the
+ * unrestricted runtime, a dead end that fails as the wrong session. Resolving
+ * the session's pending records clears its "Needs you" rows instead of
+ * offering that dead-end respond; the runtime denies unanswered requests on
+ * its own session cleanup. Exported for tests (store injectable).
+ */
+export function revokeUnrestrictedSession(
+  sessionId: string,
+  store: PendingActionStore = pendingActionStore,
+) {
+  forgetSessionMode(sessionId);
+  store.resolveSession(sessionId);
 }
 
 /** Binds an {@link AccessGrantLog} to React. Exported for tests. */

--- a/src/components/settings/AccessGrantsSection.tsx
+++ b/src/components/settings/AccessGrantsSection.tsx
@@ -3,24 +3,13 @@ import { IconCircleInfo } from "central-icons/IconCircleInfo";
 import { IconExclamationCircle } from "central-icons/IconExclamationCircle";
 import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { accessGrantLog, type AccessGrantLog } from "../../lib/access-grant-log";
-import {
-  forgetSessionMode,
-  subscribeSessionModes,
-  unrestrictedSessionIds,
-} from "../../lib/agent-session-modes";
-import { pendingActionStore, type PendingActionStore } from "../../lib/hermes-pending-actions";
 import { hermesAgentCliAccess, setHermesAgentCliAccess } from "../../lib/tauri";
 import {
   buildAllowedCommandRows,
-  buildSessionGrantRows,
-  grantDurationLabel,
-  grantScopeLabel,
-  shortSessionId,
   useAccessGrants,
   type AccessGrantsState,
   type AllowedCommandRow,
   type HermesAdminMode,
-  type SessionGrantRow,
 } from "../../lib/hermes-admin";
 import { AdminNotifications } from "./AdminNotifications";
 import { InlineNotice } from "../ui/InlineNotice";
@@ -33,41 +22,29 @@ type AccessGrantsSectionProps = {
 };
 
 /**
- * June's Access grants manager (JUN-206). One page listing everything the user
- * has granted the agent, with the scope (this session vs app-wide) and duration
- * (one time vs ongoing) of each grant, and the ability to revoke:
+ * June's Access grants manager (JUN-206). One page listing the PERSISTENT
+ * grants: app-wide, ongoing permissions that stay in effect until revoked
+ * here. One-time and session approvals expire on their own (consumed by the
+ * request, or with the session) and are deliberately not listed.
  *
  * - "Always allowed commands": the runtime's persisted `command_allowlist`
  *   (an "Always approve" answer), read and revoked through the same safe REST
- *   config write the External directories page uses. App-wide, ongoing.
- * - "Session approvals": June's local log of "Approve once" / "Approve for
- *   this session" answers. Session-scoped; a session approval expires with its
- *   session, a one-time approval was consumed by the request that asked.
- * - "Full access sessions": sessions switched to Unrestricted (no sandbox).
- *   Revoking returns the session to the sandbox on its next message.
+ *   config write the External directories page uses.
+ * - "Agent CLI access": the app-wide flag granting write access to coding CLI
+ *   state folders, revocable here; the Agent settings toggle is the primary
+ *   control.
  *
- * Remote data lives in {@link useAccessGrants}; the local log and session-mode
- * store are read synchronously. This component is presentation plus wiring.
+ * Remote data lives in {@link useAccessGrants}; the local grant log (which
+ * enriches allowlist rows with when/what granted them) is read synchronously.
+ * This component is presentation plus wiring.
  */
 export function AccessGrantsSection({ mode = "sandboxed" }: AccessGrantsSectionProps) {
   const state = useAccessGrants(mode);
-  const log = useAccessGrantLog(accessGrantLog);
-  const [unrestricted, setUnrestricted] = useState<string[]>(() => unrestrictedSessionIds());
-
-  // Track opt-ins/revokes made elsewhere in the app (e.g. the session bar)
-  // while this page stays mounted, so the list never goes stale.
-  useEffect(() => {
-    return subscribeSessionModes(() => setUnrestricted(unrestrictedSessionIds()));
-  }, []);
-
-  const revokeUnrestricted = useCallback((sessionId: string) => {
-    revokeUnrestrictedSession(sessionId);
-    setUnrestricted(unrestrictedSessionIds());
-  }, []);
+  const logEntries = useAccessGrantLog(accessGrantLog);
 
   // Agent CLI access: an app-wide, ongoing grant persisted as a flag file.
-  // Read here so the inventory really covers everything granted; the toggle in
-  // Agent settings remains the primary control.
+  // Read here so the inventory really covers every persistent grant; the
+  // toggle in Agent settings remains the primary control.
   const [cliAccess, setCliAccess] = useState<boolean | null>(null);
   const [cliBusy, setCliBusy] = useState(false);
   useEffect(() => {
@@ -96,56 +73,20 @@ export function AccessGrantsSection({ mode = "sandboxed" }: AccessGrantsSectionP
     }
   }, []);
 
-  const grantRows = buildSessionGrantRows(log.entries);
-  // Clear only the records the list shows. "always" log entries are invisible
-  // here (their live representation is the allowlist row) and clearing them
-  // would only strip the granted-when/what enrichment off those rows.
-  const clearAllGrants = useCallback(() => {
-    for (const row of buildSessionGrantRows(accessGrantLog.list())) {
-      accessGrantLog.remove(row.id);
-    }
-  }, []);
-
   return (
     <AccessGrantsView
       state={state}
-      grantRows={grantRows}
-      allowedRows={buildAllowedCommandRows(state.patterns, log.entries)}
-      unrestrictedSessions={unrestricted}
+      allowedRows={buildAllowedCommandRows(state.patterns, logEntries)}
       cliAccess={cliAccess}
       cliBusy={cliBusy}
-      onClearGrant={log.remove}
-      onClearAllGrants={clearAllGrants}
-      onRevokeUnrestricted={revokeUnrestricted}
       onRevokeCliAccess={() => void revokeCliAccess()}
     />
   );
 }
 
-/**
- * Revokes a session's full access and retires any of its still-open pending
- * actions. The retire matters: once the mode flag is gone,
- * `sessionUnrestricted()` reads false and a later Approve/Deny/answer would be
- * routed to the sandboxed gateway while the blocked request lives in the
- * unrestricted runtime, a dead end that fails as the wrong session. Resolving
- * the session's pending records clears its "Needs you" rows instead of
- * offering that dead-end respond; the runtime denies unanswered requests on
- * its own session cleanup. Exported for tests (store injectable).
- */
-export function revokeUnrestrictedSession(
-  sessionId: string,
-  store: PendingActionStore = pendingActionStore,
-) {
-  forgetSessionMode(sessionId);
-  store.resolveSession(sessionId);
-}
-
 /** Binds an {@link AccessGrantLog} to React. Exported for tests. */
 export function useAccessGrantLog(log: AccessGrantLog) {
-  const entries = useSyncExternalStore(log.subscribe, log.list, log.list);
-  const remove = useCallback((id: string) => log.remove(id), [log]);
-  const clear = useCallback(() => log.clear(), [log]);
-  return { entries, remove, clear };
+  return useSyncExternalStore(log.subscribe, log.list, log.list);
 }
 
 /**
@@ -155,25 +96,15 @@ export function useAccessGrantLog(log: AccessGrantLog) {
 export function AccessGrantsView({
   state,
   allowedRows,
-  grantRows,
-  unrestrictedSessions,
   cliAccess,
   cliBusy,
-  onClearGrant,
-  onClearAllGrants,
-  onRevokeUnrestricted,
   onRevokeCliAccess,
 }: {
   state: AccessGrantsState;
   allowedRows: AllowedCommandRow[];
-  grantRows: SessionGrantRow[];
-  unrestrictedSessions: string[];
   /** Whether Agent CLI access is granted; null when the status is unknown. */
   cliAccess: boolean | null;
   cliBusy: boolean;
-  onClearGrant: (id: string) => void;
-  onClearAllGrants: () => void;
-  onRevokeUnrestricted: (sessionId: string) => void;
   onRevokeCliAccess: () => void;
 }) {
   const [refreshSpins, setRefreshSpins] = useState(0);
@@ -191,7 +122,7 @@ export function AccessGrantsView({
       <SettingsPageHeader
         id="access-grants-heading"
         title="Access grants"
-        blurb="Everything you have granted the agent, with the scope and duration of each grant. Revoke a grant here to take it back."
+        blurb="Ongoing permissions you have granted the agent. They apply app-wide until revoked here. One-time and session approvals expire on their own and are not listed."
       />
 
       <AdminNotifications
@@ -199,8 +130,8 @@ export function AccessGrantsView({
         onDismiss={state.dismissNotification}
       />
 
-      {/* --- Always allowed commands (app-wide, ongoing; lives in the runtime's
-       * config, so this group needs the runtime to be reachable) --- */}
+      {/* --- Always allowed commands (lives in the runtime's config, so this
+       * group needs the runtime to be reachable) --- */}
       <div className="access-grants-group">
         <div className="access-grants-group-header">
           <h3 className="settings-group-heading">Always allowed commands</h3>
@@ -262,70 +193,6 @@ export function AccessGrantsView({
         </div>
       </div>
 
-      {/* --- Session approvals (June's local record) --- */}
-      <div className="access-grants-group">
-        <div className="access-grants-group-header">
-          <h3 className="settings-group-heading">Session approvals</h3>
-          {grantRows.length > 0 ? (
-            <button type="button" className="btn btn-secondary" onClick={onClearAllGrants}>
-              Clear all
-            </button>
-          ) : null}
-        </div>
-        <p className="settings-group-description">
-          Approvals you granted for a single request or for the rest of a session. A session
-          approval expires when its session ends; a one-time approval covered only the request that
-          asked. Clearing a record removes it from this list only.
-        </p>
-        <div className="settings-card">
-          {grantRows.length === 0 ? (
-            <GroupNote text="No recorded session approvals." />
-          ) : (
-            <ul className="access-grants-list">
-              {grantRows.map((row) => (
-                <SessionGrantItem key={row.id} row={row} onClear={() => onClearGrant(row.id)} />
-              ))}
-            </ul>
-          )}
-        </div>
-      </div>
-
-      {/* --- Full access sessions (Unrestricted opt-ins) --- */}
-      <div className="access-grants-group">
-        <h3 className="settings-group-heading">Full access sessions</h3>
-        <p className="settings-group-description">
-          Sessions you switched to full access, which runs without the sandbox. Revoking returns the
-          session to the sandbox the next time you send a message in it.
-        </p>
-        <div className="settings-card">
-          {unrestrictedSessions.length === 0 ? (
-            <GroupNote text="No sessions have full access." />
-          ) : (
-            <ul className="access-grants-list">
-              {unrestrictedSessions.map((sessionId) => (
-                <li key={sessionId} className="settings-row access-grant-row">
-                  <div className="settings-row-info">
-                    <h4 className="settings-row-title">Session {shortSessionId(sessionId)}</h4>
-                    <p className="settings-row-description">
-                      <GrantBadges scope="session" duration="ongoing" />
-                    </p>
-                  </div>
-                  <div className="settings-row-control">
-                    <button
-                      type="button"
-                      className="btn btn-secondary"
-                      onClick={() => onRevokeUnrestricted(sessionId)}
-                    >
-                      Revoke
-                    </button>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      </div>
-
       {/* --- Agent CLI access (app-wide flag; the Agent settings toggle is the
        * primary control, this row keeps the inventory complete) --- */}
       <div className="access-grants-group">
@@ -344,7 +211,7 @@ export function AccessGrantsView({
                 <div className="settings-row-info">
                   <h4 className="settings-row-title">Coding CLI state folders</h4>
                   <p className="settings-row-description">
-                    <GrantBadges scope="app-wide" duration="ongoing" />
+                    Applies app-wide and stays in effect until revoked.
                   </p>
                 </div>
                 <div className="settings-row-control">
@@ -392,12 +259,11 @@ function AllowedCommandItem({
             {row.command}
           </p>
         ) : null}
-        <p className="settings-row-description">
-          <GrantBadges scope={row.scope} duration={row.duration} />
-          {row.grantedAt ? (
+        {row.grantedAt ? (
+          <p className="settings-row-description">
             <span className="access-grant-when">Granted {formatGrantedAt(row.grantedAt)}</span>
-          ) : null}
-        </p>
+          </p>
+        ) : null}
       </div>
       <div className="settings-row-control">
         <button type="button" className="btn btn-secondary" disabled={busy} onClick={onRevoke}>
@@ -405,49 +271,6 @@ function AllowedCommandItem({
         </button>
       </div>
     </li>
-  );
-}
-
-function SessionGrantItem({ row, onClear }: { row: SessionGrantRow; onClear: () => void }) {
-  return (
-    <li className="settings-row access-grant-row">
-      <div className="settings-row-info">
-        <h4 className="settings-row-title">{row.title}</h4>
-        {row.command && row.command !== row.title ? (
-          <p className="settings-row-description access-grant-command" title={row.command}>
-            {row.command}
-          </p>
-        ) : null}
-        <p className="settings-row-description">
-          <GrantBadges scope={row.scope} duration={row.duration} />
-          <span className="access-grant-when">
-            Session {shortSessionId(row.sessionId)}, granted {formatGrantedAt(row.grantedAt)}
-          </span>
-        </p>
-      </div>
-      <div className="settings-row-control">
-        <button type="button" className="btn btn-secondary" onClick={onClear}>
-          Clear
-        </button>
-      </div>
-    </li>
-  );
-}
-
-/** The scope + duration pills every row carries, so the two JUN-206 dimensions
- * read consistently across the groups. */
-function GrantBadges({
-  scope,
-  duration,
-}: {
-  scope: AllowedCommandRow["scope"] | SessionGrantRow["scope"];
-  duration: AllowedCommandRow["duration"] | SessionGrantRow["duration"];
-}) {
-  return (
-    <span className="access-grant-badges">
-      <span className="status-pill">{grantScopeLabel(scope)}</span>
-      <span className="status-pill">{grantDurationLabel(duration)}</span>
-    </span>
   );
 }
 

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -100,6 +100,7 @@ import {
 import { DEFAULT_IMAGE_MODEL, IMAGE_MODELS } from "../../lib/image-models";
 import { IMAGE_GENERATION_ENABLED, VIDEO_GENERATION_ENABLED } from "../../lib/feature-flags";
 import { DEFAULT_VIDEO_MODEL, VIDEO_MODELS } from "../../lib/video-models";
+import { AccessGrantsSection } from "./AccessGrantsSection";
 import { AgentSettingsSection } from "./AgentSettingsSection";
 import { ExternalDirsSection } from "./ExternalDirsSection";
 import { InstalledSkillsSection } from "./InstalledSkillsSection";
@@ -265,6 +266,7 @@ export type SettingsTab =
   | "audio"
   | "models"
   | "agent"
+  | "access-grants"
   | "skills"
   | "external-dirs"
   | "skill-review"
@@ -290,6 +292,7 @@ export const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
   { id: "audio", label: "Audio" },
   { id: "models", label: "Models" },
   { id: "agent", label: "Agent" },
+  { id: "access-grants", label: "Access grants" },
   { id: "skills", label: "Installed skills" },
   { id: "external-dirs", label: "External skill directories" },
   { id: "skill-review", label: "Pending skill changes" },
@@ -2125,6 +2128,7 @@ export function AppSettings({
           />
         ) : null}
 
+        {activeTab === "access-grants" ? <AccessGrantsSection /> : null}
         {activeTab === "skills" ? <InstalledSkillsSection onOpenSkill={setOpenSkill} /> : null}
         {activeTab === "external-dirs" ? <ExternalDirsSection /> : null}
         {activeTab === "skill-review" ? <SkillReviewSection /> : null}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -10,6 +10,7 @@ import { IconAudio } from "central-icons/IconAudio";
 import { IconBox2 } from "central-icons/IconBox2";
 import { IconBrain2 } from "central-icons/IconBrain2";
 import { IconBuildingBlocks } from "central-icons/IconBuildingBlocks";
+import { IconKey1 } from "central-icons/IconKey1";
 import { IconElements } from "central-icons/IconElements";
 import { IconModelcontextprotocol } from "central-icons/IconModelcontextprotocol";
 import { IconCircleInfo } from "central-icons/IconCircleInfo";
@@ -260,6 +261,11 @@ const SETTINGS_SIDEBAR_GROUPS: {
       },
       { id: "models", label: "Models", icon: <IconBrain2 size={16} /> },
       { id: "agent", label: "Agent", icon: <IconRobot2 size={16} /> },
+      {
+        id: "access-grants",
+        label: "Access grants",
+        icon: <IconKey1 size={16} />,
+      },
       {
         id: "skills",
         label: "Installed skills",

--- a/src/lib/access-grant-log.ts
+++ b/src/lib/access-grant-log.ts
@@ -1,0 +1,221 @@
+/**
+ * June's local record of the approval grants the user has answered — the data
+ * source behind the "Access grants" settings page (JUN-206).
+ *
+ * When the user approves a dangerous-command request, the choice ("once" /
+ * "session" / "always") goes to the Hermes runtime over `approval.respond`.
+ * The runtime keeps "always" answers durably (its config `command_allowlist`)
+ * and "session" answers in the session's memory, but June itself kept no
+ * record — so there was nothing to show a user asking "what have I granted?".
+ * This module is that record: every approved request is logged here with the
+ * scope (this session vs app-wide) and duration (one time vs ongoing) implied
+ * by the choice.
+ *
+ * Boundaries (what this log is NOT):
+ * - It is NOT the source of truth for app-wide grants. That is the runtime's
+ *   `command_allowlist`; the settings page reads and revokes it there. Log
+ *   entries with choice "always" exist only to enrich those rows (when the
+ *   grant was made, the command that triggered it).
+ * - It cannot retract a session-scoped approval from a running session; the
+ *   runtime holds that in memory with no revoke API. Session entries track
+ *   what was granted; they expire with the session.
+ *
+ * localStorage (not the backend) because the runtime's own session store is
+ * machine-local too, and the log must be readable synchronously on render —
+ * the same reasoning as `agent-session-modes.ts`. Framework-agnostic with a
+ * `subscribe`/`getSnapshot` surface so React binds via `useSyncExternalStore`
+ * and tests drive it directly.
+ */
+
+import type { AgentApprovalChoice } from "./agent-chat-runtime";
+
+const STORAGE_KEY = "june.agent.accessGrants";
+
+/** Cap on stored entries. One-time history is the unbounded part; ongoing
+ * grants are few by nature. Eviction drops the oldest entries first. */
+export const ACCESS_GRANT_LOG_CAP = 200;
+
+/** Where a grant applies. Derived from the approval choice: "always" is
+ * app-wide; "once" and "session" never outlive the session that asked. */
+export type AccessGrantScope = "session" | "app-wide";
+
+/** How long a grant lasts. "once" is consumed by the single command that asked;
+ * "session" and "always" keep allowing matching requests. */
+export type AccessGrantDuration = "one-time" | "ongoing";
+
+/** An approval choice that granted something (i.e. not "deny"). */
+export type AccessGrantChoice = Exclude<AgentApprovalChoice, "deny">;
+
+/** One logged grant. Field contents come from the runtime's approval request
+ * (already sanitized by the event classifier — no secrets cross into here). */
+export type AccessGrantRecord = {
+  /** Stable identity: the session + request that granted it. */
+  id: string;
+  sessionId: string;
+  requestId: string;
+  choice: AccessGrantChoice;
+  /** The tool that asked, when the runtime named one (e.g. "shell"). */
+  toolName?: string;
+  /** The command that triggered the approval prompt. */
+  command?: string;
+  /** The human-readable danger description (also the runtime's pattern key). */
+  description?: string;
+  /** The runtime's pattern keys for the matched danger patterns. These are the
+   * strings an "always" answer persists into `command_allowlist`, so they are
+   * how a log entry is correlated with an allowlist row. */
+  patternKeys: string[];
+  /** Epoch ms when the user granted it. */
+  grantedAt: number;
+};
+
+/** Scope implied by an approval choice. */
+export function grantScope(choice: AccessGrantChoice): AccessGrantScope {
+  return choice === "always" ? "app-wide" : "session";
+}
+
+/** Duration implied by an approval choice. */
+export function grantDuration(choice: AccessGrantChoice): AccessGrantDuration {
+  return choice === "once" ? "one-time" : "ongoing";
+}
+
+/** Extracts the runtime's pattern keys from a sanitized approval payload
+ * (`pattern_keys` list, falling back to the single `pattern_key`). Total:
+ * junk in, empty list out. */
+export function approvalPatternKeys(payload: unknown): string[] {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return [];
+  const record = payload as Record<string, unknown>;
+  const keys = record.pattern_keys;
+  if (Array.isArray(keys)) {
+    const out = keys.filter((key): key is string => typeof key === "string" && key.length > 0);
+    if (out.length > 0) return out;
+  }
+  const single = record.pattern_key;
+  if (typeof single === "string" && single.length > 0) return [single];
+  return [];
+}
+
+export type AccessGrantLog = {
+  /** Logs a grant. Total: never throws. A re-record of the same session +
+   * request (e.g. a retried respond) replaces the earlier entry. */
+  record(entry: Omit<AccessGrantRecord, "id" | "grantedAt"> & { grantedAt?: number }): void;
+  /** Removes one entry by id. No-op when unknown. */
+  remove(id: string): void;
+  /** Removes every logged entry. */
+  clear(): void;
+  /** All entries, newest first. The array identity is stable between
+   * mutations (a `useSyncExternalStore` snapshot). */
+  list(): readonly AccessGrantRecord[];
+  /** Subscribe to changes; returns an unsubscribe. */
+  subscribe(listener: () => void): () => void;
+};
+
+function isRecordShape(value: unknown): value is AccessGrantRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === "string" &&
+    typeof record.sessionId === "string" &&
+    typeof record.requestId === "string" &&
+    (record.choice === "once" || record.choice === "session" || record.choice === "always") &&
+    typeof record.grantedAt === "number" &&
+    Array.isArray(record.patternKeys)
+  );
+}
+
+function readStore(): AccessGrantRecord[] {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isRecordShape);
+  } catch {
+    return [];
+  }
+}
+
+function writeStore(entries: readonly AccessGrantRecord[]) {
+  try {
+    if (entries.length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // Ignore; worst case the grant history has a gap. The actual permission
+    // lives with the runtime, so nothing becomes more permissive.
+  }
+}
+
+/** Creates an isolated log instance. The app holds one ({@link accessGrantLog});
+ * tests create their own so state never leaks between suites. */
+export function createAccessGrantLog(): AccessGrantLog {
+  const listeners = new Set<() => void>();
+  // The cached snapshot: newest first, identity stable between mutations.
+  let snapshot: readonly AccessGrantRecord[] | undefined;
+
+  function emit(): void {
+    for (const listener of [...listeners]) listener();
+  }
+
+  function current(): readonly AccessGrantRecord[] {
+    if (!snapshot) {
+      snapshot = readStore().sort((a, b) => b.grantedAt - a.grantedAt);
+    }
+    return snapshot;
+  }
+
+  function replace(next: AccessGrantRecord[]): void {
+    next.sort((a, b) => b.grantedAt - a.grantedAt);
+    if (next.length > ACCESS_GRANT_LOG_CAP) next.length = ACCESS_GRANT_LOG_CAP;
+    snapshot = next;
+    writeStore(next);
+    emit();
+  }
+
+  return {
+    record(entry) {
+      const sessionId = entry.sessionId.trim();
+      const requestId = entry.requestId.trim();
+      // A grant that can't be attributed to a request is untrackable; drop it
+      // rather than store a row nothing can correlate or de-duplicate.
+      if (!sessionId || !requestId) return;
+      const id = `${sessionId}:${requestId}`;
+      const record: AccessGrantRecord = {
+        id,
+        sessionId,
+        requestId,
+        choice: entry.choice,
+        toolName: entry.toolName,
+        command: entry.command,
+        description: entry.description,
+        patternKeys: entry.patternKeys.filter((key) => typeof key === "string" && key.length > 0),
+        grantedAt: entry.grantedAt ?? Date.now(),
+      };
+      replace([record, ...current().filter((existing) => existing.id !== id)]);
+    },
+    remove(id) {
+      const next = current().filter((entry) => entry.id !== id);
+      if (next.length === current().length) return;
+      replace([...next]);
+    },
+    clear() {
+      if (current().length === 0) return;
+      replace([]);
+    },
+    list() {
+      return current();
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
+/** The app-wide log. AgentWorkspace records into it when the user approves a
+ * request; the Access grants settings page reads it. A singleton (not React
+ * state) so the record survives navigation between the chat and settings. */
+export const accessGrantLog = createAccessGrantLog();

--- a/src/lib/access-grant-log.ts
+++ b/src/lib/access-grant-log.ts
@@ -1,59 +1,42 @@
 /**
- * June's local record of the approval grants the user has answered — the data
- * source behind the "Access grants" settings page (JUN-206).
+ * June's local record of the "Always approve" answers the user has given — the
+ * enrichment source behind the "Access grants" settings page (JUN-206).
  *
- * When the user approves a dangerous-command request, the choice ("once" /
- * "session" / "always") goes to the Hermes runtime over `approval.respond`.
- * The runtime keeps "always" answers durably (its config `command_allowlist`)
- * and "session" answers in the session's memory, but June itself kept no
- * record — so there was nothing to show a user asking "what have I granted?".
- * This module is that record: every approved request is logged here with the
- * scope (this session vs app-wide) and duration (one time vs ongoing) implied
- * by the choice.
+ * When the user answers a dangerous-command approval with "Always approve",
+ * the runtime persists the pattern into its config `command_allowlist`, but
+ * that list carries no history: nothing says when the grant was made or which
+ * command triggered it. This log is that record. Only "always" answers are
+ * logged: they are the persistent, app-wide, ongoing grants the settings page
+ * manages. One-time and session approvals expire on their own (consumed by the
+ * request, or with the session) and are deliberately not tracked.
  *
  * Boundaries (what this log is NOT):
- * - It is NOT the source of truth for app-wide grants. That is the runtime's
- *   `command_allowlist`; the settings page reads and revokes it there. Log
- *   entries with choice "always" exist only to enrich those rows (when the
- *   grant was made, the command that triggered it).
- * - It cannot retract a session-scoped approval from a running session; the
- *   runtime holds that in memory with no revoke API. Session entries track
- *   what was granted; they expire with the session.
+ * - It is NOT the source of truth for the grants. That is the runtime's
+ *   `command_allowlist`; the settings page reads and revokes it there. Entries
+ *   here only enrich those rows (when the grant was made, the command that
+ *   triggered it).
  *
- * localStorage (not the backend) because the runtime's own session store is
+ * localStorage (not the backend) because the runtime's own config store is
  * machine-local too, and the log must be readable synchronously on render —
  * the same reasoning as `agent-session-modes.ts`. Framework-agnostic with a
  * `subscribe`/`getSnapshot` surface so React binds via `useSyncExternalStore`
  * and tests drive it directly.
  */
 
-import type { AgentApprovalChoice } from "./agent-chat-runtime";
-
 const STORAGE_KEY = "june.agent.accessGrants";
 
-/** Cap on stored entries. One-time history is the unbounded part; ongoing
- * grants are few by nature. Eviction drops the oldest entries first. */
+/** Cap on stored entries. Ongoing grants are few by nature, but the cap keeps
+ * a pathological history bounded. Eviction drops the oldest entries first. */
 export const ACCESS_GRANT_LOG_CAP = 200;
 
-/** Where a grant applies. Derived from the approval choice: "always" is
- * app-wide; "once" and "session" never outlive the session that asked. */
-export type AccessGrantScope = "session" | "app-wide";
-
-/** How long a grant lasts. "once" is consumed by the single command that asked;
- * "session" and "always" keep allowing matching requests. */
-export type AccessGrantDuration = "one-time" | "ongoing";
-
-/** An approval choice that granted something (i.e. not "deny"). */
-export type AccessGrantChoice = Exclude<AgentApprovalChoice, "deny">;
-
-/** One logged grant. Field contents come from the runtime's approval request
- * (already sanitized by the event classifier — no secrets cross into here). */
+/** One logged grant: an "Always approve" answer. Field contents come from the
+ * runtime's approval request (already sanitized by the event classifier — no
+ * secrets cross into here) and are redacted again before persisting. */
 export type AccessGrantRecord = {
   /** Stable identity: the session + request that granted it. */
   id: string;
   sessionId: string;
   requestId: string;
-  choice: AccessGrantChoice;
   /** The tool that asked, when the runtime named one (e.g. "shell"). */
   toolName?: string;
   /** The command that triggered the approval prompt. */
@@ -67,16 +50,6 @@ export type AccessGrantRecord = {
   /** Epoch ms when the user granted it. */
   grantedAt: number;
 };
-
-/** Scope implied by an approval choice. */
-export function grantScope(choice: AccessGrantChoice): AccessGrantScope {
-  return choice === "always" ? "app-wide" : "session";
-}
-
-/** Duration implied by an approval choice. */
-export function grantDuration(choice: AccessGrantChoice): AccessGrantDuration {
-  return choice === "once" ? "one-time" : "ongoing";
-}
 
 /** Extracts the runtime's pattern keys from a sanitized approval payload
  * (`pattern_keys` list, falling back to the single `pattern_key`). Total:
@@ -96,15 +69,29 @@ export function approvalPatternKeys(payload: unknown): string[] {
 
 const REDACTED = "[redacted]";
 
+/** Authorization schemes whose following token is a credential, so the scheme
+ * AND the credential are consumed together (`Authorization: Basic dXNl...`).
+ * An unknown single-token value is redacted whole. */
+const AUTH_SCHEMES = "basic|bearer|digest|token|dpop|oauth|negotiate|ntlm|apikey|aws4-hmac-sha256";
+
+/** `Authorization` header (or key) with any scheme: the ENTIRE value —
+ * scheme and credential — is replaced, not just the first token. Quoted
+ * values are consumed whole. */
+const AUTH_HEADER = new RegExp(
+  `\\bauthorization["']?(\\s*[:=]\\s*)("[^"]*"|'[^']*'|(?:${AUTH_SCHEMES})\\s+\\S+|\\S+)`,
+  "gi",
+);
+
 /**
  * Masks credential-shaped content in a grant's free text (the command or
  * description) BEFORE it is persisted: an approval prompt can be for a shell
- * command that embeds a secret (an `Authorization: Bearer ...` header, an
- * inline `API_KEY=...`), and this log writes to localStorage, so storing the
- * raw text would create a durable copy of that secret. Mirrors the admin
- * transport's redaction heuristics for free text: bearer tokens, `key=value`
- * pairs under credential-ish key names, and long separator-free alphanumeric
- * runs (paths/URLs exempt). Total: junk in, string out; never throws.
+ * command that embeds a secret (an `Authorization: ...` header, an inline
+ * `API_KEY=...`), and this log writes to localStorage, so storing the raw
+ * text would create a durable copy of that secret. Mirrors the admin
+ * transport's redaction heuristics for free text: whole Authorization header
+ * values (any scheme, not just Bearer), bare bearer tokens, `key=value` pairs
+ * under credential-ish key names, and long separator-free alphanumeric runs
+ * (paths/URLs exempt). Total: junk in, string out; never throws.
  */
 export function redactGrantText(text: string): string;
 export function redactGrantText(text: string | undefined): string | undefined;
@@ -113,6 +100,7 @@ export function redactGrantText(text: string | undefined): string | undefined {
   const keyish =
     /\b([A-Za-z0-9_-]*(?:token|api[_-]?key|secret|password|passphrase|credential|authorization)[A-Za-z0-9_-]*)(=|:\s*)("[^"]*"|'[^']*'|\S+)/gi;
   return text
+    .replace(AUTH_HEADER, (_match, sep: string) => `Authorization${sep}${REDACTED}`)
     .replace(/\bbearer\s+\S+/gi, `Bearer ${REDACTED}`)
     .replace(keyish, (_match, key: string, sep: string) => `${key}${sep}${REDACTED}`)
     .split(/(\s+)/)
@@ -130,13 +118,10 @@ function isCredentialShaped(value: string): boolean {
 }
 
 export type AccessGrantLog = {
-  /** Logs a grant. Total: never throws. A re-record of the same session +
-   * request (e.g. a retried respond) replaces the earlier entry. */
+  /** Logs an "Always approve" grant. Total: never throws. A re-record of the
+   * same session + request (e.g. a retried respond) replaces the earlier
+   * entry. */
   record(entry: Omit<AccessGrantRecord, "id" | "grantedAt"> & { grantedAt?: number }): void;
-  /** Removes one entry by id. No-op when unknown. */
-  remove(id: string): void;
-  /** Removes every logged entry. */
-  clear(): void;
   /** All entries, newest first. The array identity is stable between
    * mutations (a `useSyncExternalStore` snapshot). */
   list(): readonly AccessGrantRecord[];
@@ -151,7 +136,9 @@ function isRecordShape(value: unknown): value is AccessGrantRecord {
     typeof record.id === "string" &&
     typeof record.sessionId === "string" &&
     typeof record.requestId === "string" &&
-    (record.choice === "once" || record.choice === "session" || record.choice === "always") &&
+    // Entries written before the page narrowed to persistent grants carried a
+    // choice; only "always" ones are grants this log still describes.
+    (record.choice === undefined || record.choice === "always") &&
     typeof record.grantedAt === "number" &&
     Array.isArray(record.patternKeys)
   );
@@ -220,7 +207,6 @@ export function createAccessGrantLog(): AccessGrantLog {
         id,
         sessionId,
         requestId,
-        choice: entry.choice,
         toolName: entry.toolName,
         // Free text can embed a secret (a bearer header, an inline API key);
         // scrub it before it lands in durable storage.
@@ -230,15 +216,6 @@ export function createAccessGrantLog(): AccessGrantLog {
         grantedAt: entry.grantedAt ?? Date.now(),
       };
       replace([record, ...current().filter((existing) => existing.id !== id)]);
-    },
-    remove(id) {
-      const next = current().filter((entry) => entry.id !== id);
-      if (next.length === current().length) return;
-      replace([...next]);
-    },
-    clear() {
-      if (current().length === 0) return;
-      replace([]);
     },
     list() {
       return current();
@@ -252,7 +229,8 @@ export function createAccessGrantLog(): AccessGrantLog {
   };
 }
 
-/** The app-wide log. AgentWorkspace records into it when the user approves a
- * request; the Access grants settings page reads it. A singleton (not React
- * state) so the record survives navigation between the chat and settings. */
+/** The app-wide log. AgentWorkspace records into it when the user answers an
+ * approval with "Always approve"; the Access grants settings page reads it. A
+ * singleton (not React state) so the record survives navigation between the
+ * chat and settings. */
 export const accessGrantLog = createAccessGrantLog();

--- a/src/lib/access-grant-log.ts
+++ b/src/lib/access-grant-log.ts
@@ -94,6 +94,41 @@ export function approvalPatternKeys(payload: unknown): string[] {
   return [];
 }
 
+const REDACTED = "[redacted]";
+
+/**
+ * Masks credential-shaped content in a grant's free text (the command or
+ * description) BEFORE it is persisted: an approval prompt can be for a shell
+ * command that embeds a secret (an `Authorization: Bearer ...` header, an
+ * inline `API_KEY=...`), and this log writes to localStorage, so storing the
+ * raw text would create a durable copy of that secret. Mirrors the admin
+ * transport's redaction heuristics for free text: bearer tokens, `key=value`
+ * pairs under credential-ish key names, and long separator-free alphanumeric
+ * runs (paths/URLs exempt). Total: junk in, string out; never throws.
+ */
+export function redactGrantText(text: string): string;
+export function redactGrantText(text: string | undefined): string | undefined;
+export function redactGrantText(text: string | undefined): string | undefined {
+  if (!text) return text;
+  const keyish =
+    /\b([A-Za-z0-9_-]*(?:token|api[_-]?key|secret|password|passphrase|credential|authorization)[A-Za-z0-9_-]*)(=|:\s*)("[^"]*"|'[^']*'|\S+)/gi;
+  return text
+    .replace(/\bbearer\s+\S+/gi, `Bearer ${REDACTED}`)
+    .replace(keyish, (_match, key: string, sep: string) => `${key}${sep}${REDACTED}`)
+    .split(/(\s+)/)
+    .map((part) => (isCredentialShaped(part) ? REDACTED : part))
+    .join("");
+}
+
+/** Value-shape secret heuristic, mirroring the admin redactor: a long
+ * (>= 32 chars), separator-free, alphanumeric run is almost never meaningful
+ * copy. A path or URL is a location, not a credential, so it is exempt. */
+function isCredentialShaped(value: string): boolean {
+  const stripped = value.replace(/^["']+|["']+$/g, "");
+  if (stripped.includes("/") || stripped.includes("\\")) return false;
+  return stripped.length >= 32 && /[A-Za-z0-9]/.test(stripped);
+}
+
 export type AccessGrantLog = {
   /** Logs a grant. Total: never throws. A re-record of the same session +
    * request (e.g. a retried respond) replaces the earlier entry. */
@@ -187,8 +222,10 @@ export function createAccessGrantLog(): AccessGrantLog {
         requestId,
         choice: entry.choice,
         toolName: entry.toolName,
-        command: entry.command,
-        description: entry.description,
+        // Free text can embed a secret (a bearer header, an inline API key);
+        // scrub it before it lands in durable storage.
+        command: redactGrantText(entry.command),
+        description: redactGrantText(entry.description),
         patternKeys: entry.patternKeys.filter((key) => typeof key === "string" && key.length > 0),
         grantedAt: entry.grantedAt ?? Date.now(),
       };

--- a/src/lib/agent-session-modes.ts
+++ b/src/lib/agent-session-modes.ts
@@ -58,3 +58,9 @@ export function rememberSessionMode(sessionId: string, unrestricted: boolean) {
 export function forgetSessionMode(sessionId: string) {
   rememberSessionMode(sessionId, false);
 }
+
+/** Every session currently recorded as Unrestricted, for the Access grants
+ * settings page. Insertion order (the order the grants were made). */
+export function unrestrictedSessionIds(): string[] {
+  return Object.keys(readStore());
+}

--- a/src/lib/agent-session-modes.ts
+++ b/src/lib/agent-session-modes.ts
@@ -53,6 +53,7 @@ export function rememberSessionMode(sessionId: string, unrestricted: boolean) {
     delete store[sessionId];
   }
   writeStore(store);
+  for (const listener of [...listeners]) listener();
 }
 
 export function forgetSessionMode(sessionId: string) {
@@ -63,4 +64,16 @@ export function forgetSessionMode(sessionId: string) {
  * settings page. Insertion order (the order the grants were made). */
 export function unrestrictedSessionIds(): string[] {
   return Object.keys(readStore());
+}
+
+const listeners = new Set<() => void>();
+
+/** Notifies when the recorded modes change in this window (e.g. an opt-in from
+ * the session bar while the Access grants settings page is open). Returns an
+ * unsubscribe. */
+export function subscribeSessionModes(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
 }

--- a/src/lib/agent-session-modes.ts
+++ b/src/lib/agent-session-modes.ts
@@ -53,27 +53,8 @@ export function rememberSessionMode(sessionId: string, unrestricted: boolean) {
     delete store[sessionId];
   }
   writeStore(store);
-  for (const listener of [...listeners]) listener();
 }
 
 export function forgetSessionMode(sessionId: string) {
   rememberSessionMode(sessionId, false);
-}
-
-/** Every session currently recorded as Unrestricted, for the Access grants
- * settings page. Insertion order (the order the grants were made). */
-export function unrestrictedSessionIds(): string[] {
-  return Object.keys(readStore());
-}
-
-const listeners = new Set<() => void>();
-
-/** Notifies when the recorded modes change in this window (e.g. an opt-in from
- * the session bar while the Access grants settings page is open). Returns an
- * unsubscribe. */
-export function subscribeSessionModes(listener: () => void): () => void {
-  listeners.add(listener);
-  return () => {
-    listeners.delete(listener);
-  };
 }

--- a/src/lib/hermes-admin/access-grants-view.ts
+++ b/src/lib/hermes-admin/access-grants-view.ts
@@ -1,0 +1,118 @@
+/**
+ * Pure, render-free view logic for the Access grants settings page (JUN-206).
+ * It reshapes two already-fetched inputs into the rows the UI renders, and owns
+ * the revoke list math, so the scope/duration labels and the allowlist-to-log
+ * correlation are unit-testable without rendering and without a network:
+ *
+ * 1. the raw `command_allowlist` list read from `GET /api/config`
+ *    ({@link readCommandAllowlist} in `./schemas`) — the runtime's persisted
+ *    "Always approve" answers, i.e. the app-wide ongoing grants;
+ * 2. June's local {@link AccessGrantRecord} log of answered approvals, which
+ *    carries the session-scoped and one-time grants and enriches allowlist
+ *    rows with when/what granted them.
+ *
+ * Nothing here talks to Hermes or Tauri; it only reshapes already-fetched data.
+ * Copy is sentence case, no em/en-dashes, per June conventions.
+ */
+
+import type { AccessGrantDuration, AccessGrantRecord, AccessGrantScope } from "../access-grant-log";
+
+/** One row in the "Always allowed commands" list: a persisted allowlist pattern
+ * (app-wide, ongoing by definition), enriched with the grant-log entry that
+ * created it when June saw that approval happen. */
+export type AllowedCommandRow = {
+  /** The allowlist pattern exactly as configured (the identity used to revoke).
+   * Human readable: the runtime stores the danger description as the key. */
+  pattern: string;
+  scope: Extract<AccessGrantScope, "app-wide">;
+  duration: Extract<AccessGrantDuration, "ongoing">;
+  /** Epoch ms when June recorded the grant, when it was granted through June. */
+  grantedAt?: number;
+  /** The command that triggered the grant, when known from the log. */
+  command?: string;
+};
+
+/** Builds the "Always allowed commands" rows by joining the configured
+ * allowlist with June's grant log. Order follows the configured list. A pattern
+ * granted outside June (or before this log existed) still renders — it simply
+ * has no grantedAt/command. The newest matching log entry wins. */
+export function buildAllowedCommandRows(
+  patterns: readonly string[],
+  log: readonly AccessGrantRecord[],
+): AllowedCommandRow[] {
+  return patterns.map((pattern) => {
+    // The log is newest first, so `find` returns the most recent grant.
+    const match = log.find(
+      (entry) =>
+        entry.choice === "always" &&
+        (entry.patternKeys.includes(pattern) || entry.description === pattern),
+    );
+    return {
+      pattern,
+      scope: "app-wide",
+      duration: "ongoing",
+      grantedAt: match?.grantedAt,
+      command: match?.command,
+    };
+  });
+}
+
+/** One row in the "Session approvals" list: an approval the user answered with
+ * "once" (one-time, consumed) or "session" (ongoing until the session ends). */
+export type SessionGrantRow = {
+  /** The log record id (the identity used to clear the record). */
+  id: string;
+  /** Primary label: the danger description, falling back to the command. */
+  title: string;
+  command?: string;
+  toolName?: string;
+  sessionId: string;
+  scope: Extract<AccessGrantScope, "session">;
+  duration: AccessGrantDuration;
+  grantedAt: number;
+};
+
+/** Builds the session-scoped rows from the grant log, newest first (the log's
+ * own order). "always" entries are excluded: their live representation is the
+ * allowlist row, so listing them here would double-count a single grant. */
+export function buildSessionGrantRows(log: readonly AccessGrantRecord[]): SessionGrantRow[] {
+  const rows: SessionGrantRow[] = [];
+  for (const entry of log) {
+    if (entry.choice === "always") continue;
+    rows.push({
+      id: entry.id,
+      title: entry.description ?? entry.command ?? entry.toolName ?? "Approved request",
+      command: entry.command,
+      toolName: entry.toolName,
+      sessionId: entry.sessionId,
+      scope: "session",
+      duration: entry.choice === "once" ? "one-time" : "ongoing",
+      grantedAt: entry.grantedAt,
+    });
+  }
+  return rows;
+}
+
+/** Removes a pattern from the allowlist by its raw configured value, preserving
+ * the order of the rest. Returns a NEW array. A pattern not present is a no-op
+ * (the same array contents), so a double-revoke can't throw. */
+export function removeAllowedCommand(existing: readonly string[], pattern: string): string[] {
+  return existing.filter((entry) => entry !== pattern);
+}
+
+/** The user-facing label for a grant's scope. */
+export function grantScopeLabel(scope: AccessGrantScope): string {
+  return scope === "app-wide" ? "App-wide" : "This session";
+}
+
+/** The user-facing label for a grant's duration. */
+export function grantDurationLabel(duration: AccessGrantDuration): string {
+  return duration === "one-time" ? "One time" : "Ongoing";
+}
+
+/** A short session handle for display: session ids are runtime-internal, so the
+ * page shows a stable truncated form rather than the full opaque string. */
+export function shortSessionId(sessionId: string): string {
+  const trimmed = sessionId.trim();
+  return trimmed.length > 12 ? `${trimmed.slice(0, 12)}...` : trimmed;
+}

--- a/src/lib/hermes-admin/access-grants-view.ts
+++ b/src/lib/hermes-admin/access-grants-view.ts
@@ -1,31 +1,30 @@
 /**
  * Pure, render-free view logic for the Access grants settings page (JUN-206).
- * It reshapes two already-fetched inputs into the rows the UI renders, and owns
- * the revoke list math, so the scope/duration labels and the allowlist-to-log
- * correlation are unit-testable without rendering and without a network:
+ * The page lists ONLY the persistent grants: app-wide, ongoing approvals that
+ * stay in effect until revoked. This module reshapes two already-fetched
+ * inputs into the rows the UI renders, and owns the revoke list math, so the
+ * allowlist-to-log correlation is unit-testable without rendering and without
+ * a network:
  *
  * 1. the raw `command_allowlist` list read from `GET /api/config`
  *    ({@link readCommandAllowlist} in `./schemas`) — the runtime's persisted
- *    "Always approve" answers, i.e. the app-wide ongoing grants;
- * 2. June's local {@link AccessGrantRecord} log of answered approvals, which
- *    carries the session-scoped and one-time grants and enriches allowlist
- *    rows with when/what granted them.
+ *    "Always approve" answers, i.e. the grants themselves;
+ * 2. June's local {@link AccessGrantRecord} log of "Always approve" answers,
+ *    which enriches allowlist rows with when/what granted them.
  *
  * Nothing here talks to Hermes or Tauri; it only reshapes already-fetched data.
  * Copy is sentence case, no em/en-dashes, per June conventions.
  */
 
-import type { AccessGrantDuration, AccessGrantRecord, AccessGrantScope } from "../access-grant-log";
+import type { AccessGrantRecord } from "../access-grant-log";
 
 /** One row in the "Always allowed commands" list: a persisted allowlist pattern
- * (app-wide, ongoing by definition), enriched with the grant-log entry that
+ * (app-wide and ongoing by definition), enriched with the grant-log entry that
  * created it when June saw that approval happen. */
 export type AllowedCommandRow = {
   /** The allowlist pattern exactly as configured (the identity used to revoke).
    * Human readable: the runtime stores the danger description as the key. */
   pattern: string;
-  scope: Extract<AccessGrantScope, "app-wide">;
-  duration: Extract<AccessGrantDuration, "ongoing">;
   /** Epoch ms when June recorded the grant, when it was granted through June. */
   grantedAt?: number;
   /** The command that triggered the grant, when known from the log. */
@@ -43,54 +42,14 @@ export function buildAllowedCommandRows(
   return patterns.map((pattern) => {
     // The log is newest first, so `find` returns the most recent grant.
     const match = log.find(
-      (entry) =>
-        entry.choice === "always" &&
-        (entry.patternKeys.includes(pattern) || entry.description === pattern),
+      (entry) => entry.patternKeys.includes(pattern) || entry.description === pattern,
     );
     return {
       pattern,
-      scope: "app-wide",
-      duration: "ongoing",
       grantedAt: match?.grantedAt,
       command: match?.command,
     };
   });
-}
-
-/** One row in the "Session approvals" list: an approval the user answered with
- * "once" (one-time, consumed) or "session" (ongoing until the session ends). */
-export type SessionGrantRow = {
-  /** The log record id (the identity used to clear the record). */
-  id: string;
-  /** Primary label: the danger description, falling back to the command. */
-  title: string;
-  command?: string;
-  toolName?: string;
-  sessionId: string;
-  scope: Extract<AccessGrantScope, "session">;
-  duration: AccessGrantDuration;
-  grantedAt: number;
-};
-
-/** Builds the session-scoped rows from the grant log, newest first (the log's
- * own order). "always" entries are excluded: their live representation is the
- * allowlist row, so listing them here would double-count a single grant. */
-export function buildSessionGrantRows(log: readonly AccessGrantRecord[]): SessionGrantRow[] {
-  const rows: SessionGrantRow[] = [];
-  for (const entry of log) {
-    if (entry.choice === "always") continue;
-    rows.push({
-      id: entry.id,
-      title: entry.description ?? entry.command ?? entry.toolName ?? "Approved request",
-      command: entry.command,
-      toolName: entry.toolName,
-      sessionId: entry.sessionId,
-      scope: "session",
-      duration: entry.choice === "once" ? "one-time" : "ongoing",
-      grantedAt: entry.grantedAt,
-    });
-  }
-  return rows;
 }
 
 /** Removes a pattern from the allowlist by its raw configured value, preserving
@@ -98,21 +57,4 @@ export function buildSessionGrantRows(log: readonly AccessGrantRecord[]): Sessio
  * (the same array contents), so a double-revoke can't throw. */
 export function removeAllowedCommand(existing: readonly string[], pattern: string): string[] {
   return existing.filter((entry) => entry !== pattern);
-}
-
-/** The user-facing label for a grant's scope. */
-export function grantScopeLabel(scope: AccessGrantScope): string {
-  return scope === "app-wide" ? "App-wide" : "This session";
-}
-
-/** The user-facing label for a grant's duration. */
-export function grantDurationLabel(duration: AccessGrantDuration): string {
-  return duration === "one-time" ? "One time" : "Ongoing";
-}
-
-/** A short session handle for display: session ids are runtime-internal, so the
- * page shows a stable truncated form rather than the full opaque string. */
-export function shortSessionId(sessionId: string): string {
-  const trimmed = sessionId.trim();
-  return trimmed.length > 12 ? `${trimmed.slice(0, 12)}...` : trimmed;
 }

--- a/src/lib/hermes-admin/client.ts
+++ b/src/lib/hermes-admin/client.ts
@@ -297,6 +297,17 @@ export type HermesAdminClient = {
      * read-merged client-side. Routes the write through Hermes' REST surface so
      * the jailed dashboard owns the `config.yaml` write (no June-side EPERM). */
     setValue(path: string, value: unknown): Promise<MutationOutcome<HermesConfigWriteResult>>;
+    /** Read-modify-writes a single dotted path with a TRANSFORM applied to the
+     * value read from the SAME fetched tree that is persisted. Use instead of
+     * `get()` + `setValue()` whenever the new value derives from the current
+     * one (e.g. pruning one entry from a list): a separately fetched snapshot
+     * can be stale by the time `setValue` re-reads the tree, and writing the
+     * precomputed value would silently revert a concurrent change to the same
+     * path. The transform must be pure and total (junk in, value out). */
+    updateValue(
+      path: string,
+      transform: (current: unknown) => unknown,
+    ): Promise<MutationOutcome<HermesConfigWriteResult>>;
     /** Segment-aware variant of {@link set}/{@link setValue}: writes `value` at
      * the exact path SEGMENTS, so a dynamic segment (a skill or MCP server name)
      * that itself contains a dot is written as ONE key, not mis-split into nested
@@ -737,6 +748,18 @@ function setConfigAtPath(tree: Record<string, unknown>, segments: string[], valu
   node[segments[segments.length - 1]!] = value;
 }
 
+/** Reads the value at the given path SEGMENTS from a config tree, or undefined
+ * when any segment is missing or not an object. The read half of
+ * `updateValue`'s single-snapshot read-modify-write. */
+function getConfigAtPath(tree: Record<string, unknown>, segments: string[]): unknown {
+  let node: unknown = tree;
+  for (const segment of segments) {
+    if (typeof node !== "object" || node === null || Array.isArray(node)) return undefined;
+    node = (node as Record<string, unknown>)[segment];
+  }
+  return node;
+}
+
 /** Deletes a value at the given path SEGMENTS from a config tree in place. No-op
  * if any segment is missing. Segment-based for the same dotted-name reason as
  * {@link setConfigAtPath}. */
@@ -791,6 +814,16 @@ function makeConfig(send: AdminTransport): HermesAdminClient["config"] {
       // manager to write the whole `skills.external_dirs` list (a static path).
       const segments = path.split(".");
       return writePath("config.set", path, (tree) => setConfigAtPath(tree, segments, value));
+    },
+    async updateValue(path, transform) {
+      // Derives the new value from the value in the SAME fetched tree that is
+      // persisted, so a concurrent write to this path between a caller's own
+      // earlier read and this write cannot be reverted by a stale precomputed
+      // value (the Access grants revoke prunes the allowlist this way).
+      const segments = path.split(".");
+      return writePath("config.set", path, (tree) =>
+        setConfigAtPath(tree, segments, transform(getConfigAtPath(tree, segments))),
+      );
     },
     async setValueAtSegments(segments, value) {
       // Segment-aware write: a skill or MCP server name may contain a dot, so a

--- a/src/lib/hermes-admin/index.ts
+++ b/src/lib/hermes-admin/index.ts
@@ -86,6 +86,8 @@ export * from "./setup-import";
 export * from "./use-setup-snapshot";
 export * from "./external-dirs-view";
 export * from "./use-external-dirs";
+export * from "./access-grants-view";
+export * from "./use-access-grants";
 export * from "./skill-bundles-view";
 export * from "./use-skill-bundles";
 export * from "./integrations-health-view";

--- a/src/lib/hermes-admin/schemas.ts
+++ b/src/lib/hermes-admin/schemas.ts
@@ -1434,6 +1434,38 @@ export function readExternalDirs(config: Record<string, unknown>): string[] {
   return out;
 }
 
+/** The dotted config path the permanent command-approval allowlist lives at in
+ * a profile's `config.yaml` (`command_allowlist`). This is where the runtime
+ * persists an "Always approve" answer to a dangerous-command approval, so it is
+ * the source of truth for app-wide, ongoing command grants. One constant for
+ * both the read and the write, so a typo can't read one key and write another. */
+export const COMMAND_ALLOWLIST_CONFIG_PATH = ["command_allowlist"] as const;
+
+/** Reads the permanently allowed command patterns out of a parsed config tree.
+ * `command_allowlist` is a list of human-readable pattern keys (the dangerous
+ * pattern descriptions, e.g. "Recursive deletion (rm -rf)"). Tolerates the key
+ * being absent, a bare string (single pattern), or a list; non-string entries
+ * are dropped. Returns the raw configured strings in declared order. */
+export function readCommandAllowlist(config: Record<string, unknown>): string[] {
+  let cursor: unknown = config;
+  for (const segment of COMMAND_ALLOWLIST_CONFIG_PATH) {
+    const record = asRecord(cursor);
+    if (!record) return [];
+    cursor = record[segment];
+  }
+  if (typeof cursor === "string") {
+    const single = cursor.trim();
+    return single.length > 0 ? [single] : [];
+  }
+  if (!Array.isArray(cursor)) return [];
+  const out: string[] = [];
+  for (const entry of cursor) {
+    const str = nonEmptyString(entry);
+    if (str) out.push(str);
+  }
+  return out;
+}
+
 // ----------------------------------------------------------------------------
 // Profiles (`GET /api/profiles`, `POST /api/profiles`, `GET /api/profiles/sessions`)
 // ----------------------------------------------------------------------------

--- a/src/lib/hermes-admin/schemas.ts
+++ b/src/lib/hermes-admin/schemas.ts
@@ -1453,13 +1453,21 @@ export function readCommandAllowlist(config: Record<string, unknown>): string[] 
     if (!record) return [];
     cursor = record[segment];
   }
-  if (typeof cursor === "string") {
-    const single = cursor.trim();
+  return commandAllowlistValue(cursor);
+}
+
+/** The value-level half of {@link readCommandAllowlist}: normalizes whatever
+ * sits at the `command_allowlist` key (absent, a bare string, a list with junk
+ * entries) into a clean string list. Exposed so a single-snapshot config
+ * transform (`config.updateValue`) can parse the value it is handed. Total. */
+export function commandAllowlistValue(value: unknown): string[] {
+  if (typeof value === "string") {
+    const single = value.trim();
     return single.length > 0 ? [single] : [];
   }
-  if (!Array.isArray(cursor)) return [];
+  if (!Array.isArray(value)) return [];
   const out: string[] = [];
-  for (const entry of cursor) {
+  for (const entry of value) {
     const str = nonEmptyString(entry);
     if (str) out.push(str);
   }

--- a/src/lib/hermes-admin/use-access-grants.ts
+++ b/src/lib/hermes-admin/use-access-grants.ts
@@ -166,18 +166,29 @@ export class AccessGrantsController {
     }
   }
 
-  /** Revokes one pattern: prunes the list and read-merge-writes it through
-   * `config.setValue`. New sessions no longer auto-allow matching commands; a
-   * matching request will prompt for approval again. */
+  /** Revokes one pattern: re-reads the LIVE allowlist, prunes the pattern from
+   * that fresh list, and writes it through `config.setValue`. Pruning the
+   * controller's last loaded snapshot instead would silently drop any grant
+   * another session persisted after this page loaded. New sessions no longer
+   * auto-allow matching commands; a matching request will prompt again. */
   async revoke(pattern: string): Promise<void> {
-    const next = removeAllowedCommand(this.patterns, pattern);
-    // A no-op revoke (pattern not present) writes nothing.
-    if (next.length === this.patterns.length) return;
+    // A no-op revoke (pattern not on screen) does nothing.
+    if (!this.patterns.includes(pattern)) return;
     if (this.busy) return;
     this.busy = true;
     this.error = undefined;
     this.recompute();
     try {
+      const current = await this.engine.client.config.get();
+      if (this.disposed) return;
+      const fresh = readCommandAllowlist(current.config);
+      const next = removeAllowedCommand(fresh, pattern);
+      if (next.length === fresh.length) {
+        // Already revoked elsewhere: nothing to write, just catch the page up.
+        this.busy = false;
+        await this.load();
+        return;
+      }
       const outcome = await this.engine.client.config.setValue(COMMAND_ALLOWLIST_PATH, next);
       if (this.disposed) return;
       this.engine.cache.afterMutation(outcome.mutation, "always allowed commands");
@@ -287,10 +298,19 @@ export function useAccessGrantsEngine(
   mode: HermesAdminMode,
   profile?: string,
 ): AccessGrantsEngine | null {
-  const target = useMemo(
-    () => (bridge ? adminTargetForMode(bridge, mode, profile) : undefined),
-    [bridge, mode, profile],
-  );
+  const target = useMemo(() => {
+    if (!bridge) return undefined;
+    // Both runtime processes share ONE `HERMES_HOME/config.yaml` (see
+    // hermes_bridge.rs: no per-process config override exists upstream), so an
+    // "Always approve" persisted from a Full-mode session lands in the same
+    // allowlist this page reads. Any running runtime can therefore serve the
+    // read and the revoke: prefer the requested mode, fall back to the other
+    // so grants stay visible and revocable when only one runtime is up.
+    const fallback: HermesAdminMode = mode === "sandboxed" ? "unrestricted" : "sandboxed";
+    return (
+      adminTargetForMode(bridge, mode, profile) ?? adminTargetForMode(bridge, fallback, profile)
+    );
+  }, [bridge, mode, profile]);
   const identity = target
     ? `${target.mode}:${target.profile}:${target.baseUrl}:${target.token}`
     : null;

--- a/src/lib/hermes-admin/use-access-grants.ts
+++ b/src/lib/hermes-admin/use-access-grants.ts
@@ -1,0 +1,349 @@
+/**
+ * The data hook behind the "Always allowed commands" half of the Access grants
+ * settings page (JUN-206). It owns the load / revoke / refresh lifecycle for
+ * one {@link HermesAdminTarget}, driving the shared admin foundation
+ * primitives, mirroring `use-external-dirs`:
+ *
+ * - {@link HermesAdminClient} `config.get()` for the persisted
+ *   `command_allowlist` (the runtime's durable "Always approve" answers) and
+ *   `config.setValue()` to write the pruned list through Hermes' REST surface
+ *   (so the jailed dashboard owns the config.yaml write — no June-side EPERM);
+ * - {@link AdminStateCache} for the durable "applies next session" notification
+ *   and the `configTree` invalidation bus;
+ * - {@link GatewayLifecycle} for the honest apply-timing banner (a config write
+ *   is `next-session`, never "applied now": a running session already loaded
+ *   the allowlist into memory).
+ *
+ * Split from the React component so revoke behavior is unit-testable against
+ * the fake Hermes server, no rendering. Profile targeting is explicit: the
+ * controller is built from ONE target's engine, so a revoke can only ever hit
+ * the runtime that target names.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { hermesBridgeStatus, type HermesBridgeStatus } from "../tauri";
+import { AdminStateCache, type AdminNotification } from "./cache";
+import { createHermesAdminClient, type HermesAdminClient } from "./client";
+import { HermesAdminError } from "./errors";
+import { GatewayLifecycle, type GatewayLifecycleSnapshot } from "./gateway-lifecycle";
+import { createRustAdminFetch } from "./rust-transport";
+import { COMMAND_ALLOWLIST_CONFIG_PATH, readCommandAllowlist } from "./schemas";
+import { adminTargetForMode, type HermesAdminMode, type HermesAdminTarget } from "./target";
+import { removeAllowedCommand } from "./access-grants-view";
+
+/** The dotted config path string the allowlist is written to. */
+const COMMAND_ALLOWLIST_PATH = COMMAND_ALLOWLIST_CONFIG_PATH.join(".");
+
+/** The wired-up foundation primitives this surface operates on, all bound to
+ * the SAME target. Production builds this from a bridge connection; tests build
+ * it from the fake-server harness. */
+export type AccessGrantsEngine = {
+  target: HermesAdminTarget;
+  client: HermesAdminClient;
+  cache: AdminStateCache;
+  lifecycle: GatewayLifecycle;
+};
+
+/** Loading/availability status of the allowlist. A missing runtime
+ * ("unavailable") is NOT an error and NOT empty: June's local grant records
+ * still render without it. */
+export type AccessGrantsStatus = "unavailable" | "loading" | "ready" | "error";
+
+/** Everything the allowlist half of the page renders, plus the actions it
+ * invokes. A pure projection of the controller's internal state. */
+export type AccessGrantsState = {
+  status: AccessGrantsStatus;
+  /** The configured allowlist patterns, in declared order. */
+  patterns: string[];
+  mode?: HermesAdminMode;
+  profile?: string;
+  /** True while a revoke write is in flight. */
+  busy: boolean;
+  /** The user-safe message when `status === "error"`, or a write failed. */
+  error?: string;
+  /** True when the failing load is worth retrying (network/5xx/timeout). */
+  retryable: boolean;
+  lifecycle: GatewayLifecycleSnapshot;
+  notifications: readonly AdminNotification[];
+  refresh: () => void;
+  /** Revokes one allowlist pattern and writes the pruned list. */
+  revoke: (pattern: string) => void;
+  dismissNotification: (id: string) => void;
+};
+
+/**
+ * The framework-free controller the hook wraps. Holds the mutable load/write
+ * state for one engine and notifies subscribers on change.
+ */
+export class AccessGrantsController {
+  private readonly engine: AccessGrantsEngine;
+  private patterns: string[] = [];
+  private status: AccessGrantsStatus = "loading";
+  private error?: string;
+  private retryable = false;
+  private busy = false;
+  private notifications: readonly AdminNotification[];
+  private lifecycleSnapshot: GatewayLifecycleSnapshot;
+  private listeners = new Set<() => void>();
+  private disposed = false;
+  private loadSeq = 0;
+  private unsubscribers: Array<() => void> = [];
+  private snapshot: AccessGrantsState;
+
+  constructor(engine: AccessGrantsEngine) {
+    this.engine = engine;
+    this.lifecycleSnapshot = engine.lifecycle.getSnapshot();
+    this.notifications = engine.cache.getNotifications();
+    this.snapshot = this.buildSnapshot();
+
+    this.unsubscribers.push(
+      engine.cache.subscribeNotifications((next) => {
+        this.notifications = next;
+        this.recompute();
+      }),
+    );
+    this.unsubscribers.push(
+      engine.lifecycle.subscribe((next) => {
+        this.lifecycleSnapshot = next;
+        this.recompute();
+      }),
+    );
+    // A configTree invalidation from ANY path (a config write elsewhere, a
+    // profile switch) reloads the list so the page stays correct.
+    this.unsubscribers.push(
+      engine.cache.subscribe("configTree", () => {
+        if (this.engine.cache.isStale("configTree")) {
+          void this.load();
+        }
+      }),
+    );
+  }
+
+  getSnapshot(): AccessGrantsState {
+    return this.snapshot;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.loadSeq += 1;
+    for (const unsubscribe of this.unsubscribers) unsubscribe();
+    this.unsubscribers = [];
+    this.listeners.clear();
+  }
+
+  /** Loads the persisted allowlist from the runtime's config tree. */
+  async load(): Promise<void> {
+    const seq = ++this.loadSeq;
+    if (this.patterns.length === 0) {
+      this.status = "loading";
+      this.recompute();
+    }
+
+    try {
+      const config = await this.engine.client.config.get();
+      if (this.disposed || seq !== this.loadSeq) return;
+
+      this.patterns = readCommandAllowlist(config.config);
+      this.engine.cache.set("configTree", config.config);
+      this.status = "ready";
+      this.error = undefined;
+      this.retryable = false;
+      this.recompute();
+    } catch (error) {
+      if (this.disposed || seq !== this.loadSeq) return;
+      const adminError = HermesAdminError.from("GET /api/config", error);
+      this.error = adminError.safeMessage;
+      this.retryable = adminError.retryable;
+      this.status = this.patterns.length > 0 ? "ready" : "error";
+      this.recompute();
+    }
+  }
+
+  /** Revokes one pattern: prunes the list and read-merge-writes it through
+   * `config.setValue`. New sessions no longer auto-allow matching commands; a
+   * matching request will prompt for approval again. */
+  async revoke(pattern: string): Promise<void> {
+    const next = removeAllowedCommand(this.patterns, pattern);
+    // A no-op revoke (pattern not present) writes nothing.
+    if (next.length === this.patterns.length) return;
+    if (this.busy) return;
+    this.busy = true;
+    this.error = undefined;
+    this.recompute();
+    try {
+      const outcome = await this.engine.client.config.setValue(COMMAND_ALLOWLIST_PATH, next);
+      if (this.disposed) return;
+      this.engine.cache.afterMutation(outcome.mutation, "always allowed commands");
+      this.engine.lifecycle.noteMutation(outcome.mutation);
+      this.busy = false;
+      await this.load();
+    } catch (error) {
+      if (this.disposed) return;
+      this.busy = false;
+      const adminError = HermesAdminError.from("PUT /api/config", error);
+      this.error = adminError.safeMessage;
+      this.recompute();
+    }
+  }
+
+  dismissNotification(id: string): void {
+    this.engine.cache.dismissNotification(id);
+  }
+
+  private buildSnapshot(): AccessGrantsState {
+    return {
+      status: this.status,
+      patterns: this.patterns,
+      mode: this.engine.target.mode,
+      profile: this.engine.target.profile,
+      busy: this.busy,
+      error: this.error,
+      retryable: this.retryable,
+      lifecycle: this.lifecycleSnapshot,
+      notifications: this.notifications,
+      refresh: this.refreshAction,
+      revoke: this.revokeAction,
+      dismissNotification: this.dismissNotificationAction,
+    };
+  }
+
+  private recompute(): void {
+    if (this.disposed) return;
+    this.snapshot = this.buildSnapshot();
+    for (const listener of [...this.listeners]) listener();
+  }
+
+  private readonly refreshAction = (): void => {
+    void this.load();
+  };
+  private readonly revokeAction = (pattern: string): void => {
+    void this.revoke(pattern);
+  };
+  private readonly dismissNotificationAction = (id: string): void => {
+    this.dismissNotification(id);
+  };
+}
+
+/** Binds an {@link AccessGrantsController} to React for one engine. A null
+ * engine yields the "unavailable" state. */
+export function useAccessGrantsController(engine: AccessGrantsEngine | null): AccessGrantsState {
+  const controller = useMemo(() => (engine ? new AccessGrantsController(engine) : null), [engine]);
+
+  const [snapshot, setSnapshot] = useState<AccessGrantsState>(() =>
+    controller ? controller.getSnapshot() : UNAVAILABLE_STATE,
+  );
+
+  useEffect(() => {
+    if (!controller) {
+      setSnapshot(UNAVAILABLE_STATE);
+      return;
+    }
+    setSnapshot(controller.getSnapshot());
+    const unsubscribe = controller.subscribe(() => {
+      setSnapshot(controller.getSnapshot());
+    });
+    void controller.load();
+    return () => {
+      unsubscribe();
+      controller.dispose();
+    };
+  }, [controller]);
+
+  return snapshot;
+}
+
+/** The frozen state shown when there is no runtime to talk to. */
+const UNAVAILABLE_STATE: AccessGrantsState = Object.freeze({
+  status: "unavailable",
+  patterns: [],
+  busy: false,
+  retryable: false,
+  lifecycle: {
+    state: "clean",
+    label: "Up to date",
+    detail: "No pending changes.",
+    canRestart: false,
+  },
+  notifications: [],
+  refresh: () => {},
+  revoke: () => {},
+  dismissNotification: () => {},
+}) as AccessGrantsState;
+
+/**
+ * Production helper: derives the {@link AccessGrantsEngine} from a live bridge
+ * status for a chosen mode, returning null when that mode is not running.
+ * Profile selection is explicit via {@link adminTargetForMode}.
+ */
+export function useAccessGrantsEngine(
+  bridge: HermesBridgeStatus | undefined,
+  mode: HermesAdminMode,
+  profile?: string,
+): AccessGrantsEngine | null {
+  const target = useMemo(
+    () => (bridge ? adminTargetForMode(bridge, mode, profile) : undefined),
+    [bridge, mode, profile],
+  );
+  const identity = target
+    ? `${target.mode}:${target.profile}:${target.baseUrl}:${target.token}`
+    : null;
+
+  return useMemo(() => {
+    if (!target) return null;
+    const client = createHermesAdminClient(target, {
+      fetch: createRustAdminFetch(target.mode),
+    });
+    const cache = new AdminStateCache(target);
+    const lifecycle = new GatewayLifecycle(client, cache);
+    return { target, client, cache, lifecycle };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by identity
+  }, [identity]);
+}
+
+/**
+ * The all-in-one production hook: fetch bridge status once, derive the engine
+ * for the given mode, and run the controller.
+ */
+export function useAccessGrants(
+  mode: HermesAdminMode = "sandboxed",
+  profile?: string,
+): AccessGrantsState {
+  const [bridge, setBridge] = useState<HermesBridgeStatus>();
+  const [bridgeError, setBridgeError] = useState<string>();
+  const loaded = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    hermesBridgeStatus()
+      .then((status) => {
+        if (!cancelled) {
+          setBridge(status);
+          loaded.current = true;
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setBridgeError(error instanceof Error ? error.message : String(error));
+          loaded.current = true;
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const engine = useAccessGrantsEngine(bridge, mode, profile);
+  const state = useAccessGrantsController(engine);
+
+  if (engine === null && bridgeError) {
+    return { ...state, status: "error", error: bridgeError, retryable: true };
+  }
+  return state;
+}

--- a/src/lib/hermes-admin/use-access-grants.ts
+++ b/src/lib/hermes-admin/use-access-grants.ts
@@ -20,7 +20,7 @@
  * the runtime that target names.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { hermesBridgeStatus, type HermesBridgeStatus } from "../tauri";
 import { AdminStateCache, type AdminNotification } from "./cache";
 import { createHermesAdminClient, type HermesAdminClient } from "./client";
@@ -343,7 +343,7 @@ export function useAccessGrants(
 ): AccessGrantsState {
   const [bridge, setBridge] = useState<HermesBridgeStatus>();
   const [bridgeError, setBridgeError] = useState<string>();
-  const loaded = useRef(false);
+  const [bridgeAttempt, setBridgeAttempt] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -351,25 +351,38 @@ export function useAccessGrants(
       .then((status) => {
         if (!cancelled) {
           setBridge(status);
-          loaded.current = true;
+          setBridgeError(undefined);
         }
       })
       .catch((error: unknown) => {
         if (!cancelled) {
           setBridgeError(error instanceof Error ? error.message : String(error));
-          loaded.current = true;
         }
       });
     return () => {
       cancelled = true;
     };
+  }, [bridgeAttempt]);
+
+  // The error state below advertises `retryable`, so its refresh action must
+  // actually retry: re-run the bridge-status load (the thing that failed),
+  // not the engine-less UNAVAILABLE_STATE no-op.
+  const retryBridgeStatus = useCallback(() => {
+    setBridgeError(undefined);
+    setBridgeAttempt((attempt) => attempt + 1);
   }, []);
 
   const engine = useAccessGrantsEngine(bridge, mode, profile);
   const state = useAccessGrantsController(engine);
 
   if (engine === null && bridgeError) {
-    return { ...state, status: "error", error: bridgeError, retryable: true };
+    return {
+      ...state,
+      status: "error",
+      error: bridgeError,
+      retryable: true,
+      refresh: retryBridgeStatus,
+    };
   }
   return state;
 }

--- a/src/lib/hermes-admin/use-access-grants.ts
+++ b/src/lib/hermes-admin/use-access-grants.ts
@@ -27,7 +27,11 @@ import { createHermesAdminClient, type HermesAdminClient } from "./client";
 import { HermesAdminError } from "./errors";
 import { GatewayLifecycle, type GatewayLifecycleSnapshot } from "./gateway-lifecycle";
 import { createRustAdminFetch } from "./rust-transport";
-import { COMMAND_ALLOWLIST_CONFIG_PATH, readCommandAllowlist } from "./schemas";
+import {
+  COMMAND_ALLOWLIST_CONFIG_PATH,
+  commandAllowlistValue,
+  readCommandAllowlist,
+} from "./schemas";
 import { adminTargetForMode, type HermesAdminMode, type HermesAdminTarget } from "./target";
 import { removeAllowedCommand } from "./access-grants-view";
 
@@ -166,10 +170,11 @@ export class AccessGrantsController {
     }
   }
 
-  /** Revokes one pattern: re-reads the LIVE allowlist, prunes the pattern from
-   * that fresh list, and writes it through `config.setValue`. Pruning the
-   * controller's last loaded snapshot instead would silently drop any grant
-   * another session persisted after this page loaded. New sessions no longer
+  /** Revokes one pattern by pruning it INSIDE the config snapshot that is
+   * written (`config.updateValue`): the transform receives the allowlist from
+   * the same freshly fetched tree the PUT persists, so a grant another session
+   * added at any point before the write survives — pruning a list read earlier
+   * (even moments earlier) could silently drop it. New sessions no longer
    * auto-allow matching commands; a matching request will prompt again. */
   async revoke(pattern: string): Promise<void> {
     // A no-op revoke (pattern not on screen) does nothing.
@@ -179,17 +184,18 @@ export class AccessGrantsController {
     this.error = undefined;
     this.recompute();
     try {
+      // Pre-check against the live list so a pattern already revoked elsewhere
+      // skips the write entirely (no spurious "applies next session" notice).
       const current = await this.engine.client.config.get();
       if (this.disposed) return;
-      const fresh = readCommandAllowlist(current.config);
-      const next = removeAllowedCommand(fresh, pattern);
-      if (next.length === fresh.length) {
-        // Already revoked elsewhere: nothing to write, just catch the page up.
+      if (!readCommandAllowlist(current.config).includes(pattern)) {
         this.busy = false;
         await this.load();
         return;
       }
-      const outcome = await this.engine.client.config.setValue(COMMAND_ALLOWLIST_PATH, next);
+      const outcome = await this.engine.client.config.updateValue(COMMAND_ALLOWLIST_PATH, (value) =>
+        removeAllowedCommand(commandAllowlistValue(value), pattern),
+      );
       if (this.disposed) return;
       this.engine.cache.afterMutation(outcome.mutation, "always allowed commands");
       this.engine.lifecycle.noteMutation(outcome.mutation);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -13230,6 +13230,74 @@ input:focus-visible,
   height: 14px;
 }
 
+/* Access grants (JUN-206): the settings page listing every grant the user has
+ * made to the agent (always-allowed commands, session approvals, full access
+ * sessions) with scope + duration pills and revoke actions. Reuses the settings
+ * chrome (.settings-card / .settings-row) and the shared .status-pill; tokens
+ * only. */
+.access-grants-group {
+  margin-top: var(--sp-8);
+}
+
+.access-grants-group:first-of-type {
+  margin-top: 0;
+}
+
+.access-grants-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+
+.access-grants-group-header .settings-group-heading {
+  margin: 0;
+}
+
+.access-grants-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.access-grants-note {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+  line-height: 1.5;
+}
+
+.access-grant-badges {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.access-grant-when {
+  margin-left: var(--sp-2);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.access-grant-command {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.access-grants-inline-error {
+  margin: 0 0 var(--sp-3);
+}
+
+.access-grants + .settings-group,
+.access-grants .inline-notice {
+  margin-top: var(--sp-8);
+}
+
 /* Agent-managed skill write review queue (Hermes admin surface, spec 12). The
  * human-in-the-loop gate: a write-approval toggle card, the lifecycle banner,
  * and a list of pending writes with expandable diffs and approve/reject. Reuses

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -13230,11 +13230,10 @@ input:focus-visible,
   height: 14px;
 }
 
-/* Access grants (JUN-206): the settings page listing every grant the user has
- * made to the agent (always-allowed commands, session approvals, full access
- * sessions) with scope + duration pills and revoke actions. Reuses the settings
- * chrome (.settings-card / .settings-row) and the shared .status-pill; tokens
- * only. */
+/* Access grants (JUN-206): the settings page listing the persistent grants the
+ * user has made to the agent (always-allowed commands, Agent CLI access) with
+ * revoke actions. Reuses the settings chrome (.settings-card / .settings-row);
+ * tokens only. */
 .access-grants-group {
   margin-top: var(--sp-8);
 }
@@ -13269,14 +13268,7 @@ input:focus-visible,
   line-height: 1.5;
 }
 
-.access-grant-badges {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--sp-2);
-}
-
 .access-grant-when {
-  margin-left: var(--sp-2);
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
 }

--- a/src/test/access-grant-log.test.ts
+++ b/src/test/access-grant-log.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ACCESS_GRANT_LOG_CAP,
+  approvalPatternKeys,
+  createAccessGrantLog,
+  grantDuration,
+  grantScope,
+} from "../lib/access-grant-log";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("access grant log — scope/duration derivation", () => {
+  it("maps the approval choice to the JUN-206 scope and duration", () => {
+    expect(grantScope("once")).toBe("session");
+    expect(grantScope("session")).toBe("session");
+    expect(grantScope("always")).toBe("app-wide");
+    expect(grantDuration("once")).toBe("one-time");
+    expect(grantDuration("session")).toBe("ongoing");
+    expect(grantDuration("always")).toBe("ongoing");
+  });
+});
+
+describe("access grant log — pattern key extraction", () => {
+  it("prefers the pattern_keys list and falls back to pattern_key", () => {
+    expect(approvalPatternKeys({ pattern_keys: ["a", "b"] })).toEqual(["a", "b"]);
+    expect(approvalPatternKeys({ pattern_key: "solo" })).toEqual(["solo"]);
+    expect(approvalPatternKeys({ pattern_keys: [], pattern_key: "solo" })).toEqual(["solo"]);
+  });
+
+  it("is total on junk", () => {
+    expect(approvalPatternKeys(undefined)).toEqual([]);
+    expect(approvalPatternKeys("nope")).toEqual([]);
+    expect(approvalPatternKeys({ pattern_keys: [1, null, ""] })).toEqual([]);
+    expect(approvalPatternKeys([])).toEqual([]);
+  });
+});
+
+describe("access grant log — record/list/remove/clear", () => {
+  it("records a grant and lists it newest first", () => {
+    const log = createAccessGrantLog();
+    log.record({
+      sessionId: "s1",
+      requestId: "r1",
+      choice: "session",
+      command: "rm -rf build",
+      description: "Recursive deletion (rm -rf)",
+      patternKeys: ["Recursive deletion (rm -rf)"],
+      grantedAt: 100,
+    });
+    log.record({
+      sessionId: "s1",
+      requestId: "r2",
+      choice: "once",
+      command: "git push --force",
+      patternKeys: [],
+      grantedAt: 200,
+    });
+
+    const entries = log.list();
+    expect(entries.map((entry) => entry.requestId)).toEqual(["r2", "r1"]);
+    expect(entries[1].command).toBe("rm -rf build");
+  });
+
+  it("persists to localStorage and reloads in a fresh instance", () => {
+    const log = createAccessGrantLog();
+    log.record({
+      sessionId: "s1",
+      requestId: "r1",
+      choice: "always",
+      patternKeys: ["Curl piped to shell"],
+      grantedAt: 100,
+    });
+
+    const fresh = createAccessGrantLog();
+    expect(fresh.list()).toHaveLength(1);
+    expect(fresh.list()[0].choice).toBe("always");
+  });
+
+  it("replaces a re-record of the same session + request", () => {
+    const log = createAccessGrantLog();
+    log.record({ sessionId: "s1", requestId: "r1", choice: "once", patternKeys: [] });
+    log.record({ sessionId: "s1", requestId: "r1", choice: "session", patternKeys: [] });
+    expect(log.list()).toHaveLength(1);
+    expect(log.list()[0].choice).toBe("session");
+  });
+
+  it("drops a grant without a session or request id", () => {
+    const log = createAccessGrantLog();
+    log.record({ sessionId: "  ", requestId: "r1", choice: "once", patternKeys: [] });
+    log.record({ sessionId: "s1", requestId: "", choice: "once", patternKeys: [] });
+    expect(log.list()).toHaveLength(0);
+  });
+
+  it("removes one entry and clears all, notifying subscribers", () => {
+    const log = createAccessGrantLog();
+    const listener = vi.fn();
+    log.subscribe(listener);
+    log.record({ sessionId: "s1", requestId: "r1", choice: "once", patternKeys: [] });
+    log.record({ sessionId: "s1", requestId: "r2", choice: "once", patternKeys: [] });
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    log.remove("s1:r1");
+    expect(log.list().map((entry) => entry.id)).toEqual(["s1:r2"]);
+
+    // Removing an unknown id is a no-op (no extra notification).
+    const calls = listener.mock.calls.length;
+    log.remove("s1:missing");
+    expect(listener).toHaveBeenCalledTimes(calls);
+
+    log.clear();
+    expect(log.list()).toHaveLength(0);
+    expect(localStorage.getItem("june.agent.accessGrants")).toBeNull();
+  });
+
+  it("keeps the snapshot identity stable between mutations", () => {
+    const log = createAccessGrantLog();
+    log.record({ sessionId: "s1", requestId: "r1", choice: "once", patternKeys: [] });
+    expect(log.list()).toBe(log.list());
+  });
+
+  it("caps the stored history, evicting the oldest entries", () => {
+    const log = createAccessGrantLog();
+    for (let i = 0; i < ACCESS_GRANT_LOG_CAP + 5; i += 1) {
+      log.record({
+        sessionId: "s1",
+        requestId: `r${i}`,
+        choice: "once",
+        patternKeys: [],
+        grantedAt: i,
+      });
+    }
+    const entries = log.list();
+    expect(entries).toHaveLength(ACCESS_GRANT_LOG_CAP);
+    // Newest kept, oldest evicted.
+    expect(entries[0].requestId).toBe(`r${ACCESS_GRANT_LOG_CAP + 4}`);
+    expect(entries.some((entry) => entry.requestId === "r0")).toBe(false);
+  });
+
+  it("tolerates malformed stored JSON", () => {
+    localStorage.setItem("june.agent.accessGrants", "{not json");
+    expect(createAccessGrantLog().list()).toEqual([]);
+    localStorage.setItem("june.agent.accessGrants", JSON.stringify([{ id: 1 }, null]));
+    expect(createAccessGrantLog().list()).toEqual([]);
+  });
+});

--- a/src/test/access-grant-log.test.ts
+++ b/src/test/access-grant-log.test.ts
@@ -5,6 +5,7 @@ import {
   createAccessGrantLog,
   grantDuration,
   grantScope,
+  redactGrantText,
 } from "../lib/access-grant-log";
 
 beforeEach(() => {
@@ -34,6 +35,38 @@ describe("access grant log — pattern key extraction", () => {
     expect(approvalPatternKeys("nope")).toEqual([]);
     expect(approvalPatternKeys({ pattern_keys: [1, null, ""] })).toEqual([]);
     expect(approvalPatternKeys([])).toEqual([]);
+  });
+});
+
+describe("access grant log — free-text redaction", () => {
+  it("masks bearer tokens, credential key pairs, and secret-shaped runs", () => {
+    expect(redactGrantText('curl -H "Authorization: Bearer sk-abc123"')).not.toContain("sk-abc123");
+    expect(redactGrantText("OPENAI_API_KEY=sk-live-123 python train.py")).toBe(
+      "OPENAI_API_KEY=[redacted] python train.py",
+    );
+    const longSecret = "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6";
+    expect(redactGrantText(`deploy --auth ${longSecret}`)).toBe("deploy --auth [redacted]");
+  });
+
+  it("leaves ordinary commands and paths intact", () => {
+    expect(redactGrantText("rm -rf build")).toBe("rm -rf build");
+    expect(
+      redactGrantText("cp /Users/me/a-very-long-path-name-over-32-characters/file.txt ."),
+    ).toContain("a-very-long-path-name-over-32-characters");
+    expect(redactGrantText(undefined)).toBeUndefined();
+  });
+
+  it("scrubs at record time so secrets never reach storage", () => {
+    const log = createAccessGrantLog();
+    log.record({
+      sessionId: "s1",
+      requestId: "r1",
+      choice: "once",
+      command: "curl -H 'Authorization: Bearer sk-secret-token-value'",
+      patternKeys: [],
+    });
+    expect(log.list()[0].command).not.toContain("sk-secret-token-value");
+    expect(localStorage.getItem("june.agent.accessGrants")).not.toContain("sk-secret-token-value");
   });
 });
 

--- a/src/test/access-grant-log.test.ts
+++ b/src/test/access-grant-log.test.ts
@@ -3,24 +3,11 @@ import {
   ACCESS_GRANT_LOG_CAP,
   approvalPatternKeys,
   createAccessGrantLog,
-  grantDuration,
-  grantScope,
   redactGrantText,
 } from "../lib/access-grant-log";
 
 beforeEach(() => {
   localStorage.clear();
-});
-
-describe("access grant log — scope/duration derivation", () => {
-  it("maps the approval choice to the JUN-206 scope and duration", () => {
-    expect(grantScope("once")).toBe("session");
-    expect(grantScope("session")).toBe("session");
-    expect(grantScope("always")).toBe("app-wide");
-    expect(grantDuration("once")).toBe("one-time");
-    expect(grantDuration("session")).toBe("ongoing");
-    expect(grantDuration("always")).toBe("ongoing");
-  });
 });
 
 describe("access grant log — pattern key extraction", () => {
@@ -48,6 +35,22 @@ describe("access grant log — free-text redaction", () => {
     expect(redactGrantText(`deploy --auth ${longSecret}`)).toBe("deploy --auth [redacted]");
   });
 
+  it("masks the whole Authorization value for any scheme, not just Bearer", () => {
+    // A short Basic credential misses the 32-char run heuristic; the header
+    // rule must catch the scheme AND the credential.
+    const basic = redactGrantText("curl -H 'Authorization: Basic dXNlcjpwYXNz' https://api.test");
+    expect(basic).not.toContain("dXNlcjpwYXNz");
+    expect(basic).toContain("https://api.test");
+    const token = redactGrantText('curl -H "Authorization: Token shorttok" -o out.json');
+    expect(token).not.toContain("shorttok");
+    expect(token).toContain("-o out.json");
+    // An unknown single-token value is redacted whole without eating the
+    // following argument.
+    const opaque = redactGrantText("curl -H 'Authorization: opaque123' -o out.json");
+    expect(opaque).not.toContain("opaque123");
+    expect(opaque).toContain("-o out.json");
+  });
+
   it("leaves ordinary commands and paths intact", () => {
     expect(redactGrantText("rm -rf build")).toBe("rm -rf build");
     expect(
@@ -61,7 +64,6 @@ describe("access grant log — free-text redaction", () => {
     log.record({
       sessionId: "s1",
       requestId: "r1",
-      choice: "once",
       command: "curl -H 'Authorization: Bearer sk-secret-token-value'",
       patternKeys: [],
     });
@@ -70,13 +72,14 @@ describe("access grant log — free-text redaction", () => {
   });
 });
 
-describe("access grant log — record/list/remove/clear", () => {
-  it("records a grant and lists it newest first", () => {
+describe("access grant log — record/list", () => {
+  it("records a grant, lists newest first, and notifies subscribers", () => {
     const log = createAccessGrantLog();
+    const listener = vi.fn();
+    log.subscribe(listener);
     log.record({
       sessionId: "s1",
       requestId: "r1",
-      choice: "session",
       command: "rm -rf build",
       description: "Recursive deletion (rm -rf)",
       patternKeys: ["Recursive deletion (rm -rf)"],
@@ -85,7 +88,6 @@ describe("access grant log — record/list/remove/clear", () => {
     log.record({
       sessionId: "s1",
       requestId: "r2",
-      choice: "once",
       command: "git push --force",
       patternKeys: [],
       grantedAt: 200,
@@ -94,6 +96,7 @@ describe("access grant log — record/list/remove/clear", () => {
     const entries = log.list();
     expect(entries.map((entry) => entry.requestId)).toEqual(["r2", "r1"]);
     expect(entries[1].command).toBe("rm -rf build");
+    expect(listener).toHaveBeenCalledTimes(2);
   });
 
   it("persists to localStorage and reloads in a fresh instance", () => {
@@ -101,55 +104,33 @@ describe("access grant log — record/list/remove/clear", () => {
     log.record({
       sessionId: "s1",
       requestId: "r1",
-      choice: "always",
       patternKeys: ["Curl piped to shell"],
       grantedAt: 100,
     });
 
     const fresh = createAccessGrantLog();
     expect(fresh.list()).toHaveLength(1);
-    expect(fresh.list()[0].choice).toBe("always");
+    expect(fresh.list()[0].patternKeys).toEqual(["Curl piped to shell"]);
   });
 
   it("replaces a re-record of the same session + request", () => {
     const log = createAccessGrantLog();
-    log.record({ sessionId: "s1", requestId: "r1", choice: "once", patternKeys: [] });
-    log.record({ sessionId: "s1", requestId: "r1", choice: "session", patternKeys: [] });
+    log.record({ sessionId: "s1", requestId: "r1", command: "sudo ls", patternKeys: [] });
+    log.record({ sessionId: "s1", requestId: "r1", command: "sudo id", patternKeys: [] });
     expect(log.list()).toHaveLength(1);
-    expect(log.list()[0].choice).toBe("session");
+    expect(log.list()[0].command).toBe("sudo id");
   });
 
   it("drops a grant without a session or request id", () => {
     const log = createAccessGrantLog();
-    log.record({ sessionId: "  ", requestId: "r1", choice: "once", patternKeys: [] });
-    log.record({ sessionId: "s1", requestId: "", choice: "once", patternKeys: [] });
+    log.record({ sessionId: "  ", requestId: "r1", patternKeys: [] });
+    log.record({ sessionId: "s1", requestId: "", patternKeys: [] });
     expect(log.list()).toHaveLength(0);
-  });
-
-  it("removes one entry and clears all, notifying subscribers", () => {
-    const log = createAccessGrantLog();
-    const listener = vi.fn();
-    log.subscribe(listener);
-    log.record({ sessionId: "s1", requestId: "r1", choice: "once", patternKeys: [] });
-    log.record({ sessionId: "s1", requestId: "r2", choice: "once", patternKeys: [] });
-    expect(listener).toHaveBeenCalledTimes(2);
-
-    log.remove("s1:r1");
-    expect(log.list().map((entry) => entry.id)).toEqual(["s1:r2"]);
-
-    // Removing an unknown id is a no-op (no extra notification).
-    const calls = listener.mock.calls.length;
-    log.remove("s1:missing");
-    expect(listener).toHaveBeenCalledTimes(calls);
-
-    log.clear();
-    expect(log.list()).toHaveLength(0);
-    expect(localStorage.getItem("june.agent.accessGrants")).toBeNull();
   });
 
   it("keeps the snapshot identity stable between mutations", () => {
     const log = createAccessGrantLog();
-    log.record({ sessionId: "s1", requestId: "r1", choice: "once", patternKeys: [] });
+    log.record({ sessionId: "s1", requestId: "r1", patternKeys: [] });
     expect(log.list()).toBe(log.list());
   });
 
@@ -159,7 +140,6 @@ describe("access grant log — record/list/remove/clear", () => {
       log.record({
         sessionId: "s1",
         requestId: `r${i}`,
-        choice: "once",
         patternKeys: [],
         grantedAt: i,
       });
@@ -169,6 +149,43 @@ describe("access grant log — record/list/remove/clear", () => {
     // Newest kept, oldest evicted.
     expect(entries[0].requestId).toBe(`r${ACCESS_GRANT_LOG_CAP + 4}`);
     expect(entries.some((entry) => entry.requestId === "r0")).toBe(false);
+  });
+
+  it("ignores legacy session-scoped entries left over from the older page", () => {
+    // Before the page narrowed to persistent grants, "once" and "session"
+    // approvals were logged too (with a `choice` field). They describe grants
+    // that expired on their own; only "always" entries still mean anything.
+    localStorage.setItem(
+      "june.agent.accessGrants",
+      JSON.stringify([
+        {
+          id: "s1:r1",
+          sessionId: "s1",
+          requestId: "r1",
+          choice: "once",
+          patternKeys: [],
+          grantedAt: 1,
+        },
+        {
+          id: "s1:r2",
+          sessionId: "s1",
+          requestId: "r2",
+          choice: "session",
+          patternKeys: [],
+          grantedAt: 2,
+        },
+        {
+          id: "s1:r3",
+          sessionId: "s1",
+          requestId: "r3",
+          choice: "always",
+          patternKeys: ["Sudo"],
+          grantedAt: 3,
+        },
+      ]),
+    );
+    const entries = createAccessGrantLog().list();
+    expect(entries.map((entry) => entry.requestId)).toEqual(["r3"]);
   });
 
   it("tolerates malformed stored JSON", () => {

--- a/src/test/access-grants.test.tsx
+++ b/src/test/access-grants.test.tsx
@@ -13,6 +13,12 @@ import {
   type AccessGrantsState,
 } from "../lib/hermes-admin";
 import type { AccessGrantRecord } from "../lib/access-grant-log";
+import {
+  forgetSessionMode,
+  rememberSessionMode,
+  subscribeSessionModes,
+  unrestrictedSessionIds,
+} from "../lib/agent-session-modes";
 import { AccessGrantsView } from "../components/settings/AccessGrantsSection";
 import { makeAdminHarness } from "./fixtures/hermes-admin-harness";
 
@@ -128,6 +134,24 @@ describe("access grants — labels and list math", () => {
   });
 });
 
+describe("access grants — session mode change notification", () => {
+  it("notifies subscribers when a session mode is remembered or forgotten", () => {
+    localStorage.clear();
+    const seen: string[][] = [];
+    const unsubscribe = subscribeSessionModes(() => {
+      seen.push(unrestrictedSessionIds());
+    });
+
+    rememberSessionMode("sess-1", true);
+    forgetSessionMode("sess-1");
+    unsubscribe();
+    rememberSessionMode("sess-2", true);
+
+    expect(seen).toEqual([["sess-1"], []]);
+    localStorage.clear();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Controller — config reads/writes through the fake Hermes server.
 // ---------------------------------------------------------------------------
@@ -169,6 +193,46 @@ describe("access grants — controller", () => {
     expect(snapshot.patterns).toEqual(["Recursive deletion (rm -rf)"]);
     expect(snapshot.lifecycle.state).toBe("changes-apply-next-session");
     expect(snapshot.notifications.at(-1)?.timing).toBe("next-session");
+    controller.dispose();
+  });
+
+  it("prunes the freshly read allowlist, preserving a grant added after load", async () => {
+    const { engine } = engineFor({ command_allowlist: ["Sudo", "Curl piped to shell"] });
+    const controller = new AccessGrantsController(engine);
+    await controller.load();
+
+    // Another session persists a new "Always approve" after this page loaded.
+    await engine.client.config.setValue("command_allowlist", [
+      "Sudo",
+      "Curl piped to shell",
+      "Force push (git push --force)",
+    ]);
+
+    await controller.revoke("Sudo");
+
+    // The revoke removed only its own pattern; the newer grant survived.
+    const after = await engine.client.config.get();
+    expect(readCommandAllowlist(after.config)).toEqual([
+      "Curl piped to shell",
+      "Force push (git push --force)",
+    ]);
+    controller.dispose();
+  });
+
+  it("a pattern already revoked elsewhere reloads without writing", async () => {
+    const { engine } = engineFor({ command_allowlist: ["Sudo"] });
+    const controller = new AccessGrantsController(engine);
+    await controller.load();
+
+    // Revoked from another window between load and click.
+    await engine.client.config.setValue("command_allowlist", []);
+
+    await controller.revoke("Sudo");
+
+    const snapshot = controller.getSnapshot();
+    expect(snapshot.patterns).toEqual([]);
+    // No write of its own: the lifecycle stays clean.
+    expect(snapshot.lifecycle.state).toBe("clean");
     controller.dispose();
   });
 

--- a/src/test/access-grants.test.tsx
+++ b/src/test/access-grants.test.tsx
@@ -1,0 +1,305 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AccessGrantsController,
+  buildAllowedCommandRows,
+  buildSessionGrantRows,
+  grantDurationLabel,
+  grantScopeLabel,
+  readCommandAllowlist,
+  removeAllowedCommand,
+  shortSessionId,
+  type AccessGrantsEngine,
+  type AccessGrantsState,
+} from "../lib/hermes-admin";
+import type { AccessGrantRecord } from "../lib/access-grant-log";
+import { AccessGrantsView } from "../components/settings/AccessGrantsSection";
+import { makeAdminHarness } from "./fixtures/hermes-admin-harness";
+
+/** A log record with sensible defaults a test can override. */
+function grant(overrides: Partial<AccessGrantRecord> & { requestId: string }): AccessGrantRecord {
+  return {
+    id: `s1:${overrides.requestId}`,
+    sessionId: "s1",
+    choice: "session",
+    patternKeys: [],
+    grantedAt: 1_000,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure view logic. No render, no network.
+// ---------------------------------------------------------------------------
+
+describe("access grants — config read", () => {
+  it("reads the command_allowlist from the config tree", () => {
+    expect(
+      readCommandAllowlist({ command_allowlist: ["Recursive deletion (rm -rf)", "Sudo"] }),
+    ).toEqual(["Recursive deletion (rm -rf)", "Sudo"]);
+  });
+
+  it("tolerates a missing key, a bare string, and non-string entries", () => {
+    expect(readCommandAllowlist({})).toEqual([]);
+    expect(readCommandAllowlist({ command_allowlist: "Sudo" })).toEqual(["Sudo"]);
+    expect(readCommandAllowlist({ command_allowlist: ["ok", 42, "", null] })).toEqual(["ok"]);
+  });
+});
+
+describe("access grants — allowed command rows", () => {
+  it("is app-wide + ongoing and enriched by the newest matching 'always' grant", () => {
+    const rows = buildAllowedCommandRows(
+      ["Recursive deletion (rm -rf)", "Sudo"],
+      [
+        grant({
+          requestId: "new",
+          choice: "always",
+          command: "rm -rf build",
+          patternKeys: ["Recursive deletion (rm -rf)"],
+          grantedAt: 2_000,
+        }),
+        grant({
+          requestId: "old",
+          choice: "always",
+          command: "rm -rf dist",
+          patternKeys: ["Recursive deletion (rm -rf)"],
+          grantedAt: 1_000,
+        }),
+      ],
+    );
+    expect(rows[0]).toMatchObject({
+      pattern: "Recursive deletion (rm -rf)",
+      scope: "app-wide",
+      duration: "ongoing",
+      grantedAt: 2_000,
+      command: "rm -rf build",
+    });
+    // Granted outside June (or before the log existed): still listed, bare.
+    expect(rows[1]).toMatchObject({ pattern: "Sudo", grantedAt: undefined });
+  });
+
+  it("correlates by description when pattern keys are absent, and never by session grants", () => {
+    const rows = buildAllowedCommandRows(
+      ["Sudo"],
+      [
+        grant({ requestId: "r1", choice: "session", description: "Sudo", command: "sudo ls" }),
+        grant({ requestId: "r2", choice: "always", description: "Sudo", command: "sudo id" }),
+      ],
+    );
+    expect(rows[0].command).toBe("sudo id");
+  });
+});
+
+describe("access grants — session grant rows", () => {
+  it("maps once to one-time and session to ongoing, excluding always", () => {
+    const rows = buildSessionGrantRows([
+      grant({ requestId: "r1", choice: "once", command: "git push --force" }),
+      grant({ requestId: "r2", choice: "session", description: "Sudo" }),
+      grant({ requestId: "r3", choice: "always", description: "Curl piped to shell" }),
+    ]);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      title: "git push --force",
+      scope: "session",
+      duration: "one-time",
+    });
+    expect(rows[1]).toMatchObject({ title: "Sudo", duration: "ongoing" });
+  });
+});
+
+describe("access grants — labels and list math", () => {
+  it("labels scope and duration in user language", () => {
+    expect(grantScopeLabel("app-wide")).toBe("App-wide");
+    expect(grantScopeLabel("session")).toBe("This session");
+    expect(grantDurationLabel("one-time")).toBe("One time");
+    expect(grantDurationLabel("ongoing")).toBe("Ongoing");
+  });
+
+  it("removes a pattern without mutating and tolerates a double revoke", () => {
+    const existing = ["a", "b"];
+    expect(removeAllowedCommand(existing, "a")).toEqual(["b"]);
+    expect(removeAllowedCommand(existing, "missing")).toEqual(["a", "b"]);
+    expect(existing).toEqual(["a", "b"]);
+  });
+
+  it("shortens long session ids for display", () => {
+    expect(shortSessionId("short")).toBe("short");
+    expect(shortSessionId("0123456789abcdef")).toBe("0123456789ab...");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Controller — config reads/writes through the fake Hermes server.
+// ---------------------------------------------------------------------------
+
+function engineFor(config: Record<string, unknown>): {
+  engine: AccessGrantsEngine;
+  harness: ReturnType<typeof makeAdminHarness>;
+} {
+  const harness = makeAdminHarness({ config });
+  return { engine: harness, harness };
+}
+
+describe("access grants — controller", () => {
+  it("loads the configured allowlist", async () => {
+    const { engine } = engineFor({ command_allowlist: ["Sudo"] });
+    const controller = new AccessGrantsController(engine);
+    await controller.load();
+
+    const snapshot = controller.getSnapshot();
+    expect(snapshot.status).toBe("ready");
+    expect(snapshot.patterns).toEqual(["Sudo"]);
+    controller.dispose();
+  });
+
+  it("revokes a pattern, writes the pruned list, and records a next-session notice", async () => {
+    const { engine } = engineFor({
+      command_allowlist: ["Sudo", "Recursive deletion (rm -rf)"],
+    });
+    const controller = new AccessGrantsController(engine);
+    await controller.load();
+
+    await controller.revoke("Sudo");
+
+    // The fake server actually persisted the pruned list.
+    const after = await engine.client.config.get();
+    expect(readCommandAllowlist(after.config)).toEqual(["Recursive deletion (rm -rf)"]);
+
+    const snapshot = controller.getSnapshot();
+    expect(snapshot.patterns).toEqual(["Recursive deletion (rm -rf)"]);
+    expect(snapshot.lifecycle.state).toBe("changes-apply-next-session");
+    expect(snapshot.notifications.at(-1)?.timing).toBe("next-session");
+    controller.dispose();
+  });
+
+  it("a revoke of an unknown pattern writes nothing", async () => {
+    const { engine } = engineFor({ command_allowlist: ["Sudo"] });
+    const controller = new AccessGrantsController(engine);
+    await controller.load();
+
+    await controller.revoke("missing");
+
+    const after = await engine.client.config.get();
+    expect(readCommandAllowlist(after.config)).toEqual(["Sudo"]);
+    expect(controller.getSnapshot().lifecycle.state).toBe("clean");
+    controller.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rendered view — labels and revoke wiring, driven with stubbed state.
+// ---------------------------------------------------------------------------
+
+function stubState(overrides: Partial<AccessGrantsState> = {}): AccessGrantsState {
+  return {
+    status: "ready",
+    patterns: [],
+    busy: false,
+    retryable: false,
+    lifecycle: { state: "clean", label: "Up to date", detail: "", canRestart: false },
+    notifications: [],
+    refresh: vi.fn(),
+    revoke: vi.fn(),
+    dismissNotification: vi.fn(),
+    ...overrides,
+  } as AccessGrantsState;
+}
+
+describe("access grants — rendered view", () => {
+  it("shows every group with scope and duration pills and wires revoke", () => {
+    const state = stubState({ patterns: ["Recursive deletion (rm -rf)"] });
+    const onClearGrant = vi.fn();
+    const onRevokeUnrestricted = vi.fn();
+    render(
+      <AccessGrantsView
+        state={state}
+        allowedRows={buildAllowedCommandRows(state.patterns, [
+          grant({
+            requestId: "r0",
+            choice: "always",
+            command: "rm -rf build",
+            patternKeys: ["Recursive deletion (rm -rf)"],
+          }),
+        ])}
+        grantRows={buildSessionGrantRows([
+          grant({ requestId: "r1", choice: "once", command: "git push --force" }),
+        ])}
+        unrestrictedSessions={["sess-full-1"]}
+        onClearGrant={onClearGrant}
+        onClearAllGrants={vi.fn()}
+        onRevokeUnrestricted={onRevokeUnrestricted}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Access grants" })).toBeTruthy();
+
+    // Always allowed command row: pattern, App-wide + Ongoing pills, Revoke.
+    const allowedRow = screen.getByText("Recursive deletion (rm -rf)").closest("li");
+    expect(allowedRow).toBeTruthy();
+    expect(within(allowedRow as HTMLElement).getByText("App-wide")).toBeTruthy();
+    expect(within(allowedRow as HTMLElement).getByText("Ongoing")).toBeTruthy();
+    fireEvent.click(within(allowedRow as HTMLElement).getByRole("button", { name: "Revoke" }));
+    expect(state.revoke).toHaveBeenCalledWith("Recursive deletion (rm -rf)");
+
+    // Session approval row: one-time pill and a Clear action.
+    const grantRow = screen.getByText("git push --force").closest("li");
+    expect(within(grantRow as HTMLElement).getByText("This session")).toBeTruthy();
+    expect(within(grantRow as HTMLElement).getByText("One time")).toBeTruthy();
+    fireEvent.click(within(grantRow as HTMLElement).getByRole("button", { name: "Clear" }));
+    expect(onClearGrant).toHaveBeenCalledWith("s1:r1");
+
+    // Full access session row revokes by session id.
+    const sessionRow = screen.getByText("Session sess-full-1").closest("li");
+    fireEvent.click(within(sessionRow as HTMLElement).getByRole("button", { name: "Revoke" }));
+    expect(onRevokeUnrestricted).toHaveBeenCalledWith("sess-full-1");
+  });
+
+  it("keeps the local groups when the runtime is unavailable", () => {
+    render(
+      <AccessGrantsView
+        state={stubState({ status: "unavailable" })}
+        allowedRows={[]}
+        grantRows={buildSessionGrantRows([grant({ requestId: "r1", choice: "session" })])}
+        unrestrictedSessions={[]}
+        onClearGrant={vi.fn()}
+        onClearAllGrants={vi.fn()}
+        onRevokeUnrestricted={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/runtime is not running/i)).toBeTruthy();
+    // The local record still renders without the runtime.
+    expect(screen.getByText("Approved request")).toBeTruthy();
+    expect(screen.getByText("No sessions have full access.")).toBeTruthy();
+  });
+
+  it("offers Clear all only when there are session approvals", () => {
+    const onClearAllGrants = vi.fn();
+    const { rerender } = render(
+      <AccessGrantsView
+        state={stubState()}
+        allowedRows={[]}
+        grantRows={[]}
+        unrestrictedSessions={[]}
+        onClearGrant={vi.fn()}
+        onClearAllGrants={onClearAllGrants}
+        onRevokeUnrestricted={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Clear all" })).toBeNull();
+
+    rerender(
+      <AccessGrantsView
+        state={stubState()}
+        allowedRows={[]}
+        grantRows={buildSessionGrantRows([grant({ requestId: "r1", choice: "once" })])}
+        unrestrictedSessions={[]}
+        onClearGrant={vi.fn()}
+        onClearAllGrants={onClearAllGrants}
+        onRevokeUnrestricted={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Clear all" }));
+    expect(onClearAllGrants).toHaveBeenCalled();
+  });
+});

--- a/src/test/access-grants.test.tsx
+++ b/src/test/access-grants.test.tsx
@@ -1,37 +1,40 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
   AccessGrantsController,
   buildAllowedCommandRows,
-  buildSessionGrantRows,
-  grantDurationLabel,
-  grantScopeLabel,
   readCommandAllowlist,
   removeAllowedCommand,
-  shortSessionId,
+  useAccessGrants,
   type AccessGrantsEngine,
   type AccessGrantsState,
 } from "../lib/hermes-admin";
 import type { AccessGrantRecord } from "../lib/access-grant-log";
-import {
-  forgetSessionMode,
-  rememberSessionMode,
-  subscribeSessionModes,
-  unrestrictedSessionIds,
-} from "../lib/agent-session-modes";
-import {
-  AccessGrantsView,
-  revokeUnrestrictedSession,
-} from "../components/settings/AccessGrantsSection";
-import { createPendingActionStore } from "../lib/hermes-pending-actions";
+import { AccessGrantsView } from "../components/settings/AccessGrantsSection";
+import { hermesBridgeStatus } from "../lib/tauri";
 import { makeAdminHarness } from "./fixtures/hermes-admin-harness";
 
-/** A log record with sensible defaults a test can override. */
+vi.mock("../lib/tauri", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/tauri")>();
+  return { ...actual, hermesBridgeStatus: vi.fn() };
+});
+
+const mockBridgeStatus = vi.mocked(hermesBridgeStatus);
+
+/** A log record with sensible defaults a test can override. Every logged
+ * grant is an "Always approve" answer. */
 function grant(overrides: Partial<AccessGrantRecord> & { requestId: string }): AccessGrantRecord {
   return {
     id: `s1:${overrides.requestId}`,
     sessionId: "s1",
-    choice: "session",
     patternKeys: [],
     grantedAt: 1_000,
     ...overrides,
@@ -57,20 +60,18 @@ describe("access grants — config read", () => {
 });
 
 describe("access grants — allowed command rows", () => {
-  it("is app-wide + ongoing and enriched by the newest matching 'always' grant", () => {
+  it("is enriched by the newest matching grant record", () => {
     const rows = buildAllowedCommandRows(
       ["Recursive deletion (rm -rf)", "Sudo"],
       [
         grant({
           requestId: "new",
-          choice: "always",
           command: "rm -rf build",
           patternKeys: ["Recursive deletion (rm -rf)"],
           grantedAt: 2_000,
         }),
         grant({
           requestId: "old",
-          choice: "always",
           command: "rm -rf dist",
           patternKeys: ["Recursive deletion (rm -rf)"],
           grantedAt: 1_000,
@@ -79,8 +80,6 @@ describe("access grants — allowed command rows", () => {
     );
     expect(rows[0]).toMatchObject({
       pattern: "Recursive deletion (rm -rf)",
-      scope: "app-wide",
-      duration: "ongoing",
       grantedAt: 2_000,
       command: "rm -rf build",
     });
@@ -88,95 +87,21 @@ describe("access grants — allowed command rows", () => {
     expect(rows[1]).toMatchObject({ pattern: "Sudo", grantedAt: undefined });
   });
 
-  it("correlates by description when pattern keys are absent, and never by session grants", () => {
+  it("correlates by description when pattern keys are absent", () => {
     const rows = buildAllowedCommandRows(
       ["Sudo"],
-      [
-        grant({ requestId: "r1", choice: "session", description: "Sudo", command: "sudo ls" }),
-        grant({ requestId: "r2", choice: "always", description: "Sudo", command: "sudo id" }),
-      ],
+      [grant({ requestId: "r2", description: "Sudo", command: "sudo id" })],
     );
     expect(rows[0].command).toBe("sudo id");
   });
 });
 
-describe("access grants — session grant rows", () => {
-  it("maps once to one-time and session to ongoing, excluding always", () => {
-    const rows = buildSessionGrantRows([
-      grant({ requestId: "r1", choice: "once", command: "git push --force" }),
-      grant({ requestId: "r2", choice: "session", description: "Sudo" }),
-      grant({ requestId: "r3", choice: "always", description: "Curl piped to shell" }),
-    ]);
-    expect(rows).toHaveLength(2);
-    expect(rows[0]).toMatchObject({
-      title: "git push --force",
-      scope: "session",
-      duration: "one-time",
-    });
-    expect(rows[1]).toMatchObject({ title: "Sudo", duration: "ongoing" });
-  });
-});
-
-describe("access grants — labels and list math", () => {
-  it("labels scope and duration in user language", () => {
-    expect(grantScopeLabel("app-wide")).toBe("App-wide");
-    expect(grantScopeLabel("session")).toBe("This session");
-    expect(grantDurationLabel("one-time")).toBe("One time");
-    expect(grantDurationLabel("ongoing")).toBe("Ongoing");
-  });
-
+describe("access grants — list math", () => {
   it("removes a pattern without mutating and tolerates a double revoke", () => {
     const existing = ["a", "b"];
     expect(removeAllowedCommand(existing, "a")).toEqual(["b"]);
     expect(removeAllowedCommand(existing, "missing")).toEqual(["a", "b"]);
     expect(existing).toEqual(["a", "b"]);
-  });
-
-  it("shortens long session ids for display", () => {
-    expect(shortSessionId("short")).toBe("short");
-    expect(shortSessionId("0123456789abcdef")).toBe("0123456789ab...");
-  });
-});
-
-describe("access grants — session mode change notification", () => {
-  it("notifies subscribers when a session mode is remembered or forgotten", () => {
-    localStorage.clear();
-    const seen: string[][] = [];
-    const unsubscribe = subscribeSessionModes(() => {
-      seen.push(unrestrictedSessionIds());
-    });
-
-    rememberSessionMode("sess-1", true);
-    forgetSessionMode("sess-1");
-    unsubscribe();
-    rememberSessionMode("sess-2", true);
-
-    expect(seen).toEqual([["sess-1"], []]);
-    localStorage.clear();
-  });
-
-  it("revoking full access retires the session's pending actions", () => {
-    localStorage.clear();
-    rememberSessionMode("sess-full", true);
-    const store = createPendingActionStore();
-    store.record(
-      {
-        kind: "pending_action",
-        receivedAt: new Date().toISOString(),
-        sessionId: "sess-full",
-        action: { kind: "approval", requestId: "req-9", allowPermanent: true },
-      },
-      "unrestricted",
-    );
-    expect(store.openCount()).toBe(1);
-
-    revokeUnrestrictedSession("sess-full", store);
-
-    // The mode flag is gone AND the blocked request no longer offers a
-    // dead-end respond (it would route to the wrong gateway).
-    expect(unrestrictedSessionIds()).toEqual([]);
-    expect(store.openCount()).toBe(0);
-    localStorage.clear();
   });
 });
 
@@ -295,6 +220,31 @@ describe("access grants — controller", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Hook — the bridge-status load and its retry wiring.
+// ---------------------------------------------------------------------------
+
+describe("access grants — bridge status retry", () => {
+  it("refresh retries a failed bridge-status load", async () => {
+    mockBridgeStatus.mockRejectedValueOnce(new Error("bridge down"));
+    mockBridgeStatus.mockResolvedValue({ running: false });
+
+    const { result } = renderHook(() => useAccessGrants("sandboxed"));
+
+    // The failed load renders as a retryable error.
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.retryable).toBe(true);
+    expect(result.current.error).toContain("bridge down");
+
+    // The advertised retry actually re-runs the load (it is not the
+    // engine-less no-op): the second attempt reaches the bridge and lands on
+    // the honest "unavailable" state.
+    act(() => result.current.refresh());
+    await waitFor(() => expect(result.current.status).toBe("unavailable"));
+    expect(mockBridgeStatus).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Rendered view — labels and revoke wiring, driven with stubbed state.
 // ---------------------------------------------------------------------------
 
@@ -314,10 +264,8 @@ function stubState(overrides: Partial<AccessGrantsState> = {}): AccessGrantsStat
 }
 
 describe("access grants — rendered view", () => {
-  it("shows every group with scope and duration pills and wires revoke", () => {
+  it("shows only the persistent grant groups and wires revoke", () => {
     const state = stubState({ patterns: ["Recursive deletion (rm -rf)"] });
-    const onClearGrant = vi.fn();
-    const onRevokeUnrestricted = vi.fn();
     const onRevokeCliAccess = vi.fn();
     render(
       <AccessGrantsView
@@ -325,51 +273,34 @@ describe("access grants — rendered view", () => {
         allowedRows={buildAllowedCommandRows(state.patterns, [
           grant({
             requestId: "r0",
-            choice: "always",
             command: "rm -rf build",
             patternKeys: ["Recursive deletion (rm -rf)"],
           }),
         ])}
-        grantRows={buildSessionGrantRows([
-          grant({ requestId: "r1", choice: "once", command: "git push --force" }),
-        ])}
-        unrestrictedSessions={["sess-full-1"]}
         cliAccess={true}
         cliBusy={false}
         onRevokeCliAccess={onRevokeCliAccess}
-        onClearGrant={onClearGrant}
-        onClearAllGrants={vi.fn()}
-        onRevokeUnrestricted={onRevokeUnrestricted}
       />,
     );
 
     expect(screen.getByRole("heading", { name: "Access grants" })).toBeTruthy();
 
-    // Always allowed command row: pattern, App-wide + Ongoing pills, Revoke.
+    // Always allowed command row: pattern, triggering command, when, Revoke.
     const allowedRow = screen.getByText("Recursive deletion (rm -rf)").closest("li");
     expect(allowedRow).toBeTruthy();
-    expect(within(allowedRow as HTMLElement).getByText("App-wide")).toBeTruthy();
-    expect(within(allowedRow as HTMLElement).getByText("Ongoing")).toBeTruthy();
+    expect(within(allowedRow as HTMLElement).getByText("rm -rf build")).toBeTruthy();
+    expect(within(allowedRow as HTMLElement).getByText(/Granted /)).toBeTruthy();
     fireEvent.click(within(allowedRow as HTMLElement).getByRole("button", { name: "Revoke" }));
     expect(state.revoke).toHaveBeenCalledWith("Recursive deletion (rm -rf)");
 
-    // Session approval row: one-time pill and a Clear action.
-    const grantRow = screen.getByText("git push --force").closest("li");
-    expect(within(grantRow as HTMLElement).getByText("This session")).toBeTruthy();
-    expect(within(grantRow as HTMLElement).getByText("One time")).toBeTruthy();
-    fireEvent.click(within(grantRow as HTMLElement).getByRole("button", { name: "Clear" }));
-    expect(onClearGrant).toHaveBeenCalledWith("s1:r1");
-
-    // Full access session row revokes by session id.
-    const sessionRow = screen.getByText("Session sess-full-1").closest("li");
-    fireEvent.click(within(sessionRow as HTMLElement).getByRole("button", { name: "Revoke" }));
-    expect(onRevokeUnrestricted).toHaveBeenCalledWith("sess-full-1");
-
-    // Agent CLI access row: app-wide pill and a working revoke.
+    // Agent CLI access row: a working revoke.
     const cliRow = screen.getByText("Coding CLI state folders").closest("li");
-    expect(within(cliRow as HTMLElement).getByText("App-wide")).toBeTruthy();
     fireEvent.click(within(cliRow as HTMLElement).getByRole("button", { name: "Revoke" }));
     expect(onRevokeCliAccess).toHaveBeenCalled();
+
+    // Session-scoped surfaces are gone: the page shows persistent grants only.
+    expect(screen.queryByText("Session approvals")).toBeNull();
+    expect(screen.queryByText("Full access sessions")).toBeNull();
   });
 
   it("shows the CLI access group as not granted when the flag is off", () => {
@@ -377,75 +308,43 @@ describe("access grants — rendered view", () => {
       <AccessGrantsView
         state={stubState()}
         allowedRows={[]}
-        grantRows={[]}
-        unrestrictedSessions={[]}
         cliAccess={false}
         cliBusy={false}
         onRevokeCliAccess={vi.fn()}
-        onClearGrant={vi.fn()}
-        onClearAllGrants={vi.fn()}
-        onRevokeUnrestricted={vi.fn()}
       />,
     );
     expect(screen.getByText("Not granted.")).toBeTruthy();
     expect(screen.queryByText("Coding CLI state folders")).toBeNull();
   });
 
-  it("keeps the local groups when the runtime is unavailable", () => {
+  it("keeps the CLI group when the runtime is unavailable", () => {
     render(
       <AccessGrantsView
         state={stubState({ status: "unavailable" })}
         allowedRows={[]}
-        grantRows={buildSessionGrantRows([grant({ requestId: "r1", choice: "session" })])}
-        unrestrictedSessions={[]}
-        cliAccess={false}
+        cliAccess={true}
         cliBusy={false}
         onRevokeCliAccess={vi.fn()}
-        onClearGrant={vi.fn()}
-        onClearAllGrants={vi.fn()}
-        onRevokeUnrestricted={vi.fn()}
       />,
     );
 
     expect(screen.getByText(/runtime is not running/i)).toBeTruthy();
-    // The local record still renders without the runtime.
-    expect(screen.getByText("Approved request")).toBeTruthy();
-    expect(screen.getByText("No sessions have full access.")).toBeTruthy();
+    // The local flag still renders without the runtime.
+    expect(screen.getByText("Coding CLI state folders")).toBeTruthy();
   });
 
-  it("offers Clear all only when there are session approvals", () => {
-    const onClearAllGrants = vi.fn();
-    const { rerender } = render(
+  it("offers Try again for a retryable load error", () => {
+    const state = stubState({ status: "error", error: "boom", retryable: true });
+    render(
       <AccessGrantsView
-        state={stubState()}
+        state={state}
         allowedRows={[]}
-        grantRows={[]}
-        unrestrictedSessions={[]}
         cliAccess={false}
         cliBusy={false}
         onRevokeCliAccess={vi.fn()}
-        onClearGrant={vi.fn()}
-        onClearAllGrants={onClearAllGrants}
-        onRevokeUnrestricted={vi.fn()}
       />,
     );
-    expect(screen.queryByRole("button", { name: "Clear all" })).toBeNull();
-
-    rerender(
-      <AccessGrantsView
-        state={stubState()}
-        allowedRows={[]}
-        grantRows={buildSessionGrantRows([grant({ requestId: "r1", choice: "once" })])}
-        unrestrictedSessions={[]}
-        cliAccess={false}
-        cliBusy={false}
-        onRevokeCliAccess={vi.fn()}
-        onClearGrant={vi.fn()}
-        onClearAllGrants={onClearAllGrants}
-        onRevokeUnrestricted={vi.fn()}
-      />,
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Clear all" }));
-    expect(onClearAllGrants).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(state.refresh).toHaveBeenCalled();
   });
 });

--- a/src/test/access-grants.test.tsx
+++ b/src/test/access-grants.test.tsx
@@ -318,6 +318,7 @@ describe("access grants — rendered view", () => {
     const state = stubState({ patterns: ["Recursive deletion (rm -rf)"] });
     const onClearGrant = vi.fn();
     const onRevokeUnrestricted = vi.fn();
+    const onRevokeCliAccess = vi.fn();
     render(
       <AccessGrantsView
         state={state}
@@ -333,6 +334,9 @@ describe("access grants — rendered view", () => {
           grant({ requestId: "r1", choice: "once", command: "git push --force" }),
         ])}
         unrestrictedSessions={["sess-full-1"]}
+        cliAccess={true}
+        cliBusy={false}
+        onRevokeCliAccess={onRevokeCliAccess}
         onClearGrant={onClearGrant}
         onClearAllGrants={vi.fn()}
         onRevokeUnrestricted={onRevokeUnrestricted}
@@ -360,6 +364,31 @@ describe("access grants — rendered view", () => {
     const sessionRow = screen.getByText("Session sess-full-1").closest("li");
     fireEvent.click(within(sessionRow as HTMLElement).getByRole("button", { name: "Revoke" }));
     expect(onRevokeUnrestricted).toHaveBeenCalledWith("sess-full-1");
+
+    // Agent CLI access row: app-wide pill and a working revoke.
+    const cliRow = screen.getByText("Coding CLI state folders").closest("li");
+    expect(within(cliRow as HTMLElement).getByText("App-wide")).toBeTruthy();
+    fireEvent.click(within(cliRow as HTMLElement).getByRole("button", { name: "Revoke" }));
+    expect(onRevokeCliAccess).toHaveBeenCalled();
+  });
+
+  it("shows the CLI access group as not granted when the flag is off", () => {
+    render(
+      <AccessGrantsView
+        state={stubState()}
+        allowedRows={[]}
+        grantRows={[]}
+        unrestrictedSessions={[]}
+        cliAccess={false}
+        cliBusy={false}
+        onRevokeCliAccess={vi.fn()}
+        onClearGrant={vi.fn()}
+        onClearAllGrants={vi.fn()}
+        onRevokeUnrestricted={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Not granted.")).toBeTruthy();
+    expect(screen.queryByText("Coding CLI state folders")).toBeNull();
   });
 
   it("keeps the local groups when the runtime is unavailable", () => {
@@ -369,6 +398,9 @@ describe("access grants — rendered view", () => {
         allowedRows={[]}
         grantRows={buildSessionGrantRows([grant({ requestId: "r1", choice: "session" })])}
         unrestrictedSessions={[]}
+        cliAccess={false}
+        cliBusy={false}
+        onRevokeCliAccess={vi.fn()}
         onClearGrant={vi.fn()}
         onClearAllGrants={vi.fn()}
         onRevokeUnrestricted={vi.fn()}
@@ -389,6 +421,9 @@ describe("access grants — rendered view", () => {
         allowedRows={[]}
         grantRows={[]}
         unrestrictedSessions={[]}
+        cliAccess={false}
+        cliBusy={false}
+        onRevokeCliAccess={vi.fn()}
         onClearGrant={vi.fn()}
         onClearAllGrants={onClearAllGrants}
         onRevokeUnrestricted={vi.fn()}
@@ -402,6 +437,9 @@ describe("access grants — rendered view", () => {
         allowedRows={[]}
         grantRows={buildSessionGrantRows([grant({ requestId: "r1", choice: "once" })])}
         unrestrictedSessions={[]}
+        cliAccess={false}
+        cliBusy={false}
+        onRevokeCliAccess={vi.fn()}
         onClearGrant={vi.fn()}
         onClearAllGrants={onClearAllGrants}
         onRevokeUnrestricted={vi.fn()}

--- a/src/test/access-grants.test.tsx
+++ b/src/test/access-grants.test.tsx
@@ -164,6 +164,22 @@ function engineFor(config: Record<string, unknown>): {
   return { engine: harness, harness };
 }
 
+describe("access grants — single-snapshot config update", () => {
+  it("updateValue transforms the value from the same tree it persists", async () => {
+    const { engine } = engineFor({ command_allowlist: ["A"], other: { keep: true } });
+    let received: unknown;
+    await engine.client.config.updateValue("command_allowlist", (value) => {
+      received = value;
+      return ["B"];
+    });
+    // The transform saw the live value, the write landed, siblings survived.
+    expect(received).toEqual(["A"]);
+    const after = await engine.client.config.get();
+    expect(readCommandAllowlist(after.config)).toEqual(["B"]);
+    expect((after.config as { other?: unknown }).other).toEqual({ keep: true });
+  });
+});
+
 describe("access grants — controller", () => {
   it("loads the configured allowlist", async () => {
     const { engine } = engineFor({ command_allowlist: ["Sudo"] });

--- a/src/test/access-grants.test.tsx
+++ b/src/test/access-grants.test.tsx
@@ -19,7 +19,11 @@ import {
   subscribeSessionModes,
   unrestrictedSessionIds,
 } from "../lib/agent-session-modes";
-import { AccessGrantsView } from "../components/settings/AccessGrantsSection";
+import {
+  AccessGrantsView,
+  revokeUnrestrictedSession,
+} from "../components/settings/AccessGrantsSection";
+import { createPendingActionStore } from "../lib/hermes-pending-actions";
 import { makeAdminHarness } from "./fixtures/hermes-admin-harness";
 
 /** A log record with sensible defaults a test can override. */
@@ -148,6 +152,30 @@ describe("access grants — session mode change notification", () => {
     rememberSessionMode("sess-2", true);
 
     expect(seen).toEqual([["sess-1"], []]);
+    localStorage.clear();
+  });
+
+  it("revoking full access retires the session's pending actions", () => {
+    localStorage.clear();
+    rememberSessionMode("sess-full", true);
+    const store = createPendingActionStore();
+    store.record(
+      {
+        kind: "pending_action",
+        receivedAt: new Date().toISOString(),
+        sessionId: "sess-full",
+        action: { kind: "approval", requestId: "req-9", allowPermanent: true },
+      },
+      "unrestricted",
+    );
+    expect(store.openCount()).toBe(1);
+
+    revokeUnrestrictedSession("sess-full", store);
+
+    // The mode flag is gone AND the blocked request no longer offers a
+    // dead-end respond (it would route to the wrong gateway).
+    expect(unrestrictedSessionIds()).toEqual([]);
+    expect(store.openCount()).toBe(0);
     localStorage.clear();
   });
 });


### PR DESCRIPTION
Closes JUN-206

## What changed

A new **Settings -> Access grants** tab that lists the persistent permissions the user has granted the agent - app-wide, ongoing grants that stay in effect until revoked here - with working revoke controls:

- **Always allowed commands** - the Hermes runtime persists an "Always approve" answer as a pattern in its config `command_allowlist`; that list is the source of truth for these grants. The page reads it via the existing admin config client and revokes by pruning the list inside the same config snapshot that is written (`config.updateValue`), through the same safe REST config write the External directories page uses (`src/lib/hermes-admin/use-access-grants.ts`, `access-grants-view.ts`, `readCommandAllowlist` in `schemas.ts`). Revoking applies to new sessions (honest next-session notice via the shared admin lifecycle/notification plumbing). Rows are enriched with when/what granted them from a small localStorage log (`src/lib/access-grant-log.ts`, key `june.agent.accessGrants`, capped at 200) that records "Always approve" answers at the respond site in `AgentWorkspace.respondToApproval`, with credential-shaped text redacted before persisting.
- **Agent CLI access** - the app-wide flag granting write access to coding CLI state folders, shown as a grant row with a Revoke; the Agent settings toggle remains the primary control.

## Product direction: persistent grants only

Per product direction, the page shows ONLY always-allowed grants (persistent, app-wide, ongoing). Session-scoped surfaces were removed rather than hidden:

- No "Session approvals" group: one-time and session approvals expire on their own (consumed by the request, or with the session) and are not tracked; the header copy says so. The grant log no longer records `once`/`session` answers, and legacy session entries in storage are filtered on read.
- No "Full access sessions" group: unrestricted session opt-ins are managed where they are made (the session bar), not listed here. The session-mode subscription plumbing added for that group was removed with it.
- Scope/duration badges were dropped: every listed grant is app-wide and ongoing by definition, so per-row pills carried no information.

## Validation

- `pnpm exec biome check --diagnostic-level=error .` - clean.
- `tsc --noEmit` - clean.
- `pnpm test` - 145 files, 2341 passed / 2 skipped, including: grant log (persistence, cap, dedupe, legacy session-entry filtering, malformed storage), redaction (whole Authorization value for any scheme, bearer tokens, key=value pairs, secret-shaped runs), allowlist parsing/row correlation, controller load/revoke against the fake Hermes server (single-snapshot prune + next-session notice), the bridge-status retry wiring, and rendered-view tests asserting the session-scoped groups are gone.
- No Rust changes.

## QA video

https://app.opensoftware.co/api/v1/files/fil_zeC3dp5uKBkw/download (also posted as a PR comment)

The walkthrough renders the real `AccessGrantsSection` in isolation against a functional Tauri shim (stateful `hermes_admin_request` config GET/PUT + `hermes_bridge_status` + CLI access flag), seeded with a grant-log entry: the page loads both persistent groups (and no session groups), revokes an always-allowed command (row leaves the list, next-session notice), and revokes Agent CLI access (flips to "Not granted."). The Rust `hermes_admin_request` routing is existing code covered by its own tests; the runtime side of the allowlist contract was verified against the Hermes source (`tools/approval.py` persists always-approvals to `command_allowlist` and reloads them per session).

## Known gaps

- The grant log only starts recording from this version; grants made before it (or from outside June) list without granted-when/what enrichment, which is by design (the allowlist itself still lists them).
- Revoking an always-allowed pattern while a session is running leaves that session's in-memory approval active until the next session, matching the runtime's behavior; the UI says so.

## Review follow-ups (Greptile, Codex, Octopus)

- Revoke prunes the allowlist inside the same config snapshot that is written (new `config.updateValue(path, transform)` on the admin client), so a grant persisted concurrently is never dropped.
- The admin target falls back to the other running runtime when the preferred one is down (both runtime processes share one `HERMES_HOME/config.yaml`).
- Access grants is in the settings sidebar nav (AI group) - the controlled-mode sidebar is built from `SETTINGS_SIDEBAR_GROUPS`, not `SETTINGS_TABS`.
- Agent CLI access is included in the inventory as an app-wide ongoing grant with a revoke; the Agent settings toggle stays the primary control.
- Grant free text is redacted before persisting: the whole Authorization header value for any scheme (not just Bearer), bare bearer tokens, credential key=value pairs, and long secret-shaped runs.
- A failed bridge-status load renders a retryable error whose Try again actually re-runs the load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786288860&installation_id=144203540&pr_number=699&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F699&signature=c0e5daef54a83ad17cf6f4543e1e7a802d84c198a5f621e245003dcac3eddb96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
