### PR TITLE
Clarify Auto model picker guidance

### DIFF
--- a/src/components/settings/ModelPickerDialog.tsx
+++ b/src/components/settings/ModelPickerDialog.tsx
@@ -350,6 +350,11 @@ function trimNumber(value: number) {
 // Falls back to a single "Pricing" row when there is no clean input/output
 // credit split.
 export function modelSpecEntries(model: VeniceModelDto): { label: string; value: string }[] {
+  // Auto is a routing preference, not a concrete model. Its eventual model,
+  // price, and context window vary by request, so fixed catalog specs would be
+  // misleading even when the compatibility catalog provides placeholders.
+  if (model.id === "open-software/auto") return [];
+
   const entries: { label: string; value: string }[] = [];
   // Use June's billed credit price (with margin) for the input/output split.
   // The raw `pricing.*.usd` on the DTO is upstream provider metadata the backend

--- a/src/components/settings/ProviderLogo.tsx
+++ b/src/components/settings/ProviderLogo.tsx
@@ -9,6 +9,7 @@ import { IconNvidia } from "central-icons/IconNvidia";
 import { IconOllama } from "central-icons/IconOllama";
 import { IconOpenai } from "central-icons/IconOpenai";
 import { IconPerplexity } from "central-icons/IconPerplexity";
+import { useId } from "react";
 
 type ProviderLogoProps = {
   provider: string;
@@ -20,6 +21,8 @@ type ProviderLogoProps = {
 export function ProviderLogo({ provider, id, name = "", size = 18 }: ProviderLogoProps) {
   const kind = classifyProvider(provider, id, name);
   switch (kind) {
+    case "open-software":
+      return <OpenSoftwareMark size={size} />;
     case "openai":
       return <IconOpenai size={size} aria-label="OpenAI" />;
     case "anthropic":
@@ -56,6 +59,7 @@ export function ProviderLogo({ provider, id, name = "", size = 18 }: ProviderLog
 export { IconAnthropic };
 
 type ProviderKind =
+  | "open-software"
   | "openai"
   | "anthropic"
   | "google"
@@ -72,6 +76,10 @@ type ProviderKind =
   | "unknown";
 
 function classifyProvider(provider: string, id: string, name: string): ProviderKind {
+  // Auto is an OpenSoftware product even when its catalog record inherits a
+  // provider value from the currently available routing backends.
+  if (id.toLowerCase() === "open-software/auto") return "open-software";
+
   // Model family takes precedence over hosting platform (e.g. Venice-hosted
   // GPT-4o still reads as OpenAI). Hosting providers (venice, fal) only win
   // when nothing more specific matched.
@@ -170,6 +178,32 @@ function Monogram({ label, size }: { label: string; size: number }) {
 const FAL_SCALE = 0.78;
 const VENICE_SCALE = 0.86;
 const ELEVENLABS_SCALE = 1.05;
+
+function OpenSoftwareMark({ size }: { size: number }) {
+  const gradientId = `open-software-mark-${useId().replace(/:/g, "")}`;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 18 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label="OpenSoftware"
+    >
+      <rect width="18" height="18" rx="4" fill={`url(#${gradientId})`} />
+      <g fill="white">
+        <path d="M14.0417 8.53571C14.2948 8.53571 14.5 8.74358 14.5 9V10.3929C14.5 10.6493 14.2948 10.8571 14.0417 10.8571H13.0462C12.9247 10.8572 12.8081 10.9061 12.7222 10.9932L12.3426 11.3777C12.2567 11.4647 12.2084 11.5828 12.2083 11.7059V12.7143C12.2083 12.9707 12.0031 13.1786 11.75 13.1786H6.62956C6.50802 13.1786 6.39144 13.2275 6.3055 13.3146L5.92594 13.6991C5.84001 13.7861 5.79169 13.9042 5.79167 14.0273V15.0357C5.79167 15.2921 5.58646 15.5 5.33333 15.5H3.95833C3.7052 15.5 3.5 15.2921 3.5 15.0357V13.6429C3.5 13.3864 3.7052 13.1786 3.95833 13.1786H4.95378C5.07531 13.1786 5.19189 13.1296 5.27783 13.0426L5.65739 12.6581C5.74333 12.571 5.79165 12.4529 5.79167 12.3298V11.3214C5.79167 11.065 5.99687 10.8571 6.25 10.8571H11.3704C11.492 10.8571 11.6086 10.8082 11.6945 10.7211L12.0741 10.3366C12.16 10.2496 12.2083 10.1315 12.2083 10.0084V9C12.2083 8.74358 12.4135 8.53571 12.6667 8.53571H14.0417Z" />
+        <path d="M14.0417 2.5C14.2948 2.5 14.5 2.70787 14.5 2.96429V4.35714C14.5 4.61356 14.2948 4.82143 14.0417 4.82143H13.0462C12.9247 4.82145 12.8081 4.8704 12.7222 4.95745L12.3426 5.34194C12.2567 5.42899 12.2084 5.54709 12.2083 5.6702V6.67857C12.2083 6.93499 12.0031 7.14286 11.75 7.14286H6.62956C6.50802 7.14288 6.39144 7.19182 6.3055 7.27888L5.92594 7.66336C5.84001 7.75042 5.79169 7.86852 5.79167 7.99163V9C5.79167 9.25642 5.58646 9.46429 5.33333 9.46429H3.95833C3.7052 9.46429 3.5 9.25642 3.5 9V7.60714C3.5 7.35072 3.7052 7.14286 3.95833 7.14286H4.95378C5.07531 7.14284 5.19189 7.09389 5.27783 7.00684L5.65739 6.62235C5.74333 6.5353 5.79165 6.4172 5.79167 6.29408V5.28571C5.79167 5.0293 5.99687 4.82143 6.25 4.82143H11.3704C11.492 4.82141 11.6086 4.77246 11.6945 4.68541L12.0741 4.30092C12.16 4.21387 12.2083 4.09577 12.2083 3.97266V2.96429C12.2083 2.70787 12.4135 2.5 12.6667 2.5H14.0417Z" />
+      </g>
+      <defs>
+        <linearGradient id={gradientId} x1="9" y1="0" x2="9" y2="18" gradientUnits="userSpaceOnUse">
+          <stop style={{ stopColor: "color-mix(in oklch, var(--brand) 55%, white)" }} />
+          <stop offset="1" style={{ stopColor: "var(--brand)" }} />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}
 
 function ElevenLabsMark({ size }: { size: number }) {
   const s = Math.round(size * ELEVENLABS_SCALE);

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -48,13 +48,13 @@ export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
       id: "open-software/auto",
       label: "Auto · Balanced",
       costQuality: 50,
-      reason: "Best for everyday work when you want a strong balance of quality and cost.",
+      reason: "Best for everyday work when you want a practical balance of quality and credit use.",
     },
     {
       id: "open-software/auto",
       label: "Auto · Lower Cost",
       costQuality: 20,
-      reason: "Best for quick or routine tasks when keeping usage costs down matters most.",
+      reason: "Best for quick or routine tasks when minimizing credit use matters most.",
     },
   ],
   transcription: [

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -7,7 +7,7 @@ export type SuggestedModel = {
   label?: string;
   /** Auto-router preference selected with this suggestion (0-100). */
   costQuality?: number;
-  /** One-line "why we recommend it", rendered under the model's meta row. */
+  /** One-line "when to choose it" guidance shown in the suggested model card. */
   reason: string;
 };
 
@@ -42,19 +42,19 @@ export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
       id: "open-software/auto",
       label: "Auto · Higher Quality",
       costQuality: 100,
-      reason: "Default: prioritize the strongest private model available for each request.",
+      reason: "Best for complex questions and important work where response quality matters most.",
     },
     {
       id: "open-software/auto",
       label: "Auto · Balanced",
       costQuality: 50,
-      reason: "Balance response quality and usage cost for everyday work.",
+      reason: "Best for everyday work when you want a strong balance of quality and cost.",
     },
     {
       id: "open-software/auto",
       label: "Auto · Lower Cost",
       costQuality: 20,
-      reason: "Prefer lower-cost private models while preserving June's tool support.",
+      reason: "Best for quick or routine tasks when keeping usage costs down matters most.",
     },
   ],
   transcription: [
@@ -133,7 +133,8 @@ export function preferredVisionFallbackModel(models: VeniceModelDto[]): VeniceMo
 }
 
 /** The curated picks that are actually present in the live catalog, in
- * curated order, with their recommendation reasons attached. */
+ * curated order. Picker-only labels and guidance replace the generic catalog
+ * name and description without changing the persisted model id. */
 export function suggestedModelsForMode(
   mode: ProviderModelMode,
   options: VeniceModelDto[],
@@ -149,7 +150,10 @@ export function suggestedModelsForMode(
     return [
       {
         key: `${suggested.id}:${suggested.costQuality ?? index}`,
-        model: suggested.label ? { ...model, name: suggested.label } : model,
+        model: {
+          ...model,
+          ...(suggested.label ? { name: suggested.label, description: suggested.reason } : {}),
+        },
         reason: suggested.reason,
         costQuality: suggested.costQuality,
       },

--- a/src/test/model-spec-entries.test.ts
+++ b/src/test/model-spec-entries.test.ts
@@ -15,6 +15,20 @@ function model(overrides: Partial<VeniceModelDto>): VeniceModelDto {
 }
 
 describe("modelSpecEntries", () => {
+  it("omits fixed pricing and context for the Auto router", () => {
+    const entries = modelSpecEntries(
+      model({
+        id: "open-software/auto",
+        priceUnit: "tokens",
+        inputCreditsPerMillionTokens: 2_100,
+        outputCreditsPerMillionTokens: 6_900,
+        contextTokens: 2_000_000,
+      }),
+    );
+
+    expect(entries).toEqual([]);
+  });
+
   it("shows June's billed credit price, never the raw upstream pricing", () => {
     // Raw upstream pricing ($2/$6) is present but must be ignored: the backend
     // keeps `pricing` as reference metadata and bills from the credit price

--- a/src/test/provider-logo.test.tsx
+++ b/src/test/provider-logo.test.tsx
@@ -3,6 +3,13 @@ import { describe, expect, it } from "vitest";
 import { ProviderLogo } from "../components/settings/ProviderLogo";
 
 describe("ProviderLogo", () => {
+  it("uses the OpenSoftware mark for Auto regardless of its routing provider", () => {
+    render(<ProviderLogo provider="venice" id="open-software/auto" name="Auto" />);
+
+    expect(screen.getByLabelText("OpenSoftware")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Venice")).not.toBeInTheDocument();
+  });
+
   it("does not classify broad Anthropic family words as Claude", () => {
     render(<ProviderLogo provider="venice" id="poetry-haiku" name="Haiku" />);
 

--- a/src/test/suggested-models.test.ts
+++ b/src/test/suggested-models.test.ts
@@ -76,12 +76,13 @@ describe("suggestedModelsForMode", () => {
       },
       {
         name: "Auto · Balanced",
-        description: "Best for everyday work when you want a strong balance of quality and cost.",
+        description:
+          "Best for everyday work when you want a practical balance of quality and credit use.",
         costQuality: 50,
       },
       {
         name: "Auto · Lower Cost",
-        description: "Best for quick or routine tasks when keeping usage costs down matters most.",
+        description: "Best for quick or routine tasks when minimizing credit use matters most.",
         costQuality: 20,
       },
     ]);

--- a/src/test/suggested-models.test.ts
+++ b/src/test/suggested-models.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { preferredVisionFallbackModel } from "../lib/suggested-models";
+import { preferredVisionFallbackModel, suggestedModelsForMode } from "../lib/suggested-models";
 import type { VeniceModelDto } from "../lib/tauri";
 
 const model = (id: string, name: string, capabilities: string[]): VeniceModelDto => ({
@@ -49,5 +49,42 @@ describe("preferredVisionFallbackModel", () => {
     const glm51 = model("zai-org-glm-5-1", "GLM 5.1", ["supportsFunctionCalling"]);
     expect(preferredVisionFallbackModel([glm52, glm51])).toBeUndefined();
     expect(preferredVisionFallbackModel([])).toBeUndefined();
+  });
+});
+
+describe("suggestedModelsForMode", () => {
+  it("replaces Auto's generic catalog description with preset-specific guidance", () => {
+    const auto = {
+      ...model("open-software/auto", "Auto", ["supportsFunctionCalling"]),
+      description: "Automatically selects an eligible private model",
+    };
+
+    const suggestions = suggestedModelsForMode("generation", [auto]);
+
+    expect(
+      suggestions.map(({ model: suggestion, costQuality }) => ({
+        name: suggestion.name,
+        description: suggestion.description,
+        costQuality,
+      })),
+    ).toEqual([
+      {
+        name: "Auto · Higher Quality",
+        description:
+          "Best for complex questions and important work where response quality matters most.",
+        costQuality: 100,
+      },
+      {
+        name: "Auto · Balanced",
+        description: "Best for everyday work when you want a strong balance of quality and cost.",
+        costQuality: 50,
+      },
+      {
+        name: "Auto · Lower Cost",
+        description: "Best for quick or routine tasks when keeping usage costs down matters most.",
+        costQuality: 20,
+      },
+    ]);
+    expect(suggestions.every(({ model: suggestion }) => suggestion.id === auto.id)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Replace generic Auto hover-card copy with guidance for Higher Quality, Balanced, and Lower Cost.
- Remove misleading fixed pricing and context rows from Auto cards.
- Show the OpenSoftware logo for Auto while preserving provider logos for explicit models.

## Root cause

The suggested-model layer supplied one generic description for every Auto preset, the shared detail card treated Auto like a fixed model with fixed catalog metadata, and provider-logo classification fell through to the current backend provider instead of recognizing Auto as an OpenSoftware product.

## Validation

- `make check typecheck test-web`: 152 files passed, 2,497 tests passed, 2 skipped.
- Focused model-picker/provider-logo suite: 15 tests passed.
- Browser hover-card walkthrough covered all three Auto presets and verified that pricing/context rows are absent.

- [x] Tested visually where it matters (UI changes: browser walkthrough completed; screenshot available in task artifacts).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Auto routing behavior, model selection, pricing, and backend deployment.
- Renaming the existing `Auto · Lower Cost` preset label.
- Changes to explicit provider-model cards.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. (No security-sensitive changes.)
- [x] Workflow action references are pinned to full-length commit SHAs. (No workflow changes.)
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. (No such changes.)
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (No backend changes.)
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786567263&installation_id=144203540&pr_number=730&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F730&signature=57a88956c66a579024db53992dbf2cbd65e9ccf5fb413318a29dddadef01b0c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->