### PR TITLE
Make Auto the suggested model experience

### DIFF
--- a/docs/auto-model-rollout.md
+++ b/docs/auto-model-rollout.md
@@ -3,8 +3,9 @@
 June supports `open-software/auto` while retaining explicit model selection. Auto persists a
 Cost-to-quality preference and forwards it through Hermes and note generation.
 
-The rollout remains reversible. Set `JUNE__UPSTREAMS__VENICE__BASE_URL` to
-`https://api.opensoftware.co/v1` and provide the dedicated os-api service key through the existing
-`JUNE__UPSTREAMS__VENICE__API_KEY` sealed secret. Then
-build the desktop release with `OS_JUNE_AUTO_MODE_DEFAULT=true`. Existing users retain their saved
-model. Roll back by restoring the upstream URL and removing the build flag.
+The rollout remains reversible. Production compose pins
+`JUNE__UPSTREAMS__VENICE__BASE_URL` to `https://api.opensoftware.co/v1`; Phala's sealed
+`JUNE__UPSTREAMS__VENICE__API_KEY` contains June's dedicated os-api service key.
+
+Build the desktop release with `OS_JUNE_AUTO_MODE_DEFAULT=true`. Existing users retain their saved
+model. Roll back by restoring the Venice URL in production compose and removing the build flag.

--- a/june-api/deploy/docker-compose.production.yml
+++ b/june-api/deploy/docker-compose.production.yml
@@ -60,7 +60,9 @@ services:
       - JUNE__OS_ACCOUNTS__P3A_INGEST_TOKEN=${JUNE__OS_ACCOUNTS__P3A_INGEST_TOKEN}
       - JUNE__UPSTREAMS__OPENAI__API_KEY=${JUNE__UPSTREAMS__OPENAI__API_KEY}
       - JUNE__UPSTREAMS__VENICE__API_KEY=${JUNE__UPSTREAMS__VENICE__API_KEY}
-      - JUNE__UPSTREAMS__VENICE__BASE_URL=${JUNE__UPSTREAMS__VENICE__BASE_URL:-https://api.venice.ai/api/v1}
+      # Production text inference is routed through os-api; the matching
+      # dedicated service key remains in Phala's sealed environment.
+      - JUNE__UPSTREAMS__VENICE__BASE_URL=https://api.opensoftware.co/v1
       - JUNE__ISSUE_REPORTS__OS_PLATFORM_API_KEY=${JUNE__ISSUE_REPORTS__OS_PLATFORM_API_KEY}
 
 volumes:

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2533,7 +2533,7 @@ export function AgentWorkspace({
   // each chat's stored model. A selection missing from the catalog still
   // shows as a name-only stub so the pill never goes blank while configured.
   const [defaultGenerationModelId, setDefaultGenerationModelId] = useState("");
-  const [generationCostQuality, setGenerationCostQuality] = useState(100);
+  const [generationCostQuality, setGenerationCostQuality] = useState<number | undefined>();
   const defaultGenerationModelIdRef = useRef("");
   const [generationModels, setGenerationModels] = useState<VeniceModelDto[]>([]);
   const generationModelsRef = useRef<VeniceModelDto[]>([]);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -121,6 +121,7 @@ import {
   setImageSafeMode,
   setImageSafeModePromptDismissed,
   setLocalGenerationEnabled,
+  setCostQuality,
   setVeniceModel,
   startHermesBridge,
   submitIssueReport,
@@ -2532,6 +2533,7 @@ export function AgentWorkspace({
   // each chat's stored model. A selection missing from the catalog still
   // shows as a name-only stub so the pill never goes blank while configured.
   const [defaultGenerationModelId, setDefaultGenerationModelId] = useState("");
+  const [generationCostQuality, setGenerationCostQuality] = useState(100);
   const defaultGenerationModelIdRef = useRef("");
   const [generationModels, setGenerationModels] = useState<VeniceModelDto[]>([]);
   const generationModelsRef = useRef<VeniceModelDto[]>([]);
@@ -3582,6 +3584,7 @@ export function AgentWorkspace({
       setGenerationProvider(provider);
       defaultGenerationModelIdRef.current = selectedModelId;
       setDefaultGenerationModelId(selectedModelId);
+      setGenerationCostQuality(settings.costQuality);
       return selectedModelId;
     },
     [],
@@ -3734,7 +3737,7 @@ export function AgentWorkspace({
   // exists. It writes the app-wide text-model default (Settings' model rows and
   // this pill refresh through the same changed event), and new sessions inherit
   // that choice at creation time.
-  async function handleSelectGenerationModel(modelId: string) {
+  async function handleSelectGenerationModel(modelId: string, costQuality?: number) {
     setComposerModelOpen(false);
     if (composerModelSelectionLocked()) {
       showComposerModelLockedNotice();
@@ -3758,6 +3761,10 @@ export function AgentWorkspace({
       return false;
     }
     try {
+      if (costQuality !== undefined) {
+        const next = await setCostQuality(costQuality);
+        setGenerationCostQuality(next.costQuality);
+      }
       await setVeniceModel("generation", modelId);
       markRemoteGenerationSelected(modelId);
       dispatchProviderModelSettingsChanged({ mode: "generation", modelId });
@@ -9513,12 +9520,15 @@ export function AgentWorkspace({
             flyout={composerModelFlyout}
             model={generationModel}
             options={modelOptions(generationModelOptions, generationModel?.id ?? "")}
+            costQuality={generationCostQuality}
             search={modelSearch}
             popoverRef={composerModelPopoverRef}
             searchRef={composerModelSearchRef}
             onFlyoutChange={setComposerModelFlyout}
             onSearchChange={setModelSearch}
-            onSelect={(modelId) => void handleSelectGenerationModel(modelId)}
+            onSelect={(modelId, costQuality) =>
+              void handleSelectGenerationModel(modelId, costQuality)
+            }
           />
         ) : null}
         {heroMode && sandboxMenuOpen ? (

--- a/src/components/agent/composer/ModelPicker.tsx
+++ b/src/components/agent/composer/ModelPicker.tsx
@@ -86,6 +86,7 @@ export function ComposerModelPopover({
   flyout,
   model,
   options,
+  costQuality,
   search,
   popoverRef,
   searchRef,
@@ -96,12 +97,13 @@ export function ComposerModelPopover({
   flyout: ComposerModelFlyout;
   model?: VeniceModelDto;
   options: VeniceModelDto[];
+  costQuality?: number;
   search: string;
   popoverRef: RefObject<HTMLDivElement>;
   searchRef: RefObject<HTMLInputElement>;
   onFlyoutChange: (flyout: ComposerModelFlyout) => void;
   onSearchChange: (value: string) => void;
-  onSelect: (modelId: string) => void;
+  onSelect: (modelId: string, costQuality?: number) => void;
 }) {
   const flyoutRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -286,7 +288,7 @@ export function ComposerModelPopover({
     ? privacyFiltered.filter((option) => modelMatchesQuery(option, query))
     : privacyFiltered;
   const detail =
-    flyout?.kind === "model" ? suggested.find((item) => item.model.id === flyout.id) : undefined;
+    flyout?.kind === "model" ? suggested.find((item) => item.key === flyout.id) : undefined;
 
   // Latest filtered rows, read by the hand-off closure without re-subscribing
   // the pointer listener on every keystroke.
@@ -389,20 +391,23 @@ export function ComposerModelPopover({
       <p className="agent-composer-model-title">Suggested</p>
       <div className="agent-composer-model-menu" role="listbox" aria-label="Suggested text models">
         {suggested.length ? (
-          suggested.map(({ model: option }) => (
+          suggested.map(({ key, model: option, costQuality: presetCostQuality }) => (
             <button
-              key={option.id}
+              key={key}
               type="button"
               className="agent-composer-model-row"
               role="option"
-              aria-selected={option.id === model.id}
-              data-model-id={option.id}
-              data-active={(flyout?.kind === "model" && flyout.id === option.id) || undefined}
+              aria-selected={
+                option.id === model.id &&
+                (presetCostQuality === undefined || presetCostQuality === costQuality)
+              }
+              data-model-id={key}
+              data-active={(flyout?.kind === "model" && flyout.id === key) || undefined}
               onMouseEnter={() => {
                 if (modelBridge.isActive()) {
                   return;
                 }
-                const open = () => onFlyoutChange({ kind: "model", id: option.id });
+                const open = () => onFlyoutChange({ kind: "model", id: key });
                 if (flyout) {
                   cancelHoverIntent();
                   open();
@@ -412,12 +417,13 @@ export function ComposerModelPopover({
               }}
               onFocus={() => {
                 cancelHoverIntent();
-                onFlyoutChange({ kind: "model", id: option.id });
+                onFlyoutChange({ kind: "model", id: key });
               }}
-              onClick={() => onSelect(option.id)}
+              onClick={() => onSelect(option.id, presetCostQuality)}
             >
               <ComposerModelOptionText model={option} />
-              {option.id === model.id ? (
+              {option.id === model.id &&
+              (presetCostQuality === undefined || presetCostQuality === costQuality) ? (
                 <IconCheckmark2Small
                   size={14}
                   aria-hidden
@@ -634,7 +640,7 @@ function ComposerModelOption({
   model: VeniceModelDto;
   selected: boolean;
   active?: boolean;
-  onSelect: (modelId: string) => void;
+  onSelect: (modelId: string, costQuality?: number) => void;
   onHover: (model: VeniceModelDto, row: HTMLElement, immediate: boolean) => void;
 }) {
   return (

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -233,7 +233,7 @@ export function NoteChatPanel({
   // at session.create or as a /model switch before the next message).
   const [models, setModels] = useState<VeniceModelDto[]>([]);
   const [modelId, setModelId] = useState("");
-  const [costQuality, setCurrentCostQuality] = useState(100);
+  const [costQuality, setCostQualityState] = useState<number | undefined>();
   const [modelOpen, setModelOpen] = useState(false);
   const [modelFlyout, setModelFlyout] = useState<ComposerModelFlyout>(null);
   const [modelSearch, setModelSearch] = useState("");
@@ -250,7 +250,7 @@ export function NoteChatPanel({
       if (stale) return;
       setModels(catalog.models);
       setModelId(settings.settings.generationModel || catalog.selectedModel);
-      setCurrentCostQuality(settings.settings.costQuality);
+      setCostQualityState(settings.settings.costQuality);
     })().catch(() => {
       // No catalog (bridge down, browser preview): the picker simply hides.
     });
@@ -264,7 +264,7 @@ export function NoteChatPanel({
     try {
       if (nextCostQuality !== undefined) {
         const next = await setCostQuality(nextCostQuality);
-        setCurrentCostQuality(next.costQuality);
+        setCostQualityState(next.costQuality);
       }
       setModelId(nextModelId);
       setSessionModel(nextModelId);

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -22,6 +22,7 @@ import {
   importHermesBridgeFile,
   listVeniceModels,
   providerModelSettings,
+  setCostQuality,
   type VeniceModelDto,
 } from "../../lib/tauri";
 import { FileTypeIcon } from "../agent/FileTypeIcon";
@@ -32,7 +33,7 @@ import {
   ComposerModelPopover,
   type ComposerModelFlyout,
 } from "../agent/composer/ModelPicker";
-import { modelOptions } from "../settings/ModelPickerDialog";
+import { modelOptions, selectedModel } from "../settings/ModelPickerDialog";
 import type { NoteChat, NoteChatAttachment } from "./useNoteChat";
 
 /** Note-tailored presets, shown as the main session view's preset chips (icon
@@ -232,6 +233,7 @@ export function NoteChatPanel({
   // at session.create or as a /model switch before the next message).
   const [models, setModels] = useState<VeniceModelDto[]>([]);
   const [modelId, setModelId] = useState("");
+  const [costQuality, setCurrentCostQuality] = useState(100);
   const [modelOpen, setModelOpen] = useState(false);
   const [modelFlyout, setModelFlyout] = useState<ComposerModelFlyout>(null);
   const [modelSearch, setModelSearch] = useState("");
@@ -248,6 +250,7 @@ export function NoteChatPanel({
       if (stale) return;
       setModels(catalog.models);
       setModelId(settings.settings.generationModel || catalog.selectedModel);
+      setCurrentCostQuality(settings.settings.costQuality);
     })().catch(() => {
       // No catalog (bridge down, browser preview): the picker simply hides.
     });
@@ -255,7 +258,22 @@ export function NoteChatPanel({
       stale = true;
     };
   }, []);
-  const model = models.find((candidate) => candidate.id === modelId);
+  const model = modelId ? selectedModel(models, modelId) : undefined;
+
+  async function selectModel(nextModelId: string, nextCostQuality?: number) {
+    try {
+      if (nextCostQuality !== undefined) {
+        const next = await setCostQuality(nextCostQuality);
+        setCurrentCostQuality(next.costQuality);
+      }
+      setModelId(nextModelId);
+      setSessionModel(nextModelId);
+      setModelOpen(false);
+      setComposerError(null);
+    } catch (err) {
+      setComposerError(messageFromError(err));
+    }
+  }
 
   useEffect(() => {
     if (!modelOpen) return;
@@ -583,16 +601,15 @@ export function NoteChatPanel({
               flyout={modelFlyout}
               model={model}
               options={modelOptions(models, model?.id ?? "")}
+              costQuality={costQuality}
               search={modelSearch}
               popoverRef={modelPopoverRef}
               searchRef={modelSearchRef}
               onFlyoutChange={setModelFlyout}
               onSearchChange={setModelSearch}
-              onSelect={(nextModelId) => {
-                setModelId(nextModelId);
-                setSessionModel(nextModelId);
-                setModelOpen(false);
-              }}
+              onSelect={(nextModelId, nextCostQuality) =>
+                void selectModel(nextModelId, nextCostQuality)
+              }
             />
           ) : null}
         </footer>

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1025,8 +1025,12 @@ export function AppSettings({
     setModelSearch("");
   }
 
-  function selectModelFromPicker(mode: ProviderModelMode, modelId: string) {
+  function selectModelFromPicker(mode: ProviderModelMode, modelId: string, costQuality?: number) {
     const picked = modelOptionsForMode(mode).find((model) => model.id === modelId);
+    if (mode === "generation" && costQuality !== undefined) {
+      setProviderSettings((current) => ({ ...current, costQuality }));
+      saveCostQuality(costQuality);
+    }
     if (mode === "generation" && picked?.provider === "local") {
       enableLocalGenerationFromPicker();
     } else {
@@ -1886,6 +1890,7 @@ export function AppSettings({
                     description="Used for generated notes and agent responses."
                     value={modelValueForMode("generation")}
                     options={generationOptions}
+                    costQuality={providerSettings.costQuality}
                     open={pickerMode === "generation"}
                     summarySuppressed={pickerMode !== undefined}
                     flyout={modelPickerFlyout}
@@ -1900,7 +1905,9 @@ export function AppSettings({
                     }
                     onFlyoutChange={setModelPickerFlyout}
                     onSearchChange={setModelSearch}
-                    onSelect={(modelId) => selectModelFromPicker("generation", modelId)}
+                    onSelect={(modelId, costQuality) =>
+                      selectModelFromPicker("generation", modelId, costQuality)
+                    }
                   />
                   {providerSettings.generationModel === "open-software/auto" ? (
                     <div className="settings-row">
@@ -2602,6 +2609,7 @@ function ModelRow({
   description,
   value,
   options,
+  costQuality,
   open,
   flyout,
   search,
@@ -2619,6 +2627,7 @@ function ModelRow({
   description: string;
   value: string;
   options: VeniceModelDto[];
+  costQuality?: number;
   open: boolean;
   flyout: ModelPickerFlyout;
   search: string;
@@ -2628,7 +2637,7 @@ function ModelRow({
   onToggle: () => void;
   onFlyoutChange: (flyout: ModelPickerFlyout) => void;
   onSearchChange: (value: string) => void;
-  onSelect: (modelId: string) => void;
+  onSelect: (modelId: string, costQuality?: number) => void;
   summarySuppressed?: boolean;
 }) {
   const model = selectedModel(options, value);
@@ -2670,6 +2679,7 @@ function ModelRow({
             flyout={flyout}
             model={model}
             options={options}
+            costQuality={costQuality}
             search={search}
             popoverRef={popoverRef}
             searchRef={searchRef}

--- a/src/components/settings/ModelPickerDialog.tsx
+++ b/src/components/settings/ModelPickerDialog.tsx
@@ -17,6 +17,13 @@ import { ProviderLogo } from "./ProviderLogo";
 
 const AUTO_MODEL_ID = "open-software/auto";
 
+type ModelPickerEntry = {
+  key: string;
+  model: VeniceModelDto;
+  reason?: string;
+  costQuality?: number;
+};
+
 function withJuneModelName(model: VeniceModelDto): VeniceModelDto {
   return model.id === AUTO_MODEL_ID && model.name !== "Auto" ? { ...model, name: "Auto" } : model;
 }
@@ -81,6 +88,7 @@ export function ModelPickerDialog({
   mode,
   value,
   options,
+  costQuality,
   search,
   onSearchChange,
   onClose,
@@ -90,10 +98,11 @@ export function ModelPickerDialog({
   mode: ProviderModelMode;
   value: string;
   options: VeniceModelDto[];
+  costQuality?: number;
   search: string;
   onSearchChange: (value: string) => void;
   onClose: () => void;
-  onSelect: (modelId: string) => void;
+  onSelect: (modelId: string, costQuality?: number) => void;
 }) {
   // "Suggested" leads with the few models we actually recommend (benchmarks,
   // price, tool use, privacy — see SUGGESTED_MODELS); "All" is the full
@@ -114,26 +123,24 @@ export function ModelPickerDialog({
   );
   const query = search.trim().toLowerCase();
   const searching = query.length > 0;
-  const reasonsById = useMemo(
-    () => new Map(suggested.map((item) => [item.model.id, item.reason])),
-    [suggested],
-  );
-  const filteredOptions = useMemo(() => {
+  const filteredOptions = useMemo<ModelPickerEntry[]>(() => {
     if (searching) {
-      return availableOptions.filter((model) =>
-        [model.name, model.id, model.description, model.privacy, ...model.traits]
-          .filter(Boolean)
-          .join(" ")
-          .toLowerCase()
-          .includes(query),
-      );
+      return availableOptions
+        .filter((model) =>
+          [model.name, model.id, model.description, model.privacy, ...model.traits]
+            .filter(Boolean)
+            .join(" ")
+            .toLowerCase()
+            .includes(query),
+        )
+        .map((model) => ({ key: model.id, model }));
     }
     // No suggestions in the catalog (drift, still loading): the empty tab
     // would read as "no models", so fall through to the full list.
     if (tab === "suggested" && suggested.length > 0) {
-      return suggested.map((item) => item.model);
+      return suggested;
     }
-    return availableOptions;
+    return availableOptions.map((model) => ({ key: model.id, model }));
   }, [availableOptions, query, searching, suggested, tab]);
   const showReasons = !searching && tab === "suggested" && suggested.length > 0;
   const title =
@@ -185,22 +192,26 @@ export function ModelPickerDialog({
         </div>
       ) : null}
       <div className="model-picker-list" role="listbox" aria-label={title}>
-        {filteredOptions.map((model) => {
-          const selected = model.id === value;
-          const reason = showReasons ? reasonsById.get(model.id) : undefined;
+        {filteredOptions.map((item) => {
+          const { model } = item;
+          const presetCostQuality = item.costQuality;
+          const selected =
+            model.id === value &&
+            (presetCostQuality === undefined || presetCostQuality === costQuality);
+          const reason = showReasons ? item.reason : undefined;
           // A local (bring-your-own) endpoint is selectable, but its tool
           // support can't be verified from here, so it carries a non-blocking
           // caveat rather than the disabling no-tools treatment.
           const localCaveat = mode === "generation" && model.provider === "local";
           return (
             <button
-              key={model.id}
+              key={item.key}
               type="button"
               className="model-picker-option"
               role="option"
               aria-selected={selected}
               data-selected={selected}
-              onClick={() => onSelect(model.id)}
+              onClick={() => onSelect(model.id, presetCostQuality)}
             >
               <span className="model-picker-logo" aria-hidden>
                 <ProviderLogo provider={model.provider} id={model.id} name={model.name} />

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -37,6 +37,7 @@ export function ModelPickerPopover({
   flyout,
   model,
   options,
+  costQuality,
   search,
   popoverRef,
   searchRef,
@@ -53,6 +54,7 @@ export function ModelPickerPopover({
   flyout: ModelPickerFlyout;
   model?: VeniceModelDto;
   options: VeniceModelDto[];
+  costQuality?: number;
   search: string;
   popoverRef: RefObject<HTMLDivElement>;
   searchRef: RefObject<HTMLInputElement>;
@@ -63,7 +65,7 @@ export function ModelPickerPopover({
   allModelsLabel?: string;
   onFlyoutChange: (flyout: ModelPickerFlyout) => void;
   onSearchChange: (value: string) => void;
-  onSelect: (modelId: string) => void;
+  onSelect: (modelId: string, costQuality?: number) => void;
 }) {
   const flyoutRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -257,7 +259,7 @@ export function ModelPickerPopover({
     ? privacyFiltered.filter((option) => modelMatchesQuery(option, query))
     : privacyFiltered;
   const detail =
-    flyout?.kind === "model" ? suggested.find((item) => item.model.id === flyout.id) : undefined;
+    flyout?.kind === "model" ? suggested.find((item) => item.key === flyout.id) : undefined;
 
   // Latest filtered rows, read by the hand-off closure without re-subscribing
   // the pointer listener on every keystroke.
@@ -428,20 +430,23 @@ export function ModelPickerPopover({
       <p className="agent-composer-model-title">{title}</p>
       <div className="agent-composer-model-menu" role="listbox" aria-label={suggestedListLabel}>
         {suggested.length ? (
-          suggested.map(({ model: option }) => (
+          suggested.map(({ key, model: option, costQuality: presetCostQuality }) => (
             <button
-              key={option.id}
+              key={key}
               type="button"
               className="agent-composer-model-row"
               role="option"
-              aria-selected={option.id === model.id}
-              data-model-id={option.id}
-              data-active={(flyout?.kind === "model" && flyout.id === option.id) || undefined}
+              aria-selected={
+                option.id === model.id &&
+                (presetCostQuality === undefined || presetCostQuality === costQuality)
+              }
+              data-model-id={key}
+              data-active={(flyout?.kind === "model" && flyout.id === key) || undefined}
               onMouseEnter={() => {
                 if (modelBridge.isActive()) {
                   return;
                 }
-                const open = () => onFlyoutChange({ kind: "model", id: option.id });
+                const open = () => onFlyoutChange({ kind: "model", id: key });
                 if (flyout) {
                   cancelHoverIntent();
                   open();
@@ -451,12 +456,13 @@ export function ModelPickerPopover({
               }}
               onFocus={() => {
                 cancelHoverIntent();
-                onFlyoutChange({ kind: "model", id: option.id });
+                onFlyoutChange({ kind: "model", id: key });
               }}
-              onClick={() => onSelect(option.id)}
+              onClick={() => onSelect(option.id, presetCostQuality)}
             >
               <ModelPickerOptionText model={option} />
-              {option.id === model.id ? (
+              {option.id === model.id &&
+              (presetCostQuality === undefined || presetCostQuality === costQuality) ? (
                 <IconCheckmark2Small
                   size={14}
                   aria-hidden
@@ -651,7 +657,7 @@ function ModelPickerOption({
   model: VeniceModelDto;
   selected: boolean;
   active?: boolean;
-  onSelect: (modelId: string) => void;
+  onSelect: (modelId: string, costQuality?: number) => void;
   onHover: (model: VeniceModelDto, row: HTMLElement, immediate: boolean) => void;
 }) {
   return (

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -3,9 +3,18 @@ import type { ProviderModelMode, VeniceModelDto } from "./tauri";
 
 export type SuggestedModel = {
   id: string;
+  /** Picker-only label. The persisted provider model id is unchanged. */
+  label?: string;
+  /** Auto-router preference selected with this suggestion (0-100). */
+  costQuality?: number;
   /** One-line "why we recommend it", rendered under the model's meta row. */
   reason: string;
 };
+
+// Auto owns the visible text suggestions, but image attachment recovery still
+// needs a concrete vision-capable model. Keep that operational fallback
+// independent from picker curation.
+const PREFERRED_VISION_FALLBACK_IDS = ["kimi-k2-6"];
 
 /**
  * Curated picks for the model picker's "Suggested" tab — the handful of
@@ -14,16 +23,9 @@ export type SuggestedModel = {
  * is zero-retention privacy, so every text pick here is a "private" catalog
  * model that supports tools).
  *
- * Curation snapshot (June 2026), from the live Venice catalog plus public
- * benchmarks (SWE-bench agentic coding, Artificial Analysis intelligence
- * index):
- * - GLM 5.2: latest GLM flagship and June's default text model, with
- *   reasoning effort controls, tool use, 200K context, $1.75/$5.50 per 1M
- *   tokens.
- * - Kimi K2.6: leads the open-weights intelligence rankings, built for long
- *   agentic tool runs, 256K context, $0.85/$4.66.
- * - GLM 5.1: previous GLM flagship, top-tier agentic coding and tool use
- *   among open models, 200K context, $1.75/$5.50 per 1M tokens.
+ * Text suggestions are the three useful ways to run Auto. Auto selects the
+ * best currently available private model for each request; these presets tune
+ * that routing decision without making people understand the provider catalog.
  * - Parakeet: fast, accurate everyday dictation at the lowest price tier.
  * - Whisper Large v3: best multilingual accuracy at the same low price.
  *
@@ -37,19 +39,22 @@ export type SuggestedModel = {
 export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
   generation: [
     {
-      id: "zai-org-glm-5-2",
-      reason:
-        "Default pick: latest GLM flagship with strong reasoning, tool use, structured output, and zero data retention.",
+      id: "open-software/auto",
+      label: "Auto · Higher Quality",
+      costQuality: 100,
+      reason: "Default: prioritize the strongest private model available for each request.",
     },
     {
-      id: "kimi-k2-6",
-      reason:
-        "Best alternate: leads independent intelligence rankings and excels at long tool-driven tasks, with zero data retention.",
+      id: "open-software/auto",
+      label: "Auto · Balanced",
+      costQuality: 50,
+      reason: "Balance response quality and usage cost for everyday work.",
     },
     {
-      id: "zai-org-glm-5-1",
-      reason:
-        "Stable GLM alternate: previous GLM flagship with top-tier agentic coding, tool use, and zero data retention.",
+      id: "open-software/auto",
+      label: "Auto · Lower Cost",
+      costQuality: 20,
+      reason: "Prefer lower-cost private models while preserving June's tool support.",
     },
   ],
   transcription: [
@@ -110,22 +115,20 @@ export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
  * non-vision model is active. The switch must land on a model that can both
  * read images AND run tools — a vision model without function calling would
  * brick the agent the same way the model picker guards against — so we filter
- * on both capabilities. Among the eligible models we prefer a curated
- * suggested pick (Kimi K2.6 is the suggested vision model), so the one-tap fix
+ * on both capabilities. Among the eligible models we prefer a concrete
+ * vision pick (currently Kimi K2.6), so the one-tap fix
  * lands on a sensible default instead of the alphabetically-first vision model
  * (which is otherwise arbitrary — the catalog sorts by display name). If no
- * suggested model is eligible we fall back to the first eligible catalog model
- * so a suggested-list change can never leave the fallback empty. The target is
- * derived entirely from live catalog capabilities: no model id is hardcoded,
- * so a retired model can never become the fallback.
+ * preferred model is eligible we fall back to the first eligible catalog model.
+ * A retired preference is ignored because it is resolved against the live catalog.
  */
 export function preferredVisionFallbackModel(models: VeniceModelDto[]): VeniceModelDto | undefined {
   const eligible = models.filter(
     (model) => modelSupportsImageInput(model) && modelSupportsTools(model),
   );
-  const suggested = SUGGESTED_MODELS.generation
-    .map((pick) => eligible.find((model) => model.id === pick.id))
-    .find((model): model is VeniceModelDto => model !== undefined);
+  const suggested = PREFERRED_VISION_FALLBACK_IDS.map((id) =>
+    eligible.find((model) => model.id === id),
+  ).find((model): model is VeniceModelDto => model !== undefined);
   return suggested ?? eligible[0];
 }
 
@@ -134,9 +137,22 @@ export function preferredVisionFallbackModel(models: VeniceModelDto[]): VeniceMo
 export function suggestedModelsForMode(
   mode: ProviderModelMode,
   options: VeniceModelDto[],
-): Array<{ model: VeniceModelDto; reason: string }> {
-  return SUGGESTED_MODELS[mode].flatMap((suggested) => {
+): Array<{
+  key: string;
+  model: VeniceModelDto;
+  reason: string;
+  costQuality?: number;
+}> {
+  return SUGGESTED_MODELS[mode].flatMap((suggested, index) => {
     const model = options.find((option) => option.id === suggested.id);
-    return model ? [{ model, reason: suggested.reason }] : [];
+    if (!model) return [];
+    return [
+      {
+        key: `${suggested.id}:${suggested.costQuality ?? index}`,
+        model: suggested.label ? { ...model, name: suggested.label } : model,
+        reason: suggested.reason,
+        costQuality: suggested.costQuality,
+      },
+    ];
   });
 }

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -64,6 +64,7 @@ const mocks = vi.hoisted(() => ({
   openFileDialog: vi.fn(),
   setImageSafeMode: vi.fn(),
   setImageSafeModePromptDismissed: vi.fn(),
+  setCostQuality: vi.fn(),
   setVeniceModel: vi.fn(),
   setLocalGenerationEnabled: vi.fn(),
   providerModelSettings: vi.fn(),
@@ -136,6 +137,7 @@ vi.mock("../lib/tauri", () => ({
   setHermesAgentCliAccess: mocks.setHermesAgentCliAccess,
   setImageSafeMode: mocks.setImageSafeMode,
   setImageSafeModePromptDismissed: mocks.setImageSafeModePromptDismissed,
+  setCostQuality: mocks.setCostQuality,
   setLocalGenerationEnabled: mocks.setLocalGenerationEnabled,
   setVeniceModel: mocks.setVeniceModel,
   saveAgentAssistantMessage: mocks.saveAgentAssistantMessage,
@@ -417,6 +419,7 @@ describe("AgentWorkspace", () => {
         transcriptionProvider: "venice",
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
         generationModel: "zai-org-glm-5-2",
+        costQuality: 100,
       },
     });
     mocks.imagePromptMayBeExplicit.mockResolvedValue(false);
@@ -440,6 +443,15 @@ describe("AgentWorkspace", () => {
       selectedModel: "zai-org-glm-5-2",
       models: [
         {
+          provider: "open-software",
+          id: "open-software/auto",
+          name: "Automatic private model",
+          modelType: "text",
+          privacy: "private",
+          traits: [],
+          capabilities: ["functionCalling"],
+        },
+        {
           provider: "venice",
           id: "zai-org-glm-5-2",
           name: "GLM 5.2",
@@ -459,6 +471,12 @@ describe("AgentWorkspace", () => {
         },
       ],
     });
+    mocks.setCostQuality.mockImplementation(async (costQuality: number) => ({
+      transcriptionProvider: "venice",
+      transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+      generationModel: "open-software/auto",
+      costQuality,
+    }));
     mocks.getAgentTask.mockResolvedValue(existingTask);
     mocks.hermesBridgeStatus.mockResolvedValue({
       running: true,
@@ -3655,6 +3673,36 @@ describe("AgentWorkspace", () => {
       sessionId: expect.any(String),
       model: "anonymous-only",
     });
+  });
+
+  it("offers the three Auto presets and persists the selected routing preference", async () => {
+    mocks.listAgentTasks.mockResolvedValue({ items: [] });
+    mocks.listHermesSessions.mockResolvedValue([]);
+    mocks.setVeniceModel.mockImplementation(async () => {
+      const settings = {
+        transcriptionProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "open-software/auto",
+        costQuality: 20,
+      };
+      mocks.providerModelSettings.mockResolvedValue({ settings });
+      return settings;
+    });
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace />);
+
+    await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
+    const dialog = await screen.findByRole("dialog", { name: "Choose text model" });
+    expect(within(dialog).getByRole("option", { name: /Auto · Higher Quality/ })).toBeVisible();
+    expect(within(dialog).getByRole("option", { name: /Auto · Balanced/ })).toBeVisible();
+    expect(within(dialog).getByRole("option", { name: /Auto · Lower Cost/ })).toBeVisible();
+
+    await user.click(within(dialog).getByRole("option", { name: /Auto · Lower Cost/ }));
+
+    await waitFor(() => expect(mocks.setCostQuality).toHaveBeenCalledWith(20));
+    expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "open-software/auto");
+    expect(await screen.findByRole("button", { name: "Model: Auto" })).toBeInTheDocument();
   });
 
   it("ignores a stale pending New Session marker left over from a reload", async () => {
@@ -11623,7 +11671,9 @@ describe("AgentWorkspace", () => {
       const dialog = await screen.findByRole("dialog", {
         name: "Choose text model",
       });
-      await user.click(within(dialog).getByRole("option", { name: /Kimi K2\.6/ }));
+      await user.click(within(dialog).getByRole("button", { name: "All models" }));
+      const panel = await screen.findByRole("group", { name: "All text models" });
+      await user.click(within(panel).getByRole("option", { name: /Kimi K2\.6/ }));
 
       await waitFor(() =>
         expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "kimi-k2-6"),

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -340,6 +340,16 @@ describe("AppSettings", () => {
             ]
           : [
               {
+                provider: "open-software",
+                id: "open-software/auto",
+                name: "Automatic private model",
+                modelType: "text",
+                description: "Routes each request to the best available private model.",
+                privacy: "private",
+                traits: [],
+                capabilities: ["supportsFunctionCalling"],
+              },
+              {
                 provider: "venice",
                 id: "zai-org-glm-5-2",
                 name: "GLM 5.2",
@@ -3206,11 +3216,21 @@ describe("AppSettings", () => {
 
     // Suggested is the default view: only the curated picks present in the
     // catalog show in the compact root menu.
-    expect(await screen.findByRole("option", { name: /GLM 5\.2/ })).toBeInTheDocument();
-    expect(await screen.findByRole("option", { name: /GLM 5\.1/ })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: /Kimi K2\.6/ })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: /Auto · Higher Quality/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Auto · Balanced/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Auto · Lower Cost/ })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /Venice Uncensored/ })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "All models" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("option", { name: /Auto · Balanced/ }));
+    await waitFor(() => expect(mocks.setCostQuality).toHaveBeenCalledWith(50));
+    await waitFor(() =>
+      expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "open-software/auto"),
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Change text model" }));
 
     // All models shows the full available catalog in the flyout.
     await user.click(screen.getByRole("button", { name: "All models" }));


### PR DESCRIPTION
## Summary
- rename the private router everywhere in June's picker surfaces to `Auto`
- replace concrete text-model suggestions with three Auto presets: Higher Quality, Balanced, and Lower Cost
- persist the chosen cost/quality preset from the home composer, Settings, and note chat pickers
- preserve Kimi K2.6 as the image-capable fallback independently of picker curation
- pin production June API text inference to os-api now that Phala has the dedicated sealed service key

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (2,494 passed, 2 skipped)
- `make local-ci` (frontend and rust-macos signoffs posted)

## Rollout
Release candidate only. Stable remains untouched. Production June API promotion and live three-preset verification will happen after merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786557816&installation_id=144203540&pr_number=726&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F726&signature=3ddf78cfc4ad10b7b416581fb0ac2a1aa66a9330774c1eba9448808ba85fdfcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->