### PR TITLE
Auto toggle, preference drill-in, and preset readback on the composer pill

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -248,8 +248,12 @@ import {
   rawLocalGenerationModelId,
   withLocalGenerationOption,
 } from "../../lib/local-generation";
-import { preferredVisionFallbackModel } from "../../lib/suggested-models";
-import { modelOptions, selectedModel as selectedModelOption } from "../settings/ModelPickerDialog";
+import { autoPillDesignation, preferredVisionFallbackModel } from "../../lib/suggested-models";
+import {
+  AUTO_MODEL_ID,
+  modelOptions,
+  selectedModel as selectedModelOption,
+} from "../settings/ModelPickerDialog";
 import { ModelPickerPopover, type ModelPickerFlyout } from "../settings/ModelPickerPopover";
 import {
   HERMES_SERVER_ERROR_MESSAGE,
@@ -9337,6 +9341,11 @@ export function AgentWorkspace({
               <ComposerModelPicker
                 open={composerModelOpen}
                 model={generationModel}
+                detail={
+                  generationModel?.id === AUTO_MODEL_ID
+                    ? autoPillDesignation(generationCostQuality)
+                    : undefined
+                }
                 readOnly={composerModelLocked}
                 triggerRef={composerModelTriggerRef}
                 onToggleOpen={() => {

--- a/src/components/agent/composer/ModelPicker.tsx
+++ b/src/components/agent/composer/ModelPicker.tsx
@@ -29,12 +29,16 @@ import { ModelPickerCardContent } from "../../settings/ModelPickerPopover";
 export function ComposerModelPicker({
   open,
   model,
+  detail,
   readOnly = false,
   triggerRef,
   onToggleOpen,
 }: {
   open: boolean;
   model?: VeniceModelDto;
+  /** Ghosted designation beside the name — the Auto routing preference
+   * ("Auto Higher"), quieter than the model name. */
+  detail?: string;
   readOnly?: boolean;
   triggerRef: RefObject<HTMLButtonElement>;
   onToggleOpen: () => void;
@@ -45,6 +49,7 @@ export function ComposerModelPicker({
       <div className="agent-composer-model" data-readonly="true">
         <span className="agent-composer-model-label">
           <span>{model.name}</span>
+          {detail ? <span className="agent-composer-model-trigger-detail">{detail}</span> : null}
         </span>
       </div>
     );
@@ -55,12 +60,13 @@ export function ComposerModelPicker({
         ref={triggerRef}
         type="button"
         className="agent-composer-model-trigger"
-        aria-label={`Model: ${model.name}`}
+        aria-label={`Model: ${model.name}${detail ? ` (${detail})` : ""}`}
         aria-haspopup="dialog"
         aria-expanded={open}
         onClick={onToggleOpen}
       >
         <span>{model.name}</span>
+        {detail ? <span className="agent-composer-model-trigger-detail">{detail}</span> : null}
         <IconChevronDownSmall size={12} aria-hidden />
       </button>
     </div>

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -33,7 +33,8 @@ import {
   ComposerModelPopover,
   type ComposerModelFlyout,
 } from "../agent/composer/ModelPicker";
-import { modelOptions, selectedModel } from "../settings/ModelPickerDialog";
+import { autoPillDesignation } from "../../lib/suggested-models";
+import { AUTO_MODEL_ID, modelOptions, selectedModel } from "../settings/ModelPickerDialog";
 import type { NoteChat, NoteChatAttachment } from "./useNoteChat";
 
 /** Note-tailored presets, shown as the main session view's preset chips (icon
@@ -546,6 +547,9 @@ export function NoteChatPanel({
                 <ComposerModelPicker
                   open={modelOpen}
                   model={model}
+                  detail={
+                    model?.id === AUTO_MODEL_ID ? autoPillDesignation(costQuality) : undefined
+                  }
                   triggerRef={modelTriggerRef}
                   onToggleOpen={() => {
                     setModelFlyout(null);

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -33,6 +33,11 @@ import {
   ComposerModelPopover,
   type ComposerModelFlyout,
 } from "../agent/composer/ModelPicker";
+import {
+  dispatchProviderModelSettingsChanged,
+  PROVIDER_MODEL_SETTINGS_CHANGED_EVENT,
+  type ProviderModelSettingsChangedDetail,
+} from "../../lib/model-privacy";
 import { autoPillDesignation } from "../../lib/suggested-models";
 import { AUTO_MODEL_ID, modelOptions, selectedModel } from "../settings/ModelPickerDialog";
 import type { NoteChat, NoteChatAttachment } from "./useNoteChat";
@@ -259,6 +264,24 @@ export function NoteChatPanel({
       stale = true;
     };
   }, []);
+  // The Auto designation mirrors the app-wide preference, which the workspace
+  // and Settings pickers can change while this panel stays mounted — re-read
+  // it whenever a generation model change is announced. The session's model
+  // choice itself stays local on purpose.
+  useEffect(() => {
+    function handleSettingsChanged(event: Event) {
+      const detail = (event as CustomEvent<ProviderModelSettingsChangedDetail>).detail;
+      if (detail?.mode !== "generation") return;
+      void providerModelSettings()
+        .then((settings) => setCostQualityState(settings.settings.costQuality))
+        .catch(() => {
+          // No settings (bridge down, browser preview): keep the last value.
+        });
+    }
+    window.addEventListener(PROVIDER_MODEL_SETTINGS_CHANGED_EVENT, handleSettingsChanged);
+    return () =>
+      window.removeEventListener(PROVIDER_MODEL_SETTINGS_CHANGED_EVENT, handleSettingsChanged);
+  }, []);
   const model = modelId ? selectedModel(models, modelId) : undefined;
 
   async function selectModel(nextModelId: string, nextCostQuality?: number) {
@@ -266,6 +289,10 @@ export function NoteChatPanel({
       if (nextCostQuality !== undefined) {
         const next = await setCostQuality(nextCostQuality);
         setCostQualityState(next.costQuality);
+        // The preference is app-wide even though the model choice is
+        // session-local: announce it so the workspace pill's designation
+        // refreshes (the mirror of the listener above).
+        dispatchProviderModelSettingsChanged({ mode: "generation", modelId: nextModelId });
       }
       setModelId(nextModelId);
       setSessionModel(nextModelId);

--- a/src/components/settings/ModelPickerDialog.tsx
+++ b/src/components/settings/ModelPickerDialog.tsx
@@ -15,7 +15,7 @@ import { HoverTip } from "../ui/HoverTip";
 import { ModelPrivacyChip } from "../ui/ModelPrivacyChip";
 import { ProviderLogo } from "./ProviderLogo";
 
-const AUTO_MODEL_ID = "open-software/auto";
+export const AUTO_MODEL_ID = "open-software/auto";
 
 type ModelPickerEntry = {
   key: string;

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -17,6 +17,19 @@ export type SuggestedModel = {
 const PREFERRED_VISION_FALLBACK_IDS = ["kimi-k2-6"];
 
 /**
+ * The composer pill's ghosted designation while Auto is selected ("Auto
+ * Higher"): one word, since the pill is a glance surface. The thresholds
+ * bucket any persisted cost-to-quality value onto the nearest of the three
+ * suggested presets (20 / 50 / 100).
+ */
+export function autoPillDesignation(costQuality: number | undefined): string | undefined {
+  if (costQuality === undefined) return undefined;
+  if (costQuality < 34) return "Lower";
+  if (costQuality > 66) return "Higher";
+  return "Balanced";
+}
+
+/**
  * Curated picks for the model picker's "Suggested" tab — the handful of
  * models we actually recommend, weighed on benchmark performance, price,
  * tool use, and privacy (June's agent needs tool calling, and June's pitch

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6000,6 +6000,10 @@ input:focus-visible,
 }
 
 .agent-composer-model-trigger {
+  /* A touch above the toolbar's resting grey: the pill names the active
+   * model, so it reads as content, not chrome. Hover still lifts it to full
+   * foreground. */
+  color: color-mix(in oklch, var(--foreground) 40%, var(--muted-foreground));
   transition:
     background-color var(--t-fast) var(--ease-out),
     color var(--t-fast) var(--ease-out);
@@ -6023,6 +6027,14 @@ input:focus-visible,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* The Auto preference designation beside the pill's model name ("Auto
+ * Higher"): one step quieter than the name in every state — it stays at
+ * muted while hover lifts the name to full foreground. */
+.agent-composer-model-trigger-detail {
+  flex: 0 1 auto;
+  color: var(--muted-foreground);
 }
 
 .agent-composer-model-popover {
@@ -6203,8 +6215,11 @@ input:focus-visible,
   overflow: hidden;
   border: 1px solid var(--popover-border);
   border-radius: var(--r-md);
+  /* No background-clip here: the translucent border must blend over the
+   * surface's own fill, exactly like the root popover's, or the same token
+   * reads darker on flyouts (it would composite over the page and the
+   * neighboring panel's shadow halo instead). */
   background: var(--popover);
-  background-clip: padding-box;
   color: var(--popover-foreground);
   /* The surface owns the only elevation for this layer. Scroll fades and
    * search/list content are descendants clipped inside this rounded box, so

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3702,7 +3702,8 @@ describe("AgentWorkspace", () => {
 
     await waitFor(() => expect(mocks.setCostQuality).toHaveBeenCalledWith(20));
     expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "open-software/auto");
-    expect(await screen.findByRole("button", { name: "Model: Auto" })).toBeInTheDocument();
+    // The pill ghosts the active preset designation beside the model name.
+    expect(await screen.findByRole("button", { name: "Model: Auto (Lower)" })).toBeInTheDocument();
   });
 
   it("ignores a stale pending New Session marker left over from a reload", async () => {


### PR DESCRIPTION
## Summary

- **Auto toggle in the model picker** (workspace composer and Settings → Models): a pinned section above the suggested rows with a switch that selects `open-software/auto` while keeping the popover open; toggling off lands on the leading suggested pick (GLM 5.2). Suggested rows return to concrete models (GLM 5.2 / Kimi K2.6 / GLM 5.1) — this deliberately replaces the three Auto preset rows from #726 with the toggle design (product decision by @andrewwashuta).
- **Preference drill-in**: while Auto is on, a "Preference · Higher quality ›" row opens a side flyout with the three cost-to-quality presets as rows, each with a one-line explanation and a checkmark on the active one. Writes persist via `set_cost_quality` and announce the settings-changed event so every surface stays in sync.
- **Composer pill readback** (workspace and note chat): the pill ghosts the active preset beside the name — "Auto Higher / Balanced / Lower" — one visual step quieter than the model name in every state. Pill resting contrast steps up from muted grey toward foreground.
- **Picker layer polish**: second-layer surfaces drop `background-clip: padding-box` so their translucent border composites over the surface's own fill like the root popover (same token, no more darker second-layer border), and the preference flyout gets the catalog panel's `--sp-1` content inset.
- Note-chat designation staleness fixed per review: the panel subscribes to `june:provider-model-settings-changed` and re-reads the preference; its own preset writes dispatch the same event for the mirror direction.

## Root cause

(Border fix) `.agent-composer-model-surface` set `background-clip: padding-box`, so its translucent `--popover-border` blended over the backdrop behind the panel (page + neighboring panel's shadow halo) rather than over the panel's own fill like the root popover — same token, darker composite.

## Validation

- `pnpm typecheck`, Biome clean on changed files; 354 tests pass across `agent-workspace`, `app-settings`, `suggested-models`, `model-picker-dialog`, `note-chat-sessions`, and `hermes-model-switch`, including rewritten coverage: toggling Auto on from the picker, drilling into the preference flyout, and the pill designation tracking the persisted value.

- [x] Tested visually where it matters (toggle, drill-in, pill, and border treatments were iterated live in the dev app during design review).
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- frontend-only -->

## Out of scope

- The note chat panel's own picker popover (duplicated component) doesn't render the Auto toggle section yet — its pill shows the designation and stays in sync, but preference editing happens from the workspace picker or Settings. Consolidating the duplicated popovers is a natural follow-up.
- Shifting the Auto preference for in-flight work — the preference is read per request today, so streams in progress keep their routing decision.

## Followups

- JUN-306: backend contract for changing the Auto routing preference while work is in flight.
- Consolidate `ComposerModelPopover` (note chat) with the shared `ModelPickerPopover` so the Auto section exists in one place.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)