### PR TITLE
Restyle the non-vision image warning as a docked composer card

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -9144,6 +9144,48 @@ export function AgentWorkspace({
             ) : null}
           </section>
         ) : null}
+        <AnimatePresence>
+          {showImageModelWarning ? (
+            // Docked above the box in the FundingNotice family — same surface
+            // recipe, so the pair reads as one floating unit. The warm triangle
+            // carries the caution tone.
+            <motion.section
+              key="image-model-warning"
+              className="agent-composer-image-warning"
+              role="status"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.22, ease: "easeOut" }}
+            >
+              <span className="agent-composer-image-warning-icon" aria-hidden>
+                <IconExclamationTriangle size={14} />
+              </span>
+              <p className="agent-composer-image-warning-text">{imageModelWarningText}</p>
+              {preferredVisionModel && !composerModelLocked ? (
+                <div className="agent-composer-image-warning-actions">
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    onClick={() =>
+                      // Switch straight to the preferred image-capable model. The
+                      // label promises a one-tap fix, and the generic model picker
+                      // isn't vision-scoped — opening it for the multi-candidate
+                      // case would drop the user into an unfiltered list that
+                      // doesn't surface the eligible models. preferredVisionModel
+                      // is pre-filtered to image + tool support and prefers a
+                      // suggested pick. This only appears before a thread
+                      // exists, where model changes still update the default.
+                      void handleSelectGenerationModel(preferredVisionModel.id)
+                    }
+                  >
+                    Switch to {preferredVisionModel.name}
+                  </button>
+                </div>
+              ) : null}
+            </motion.section>
+          ) : null}
+        </AnimatePresence>
         <div ref={composerBoxRef} className="agent-composer-box">
           {attachments.length ? (
             <div className="agent-composer-attachments">
@@ -9154,35 +9196,6 @@ export function AgentWorkspace({
                   onRemove={() => removeAttachment(attachment.id)}
                 />
               ))}
-            </div>
-          ) : null}
-          {showImageModelWarning ? (
-            <div className="agent-composer-image-warning" role="status">
-              <IconExclamationTriangle
-                size={14}
-                aria-hidden
-                className="agent-composer-image-warning-icon"
-              />
-              <span className="agent-composer-image-warning-text">{imageModelWarningText}</span>
-              {preferredVisionModel && !composerModelLocked ? (
-                <button
-                  type="button"
-                  className="agent-composer-notice-button agent-composer-image-warning-action"
-                  onClick={() =>
-                    // Switch straight to the preferred image-capable model. The
-                    // label promises a one-tap fix, and the generic model picker
-                    // isn't vision-scoped — opening it for the multi-candidate
-                    // case would drop the user into an unfiltered list that
-                    // doesn't surface the eligible models. preferredVisionModel
-                    // is pre-filtered to image + tool support and prefers a
-                    // suggested pick. This only appears before a thread
-                    // exists, where model changes still update the default.
-                    void handleSelectGenerationModel(preferredVisionModel.id)
-                  }
-                >
-                  Switch to {preferredVisionModel.name}
-                </button>
-              ) : null}
             </div>
           ) : null}
           {visibleComposerSizeWarning ? (

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4899,7 +4899,9 @@ input:focus-visible,
   gap: var(--sp-2) var(--sp-3);
   width: 100%;
   max-width: min(var(--chat-max), var(--content-max));
-  margin: 0 auto var(--sp-3);
+  /* sp-2 below, like every card docked on the composer box (the steer queue,
+   * the image warning), so a stacked column keeps one even rhythm. */
+  margin: 0 auto var(--sp-2);
   padding: var(--sp-2) var(--sp-2) var(--sp-2) var(--sp-3);
   /* Ring-in-shadow like the composer box: the transparent border only holds
    * the layout box (see --composer-ring). */
@@ -5072,13 +5074,14 @@ input:focus-visible,
   min-width: 16ch;
   /* Centers a single line inside the control-height zone the badge and CTA
    * occupy; a wrapped second line grows downward from there. */
-  margin: calc((var(--control-md) - 1.5 * var(--fs-sm)) / 2) 0 0;
+  margin: calc((var(--control-md) - 1.5 * var(--fs-md)) / 2) 0 0;
   /* A shade under full foreground: present, but not competing with the
    * conversation. */
   color: color-mix(in oklch, var(--foreground) 72%, var(--muted-foreground));
-  /* Two steps below conversation text: this annotates the chat rather than
-   * competing with it, while the CTA remains the clear action at the right. */
-  font-size: var(--fs-sm);
+  /* One step below conversation text: this annotates the chat rather than
+   * competing with it, while the CTA remains the clear action at the right.
+   * (Shared with the composer image warning — move them together.) */
+  font-size: var(--fs-md);
   line-height: 1.5;
 }
 
@@ -6587,15 +6590,76 @@ input:focus-visible,
   padding: var(--sp-1) var(--sp-1) 0;
 }
 
-/* Non-vision model + image attachment: a quiet inline row between the chips and
- * the editor. The active model can't read the image, so warn before send and
- * offer a one-tap switch to an image-capable model (the send-time fallback in
- * unsupportedImageInputPrompt still degrades gracefully if the user sends
- * anyway). */
-.agent-composer-image-warning,
+/* Non-vision model + image attachment: docks above the composer box in the
+ * FundingNotice family — the same row anatomy (leading glyph, fs-sm body,
+ * trailing CTA) on the composer box's own surface recipe (card,
+ * ring-in-shadow, --shadow-md) so the pair reads as one floating unit. The
+ * warm triangle carries the caution tone; the one-tap switch is the way out
+ * (the send-time fallback in unsupportedImageInputPrompt still degrades
+ * gracefully if the user sends anyway). */
+.agent-composer-image-warning {
+  pointer-events: auto;
+  display: flex;
+  flex-wrap: wrap;
+  /* First-line anchoring, like the funding notice: the glyph and the CTA pin
+   * to the first text line instead of floating centered if the body wraps. */
+  align-items: flex-start;
+  gap: var(--sp-2) var(--sp-3);
+  width: 100%;
+  max-width: min(var(--chat-max), var(--content-max));
+  margin-bottom: var(--sp-2);
+  padding: var(--sp-2) var(--sp-2) var(--sp-2) var(--sp-3);
+  border: 1px solid transparent;
+  border-radius: var(--r-xl);
+  background: var(--card);
+  box-shadow:
+    var(--shadow-md),
+    0 0 0 1px color-mix(in oklch, var(--border-subtle) 60%, transparent);
+}
+
+/* Track the hero box's deliberate 640px cap so their edges align. */
+.agent-composer[data-hero="true"] .agent-composer-image-warning {
+  max-width: 640px;
+}
+
+.agent-composer-image-warning-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  /* CTA-height zone so the glyph centers on the first text line. */
+  height: var(--control-md);
+  color: var(--warm-strong);
+}
+
+.agent-composer-image-warning-text {
+  flex: 1;
+  min-width: 16ch;
+  /* Centers a single line inside the control-height zone the glyph and CTA
+   * occupy; a wrapped second line grows downward from there. */
+  margin: calc((var(--control-md) - 1.5 * var(--fs-md)) / 2) 0 0;
+  color: color-mix(in oklch, var(--foreground) 72%, var(--muted-foreground));
+  /* One step below conversation text, matching .funding-notice-body — the
+   * two dock on the same surface, so their bodies move together. */
+  font-size: var(--fs-md);
+  line-height: 1.5;
+}
+
+.agent-composer-image-warning-actions {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  margin-left: auto;
+}
+
+.agent-composer-image-warning-actions .btn {
+  white-space: nowrap;
+}
+
+/* Oversize draft: a quiet inline row between the chips and the editor. */
 .agent-composer-size-warning {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  flex-wrap: wrap;
   gap: var(--sp-1);
   margin: var(--sp-1) var(--sp-1) 0;
   padding: var(--sp-1) var(--sp-2);
@@ -6605,23 +6669,13 @@ input:focus-visible,
   font-size: var(--fs-sm);
 }
 
-.agent-composer-size-warning {
-  align-items: flex-start;
-  flex-wrap: wrap;
-}
-
-.agent-composer-image-warning-icon,
 .agent-composer-size-warning-icon {
   flex: 0 0 auto;
   color: var(--muted-foreground);
 }
 
-.agent-composer-image-warning-text,
 .agent-composer-size-warning-text {
   min-width: 0;
-}
-
-.agent-composer-size-warning-text {
   flex: 1 1 240px;
 }
 
@@ -6631,11 +6685,6 @@ input:focus-visible,
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: var(--sp-1);
-  margin-left: auto;
-}
-
-.agent-composer-image-warning-action {
-  flex: 0 0 auto;
   margin-left: auto;
 }
 


### PR DESCRIPTION
## Summary

- The composer's "GLM 5.2 can't read images" warning was a full-width grey slab inside the composer box with a muted icon and a boxy bordered button - off-brand next to the new steering ("Up next") and funding surfaces.
- It now docks above the composer box in the FundingNotice family: same row anatomy (leading glyph, body, `.btn btn-secondary` CTA pinned to the first text line) on the composer box's own surface recipe (solid card, `--r-xl`, `--shadow-md` with the hairline ring folded into the shadow), so the stacked pair reads as one floating unit. The triangle wears `--warm-strong` (warm is the caution tone), the card fades in/out through the composer's existing `AnimatePresence`, and it tracks the hero box's 640px cap so edges align in hero mode.
- Family alignment while in there: both notice bodies (`.funding-notice-body` and the new warning) move from `--fs-sm` (12px) to `--fs-md` (13px) - one step under conversation text instead of two, the 12px body read too small in situ - and the funding notice's bottom margin drops from `--sp-3` to `--sp-2` so every card docked on the composer box keeps one even 6px rhythm.
- Behavior untouched: same trigger conditions (image attached or `/image` drafted on a non-vision model), same one-tap switch to the preferred vision model, same send-time fallback if the user sends anyway.

## Validation

- `pnpm typecheck`, Biome clean on both files.
- Covering tests pass: "warns and offers a one-tap switch when an image is attached to a non-vision model", "blocks /image on a non-vision model until the user switches explicitly" (agent-workspace), and all 23 funding-notice tests.
- [x] Tested visually where it matters (verified in the running app; the docked card and the funding notice stack with even spacing).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- The oversize-draft token warning (`.agent-composer-size-warning`) keeps the old quiet in-box row; its CSS was decoupled from the image warning here but not restyled (it carries three actions, so it wants its own layout pass).

## Followups

- Restyle the size warning into the same docked family if this direction holds.
- Optional `__imageWarningDemo()` dev command alongside `__upNextDemo` to park the warning state for design iteration.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786551556&installation_id=144203540&pr_number=721&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F721&signature=70f21c28b08bec26d7ff556b345c29c2c96aca1e7365ebd36141e6416ec52889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->