### PR TITLE
Avoid unsupported WebGL probes

### DIFF
--- a/src/components/brand/JuneGlassMark.tsx
+++ b/src/components/brand/JuneGlassMark.tsx
@@ -20,6 +20,17 @@ const GlassMarkCanvas = lazy(() => import("./glass-mark-canvas"));
 let webglSupport: boolean | undefined;
 function hasWebGL(): boolean {
   if (webglSupport !== undefined) return webglSupport;
+  // WebGL-less browsers and DOM implementations such as jsdom do not expose
+  // the context constructor. Bail out before calling getContext: jsdom reports
+  // unsupported canvas APIs to stderr instead of throwing, which otherwise
+  // makes every surface containing the mark emit noisy errors.
+  // Do not cache the server-side answer: hydration may run in a WebGL-capable
+  // browser after an SSR pass without a document.
+  if (typeof document === "undefined") return false;
+  if (typeof globalThis.WebGLRenderingContext === "undefined") {
+    webglSupport = false;
+    return webglSupport;
+  }
   try {
     const canvas = document.createElement("canvas");
     webglSupport = !!(

--- a/src/test/june-glass-mark.test.tsx
+++ b/src/test/june-glass-mark.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { JuneGlassMark } from "../components/brand/JuneGlassMark";
 
 // jsdom has no WebGL, so JuneGlassMark's WebGL probe fails and it renders the
@@ -8,8 +8,10 @@ import { JuneGlassMark } from "../components/brand/JuneGlassMark";
 // environment gets — renders a visible June mark with no thrown error.
 describe("JuneGlassMark", () => {
   it("renders the static fallback mark when WebGL is unavailable", () => {
+    const getContext = vi.spyOn(HTMLCanvasElement.prototype, "getContext");
     render(<JuneGlassMark />);
     // The fallback is the flat JuneGradientMark: an <svg> titled "June".
     expect(screen.getByTitle("June")).toBeInTheDocument();
+    expect(getContext).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What changed\n- skip canvas context probes when the client has no WebGL constructor\n- avoid caching the server-side fallback across hydration\n- assert that degraded rendering never calls the unsupported canvas API\n\n## Why\njsdom reports unsupported canvas calls to stderr rather than throwing, so the brand mark polluted many unrelated test runs with repeated errors. WebGL-less clients also had no reason to attempt the probe.\n\n## Impact\nWebGL-capable browsers keep the animated mark. SSR and WebGL-less clients render the existing static fallback without noisy probes.\n\n## Validation\n- pnpm test (2,378 passed, 2 skipped)\n- pnpm typecheck\n- Biome check on changed files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786376906&installation_id=144203540&pr_number=706&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F706&signature=1fd95490d1de022dc874109c0497f01685f54a6b37727abbba01285e2d7876dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->