### PR TITLE
Model/effort/speed controls for repo-delegate runners + token-burn defaults

### DIFF
--- a/.agents/skills/repo-delegate/PROMPT.md
+++ b/.agents/skills/repo-delegate/PROMPT.md
@@ -32,6 +32,8 @@ improvising around them.
 - Keep edits scoped to the task and nearby supporting tests.
 - Do NOT commit, push, tag, or otherwise mutate git state — read-only git is
   fine. The caller reviews the diff and commits.
+- Do not spawn subagents; do the work in this session, unless the brief
+  explicitly says otherwise.
 - Extra constraints from the caller: {{CONSTRAINTS}}
 </constraints>
 
@@ -45,6 +47,8 @@ it, not the exit code.
 </validation>
 
 <output_contract>
+Once the gate passes and the brief's scope is covered, stop and write the
+report — do not keep polishing, refactoring, or expanding scope.
 Return a compact markdown report, nothing else:
 - `## Changes` — what changed and why, per file.
 - `## Validation` — each command run and its real result.

--- a/.agents/skills/repo-delegate/SKILL.md
+++ b/.agents/skills/repo-delegate/SKILL.md
@@ -58,9 +58,50 @@ orchestrating model (see repo-build-pr's model orchestration rules).
    `pnpm check && pnpm typecheck && pnpm test`):
 
    ```bash
-   scripts/run-codex.sh  -t <brief.md> [-C <worktree>] [-g "<gate>"] [-c "<extra constraints>"] [-o <out>]
-   scripts/run-claude.sh -t <brief.md> [same flags]
+   scripts/run-codex.sh  -t <brief.md> [-C <worktree>] [-g "<gate>"] [-c "<extra constraints>"] [-o <out>] \
+                         [-m <model>] [-e <effort>] [-S <tier>]
+   scripts/run-claude.sh -t <brief.md> [same flags, minus -S; -m takes
+                         sonnet|opus|haiku (default opus), -e takes
+                         low|medium|high|xhigh|max (default medium — the
+                         brief carries the hard thinking; bump for subtle
+                         defect fixes)]
    ```
+
+   **Codex model/effort/speed** (defaults come from `~/.codex/config.toml`;
+   only pass a flag when the user asked for something specific):
+
+   Allowed models (for now): `gpt-5.6-sol` (config default; main work),
+   `gpt-5.6-terra` (quick review/feedback passes), `gpt-5.6-luna` (cheap fast
+   bulk; not a primary pick) — the script rejects anything else.
+
+   | User says | Flag |
+   |---|---|
+   | "sol" / "terra" / "luna" | `-m gpt-5.6-sol` / `-m gpt-5.6-terra` / `-m gpt-5.6-luna` |
+   | "think hard" | `-e high` |
+   | "max effort" | `-e xhigh` (rarely needed — high covers almost everything) |
+   | "quick pass" / "low effort" | `-e low` (or `minimal`/`none`) |
+   | "fast" | `-S fast` (bills ~2.5x credits — see below) |
+   | "standard speed" | `-S standard` (the script's default) |
+
+   Effort is `none|minimal|low|medium|high|xhigh` (validated client-side; the
+   API only rejects a bad value after the session has started). Calibration:
+   medium is the workhorse, high for genuinely hard briefs, xhigh almost
+   never — 5.6 at medium/high already runs long and completes tasks
+   end-to-end.
+
+   Speed maps to Codex's `service_tier` config: fast = `priority`, standard =
+   `default` — the only two tiers the gpt-5.6 models advertise; anything else
+   is silently dropped by Codex, so the script fails closed on other values.
+   **The script defaults to standard**, overriding the user config's
+   `priority`: fast bills ~2.5x credits, and 5.6's long autonomous runs make
+   the burn unpredictable. Delegations are background work; only pass
+   `-S fast` when the user explicitly asks.
+
+   After the run the script prints the Codex **session id**; follow up in the
+   same session with `codex exec resume <id> "<prompt>"`. Sessions cannot be
+   named at dispatch (`/rename` is TUI-only as of codex 0.144) — the id is
+   the handle. Resume only for short follow-ups: gpt-5.6 input past ~272k
+   tokens bills 2x, so a fresh scoped brief beats resuming a long session.
 
    `--dry-run` on either prints the filled prompt. `run-codex.sh` uses
    `codex exec -s workspace-write` (OS sandbox caps writes to the worktree);

--- a/.agents/skills/repo-delegate/scripts/run-claude.sh
+++ b/.agents/skills/repo-delegate/scripts/run-claude.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 # Delegate a task to Claude Code (headless `claude -p`, acceptEdits).
-# Usage: run-claude.sh -t <task-file> [-C <worktree>] [-g <gate>] [-c <constraints>] [-o <out>] [--dry-run]
+# Usage: run-claude.sh -t <task-file> [-C <worktree>] [-g <gate>] [-c <constraints>] [-o <out>]
+#                      [-m <model>] [--dry-run]
 #   Flags as in fill-prompt.sh, plus:
 #   -o <out>    file for the delegate's report; default: mktemp (path is printed)
+#   -m <model>  sonnet|opus|haiku (default: opus)
+#   -e <effort> low|medium|high|xhigh|max (default: medium — the brief already
+#               carries the hard thinking; bump to high for subtle defect
+#               fixes where the root cause isn't fully pinned)
 #   --allow-untracked  proceed despite untracked files in the worktree
 #   --dry-run   print the filled prompt instead of running Claude
+#
+# Token discipline: runs with --strict-mcp-config (no MCP servers — their tool
+# schemas would bloat every request), --setting-sources project (no user-level
+# skills/rules), and the Agent/Task tools denied (no subagent fan-out; the
+# prompt contract forbids it too).
 #
 # Enforcement is policy-level, not an OS sandbox: acceptEdits auto-approves
 # file edits (anywhere the session may write, not just the worktree), and the
@@ -12,13 +22,15 @@
 # the Codex runner when you want OS-level write confinement.
 set -euo pipefail
 
-usage() { sed -n '2,7p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
+usage() { sed -n '2,11p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
 
 task_file=""
 worktree=$(pwd)
 gate=""
 constraints=""
 out=""
+model="opus"
+effort=""
 dry_run=0
 allow_untracked=0
 while [ $# -gt 0 ]; do
@@ -28,12 +40,22 @@ while [ $# -gt 0 ]; do
     -g) gate=$2; shift 2 ;;
     -c) constraints=$2; shift 2 ;;
     -o) out=$2; shift 2 ;;
+    -m) model=$2; shift 2 ;;
+    -e) effort=$2; shift 2 ;;
     --allow-untracked) allow_untracked=1; shift ;;
     --dry-run) dry_run=1; shift ;;
     -h|--help) usage ;;
     *) echo "unknown argument: $1" >&2; usage ;;
   esac
 done
+
+case "$model" in sonnet|opus|haiku) ;;
+  *) echo "error: -m must be sonnet|opus|haiku (got: $model)" >&2; exit 2 ;;
+esac
+case "$effort" in ""|low|medium|high|xhigh|max) ;;
+  *) echo "error: -e must be low|medium|high|xhigh|max (got: $effort)" >&2; exit 2 ;;
+esac
+effort=${effort:-medium}
 
 fill="$(cd "$(dirname "$0")" && pwd)/fill-prompt.sh"
 prompt=$("$fill" -t "$task_file" -C "$worktree" \
@@ -76,6 +98,11 @@ harness_rc=0
 # gate script appears.
 printf '%s\n' "$prompt" | claude -p \
   --permission-mode acceptEdits \
+  --model "$model" \
+  --effort "$effort" \
+  --strict-mcp-config \
+  --setting-sources project \
+  --disallowedTools "Agent" "Task" \
   --allowedTools "Bash(pnpm check:*)" "Bash(pnpm typecheck:*)" "Bash(pnpm test:*)" \
     "Bash(pnpm test:rust:*)" "Bash(pnpm test:june-api:*)" "Bash(pnpm test:hermes-smoke:*)" \
     "Bash(pnpm install:*)" "Bash(pnpm build:*)" \

--- a/.agents/skills/repo-delegate/scripts/run-claude.sh
+++ b/.agents/skills/repo-delegate/scripts/run-claude.sh
@@ -35,13 +35,18 @@ dry_run=0
 allow_untracked=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    -t) task_file=$2; shift 2 ;;
-    -C) worktree=$2; shift 2 ;;
-    -g) gate=$2; shift 2 ;;
-    -c) constraints=$2; shift 2 ;;
-    -o) out=$2; shift 2 ;;
-    -m) model=$2; shift 2 ;;
-    -e) effort=$2; shift 2 ;;
+    -t|-C|-g|-c|-o|-m|-e)
+      [ $# -ge 2 ] || { echo "error: $1 requires a value" >&2; exit 2; }
+      case "$1" in
+        -t) task_file=$2 ;;
+        -C) worktree=$2 ;;
+        -g) gate=$2 ;;
+        -c) constraints=$2 ;;
+        -o) out=$2 ;;
+        -m) model=$2 ;;
+        -e) effort=$2 ;;
+      esac
+      shift 2 ;;
     --allow-untracked) allow_untracked=1; shift ;;
     --dry-run) dry_run=1; shift ;;
     -h|--help) usage ;;

--- a/.agents/skills/repo-delegate/scripts/run-codex.sh
+++ b/.agents/skills/repo-delegate/scripts/run-codex.sh
@@ -1,22 +1,31 @@
 #!/usr/bin/env bash
 # Delegate a task to Codex (codex exec, workspace-write sandbox).
-# Usage: run-codex.sh -t <task-file> [-C <worktree>] [-g <gate>] [-c <constraints>] [-o <out>] [--dry-run]
+# Usage: run-codex.sh -t <task-file> [-C <worktree>] [-g <gate>] [-c <constraints>] [-o <out>]
+#                     [-m <model>] [-e <effort>] [-S <tier>] [--dry-run]
 #   Flags as in fill-prompt.sh, plus:
 #   -o <out>    file for the delegate's report; default: mktemp (path is printed)
+#   -m <model>  Codex model: gpt-5.6-sol|gpt-5.6-terra|gpt-5.6-luna (default: config, gpt-5.6-sol)
+#   -e <effort> reasoning effort: none|minimal|low|medium|high|xhigh (default: config)
+#   -S <speed>  speed: fast|standard (default: standard — fast bills ~2.5x credits
+#               and 5.6 runs long; reserve fast for interactive sessions)
 #   --allow-untracked  proceed despite untracked files in the worktree
 #   --dry-run   print the filled prompt instead of running Codex
+#   The session id is printed after the run for `codex exec resume <id>`.
 #
 # The OS sandbox confines writes to the worktree; git mutations are forbidden
 # by the prompt contract, not the sandbox — review the diff before committing.
 set -euo pipefail
 
-usage() { sed -n '2,7p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
+usage() { sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
 
 task_file=""
 worktree=$(pwd)
 gate=""
 constraints=""
 out=""
+model=""
+effort=""
+speed=""
 dry_run=0
 allow_untracked=0
 while [ $# -gt 0 ]; do
@@ -26,12 +35,33 @@ while [ $# -gt 0 ]; do
     -g) gate=$2; shift 2 ;;
     -c) constraints=$2; shift 2 ;;
     -o) out=$2; shift 2 ;;
+    -m) model=$2; shift 2 ;;
+    -e) effort=$2; shift 2 ;;
+    -S) speed=$2; shift 2 ;;
     --allow-untracked) allow_untracked=1; shift ;;
     --dry-run) dry_run=1; shift ;;
     -h|--help) usage ;;
     *) echo "unknown argument: $1" >&2; usage ;;
   esac
 done
+
+# Fail fast on bad values: the API 400s on a bad effort only after the session
+# has started, and a bad service_tier is silently dropped with just a warning.
+case "$effort" in ""|none|minimal|low|medium|high|xhigh) ;;
+  *) echo "error: -e must be none|minimal|low|medium|high|xhigh (got: $effort)" >&2; exit 2 ;;
+esac
+# "fast"/"standard" are Codex's UI names; the config values are priority/default.
+# Default standard: fast bills ~2.5x credits and delegations are background work
+# (the user's config.toml default is priority, so this must be explicit).
+tier=""
+case "${speed:-standard}" in
+  fast|priority) tier="priority" ;;
+  standard|default) tier="default" ;;
+  *) echo "error: -S must be fast|standard (got: $speed)" >&2; exit 2 ;;
+esac
+case "$model" in ""|gpt-5.6-sol|gpt-5.6-terra|gpt-5.6-luna) ;;
+  *) echo "error: -m must be gpt-5.6-sol|gpt-5.6-terra|gpt-5.6-luna (got: $model)" >&2; exit 2 ;;
+esac
 
 fill="$(cd "$(dirname "$0")" && pwd)/fill-prompt.sh"
 prompt=$("$fill" -t "$task_file" -C "$worktree" \
@@ -63,7 +93,12 @@ fi
 
 state_before=$(git_state "$worktree")
 harness_rc=0
-printf '%s\n' "$prompt" | codex exec -s workspace-write -C "$worktree" -o "$out" - \
+run_log=$(mktemp "${TMPDIR:-/tmp}/repo-delegate-codex-log.XXXXXX")
+printf '%s\n' "$prompt" | codex exec -s workspace-write -C "$worktree" -o "$out" \
+  ${model:+-m "$model"} \
+  ${effort:+-c model_reasoning_effort="$effort"} \
+  ${tier:+-c service_tier="$tier"} \
+  - 2>&1 | tee "$run_log" \
   || harness_rc=$?
 state_after=$(git_state "$worktree")
 if [ "$state_before" != "$state_after" ]; then
@@ -71,5 +106,9 @@ if [ "$state_before" != "$state_after" ]; then
   exit 1
 fi
 [ "$harness_rc" -eq 0 ] || { echo "error: harness exited $harness_rc" >&2; exit "$harness_rc"; }
+session_id=$(grep -m1 '^session id:' "$run_log" | awk '{print $3}') || true
+if [ -n "${session_id:-}" ]; then
+  printf '\n--- session %s (follow up: codex exec resume %s) ---\n' "$session_id" "$session_id"
+fi
 printf '\n--- report (%s) ---\n' "$out"
 cat "$out"

--- a/.agents/skills/repo-delegate/scripts/run-codex.sh
+++ b/.agents/skills/repo-delegate/scripts/run-codex.sh
@@ -30,14 +30,19 @@ dry_run=0
 allow_untracked=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    -t) task_file=$2; shift 2 ;;
-    -C) worktree=$2; shift 2 ;;
-    -g) gate=$2; shift 2 ;;
-    -c) constraints=$2; shift 2 ;;
-    -o) out=$2; shift 2 ;;
-    -m) model=$2; shift 2 ;;
-    -e) effort=$2; shift 2 ;;
-    -S) speed=$2; shift 2 ;;
+    -t|-C|-g|-c|-o|-m|-e|-S)
+      [ $# -ge 2 ] || { echo "error: $1 requires a value" >&2; exit 2; }
+      case "$1" in
+        -t) task_file=$2 ;;
+        -C) worktree=$2 ;;
+        -g) gate=$2 ;;
+        -c) constraints=$2 ;;
+        -o) out=$2 ;;
+        -m) model=$2 ;;
+        -e) effort=$2 ;;
+        -S) speed=$2 ;;
+      esac
+      shift 2 ;;
     --allow-untracked) allow_untracked=1; shift ;;
     --dry-run) dry_run=1; shift ;;
     -h|--help) usage ;;
@@ -91,14 +96,18 @@ if [ -n "$untracked" ] && [ "$allow_untracked" != 1 ]; then
   exit 1
 fi
 
+# tier is always set (defaults to standard), so the array is never empty —
+# important under set -u with macOS bash 3.2, where "${empty[@]}" errors.
+codex_args=(-c "service_tier=$tier")
+if [ -n "$model" ]; then codex_args+=(-m "$model"); fi
+if [ -n "$effort" ]; then codex_args+=(-c "model_reasoning_effort=$effort"); fi
+
 state_before=$(git_state "$worktree")
 harness_rc=0
 run_log=$(mktemp "${TMPDIR:-/tmp}/repo-delegate-codex-log.XXXXXX")
+trap 'rm -f "$run_log"' EXIT
 printf '%s\n' "$prompt" | codex exec -s workspace-write -C "$worktree" -o "$out" \
-  ${model:+-m "$model"} \
-  ${effort:+-c model_reasoning_effort="$effort"} \
-  ${tier:+-c service_tier="$tier"} \
-  - 2>&1 | tee "$run_log" \
+  "${codex_args[@]}" - 2>&1 | tee "$run_log" \
   || harness_rc=$?
 state_after=$(git_state "$worktree")
 if [ "$state_before" != "$state_after" ]; then
@@ -109,6 +118,8 @@ fi
 session_id=$(grep -m1 '^session id:' "$run_log" | awk '{print $3}') || true
 if [ -n "${session_id:-}" ]; then
   printf '\n--- session %s (follow up: codex exec resume %s) ---\n' "$session_id" "$session_id"
+else
+  echo "warning: no session id found in codex output (format change?) — resume via codex exec resume --last" >&2
 fi
 printf '\n--- report (%s) ---\n' "$out"
 cat "$out"

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ coverage
 # Agent worktrees
 .claude/worktrees/
 .worktrees/
+
+# Per-machine Codex instructions (Codex reads AGENTS.override.md alongside
+# AGENTS.md — the CLAUDE.local.md equivalent)
+AGENTS.override.md

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ coverage
 .claude/worktrees/
 .worktrees/
 
-# Per-machine Codex instructions (Codex reads AGENTS.override.md alongside
-# AGENTS.md — the CLAUDE.local.md equivalent)
+# Per-machine agent instructions: Codex reads AGENTS.override.md alongside
+# AGENTS.md; Claude Code reads CLAUDE.local.md alongside CLAUDE.md
 AGENTS.override.md
+CLAUDE.local.md


### PR DESCRIPTION
## Summary

- `run-codex.sh`: new `-m` (model, allowlisted to `gpt-5.6-sol|terra|luna`), `-e` (effort `none..xhigh`), `-S` (speed `fast|standard`) flags with fail-fast client-side validation — the API rejects a bad effort only after the session has started, and a bad service tier is silently dropped with a warning. Speed defaults to **standard**: fast bills ~2.5x credits and delegations are background work. The Codex session id is printed after each run for `codex exec resume <id>`.
- `run-claude.sh`: new `-m` (`sonnet|opus|haiku`, default opus) and `-e` (`low..max`, default medium) flags, plus token discipline for headless runs: `--strict-mcp-config` (no MCP tool schemas riding along), `--setting-sources project` (no user-level rules/skills), and `Agent`/`Task` tools denied (no subagent fan-out).
- `PROMPT.md`: delegates must not spawn subagents unless the brief says so, and must stop once the gate passes (GPT-5.6's failure mode is overrunning scope, not stopping early).
- `SKILL.md`: natural-language → flag mapping, effort/speed calibration, model roles, and a resume caution (input past ~272k tokens bills 2x — prefer a fresh scoped brief).
- `.gitignore`: `AGENTS.override.md` (Codex reads it alongside AGENTS.md as per-machine instructions) and `CLAUDE.local.md` (the Claude Code equivalent).

Defaults rationale: the orchestrator writes the brief, so the delegate executes a spec rather than solves an open problem — medium effort is the workhorse; higher effort and fast mode are explicit opt-ins.

## Validation

- `bash -n` on both runners; every validation path exercised (bad effort/speed/model values rejected with rc=2 before any tokens burn).
- End-to-end flag plumbing verified with a stub `codex` binary in a throwaway repo: flags arrive as `-m gpt-5.6-luna -c model_reasoning_effort=xhigh -c service_tier=priority`; session id captured and echoed; the git-state mutation guard still trips correctly.
- Effort enum, service-tier behavior (per-model: sol advertises only `priority`/`default`), and global `AGENTS.override.md`/`AGENTS.md` loading verified live against codex 0.144.1.

- [ ] Tested visually where it matters (no UI changes).
- [ ] Needs a June API (backend) deploy before it works end to end — no.

## Out of scope

- `~/.codex/config.toml` still defaults interactive sessions to the priority tier; only delegations force standard.
- No effort/speed surface for `fill-prompt.sh` itself (prompt content is unchanged apart from the two contract lines).

## Followups

- Revisit the `gpt-5.6-sol|terra|luna` allowlist when the model set changes ("for now" by design).
- Session naming at dispatch if Codex ever exposes it outside the TUI (`/rename` is TUI-only as of 0.144).

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs (n/a).
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review (n/a).
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (n/a).
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786527634&installation_id=144203540&pr_number=714&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F714&signature=820fe78fcb58a33acca8e5966d486ee1c5f97e7fa6bcad2e0e8879bad8d9b475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->