### PR TITLE
Prioritize user intent in session titles

### DIFF
--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -1356,6 +1356,8 @@ fn drop_leading_orphan_tool_messages(messages: &mut Vec<serde_json::Value>) {
     }
 }
 
+const AGENT_SESSION_TITLE_SYSTEM_PROMPT: &str = "Name this agent session for the user's primary intent or topic. The user request is authoritative. Use an assistant reply excerpt only as secondary context to clarify concrete work, never as the title's point of view. Do not title an acknowledgement, conversational preamble, clarification question, or other wording from the assistant reply. If the user request is already clear, base the title on it even when the assistant asks a follow-up question. Example: for the request 'tell me about my calendar' and reply 'Sure! Which calendar service are you using?', return 'Calendar overview'. Return only a concrete 2 to 5 word title in sentence case: capitalize the first word and proper nouns only, never every word. Avoid first person, words like please/help/you, trailing ellipses, quotes, punctuation wrappers, markdown, or explanations.";
+
 pub async fn suggest_agent_session_title(
     prompt: &str,
     response: Option<&str>,
@@ -1372,7 +1374,7 @@ pub async fn suggest_agent_session_title(
         "messages": [
             {
                 "role": "system",
-                "content": "Name this agent session by the work being done, not by repeating the user's request. Return only a concrete 2 to 5 word title in sentence case: capitalize the first word and proper nouns only, never every word. Avoid first person, words like please/help/you, trailing ellipses, quotes, punctuation wrappers, markdown, or explanations. When an assistant reply excerpt is provided, name the session by the work described there."
+                "content": AGENT_SESSION_TITLE_SYSTEM_PROMPT
             },
             {
                 "role": "user",
@@ -1962,7 +1964,9 @@ fn agent_session_title_user_content(prompt: &str, response: Option<&str>) -> Str
     // crowds the shared max_tokens budget. The frontend caps to the same
     // length before invoking; this cap is the trust-boundary backstop.
     let response: String = response.chars().take(1200).collect();
-    format!("User request:\n{prompt}\n\nAssistant reply excerpt:\n{response}")
+    format!(
+        "Primary user intent (authoritative):\n{prompt}\n\nSecondary assistant context (clarification only):\n{response}"
+    )
 }
 
 fn clean_agent_session_title(value: &str) -> Option<String> {
@@ -3012,8 +3016,16 @@ data: \"data\":{\"content\":\"Joined\",\"titleSuggestion\":null,\"provider\":\"v
                 "  Refactor this parser  ",
                 Some("  I rewrote the tokenizer and added coverage.  "),
             ),
-            "User request:\nRefactor this parser\n\nAssistant reply excerpt:\nI rewrote the tokenizer and added coverage."
+            "Primary user intent (authoritative):\nRefactor this parser\n\nSecondary assistant context (clarification only):\nI rewrote the tokenizer and added coverage."
         );
+    }
+
+    #[test]
+    fn agent_session_title_prompt_prioritizes_clear_user_intent_over_reply() {
+        assert!(AGENT_SESSION_TITLE_SYSTEM_PROMPT.contains("user request is authoritative"));
+        assert!(AGENT_SESSION_TITLE_SYSTEM_PROMPT.contains("clarification question"));
+        assert!(AGENT_SESSION_TITLE_SYSTEM_PROMPT.contains("tell me about my calendar"));
+        assert!(AGENT_SESSION_TITLE_SYSTEM_PROMPT.contains("Calendar overview"));
     }
 
     #[test]
@@ -3021,7 +3033,9 @@ data: \"data\":{\"content\":\"Joined\",\"titleSuggestion\":null,\"provider\":\"v
         let response = "é".repeat(1201);
         let content = agent_session_title_user_content("Summarize the work", Some(&response));
         let excerpt = content
-            .strip_prefix("User request:\nSummarize the work\n\nAssistant reply excerpt:\n")
+            .strip_prefix(
+                "Primary user intent (authoritative):\nSummarize the work\n\nSecondary assistant context (clarification only):\n",
+            )
             .expect("formatted content should include assistant reply prefix");
         assert_eq!(excerpt.chars().count(), 1200);
         assert_eq!(excerpt, "é".repeat(1200));


### PR DESCRIPTION
## What changed

- Make the user's first request the authoritative source for generated session titles.
- Treat the assistant reply as secondary context only, so acknowledgements and clarification questions do not become titles.
- Add the reported calendar conversation as a regression example in the title-generation contract and cover the contract with a unit test.

## Root cause

The title prompt explicitly instructed the model to name the session from the assistant reply whenever a reply excerpt was present. For a request such as `tell me about my calendar`, the assistant's follow-up question could therefore override the clear calendar topic.

## User impact

Sessions should now be named for what the user is trying to do or discuss. In the reported case, the expected title is `Calendar overview` instead of `Sure! Which calendar service are you using`.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked agent_session_title_ --lib` (5 passed)
- `pnpm test:rust` (663 passed, 4 ignored; all integration tests passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786565276&installation_id=144203540&pr_number=729&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F729&signature=4523f2772e7c32b79b2cac1e0ae7ba7fefd702509f84a6509db343b047a42bf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->