### PR TITLE
Remove reintroduced live microphone silence prompt

### DIFF
--- a/specs/001-tauri-note-mvp/contracts/ui.md
+++ b/specs/001-tauri-note-mvp/contracts/ui.md
@@ -65,7 +65,7 @@ Idle/draft:
 
 Recording:
 - UI shows active state, elapsed time, live waveform/level movement, and reachable `Pause` and `Done`.
-- Sustained silence or no bytes written produces a visible warning before Done.
+- Sustained silence does not add live warning copy. After Done, validation explains unusable audio before note generation.
 - `Pause` toggles to resume behavior without losing previously recorded audio.
 
 Done/finalizing:

--- a/specs/001-tauri-note-mvp/manual-validation.md
+++ b/specs/001-tauri-note-mvp/manual-validation.md
@@ -39,7 +39,7 @@ Manual-only because they require real microphone input, macOS privacy prompts, f
 
 - [ ] Mute or disconnect microphone input.
 - [ ] Record for at least 10 seconds.
-- [ ] Confirm the UI warns that microphone input appears silent.
+- [ ] Confirm no live silence prompt appears, then select Done and verify validation explains the unusable audio.
 - [ ] Confirm Done does not generate a note from unusable audio.
 
 ## Network/Provider Failure Retry

--- a/specs/001-tauri-note-mvp/quickstart.md
+++ b/specs/001-tauri-note-mvp/quickstart.md
@@ -53,7 +53,6 @@ Expected result: saved readable audio, transcript, generated note, and persisted
 2. Mute or disconnect microphone input if possible.
 3. Record for at least 10 seconds.
 4. Select Done and verify validation explains that the audio is unusable.
-5. Click Done.
 
 Expected result: validation fails or warns before provider processing, and the app does not generate a note from unusable audio.
 

--- a/specs/001-tauri-note-mvp/quickstart.md
+++ b/specs/001-tauri-note-mvp/quickstart.md
@@ -52,7 +52,7 @@ Expected result: saved readable audio, transcript, generated note, and persisted
 1. Create a note.
 2. Mute or disconnect microphone input if possible.
 3. Record for at least 10 seconds.
-4. Verify the UI warns that input appears silent.
+4. Select Done and verify validation explains that the audio is unusable.
 5. Click Done.
 
 Expected result: validation fails or warns before provider processing, and the app does not generate a note from unusable audio.

--- a/specs/001-tauri-note-mvp/spec.md
+++ b/specs/001-tauri-note-mvp/spec.md
@@ -121,7 +121,7 @@ A user does not lose a recording if the app is closed, crashes, or loses network
 - **RR-001**: Recording MUST NOT be considered successful until an audio file has been finalized and verified as readable.
 - **RR-002**: The app MUST record session checkpoints at start, pause, resume, done, validation, transcription, generation, and completion.
 - **RR-003**: The app MUST compare expected elapsed recording time with actual saved audio duration and flag mismatches above tolerance.
-- **RR-004**: The app MUST detect sustained silence during active recording and make that state visible to the user before Done.
+- **RR-004**: The app MUST detect sustained silence for recording validation without showing a live silence prompt; unusable audio is explained after Done through validation or recovery UI.
 - **RR-005**: The app MUST support retrying transcription/generation from saved audio without requiring a new recording.
 - **RR-006**: The app MUST make it visually obvious when it is listening, paused, validating, transcribing, generating, failed, or ready.
 

--- a/specs/001-tauri-note-mvp/spec.md
+++ b/specs/001-tauri-note-mvp/spec.md
@@ -19,7 +19,7 @@ A user opens the desktop app, creates a new note, records from the microphone, s
 
 1. **Given** the user has granted microphone access and is on the new note screen, **When** they start recording and speak, **Then** the recording UI shows elapsed time, active waveform movement, and a non-idle recording state.
 2. **Given** the user has been recording for at least 10 seconds, **When** they select Done, **Then** the app finalizes the audio file, validates that it contains usable audio, transcribes it, and generates note content without requiring the user to copy/paste the transcript.
-3. **Given** the microphone is muted, disconnected, or producing no meaningful signal, **When** the user records, **Then** the app warns that audio capture appears silent before allowing them to generate a note.
+3. **Given** the microphone is muted, disconnected, or producing no meaningful signal, **When** the user finishes recording, **Then** validation explains that the audio is unusable before allowing note generation.
 4. **Given** transcription or AI note generation fails after audio was saved, **When** the user views the note, **Then** the saved audio and recording metadata remain available for retry.
 
 ---
@@ -156,7 +156,7 @@ A user does not lose a recording if the app is closed, crashes, or loses network
 
 - **SC-001**: In 20 consecutive manual recordings of at least 30 seconds each with audible speech, the app saves a readable audio file every time.
 - **SC-002**: For a valid 60-second recording, the user can complete capture, validation, transcription, and note generation without manually copying transcript text.
-- **SC-003**: When the microphone is muted or silent for 10 seconds during active recording, the app visibly warns the user before Done.
+- **SC-003**: When a finished recording contains only silence, validation visibly explains that the audio is unusable before note generation.
 - **SC-004**: When network access is disabled after recording, the audio remains saved locally and the note can be retried after network access returns.
 - **SC-005**: The notes list, folder selection, and note editor remain responsive with at least 500 local notes.
 - **SC-006**: A long transcript of at least 10,000 characters can be opened and scrolled without blocking note editing.

--- a/specs/001-tauri-note-mvp/tasks.md
+++ b/specs/001-tauri-note-mvp/tasks.md
@@ -48,7 +48,7 @@
 
 - [x] T014 [P] [US1] Add audio validation tests for readable WAV, zero-byte file, duration mismatch, too-short audio, and silence detection in src-tauri/tests/recording_validation.rs
 - [x] T015 [P] [US1] Add provider pipeline tests for mock transcription, empty transcript failure, generated-note constraints, and retryable provider failure in src-tauri/tests/processing.rs
-- [x] T016 [P] [US1] Add frontend recorder component tests for elapsed state, waveform levels, pause/resume, Done, silence warning, and failed validation in src/test/recorder.test.tsx
+- [x] T016 [P] [US1] Add frontend recorder component tests for elapsed state, waveform levels, pause/resume, Done, suppressed live silence prompts, and failed validation in src/test/recorder.test.tsx
 
 ### Implementation for User Story 1
 

--- a/specs/002-system-audio-source-mode/contracts/ui.md
+++ b/specs/002-system-audio-source-mode/contracts/ui.md
@@ -39,7 +39,8 @@ Start behavior:
 
 `Microphone only`:
 
-- Preserves the existing recorder layout, elapsed time, waveform, Pause, Resume, Done, silence warning, and validation states.
+- Preserves the existing recorder layout, elapsed time, waveform, Pause, Resume, Done, and validation states.
+- Does not surface the live silence heuristic as warning copy. Unusable audio is explained after validation.
 
 `Microphone + system audio`:
 

--- a/specs/002-system-audio-source-mode/tasks.md
+++ b/specs/002-system-audio-source-mode/tasks.md
@@ -71,7 +71,7 @@
 - [x] T023 [US2] Add macOS helper source, build script, and process manager for system audio capture in `src-tauri/native/mac-system-audio-recorder/main.swift`, `src-tauri/build.rs`, and `src-tauri/src/audio/system_macos.rs`
 - [x] T024 [US2] Implement dual-source start, pause, resume, status, finish, validation, and partial-source warnings in `src-tauri/src/audio/capture.rs` and `src-tauri/src/commands.rs`
 - [x] T025 [US2] Persist source artifacts and source-labeled transcripts from finished recordings in `src-tauri/src/db/repositories.rs` and `src-tauri/src/domain/processing.rs`
-- [x] T026 [US2] Render per-source levels, bytes, silence warnings, source labels, and labeled transcript content in `src/components/recorder/RecorderBar.tsx`, `src/components/recorder/Waveform.tsx`, and `src/components/note-editor/NoteEditor.tsx`
+- [x] T026 [US2] Render per-source levels, bytes, post-validation source warnings, source labels, and labeled transcript content in `src/components/recorder/RecorderBar.tsx`, `src/components/recorder/Waveform.tsx`, and `src/components/note-editor/NoteEditor.tsx`
 - [x] T027 [US2] Run US2 frontend and Rust tests, then mark the story complete only after they pass
 
 ---

--- a/src/components/recorder/GlobalRecorderPill.tsx
+++ b/src/components/recorder/GlobalRecorderPill.tsx
@@ -2,7 +2,6 @@ import { useRef } from "react";
 import type { RecordingStatusDto } from "../../lib/tauri";
 import { combineSourceAudioLevels, Waveform } from "./Waveform";
 import { useRecordingPresenceBounds } from "../../lib/recording-presence-bounds";
-import { hasMicrophoneSilenceWarning } from "./RecorderBar";
 
 type GlobalRecorderPillProps = {
   status: RecordingStatusDto;
@@ -20,7 +19,6 @@ type GlobalRecorderPillProps = {
 export function GlobalRecorderPill({ status, title, onOpen }: GlobalRecorderPillProps) {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const recording = status.state === "recording";
-  const microphoneSilent = hasMicrophoneSilenceWarning(status);
   useRecordingPresenceBounds(buttonRef);
   // status.level is mic-only; status.sources carries mic+system when available.
   const meterLevel =
@@ -36,11 +34,9 @@ export function GlobalRecorderPill({ status, title, onOpen }: GlobalRecorderPill
       data-state={status.state}
       onClick={onOpen}
       aria-label={`Open recording: ${title}`}
-      title={microphoneSilent ? "Mic looks silent" : "Open recording"}
-      data-warning={microphoneSilent ? "silence" : undefined}
+      title="Open recording"
     >
       <Waveform level={meterLevel} active={recording} />
-      {microphoneSilent ? <span className="global-recorder-warning">Mic looks silent</span> : null}
     </button>
   );
 }

--- a/src/components/recorder/RecorderBar.tsx
+++ b/src/components/recorder/RecorderBar.tsx
@@ -14,7 +14,6 @@ type RecorderBarProps = {
 export function RecorderBar({ status, onPause, onResume, onDone }: RecorderBarProps) {
   const paused = status.state === "paused";
   const controlsEnabled = status.state === "recording" || status.state === "paused";
-  const microphoneSilent = hasMicrophoneSilenceWarning(status);
   // status.level is mic-only; status.sources carries mic+system when available.
   const meterLevel =
     status.sources && status.sources.length > 0
@@ -43,9 +42,6 @@ export function RecorderBar({ status, onPause, onResume, onDone }: RecorderBarPr
       <div className="recorder-meter">
         <span className="elapsed">{formatElapsed(status.elapsedMs)}</span>
         <Waveform level={meterLevel} active={status.state === "recording"} />
-        {microphoneSilent ? (
-          <span className="recorder-silence-warning">Mic looks silent</span>
-        ) : null}
       </div>
       <button
         type="button"
@@ -59,11 +55,6 @@ export function RecorderBar({ status, onPause, onResume, onDone }: RecorderBarPr
       </button>
     </div>
   );
-}
-
-export function hasMicrophoneSilenceWarning(status: RecordingStatusDto) {
-  const microphone = status.sources?.find((source) => source.source === "microphone");
-  return microphone?.silenceWarning ?? status.silenceWarning;
 }
 
 export function formatElapsed(ms: number) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11413,15 +11413,6 @@ input:focus-visible,
   font-weight: 400;
 }
 
-/* A live mic that has produced only silence is a session about to be lost;
- * the hint reads as a problem (destructive), not ambience. */
-.recorder-silence-warning,
-.global-recorder-warning {
-  color: var(--destructive);
-  font-size: var(--fs-xs);
-  white-space: nowrap;
-}
-
 /* Waveform ---------------------------------------------------------- */
 
 /* Mirrors the dictation HUD bars (.hud-bar) so the recorder waveform reads as

--- a/src/test/recorder.test.tsx
+++ b/src/test/recorder.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { GlobalRecorderPill } from "../components/recorder/GlobalRecorderPill";
 import { RecorderBar } from "../components/recorder/RecorderBar";
 import {
   combineAudioLevels,
@@ -8,6 +9,10 @@ import {
   SOURCE_VISUAL_GAIN,
   visualPeakScale,
 } from "../components/recorder/Waveform";
+
+vi.mock("../lib/recording-presence-bounds", () => ({
+  useRecordingPresenceBounds: vi.fn(),
+}));
 
 describe("RecorderBar", () => {
   it("shows elapsed time, waveform evidence, and pause/done actions while recording", () => {
@@ -287,5 +292,41 @@ describe("RecorderBar", () => {
     expect(loud).toBeLessThan(0.95);
     // A genuine peak still reaches (effectively) full height.
     expect(visualPeakScale(0.9)).toBeGreaterThanOrEqual(0.99);
+  });
+});
+
+describe("GlobalRecorderPill", () => {
+  it("does not surface a live silence prompt", () => {
+    render(
+      <GlobalRecorderPill
+        status={{
+          sessionId: "session-1",
+          state: "recording",
+          elapsedMs: 15_000,
+          level: { peak: 0, rms: 0, recentPeaks: [] },
+          silenceWarning: true,
+          sources: [
+            {
+              source: "microphone",
+              state: "recording",
+              elapsedMs: 15_000,
+              bytesWritten: 4096,
+              level: { peak: 0, rms: 0, recentPeaks: [] },
+              silenceWarning: true,
+              pathFinalized: false,
+            },
+          ],
+          bytesWritten: 4096,
+        }}
+        title="Test note"
+        onOpen={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/silent/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open recording: Test note" })).toHaveAttribute(
+      "title",
+      "Open recording",
+    );
   });
 });

--- a/src/test/recorder.test.tsx
+++ b/src/test/recorder.test.tsx
@@ -60,7 +60,7 @@ describe("RecorderBar", () => {
     expect(onDone).toHaveBeenCalledWith("session-1");
   });
 
-  it("shows the mic silence warning when the microphone source reports it", () => {
+  it("does not surface a live silence prompt when the microphone source reports one", () => {
     render(
       <RecorderBar
         status={{
@@ -88,10 +88,10 @@ describe("RecorderBar", () => {
       />,
     );
 
-    expect(screen.getByText("Mic looks silent")).toBeInTheDocument();
+    expect(screen.queryByText(/silent/i)).not.toBeInTheDocument();
   });
 
-  it("does not show the mic silence warning while the mic has signal", () => {
+  it("does not show a mic silence warning while the mic has signal", () => {
     render(
       <RecorderBar
         status={{
@@ -119,7 +119,7 @@ describe("RecorderBar", () => {
       />,
     );
 
-    expect(screen.queryByText("Mic looks silent")).not.toBeInTheDocument();
+    expect(screen.queryByText(/silent/i)).not.toBeInTheDocument();
   });
 
   it("uses resume action when paused", async () => {
@@ -184,7 +184,7 @@ describe("RecorderBar", () => {
       />,
     );
 
-    expect(screen.queryByText("Microphone input appears silent")).not.toBeInTheDocument();
+    expect(screen.queryByText(/silent/i)).not.toBeInTheDocument();
   });
 
   it("drives the waveform from system audio when the mic is quiet", () => {

--- a/src/test/recorder.test.tsx
+++ b/src/test/recorder.test.tsx
@@ -94,37 +94,10 @@ describe("RecorderBar", () => {
     );
 
     expect(screen.queryByText(/silent/i)).not.toBeInTheDocument();
-  });
-
-  it("does not show a mic silence warning while the mic has signal", () => {
-    render(
-      <RecorderBar
-        status={{
-          sessionId: "session-1",
-          state: "recording",
-          elapsedMs: 15_000,
-          level: { peak: 0.7, rms: 0.3, recentPeaks: [0.4] },
-          silenceWarning: false,
-          sources: [
-            {
-              source: "microphone",
-              state: "recording",
-              elapsedMs: 15_000,
-              bytesWritten: 4096,
-              level: { peak: 0.7, rms: 0.3, recentPeaks: [0.4] },
-              silenceWarning: false,
-              pathFinalized: false,
-            },
-          ],
-          bytesWritten: 4096,
-        }}
-        onPause={vi.fn()}
-        onResume={vi.fn()}
-        onDone={vi.fn()}
-      />,
+    expect(screen.getByLabelText("Audio activity").parentElement).toHaveProperty(
+      "childElementCount",
+      2,
     );
-
-    expect(screen.queryByText(/silent/i)).not.toBeInTheDocument();
   });
 
   it("uses resume action when paused", async () => {
@@ -190,6 +163,10 @@ describe("RecorderBar", () => {
     );
 
     expect(screen.queryByText(/silent/i)).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Audio activity").parentElement).toHaveProperty(
+      "childElementCount",
+      2,
+    );
   });
 
   it("drives the waveform from system audio when the mic is quiet", () => {
@@ -327,6 +304,13 @@ describe("GlobalRecorderPill", () => {
     expect(screen.getByRole("button", { name: "Open recording: Test note" })).toHaveAttribute(
       "title",
       "Open recording",
+    );
+    expect(screen.getByRole("button", { name: "Open recording: Test note" })).not.toHaveAttribute(
+      "data-warning",
+    );
+    expect(screen.getByRole("button", { name: "Open recording: Test note" })).toHaveProperty(
+      "childElementCount",
+      1,
     );
   });
 });


### PR DESCRIPTION
## Summary

- remove the reintroduced live microphone-silence prompt from the in-note recorder and off-note recording pill
- keep silence detection and post-recording validation/recovery messaging intact
- align the recording specs and QA checklists with the no-live-prompt decision
- strengthen regression coverage for top-level and per-source silence flags, recorder DOM shape, and the off-note tooltip/state

Closes JUN-303

## Root cause

The July recording-reliability batch reintroduced `Mic looks silent` after the live silence prompt had previously been removed. It appended the copy to recorder surfaces whose fixed dimensions only budgeted for the timer, waveform, and controls, causing the warning and waveform to overrun neighboring elements.

## Validation

- `make verify` - passed (2,382 frontend tests passed, 2 skipped; Tauri and June API fmt, clippy, and tests passed)
- focused recorder/note reliability tests - 67 passed before the full gate; final recorder suite - 13 passed
- `pnpm typecheck` - passed after the final review fixes
- live Chromium QA with both top-level and microphone-source silence flags forced on - no live silence copy, 240px in-note shell preserved, timer/waveform/stop bounds separated, 58px off-note pill preserved
- standard review battery - Standards clean, Spec clean, Adversarial approve

## Visual evidence

![Recorder with the live silence prompt suppressed](https://app.opensoftware.co/api/v1/files/fil_6IxeIQYjdX4J/download)

[QA recording](https://app.opensoftware.co/api/v1/files/fil_kOECwnL7jgzO/download)

- [x] Tested visually where it matters (screenshot and recording embedded above).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- backend silence detection, saved-audio validation, and post-recording failure messaging
- designing a distinct away-from-note affordance for hard microphone stream failures

## Followups

- Consider a separate away-from-note hard stream failure affordance driven by `status.warnings`; the existing `silenceWarning` boolean conflates the heuristic with stream issues and should not be reused for user-facing copy.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. None.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow changes.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such changes.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend changes.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786549792&installation_id=144203540&pr_number=716&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F716&signature=726ae022b9dd2a63bc203f371247db462654c72460848491629cf10f0b9c3f48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
