### PR TITLE
JUN-239: Refine tab truncation and close interactions

### DIFF
--- a/src/components/tabs/TabBar.tsx
+++ b/src/components/tabs/TabBar.tsx
@@ -497,6 +497,7 @@ export function TabBar({
         <button
           type="button"
           className="tab-close"
+          tabIndex={-1}
           aria-label={`Close ${tab.title}`}
           onClick={(event) => {
             event.stopPropagation();

--- a/src/components/tabs/TabBar.tsx
+++ b/src/components/tabs/TabBar.tsx
@@ -498,6 +498,7 @@ export function TabBar({
           type="button"
           className="tab-close"
           tabIndex={-1}
+          aria-hidden="true"
           aria-label={`Close ${tab.title}`}
           onClick={(event) => {
             event.stopPropagation();
@@ -600,6 +601,7 @@ export function TabBar({
                   type="button"
                   className="tab-overflow-close"
                   tabIndex={-1}
+                  aria-hidden="true"
                   aria-label={`Close ${tab.title}`}
                   onClick={(event) => {
                     event.stopPropagation();

--- a/src/components/tabs/TabBar.tsx
+++ b/src/components/tabs/TabBar.tsx
@@ -599,6 +599,7 @@ export function TabBar({
                 <button
                   type="button"
                   className="tab-overflow-close"
+                  tabIndex={-1}
                   aria-label={`Close ${tab.title}`}
                   onClick={(event) => {
                     event.stopPropagation();

--- a/src/components/tabs/TabBar.tsx
+++ b/src/components/tabs/TabBar.tsx
@@ -226,10 +226,6 @@ export function TabBar({
     return () => observer.disconnect();
   }, []);
 
-  // A lone tab carries no meaning to switch between, but the strip stays so the
-  // "+" affordance is always discoverable.
-  const showClose = tabs.length > 1;
-
   // How wide each visible tab would render if they all shared evenly, so the
   // strip can shed labels as it tightens — deterministic (vs. relying on CSS
   // container queries to fire) since we already know the width. Below full
@@ -306,7 +302,7 @@ export function TabBar({
 
   function handleAuxClick(event: MouseEvent<HTMLDivElement>, id: string) {
     // Middle-click closes, matching every browser.
-    if (event.button === 1 && showClose) {
+    if (event.button === 1) {
       event.preventDefault();
       onClose(id);
     }
@@ -498,20 +494,18 @@ export function TabBar({
           {tab.icon}
         </span>
         <span className="tab-label">{tab.title}</span>
-        {showClose ? (
-          <button
-            type="button"
-            className="tab-close"
-            aria-label={`Close ${tab.title}`}
-            onClick={(event) => {
-              event.stopPropagation();
-              onClose(tab.id);
-            }}
-            onPointerDown={(event) => event.stopPropagation()}
-          >
-            <IconCrossSmall size={12} />
-          </button>
-        ) : null}
+        <button
+          type="button"
+          className="tab-close"
+          aria-label={`Close ${tab.title}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onClose(tab.id);
+          }}
+          onPointerDown={(event) => event.stopPropagation()}
+        >
+          <IconCrossSmall size={12} />
+        </button>
       </div>
     );
   }
@@ -601,19 +595,17 @@ export function TabBar({
                   {tab.icon}
                 </span>
                 <span className="tab-overflow-title">{tab.title}</span>
-                {showClose ? (
-                  <button
-                    type="button"
-                    className="tab-overflow-close"
-                    aria-label={`Close ${tab.title}`}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onClose(tab.id);
-                    }}
-                  >
-                    <IconCrossSmall size={12} />
-                  </button>
-                ) : null}
+                <button
+                  type="button"
+                  className="tab-overflow-close"
+                  aria-label={`Close ${tab.title}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onClose(tab.id);
+                  }}
+                >
+                  <IconCrossSmall size={12} />
+                </button>
               </div>
             );
           })}
@@ -637,17 +629,18 @@ export function TabBar({
           >
             Close tab
           </button>
-          <button
-            type="button"
-            role="menuitem"
-            disabled={tabs.length <= 1}
-            onClick={() => {
-              onCloseOthers(menu.tabId);
-              setMenu(null);
-            }}
-          >
-            Close other tabs
-          </button>
+          {tabs.length > 1 ? (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                onCloseOthers(menu.tabId);
+                setMenu(null);
+              }}
+            >
+              Close other tabs
+            </button>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9026,21 +9026,25 @@ input:focus-visible,
   opacity: 0.65;
 }
 
-/* The label runs the tab's full width and fades out at its right edge instead
- * of ellipsizing — the close button floats above that faded tail, so squeezed
- * tabs keep every pixel of title. The fade completes 14px in — the close
- * button's left edge — so text never collides with the x. */
+/* At rest, long labels dissolve through the tab's trailing edge. */
 .tab-label {
   flex: 1;
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
+  -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 30px), transparent 100%);
+  mask-image: linear-gradient(to right, #000 calc(100% - 30px), transparent 100%);
+}
+
+/* During interaction, finish the fade before the close control so its glyph
+ * appears on a clear patch instead of competing with the title. */
+.tab:hover .tab-label {
   -webkit-mask-image: linear-gradient(
     to right,
     #000 calc(100% - 38px),
-    transparent calc(100% - 14px)
+    transparent calc(100% - 22px)
   );
-  mask-image: linear-gradient(to right, #000 calc(100% - 38px), transparent calc(100% - 14px));
+  mask-image: linear-gradient(to right, #000 calc(100% - 38px), transparent calc(100% - 22px));
 }
 
 /* Overlaid on the tab's right edge, above the label's faded tail, so showing
@@ -9070,10 +9074,9 @@ input:focus-visible,
     color var(--t-fast) var(--ease-out);
 }
 
-/* Close stays hidden on idle inactive tabs so the strip reads as labels, not a
- * row of x's — it fades in on hover and is always present on the active tab. */
-.tab:hover .tab-close,
-.tab[data-active] .tab-close {
+/* Close stays hidden until the tab is being directly interacted with, so the
+ * active tab keeps the same clean resting state as every other tab. */
+.tab:hover .tab-close {
   opacity: 1;
 }
 

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -330,10 +330,12 @@ describe("TabBar", () => {
 
   it("offers a close control when only one tab is open", () => {
     const onlyTab = { id: "tab-1", title: "New session", icon: <span aria-hidden /> };
-    const { props } = renderTabBar({ tabs: [onlyTab] });
-    const close = screen.getByRole("button", { name: "Close New session" });
+    const { container, props } = renderTabBar({ tabs: [onlyTab] });
+    const close = container.querySelector<HTMLButtonElement>(".tab-close");
+    if (!close) throw new Error("Expected the sole tab close control");
 
     expect(close).toHaveAttribute("tabindex", "-1");
+    expect(close).toHaveAttribute("aria-hidden", "true");
     fireEvent.click(close);
 
     expect(props.onClose).toHaveBeenCalledWith("tab-1");
@@ -373,6 +375,7 @@ describe("TabBar", () => {
       expect(overflowCloses).toHaveLength(6);
       for (const close of overflowCloses) {
         expect(close).toHaveAttribute("tabindex", "-1");
+        expect(close).toHaveAttribute("aria-hidden", "true");
       }
     } finally {
       restoreWidth();

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -357,6 +357,28 @@ describe("TabBar", () => {
     expect(screen.getByRole("menuitem", { name: "Close other tabs" })).toBeInTheDocument();
   });
 
+  it("keeps hover-only overflow close controls out of the tab order", () => {
+    const restoreWidth = mockStripWidth(360);
+    try {
+      const manyTabs = Array.from({ length: 6 }, (_, index) => ({
+        id: `tab-${index + 1}`,
+        title: `Tab ${index + 1}`,
+        icon: <span aria-hidden />,
+      }));
+      const { container } = renderTabBar({ tabs: manyTabs, activeTabId: "tab-1" });
+
+      fireEvent.click(screen.getByRole("button", { name: "Show all 6 tabs" }));
+
+      const overflowCloses = container.querySelectorAll<HTMLButtonElement>(".tab-overflow-close");
+      expect(overflowCloses).toHaveLength(6);
+      for (const close of overflowCloses) {
+        expect(close).toHaveAttribute("tabindex", "-1");
+      }
+    } finally {
+      restoreWidth();
+    }
+  });
+
   it("freezes adaptive layout while the sidebar is being resized", () => {
     let observerCallback: ResizeObserverCallback | undefined;
     const OriginalResizeObserver = globalThis.ResizeObserver;

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -331,8 +331,10 @@ describe("TabBar", () => {
   it("offers a close control when only one tab is open", () => {
     const onlyTab = { id: "tab-1", title: "New session", icon: <span aria-hidden /> };
     const { props } = renderTabBar({ tabs: [onlyTab] });
+    const close = screen.getByRole("button", { name: "Close New session" });
 
-    fireEvent.click(screen.getByRole("button", { name: "Close New session" }));
+    expect(close).toHaveAttribute("tabindex", "-1");
+    fireEvent.click(close);
 
     expect(props.onClose).toHaveBeenCalledWith("tab-1");
   });

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -310,13 +310,49 @@ describe("TabBar", () => {
     }
   });
 
-  it("floats the close button over the label's faded tail", () => {
+  it("fades idle labels and reserves the close control for interaction", () => {
     const closeRule = cssRuleFor(".tab-close");
     const labelRule = cssRuleFor(".tab-label");
+    const interactiveLabelRule = cssRuleFor(".tab:hover .tab-label");
+    const interactiveCloseRule = cssRuleFor(".tab:hover .tab-close");
 
     expect(closeRule).toContain("position: absolute;");
     expect(labelRule).toContain("mask-image: linear-gradient(");
     expect(labelRule).not.toContain("text-overflow");
+    expect(labelRule).toContain("#000 calc(100% - 30px)");
+    expect(labelRule).toContain("transparent 100%");
+    expect(interactiveLabelRule).toContain("#000 calc(100% - 38px)");
+    expect(interactiveLabelRule).toContain("transparent calc(100% - 22px)");
+    expect(interactiveCloseRule).toContain("opacity: 1;");
+    expect(appCss).not.toContain(".tab:focus-within .tab-label");
+    expect(appCss).not.toContain(".tab:focus-within .tab-close");
+  });
+
+  it("offers a close control when only one tab is open", () => {
+    const onlyTab = { id: "tab-1", title: "New session", icon: <span aria-hidden /> };
+    const { props } = renderTabBar({ tabs: [onlyTab] });
+
+    fireEvent.click(screen.getByRole("button", { name: "Close New session" }));
+
+    expect(props.onClose).toHaveBeenCalledWith("tab-1");
+  });
+
+  it("hides Close other tabs when only one tab is open", () => {
+    const onlyTab = { id: "tab-1", title: "New session", icon: <span aria-hidden /> };
+    renderTabBar({ tabs: [onlyTab] });
+
+    fireEvent.contextMenu(screen.getByRole("tab", { name: "New session" }));
+
+    expect(screen.getByRole("menuitem", { name: "Close tab" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Close other tabs" })).not.toBeInTheDocument();
+  });
+
+  it("offers Close other tabs when multiple tabs are open", () => {
+    renderTabBar();
+
+    fireEvent.contextMenu(screen.getByRole("tab", { name: "New session" }));
+
+    expect(screen.getByRole("menuitem", { name: "Close other tabs" })).toBeInTheDocument();
   });
 
   it("freezes adaptive layout while the sidebar is being resized", () => {


### PR DESCRIPTION
## Summary

- Fade long tab titles through the trailing edge at rest, then shift the fade before the close affordance on hover.
- Show tab close controls only on pointer hover, including when a single tab is open.
- Hide "Close other tabs" from the context menu when there is only one tab.

## Root cause

The tab bar used one static title mask, kept the active tab's close control visible, and suppressed close controls entirely for a single-tab strip. Focus styling also reused the hover treatment, so clicking a tab could leave the close control visible. The single-tab context menu disabled "Close other tabs" instead of omitting an unavailable action.

## Validation

- `pnpm test` (full frontend suite)
- `pnpm test -- src/test/tab-bar.test.tsx` (16 tests)
- `pnpm typecheck`
- Touched-file Biome check and `git diff --check`

- [x] Tested visually where it matters in the live desktop app; behavior was reviewed and approved during implementation.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is required.

## Out of scope

- Changes to tab sizing, drag reordering, overflow layout, or keyboard shortcuts.
- Changes to the semantics of closing the final tab, which continues to reset it to a fresh chat.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] No security-sensitive behavior changed.
- [x] No workflow action references changed.
- [x] No desktop signing, updater, entitlement, capability, or release behavior changed.
- [x] No backend auth, billing, metering, CORS, rate limit, or logging behavior changed.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786318662&installation_id=144203540&pr_number=705&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F705&signature=d28ee0b68eec632720c4c40e1ce0716d4263f24909c91b8202ae9226a3419dd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->