### PR TITLE
Fix accent select popover positioning

### DIFF
--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1466,6 +1466,7 @@ export function AppSettings({
                   <div className="settings-row-control">
                     <Select
                       className="accent-select"
+                      popoverWidth="trigger"
                       value={brand}
                       options={BRAND_PRESETS.map((preset) => ({
                         value: preset.id,

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -210,16 +210,20 @@ export function Select({
     setOpen((current) => !current);
   }
 
-  const fixedStyle: CSSProperties | undefined = anchor
-    ? {
-        position: "fixed",
-        ...selectPopoverHorizontalStyle(
-          anchor,
-          popoverWidth === "trigger" ? anchor.width : POPOVER_MIN_WIDTH,
-        ),
-        ...fixedVerticalStyle(placement, Math.max(selectedIndex, 0), anchor),
-      }
+  const horizontalStyle = anchor
+    ? selectPopoverHorizontalStyle(
+        anchor,
+        popoverWidth === "trigger" ? Math.max(anchor.width, 1) : POPOVER_MIN_WIDTH,
+      )
     : undefined;
+  const fixedStyle: CSSProperties | undefined =
+    horizontalStyle && horizontalStyle.width !== 0 && anchor
+      ? {
+          position: "fixed",
+          ...horizontalStyle,
+          ...fixedVerticalStyle(placement, Math.max(selectedIndex, 0), anchor),
+        }
+      : undefined;
 
   return (
     <div className={`select-control${className ? ` ${className}` : ""}`} ref={wrapRef}>
@@ -241,7 +245,7 @@ export function Select({
         ) : null}
         <IconChevronDownSmall size={14} />
       </button>
-      {open && anchor
+      {open && fixedStyle
         ? createPortal(
             <ul
               ref={popoverRef}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -66,6 +66,29 @@ export function selectPopoverStyle(
   return { top: -(3 + selectedIndex * 28) };
 }
 
+const POPOVER_VIEWPORT_INSET = 12;
+const POPOVER_MIN_WIDTH = 260;
+
+/**
+ * Keeps a portaled select popover in view without disturbing its trigger
+ * alignment unless the viewport has no room to its right.
+ */
+export function selectPopoverHorizontalStyle(
+  rect: DOMRect,
+  minimumWidth = POPOVER_MIN_WIDTH,
+): CSSProperties {
+  const width = Math.min(
+    Math.max(rect.width, minimumWidth),
+    window.innerWidth - POPOVER_VIEWPORT_INSET * 2,
+  );
+  const left = Math.min(
+    Math.max(rect.left, POPOVER_VIEWPORT_INSET),
+    window.innerWidth - width - POPOVER_VIEWPORT_INSET,
+  );
+
+  return { left, width, minWidth: width, maxWidth: width };
+}
+
 /**
  * The same placement math as {@link selectPopoverStyle} but resolved to fixed
  * viewport coordinates, so the popover can render in a body portal (escaping any
@@ -112,6 +135,7 @@ export function Select({
   onChange,
   ariaLabel,
   className,
+  popoverWidth = "content",
 }: {
   value: string | null;
   options: SelectOption[];
@@ -120,6 +144,8 @@ export function Select({
   onChange: (value: string) => void;
   ariaLabel: string;
   className?: string;
+  /** Match the trigger for compact option sets such as the accent presets. */
+  popoverWidth?: "content" | "trigger";
 }) {
   const [open, setOpen] = useState(false);
   const [placement, setPlacement] = useState<SelectPopoverPlacement>("align-selected");
@@ -128,7 +154,7 @@ export function Select({
   // The popover is rendered in a portal so it escapes any ancestor card's
   // `overflow: hidden` clipping; fixed coordinates are measured from the
   // trigger on open (and on scroll/resize while open).
-  const [anchor, setAnchor] = useState<{ left: number; width: number; rect: DOMRect } | null>(null);
+  const [anchor, setAnchor] = useState<DOMRect | null>(null);
 
   const selectedIndex = options.findIndex((option) => option.value === value);
   const selected = selectedIndex === -1 ? undefined : options[selectedIndex];
@@ -161,7 +187,7 @@ export function Select({
       const el = wrapRef.current;
       if (!el) return;
       const rect = el.getBoundingClientRect();
-      setAnchor({ left: rect.left, width: rect.width, rect });
+      setAnchor(rect);
     };
     measure();
     window.addEventListener("scroll", measure, true);
@@ -188,9 +214,11 @@ export function Select({
   const fixedStyle: CSSProperties | undefined = anchor
     ? {
         position: "fixed",
-        left: anchor.left,
-        minWidth: Math.max(anchor.width, 260),
-        ...fixedVerticalStyle(placement, Math.max(selectedIndex, 0), anchor.rect),
+        ...selectPopoverHorizontalStyle(
+          anchor,
+          popoverWidth === "trigger" ? anchor.width : POPOVER_MIN_WIDTH,
+        ),
+        ...fixedVerticalStyle(placement, Math.max(selectedIndex, 0), anchor),
       }
     : undefined;
 

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -77,13 +77,12 @@ export function selectPopoverHorizontalStyle(
   rect: DOMRect,
   minimumWidth = POPOVER_MIN_WIDTH,
 ): CSSProperties {
-  const width = Math.min(
-    Math.max(rect.width, minimumWidth),
-    window.innerWidth - POPOVER_VIEWPORT_INSET * 2,
-  );
+  const viewportWidth = Math.max(0, window.innerWidth);
+  const maxViewportWidth = Math.max(0, viewportWidth - POPOVER_VIEWPORT_INSET * 2);
+  const width = Math.min(Math.max(rect.width, minimumWidth), maxViewportWidth);
   const left = Math.min(
     Math.max(rect.left, POPOVER_VIEWPORT_INSET),
-    window.innerWidth - width - POPOVER_VIEWPORT_INSET,
+    Math.max(POPOVER_VIEWPORT_INSET, viewportWidth - width - POPOVER_VIEWPORT_INSET),
   );
 
   return { left, width, minWidth: width, maxWidth: width };

--- a/src/styleguide/sections/SelectionControls.tsx
+++ b/src/styleguide/sections/SelectionControls.tsx
@@ -89,6 +89,8 @@ export function SelectionControls() {
             <span className="sg-token-name">Select (color swatches)</span>
           </div>
           <Select
+            className="accent-select"
+            popoverWidth="trigger"
             value={accent}
             options={ACCENT_OPTIONS}
             placeholder="Choose an accent"

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -16608,14 +16608,13 @@ input:focus-visible,
  * specificity than that rule so it stays a fixed square. */
 .select-trigger > .select-swatch:first-child {
   flex: none;
-  margin-right: var(--sp-2);
   overflow: visible;
 }
 
 /* Option rows gain a leading track for the swatch ahead of label + check. The
- * track matches the swatch (14px) and the sp-2 column gap mirrors the trigger
- * swatch's margin, so swatch and label both overlay their trigger twins when
- * the popover opens in place. */
+ * track matches the swatch (14px) and the sp-2 column gap mirrors the trigger,
+ * so swatch and label both overlay their trigger twins when the popover opens
+ * in place. */
 .select-popover button.has-swatch {
   grid-template-columns: 14px minmax(0, 1fr) 16px;
   column-gap: var(--sp-2);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -16611,10 +16611,9 @@ input:focus-visible,
   overflow: visible;
 }
 
-/* Option rows gain a leading track for the swatch ahead of label + check. The
- * track matches the swatch (14px) and the sp-2 column gap mirrors the trigger,
- * so swatch and label both overlay their trigger twins when the popover opens
- * in place. */
+/* Option rows gain a leading track for the swatch ahead of label + check. Both
+ * the trigger and its option rows use one sp-2 gap after the swatch, so their
+ * labels overlay when the popover opens in place without adding extra margin. */
 .select-popover button.has-swatch {
   grid-template-columns: 14px minmax(0, 1fr) 16px;
   column-gap: var(--sp-2);

--- a/src/test/select-popover.test.ts
+++ b/src/test/select-popover.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { selectPopoverHorizontalStyle } from "../components/ui/Select";
+
+describe("selectPopoverHorizontalStyle", () => {
+  it("keeps the popover aligned with its trigger when there is room", () => {
+    const style = selectPopoverHorizontalStyle({ left: 400, width: 128 } as DOMRect);
+
+    expect(style).toMatchObject({ left: 400, width: 260, minWidth: 260, maxWidth: 260 });
+  });
+
+  it("shifts a wide popover left to keep it inside a narrow window", () => {
+    vi.stubGlobal("innerWidth", 560);
+
+    try {
+      const style = selectPopoverHorizontalStyle({ left: 400, width: 128 } as DOMRect);
+
+      expect(style).toMatchObject({ left: 288, width: 260, minWidth: 260, maxWidth: 260 });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("keeps a compact color picker aligned with its trigger in a narrow window", () => {
+    vi.stubGlobal("innerWidth", 560);
+
+    try {
+      const style = selectPopoverHorizontalStyle({ left: 400, width: 128 } as DOMRect, 128);
+
+      expect(style).toMatchObject({ left: 400, width: 128, minWidth: 128, maxWidth: 128 });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/src/test/select-popover.test.ts
+++ b/src/test/select-popover.test.ts
@@ -31,4 +31,16 @@ describe("selectPopoverHorizontalStyle", () => {
       vi.unstubAllGlobals();
     }
   });
+
+  it("never returns negative dimensions when the viewport is smaller than its insets", () => {
+    vi.stubGlobal("innerWidth", 20);
+
+    try {
+      const style = selectPopoverHorizontalStyle({ left: 0, width: 128 } as DOMRect);
+
+      expect(style).toMatchObject({ left: 12, width: 0, minWidth: 0, maxWidth: 0 });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });

--- a/src/test/select.test.tsx
+++ b/src/test/select.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Select } from "../components/ui/Select";
+
+describe("Select", () => {
+  it("does not mount a popover when the viewport has no usable width", () => {
+    vi.stubGlobal("innerWidth", 20);
+
+    try {
+      render(
+        <Select
+          ariaLabel="Accent color"
+          onChange={vi.fn()}
+          options={[{ color: "#b5551f", label: "Clay", value: "clay" }]}
+          placeholder="Clay"
+          value="clay"
+        />,
+      );
+      const trigger = screen.getByRole("button", { name: "Accent color" });
+      const control = trigger.parentElement;
+      if (!control) throw new Error("Select trigger is missing its control wrapper");
+      vi.spyOn(control, "getBoundingClientRect").mockReturnValue({
+        bottom: 82,
+        left: 0,
+        top: 50,
+        width: 128,
+      } as DOMRect);
+
+      fireEvent.click(trigger);
+
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Keep shared select popovers inside narrow windows.
- Make the Accent menu match its compact trigger and remove the duplicated swatch spacing.

## Root cause

Portaled selects had a fixed 260px minimum width and always anchored from the trigger’s left edge, so the Accent menu could overflow a narrow window. Its swatch also received both flex gap and an additional right margin.

## Validation

- `pnpm exec vitest run src/test/select-popover.test.ts src/test/app-settings.test.tsx`
- `pnpm typecheck`
- Browser verification at a 560px viewport, including each Accent preset reopening aligned to its trigger.

- [x] Tested visually where it matters (UI changes: narrow-window styleguide capture).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Does not change the visual width of general text-select menus.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [ ] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786318619&installation_id=144203540&pr_number=704&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F704&signature=b403efbf28b5622a50667e76e90e317d7bdd4a7104cad759a60730d41fa8701c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->