### PR TITLE
Export meeting notes as PDF

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -138,6 +138,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             theme_icon::set_dock_icon,
+            print_current_webview,
             commands::bootstrap_app,
             commands::create_note,
             commands::list_notes,
@@ -550,6 +551,11 @@ fn main_window_focus_state(app: &tauri::AppHandle) -> Option<bool> {
 
 fn should_emit_close_tab_event(main_window_focused: Option<bool>) -> bool {
     main_window_focused == Some(true)
+}
+
+#[tauri::command]
+fn print_current_webview(window: tauri::WebviewWindow) -> Result<(), String> {
+    window.print().map_err(|error| error.to_string())
 }
 
 #[tauri::command]

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -711,6 +711,18 @@ export function App() {
   const noteChat = useNoteChat(
     selectedNote ? { id: selectedNote.id, title: selectedNote.title } : null,
   );
+  async function handleExportNotePdf() {
+    if (!selectedNote) return;
+    await exportNoteAsPdf(selectedNote.title, {
+      showNotes:
+        selectedNote.activeTab === "transcription"
+          ? async () => {
+              const note = await updateNote({ noteId: selectedNote.id, activeTab: "notes" });
+              dispatch({ type: "noteUpdated", note });
+            }
+          : undefined,
+    });
+  }
   const noteToolbarActions = selectedNote ? (
     <NoteHeaderActions
       noteId={selectedNote.id}
@@ -718,7 +730,7 @@ export function App() {
       askJuneOpen={noteChatOpen}
       askJuneWorking={noteChat.working}
       onAskJune={() => setNoteChatOpen((open) => !open)}
-      onExportPdf={() => exportNoteAsPdf(selectedNote.title)}
+      onExportPdf={() => void handleExportNotePdf()}
       onDelete={() => setConfirmDeleteNote(true)}
     />
   ) : null;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -31,6 +31,7 @@ import { MoveNoteToFolderDialog } from "../components/folders/MoveNoteToFolderDi
 import { MoveSessionToProjectDialog } from "../components/folders/MoveSessionToProjectDialog";
 import { NoteEditor } from "../components/note-editor/NoteEditor";
 import { NoteHeaderActions } from "../components/note-editor/NoteHeaderActions";
+import { exportNoteAsPdf } from "../lib/note-pdf";
 import { NoteChatPanel } from "../components/note-chat/NoteChatPanel";
 import { useNoteChat } from "../components/note-chat/useNoteChat";
 import { GlobalRecorderPill } from "../components/recorder/GlobalRecorderPill";
@@ -717,6 +718,7 @@ export function App() {
       askJuneOpen={noteChatOpen}
       askJuneWorking={noteChat.working}
       onAskJune={() => setNoteChatOpen((open) => !open)}
+      onExportPdf={() => exportNoteAsPdf(selectedNote.title)}
       onDelete={() => setConfirmDeleteNote(true)}
     />
   ) : null;

--- a/src/components/note-editor/NoteHeaderActions.tsx
+++ b/src/components/note-editor/NoteHeaderActions.tsx
@@ -2,6 +2,7 @@ import { IconBubble3 } from "central-icons/IconBubble3";
 import { IconChainLink1 } from "central-icons/IconChainLink1";
 import { IconCheckmark2Small } from "central-icons/IconCheckmark2Small";
 import { IconDotGrid1x3Horizontal } from "central-icons/IconDotGrid1x3Horizontal";
+import { IconArrowInbox } from "central-icons/IconArrowInbox";
 import { IconTrashCan } from "central-icons/IconTrashCan";
 import { useEffect, useRef, useState } from "react";
 
@@ -16,6 +17,7 @@ export function NoteHeaderActions({
   askJuneOpen,
   askJuneWorking,
   onAskJune,
+  onExportPdf,
   onDelete,
 }: {
   noteId: string;
@@ -26,6 +28,8 @@ export function NoteHeaderActions({
    * the panel is closed, so a fired-off question is visibly still running. */
   askJuneWorking?: boolean;
   onAskJune?: () => void;
+  /** Opens the system print sheet with a PDF-ready version of the note. */
+  onExportPdf?: () => void;
   /** Opens the delete-note confirmation. Omitted → no overflow menu. */
   onDelete?: () => void;
 }) {
@@ -44,12 +48,20 @@ export function NoteHeaderActions({
         {askJuneWorking ? <span className="note-header-ask-dot" aria-hidden /> : null}
       </button>
       <CopyNoteReferenceButton noteId={noteId} title={noteTitle} />
-      {onDelete ? <NoteOverflowMenu onDelete={onDelete} /> : null}
+      {onExportPdf || onDelete ? (
+        <NoteOverflowMenu onExportPdf={onExportPdf} onDelete={onDelete} />
+      ) : null}
     </div>
   );
 }
 
-function NoteOverflowMenu({ onDelete }: { onDelete: () => void }) {
+function NoteOverflowMenu({
+  onExportPdf,
+  onDelete,
+}: {
+  onExportPdf?: () => void;
+  onDelete?: () => void;
+}) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
 
@@ -83,18 +95,33 @@ function NoteOverflowMenu({ onDelete }: { onDelete: () => void }) {
       </button>
       {open ? (
         <div className="sidebar-identity-menu note-actions-menu" role="menu">
-          <button
-            type="button"
-            role="menuitem"
-            className="destructive"
-            onClick={() => {
-              setOpen(false);
-              onDelete();
-            }}
-          >
-            <IconTrashCan size={14} />
-            Delete note
-          </button>
+          {onExportPdf ? (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false);
+                onExportPdf();
+              }}
+            >
+              <IconArrowInbox size={14} />
+              Export as PDF
+            </button>
+          ) : null}
+          {onDelete ? (
+            <button
+              type="button"
+              role="menuitem"
+              className="destructive"
+              onClick={() => {
+                setOpen(false);
+                onDelete();
+              }}
+            >
+              <IconTrashCan size={14} />
+              Delete note
+            </button>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/src/lib/note-pdf.ts
+++ b/src/lib/note-pdf.ts
@@ -5,7 +5,26 @@
  * their equivalent PDF destination. `window.print()` blocks until that sheet
  * closes, so the app title can be restored immediately afterwards.
  */
-export function exportNoteAsPdf(noteTitle: string, print = () => window.print()) {
+type ExportNoteAsPdfOptions = {
+  showNotes?: () => void | Promise<void>;
+  waitForPaint?: () => void | Promise<void>;
+  print?: () => void;
+};
+
+export async function exportNoteAsPdf(
+  noteTitle: string,
+  {
+    showNotes,
+    waitForPaint = () =>
+      new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve())),
+    print = () => window.print(),
+  }: ExportNoteAsPdfOptions = {},
+) {
+  if (showNotes) {
+    await showNotes();
+    await waitForPaint();
+  }
+
   const previousTitle = document.title;
   document.title = noteTitle.trim() || "Meeting notes";
 

--- a/src/lib/note-pdf.ts
+++ b/src/lib/note-pdf.ts
@@ -1,0 +1,17 @@
+/**
+ * Open the platform print sheet with a useful default PDF filename.
+ *
+ * The native macOS print sheet exposes Save as PDF, while browsers expose
+ * their equivalent PDF destination. `window.print()` blocks until that sheet
+ * closes, so the app title can be restored immediately afterwards.
+ */
+export function exportNoteAsPdf(noteTitle: string, print = () => window.print()) {
+  const previousTitle = document.title;
+  document.title = noteTitle.trim() || "Meeting notes";
+
+  try {
+    print();
+  } finally {
+    document.title = previousTitle;
+  }
+}

--- a/src/lib/note-pdf.ts
+++ b/src/lib/note-pdf.ts
@@ -1,14 +1,16 @@
+import { printCurrentWebview } from "./tauri";
+
 /**
  * Open the platform print sheet with a useful default PDF filename.
  *
- * The native macOS print sheet exposes Save as PDF, while browsers expose
- * their equivalent PDF destination. `window.print()` blocks until that sheet
- * closes, so the app title can be restored immediately afterwards.
+ * The native print sheet exposes Save as PDF on macOS and the equivalent PDF
+ * destination on other platforms. June invokes it through Tauri because
+ * WKWebView does not implement `window.print()`.
  */
 type ExportNoteAsPdfOptions = {
   showNotes?: () => void | Promise<void>;
   waitForPaint?: () => void | Promise<void>;
-  print?: () => void;
+  print?: () => void | Promise<void>;
 };
 
 export async function exportNoteAsPdf(
@@ -17,7 +19,7 @@ export async function exportNoteAsPdf(
     showNotes,
     waitForPaint = () =>
       new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve())),
-    print = () => window.print(),
+    print = printCurrentWebview,
   }: ExportNoteAsPdfOptions = {},
 ) {
   if (showNotes) {
@@ -29,7 +31,7 @@ export async function exportNoteAsPdf(
   document.title = noteTitle.trim() || "Meeting notes";
 
   try {
-    print();
+    await print();
   } finally {
     document.title = previousTitle;
   }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -5,6 +5,10 @@ import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 // bindings use, rather than reaching into `@tauri-apps/api/core` directly.
 export { invoke };
 
+export async function printCurrentWebview() {
+  return invoke<void>("print_current_webview");
+}
+
 export type ProcessingStatus =
   | "draft"
   | "recording"

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -25232,6 +25232,7 @@ input:focus-visible,
   .main-panel,
   .main-panel-body,
   .workspace,
+  .note-detail-scroll,
   .note-editor,
   .editor-content,
   .note-body-stack {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -25212,3 +25212,101 @@ input:focus-visible,
 .app-shell[data-note-chat-resizing="true"] .note-chat-panel {
   transition: none;
 }
+
+/* PDF export uses the platform print sheet. Strip the application chrome and
+ * release every viewport-bound scroller so the full formatted note paginates. */
+@media print {
+  @page {
+    margin: 18mm;
+  }
+
+  html,
+  body,
+  #root,
+  .app-shell,
+  .main-column,
+  .main-panel,
+  .main-panel-body,
+  .workspace,
+  .note-editor,
+  .editor-content,
+  .note-body-stack {
+    width: auto !important;
+    min-width: 0 !important;
+    max-width: none !important;
+    height: auto !important;
+    min-height: 0 !important;
+    overflow: visible !important;
+  }
+
+  body {
+    background: white !important;
+    color: black !important;
+  }
+
+  .app-shell {
+    display: block !important;
+  }
+
+  .titlebar-drag,
+  .chrome-sidebar-toggle,
+  .sidebar,
+  .sidebar-resize-handle,
+  .tab-bar,
+  .permission-banner,
+  .error-banner,
+  .notice-banner,
+  .note-header-actions,
+  .segmented,
+  .editor-footer,
+  .note-chat-panel,
+  .note-chat-resize-handle,
+  .selection-toolbar,
+  .note-processing-progress {
+    display: none !important;
+  }
+
+  .main-panel,
+  .main-panel-body,
+  .workspace,
+  .note-editor {
+    margin: 0 !important;
+    padding: 0 !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: white !important;
+    box-shadow: none !important;
+  }
+
+  .note-editor {
+    display: block !important;
+    color: black !important;
+  }
+
+  .editor-header {
+    margin-bottom: 10mm;
+  }
+
+  .note-title {
+    color: black !important;
+    -webkit-text-fill-color: black !important;
+  }
+
+  .note-overline,
+  .note-preview,
+  .note-preview h1,
+  .note-preview h2,
+  .note-preview p,
+  .note-preview ul {
+    color: black !important;
+  }
+
+  .note-body-stack,
+  .note-preview {
+    padding: 0 !important;
+  }
+
+  .note-preview {
+    caret-color: transparent;
+  }
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -25220,6 +25220,10 @@ input:focus-visible,
     margin: 18mm;
   }
 
+  :root {
+    color-scheme: light;
+  }
+
   html,
   body,
   #root,

--- a/src/test/agent-note-entry-points.test.ts
+++ b/src/test/agent-note-entry-points.test.ts
@@ -167,6 +167,23 @@ describe("note header actions", () => {
     );
     await waitFor(() => expect(copyButton).toHaveAttribute("data-copied", "true"));
   });
+
+  it("exports the note from the actions menu", async () => {
+    const user = userEvent.setup();
+    const onExportPdf = vi.fn();
+    render(
+      createElement(NoteHeaderActions, {
+        noteId: "note-1",
+        noteTitle: "Launch plan",
+        onExportPdf,
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Note actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Export as PDF" }));
+
+    expect(onExportPdf).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("composer note reference trigger", () => {

--- a/src/test/note-pdf.test.ts
+++ b/src/test/note-pdf.test.ts
@@ -3,19 +3,37 @@ import { describe, expect, it, vi } from "vitest";
 import { exportNoteAsPdf } from "../lib/note-pdf";
 
 describe("note PDF export", () => {
-  it("uses the note title while opening the print sheet and restores the app title", () => {
+  it("uses the note title while opening the print sheet and restores the app title", async () => {
     document.title = "June";
     const print = vi.fn(() => expect(document.title).toBe("Weekly sync"));
 
-    exportNoteAsPdf("  Weekly sync  ", print);
+    await exportNoteAsPdf("  Weekly sync  ", { print });
 
     expect(print).toHaveBeenCalledTimes(1);
     expect(document.title).toBe("June");
   });
 
-  it("uses a readable filename for untitled notes", () => {
+  it("uses a readable filename for untitled notes", async () => {
     const print = vi.fn(() => expect(document.title).toBe("Meeting notes"));
 
-    exportNoteAsPdf("   ", print);
+    await exportNoteAsPdf("   ", { print });
+  });
+
+  it("renders the formatted notes view before printing", async () => {
+    const order: string[] = [];
+
+    await exportNoteAsPdf("Weekly sync", {
+      showNotes: async () => {
+        order.push("show notes");
+      },
+      waitForPaint: () => {
+        order.push("paint");
+      },
+      print: () => {
+        order.push("print");
+      },
+    });
+
+    expect(order).toEqual(["show notes", "paint", "print"]);
   });
 });

--- a/src/test/note-pdf.test.ts
+++ b/src/test/note-pdf.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { exportNoteAsPdf } from "../lib/note-pdf";
+
+describe("note PDF export", () => {
+  it("uses the note title while opening the print sheet and restores the app title", () => {
+    document.title = "June";
+    const print = vi.fn(() => expect(document.title).toBe("Weekly sync"));
+
+    exportNoteAsPdf("  Weekly sync  ", print);
+
+    expect(print).toHaveBeenCalledTimes(1);
+    expect(document.title).toBe("June");
+  });
+
+  it("uses a readable filename for untitled notes", () => {
+    const print = vi.fn(() => expect(document.title).toBe("Meeting notes"));
+
+    exportNoteAsPdf("   ", print);
+  });
+});


### PR DESCRIPTION
Closes JUN-252

## What changed
- add an **Export as PDF** action to the note overflow menu
- invoke native Tauri webview printing so macOS opens the real print sheet
- switch from Transcription to the formatted Notes view before printing
- reset the full note detail scroll chain so long notes paginate without clipping
- use the note title as the default PDF filename and force a light print color scheme
- cover menu invocation, title restoration, and the notes-before-print sequence with tests

## Why
Meeting notes need a portable, printable format for downloading and sharing. Tauri native webview printing provides the macOS Save as PDF workflow without adding a PDF rendering dependency.

## Validation
- `pnpm test` (full frontend suite passed before review fixes)
- `pnpm exec vitest run src/test/note-pdf.test.ts src/test/agent-note-entry-points.test.ts` (14 tests passed after review fixes)
- `pnpm build`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked print_current_webview --no-default-features`
- `cargo build --manifest-path src-tauri/Cargo.toml --locked --no-default-features`
- CI Biome, repository hygiene, security, and automated review checks

## Live native walkthrough
PASS: launched a uniquely identified debug Tauri app with local development credentials sourced from the existing environment. Created a formatted meeting note, opened Transcription, selected Export as PDF, verified June switched back to Notes, and observed the native macOS print sheet with the formatted note preview.

QA video: https://app.opensoftware.co/api/v1/files/fil_XN6augtac54l/download

## Known gaps
- The walkthrough used a one-page note. Long-note pagination is covered by resetting `.note-detail-scroll` and all ancestor overflow constraints, but was not recorded as a multi-page print preview.