### PR TITLE
Add a show-thinking display toggle for agent chats (JUN-246)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -266,6 +266,7 @@ pub fn run() {
             providers::clear_venice_api_key,
             providers::set_image_safe_mode,
             providers::set_image_safe_mode_prompt_dismissed,
+            providers::set_show_thinking,
             image_safety::image_prompt_may_be_explicit,
             providers::generate_image,
             providers::edit_image,

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -98,6 +98,12 @@ pub struct ProviderModelSettings {
     /// carry an incidental `false` the user never picked.
     #[serde(default)]
     pub image_safe_mode_set_by_user: bool,
+    /// When true, the agent chat shows the model's thinking as a collapsible
+    /// disclosure. Display-only: turning it off hides the reasoning output
+    /// but does not change what the model does. Defaulted so settings files
+    /// predating this field still deserialize to the current default (on).
+    #[serde(default = "default_show_thinking")]
+    pub show_thinking: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -126,6 +132,7 @@ pub struct ProviderModelSettingsDto {
     pub local_generation: LocalGenerationSettings,
     pub image_safe_mode: bool,
     pub image_safe_mode_prompt_dismissed: bool,
+    pub show_thinking: bool,
 }
 
 impl From<&ProviderModelSettings> for ProviderModelSettingsDto {
@@ -145,6 +152,7 @@ impl From<&ProviderModelSettings> for ProviderModelSettingsDto {
             local_generation: settings.local_generation.clone(),
             image_safe_mode: settings.image_safe_mode,
             image_safe_mode_prompt_dismissed: settings.image_safe_mode_prompt_dismissed,
+            show_thinking: settings.show_thinking,
         }
     }
 }
@@ -491,6 +499,24 @@ fn set_image_safe_mode_impl(
         if request.enabled {
             settings.image_safe_mode_prompt_dismissed = false;
         }
+    })
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SetShowThinkingRequest {
+    pub enabled: bool,
+}
+
+/// Persists whether the agent chat displays the model's thinking. On by
+/// default; display-only, so it never changes the request sent to the model.
+#[tauri::command]
+pub fn set_show_thinking(
+    state: State<'_, ProviderSettingsState>,
+    request: SetShowThinkingRequest,
+) -> Result<ProviderModelSettingsDto, AppError> {
+    update_settings(&state, |settings| {
+        settings.show_thinking = request.enabled;
     })
 }
 
@@ -1033,6 +1059,7 @@ fn default_settings() -> ProviderModelSettings {
         image_safe_mode: true,
         image_safe_mode_prompt_dismissed: false,
         image_safe_mode_set_by_user: false,
+        show_thinking: true,
     }
 }
 
@@ -1061,6 +1088,10 @@ fn default_video_model() -> String {
 }
 
 fn default_image_safe_mode() -> bool {
+    true
+}
+
+fn default_show_thinking() -> bool {
     true
 }
 
@@ -1137,6 +1168,7 @@ fn sanitize_settings(
         image_safe_mode,
         image_safe_mode_prompt_dismissed: settings.image_safe_mode_prompt_dismissed,
         image_safe_mode_set_by_user: settings.image_safe_mode_set_by_user,
+        show_thinking: settings.show_thinking,
     }
 }
 
@@ -1506,6 +1538,30 @@ mod tests {
         assert!(settings.image_safe_mode);
         assert!(!settings.image_safe_mode_prompt_dismissed);
         assert!(!settings.image_safe_mode_set_by_user);
+    }
+
+    #[test]
+    fn provider_settings_default_show_thinking_on_and_persist_an_explicit_off() {
+        // A settings file written before the field existed reads as on...
+        let legacy = serde_json::from_value::<ProviderModelSettings>(serde_json::json!({
+            "transcriptionProvider": "venice",
+            "transcriptionModel": "nvidia/parakeet-tdt-0.6b-v3",
+            "generationModel": "zai-org-glm-5-2",
+            "imageModel": "venice-sd35"
+        }))
+        .unwrap();
+        assert!(sanitize_settings(legacy, &default_settings()).show_thinking);
+
+        // ...while an explicit off survives the load-time sanitize pass.
+        let opted_out = serde_json::from_value::<ProviderModelSettings>(serde_json::json!({
+            "transcriptionProvider": "venice",
+            "transcriptionModel": "nvidia/parakeet-tdt-0.6b-v3",
+            "generationModel": "zai-org-glm-5-2",
+            "imageModel": "venice-sd35",
+            "showThinking": false
+        }))
+        .unwrap();
+        assert!(!sanitize_settings(opted_out, &default_settings()).show_thinking);
     }
 
     #[test]

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2446,6 +2446,10 @@ export function AgentWorkspace({
   // null until the persisted value loads: reasoning stays hidden during that
   // window so a saved opt-out is never flashed before settings resolve.
   const [showThinkingSetting, setShowThinkingSetting] = useState<boolean | null>(null);
+  // True once the live settings-toggle event has delivered a value. That value
+  // comes from the persisted write that just completed, so it is strictly newer
+  // than any settings fetch already in flight - those must not overwrite it.
+  const showThinkingLiveRef = useRef(false);
   const showThinking = showThinkingSetting === true;
   const [workingTaskIds, setWorkingTaskIds] = useState<Set<string>>(() => new Set());
   const activityStoreVersion = useSyncExternalStore(
@@ -3592,7 +3596,9 @@ export function AgentWorkspace({
       setGenerationProvider(provider);
       defaultGenerationModelIdRef.current = selectedModelId;
       setDefaultGenerationModelId(selectedModelId);
-      setShowThinkingSetting(settings.showThinking ?? true);
+      if (!showThinkingLiveRef.current) {
+        setShowThinkingSetting(settings.showThinking ?? true);
+      }
       return selectedModelId;
     },
     [],
@@ -3670,7 +3676,9 @@ export function AgentWorkspace({
   useEffect(() => {
     function handleShowThinkingChanged(event: Event) {
       const detail = (event as CustomEvent<ShowThinkingChangedDetail>).detail;
-      if (detail) setShowThinkingSetting(detail.enabled);
+      if (!detail) return;
+      showThinkingLiveRef.current = true;
+      setShowThinkingSetting(detail.enabled);
     }
     window.addEventListener(SHOW_THINKING_CHANGED_EVENT, handleShowThinkingChanged);
     return () => {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -242,6 +242,10 @@ import {
   MODEL_SWITCH_DEFAULT_ONLY_NOTICE,
 } from "../../lib/hermes-model-switch";
 import {
+  SHOW_THINKING_CHANGED_EVENT,
+  type ShowThinkingChangedDetail,
+} from "../../lib/show-thinking-settings";
+import {
   LOCAL_GENERATION_OPTION_ID_PREFIX,
   isLoopbackUrl,
   localGenerationOptionId,
@@ -2437,6 +2441,9 @@ export function AgentWorkspace({
     () => continuity?.liveEvents ?? {},
   );
   const [thinkingOpenByKey, setThinkingOpenByKey] = useState<Record<string, boolean>>({});
+  // Whether the chat displays the model's thinking (JUN-246). Display-only;
+  // synced from provider settings on load and live from the settings toggle.
+  const [showThinking, setShowThinkingState] = useState(true);
   const [workingTaskIds, setWorkingTaskIds] = useState<Set<string>>(() => new Set());
   const activityStoreVersion = useSyncExternalStore(
     hermesActivityStore.subscribe,
@@ -3582,6 +3589,7 @@ export function AgentWorkspace({
       setGenerationProvider(provider);
       defaultGenerationModelIdRef.current = selectedModelId;
       setDefaultGenerationModelId(selectedModelId);
+      setShowThinkingState(settings.showThinking ?? true);
       return selectedModelId;
     },
     [],
@@ -3652,6 +3660,17 @@ export function AgentWorkspace({
       );
     };
   }, [loadGenerationModel]);
+
+  useEffect(() => {
+    function handleShowThinkingChanged(event: Event) {
+      const detail = (event as CustomEvent<ShowThinkingChangedDetail>).detail;
+      if (detail) setShowThinkingState(detail.enabled);
+    }
+    window.addEventListener(SHOW_THINKING_CHANGED_EVENT, handleShowThinkingChanged);
+    return () => {
+      window.removeEventListener(SHOW_THINKING_CHANGED_EVENT, handleShowThinkingChanged);
+    };
+  }, []);
 
   useEffect(() => {
     if (composerModelLocked) setComposerModelOpen(false);
@@ -9620,6 +9639,7 @@ export function AgentWorkspace({
             onEnable: () => void enableCliAccessFromChat(),
           }}
           thinkingOpen={thinkingOpen}
+          showThinking={showThinking}
           onThinkingOpenChange={setThinkingOpen}
           onDownloadArtifact={downloadArtifact}
           onOpenArtifact={openArtifact}
@@ -9736,6 +9756,7 @@ export function AgentWorkspace({
               onEnable: () => void enableCliAccessFromChat(),
             }}
             thinkingOpen={thinkingOpen}
+            showThinking={showThinking}
             onThinkingOpenChange={setThinkingOpen}
             onDownloadArtifact={downloadArtifact}
             onOpenArtifact={openArtifact}
@@ -11473,6 +11494,7 @@ function AgentChatTurnRow({
   secretSubmitting,
   cliAccess,
   thinkingOpen,
+  showThinking = true,
   onApproval,
   onClarify,
   onSudo,
@@ -11503,6 +11525,9 @@ function AgentChatTurnRow({
    * Optional so the dev gallery can render rows without the live setting. */
   cliAccess?: AgentCliAccessCardProps;
   thinkingOpen: (key: string) => boolean;
+  /** Whether the Thinking disclosure renders at all (the user's display
+   * preference). Default on; the dev gallery omits it. */
+  showThinking?: boolean;
   onApproval: (
     part: Extract<AgentChatPart, { type: "approval" }>,
     choice: AgentApprovalChoice,
@@ -11595,6 +11620,14 @@ function AgentChatTurnRow({
     (part): part is Extract<AgentChatPart, { type: "context" }> => part.type === "context",
   );
   const nonTextParts = turn.parts.filter((part) => part.type !== "text");
+  // With the thinking display off, a reasoning-only turn has nothing visible:
+  // while running it shows the plain "Thinking…" shimmer instead (so the app
+  // never looks stalled mid-reasoning), and once finished it renders nothing.
+  const hiddenThinkingOnly =
+    !showThinking &&
+    textParts.length === 0 &&
+    nonTextParts.length > 0 &&
+    nonTextParts.every((part) => part.type === "reasoning");
   const concreteResponse = turnIsConcreteResponse(turn);
   const copyText = copyableTextForTurn(turn);
 
@@ -11727,7 +11760,7 @@ function AgentChatTurnRow({
   return (
     <article className="agent-assistant-turn" data-status={turn.status}>
       <div className="agent-assistant-turn-body">
-        {reasoningParts.length > 0 ? (
+        {showThinking && reasoningParts.length > 0 ? (
           <AgentThinkingGroup
             reasoning={reasoningParts}
             running={thinkingRunning}
@@ -11825,11 +11858,12 @@ function AgentChatTurnRow({
           onDownload={onDownloadArtifact}
           onOpen={onOpenArtifact}
         />
-        {textParts.length === 0 && nonTextParts.length === 0 ? (
+        {(textParts.length === 0 && nonTextParts.length === 0) ||
+        (hiddenThinkingOnly && thinkingRunning) ? (
           <p className="agent-assistant-empty">
             <span className="text-shimmer shimmer">Thinking…</span>
           </p>
-        ) : (
+        ) : hiddenThinkingOnly ? null : (
           // No actions on an empty/in-flight turn. There is nothing useful to
           // copy or fork from yet.
           turnActions

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2443,7 +2443,10 @@ export function AgentWorkspace({
   const [thinkingOpenByKey, setThinkingOpenByKey] = useState<Record<string, boolean>>({});
   // Whether the chat displays the model's thinking (JUN-246). Display-only;
   // synced from provider settings on load and live from the settings toggle.
-  const [showThinking, setShowThinkingState] = useState(true);
+  // null until the persisted value loads: reasoning stays hidden during that
+  // window so a saved opt-out is never flashed before settings resolve.
+  const [showThinkingSetting, setShowThinkingSetting] = useState<boolean | null>(null);
+  const showThinking = showThinkingSetting === true;
   const [workingTaskIds, setWorkingTaskIds] = useState<Set<string>>(() => new Set());
   const activityStoreVersion = useSyncExternalStore(
     hermesActivityStore.subscribe,
@@ -3589,7 +3592,7 @@ export function AgentWorkspace({
       setGenerationProvider(provider);
       defaultGenerationModelIdRef.current = selectedModelId;
       setDefaultGenerationModelId(selectedModelId);
-      setShowThinkingState(settings.showThinking ?? true);
+      setShowThinkingSetting(settings.showThinking ?? true);
       return selectedModelId;
     },
     [],
@@ -3620,6 +3623,9 @@ export function AgentWorkspace({
         defaultGenerationModelIdRef.current = "";
         generationModelsRef.current = [];
         setDefaultGenerationModelId("");
+        // The persisted preference is unreadable; fall back to the product
+        // default (thinking shown) rather than hiding reasoning forever.
+        setShowThinkingSetting((current) => current ?? true);
       }
       return null;
     }
@@ -3664,7 +3670,7 @@ export function AgentWorkspace({
   useEffect(() => {
     function handleShowThinkingChanged(event: Event) {
       const detail = (event as CustomEvent<ShowThinkingChangedDetail>).detail;
-      if (detail) setShowThinkingState(detail.enabled);
+      if (detail) setShowThinkingSetting(detail.enabled);
     }
     window.addEventListener(SHOW_THINKING_CHANGED_EVENT, handleShowThinkingChanged);
     return () => {

--- a/src/components/settings/AgentSettingsSection.tsx
+++ b/src/components/settings/AgentSettingsSection.tsx
@@ -15,6 +15,7 @@ import {
   agentHudHide,
   agentHudShow,
   juneCharacter,
+  providerModelSettings,
   revealPath,
   setHermesAgentCliAccess,
   setJuneCharacter,
@@ -29,6 +30,7 @@ import {
   setAgentHudEnabled,
   type AgentHudVisibilityChangedDetail,
 } from "../../lib/agent-hud-settings";
+import { saveShowThinking } from "../../lib/show-thinking-settings";
 import { withTimeout } from "../../lib/async-timeout";
 import {
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE,
@@ -74,6 +76,9 @@ export function AgentSettingsSection({
   // default for a setting with security weight.
   const [cliAccessEnabled, setCliAccessEnabled] = useState<boolean | null>(null);
   const [cliAccessSaving, setCliAccessSaving] = useState(false);
+  // null until provider settings load, so the switch never flashes a default.
+  const [showThinkingEnabled, setShowThinkingEnabled] = useState<boolean | null>(null);
+  const [showThinkingSaving, setShowThinkingSaving] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -84,10 +89,30 @@ export function AgentSettingsSection({
       .catch((err: unknown) => {
         if (!cancelled) setError(messageFromError(err));
       });
+    providerModelSettings()
+      .then((response) => {
+        if (!cancelled) setShowThinkingEnabled(response.settings.showThinking);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(messageFromError(err));
+      });
     return () => {
       cancelled = true;
     };
   }, []);
+
+  async function handleShowThinkingChange(enabled: boolean) {
+    setShowThinkingSaving(true);
+    try {
+      const settings = await saveShowThinking(enabled);
+      setShowThinkingEnabled(settings.showThinking);
+      setError(null);
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setShowThinkingSaving(false);
+    }
+  }
 
   async function handleCliAccessChange(enabled: boolean) {
     setCliAccessSaving(true);
@@ -338,6 +363,23 @@ export function AgentSettingsSection({
                   checked={agentHudEnabled}
                   onCheckedChange={(enabled) => void handleAgentHudEnabledChange(enabled)}
                   aria-label="Show sessions HUD"
+                />
+              </div>
+            </div>
+            <div className="settings-row">
+              <div className="settings-row-info">
+                <h3 className="settings-row-title">Show thinking</h3>
+                <p className="settings-row-description">
+                  Show the model's thinking in agent chats. Hiding it only changes what you see, not
+                  how the model works.
+                </p>
+              </div>
+              <div className="settings-row-control">
+                <Switch
+                  checked={showThinkingEnabled === true}
+                  disabled={showThinkingEnabled === null || showThinkingSaving}
+                  onCheckedChange={(enabled) => void handleShowThinkingChange(enabled)}
+                  aria-label="Show thinking in agent chats"
                 />
               </div>
             </div>

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -252,6 +252,8 @@ const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
   // On by default, matching the Rust providers default.
   imageSafeMode: true,
   imageSafeModePromptDismissed: false,
+  // On by default, matching the Rust providers default.
+  showThinking: true,
 };
 
 const MIC_TEST_DURATION_SECONDS = 5;

--- a/src/lib/show-thinking-settings.ts
+++ b/src/lib/show-thinking-settings.ts
@@ -1,0 +1,20 @@
+import { setShowThinking, type ProviderModelSettingsDto } from "./tauri";
+
+export const SHOW_THINKING_CHANGED_EVENT = "june:show-thinking-changed";
+
+export type ShowThinkingChangedDetail = {
+  enabled: boolean;
+};
+
+/** Persists the show-thinking display preference and broadcasts the change so
+ * open chat surfaces re-render without refetching settings. Display-only: it
+ * never changes what the model does. */
+export async function saveShowThinking(enabled: boolean): Promise<ProviderModelSettingsDto> {
+  const settings = await setShowThinking(enabled);
+  window.dispatchEvent(
+    new CustomEvent<ShowThinkingChangedDetail>(SHOW_THINKING_CHANGED_EVENT, {
+      detail: { enabled: settings.showThinking },
+    }),
+  );
+  return settings;
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -194,6 +194,9 @@ export type ProviderModelSettingsDto = {
   imageSafeMode: boolean;
   /** Whether the user chose "don't ask again" on the safe-mode consent dialog. */
   imageSafeModePromptDismissed: boolean;
+  /** Whether the agent chat shows the model's thinking. Display-only; it does
+   * not change what the model does. On by default. */
+  showThinking: boolean;
 };
 
 export type LocalGenerationSettingsDto = {
@@ -1759,6 +1762,14 @@ export async function setImageSafeMode(enabled: boolean) {
 export async function setImageSafeModePromptDismissed(dismissed: boolean) {
   return invoke<ProviderModelSettingsDto>("set_image_safe_mode_prompt_dismissed", {
     request: { dismissed },
+  });
+}
+
+// Toggles whether the agent chat displays the model's thinking. Display-only:
+// the reasoning still streams and is kept in the transcript, just not shown.
+export async function setShowThinking(enabled: boolean) {
+  return invoke<ProviderModelSettingsDto>("set_show_thinking", {
+    request: { enabled },
   });
 }
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6715,6 +6715,72 @@ describe("AgentWorkspace", () => {
     ).toBeInTheDocument();
   });
 
+  it("never flashes reasoning that streams before a saved opt-out resolves", async () => {
+    // The settings load is held open so reasoning arrives while the persisted
+    // preference is still unknown; the disclosure must not appear in that
+    // window, and the late showThinking:false keeps it hidden.
+    let resolveSettings: (value: unknown) => void = () => {};
+    mocks.providerModelSettings.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSettings = resolve;
+      }),
+    );
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "think before settings load",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "think before settings load",
+      }),
+    );
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "thinking.delta",
+          session_id: "runtime-session-2",
+          payload: { delta: "Early reasoning before settings resolve." },
+        });
+      }
+    });
+
+    // While the preference is unresolved, only the plain shimmer shows.
+    await waitFor(() => expect(screen.getByText("Thinking…")).toBeInTheDocument());
+    expect(screen.queryByText("Thinking")).toBeNull();
+    expect(screen.queryByText("Early reasoning before settings resolve.")).toBeNull();
+
+    act(() => {
+      resolveSettings({
+        settings: {
+          transcriptionProvider: "venice",
+          transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+          generationModel: "zai-org-glm-5-2",
+          showThinking: false,
+        },
+      });
+    });
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "message.complete",
+          session_id: "runtime-session-2",
+          payload: { text: "Done." },
+        });
+      }
+    });
+
+    expect(await screen.findByText("Done.")).toBeInTheDocument();
+    expect(screen.queryByText("Thought")).toBeNull();
+    expect(screen.queryByText("Early reasoning before settings resolve.")).toBeNull();
+  });
+
   it("does not force the transcript to the bottom while subagent progress streams", async () => {
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -22,6 +22,10 @@ import {
   PROVIDER_MODEL_SETTINGS_CHANGED_EVENT,
 } from "../lib/model-privacy";
 import { HermesGatewayError } from "../lib/hermes-gateway";
+import {
+  SHOW_THINKING_CHANGED_EVENT,
+  type ShowThinkingChangedDetail,
+} from "../lib/show-thinking-settings";
 import { AGENT_SESSION_STATUS_EVENT, type AgentSessionStatusDetail } from "../lib/agent-events";
 import { classifyHermesEvent } from "../lib/hermes-control-plane";
 import { hermesActivityStore, type AgentActivityRecord } from "../lib/hermes-activity-store";
@@ -6638,6 +6642,77 @@ describe("AgentWorkspace", () => {
     expect(thoughtDetails).toHaveClass("agent-reasoning");
     expect(thoughtDetails).not.toContainElement(toolLabel);
     expect(await screen.findByText("Done.")).toBeInTheDocument();
+  });
+
+  it("hides the thinking disclosure when the show-thinking preference is off", async () => {
+    mocks.providerModelSettings.mockResolvedValue({
+      settings: {
+        transcriptionProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "zai-org-glm-5-2",
+        showThinking: false,
+      },
+    });
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "think quietly",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "think quietly",
+      }),
+    );
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "thinking.delta",
+          session_id: "runtime-session-2",
+          payload: { delta: "Checking the project state." },
+        });
+      }
+    });
+
+    // With the preference off, streamed reasoning renders as the plain
+    // "Thinking…" shimmer instead of the disclosure, and never leaks its text.
+    await waitFor(() => expect(screen.getByText("Thinking…")).toBeInTheDocument());
+    expect(screen.queryByText("Thinking")).toBeNull();
+    expect(screen.queryByText("Checking the project state.")).toBeNull();
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "message.complete",
+          session_id: "runtime-session-2",
+          payload: { text: "Done." },
+        });
+      }
+    });
+
+    expect(await screen.findByText("Done.")).toBeInTheDocument();
+    expect(screen.queryByText("Thought")).toBeNull();
+
+    // The preference is display-only: the reasoning stayed in the transcript,
+    // so flipping the setting back on reveals the completed disclosure live.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent<ShowThinkingChangedDetail>(SHOW_THINKING_CHANGED_EVENT, {
+          detail: { enabled: true },
+        }),
+      );
+    });
+    expect(await screen.findByText("Thought")).toBeInTheDocument();
+    expect(
+      within(screen.getByText("Thought").closest("details") as HTMLElement).getByText(
+        "Checking the project state.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("does not force the transcript to the bottom while subagent progress streams", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6781,6 +6781,73 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByText("Early reasoning before settings resolve.")).toBeNull();
   });
 
+  it("keeps a live toggle-off from being overwritten by a stale settings response", async () => {
+    // The mount-time settings fetch is held open past a live toggle: its stale
+    // showThinking:true must not clobber the newer opt-out the settings switch
+    // just broadcast after persisting.
+    let resolveSettings: (value: unknown) => void = () => {};
+    mocks.providerModelSettings.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSettings = resolve;
+      }),
+    );
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "race the settings fetch",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "race the settings fetch",
+      }),
+    );
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "thinking.delta",
+          session_id: "runtime-session-2",
+          payload: { delta: "Reasoning the user opted out of seeing." },
+        });
+        handler({
+          type: "message.complete",
+          session_id: "runtime-session-2",
+          payload: { text: "Done." },
+        });
+      }
+    });
+    expect(await screen.findByText("Done.")).toBeInTheDocument();
+
+    // The user turns thinking off while the mount fetch is still in flight.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent<ShowThinkingChangedDetail>(SHOW_THINKING_CHANGED_EVENT, {
+          detail: { enabled: false },
+        }),
+      );
+    });
+    expect(screen.queryByText("Thought")).toBeNull();
+
+    // The stale response (thinking on) lands afterwards and must lose.
+    await act(async () => {
+      resolveSettings({
+        settings: {
+          transcriptionProvider: "venice",
+          transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+          generationModel: "zai-org-glm-5-2",
+          showThinking: true,
+        },
+      });
+    });
+    expect(screen.queryByText("Thought")).toBeNull();
+    expect(screen.queryByText("Reasoning the user opted out of seeing.")).toBeNull();
+  });
+
   it("does not force the transcript to the bottom while subagent progress streams", async () => {
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,


### PR DESCRIPTION
A new "Show thinking" switch in Settings -> Agent controls whether the chat renders the model's reasoning as the collapsible Thinking/Thought disclosure. Display-only: reasoning still streams and stays in the transcript, so re-enabling reveals past thinking instantly via a window event open chats listen to. While reasoning streams with the display off, the plain "Thinking..." shimmer keeps the turn visibly alive.

Persisted as show_thinking on ProviderModelSettings (the image_safe_mode pattern), serde-defaulted to on so settings files from older builds keep today's behavior.

## Summary

-

## Root cause

<!-- Bug fixes only: what actually caused the bug (not just the symptom).
     Delete this section for non-bug PRs. -->

## Validation

-

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- check if yes; say which change -->

## Out of scope

<!-- What this PR deliberately does NOT do (related work left untouched, on purpose). -->

## Followups

<!-- Follow-up work this PR sets up or defers; link issues where possible. -->

## Security and release checklist

- [ ] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [ ] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [ ] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786509276&installation_id=144203540&pr_number=711&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F711&signature=d652046a761bd515cd0a0763021cdcdcbd1a480a64b948057ed18619446628af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->