### PR TITLE
Hide June video from MCP server settings

### DIFF
--- a/src/lib/hermes-admin/mcp-servers-view.ts
+++ b/src/lib/hermes-admin/mcp-servers-view.ts
@@ -28,6 +28,7 @@ export const INTERNAL_MCP_SERVER_NAMES = [
   "june_context",
   "june_web",
   "june_image",
+  "june_video",
   "june_recorder",
 ] as const;
 

--- a/src/test/mcp-servers.test.tsx
+++ b/src/test/mcp-servers.test.tsx
@@ -143,6 +143,7 @@ describe("mcp servers — view logic", () => {
   });
 
   it("hides June-owned internal MCP servers from user-managed lists", () => {
+    expect(INTERNAL_MCP_SERVER_NAMES).toContain("june_video");
     const servers = [
       ...INTERNAL_MCP_SERVER_NAMES.map((name) =>
         serverFromWire({


### PR DESCRIPTION
Closes JUN-259

## What changed
- classify `june_video` as a June-owned internal MCP server
- add a regression assertion to the MCP server filtering suite

## Why
The built-in video server is an implementation detail, but it was rendered in Settings > MCP servers as if users could manage it. The original Issue description referenced the wrong Centaur surface; this PR implements the clarified June app behavior.

## Validation
- `pnpm test -- src/test/mcp-servers.test.tsx` (56 passed)
- `pnpm run typecheck`
- `pnpm build`
- `pnpm run check` (completed with existing unrelated warnings; changed files clean)

## Live walkthrough
Skipped a browser/native walkthrough because the behavior is a pure centralized list filter covered by the rendered MCP component suite, and a web preview would require a temporary Tauri IPC harness. No native behavior or layout changed.

## Gaps
- No live Hermes runtime was needed or exercised.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786389217&installation_id=144203540&pr_number=708&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F708&signature=31f233b95909d0636b7c1a1eb8eb46e00c19731528b2ba834258f9347cdfae97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->