### PR TITLE
Staging domain parity, make dev-staging, ephemeral Phala CVMs (JUN-247)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 
 # --- June API -------------------------------------------------------------
 # Local development default is http://127.0.0.1:8080 when unset.
-# Use this to point the desktop app at local/staging June API.
+# Staging is https://june-api-staging.opensoftware.co.
 JUNE_API_URL=http://127.0.0.1:8080
 
 # Open source local mode. The desktop app uses this bearer token instead of
@@ -37,6 +37,9 @@ VENICE_GENERATION_MODEL=zai-org-glm-5-2
 # Staging example:
 #   OS_ACCOUNTS_URL=https://os-accounts-portal-staging.up.railway.app
 #   OS_ACCOUNTS_API_URL=https://os-accounts-api-staging.up.railway.app
+# `make dev-staging` overrides both URLs. Set the staging OS_ACCOUNTS_CLIENT_ID
+# (format: ocl_...) here or in the shell for login to work.
+# Set OS_JUNE_DEV_PLAINTEXT_TOKEN_STORE=1 to avoid repeated Keychain prompts in dev.
 OS_ACCOUNTS_URL=
 OS_ACCOUNTS_API_URL=
 # OAuth client id issued by the OS Accounts admin console (format: ocl_...).

--- a/.github/workflows/build-june-api.yml
+++ b/.github/workflows/build-june-api.yml
@@ -110,6 +110,11 @@ jobs:
           image-ref: ${{ env.IMAGE }}:${{ needs.build.outputs.sha_short }}
           api-key: ${{ secrets.PHALA_CLOUD_API_KEY }}
 
+      # Ordering mirrors promote-june-api.yml: verify before the digest
+      # record, so a broken ingress fails the run. A verify failure therefore
+      # skips the record for a deploy that DID happen; the record is
+      # create-once, so re-running this job after the ingress recovers fills
+      # it in safely.
       - name: Verify public endpoint after deploy
         if: steps.deploy.outputs.deployed == 'true'
         run: |

--- a/.github/workflows/build-june-api.yml
+++ b/.github/workflows/build-june-api.yml
@@ -110,6 +110,27 @@ jobs:
           image-ref: ${{ env.IMAGE }}:${{ needs.build.outputs.sha_short }}
           api-key: ${{ secrets.PHALA_CLOUD_API_KEY }}
 
+      - name: Verify public endpoint after deploy
+        if: steps.deploy.outputs.deployed == 'true'
+        run: |
+          set -euo pipefail
+          base="https://june-api-staging.opensoftware.co"
+          # The CVM restarts its containers on update; give the ingress up to
+          # 10 minutes to come back before judging the deploy.
+          code=""
+          for _ in $(seq 1 60); do
+            # `|| true`, not `|| echo`: curl prints its own %{http_code} (000)
+            # on transport failure, so a fallback echo would corrupt the value.
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$base/healthz" || true)
+            [[ "$code" == "200" ]] && break
+            sleep 10
+          done
+          if [[ "$code" != "200" ]]; then
+            echo "::error::$base/healthz did not return 200 within 10 minutes of the deploy (last: $code)."
+            exit 1
+          fi
+          echo "healthz OK"
+
       # Anchor "b": record that commit <sha> deployed image digest <D> as an
       # annotated git tag. Gives a verifier an in-repo, immutable link from the
       # attested tag to a content digest, without trusting the registry's

--- a/.github/workflows/promote-june-api.yml
+++ b/.github/workflows/promote-june-api.yml
@@ -128,9 +128,9 @@ jobs:
           image-ref: ${{ env.IMAGE }}:${{ steps.image.outputs.sha_short }}
           api-key: ${{ secrets.PHALA_CLOUD_API_KEY }}
 
-      # The public endpoint is the only place the dstack-ingress container can
-      # be exercised (staging has no ingress), so check it before accepting
-      # the promote: a broken ingress boot would otherwise surface only via
+      # Staging exercises the same ingress stack before promote, but production
+      # must still pass its own public endpoint check before accepting the
+      # promote: a broken production ingress boot would otherwise surface via
       # the 30-minute watchdog. Runs before the retag/record steps so a
       # failure fails the promotion and leaves :production on the last-good
       # digest. Deeper checks (e.g. body-size probes after an ingress change)

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ coverage
 .claude/worktrees/
 .worktrees/
 
-# Ephemeral Phala CVM state (holds a per-run bearer token; mode 600)
-.ephemeral-june-api.json
+# Ephemeral Phala CVM state (holds a per-run bearer token; mode 600).
+# The glob also covers write_state's atomic-rename temps (.json.XXXXXX).
+.ephemeral-june-api.json*

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ coverage
 # Agent worktrees
 .claude/worktrees/
 .worktrees/
+
+# Ephemeral Phala CVM state (holds a per-run bearer token; mode 600)
+.ephemeral-june-api.json

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # and the desktop app together locally; production builds use `pnpm tauri:build`.
 .PHONY: help install \
 	dev dev-staging dev-api \
+	ephemeral-api ephemeral-api-down dev-with-ephemeral-api \
 	check format typecheck test-web \
 	tauri-fmt tauri-fmt-check tauri-lint tauri-test \
 	june-api-fmt june-api-fmt-check june-api-lint june-api-test \
@@ -42,6 +43,20 @@ dev-staging:  ## Run the desktop app against staging June API (real OS Accounts 
 
 dev-api:  ## Run only june-api locally on :8080 (loads june-api/.env)
 	cd june-api && cargo run
+
+# Ephemeral Phala CVM: the working-tree june-api inside a real TEE, on demand.
+# Cost model: tdx.small bills $0.058/hr from creation until you delete it, and
+# the ttl.sh image tag expires after 4h (the CVM keeps running, but a restart
+# past expiry cannot re-pull the image). `dev-with-ephemeral-api` always deletes
+# the CVM on exit; the other two leave it up, so remember `ephemeral-api-down`.
+ephemeral-api:  ## Deploy the working-tree june-api to a disposable Phala CVM
+	./scripts/ephemeral-june-api.sh up
+
+ephemeral-api-down:  ## Delete the ephemeral CVM
+	./scripts/ephemeral-june-api.sh down
+
+dev-with-ephemeral-api:  ## Run the app against a fresh ephemeral CVM; deletes it on exit
+	./scripts/ephemeral-june-api.sh dev
 
 # --- Frontend (src/, scripts/) ---
 check:  ## Biome check (format + lint, incl. the lucide ban)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # `make verify` locally should mean green CI. Use `make dev` to run june-api
 # and the desktop app together locally; production builds use `pnpm tauri:build`.
 .PHONY: help install \
-	dev dev-api \
+	dev dev-staging dev-api \
 	check format typecheck test-web \
 	tauri-fmt tauri-fmt-check tauri-lint tauri-test \
 	june-api-fmt june-api-fmt-check june-api-lint june-api-test \
@@ -30,6 +30,15 @@ install:  ## Install frontend deps (Rust builds via cargo)
 # one command.
 dev:  ## Run the desktop app + june-api together (Ctrl-C stops both)
 	pnpm tauri:dev
+
+# Uses real staging OS Accounts login; the local-dev bearer does not work against staging.
+dev-staging:  ## Run the desktop app against staging June API (real OS Accounts login)
+	JUNE_API_URL=https://june-api-staging.opensoftware.co \
+		OS_JUNE_LOCAL_DEV=0 \
+		OS_ACCOUNTS_URL=https://os-accounts-portal-staging.up.railway.app \
+		OS_ACCOUNTS_API_URL=https://os-accounts-api-staging.up.railway.app \
+		JUNE_DEV_SKIP_LOCAL_API=1 \
+		pnpm tauri:dev
 
 dev-api:  ## Run only june-api locally on :8080 (loads june-api/.env)
 	cd june-api && cargo run

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,7 @@ built-in fallback ← `config.toml` ← the **live Venice catalog at boot**.
 
 | Var | Purpose | Default |
 |-----|---------|---------|
-| `JUNE_API_URL` | Backend base URL the app calls | `http://127.0.0.1:8080` |
+| `JUNE_API_URL` | June API base URL the app calls | `https://june-api.opensoftware.co` in code; `.env` (from `.env.example`) sets `http://127.0.0.1:8080` for local dev |
 | `OS_JUNE_LOCAL_DEV` | Use a local bearer token instead of Login with Open Software | `1` (example) |
 | `OS_JUNE_LOCAL_DEV_BEARER_TOKEN` / `_USER_ID` | The local-mode identity | `local-dev-token` / `usr_local_dev` |
 | `OS_ACCOUNTS_URL` / `OS_ACCOUNTS_API_URL` | OS Accounts portal + API (optional in local mode) | unset |

--- a/docs/development.md
+++ b/docs/development.md
@@ -112,9 +112,11 @@ deploys a `tdx.small` CVM, and polls `/healthz` for up to 10 minutes. On
 timeout it exits non-zero and leaves the CVM up and billing, so tear it down
 by hand. `dev-with-ephemeral-api` deploys a fresh CVM, runs `pnpm tauri:dev`
 against it, and always deletes it on exit, whether you quit cleanly, hit
-Ctrl-C, or the run fails after the CVM came up. That is the invariant worth
-remembering: only `dev-with-ephemeral-api` cleans up after itself.
-`ephemeral-api` leaves the CVM running until `ephemeral-api-down`.
+Ctrl-C, close the terminal, or the run fails after the CVM came up. A hard
+kill or power loss can still skip cleanup; `make ephemeral-api-down` recovers
+from the state file, so run it if a session ended abnormally. That is the
+invariant worth remembering: only `dev-with-ephemeral-api` cleans up after
+itself. `ephemeral-api` leaves the CVM running until `ephemeral-api-down`.
 
 Prerequisites: Docker running, the `phala` CLI installed and authenticated
 (`phala auth login`), and a `june-api/.env` holding the upstream provider

--- a/docs/development.md
+++ b/docs/development.md
@@ -93,8 +93,11 @@ container inside the staging CVM. It terminates TLS on 443 and proxies to
 external port of its own.
 
 Phala sealed envs are full-replacement on `phala envs update`: every variable
-must be re-supplied on each update, including the ingress ones. Read the
-comments in `june-api/deploy/docker-compose.staging.yml` before touching them.
+must be re-supplied on each update, including the ingress ones. Seal new
+variables BEFORE deploying a compose that references them; containers boot
+against whatever is already sealed, so the reverse order boots the ingress
+without its Cloudflare credentials. Read the comments in
+`june-api/deploy/docker-compose.staging.yml` before touching them.
 
 ### Ephemeral Phala CVM
 
@@ -150,6 +153,7 @@ up by `ephemeral-api`:
 export JUNE_API_URL="$(jq -r .url .ephemeral-june-api.json)"
 export OS_JUNE_LOCAL_DEV=1
 export OS_JUNE_LOCAL_DEV_BEARER_TOKEN="$(jq -r .token .ephemeral-june-api.json)"
+export JUNE_DEV_SKIP_LOCAL_API=1
 ```
 
 Ephemeral CVMs get no `dstack-ingress` and no custom domain. The dstack

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,7 +21,9 @@ pnpm tauri:dev
 `pnpm tauri:dev` starts Vite and a local June API when their ports are free.
 If `127.0.0.1:1421` or `127.0.0.1:8080` is already listening, the script
 reuses the existing service. Set `VITE_PORT` or `JUNE_API_PORT` to choose a
-different port.
+different port. Set `JUNE_DEV_SKIP_LOCAL_API=1` to skip the local June API
+entirely and leave the port probe alone; the staging and ephemeral targets
+below already do this.
 
 Replay first-run onboarding without wiping all app data:
 
@@ -49,6 +51,107 @@ interface, replace the default local bearer token in both env files first.
 Provider keys and the OS Accounts App API key belong only in `june-api/.env`,
 never in the root desktop `.env`. Add `JUNE__UPSTREAMS__OPENAI__API_KEY` only
 if you want to use OpenAI transcription models.
+
+## Running against hosted June API
+
+Two ways to run the desktop app against a June API in a real TEE instead of
+the local one: the shared staging deployment, or a disposable Phala CVM built
+from your working tree.
+
+### Staging
+
+```sh
+make dev-staging
+```
+
+The target runs `pnpm tauri:dev` with five overrides:
+
+- `JUNE_API_URL=https://june-api-staging.opensoftware.co`
+- `OS_JUNE_LOCAL_DEV=0`
+- `OS_ACCOUNTS_URL=https://os-accounts-portal-staging.up.railway.app`
+- `OS_ACCOUNTS_API_URL=https://os-accounts-api-staging.up.railway.app`
+- `JUNE_DEV_SKIP_LOCAL_API=1`
+
+Process env beats `.env`, so these win even when `.env` selects local mode.
+The target does not set `OS_ACCOUNTS_CLIENT_ID`: put the staging client id
+(`ocl_...`) in `.env` or export it in the shell, or login fails with
+`os_accounts_unconfigured`. You also need an OS Accounts staging account with
+credits, because staging meters every request. Set
+`OS_JUNE_DEV_PLAINTEXT_TOKEN_STORE=1` in a debug build to avoid a Keychain
+prompt on every run.
+
+Auth is a real Login with Open Software against staging OS Accounts. The
+local-dev bearer token does not work: staging June API boots with
+`JUNE__LOCAL_DEV__ENABLED` unset, so it verifies OS Accounts JWTs and charges
+credits. Staging stays JWT-only on purpose. Every June API image soaks there
+before it is promoted to production, so it has to exercise the same auth and
+metering path production runs.
+
+`https://june-api-staging.opensoftware.co` is served by a `dstack-ingress`
+container inside the staging CVM. It terminates TLS on 443 and proxies to
+`june-api:8080` over the internal compose network; the app publishes no
+external port of its own.
+
+Phala sealed envs are full-replacement on `phala envs update`: every variable
+must be re-supplied on each update, including the ingress ones. Read the
+comments in `june-api/deploy/docker-compose.staging.yml` before touching them.
+
+### Ephemeral Phala CVM
+
+Deploy the june-api in your working tree to a disposable Phala CVM, use it,
+delete it. Backed by `scripts/ephemeral-june-api.sh`.
+
+```sh
+make ephemeral-api            # deploy, health-check, print the URL; leaves it up
+make dev-with-ephemeral-api   # deploy, run the app against it, delete on exit
+make ephemeral-api-down       # delete the CVM recorded in the state file
+```
+
+`ephemeral-api` builds june-api for `linux/amd64`, pushes it to `ttl.sh`,
+deploys a `tdx.small` CVM, and polls `/healthz` for up to 10 minutes. On
+timeout it exits non-zero and leaves the CVM up and billing, so tear it down
+by hand. `dev-with-ephemeral-api` deploys a fresh CVM, runs `pnpm tauri:dev`
+against it, and always deletes it on exit, whether you quit cleanly, hit
+Ctrl-C, or the run fails after the CVM came up. That is the invariant worth
+remembering: only `dev-with-ephemeral-api` cleans up after itself.
+`ephemeral-api` leaves the CVM running until `ephemeral-api-down`.
+
+Prerequisites: Docker running, the `phala` CLI installed and authenticated
+(`phala auth login`), and a `june-api/.env` holding the upstream provider
+keys. The script also needs `jq`, `curl`, `openssl`, `perl`, and `uuidgen`. It
+copies `JUNE__UPSTREAMS__VENICE__API_KEY` and `JUNE__UPSTREAMS__OPENAI__API_KEY`
+from `june-api/.env` verbatim; a key that is missing there stays missing, and
+June API drops the models whose provider it cannot reach.
+
+Cost: `tdx.small` bills $0.058/hr from creation until you delete the CVM. The
+image is pushed to `ttl.sh` with a `4h` tag. Tags there expire; the CVM keeps
+running past expiry, but it can no longer re-pull its image, so a restart
+after that point is fatal. Treat an ephemeral CVM as dead once its tag
+expires.
+
+Security: the ttl.sh image is briefly public and carries no secrets. Secrets
+ride Phala sealed env and are injected at boot inside the CVM, and the deploy
+passes `--no-public-logs --no-public-sysinfo`. Auth is local-dev mode with a
+random bearer token minted per run, never printed, and gone when the VM is
+deleted. Local-dev mode replaces JWT verification and disables OS Accounts
+metering, so no OS Accounts App API key ever reaches an ephemeral CVM. There
+is no issue-report key either, so issue reports stay in the CVM logs.
+
+The CVM name, URL, bearer token, image ref, git sha, and creation time land in
+`.ephemeral-june-api.json` (mode 600, gitignored). It is written before the
+deploy starts, because a deploy that dies halfway can still leave a billing
+CVM behind and the state file is the only record of its name. `ephemeral-api`
+refuses to run while that file exists. To point a manual session at a CVM left
+up by `ephemeral-api`:
+
+```sh
+export JUNE_API_URL="$(jq -r .url .ephemeral-june-api.json)"
+export OS_JUNE_LOCAL_DEV=1
+export OS_JUNE_LOCAL_DEV_BEARER_TOKEN="$(jq -r .token .ephemeral-june-api.json)"
+```
+
+Ephemeral CVMs get no `dstack-ingress` and no custom domain. The dstack
+gateway's own HTTPS endpoint for the published port is the only way in.
 
 ## Local data
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ Per-repo config the engineering skills read before acting (see the
 - [telemetry-p3a-implementation-plan.md](telemetry-p3a-implementation-plan.md) — implementation plan for June P3A phases
 - [telemetry-questions.md](telemetry-questions.md) — public P3A question catalog and buckets
 - [configuration.md](configuration.md) — env + config reference (desktop client + June API)
-- [development.md](development.md) — local development: quick start, local data, permissions, agent skills, verification commands
+- [development.md](development.md) — local development: quick start, running against staging or an ephemeral Phala CVM, local data, permissions, agent skills, verification commands
 - [os-accounts-login.md](os-accounts-login.md) — Login with Open Software: PKCE, keychain, account gates
 - [onboarding-design.md](onboarding-design.md) — onboarding flow design (verify against what shipped)
 - ~~os-accounts-backend.md~~ — historical; superseded by `june-api-prd.md`

--- a/june-api/.dockerignore
+++ b/june-api/.dockerignore
@@ -4,3 +4,9 @@ target
 deploy
 **/*.md
 !crates/services/src/prompts/*.md
+# Local env files hold real provider keys. CI checkouts have none, but local
+# `make ephemeral-api` builds do, and the chef/planner stages `COPY . .` -
+# without this they land in the builder cache. Secrets reach a CVM only via
+# Phala sealed env, never via the image.
+.env
+.env.*

--- a/june-api/deploy/docker-compose.ephemeral.yml
+++ b/june-api/deploy/docker-compose.ephemeral.yml
@@ -11,6 +11,11 @@
 # The image comes from ttl.sh, an anonymous registry whose tags expire a few
 # hours after push. The CVM keeps running past expiry, but a restart cannot
 # re-pull the image: treat an ephemeral CVM as dead once its tag expires.
+#
+# The /verify page still renders the packaged config.toml attestation facts
+# (GHCR image repo, production Trust Center); those describe production, not
+# this throwaway build. Its source commit is stamped from the working tree
+# and suffixed "-dirty" when uncommitted changes were baked in.
 services:
   june-api:
     image: ${JUNE_IMAGE}

--- a/june-api/deploy/docker-compose.ephemeral.yml
+++ b/june-api/deploy/docker-compose.ephemeral.yml
@@ -1,0 +1,36 @@
+# Ephemeral June API CVM: a throwaway Phala TEE running the CURRENT june-api
+# working tree, so a developer can exercise a real confidential VM without
+# touching staging. Created by `make ephemeral-api`, deleted by
+# `make ephemeral-api-down` (see scripts/ephemeral-june-api.sh).
+#
+# Auth is local-dev mode, not OS Accounts: the bearer token is generated fresh
+# per run, never printed, and dies with the VM. Hence no OS Accounts refs
+# (local-dev mode replaces JWT auth and metering) and no issue-report key
+# (reports land in the CVM logs).
+#
+# The image comes from ttl.sh, an anonymous registry whose tags expire a few
+# hours after push. The CVM keeps running past expiry, but a restart cannot
+# re-pull the image: treat an ephemeral CVM as dead once its tag expires.
+services:
+  june-api:
+    image: ${JUNE_IMAGE}
+    restart: unless-stopped
+    # Reachable on the dstack gateway URL. Ephemeral VMs get no dstack-ingress
+    # and no custom domain, so the gateway's own HTTPS endpoint for the
+    # published port is the sole entry point.
+    ports:
+      - "8080:8080"
+    volumes:
+      - /var/run/dstack.sock:/var/run/dstack.sock
+    # App secrets are encrypted per-CVM via Phala sealed env (`phala envs`) and
+    # injected at boot by ${VAR} interpolation, so reference each one unquoted.
+    # An empty `KEY: ""` clobbers the sealed value with a blank; omitting the
+    # ref injects nothing. Both leave the app seeing the config as missing.
+    # Docs: https://docs.phala.com/phala-cloud/phala-cloud-user-guides/create-cvm/set-secure-environment-variables
+    environment:
+      - RUST_LOG=june=info,june_api=info,june_services=info,june_providers=info,tower_http=info
+      - JUNE__LOCAL_DEV__ENABLED=${JUNE__LOCAL_DEV__ENABLED}
+      - JUNE__LOCAL_DEV__BEARER_TOKEN=${JUNE__LOCAL_DEV__BEARER_TOKEN}
+      - JUNE__LOCAL_DEV__USER_ID=${JUNE__LOCAL_DEV__USER_ID}
+      - JUNE__UPSTREAMS__VENICE__API_KEY=${JUNE__UPSTREAMS__VENICE__API_KEY}
+      - JUNE__UPSTREAMS__OPENAI__API_KEY=${JUNE__UPSTREAMS__OPENAI__API_KEY}

--- a/june-api/deploy/docker-compose.ephemeral.yml
+++ b/june-api/deploy/docker-compose.ephemeral.yml
@@ -14,8 +14,10 @@
 #
 # The /verify page still renders the packaged config.toml attestation facts
 # (GHCR image repo, production Trust Center); those describe production, not
-# this throwaway build. Its source commit is stamped from the working tree
-# and suffixed "-dirty" when uncommitted changes were baked in.
+# this throwaway build. Source commit: a clean tree stamps the exact HEAD;
+# a dirty tree stamps "<sha>-dirty", which /verify deliberately renders as
+# "not stamped" (short_commit accepts only pure hex) - a dirty build claims
+# no commit rather than a wrong one.
 services:
   june-api:
     image: ${JUNE_IMAGE}

--- a/june-api/deploy/docker-compose.production.yml
+++ b/june-api/deploy/docker-compose.production.yml
@@ -11,7 +11,7 @@ services:
   dstack-ingress:
     image: dstacktee/dstack-ingress:20251013@sha256:fee7a6075a271adb5a5ff72ff3ff49bcb9e22d5f4c9fa68fa683cfb3932f911c
     restart: unless-stopped
-    # Start after the app so the proxy isn't pointed at a cold backend on first
+    # Start after the app so the proxy isn't pointed at a cold June API on first
     # boot. Plain start-ordering, not health-gated: the slim runtime image has no
     # curl/wget for a healthcheck, and restart-policy + the proxy's own retry
     # cover the brief window until june-api binds 8080.

--- a/june-api/deploy/docker-compose.staging.yml
+++ b/june-api/deploy/docker-compose.staging.yml
@@ -24,11 +24,11 @@ services:
       - TARGET_ENDPOINT=http://june-api:8080
       - GATEWAY_DOMAIN=_.${DSTACK_GATEWAY_DOMAIN}
       - SET_CAA=true
-      # nginx's default client_max_body_size (1m) rejected image-edit requests
-      # (multi-MB base64 source image) with an HTML 413 the app cannot parse.
-      # Must stay above june-api's own per-route body caps (the largest is
-      # max_image_edit_bytes, ~67m); june-api still enforces the precise limits.
-      - CLIENT_MAX_BODY_SIZE=80m
+      # nginx's default client_max_body_size (1m) rejects large multipart and
+      # image-edit requests with an HTML 413 the app cannot parse. Keep this
+      # above june-api's largest route cap: issue reports have a 301 MiB total
+      # budget. June API still enforces every route's precise application cap.
+      - CLIENT_MAX_BODY_SIZE=302m
       - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
       - CERTBOT_EMAIL=${CERTBOT_EMAIL}
     volumes:

--- a/june-api/deploy/docker-compose.staging.yml
+++ b/june-api/deploy/docker-compose.staging.yml
@@ -11,7 +11,7 @@ services:
   dstack-ingress:
     image: dstacktee/dstack-ingress:20251013@sha256:fee7a6075a271adb5a5ff72ff3ff49bcb9e22d5f4c9fa68fa683cfb3932f911c
     restart: unless-stopped
-    # Start after the app so the proxy isn't pointed at a cold backend on first
+    # Start after the app so the proxy isn't pointed at a cold June API on first
     # boot. Plain start-ordering, not health-gated: the slim runtime image has no
     # curl/wget for a healthcheck, and restart-policy + the proxy's own retry
     # cover the brief window until june-api binds 8080.

--- a/june-api/deploy/docker-compose.staging.yml
+++ b/june-api/deploy/docker-compose.staging.yml
@@ -1,15 +1,54 @@
 services:
+  # TLS terminator + custom-domain manager for june-api-staging.opensoftware.co.
+  # Terminates HTTPS on 443, auto-provisions the Let's Encrypt cert and the
+  # Cloudflare DNS records (via CLOUDFLARE_API_TOKEN), and reverse-proxies to the
+  # app over the internal compose network (TARGET_ENDPOINT). SET_CAA pins cert
+  # issuance to the TEE's Let's Encrypt account for domain attestation — this
+  # works only because we use a SUBDOMAIN; Cloudflare overrides CAA at the apex.
+  # Digest-pinned per Phala guidance; public docker.io image, pulled anonymously
+  # (independent of the GHCR prelaunch login / DSTACK_DOCKER_REGISTRY).
+  # Docs: https://docs.phala.com/phala-cloud/networking/setup-custom-domain
+  dstack-ingress:
+    image: dstacktee/dstack-ingress:20251013@sha256:fee7a6075a271adb5a5ff72ff3ff49bcb9e22d5f4c9fa68fa683cfb3932f911c
+    restart: unless-stopped
+    # Start after the app so the proxy isn't pointed at a cold backend on first
+    # boot. Plain start-ordering, not health-gated: the slim runtime image has no
+    # curl/wget for a healthcheck, and restart-policy + the proxy's own retry
+    # cover the brief window until june-api binds 8080.
+    depends_on:
+      - june-api
+    ports:
+      - "443:443"
+    environment:
+      - DOMAIN=june-api-staging.opensoftware.co
+      - TARGET_ENDPOINT=http://june-api:8080
+      - GATEWAY_DOMAIN=_.${DSTACK_GATEWAY_DOMAIN}
+      - SET_CAA=true
+      # nginx's default client_max_body_size (1m) rejected image-edit requests
+      # (multi-MB base64 source image) with an HTML 413 the app cannot parse.
+      # Must stay above june-api's own per-route body caps (the largest is
+      # max_image_edit_bytes, ~67m); june-api still enforces the precise limits.
+      - CLIENT_MAX_BODY_SIZE=80m
+      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
+      - CERTBOT_EMAIL=${CERTBOT_EMAIL}
+    volumes:
+      - /var/run/dstack.sock:/var/run/dstack.sock
+      - cert-data:/etc/letsencrypt
+
   june-api:
     image: ${JUNE_IMAGE}
     restart: unless-stopped
-    ports:
-      - "8080:8080"
+    # No published ports: dstack-ingress is the sole external entry point
+    # (https://june-api-staging.opensoftware.co). The ingress reaches the app
+    # over the internal compose network via TARGET_ENDPOINT=http://june-api:8080.
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
     # App secrets are encrypted per-CVM via Phala sealed env (`phala envs`) and
     # injected at boot by ${VAR} interpolation — reference each one, unquoted.
     # An empty `KEY: ""` clobbers the sealed value with a blank; omitting the ref
     # injects nothing — both leave the app seeing the config as missing.
+    # `phala envs update` is FULL REPLACEMENT: re-supply EVERY var each time
+    # (incl. the dstack-ingress CLOUDFLARE_API_TOKEN + CERTBOT_EMAIL below).
     # Docs: https://docs.phala.com/phala-cloud/phala-cloud-user-guides/create-cvm/set-secure-environment-variables
     # DSTACK_DOCKER_* (registry auth) is consumed by the prelaunch, not the app.
     environment:
@@ -20,3 +59,6 @@ services:
       - JUNE__UPSTREAMS__OPENAI__API_KEY=${JUNE__UPSTREAMS__OPENAI__API_KEY}
       - JUNE__UPSTREAMS__VENICE__API_KEY=${JUNE__UPSTREAMS__VENICE__API_KEY}
       - JUNE__ISSUE_REPORTS__OS_PLATFORM_API_KEY=${JUNE__ISSUE_REPORTS__OS_PLATFORM_API_KEY}
+
+volumes:
+  cert-data:

--- a/scripts/ephemeral-june-api.sh
+++ b/scripts/ephemeral-june-api.sh
@@ -37,6 +37,10 @@ cleanup() {
 trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
+# Closing the terminal delivers SIGHUP; untrapped it is fatal WITHOUT the
+# EXIT trap, which would skip teardown. SIGKILL/power loss remain uncoverable:
+# `make ephemeral-api-down` recovers from the state file.
+trap 'exit 129' HUP
 
 die() {
   echo "$*" >&2
@@ -49,6 +53,9 @@ die() {
 write_state() {
   local name="$1" uuid="$2" url="$3" token="$4" image="$5" git_sha="$6" created="$7" tmp
   tmp="$(mktemp "${STATE_FILE}.XXXXXX")"
+  # Register for cleanup: a crash between write and rename must not leave a
+  # token-bearing temp behind (rm -f after a successful mv is a no-op).
+  TMP_FILES+=("$tmp")
   chmod 600 "$tmp"
   jq -n \
     --arg name "$name" \
@@ -65,6 +72,24 @@ write_state() {
 
 read_state() {
   jq -r --arg key "$1" '.[$key] // empty' "$STATE_FILE"
+}
+
+# Tri-state existence probe via the /apps listing (same shape the CI
+# phala-deploy action uses): "listed", "absent" (the API answered and does
+# not know the name), or "ambiguous" (probe failed / non-JSON).
+probe_cvm_listed() {
+  local name="$1" apps
+  if apps="$(phala api /apps --json -f page=1 -f page_size=100 -f "search=${name}" 2>/dev/null)" \
+    && printf '%s' "$apps" | jq -e . >/dev/null 2>&1; then
+    if printf '%s' "$apps" \
+      | jq -e --arg n "$name" 'any(.dstack_apps[]?; .current_cvm.name? == $n)' >/dev/null; then
+      echo listed
+    else
+      echo absent
+    fi
+  else
+    echo ambiguous
+  fi
 }
 
 # Copy a key from june-api/.env verbatim. A missing or empty key is copied as
@@ -240,21 +265,27 @@ cmd_down() {
     # contain this name (covers tombstoned and never-created alike; a
     # `cvms get` probe cannot, it 404s on both). A failed or non-JSON
     # listing is ambiguous and keeps the state.
-    local apps
-    if apps="$(phala api /apps --json -f page=1 -f page_size=100 -f "search=${name}" 2>/dev/null)" \
-      && printf '%s' "$apps" | jq -e . >/dev/null 2>&1; then
-      if printf '%s' "$apps" \
-        | jq -e --arg n "$name" 'any(.dstack_apps[]?; .current_cvm.name? == $n)' >/dev/null; then
+    local listed
+    listed="$(probe_cvm_listed "$name")"
+    # An interrupt before the uuid was captured can race server-side
+    # registration: an aborted create may not be listed YET. Absence at one
+    # instant is not absence forever - re-probe once before trusting it.
+    if [[ "$listed" == "absent" && -z "$(read_state uuid)" ]]; then
+      sleep 10
+      listed="$(probe_cvm_listed "$name")"
+    fi
+    case "$listed" in
+      listed)
         echo "Could not delete $name and it still exists; keeping $STATE_FILE." >&2
         echo "Retry with: make ephemeral-api-down" >&2
-        return 1
-      fi
-      echo "Delete reported failure but the API no longer lists $name; dropping the state file." >&2
-    else
-      echo "Could not delete $name and could not confirm it is gone; keeping $STATE_FILE." >&2
-      echo "Retry with: make ephemeral-api-down" >&2
-      return 1
-    fi
+        return 1 ;;
+      absent)
+        echo "Delete reported failure but the API no longer lists $name; dropping the state file." >&2 ;;
+      *)
+        echo "Could not delete $name and could not confirm it is gone; keeping $STATE_FILE." >&2
+        echo "Retry with: make ephemeral-api-down" >&2
+        return 1 ;;
+    esac
   fi
   rm -f "$STATE_FILE"
   echo "Ephemeral June API torn down."

--- a/scripts/ephemeral-june-api.sh
+++ b/scripts/ephemeral-june-api.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Deploy the working-tree june-api to a disposable Phala CVM, use it, delete it.
+#
+#   up    build+push the image to ttl.sh, deploy a CVM, health-check it
+#   down  delete the CVM recorded in the state file
+#   dev   up, run `pnpm tauri:dev` against it, always down on exit
+#
+# The CVM bills at $0.058/hr (tdx.small) until deleted. Deps: bash, git, docker,
+# phala, jq, curl, openssl, perl, uuidgen.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+COMPOSE_FILE="june-api/deploy/docker-compose.ephemeral.yml"
+API_ENV_FILE="june-api/.env"
+STATE_FILE=".ephemeral-june-api.json"
+LOCAL_DEV_USER_ID="usr_local_dev"
+
+TMP_FILES=()
+DEV_MODE=0
+TEARDOWN_CVM=0
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+  local f
+  for f in "${TMP_FILES[@]:-}"; do
+    if [[ -n "$f" ]]; then rm -f "$f"; fi
+  done
+  # `dev` only: no ephemeral CVM outlives the dev session, whether it ended by
+  # a clean quit, Ctrl-C, or a failure after the CVM came up.
+  if [[ "$TEARDOWN_CVM" == "1" ]]; then
+    cmd_down || echo "Teardown failed. Delete it by hand: phala cvms delete <name> --force" >&2
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+die() {
+  echo "$*" >&2
+  exit 1
+}
+
+# The state file is the only record of the CVM name and its bearer token.
+write_state() {
+  local name="$1" url="$2" token="$3" image="$4" git_sha="$5" created="$6"
+  : >"$STATE_FILE"
+  chmod 600 "$STATE_FILE"
+  jq -n \
+    --arg name "$name" \
+    --arg url "$url" \
+    --arg token "$token" \
+    --arg image "$image" \
+    --arg git_sha "$git_sha" \
+    --arg created "$created" \
+    '{name: $name, url: $url, token: $token, image: $image, git_sha: $git_sha, created: $created}' \
+    >"$STATE_FILE"
+}
+
+read_state() {
+  jq -r --arg key "$1" '.[$key] // empty' "$STATE_FILE"
+}
+
+# Copy a key from june-api/.env verbatim. A missing or empty key is copied as
+# absent: june-api must see it as unset, never as a value we invented.
+copy_env_line() {
+  local key="$1" line
+  line="$(grep -E "^${key}=." "$API_ENV_FILE" | tail -n 1 || true)"
+  if [[ -n "$line" ]]; then printf '%s\n' "$line"; fi
+}
+
+cmd_up() {
+  command -v docker >/dev/null 2>&1 || die "docker is required. Install Docker Desktop."
+  docker info >/dev/null 2>&1 || die "The Docker daemon is unreachable. Start Docker Desktop and retry."
+  command -v phala >/dev/null 2>&1 || die "The phala CLI is required. Install it with: npm install -g phala"
+  phala status >/dev/null 2>&1 || die "The phala CLI is not authenticated. Run: phala auth login"
+  [[ -f "$API_ENV_FILE" ]] || die "$API_ENV_FILE is missing. Copy june-api/.env.example and fill in the upstream keys."
+  if [[ -f "$STATE_FILE" ]]; then
+    die "An ephemeral CVM is already recorded in $STATE_FILE. Run \`make ephemeral-api-down\` first."
+  fi
+
+  local git_sha image name token created
+  git_sha="$(git rev-parse HEAD)"
+  image="ttl.sh/june-api-eph-$(uuidgen | perl -ne 'print lc'):4h"
+  name="june-api-eph-$(whoami | perl -pe 'chomp; $_ = lc; s/[^a-z0-9]+/-/g')-$(openssl rand -hex 2)"
+  token="$(openssl rand -hex 32)"
+  created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  echo "Building june-api for linux/amd64 and pushing to $image ..."
+  # --provenance/--sbom off: attestations turn the pushed artifact into an OCI
+  # index, and dstack's prelaunch puller is only proven against plain
+  # single-arch manifests. Same rationale as .github/workflows/build-june-api.yml.
+  docker buildx build \
+    --platform linux/amd64 \
+    --build-arg "GIT_SHA=${git_sha}" \
+    --provenance=false \
+    --sbom=false \
+    -t "$image" \
+    --push \
+    june-api
+
+  local rendered env_file
+  rendered="$(mktemp)"
+  env_file="$(mktemp)"
+  TMP_FILES+=("$rendered" "$env_file")
+  chmod 600 "$env_file"
+
+  IMAGE_REF="$image" perl -0pe 's/\$\{JUNE_IMAGE\}/$ENV{IMAGE_REF}/g' "$COMPOSE_FILE" >"$rendered"
+
+  {
+    printf 'JUNE__LOCAL_DEV__ENABLED=true\n'
+    printf 'JUNE__LOCAL_DEV__BEARER_TOKEN=%s\n' "$token"
+    printf 'JUNE__LOCAL_DEV__USER_ID=%s\n' "$LOCAL_DEV_USER_ID"
+    copy_env_line JUNE__UPSTREAMS__VENICE__API_KEY
+    copy_env_line JUNE__UPSTREAMS__OPENAI__API_KEY
+  } >"$env_file"
+
+  # Record the CVM before the deploy, not after: the state file is what makes
+  # `down` able to delete it, and a deploy that dies halfway can still have left
+  # a billing CVM behind. Arm the `dev` teardown on the same line of reasoning,
+  # and only here, so an early guard failure never deletes a pre-existing CVM.
+  write_state "$name" "" "$token" "$image" "$git_sha" "$created"
+  if [[ "$DEV_MODE" == "1" ]]; then
+    TEARDOWN_CVM=1
+  fi
+
+  echo "Deploying CVM $name ..."
+  # Dev VM: logs and sysinfo stay private, unlike the production defaults.
+  phala deploy \
+    -c "$rendered" \
+    -n "$name" \
+    -t tdx.small \
+    --disk-size 20G \
+    --no-public-logs \
+    --no-public-sysinfo \
+    -e "$env_file" \
+    --wait
+
+  # `phala cvms get --json` spreads its detail fields to the top level, but the
+  # public-endpoint field is API-version dependent: `public_urls` (v2025-10-28)
+  # or `endpoints` (default), both arrays of {app, instance}. Walk every nested
+  # object and take the first .app URL so either shape works.
+  local url
+  url="$(phala cvms get "$name" --json \
+    | jq -r 'first((.. | objects | .app? | select(type == "string" and startswith("http")))) // empty')" || url=""
+  [[ -n "$url" ]] || die "Could not resolve a public URL for $name. Inspect it with: phala cvms get $name"
+  write_state "$name" "$url" "$token" "$image" "$git_sha" "$created"
+
+  echo "Waiting for $url/healthz ..."
+  local code=""
+  for _ in $(seq 1 60); do
+    # `|| true`, not `|| echo`: curl prints its own %{http_code} (000) on
+    # transport failure, so a fallback echo would corrupt the value.
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url/healthz" || true)"
+    [[ "$code" == "200" ]] && break
+    sleep 10
+  done
+  if [[ "$code" != "200" ]]; then
+    echo "$url/healthz did not return 200 within 10 minutes (last: $code)." >&2
+    echo "The CVM $name is still up and still billing. Inspect it with:" >&2
+    echo "  phala cvms get $name" >&2
+    echo "Delete it with: make ephemeral-api-down" >&2
+    exit 1
+  fi
+
+  cat <<EOF
+
+Ephemeral June API is up.
+  CVM:   $name
+  URL:   $url
+  Image: $image (ttl.sh tag expires in 4h; a restart after that cannot re-pull)
+
+It bills at \$0.058/hr (tdx.small) until deleted.
+
+Run the app against a FRESH ephemeral CVM (its own flow, this one is not reused):
+  make dev-with-ephemeral-api
+
+Or use this one from a manual session (token is in $STATE_FILE, mode 600):
+  export JUNE_API_URL=$url
+  export OS_JUNE_LOCAL_DEV=1
+  export OS_JUNE_LOCAL_DEV_BEARER_TOKEN="\$(jq -r .token $STATE_FILE)"
+
+Tear it down with:
+  make ephemeral-api-down
+EOF
+}
+
+cmd_down() {
+  if [[ ! -f "$STATE_FILE" ]]; then
+    echo "No $STATE_FILE; nothing to tear down."
+    return 0
+  fi
+
+  local name
+  name="$(read_state name)"
+  [[ -n "$name" ]] || die "$STATE_FILE has no CVM name. Delete it by hand: phala cvms delete <name> --force"
+
+  echo "Deleting CVM $name ..."
+  if ! phala cvms delete "$name" --force; then
+    echo "Could not delete $name; it may already be gone. Dropping the state file anyway." >&2
+  fi
+  rm -f "$STATE_FILE"
+  echo "Ephemeral June API torn down."
+}
+
+cmd_dev() {
+  # cmd_up arms the teardown once it is about to create the CVM, so every exit
+  # path from there on (clean quit, Ctrl-C, failure) deletes it, while its
+  # already-up guard still aborts without touching the recorded CVM.
+  DEV_MODE=1
+  cmd_up
+
+  local url token
+  url="$(read_state url)"
+  token="$(read_state token)"
+
+  echo "Starting the desktop app against $url ..."
+  JUNE_API_URL="$url" \
+    OS_JUNE_LOCAL_DEV=1 \
+    OS_JUNE_LOCAL_DEV_BEARER_TOKEN="$token" \
+    OS_JUNE_LOCAL_DEV_USER_ID="$LOCAL_DEV_USER_ID" \
+    JUNE_DEV_SKIP_LOCAL_API=1 \
+    pnpm tauri:dev
+}
+
+case "${1:-}" in
+  up) cmd_up ;;
+  down) cmd_down ;;
+  dev) cmd_dev ;;
+  *) die "Usage: $0 {up|down|dev}" ;;
+esac

--- a/scripts/ephemeral-june-api.sh
+++ b/scripts/ephemeral-june-api.sh
@@ -44,19 +44,23 @@ die() {
 }
 
 # The state file is the only record of the CVM name and its bearer token.
+# Written atomically (temp + rename): a truncate-in-place could leave empty
+# JSON if jq dies mid-write, losing the teardown handle of a live CVM.
 write_state() {
-  local name="$1" url="$2" token="$3" image="$4" git_sha="$5" created="$6"
-  : >"$STATE_FILE"
-  chmod 600 "$STATE_FILE"
+  local name="$1" uuid="$2" url="$3" token="$4" image="$5" git_sha="$6" created="$7" tmp
+  tmp="$(mktemp "${STATE_FILE}.XXXXXX")"
+  chmod 600 "$tmp"
   jq -n \
     --arg name "$name" \
+    --arg uuid "$uuid" \
     --arg url "$url" \
     --arg token "$token" \
     --arg image "$image" \
     --arg git_sha "$git_sha" \
     --arg created "$created" \
-    '{name: $name, url: $url, token: $token, image: $image, git_sha: $git_sha, created: $created}' \
-    >"$STATE_FILE"
+    '{name: $name, uuid: $uuid, url: $url, token: $token, image: $image, git_sha: $git_sha, created: $created}' \
+    >"$tmp"
+  mv "$tmp" "$STATE_FILE"
 }
 
 read_state() {
@@ -96,7 +100,9 @@ cmd_up() {
   local git_sha image name token created
   git_sha="$(git rev-parse HEAD)"
   image="ttl.sh/june-api-eph-$(uuidgen | perl -ne 'print lc'):4h"
-  name="june-api-eph-$(whoami | perl -pe 'chomp; $_ = lc; s/[^a-z0-9]+/-/g')-$(openssl rand -hex 2)"
+  # 32 bits of suffix entropy: teardown deletes by name until the UUID is
+  # captured, so a cross-session name collision must be negligible.
+  name="june-api-eph-$(whoami | perl -pe 'chomp; $_ = lc; s/[^a-z0-9]+/-/g')-$(openssl rand -hex 4)"
   token="$(openssl rand -hex 32)"
   created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
@@ -133,7 +139,7 @@ cmd_up() {
   # `down` able to delete it, and a deploy that dies halfway can still have left
   # a billing CVM behind. Arm the `dev` teardown on the same line of reasoning,
   # and only here, so an early guard failure never deletes a pre-existing CVM.
-  write_state "$name" "" "$token" "$image" "$git_sha" "$created"
+  write_state "$name" "" "" "$token" "$image" "$git_sha" "$created"
   if [[ "$DEV_MODE" == "1" ]]; then
     TEARDOWN_CVM=1
   fi
@@ -154,11 +160,15 @@ cmd_up() {
   # public-endpoint field is API-version dependent: `public_urls` (v2025-10-28)
   # or `endpoints` (default), both arrays of {app, instance}. Walk every nested
   # object and take the first .app URL so either shape works.
-  local url
-  url="$(phala cvms get "$name" --json \
+  local detail url uuid
+  detail="$(phala cvms get "$name" --json)" || detail=""
+  url="$(printf '%s' "$detail" \
     | jq -r 'first((.. | objects | .app? | select(type == "string" and startswith("http")))) // empty')" || url=""
+  # The immutable VM UUID makes teardown collision-proof: names are only
+  # unique by convention, and `phala cvms delete` accepts either.
+  uuid="$(printf '%s' "$detail" | jq -r '.vm_uuid // .id // empty')" || uuid=""
   [[ -n "$url" ]] || die "Could not resolve a public URL for $name. Inspect it with: phala cvms get $name"
-  write_state "$name" "$url" "$token" "$image" "$git_sha" "$created"
+  write_state "$name" "$uuid" "$url" "$token" "$image" "$git_sha" "$created"
 
   echo "Waiting for $url/healthz ..."
   local code=""
@@ -214,8 +224,14 @@ cmd_down() {
     return 0
   fi
 
+  # Delete by immutable UUID when the state has one (post-deploy it always
+  # does); the name is a pre-deploy fallback and only unique by convention.
+  local target
+  target="$(read_state uuid)"
+  [[ -n "$target" ]] || target="$name"
+
   echo "Deleting CVM $name ..."
-  if ! phala cvms delete "$name" --force; then
+  if ! phala cvms delete "$target" --force; then
     # A failed delete may mean already-gone, never-created (deploy failed),
     # OR a transient auth/network/API failure - and the same outage that
     # broke delete usually breaks a probe too. The state file is the only

--- a/scripts/ephemeral-june-api.sh
+++ b/scripts/ephemeral-june-api.sh
@@ -30,7 +30,11 @@ cleanup() {
   # `dev` only: no ephemeral CVM outlives the dev session, whether it ended by
   # a clean quit, Ctrl-C, or a failure after the CVM came up.
   if [[ "$TEARDOWN_CVM" == "1" ]]; then
-    cmd_down || echo "Teardown failed. Delete it by hand: phala cvms delete <name> --force" >&2
+    if ! cmd_down; then
+      # A swallowed failure here would report success while the CVM bills on.
+      echo "Teardown failed; the CVM may still be billing. Retry: make ephemeral-api-down" >&2
+      if [[ "$status" -eq 0 ]]; then status=1; fi
+    fi
   fi
   exit "$status"
 }
@@ -124,6 +128,8 @@ cmd_up() {
 
   local git_sha image name token created
   git_sha="$(git rev-parse HEAD)"
+  # /verify must not claim a commit the build did not match: mark dirty trees.
+  git diff --quiet && git diff --cached --quiet || git_sha="${git_sha}-dirty"
   image="ttl.sh/june-api-eph-$(uuidgen | perl -ne 'print lc'):4h"
   # 32 bits of suffix entropy: teardown deletes by name until the UUID is
   # captured, so a cross-session name collision must be negligible.
@@ -227,6 +233,7 @@ Run the app against a FRESH ephemeral CVM (its own flow, this one is not reused)
 Or use this one from a manual session (token is in $STATE_FILE, mode 600):
   export JUNE_API_URL=$url
   export OS_JUNE_LOCAL_DEV=1
+  export JUNE_DEV_SKIP_LOCAL_API=1
   export OS_JUNE_LOCAL_DEV_BEARER_TOKEN="\$(jq -r .token $STATE_FILE)"
 
 Tear it down with:

--- a/scripts/ephemeral-june-api.sh
+++ b/scripts/ephemeral-june-api.sh
@@ -77,9 +77,13 @@ cmd_up() {
   command -v phala >/dev/null 2>&1 || die "The phala CLI is required. Install it with: npm install -g phala"
   phala status >/dev/null 2>&1 || die "The phala CLI is not authenticated. Run: phala auth login"
   [[ -f "$API_ENV_FILE" ]] || die "$API_ENV_FILE is missing. Copy june-api/.env.example and fill in the upstream keys."
-  if [[ -f "$STATE_FILE" ]]; then
+  # Atomic reservation (noclobber): two concurrent `up`s must not both pass a
+  # plain -f guard during the long image build and then overwrite each other's
+  # only CVM record. Whoever creates the file owns the run.
+  if ! (set -C; : >"$STATE_FILE") 2>/dev/null; then
     die "An ephemeral CVM is already recorded in $STATE_FILE. Run \`make ephemeral-api-down\` first."
   fi
+  chmod 600 "$STATE_FILE"
 
   local git_sha image name token created
   git_sha="$(git rev-parse HEAD)"
@@ -195,11 +199,25 @@ cmd_down() {
 
   local name
   name="$(read_state name)"
-  [[ -n "$name" ]] || die "$STATE_FILE has no CVM name. Delete it by hand: phala cvms delete <name> --force"
+  if [[ -z "$name" ]]; then
+    # A reservation that never reached the deploy: nothing exists to delete.
+    rm -f "$STATE_FILE"
+    echo "Dropped an empty reservation; no CVM was created."
+    return 0
+  fi
 
   echo "Deleting CVM $name ..."
   if ! phala cvms delete "$name" --force; then
-    echo "Could not delete $name; it may already be gone. Dropping the state file anyway." >&2
+    # A failed delete may mean already-gone OR a transient auth/network/API
+    # failure. The state file is the only record of a billing CVM's name, so
+    # drop it only once the CVM is confirmed absent.
+    if phala cvms get "$name" --json 2>/dev/null \
+      | jq -e --arg n "$name" '.name == $n' >/dev/null 2>&1; then
+      echo "Could not delete $name and it still exists; keeping $STATE_FILE." >&2
+      echo "Retry with: make ephemeral-api-down" >&2
+      return 1
+    fi
+    echo "Delete reported failure but $name is no longer listed; dropping the state file." >&2
   fi
   rm -f "$STATE_FILE"
   echo "Ephemeral June API torn down."

--- a/scripts/ephemeral-june-api.sh
+++ b/scripts/ephemeral-june-api.sh
@@ -64,11 +64,19 @@ read_state() {
 }
 
 # Copy a key from june-api/.env verbatim. A missing or empty key is copied as
-# absent: june-api must see it as unset, never as a value we invented.
+# absent: june-api must see it as unset, never as a value we invented. The
+# sealed-env parser takes values raw, while dotenvy strips quotes and trailing
+# comments locally - a quoted value would work in `make dev` and silently
+# corrupt only on the CVM, so fail fast instead of guessing dotenv semantics.
 copy_env_line() {
   local key="$1" line
   line="$(grep -E "^${key}=." "$API_ENV_FILE" | tail -n 1 || true)"
-  if [[ -n "$line" ]]; then printf '%s\n' "$line"; fi
+  if [[ -z "$line" ]]; then return 0; fi
+  case "$line" in
+    *\"* | *\'* | *" #"*)
+      die "$API_ENV_FILE: $key is quoted or has a trailing comment; use a plain KEY=value line (sealed env takes values raw)." ;;
+  esac
+  printf '%s\n' "$line"
 }
 
 cmd_up() {
@@ -208,16 +216,29 @@ cmd_down() {
 
   echo "Deleting CVM $name ..."
   if ! phala cvms delete "$name" --force; then
-    # A failed delete may mean already-gone OR a transient auth/network/API
-    # failure. The state file is the only record of a billing CVM's name, so
-    # drop it only once the CVM is confirmed absent.
-    if phala cvms get "$name" --json 2>/dev/null \
-      | jq -e --arg n "$name" '.name == $n' >/dev/null 2>&1; then
-      echo "Could not delete $name and it still exists; keeping $STATE_FILE." >&2
+    # A failed delete may mean already-gone, never-created (deploy failed),
+    # OR a transient auth/network/API failure - and the same outage that
+    # broke delete usually breaks a probe too. The state file is the only
+    # record of a billing CVM's name, so drop it only on POSITIVE
+    # confirmation of absence: a successful /apps listing that does not
+    # contain this name (covers tombstoned and never-created alike; a
+    # `cvms get` probe cannot, it 404s on both). A failed or non-JSON
+    # listing is ambiguous and keeps the state.
+    local apps
+    if apps="$(phala api /apps --json -f page=1 -f page_size=100 -f "search=${name}" 2>/dev/null)" \
+      && printf '%s' "$apps" | jq -e . >/dev/null 2>&1; then
+      if printf '%s' "$apps" \
+        | jq -e --arg n "$name" 'any(.dstack_apps[]?; .current_cvm.name? == $n)' >/dev/null; then
+        echo "Could not delete $name and it still exists; keeping $STATE_FILE." >&2
+        echo "Retry with: make ephemeral-api-down" >&2
+        return 1
+      fi
+      echo "Delete reported failure but the API no longer lists $name; dropping the state file." >&2
+    else
+      echo "Could not delete $name and could not confirm it is gone; keeping $STATE_FILE." >&2
       echo "Retry with: make ephemeral-api-down" >&2
       return 1
     fi
-    echo "Delete reported failure but $name is no longer listed; dropping the state file." >&2
   fi
   rm -f "$STATE_FILE"
   echo "Ephemeral June API torn down."

--- a/scripts/tauri-before-dev.mjs
+++ b/scripts/tauri-before-dev.mjs
@@ -10,6 +10,7 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 const apiDir = path.join(rootDir, "june-api");
 const frontendPort = Number.parseInt(process.env.VITE_PORT ?? "1421", 10);
 const apiPort = Number.parseInt(process.env.JUNE_API_PORT ?? "8080", 10);
+const skipLocalApi = process.env.JUNE_DEV_SKIP_LOCAL_API === "1";
 const shell = process.platform === "win32";
 
 let apiChild = null;
@@ -66,20 +67,24 @@ for (const signal of ["SIGINT", "SIGTERM"]) {
   process.on(signal, () => exitFromChild(0, signal));
 }
 
-if (!fs.existsSync(path.join(apiDir, "Cargo.toml"))) {
-  console.error(`Could not find june-api/Cargo.toml under ${rootDir}`);
-  process.exit(1);
-}
-
-if (await portIsOpen(apiPort)) {
-  console.error(`June API port ${apiPort} is already in use. Reusing it for Tauri dev.`);
+if (skipLocalApi) {
+  console.error("Skipping local June API because JUNE_DEV_SKIP_LOCAL_API=1.");
 } else {
-  apiChild = spawnManaged("june-api", "cargo", ["run", "-p", "june", "--", "serve"], apiDir);
-  apiChild.on("exit", (code, signal) => {
-    if (shuttingDown) return;
-    console.error(`june-api exited with ${signal ?? code}`);
-    exitFromChild(code, signal);
-  });
+  if (!fs.existsSync(path.join(apiDir, "Cargo.toml"))) {
+    console.error(`Could not find june-api/Cargo.toml under ${rootDir}`);
+    process.exit(1);
+  }
+
+  if (await portIsOpen(apiPort)) {
+    console.error(`June API port ${apiPort} is already in use. Reusing it for Tauri dev.`);
+  } else {
+    apiChild = spawnManaged("june-api", "cargo", ["run", "-p", "june", "--", "serve"], apiDir);
+    apiChild.on("exit", (code, signal) => {
+      if (shuttingDown) return;
+      console.error(`june-api exited with ${signal ?? code}`);
+      exitFromChild(code, signal);
+    });
+  }
 }
 
 if (await portIsOpen(frontendPort)) {


### PR DESCRIPTION
Closes JUN-247

## Summary

Local dev can now run against hosted June API in a real TEE instead of the ad hoc local setup, and staging runs the same stack as production:

- **`make dev-staging`** runs the desktop app against `https://june-api-staging.opensoftware.co` with a real Login with Open Software against staging OS Accounts (`OS_JUNE_LOCAL_DEV=0`; the new `JUNE_DEV_SKIP_LOCAL_API=1` knob stops `tauri-before-dev.mjs` from booting a local June API). Staging deliberately stays JWT-only: june-api's local-dev bearer mode replaces JWT verification and disables metering, which would degrade staging's release-soak fidelity.
- **Staging compose parity**: `docker-compose.staging.yml` now mirrors production - `dstack-ingress` terminating TLS on 443 for `june-api-staging.opensoftware.co` (CAA-pinned Let's Encrypt, Cloudflare DNS auto-provisioning), app publishes no ports. `build-june-api.yml` gains a post-deploy healthz gate mirroring promote's; the stale "staging has no ingress" comment in `promote-june-api.yml` is fixed.
- **Ephemeral Phala CVMs**: `make ephemeral-api` builds the working-tree june-api for linux/amd64, pushes to ttl.sh (auto-expiring anonymous registry; no secrets ride the image, `.dockerignore` now excludes `.env*`), deploys a `tdx.small` CVM ($0.058/hr - the same size staging and production run) with a per-run random bearer sealed via Phala sealed env, and polls healthz. `make dev-with-ephemeral-api` runs the app against a fresh CVM and always deletes it on exit (EXIT/INT/TERM/HUP trapped). `make ephemeral-api-down` tears down from the 0600 state file. Teardown is deliberately conservative: the state file (the only record of a billing CVM) is dropped only on positive API confirmation of absence.

The staging rollout was executed live during this build: sealed envs updated (full replacement) with the two new ingress secrets, compose deployed, domain verified. That same env update healed a pre-existing 3-day staging outage - #655 made `os_accounts.p3a_ingest_token` a hard boot requirement and it was never sealed on staging, so the container crash-looped since the next deploy (the watchdog only probes production).

## Root cause

(for the staging outage fixed by the rollout, not by this diff) #655 turned the P3A ingest token into required config outside local-dev mode; staging's sealed store never received `JUNE__OS_ACCOUNTS__P3A_INGEST_TOKEN`, the compose interpolated it to empty, config validation refused boot, and the CVM crash-looped for ~3 days unnoticed because the watchdog monitors production only.

## Validation

- `make verify` green pre- and post-rebase (vitest 143 files / 2302 passed, both cargo workspaces green; post-rebase run after `sfw pnpm install` under the new pnpm 11 pin).
- **Live ephemeral cycle on a real Phala CVM**: deploy → healthz 200 → `/verify` attested the exact HEAD commit → `/v1/models` served 107 models → bearer gating verified (missing/wrong token 401, per-run token accepted) → `make ephemeral-api-down` → CVM confirmed gone via API. Total cost ~$0.02.
- **Staging domain live**: healthz 200 on `https://june-api-staging.opensoftware.co` with CN-matching CAA-pinned cert; DNS CNAME/TXT/CAA auto-provisioned by the ingress; container up continuously since the rollout (crash-loop healed).
- **dev-staging walkthrough**: local June API skip confirmed in the boot log; user logged in with staging OS Accounts and an agent chat request reached `https://june-api-staging.opensoftware.co/v1/chat/completions` (screenshot in session). The one failure observed was DNS negative caching from the domain's first minutes (SOA min TTL 1800s) - a one-time bootstrap artifact, not a defect.
- Teardown edge cases exercised for real: empty reservation, never-created CVM (positive-absence drop), unavailable CLI (state kept, nonzero exit), reservation collision guard.
- **Review battery**: full Standards + Spec + 5 adversarial rounds alternating Codex/Claude runners (this branch's chunks were implemented by both harnesses, so alternation preserved reviewer-didn't-write-it). 13 findings fixed across rounds (env files in Docker context, correlated-failure teardown races, atomic state writes, name-collision entropy + delete-by-UUID, SIGHUP trap, token-bearing temp files, silent teardown failure). Final Standards pass: clean. Final Spec pass: clean after a one-sentence ordering doc fix.

- [x] Tested visually where it matters (login + agent request screenshot against the staging domain).
- [ ] Needs a June API (backend) deploy before it works end to end - **not needed**: the staging CVM was already updated live via the phala CLI; the next main deploy re-applies the same compose (plus the 302m body-cap sync, see below).

## Out of scope

- Restructuring `:staging` tag publication so promote can only take health-verified images (adversarial finding, pre-existing: the tag-push ordering is unchanged from before this PR, which added the first staging health gate at all).
- Multi-workspace phala profile binding for the ephemeral state file (niche: requires switching phala profiles mid-session; bounded impact; needs CLI introspection surface worth verifying properly).
- Production sealed-env update (see followups - required before the next promote).
- Ephemeral `/verify` still renders production attestation facts from the packaged config.toml; documented in the compose header, and dirty builds now stamp a `-dirty` source commit.

## Followups

- **Before the next `promote-june-api` run**: seal `JUNE__OS_ACCOUNTS__P3A_INGEST_TOKEN` on `os-june-api-production` (full-replacement update - re-supply every var). The current production image predates #655; the next promote ships the requirement and will crash production exactly like staging.
- The live staging CVM currently runs an 80m ingress body cap (deployed mid-build, before main moved to 302m); the first main deploy after this merges syncs it.
- Consider gating `:staging` tag publication on the staging healthz verify (see out of scope).

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed. (The rollout secrets lived in a session-local template outside the repo and were deleted after sealing; `.dockerignore` and the state-file gitignore glob were hardened in review.)
- [x] Security-sensitive changes were called out in the summary (sealed-env handling, bearer lifecycle, image context hygiene).
- [x] Workflow action references are pinned to full-length commit SHAs. (No new action references; the healthz step is plain bash.)
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. (None touched.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786524263&installation_id=144203540&pr_number=713&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F713&signature=342ce09c6750808fee4ca5cf701948f87f8331b9e26d820ef55512b36ceea64c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->