### PR TITLE
Route stale dictation models through ASR fallback

### DIFF
--- a/june-api/crates/api/src/handlers/dictate.rs
+++ b/june-api/crates/api/src/handlers/dictate.rs
@@ -3,7 +3,7 @@ use crate::{
     auth::{authenticated_user, provider_credentials},
     envelope::ApiResponse,
     error::ApiError,
-    handlers::notes::{require_priced_model, required, resolve_priced_text_model},
+    handlers::notes::{required, resolve_priced_asr_model, resolve_priced_text_model},
     multipart::MultipartFields,
     state::ApiState,
     validation,
@@ -13,7 +13,7 @@ use axum::{
     extract::{Multipart, State},
     http::HeaderMap,
 };
-use june_domain::{ModelId, ModelKind};
+use june_domain::ModelId;
 use june_services::{
     DictateCleanupOutput, DictateCleanupParams, DictateTranscribeOutput, DictateTranscribeParams,
 };
@@ -32,7 +32,7 @@ pub(crate) async fn transcribe(
     validate_audio(&audio)?;
     let model_id = form.required_text("model")?;
     validation::validate_text_len("model", &model_id, validation::MAX_MODEL_CHARS)?;
-    require_priced_model(&state, &model_id, ModelKind::Asr)?;
+    let model_id = resolve_priced_asr_model(&state, &model_id)?;
     let session_id = form.required_text("sessionId")?;
     validation::validate_text_len("session_id", &session_id, validation::MAX_ID_CHARS)?;
     let utterance_id = form.required_text("utteranceId")?;

--- a/june-api/crates/api/src/handlers/notes.rs
+++ b/june-api/crates/api/src/handlers/notes.rs
@@ -348,6 +348,7 @@ pub(crate) fn require_priced_model(
 }
 
 const AUTO_TEXT_MODEL: &str = "open-software/auto";
+const DEFAULT_ASR_MODEL: &str = "nvidia/parakeet-tdt-0.6b-v3";
 
 /// Older June clients may retain a Venice model that disappeared when the
 /// production catalog moved behind os-api. Preserve those sessions by routing
@@ -368,6 +369,42 @@ fn resolve_priced_text_model_kind(
         Err(PricingError::NotPriced | PricingError::MissingRate) => {
             require_priced_model_kind(pricing, AUTO_TEXT_MODEL, ModelKind::Text)?;
             Ok(AUTO_TEXT_MODEL.to_string())
+        }
+        Err(PricingError::WrongUnit) => Err(ApiError::unprocessable("model_type_invalid")),
+        Err(PricingError::Overflow) => Err(ApiError::unprocessable("price_overflow")),
+    }
+}
+
+/// Preserve dictation for clients with a retired ASR selection. Prefer June's
+/// default private transcription model, then any currently priced ASR model.
+/// A text-model selection remains a hard type error.
+pub(crate) fn resolve_priced_asr_model(
+    state: &ApiState,
+    requested_model_id: &str,
+) -> Result<String, ApiError> {
+    resolve_priced_asr_model_kind(state.pricing(), requested_model_id)
+}
+
+fn resolve_priced_asr_model_kind(
+    pricing: &PricingTable,
+    requested_model_id: &str,
+) -> Result<String, ApiError> {
+    match pricing.ensure_model_kind(requested_model_id, ModelKind::Asr) {
+        Ok(()) => Ok(requested_model_id.to_string()),
+        Err(PricingError::NotPriced | PricingError::MissingRate) => {
+            if pricing
+                .ensure_model_kind(DEFAULT_ASR_MODEL, ModelKind::Asr)
+                .is_ok()
+            {
+                return Ok(DEFAULT_ASR_MODEL.to_string());
+            }
+            pricing
+                .priced_models(Some(ModelKind::Asr))
+                .into_iter()
+                .map(|(model_id, _)| model_id)
+                .find(|model_id| pricing.ensure_model_kind(model_id, ModelKind::Asr).is_ok())
+                .cloned()
+                .ok_or_else(|| ApiError::unprocessable("model_not_priced"))
         }
         Err(PricingError::WrongUnit) => Err(ApiError::unprocessable("model_type_invalid")),
         Err(PricingError::Overflow) => Err(ApiError::unprocessable("price_overflow")),
@@ -397,7 +434,7 @@ fn parse_preview_flag(value: Option<&str>) -> bool {
 mod tests {
     use super::{
         AUTO_TEXT_MODEL, parse_preview_flag, require_priced_model_kind,
-        resolve_priced_text_model_kind,
+        resolve_priced_asr_model_kind, resolve_priced_text_model_kind,
     };
     use crate::ApiError;
     use june_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
@@ -476,6 +513,30 @@ mod tests {
         let resolved = resolve_priced_text_model_kind(&pricing_table(), "text-model")
             .expect("priced text model should remain explicit");
         assert_eq!(resolved, "text-model");
+    }
+
+    #[test]
+    fn stale_asr_model_falls_back_to_a_priced_asr_model() {
+        let resolved = resolve_priced_asr_model_kind(&pricing_table(), "retired-asr-model")
+            .expect("stale ASR model should remain usable");
+        assert_eq!(resolved, "asr-model");
+    }
+
+    #[test]
+    fn priced_asr_model_is_preserved() {
+        let resolved = resolve_priced_asr_model_kind(&pricing_table(), "asr-model")
+            .expect("priced ASR model should remain explicit");
+        assert_eq!(resolved, "asr-model");
+    }
+
+    #[test]
+    fn text_model_cannot_fall_back_into_asr() {
+        let error = resolve_priced_asr_model_kind(&pricing_table(), "text-model")
+            .expect_err("text model must not be accepted for transcription");
+        assert!(matches!(
+            error,
+            ApiError::Unprocessable { message, .. } if message == "model_type_invalid"
+        ));
     }
 
     #[test]

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -818,6 +818,27 @@ async fn integration_note_transcribe_rejects_unsupported_audio() -> Result<(), B
 }
 
 #[tokio::test]
+async fn integration_dictate_routes_retired_asr_model_through_priced_fallback()
+-> Result<(), Box<dyn Error>> {
+    let response = send(multipart_request(
+        "/v1/dictate",
+        multipart_body([
+            text_part("model", "retired-asr-model"),
+            text_part("sessionId", "session-stale-asr"),
+            text_part("utteranceId", "utterance-stale-asr"),
+            file_part("audio", "dictation.wav", valid_wav()),
+        ]),
+    )?)
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["text"], "Transcribed audio");
+    Ok(())
+}
+
+#[tokio::test]
 async fn integration_dictate_fills_language_when_provider_returns_none()
 -> Result<(), Box<dyn Error>> {
     // Venice ASR never returns a detected language, so the provider yields


### PR DESCRIPTION
## What changed

- resolves a retired or missing-rate dictation ASR selection to June’s default private ASR model
- falls back to another currently priced ASR model if the default is unavailable
- preserves valid explicit ASR selections
- continues to reject text models with `model_type_invalid`

## Root cause

The earlier stale-model compatibility patch covered text generation paths, including dictation cleanup, but `/v1/dictate` retained a strict pre-transcription ASR pricing check. Older saved ASR selections could therefore still return `model_not_priced`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (402 tests passed)
- new HTTP boundary test proves a retired ASR model returns 200 and transcribes through a priced ASR fallback

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786561919&installation_id=144203540&pr_number=727&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F727&signature=75ae6d2fba771b2272a6af2e2388af7c1e8dffba2e6a342fe3e75b8c7914c674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->