### PR TITLE
Add the referral delight nudge

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -51,6 +51,13 @@ import { IconZap } from "central-icons/IconZap";
 import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconSettingsGear4 } from "central-icons/IconSettingsGear4";
 import { ConnectorApprovalsTray } from "../components/connectors/ConnectorApprovalsTray";
+import {
+  OPEN_REFERRAL_DIALOG_EVENT,
+  ReferralNudge,
+  type ReferralNudgeMoment,
+} from "../components/referral/ReferralNudge";
+import { markReferralNudgeClickedThrough, recordDictationFinished } from "../lib/referral-nudge";
+import { useReferralNudgeTriggers } from "./referral-nudge-triggers";
 import { Dialog } from "../components/ui/Dialog";
 import {
   assignNoteToFolder,
@@ -535,6 +542,31 @@ export function App() {
       dispose?.();
     };
   }, []);
+  // The referral delight nudge (bottom-left card). Real shows come from the
+  // trigger layer (useReferralNudgeTriggers below); the dev console driver
+  // (window.__referralNudge) parks the card without touching the persisted
+  // caps, which is why the source is tracked — only trigger-shown cards may
+  // record a click-through.
+  const [referralNudgeMoment, setReferralNudgeMoment] = useState<ReferralNudgeMoment | null>(null);
+  const referralNudgeSourceRef = useRef<"trigger" | "demo">("trigger");
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    let cancelled = false;
+    let dispose: (() => void) | undefined;
+    void import("../lib/referral-nudge-demo").then(({ registerReferralNudgeDemo }) => {
+      if (cancelled) return;
+      ({ dispose } = registerReferralNudgeDemo({
+        setMoment: (moment) => {
+          referralNudgeSourceRef.current = "demo";
+          setReferralNudgeMoment(moment);
+        },
+      }));
+    });
+    return () => {
+      cancelled = true;
+      dispose?.();
+    };
+  }, []);
   // Dev console driver for the sidebar "Relaunch to update" card
   // (window.__updateCard). Pushes synthetic values into the real update state
   // so the card's styling can be parked and inspected without a live update.
@@ -817,6 +849,21 @@ export function App() {
   // holds bootstrap, update checks, and eager permission probes because the
   // wizard owns the permission prompts while it is on screen.
   const appBlocked = accountLoading || signInRequired || onboardingRequired;
+  // The referral delight nudge's trigger layer: counts the moments (5th note,
+  // first agent completion, 25th dictation) and surfaces the card when the
+  // caps and gates allow. T4 (positive feedback) records from the report flow
+  // directly.
+  // Gated on captureActive too: a growth card sliding in mid-meeting is the
+  // one timing guaranteed to annoy. A moment that fires during a recording is
+  // consumed without showing (the caps never queue).
+  useReferralNudgeTriggers({
+    notes: state.notes,
+    enabled: account.signedIn && !account.localDev && onboardingDone && !captureActive,
+    onShow: (moment) => {
+      referralNudgeSourceRef.current = "trigger";
+      setReferralNudgeMoment(moment);
+    },
+  });
   const publishAgentMenuBarState = useCallback(() => {
     void emitAgentMenuBarState(
       buildAgentMenuBarState({
@@ -1817,6 +1864,12 @@ export function App() {
     void listen<string>("dictation-event", (event) => {
       const helperEvent = parseDictationHelperEvent(event.payload);
       if (!helperEvent) return;
+      if (helperEvent.type === "final_transcript") {
+        // T3 of the referral delight nudge: a dictation landed (often while
+        // June is backgrounded; the card waits to be found).
+        recordDictationFinished();
+        return;
+      }
       if (helperEvent.type === "agent_session_prompt") {
         const prompt = stringPayloadValue(helperEvent.payload?.prompt) ?? "";
         dispatchAgentSessionStatus({
@@ -4040,6 +4093,22 @@ export function App() {
       {/* Connector action approvals (approval trust mode) can arrive from a
           routine or chat in any view, so the tray is mounted at the shell. */}
       <ConnectorApprovalsTray />
+      {/* The referral delight nudge floats bottom-left at the shell so it can
+          appear over any view; click-through opens the sidebar-owned referral
+          dialog by event. */}
+      {referralNudgeMoment ? (
+        <ReferralNudge
+          moment={referralNudgeMoment}
+          onInvite={() => {
+            // Ends all future nudging, per the frequency rules — but only for
+            // real trigger shows; demo cards must not poison the caps.
+            if (referralNudgeSourceRef.current === "trigger") markReferralNudgeClickedThrough();
+            setReferralNudgeMoment(null);
+            window.dispatchEvent(new Event(OPEN_REFERRAL_DIALOG_EVENT));
+          }}
+          onDismiss={() => setReferralNudgeMoment(null)}
+        />
+      ) : null}
     </main>
   );
 }

--- a/src/app/referral-nudge-triggers.ts
+++ b/src/app/referral-nudge-triggers.ts
@@ -78,6 +78,9 @@ export function useReferralNudgeTriggers({
       probingRef.current = true;
       osAccountsReferralSummary()
         .then(() => {
+          // The gates can flip while the probe is in flight (a recording
+          // starts, the user signs out) — re-check before showing.
+          if (!enabledRef.current) return;
           markReferralNudgeShown();
           onShowRef.current(moment);
         })

--- a/src/app/referral-nudge-triggers.ts
+++ b/src/app/referral-nudge-triggers.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from "react";
+import { AGENT_SESSION_STATUS_EVENT, type AgentSessionStatusDetail } from "../lib/agent-events";
+import {
+  REFERRAL_NUDGE_EVENT,
+  type ReferralNudgeMoment,
+  markReferralNudgeShown,
+  recordAgentTaskCompleted,
+  recordMeetingNoteGenerated,
+} from "../lib/referral-nudge";
+import type { NoteListItemDto, ProcessingStatus } from "../lib/tauri";
+import { osAccountsReferralSummary } from "../lib/tauri";
+
+/**
+ * Wires the referral delight nudge's trigger moments to the signals the shell
+ * already carries (see src/lib/referral-nudge.ts for the caps):
+ *
+ *   T1  a note's processingStatus transitions into "ready" (5th fires)
+ *   T2  an agent session reports "completed" (first fires)
+ *   T3  records from App's existing dictation-event listener, not here (a
+ *       second "dictation-event" subscription would double-handle the shared
+ *       channel)
+ *   T4  lives with the report flow (see ReportDialog / the chip-flow
+ *       delivery in AgentWorkspace)
+ *
+ * Signals always record — counting is harmless anywhere — but a nudge only
+ * shows when `enabled` (signed in, onboarded, not local dev) and this
+ * deployment actually offers referrals (the summary probe; a deployment
+ * without /referrals/me quietly consumes the moment instead of showing a
+ * card whose dialog would dead-end).
+ */
+export function useReferralNudgeTriggers({
+  notes,
+  enabled,
+  onShow,
+}: {
+  notes: NoteListItemDto[];
+  enabled: boolean;
+  onShow: (moment: ReferralNudgeMoment) => void;
+}) {
+  // T1: notes crossing into "ready". The first snapshot is a baseline — notes
+  // that load already-ready (app start, bootstrap) are history, not moments;
+  // only a note observed in a pre-ready state that then flips counts.
+  const noteStatusesRef = useRef<Map<string, ProcessingStatus> | null>(null);
+  useEffect(() => {
+    const previous = noteStatusesRef.current;
+    noteStatusesRef.current = new Map(notes.map((note) => [note.id, note.processingStatus]));
+    if (!previous) return;
+    for (const note of notes) {
+      const before = previous.get(note.id);
+      if (before !== undefined && before !== "ready" && note.processingStatus === "ready") {
+        recordMeetingNoteGenerated();
+      }
+    }
+  }, [notes]);
+
+  // T2: session status events only fire for live transitions (the gateway
+  // streams them), so "completed" here is a task finishing now, not history.
+  // Failed and cancelled sessions never trigger.
+  useEffect(() => {
+    const onStatus = (event: Event) => {
+      const detail = (event as CustomEvent<AgentSessionStatusDetail>).detail;
+      if (detail?.status === "completed") recordAgentTaskCompleted();
+    };
+    window.addEventListener(AGENT_SESSION_STATUS_EVENT, onStatus);
+    return () => window.removeEventListener(AGENT_SESSION_STATUS_EVENT, onStatus);
+  }, []);
+
+  // The show path. Refs so the listener never closes over stale props.
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+  const onShowRef = useRef(onShow);
+  onShowRef.current = onShow;
+  const probingRef = useRef(false);
+  useEffect(() => {
+    const onNudge = (event: Event) => {
+      const moment = (event as CustomEvent<{ moment: ReferralNudgeMoment }>).detail?.moment;
+      if (!moment || probingRef.current || !enabledRef.current) return;
+      probingRef.current = true;
+      osAccountsReferralSummary()
+        .then(() => {
+          markReferralNudgeShown();
+          onShowRef.current(moment);
+        })
+        .catch(() => {
+          // Referrals unavailable here (or offline): skip quietly. The
+          // moment stays consumed — no queueing, per the frequency rules.
+        })
+        .finally(() => {
+          probingRef.current = false;
+        });
+    };
+    window.addEventListener(REFERRAL_NUDGE_EVENT, onNudge);
+    return () => window.removeEventListener(REFERRAL_NUDGE_EVENT, onNudge);
+  }, []);
+}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -205,6 +205,7 @@ import {
   type BranchSessionResult,
 } from "../../lib/hermes-session-branch";
 import { normalizeSteerText } from "../../lib/hermes-session-steer";
+import { recordPositiveFeedbackSent } from "../../lib/referral-nudge";
 import { useScrollFade } from "../../lib/use-scroll-fade";
 import { unsupportedEventStore } from "../../lib/hermes-unsupported-events";
 import { pendingActionStore } from "../../lib/hermes-pending-actions";
@@ -5696,6 +5697,10 @@ export function AgentWorkspace({
       toast.success(issueReportSentMessage(response?.skippedAttachmentNames), {
         id: ISSUE_REPORT_SENT_TOAST_ID,
       });
+      // T4 of the referral delight nudge: positive feedback only. The
+      // error-report path deliberately doesn't record — a report sent from a
+      // failure is not a delight moment, whatever its category.
+      if (report.category === "feedback") recordPositiveFeedbackSent();
       return { sent: true };
     } catch (err) {
       const errorMessage = `The issue report could not be sent. ${messageFromError(err)}`;

--- a/src/components/agent/ReportDialog.tsx
+++ b/src/components/agent/ReportDialog.tsx
@@ -4,6 +4,7 @@ import { type ClipboardEvent, type DragEvent, useId, useMemo, useRef, useState }
 
 import { clipboardImageFiles } from "../../lib/clipboard-files";
 import { messageFromError } from "../../lib/errors";
+import { recordPositiveFeedbackSent } from "../../lib/referral-nudge";
 import { submitIssueReport } from "../../lib/tauri";
 import { DotSpinner } from "../DotSpinner";
 import { Dialog, DialogField } from "../ui/Dialog";
@@ -195,6 +196,9 @@ export function ReportDialog({
       setSubmitting(false);
       setSkippedAttachmentNames(response?.skippedAttachmentNames ?? []);
       setSent(true);
+      // T4 of the referral delight nudge: positive feedback only, never bug
+      // reports or feature requests.
+      if (category === "feedback") recordPositiveFeedbackSent();
       onSent();
     } catch (err) {
       setSubmitting(false);

--- a/src/components/referral/ReferralNudge.tsx
+++ b/src/components/referral/ReferralNudge.tsx
@@ -1,0 +1,110 @@
+import { IconCrossMedium } from "central-icons/IconCrossMedium";
+import { useEffect, useState } from "react";
+import type { ReferralNudgeMoment } from "../../lib/referral-nudge";
+import { JuneGlassMark } from "../brand/JuneGlassMark";
+
+export type { ReferralNudgeMoment };
+
+/**
+ * The referral delight nudge: a rare, dismissible invite card that appears at
+ * moments June has just delivered value (5th meeting note, first successful
+ * agent task, 25th dictation, positive feedback). Deliberately a small cousin
+ * of the referral dialog's hero — the same terracotta gradient, grain, and
+ * June mark — so clicking through into that dialog feels continuous.
+ *
+ * The card never auto-dismisses (a dictation lands while June is backgrounded;
+ * the card waits to be found) and never steals focus. Trigger moments and
+ * frequency caps live with the caller, not here.
+ */
+
+/** Fired on click-through; the sidebar owns the referral dialog and listens. */
+export const OPEN_REFERRAL_DIALOG_EVENT = "june:open-referral-dialog";
+
+const MOMENT_COPY: Record<ReferralNudgeMoment, { title: string; body: string }> = {
+  meetings: {
+    title: "Five meetings, all captured",
+    body: "Know someone who lives in meetings? They get a free month of June, and when they subscribe, so do you.",
+  },
+  agent: {
+    title: "Give a month, get a month",
+    body: "Share June with a friend. They get a free month, and when they subscribe, so do you.",
+  },
+  dictation: {
+    title: "Twenty-five dictations in",
+    body: "Know someone who types too much? They get a free month of June, and when they subscribe, so do you.",
+  },
+  feedback: {
+    title: "Glad you're enjoying June",
+    body: "Share it with a friend. They get a free month, and when they subscribe, so do you.",
+  },
+};
+
+/** Matches the card's --t-med exit transition. */
+const EXIT_MS = 160;
+
+export function ReferralNudge({
+  moment,
+  onInvite,
+  onDismiss,
+}: {
+  moment: ReferralNudgeMoment;
+  onInvite: () => void;
+  onDismiss: () => void;
+}) {
+  // Dismiss plays a short fade-down before the caller unmounts the card;
+  // click-through is immediate (the opening dialog covers the exit).
+  const [leaving, setLeaving] = useState(false);
+  const copy = MOMENT_COPY[moment];
+
+  function dismiss() {
+    if (leaving) return;
+    setLeaving(true);
+    window.setTimeout(onDismiss, EXIT_MS);
+  }
+
+  // Escape clears the card from anywhere — it must never demand a mouse trip
+  // to its X. Dialogs keep first claim on the key: while one is open (it sits
+  // above the card anyway), Escape belongs to it, not to us.
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      if (document.querySelector('[role="dialog"]')) return;
+      dismiss();
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
+
+  return (
+    <aside className="referral-nudge" role="status" data-leaving={leaving || undefined}>
+      <div className="referral-nudge-hero">
+        {/* The sign-in surfaces' 3D glass mark, reprised at gift scale — the
+            same object the user met at their first sign-in, now the thing
+            they're invited to hand to a friend. Falls back to the flat
+            gradient mark (recolored white via --brand below) without WebGL
+            or under reduced motion. */}
+        <span className="referral-nudge-mark-glass" aria-hidden>
+          <JuneGlassMark />
+        </span>
+        <p className="referral-nudge-title">{copy.title}</p>
+      </div>
+      <button
+        type="button"
+        className="referral-nudge-dismiss"
+        aria-label="Dismiss"
+        onClick={dismiss}
+      >
+        <IconCrossMedium size={14} />
+      </button>
+      <div className="referral-nudge-body">
+        <p className="referral-nudge-copy">{copy.body}</p>
+      </div>
+      <div className="referral-nudge-footer">
+        <button type="button" className="referral-nudge-cta" onClick={onInvite} disabled={leaving}>
+          Invite friends
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/referral/ReferralNudge.tsx
+++ b/src/components/referral/ReferralNudge.tsx
@@ -101,7 +101,12 @@ export function ReferralNudge({
         <p className="referral-nudge-copy">{copy.body}</p>
       </div>
       <div className="referral-nudge-footer">
-        <button type="button" className="referral-nudge-cta" onClick={onInvite} disabled={leaving}>
+        <button
+          type="button"
+          className="primary-action primary-solid"
+          onClick={onInvite}
+          disabled={leaving}
+        >
           Invite friends
         </button>
       </div>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -91,6 +91,7 @@ import type {
 } from "../../lib/tauri";
 import { osAccountsReferralSummary } from "../../lib/tauri";
 import { JuneMark } from "../account/AccountGate";
+import { OPEN_REFERRAL_DIALOG_EVENT } from "../referral/ReferralNudge";
 import { SETTINGS_TABS, type SettingsTab } from "../settings/AppSettings";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { Dialog } from "../ui/Dialog";
@@ -545,6 +546,19 @@ export function Sidebar({
       void loadReferralSummary();
     }
   }
+
+  // Shell surfaces outside the sidebar (the referral delight nudge) open the
+  // referral dialog by window event, since the dialog lives here. Re-attached
+  // every render (the command-prompt keydown pattern below) so the handler
+  // never closes over stale account state.
+  useEffect(() => {
+    function onOpenReferralDialog() {
+      openReferralDialog();
+    }
+
+    window.addEventListener(OPEN_REFERRAL_DIALOG_EVENT, onOpenReferralDialog);
+    return () => window.removeEventListener(OPEN_REFERRAL_DIALOG_EVENT, onOpenReferralDialog);
+  });
 
   async function copyReferralLink() {
     if (!referralSummary) return;

--- a/src/lib/referral-nudge-demo.ts
+++ b/src/lib/referral-nudge-demo.ts
@@ -1,0 +1,65 @@
+// Dev-only console driver for the referral delight nudge card.
+//
+//   window.__referralNudge()             show the T2 agent variant
+//   window.__referralNudge("meetings")   T1: 5th meeting note captured
+//   window.__referralNudge("agent")      T2: first successful agent task
+//   window.__referralNudge("dictation")  T3: 25th dictation landed
+//   window.__referralNudge("feedback")   T4: positive feedback sent
+//   window.__referralNudge("clear")      dismiss the card
+//
+// Parks the card bottom-left on any view so its styling, motion, and both
+// actions can be inspected without earning a real delight moment. The
+// "Invite friends" click-through opens the real referral dialog (signed-in
+// accounts only; local-dev accounts skip the dialog by design). Never bundled
+// in production: App gates the dynamic import on import.meta.env.DEV.
+
+import type { ReferralNudgeMoment } from "../components/referral/ReferralNudge";
+
+export type ReferralNudgeDemoApi = {
+  /** Remove the window hook. */
+  dispose: () => void;
+};
+
+const MOMENTS: ReferralNudgeMoment[] = ["meetings", "agent", "dictation", "feedback"];
+
+const HELP = [
+  "Referral delight nudge demo:",
+  "  __referralNudge()             show the T2 agent variant",
+  '  __referralNudge("meetings")   T1: 5th meeting note captured',
+  '  __referralNudge("agent")      T2: first successful agent task',
+  '  __referralNudge("dictation")  T3: 25th dictation landed',
+  '  __referralNudge("feedback")   T4: positive feedback sent',
+  '  __referralNudge("clear")      dismiss the card',
+  "",
+  "Parks the card bottom-left on any view. Dev only.",
+].join("\n");
+
+export function registerReferralNudgeDemo({
+  setMoment,
+}: {
+  setMoment: (moment: ReferralNudgeMoment | null) => void;
+}): ReferralNudgeDemoApi {
+  const hook = (state?: string) => {
+    if (state === "clear" || state === "stop") {
+      setMoment(null);
+      return "Referral nudge dismissed.";
+    }
+    if (state === undefined || state === "agent") {
+      setMoment("agent");
+      return 'Agent variant parked. __referralNudge("clear") to dismiss.';
+    }
+    if ((MOMENTS as string[]).includes(state)) {
+      setMoment(state as ReferralNudgeMoment);
+      return `${state} variant parked. __referralNudge("clear") to dismiss.`;
+    }
+    return HELP;
+  };
+
+  (window as unknown as Record<string, unknown>).__referralNudge = hook;
+
+  function dispose() {
+    delete (window as unknown as Record<string, unknown>).__referralNudge;
+  }
+
+  return { dispose };
+}

--- a/src/lib/referral-nudge.ts
+++ b/src/lib/referral-nudge.ts
@@ -73,11 +73,15 @@ function loadState(): ReferralNudgeState {
   }
 }
 
-function saveState(state: ReferralNudgeState) {
+/** Returns false when storage is full or unavailable. Callers fail CLOSED on
+ *  that: a moment we cannot record must never show, or an install with broken
+ *  storage would re-nudge on every trigger, ignoring the caps entirely. */
+function saveState(state: ReferralNudgeState): boolean {
   try {
     window.localStorage.setItem(REFERRAL_NUDGE_STORAGE_KEY, JSON.stringify(state));
+    return true;
   } catch {
-    // Storage full or unavailable: the nudge quietly never fires.
+    return false;
   }
 }
 
@@ -100,8 +104,8 @@ function fireMoment(
   if (state.consumed.includes(moment)) return null;
   state.consumed.push(moment);
   const allowed = capsAllow(state, now);
-  saveState(state);
-  if (!allowed) return null;
+  const persisted = saveState(state);
+  if (!allowed || !persisted) return null;
   window.dispatchEvent(new CustomEvent(REFERRAL_NUDGE_EVENT, { detail: { moment } }));
   return moment;
 }

--- a/src/lib/referral-nudge.ts
+++ b/src/lib/referral-nudge.ts
@@ -73,6 +73,19 @@ function loadState(): ReferralNudgeState {
   }
 }
 
+/** One failed write latches the module fail-closed until restart. The
+ *  post-show writes (markReferralNudgeShown, markReferralNudgeClickedThrough)
+ *  have no caller that can retry or undo the show, so a show or opt-out we
+ *  could not record must suppress everything for the rest of the session;
+ *  the next launch re-reads whatever state last persisted and fireMoment's
+ *  own fail-closed check covers storage that is still broken. */
+let writeFailedThisSession = false;
+
+/** Test-only: clears the session fail-closed latch. */
+export function resetReferralNudgeSessionLatchForTests() {
+  writeFailedThisSession = false;
+}
+
 /** Returns false when storage is full or unavailable. Callers fail CLOSED on
  *  that: a moment we cannot record must never show, or an install with broken
  *  storage would re-nudge on every trigger, ignoring the caps entirely. */
@@ -81,11 +94,13 @@ function saveState(state: ReferralNudgeState): boolean {
     window.localStorage.setItem(REFERRAL_NUDGE_STORAGE_KEY, JSON.stringify(state));
     return true;
   } catch {
+    writeFailedThisSession = true;
     return false;
   }
 }
 
 function capsAllow(state: ReferralNudgeState, now: number): boolean {
+  if (writeFailedThisSession) return false;
   if (state.clickedThrough) return false;
   if (state.shownCount >= REFERRAL_NUDGE_LIFETIME_MAX) return false;
   if (state.lastShownAt !== null && now - state.lastShownAt < REFERRAL_NUDGE_MIN_INTERVAL_MS) {

--- a/src/lib/referral-nudge.ts
+++ b/src/lib/referral-nudge.ts
@@ -1,0 +1,156 @@
+// Trigger state for the referral delight nudge (see the ReferralNudge
+// component for the card itself). The nudge appears at moments June has just
+// delivered value; this module owns the per-install counters and the
+// frequency caps that make it rare:
+//
+//   - each moment fires once per install, ever (a suppressed moment is
+//     consumed, not queued);
+//   - at most one nudge per 14 days, at most 2 lifetime;
+//   - a click-through into the referral dialog ends all nudging, forever.
+//
+// The record* functions are called from wherever the product signal lives
+// (note processing, agent session status, the dictation helper, the report
+// flow). They persist progress and, when a threshold event occurs AND the
+// caps permit showing, dispatch REFERRAL_NUDGE_EVENT. The shell decides
+// whether the card actually appears (signed in, onboarded, not local dev,
+// referrals available on this deployment) and then confirms with
+// markReferralNudgeShown / markReferralNudgeClickedThrough.
+//
+// Counters start at zero when this ships: an install that already has many
+// notes or dictations earns its thresholds from here forward, which keeps
+// every fire a genuine "June just did this for you" moment rather than a
+// backfill surprise on update.
+
+export type ReferralNudgeMoment = "meetings" | "agent" | "dictation" | "feedback";
+
+/** Dispatched on window when a moment fires and the caps permit showing. */
+export const REFERRAL_NUDGE_EVENT = "june:referral-nudge";
+
+export const REFERRAL_NUDGE_STORAGE_KEY = "june.referralNudge";
+
+export const REFERRAL_NUDGE_NOTE_THRESHOLD = 5;
+export const REFERRAL_NUDGE_DICTATION_THRESHOLD = 25;
+export const REFERRAL_NUDGE_MIN_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000;
+export const REFERRAL_NUDGE_LIFETIME_MAX = 2;
+
+type ReferralNudgeState = {
+  noteCount: number;
+  dictationCount: number;
+  consumed: ReferralNudgeMoment[];
+  shownCount: number;
+  lastShownAt: number | null;
+  clickedThrough: boolean;
+};
+
+// A function, not a constant: fireMoment mutates state (consumed.push), so
+// every load must own a fresh consumed array.
+function freshState(): ReferralNudgeState {
+  return {
+    noteCount: 0,
+    dictationCount: 0,
+    consumed: [],
+    shownCount: 0,
+    lastShownAt: null,
+    clickedThrough: false,
+  };
+}
+
+function loadState(): ReferralNudgeState {
+  try {
+    const raw = window.localStorage.getItem(REFERRAL_NUDGE_STORAGE_KEY);
+    if (!raw) return freshState();
+    const parsed = JSON.parse(raw) as Partial<ReferralNudgeState>;
+    return {
+      noteCount: typeof parsed.noteCount === "number" ? parsed.noteCount : 0,
+      dictationCount: typeof parsed.dictationCount === "number" ? parsed.dictationCount : 0,
+      consumed: Array.isArray(parsed.consumed) ? (parsed.consumed as ReferralNudgeMoment[]) : [],
+      shownCount: typeof parsed.shownCount === "number" ? parsed.shownCount : 0,
+      lastShownAt: typeof parsed.lastShownAt === "number" ? parsed.lastShownAt : null,
+      clickedThrough: parsed.clickedThrough === true,
+    };
+  } catch {
+    return freshState();
+  }
+}
+
+function saveState(state: ReferralNudgeState) {
+  try {
+    window.localStorage.setItem(REFERRAL_NUDGE_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Storage full or unavailable: the nudge quietly never fires.
+  }
+}
+
+function capsAllow(state: ReferralNudgeState, now: number): boolean {
+  if (state.clickedThrough) return false;
+  if (state.shownCount >= REFERRAL_NUDGE_LIFETIME_MAX) return false;
+  if (state.lastShownAt !== null && now - state.lastShownAt < REFERRAL_NUDGE_MIN_INTERVAL_MS) {
+    return false;
+  }
+  return true;
+}
+
+/** Consumes the moment (once per install, ever) and, if the caps permit,
+ *  announces it. Returns the moment when it was announced, else null. */
+function fireMoment(
+  state: ReferralNudgeState,
+  moment: ReferralNudgeMoment,
+  now: number,
+): ReferralNudgeMoment | null {
+  if (state.consumed.includes(moment)) return null;
+  state.consumed.push(moment);
+  const allowed = capsAllow(state, now);
+  saveState(state);
+  if (!allowed) return null;
+  window.dispatchEvent(new CustomEvent(REFERRAL_NUDGE_EVENT, { detail: { moment } }));
+  return moment;
+}
+
+/** T1: a meeting note finished generating. Fires on the 5th. */
+export function recordMeetingNoteGenerated(now = Date.now()): ReferralNudgeMoment | null {
+  const state = loadState();
+  if (state.noteCount >= REFERRAL_NUDGE_NOTE_THRESHOLD) return null;
+  state.noteCount += 1;
+  if (state.noteCount < REFERRAL_NUDGE_NOTE_THRESHOLD) {
+    saveState(state);
+    return null;
+  }
+  return fireMoment(state, "meetings", now);
+}
+
+/** T2: an agent task completed successfully. Fires on the first. */
+export function recordAgentTaskCompleted(now = Date.now()): ReferralNudgeMoment | null {
+  return fireMoment(loadState(), "agent", now);
+}
+
+/** T3: a dictation landed. Fires on the 25th. */
+export function recordDictationFinished(now = Date.now()): ReferralNudgeMoment | null {
+  const state = loadState();
+  if (state.dictationCount >= REFERRAL_NUDGE_DICTATION_THRESHOLD) return null;
+  state.dictationCount += 1;
+  if (state.dictationCount < REFERRAL_NUDGE_DICTATION_THRESHOLD) {
+    saveState(state);
+    return null;
+  }
+  return fireMoment(state, "dictation", now);
+}
+
+/** T4: the user sent positive feedback (report category "feedback"). */
+export function recordPositiveFeedbackSent(now = Date.now()): ReferralNudgeMoment | null {
+  return fireMoment(loadState(), "feedback", now);
+}
+
+/** The card actually appeared: starts the 14-day window, counts the show. */
+export function markReferralNudgeShown(now = Date.now()) {
+  const state = loadState();
+  state.shownCount += 1;
+  state.lastShownAt = now;
+  saveState(state);
+}
+
+/** The user clicked through to the referral dialog: no further nudges, ever. */
+export function markReferralNudgeClickedThrough() {
+  const state = loadState();
+  state.clickedThrough = true;
+  saveState(state);
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -21060,6 +21060,232 @@ input:focus-visible,
   font-size: var(--fs-md);
 }
 
+/* Referral delight nudge --------------------------------------------
+   A rare invite card parked bottom-left of the window at delight moments
+   (5th meeting note, first agent completion, 25th dictation). Fixed like
+   the connector approvals tray but in the opposite corner, so the two
+   never collide; under the dialog layer. Visually a small cousin of the
+   referral dialog above — the same terracotta hero recipe (gradient,
+   grain, June mark) — so the click-through feels continuous. */
+.referral-nudge {
+  position: fixed;
+  /* Window bottom-left (the Linear/Cursor corner), tucked to the same --sp-3
+     inset as the main-panel card so the two share a bottom line. Keep this a
+     static inset: anchoring to the animated --sidebar-w-current made the
+     compositor move a blend-mode + WebGL stack continuously, which read as
+     noise flashing on the hero. It overlaps the sidebar footer while parked;
+     Escape and the X both clear it. */
+  left: var(--sp-3);
+  bottom: var(--sp-3);
+  z-index: 60;
+  width: min(300px, calc(100vw - 2 * var(--sp-3)));
+  overflow: hidden;
+  border-radius: var(--r-xl);
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow:
+    var(--shadow-md),
+    0 0 0 1px color-mix(in oklch, var(--border-subtle) 60%, transparent);
+  animation: referral-nudge-enter var(--t-med) var(--ease-out) both;
+  transition:
+    opacity var(--t-med) var(--ease-out),
+    transform var(--t-med) var(--ease-out);
+}
+
+/* Dismissing: drop the (filled) enter animation so the exit transition can
+   drive the same properties, then fade back down. */
+.referral-nudge[data-leaving] {
+  animation: none;
+  opacity: 0;
+  transform: translateY(4px);
+}
+
+@keyframes referral-nudge-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .referral-nudge {
+    animation-name: referral-nudge-enter-reduced;
+  }
+
+  .referral-nudge[data-leaving] {
+    transform: none;
+  }
+}
+
+@keyframes referral-nudge-enter-reduced {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* The dialog hero's gradient recipe, shrunk to a banner that carries the
+   title. Inset and concentric with the card (r-xl minus the --sp-2 frame
+   = r-md), the steer queue's 6px-frame recipe. */
+.referral-nudge-hero {
+  position: relative;
+  overflow: hidden;
+  /* Contain the grain's soft-light blend to this hero's own stacking context
+     so the compositor never reads back through the card/canvas layers. */
+  isolation: isolate;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: var(--sp-2);
+  min-height: 128px;
+  margin: var(--sp-2) var(--sp-2) 0;
+  padding: var(--sp-4);
+  border-radius: var(--r-md);
+  color: var(--on-solid);
+  background:
+    radial-gradient(
+      120% 120% at 12% 8%,
+      color-mix(in oklch, var(--brand) 82%, white),
+      transparent 55%
+    ),
+    linear-gradient(152deg, var(--brand) 0%, color-mix(in oklch, var(--brand) 68%, black) 100%);
+}
+
+/* The signature grain, as on the dialog hero. */
+.referral-nudge-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.5;
+  mix-blend-mode: soft-light;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* The 3D glass June mark (the welcome surface's centerpiece) at gift scale,
+   centered above the title. The square box reserves identical space for the
+   canvas and its fallbacks, as .welcome-mark-glass does. */
+.referral-nudge-mark-glass {
+  /* Above the grain ::after — the soft-light blend must never paint over the
+     WebGL canvas (compositors alternate-rasterize that stack, which shows as
+     noise flashing on the mark). Same layering as .referral-hero > *. */
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: center;
+  width: 96px;
+  height: 96px;
+  line-height: 0;
+  /* The gradient-mark fallback derives its stops from --brand, which would
+     vanish brand-on-brand against this terracotta hero; remapping --brand to
+     the hero's ink renders it as the white mark instead. The WebGL palette
+     is JS-side and unaffected. */
+  --brand: var(--on-solid);
+}
+
+.referral-nudge-mark-glass svg {
+  display: block;
+  width: 48px;
+  height: auto;
+}
+
+/* The per-moment title lives in the hero (the dialog hero's title, one
+   type step down for the card's width). */
+.referral-nudge-title {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  font-size: var(--fs-xl);
+  font-weight: var(--fw-medium);
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+/* The system dismiss (.dialog-close's geometry and ghost hover), recolored
+   for the terracotta it floats over; its focus ring is on-solid rather
+   than the neutral --ring-focus for the same reason. */
+.referral-nudge-dismiss {
+  position: absolute;
+  top: var(--sp-4);
+  right: var(--sp-4);
+  z-index: 1;
+  display: inline-grid;
+  place-items: center;
+  width: var(--control-md);
+  height: var(--control-md);
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: color-mix(in oklch, var(--on-solid) 85%, transparent);
+  cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.referral-nudge-dismiss:hover {
+  background: color-mix(in oklch, var(--on-solid) 18%, transparent);
+  color: var(--on-solid);
+}
+
+.referral-nudge-dismiss:focus-visible {
+  outline: 2px solid color-mix(in oklch, var(--on-solid) 80%, transparent);
+  outline-offset: 2px;
+}
+
+/* Body and footer share the hero text's left edge (--sp-2 frame + --sp-4
+   hero padding). */
+.referral-nudge-body {
+  padding: var(--sp-4) var(--sp-6) 0;
+}
+
+.referral-nudge-copy {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+}
+
+.referral-nudge-footer {
+  display: flex;
+  justify-content: flex-start;
+  padding: var(--sp-4) var(--sp-6) var(--sp-5);
+}
+
+.referral-nudge-cta {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--control-md);
+  padding: 0 var(--sp-3);
+  border: 0;
+  border-radius: var(--r-md);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: var(--fs-sm);
+  font-weight: 400;
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+.referral-nudge-cta:hover {
+  background: color-mix(in oklch, var(--primary) 92%, var(--foreground));
+}
+
+.referral-nudge-cta:focus-visible {
+  outline: 2px solid var(--ring-focus);
+  outline-offset: 2px;
+}
+
 /* Generous padding (+ negative outer margin) so the inputs' focus
  * rings (3px outer box-shadow) can paint without being clipped by the
  * dialog-card or by overflow on inner scrollers. */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -21069,12 +21069,12 @@ input:focus-visible,
    grain, June mark) — so the click-through feels continuous. */
 .referral-nudge {
   position: fixed;
-  /* Window bottom-left (the Linear/Cursor corner), tucked to the same --sp-3
-     inset as the main-panel card so the two share a bottom line. Keep this a
-     static inset: anchoring to the animated --sidebar-w-current made the
-     compositor move a blend-mode + WebGL stack continuously, which read as
-     noise flashing on the hero. It overlaps the sidebar footer while parked;
-     Escape and the X both clear it. */
+  /* Window bottom-left, on the main-panel card's --sp-3 inset so the two
+     share a bottom line (a near-miss offset here reads as misalignment).
+     Keep this a static inset: anchoring to the animated --sidebar-w-current
+     made the compositor move a blend-mode + WebGL stack continuously, which
+     read as noise flashing on the hero. It overlaps the sidebar footer while
+     parked; Escape and the X both clear it. */
   left: var(--sp-3);
   bottom: var(--sp-3);
   z-index: 60;
@@ -21249,41 +21249,21 @@ input:focus-visible,
   padding: var(--sp-4) var(--sp-6) 0;
 }
 
+/* Same size as .funding-notice-body — the other floating card in this
+   region — so the two surfaces read as one family. */
 .referral-nudge-copy {
   margin: 0;
   color: var(--muted-foreground);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-md);
   line-height: 1.5;
 }
 
+/* The action is the stock solid primary button (.primary-action
+   .primary-solid), so only the footer's frame lives here. */
 .referral-nudge-footer {
   display: flex;
   justify-content: flex-start;
   padding: var(--sp-4) var(--sp-6) var(--sp-5);
-}
-
-.referral-nudge-cta {
-  display: inline-flex;
-  align-items: center;
-  min-height: var(--control-md);
-  padding: 0 var(--sp-3);
-  border: 0;
-  border-radius: var(--r-md);
-  background: var(--primary);
-  color: var(--primary-foreground);
-  font-size: var(--fs-sm);
-  font-weight: 400;
-  cursor: pointer;
-  transition: background-color var(--t-fast) var(--ease-out);
-}
-
-.referral-nudge-cta:hover {
-  background: color-mix(in oklch, var(--primary) 92%, var(--foreground));
-}
-
-.referral-nudge-cta:focus-visible {
-  outline: 2px solid var(--ring-focus);
-  outline-offset: 2px;
 }
 
 /* Generous padding (+ negative outer margin) so the inputs' focus

--- a/src/test/referral-nudge.test.ts
+++ b/src/test/referral-nudge.test.ts
@@ -117,4 +117,20 @@ describe("referral nudge frequency caps", () => {
     window.localStorage.setItem(REFERRAL_NUDGE_STORAGE_KEY, "{not json");
     expect(recordAgentTaskCompleted(T0)).toBe("agent");
   });
+
+  it("fails closed when storage writes fail (never shows what it cannot record)", () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("QuotaExceededError");
+    });
+    try {
+      expect(recordAgentTaskCompleted(T0)).toBeNull();
+      expect(announced).toEqual([]);
+    } finally {
+      setItem.mockRestore();
+    }
+    // Storage recovers: the moment was never persisted as consumed, so the
+    // caps stay intact and it can fire properly now.
+    expect(recordAgentTaskCompleted(T0)).toBe("agent");
+    expect(announced).toEqual(["agent"]);
+  });
 });

--- a/src/test/referral-nudge.test.ts
+++ b/src/test/referral-nudge.test.ts
@@ -11,6 +11,7 @@ import {
   recordDictationFinished,
   recordMeetingNoteGenerated,
   recordPositiveFeedbackSent,
+  resetReferralNudgeSessionLatchForTests,
 } from "../lib/referral-nudge";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -23,6 +24,7 @@ const onNudge = (event: Event) => {
 
 beforeEach(() => {
   window.localStorage.clear();
+  resetReferralNudgeSessionLatchForTests();
   announced = [];
   window.addEventListener(REFERRAL_NUDGE_EVENT, onNudge);
 });
@@ -128,9 +130,40 @@ describe("referral nudge frequency caps", () => {
     } finally {
       setItem.mockRestore();
     }
-    // Storage recovers: the moment was never persisted as consumed, so the
-    // caps stay intact and it can fire properly now.
+    // A failed write also latches the session closed; clear it to verify the
+    // moment itself was never persisted as consumed.
+    resetReferralNudgeSessionLatchForTests();
     expect(recordAgentTaskCompleted(T0)).toBe("agent");
     expect(announced).toEqual(["agent"]);
+  });
+
+  it("latches the session closed when a post-show write fails", () => {
+    expect(recordAgentTaskCompleted(T0)).toBe("agent");
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("QuotaExceededError");
+    });
+    try {
+      markReferralNudgeShown(T0);
+    } finally {
+      setItem.mockRestore();
+    }
+    // The show was never persisted (no lastShownAt, no shownCount), but the
+    // latch still suppresses every later moment this session.
+    const later = T0 + REFERRAL_NUDGE_MIN_INTERVAL_MS + DAY_MS;
+    expect(recordPositiveFeedbackSent(later)).toBeNull();
+    expect(announced).toEqual(["agent"]);
+  });
+
+  it("latches the session closed when the click-through opt-out cannot be saved", () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("QuotaExceededError");
+    });
+    try {
+      markReferralNudgeClickedThrough();
+    } finally {
+      setItem.mockRestore();
+    }
+    expect(recordAgentTaskCompleted(T0)).toBeNull();
+    expect(announced).toEqual([]);
   });
 });

--- a/src/test/referral-nudge.test.ts
+++ b/src/test/referral-nudge.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  REFERRAL_NUDGE_DICTATION_THRESHOLD,
+  REFERRAL_NUDGE_EVENT,
+  REFERRAL_NUDGE_MIN_INTERVAL_MS,
+  REFERRAL_NUDGE_NOTE_THRESHOLD,
+  REFERRAL_NUDGE_STORAGE_KEY,
+  markReferralNudgeClickedThrough,
+  markReferralNudgeShown,
+  recordAgentTaskCompleted,
+  recordDictationFinished,
+  recordMeetingNoteGenerated,
+  recordPositiveFeedbackSent,
+} from "../lib/referral-nudge";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const T0 = 1_700_000_000_000;
+
+let announced: string[] = [];
+const onNudge = (event: Event) => {
+  announced.push((event as CustomEvent<{ moment: string }>).detail.moment);
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  announced = [];
+  window.addEventListener(REFERRAL_NUDGE_EVENT, onNudge);
+});
+
+afterEach(() => {
+  window.removeEventListener(REFERRAL_NUDGE_EVENT, onNudge);
+  vi.restoreAllMocks();
+});
+
+describe("referral nudge thresholds", () => {
+  it("fires the meetings moment on exactly the 5th generated note", () => {
+    for (let i = 1; i < REFERRAL_NUDGE_NOTE_THRESHOLD; i += 1) {
+      expect(recordMeetingNoteGenerated(T0)).toBeNull();
+    }
+    expect(announced).toEqual([]);
+    expect(recordMeetingNoteGenerated(T0)).toBe("meetings");
+    expect(announced).toEqual(["meetings"]);
+    // Further notes never re-fire.
+    expect(recordMeetingNoteGenerated(T0)).toBeNull();
+    expect(announced).toEqual(["meetings"]);
+  });
+
+  it("fires the agent moment on the first successful completion only", () => {
+    expect(recordAgentTaskCompleted(T0)).toBe("agent");
+    expect(recordAgentTaskCompleted(T0)).toBeNull();
+    expect(announced).toEqual(["agent"]);
+  });
+
+  it("fires the dictation moment on exactly the 25th dictation", () => {
+    for (let i = 1; i < REFERRAL_NUDGE_DICTATION_THRESHOLD; i += 1) {
+      expect(recordDictationFinished(T0)).toBeNull();
+    }
+    expect(recordDictationFinished(T0)).toBe("dictation");
+    expect(recordDictationFinished(T0)).toBeNull();
+    expect(announced).toEqual(["dictation"]);
+  });
+
+  it("fires the feedback moment once", () => {
+    expect(recordPositiveFeedbackSent(T0)).toBe("feedback");
+    expect(recordPositiveFeedbackSent(T0)).toBeNull();
+  });
+
+  it("persists counter progress across module reloads (storage-backed)", () => {
+    recordMeetingNoteGenerated(T0);
+    const raw = window.localStorage.getItem(REFERRAL_NUDGE_STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw as string).noteCount).toBe(1);
+  });
+});
+
+describe("referral nudge frequency caps", () => {
+  it("suppresses (and consumes) a moment within 14 days of the last show", () => {
+    expect(recordAgentTaskCompleted(T0)).toBe("agent");
+    markReferralNudgeShown(T0);
+    expect(recordPositiveFeedbackSent(T0 + DAY_MS)).toBeNull();
+    // The suppressed moment was consumed, not queued: it never fires again,
+    // even outside the window.
+    expect(recordPositiveFeedbackSent(T0 + REFERRAL_NUDGE_MIN_INTERVAL_MS + DAY_MS)).toBeNull();
+    expect(announced).toEqual(["agent"]);
+  });
+
+  it("allows a second moment after the 14-day window", () => {
+    expect(recordAgentTaskCompleted(T0)).toBe("agent");
+    markReferralNudgeShown(T0);
+    const later = T0 + REFERRAL_NUDGE_MIN_INTERVAL_MS + DAY_MS;
+    expect(recordPositiveFeedbackSent(later)).toBe("feedback");
+  });
+
+  it("caps lifetime shows at two", () => {
+    expect(recordAgentTaskCompleted(T0)).toBe("agent");
+    markReferralNudgeShown(T0);
+    const second = T0 + REFERRAL_NUDGE_MIN_INTERVAL_MS + DAY_MS;
+    expect(recordPositiveFeedbackSent(second)).toBe("feedback");
+    markReferralNudgeShown(second);
+    const third = second + REFERRAL_NUDGE_MIN_INTERVAL_MS + DAY_MS;
+    for (let i = 0; i < REFERRAL_NUDGE_NOTE_THRESHOLD; i += 1) {
+      recordMeetingNoteGenerated(third);
+    }
+    expect(announced).toEqual(["agent", "feedback"]);
+  });
+
+  it("never fires again after a click-through", () => {
+    markReferralNudgeClickedThrough();
+    expect(recordAgentTaskCompleted(T0)).toBeNull();
+    for (let i = 0; i < REFERRAL_NUDGE_NOTE_THRESHOLD; i += 1) {
+      recordMeetingNoteGenerated(T0);
+    }
+    expect(announced).toEqual([]);
+  });
+
+  it("survives corrupt storage by starting fresh", () => {
+    window.localStorage.setItem(REFERRAL_NUDGE_STORAGE_KEY, "{not json");
+    expect(recordAgentTaskCompleted(T0)).toBe("agent");
+  });
+});


### PR DESCRIPTION
## Summary

- New `ReferralNudge` card: a small, non-modal, dismissible invite surface anchored bottom-left of the main window (tucked to the main panel's `--sp-3` inset), styled as a small cousin of the referral dialog's hero — the same terracotta gradient + grain in an inset concentric banner (`r-xl` − 6px frame = `r-md`), the 3D glass June mark as its visual (flat gradient-mark fallback without WebGL / under reduced motion), the per-moment title inside the banner, reward copy and an "Invite friends" action below. Click-through opens the existing "Give a month, get a month" dialog (via a window event the sidebar listens for) — the dialog itself is unchanged.
- Trigger layer (`src/lib/referral-nudge.ts` + `src/app/referral-nudge-triggers.ts`) implementing the PRD's locked rules: four moments (5th meeting note generated, first successful agent task, 25th dictation, positive feedback via the report flow), each once per install ever; suppressed moments are consumed, never queued; max one nudge per 14 days and two lifetime; click-through ends nudging forever. State persists in localStorage and survives sign-out.
- Show gates beyond the caps: signed in, onboarding complete, not local dev, **no active recording**, and the deployment must actually offer referrals (probed via the referral summary before showing; failures skip silently).
- Anti-annoyance details: never steals or traps focus, announced politely, Escape dismisses from anywhere (dialogs keep first claim on the key), dismiss X at full control size, enter/exit motion with reduced-motion fallbacks. Counters start at zero on ship, so existing installs earn their thresholds from here forward instead of getting a backfill nudge on update.
- Dev console driver `window.__referralNudge("meetings" | "agent" | "dictation" | "feedback" | "clear")` parks any variant; demo-shown cards never touch the persisted caps.

## Root cause

(One pre-ship bug found while building, for the record: the hero's soft-light grain layer originally painted *over* the glass mark's WebGL canvas, which the compositor rendered as intermittent noise flashing. Fixed by lifting the mark above the grain and isolating the blend to the hero's stacking context — same layering as the referral dialog hero.)

## Validation

- `pnpm test` green: 153 files, 2504 passed (includes 10 new unit tests covering thresholds, the 14-day window, the lifetime cap, consume-not-queue suppression, click-through kill, and corrupt-storage recovery).
- `pnpm check`, `pnpm typecheck` green.
- Iterated visually in the browser preview across all four copy variants (owner drove the review in-browser; no screenshots attached by convention).

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- No: reuses the existing referral summary endpoint and dialog. -->

## Out of scope

- The referral dialog, sidebar "Invite friends" entry, and reward mechanics (unchanged, per the PRD).
- T4 recording from the error-report path (a report sent from a failure is not a delight moment, whatever its category).
- Any impression/click telemetry (none by design; success reads from OS Accounts referral counters).

## Followups

- Native QA pass on the real T1/T2 flows (fresh localStorage, generate five notes / complete an agent task) and the PRD's check across the 6 accent presets (brand terracotta is fixed across themes, so low risk).
- Watch item: the glass mark's idle sway on a long-parked card; if it reads as nagging, settle to the static mark after a couple of minutes.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786569225&installation_id=144203540&pr_number=731&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F731&signature=370bcaa27a9bf40be2dea62fb7f0e4c8a811754c2227f62486359c961bce0edf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->