### PR TITLE
Restore the Auto toggle and preference drill-in to the model picker

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2540,9 +2540,12 @@ export function AgentWorkspace({
   const [generationCostQuality, setGenerationCostQuality] = useState<number | undefined>();
   // Preference saves from the picker's drill-in: writes are chained so they
   // persist in click order, and versioned so only the newest call's outcome
-  // touches the UI (mirrors Settings' saveCostQuality discipline).
+  // touches the UI (mirrors Settings' saveCostQuality discipline). Rollback
+  // targets the last CONFIRMED value (persisted read or successful save) —
+  // never an optimistic value a still-in-flight click painted.
   const costQualitySaveChainRef = useRef<Promise<unknown>>(Promise.resolve());
   const latestCostQualitySaveRef = useRef(0);
+  const confirmedCostQualityRef = useRef<number | undefined>(undefined);
   const defaultGenerationModelIdRef = useRef("");
   const [generationModels, setGenerationModels] = useState<VeniceModelDto[]>([]);
   const generationModelsRef = useRef<VeniceModelDto[]>([]);
@@ -3593,6 +3596,7 @@ export function AgentWorkspace({
       setGenerationProvider(provider);
       defaultGenerationModelIdRef.current = selectedModelId;
       setDefaultGenerationModelId(selectedModelId);
+      confirmedCostQualityRef.current = settings.costQuality;
       setGenerationCostQuality(settings.costQuality);
       return selectedModelId;
     },
@@ -3751,7 +3755,6 @@ export function AgentWorkspace({
     // newest call's outcome (success or rollback) touches the UI — the same
     // discipline as Settings' saveCostQuality.
     const version = ++latestCostQualitySaveRef.current;
-    const confirmed = generationCostQuality;
     setGenerationCostQuality(value);
     const save = costQualitySaveChainRef.current.then(() => setCostQuality(value));
     costQualitySaveChainRef.current = save.then(
@@ -3760,6 +3763,7 @@ export function AgentWorkspace({
     );
     void save.then(
       (next) => {
+        confirmedCostQualityRef.current = next.costQuality;
         if (version !== latestCostQualitySaveRef.current) return;
         setGenerationCostQuality(next.costQuality);
         dispatchProviderModelSettingsChanged({
@@ -3770,7 +3774,7 @@ export function AgentWorkspace({
       },
       (err) => {
         if (version !== latestCostQualitySaveRef.current) return;
-        setGenerationCostQuality(confirmed);
+        setGenerationCostQuality(confirmedCostQualityRef.current);
         setError(messageFromError(err));
       },
     );

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2538,6 +2538,11 @@ export function AgentWorkspace({
   // shows as a name-only stub so the pill never goes blank while configured.
   const [defaultGenerationModelId, setDefaultGenerationModelId] = useState("");
   const [generationCostQuality, setGenerationCostQuality] = useState<number | undefined>();
+  // Preference saves from the picker's drill-in: writes are chained so they
+  // persist in click order, and versioned so only the newest call's outcome
+  // touches the UI (mirrors Settings' saveCostQuality discipline).
+  const costQualitySaveChainRef = useRef<Promise<unknown>>(Promise.resolve());
+  const latestCostQualitySaveRef = useRef(0);
   const defaultGenerationModelIdRef = useRef("");
   const [generationModels, setGenerationModels] = useState<VeniceModelDto[]>([]);
   const generationModelsRef = useRef<VeniceModelDto[]>([]);
@@ -3740,21 +3745,35 @@ export function AgentWorkspace({
   // The Auto section's Preference drill-in writes the app-wide preference
   // without changing the model; announce it so other surfaces (Settings, the
   // note chat panel) refresh their designation.
-  async function handleCostQualityChange(value: number) {
-    const previous = generationCostQuality;
+  function handleCostQualityChange(value: number) {
+    // Rapid preset clicks overlap: the chain keeps the writes ordered so the
+    // last click is what persists, and the version gate makes sure only the
+    // newest call's outcome (success or rollback) touches the UI — the same
+    // discipline as Settings' saveCostQuality.
+    const version = ++latestCostQualitySaveRef.current;
+    const confirmed = generationCostQuality;
     setGenerationCostQuality(value);
-    try {
-      const next = await setCostQuality(value);
-      setGenerationCostQuality(next.costQuality);
-      dispatchProviderModelSettingsChanged({
-        mode: "generation",
-        modelId: defaultGenerationModelIdRef.current,
-      });
-      setError(null);
-    } catch (err) {
-      setGenerationCostQuality(previous);
-      setError(messageFromError(err));
-    }
+    const save = costQualitySaveChainRef.current.then(() => setCostQuality(value));
+    costQualitySaveChainRef.current = save.then(
+      () => undefined,
+      () => undefined,
+    );
+    void save.then(
+      (next) => {
+        if (version !== latestCostQualitySaveRef.current) return;
+        setGenerationCostQuality(next.costQuality);
+        dispatchProviderModelSettingsChanged({
+          mode: "generation",
+          modelId: defaultGenerationModelIdRef.current,
+        });
+        setError(null);
+      },
+      (err) => {
+        if (version !== latestCostQualitySaveRef.current) return;
+        setGenerationCostQuality(confirmed);
+        setError(messageFromError(err));
+      },
+    );
   }
 
   // Switching the model from the composer is only allowed before a thread
@@ -9564,7 +9583,7 @@ export function AgentWorkspace({
             onSelect={(modelId, costQuality, options) =>
               void handleSelectGenerationModel(modelId, costQuality, options)
             }
-            onCostQualityChange={(value) => void handleCostQualityChange(value)}
+            onCostQualityChange={handleCostQualityChange}
           />
         ) : null}
         {heroMode && sandboxMenuOpen ? (

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -3737,12 +3737,38 @@ export function AgentWorkspace({
     return true;
   }
 
+  // The Auto section's Preference drill-in writes the app-wide preference
+  // without changing the model; announce it so other surfaces (Settings, the
+  // note chat panel) refresh their designation.
+  async function handleCostQualityChange(value: number) {
+    const previous = generationCostQuality;
+    setGenerationCostQuality(value);
+    try {
+      const next = await setCostQuality(value);
+      setGenerationCostQuality(next.costQuality);
+      dispatchProviderModelSettingsChanged({
+        mode: "generation",
+        modelId: defaultGenerationModelIdRef.current,
+      });
+      setError(null);
+    } catch (err) {
+      setGenerationCostQuality(previous);
+      setError(messageFromError(err));
+    }
+  }
+
   // Switching the model from the composer is only allowed before a thread
   // exists. It writes the app-wide text-model default (Settings' model rows and
   // this pill refresh through the same changed event), and new sessions inherit
   // that choice at creation time.
-  async function handleSelectGenerationModel(modelId: string, costQuality?: number) {
-    setComposerModelOpen(false);
+  async function handleSelectGenerationModel(
+    modelId: string,
+    costQuality?: number,
+    options?: { keepOpen?: boolean },
+  ) {
+    // The Auto toggle switches models mid-flow, so it asks to keep the picker
+    // open; a row pick is a final choice and closes it.
+    if (!options?.keepOpen) setComposerModelOpen(false);
     if (composerModelSelectionLocked()) {
       showComposerModelLockedNotice();
       return false;
@@ -9535,9 +9561,10 @@ export function AgentWorkspace({
             searchRef={composerModelSearchRef}
             onFlyoutChange={setComposerModelFlyout}
             onSearchChange={setModelSearch}
-            onSelect={(modelId, costQuality) =>
-              void handleSelectGenerationModel(modelId, costQuality)
+            onSelect={(modelId, costQuality, options) =>
+              void handleSelectGenerationModel(modelId, costQuality, options)
             }
+            onCostQualityChange={(value) => void handleCostQualityChange(value)}
           />
         ) : null}
         {heroMode && sandboxMenuOpen ? (

--- a/src/components/agent/composer/ModelPicker.tsx
+++ b/src/components/agent/composer/ModelPicker.tsx
@@ -77,7 +77,13 @@ export function ComposerModelPicker({
 // lists the curated suggested models as plain rows, and a flyout panel
 // opens beside it — hover details for a suggested row, or the searchable
 // full catalog behind the "All models" row.
-export type ComposerModelFlyout = { kind: "model"; id: string } | { kind: "all" } | null;
+// "auto" matches the shared hover-bridge union; this popover has no Auto
+// section yet, so it never sets the kind itself.
+export type ComposerModelFlyout =
+  | { kind: "model"; id: string }
+  | { kind: "all" }
+  | { kind: "auto" }
+  | null;
 
 // Row hovers should feel quick while moving through models, but still keep a
 // tiny intent delay so a pointer sweep does not flash every card open. Click

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -94,8 +94,11 @@ import {
 import { ProviderLogo } from "./ProviderLogo";
 import { modelOptions, selectedModel } from "./ModelPickerDialog";
 import {
+  AUTO_PREFERENCE_VALUES,
+  autoPreferenceFromCostQuality,
   ModelPickerCardContent,
   ModelPickerPopover,
+  type AutoPreference,
   type ModelPickerFlyout,
 } from "./ModelPickerPopover";
 import { DEFAULT_IMAGE_MODEL, IMAGE_MODELS } from "../../lib/image-models";
@@ -192,8 +195,6 @@ const RELEASE_CHANNEL_OPTIONS: readonly {
   { value: "rc", label: "Release candidate" },
 ];
 
-type AutoPreference = "cost" | "balanced" | "quality";
-
 const AUTO_PREFERENCE_OPTIONS: readonly {
   value: AutoPreference;
   label: ReactNode;
@@ -202,20 +203,6 @@ const AUTO_PREFERENCE_OPTIONS: readonly {
   { value: "balanced", label: "Balanced" },
   { value: "quality", label: "Higher quality" },
 ];
-
-const AUTO_PREFERENCE_VALUES: Record<AutoPreference, number> = {
-  // Keep the cost-first preset above the lowest-quality routing tier. Live
-  // integration evals showed that tier dropping facts and inventing dates.
-  cost: 20,
-  balanced: 50,
-  quality: 100,
-};
-
-function autoPreferenceFromCostQuality(value: number): AutoPreference {
-  if (value < 34) return "cost";
-  if (value > 66) return "quality";
-  return "balanced";
-}
 
 const EMPTY_MODIFIERS: DictationShortcutModifiers = {
   command: false,
@@ -1025,18 +1012,31 @@ export function AppSettings({
     setModelSearch("");
   }
 
-  function selectModelFromPicker(mode: ProviderModelMode, modelId: string, costQuality?: number) {
+  // Optimistic apply + persisted save, shared by the Models row's segmented
+  // control and the model picker popover's Auto section.
+  function applyCostQuality(costQuality: number) {
+    setProviderSettings((current) => ({ ...current, costQuality }));
+    saveCostQuality(costQuality);
+  }
+
+  function selectModelFromPicker(
+    mode: ProviderModelMode,
+    modelId: string,
+    costQuality?: number,
+    options?: { keepOpen?: boolean },
+  ) {
     const picked = modelOptionsForMode(mode).find((model) => model.id === modelId);
     if (mode === "generation" && costQuality !== undefined) {
-      setProviderSettings((current) => ({ ...current, costQuality }));
-      saveCostQuality(costQuality);
+      applyCostQuality(costQuality);
     }
     if (mode === "generation" && picked?.provider === "local") {
       enableLocalGenerationFromPicker();
     } else {
       void selectVeniceModel(mode, modelId);
     }
-    closeModelPicker();
+    // The Auto toggle switches models mid-flow, so it asks to keep the picker
+    // open; a row pick is a final choice and closes it.
+    if (!options?.keepOpen) closeModelPicker();
   }
 
   // True when the draft matches what's persisted, so enabling can skip a
@@ -1905,9 +1905,10 @@ export function AppSettings({
                     }
                     onFlyoutChange={setModelPickerFlyout}
                     onSearchChange={setModelSearch}
-                    onSelect={(modelId, costQuality) =>
-                      selectModelFromPicker("generation", modelId, costQuality)
+                    onSelect={(modelId, costQuality, options) =>
+                      selectModelFromPicker("generation", modelId, costQuality, options)
                     }
+                    onCostQualityChange={applyCostQuality}
                   />
                   {providerSettings.generationModel === "open-software/auto" ? (
                     <div className="settings-row">
@@ -1922,14 +1923,9 @@ export function AppSettings({
                           aria-label="Auto preference"
                           value={autoPreferenceFromCostQuality(providerSettings.costQuality)}
                           options={AUTO_PREFERENCE_OPTIONS}
-                          onValueChange={(preference) => {
-                            const costQuality = AUTO_PREFERENCE_VALUES[preference];
-                            setProviderSettings((current) => ({
-                              ...current,
-                              costQuality,
-                            }));
-                            saveCostQuality(costQuality);
-                          }}
+                          onValueChange={(preference) =>
+                            applyCostQuality(AUTO_PREFERENCE_VALUES[preference])
+                          }
                         />
                       </div>
                     </div>
@@ -2620,6 +2616,7 @@ function ModelRow({
   onFlyoutChange,
   onSearchChange,
   onSelect,
+  onCostQualityChange,
   summarySuppressed,
 }: {
   mode: ProviderModelMode;
@@ -2637,7 +2634,8 @@ function ModelRow({
   onToggle: () => void;
   onFlyoutChange: (flyout: ModelPickerFlyout) => void;
   onSearchChange: (value: string) => void;
-  onSelect: (modelId: string, costQuality?: number) => void;
+  onSelect: (modelId: string, costQuality?: number, options?: { keepOpen?: boolean }) => void;
+  onCostQualityChange?: (value: number) => void;
   summarySuppressed?: boolean;
 }) {
   const model = selectedModel(options, value);
@@ -2689,6 +2687,7 @@ function ModelRow({
             onFlyoutChange={onFlyoutChange}
             onSearchChange={onSearchChange}
             onSelect={onSelect}
+            onCostQualityChange={onCostQualityChange}
           />
         ) : null}
       </div>

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -12,10 +12,7 @@ import {
 import type { RefObject } from "react";
 import { createPortal } from "react-dom";
 import { modelAvailableForMode, modelIsPrivate, modelPrivacyBadge } from "../../lib/model-privacy";
-import {
-  DEFAULT_GENERATION_SUGGESTION_ID,
-  suggestedModelsForMode,
-} from "../../lib/suggested-models";
+import { suggestedModelsForMode } from "../../lib/suggested-models";
 import type { ProviderModelMode, VeniceModelDto } from "../../lib/tauri";
 import { useScrollFade } from "../../lib/use-scroll-fade";
 import { rectFromElement, type HoverBridgeRect } from "../ui/hoverBridge";
@@ -325,6 +322,13 @@ export function ModelPickerPopover({
   // Toggling stays inside the popover: turning Auto off lands on the leading
   // suggested pick (the default generation model) so the next step — choosing
   // an explicit model — is right there, one row away.
+  // The concrete model toggling Auto off lands on: the leading suggested
+  // pick, else the first selectable catalog model. Undefined while the
+  // catalog is empty or unloaded — the switch renders disabled then, so it
+  // neither no-ops silently nor persists a model the catalog can't vouch for.
+  const autoOffTarget =
+    suggested.find((item) => item.model.id !== AUTO_MODEL_ID)?.model.id ??
+    selectable.find((option) => option.id !== AUTO_MODEL_ID)?.id;
   const toggleAuto = useCallback(
     (on: boolean) => {
       onFlyoutChange(null);
@@ -332,15 +336,9 @@ export function ModelPickerPopover({
         onSelect(AUTO_MODEL_ID, undefined, { keepOpen: true });
         return;
       }
-      // An empty or unloaded catalog must not trap the switch on: fall back
-      // to the curated default id, which is safe to select sight-unseen.
-      const fallback =
-        suggested.find((item) => item.model.id !== AUTO_MODEL_ID)?.model.id ??
-        selectable.find((option) => option.id !== AUTO_MODEL_ID)?.id ??
-        DEFAULT_GENERATION_SUGGESTION_ID;
-      onSelect(fallback, undefined, { keepOpen: true });
+      if (autoOffTarget) onSelect(autoOffTarget, undefined, { keepOpen: true });
     },
-    [onFlyoutChange, onSelect, selectable, suggested],
+    [autoOffTarget, onFlyoutChange, onSelect],
   );
   const privacyFiltered = privateOnly ? selectable.filter(modelIsPrivate) : selectable;
   const filteredOptions = query
@@ -523,7 +521,15 @@ export function ModelPickerPopover({
             <Switch
               checked={autoEnabled}
               onCheckedChange={toggleAuto}
-              aria-label="Choose the model automatically"
+              // With Auto on and no concrete model loaded yet there is nothing
+              // to land on; a visibly disabled switch is honest about that and
+              // re-enables the moment the catalog arrives.
+              disabled={autoEnabled && !autoOffTarget}
+              aria-label={
+                autoEnabled && !autoOffTarget
+                  ? "Choose the model automatically (waiting for the model catalog)"
+                  : "Choose the model automatically"
+              }
             />
           </div>
           {autoEnabled ? (

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -12,7 +12,10 @@ import {
 import type { RefObject } from "react";
 import { createPortal } from "react-dom";
 import { modelAvailableForMode, modelIsPrivate, modelPrivacyBadge } from "../../lib/model-privacy";
-import { suggestedModelsForMode } from "../../lib/suggested-models";
+import {
+  DEFAULT_GENERATION_SUGGESTION_ID,
+  suggestedModelsForMode,
+} from "../../lib/suggested-models";
 import type { ProviderModelMode, VeniceModelDto } from "../../lib/tauri";
 import { useScrollFade } from "../../lib/use-scroll-fade";
 import { rectFromElement, type HoverBridgeRect } from "../ui/hoverBridge";
@@ -329,10 +332,13 @@ export function ModelPickerPopover({
         onSelect(AUTO_MODEL_ID, undefined, { keepOpen: true });
         return;
       }
+      // An empty or unloaded catalog must not trap the switch on: fall back
+      // to the curated default id, which is safe to select sight-unseen.
       const fallback =
         suggested.find((item) => item.model.id !== AUTO_MODEL_ID)?.model.id ??
-        selectable.find((option) => option.id !== AUTO_MODEL_ID)?.id;
-      if (fallback) onSelect(fallback, undefined, { keepOpen: true });
+        selectable.find((option) => option.id !== AUTO_MODEL_ID)?.id ??
+        DEFAULT_GENERATION_SUGGESTION_ID;
+      onSelect(fallback, undefined, { keepOpen: true });
     },
     [onFlyoutChange, onSelect, selectable, suggested],
   );

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -19,10 +19,58 @@ import { rectFromElement, type HoverBridgeRect } from "../ui/hoverBridge";
 import { useCatalogHoverBridge, useModelDetailHoverBridge } from "../ui/useModelHoverBridge";
 import { ModelPrivacyChip, ModelRowPrivacyBadge } from "../ui/ModelPrivacyChip";
 import { Switch } from "../ui/Switch";
-import { modelSpecEntries } from "./ModelPickerDialog";
+import { AUTO_MODEL_ID, modelSpecEntries } from "./ModelPickerDialog";
 import { ProviderLogo } from "./ProviderLogo";
 
-export type ModelPickerFlyout = { kind: "model"; id: string } | { kind: "all" } | null;
+export type ModelPickerFlyout =
+  | { kind: "model"; id: string }
+  | { kind: "all" }
+  | { kind: "auto" }
+  | null;
+
+// The automatic router's cost-to-quality preference, shared by this popover's
+// Auto section and the Settings "Auto preference" row so both surfaces read
+// and write the same three presets.
+export type AutoPreference = "cost" | "balanced" | "quality";
+
+export const AUTO_PREFERENCE_VALUES: Record<AutoPreference, number> = {
+  // Keep the cost-first preset above the lowest-quality routing tier. Live
+  // integration evals showed that tier dropping facts and inventing dates.
+  cost: 20,
+  balanced: 50,
+  quality: 100,
+};
+
+export function autoPreferenceFromCostQuality(value: number): AutoPreference {
+  if (value < 34) return "cost";
+  if (value > 66) return "quality";
+  return "balanced";
+}
+
+// The Preference flyout's option rows: each preset carries a one-line
+// explanation, which is the point of drilling in rather than showing bare
+// values.
+const AUTO_PREFERENCE_DETAILS: readonly {
+  value: AutoPreference;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "cost",
+    label: "Lower cost",
+    description: "Favors cheaper models to stretch your credits.",
+  },
+  {
+    value: "balanced",
+    label: "Balanced",
+    description: "Weighs quality against cost on every request.",
+  },
+  {
+    value: "quality",
+    label: "Higher quality",
+    description: "Routes to the strongest model for the job.",
+  },
+];
 
 // Row hovers should feel quick while moving through models, but still keep a
 // tiny intent delay so a pointer sweep does not flash every card open.
@@ -49,6 +97,7 @@ export function ModelPickerPopover({
   onFlyoutChange,
   onSearchChange,
   onSelect,
+  onCostQualityChange,
 }: {
   mode: ProviderModelMode;
   flyout: ModelPickerFlyout;
@@ -65,7 +114,13 @@ export function ModelPickerPopover({
   allModelsLabel?: string;
   onFlyoutChange: (flyout: ModelPickerFlyout) => void;
   onSearchChange: (value: string) => void;
-  onSelect: (modelId: string, costQuality?: number) => void;
+  /** `keepOpen` asks the host to leave the popover mounted (used by the Auto
+   * toggle, where switching is a mid-flow adjustment, not a final pick). */
+  onSelect: (modelId: string, costQuality?: number, options?: { keepOpen?: boolean }) => void;
+  /** Enables the pinned Auto section (generation surfaces): a toggle that
+   * swaps the selection to/from the Auto router, plus the Preference
+   * drill-in writing through this callback while Auto is on. */
+  onCostQualityChange?: (value: number) => void;
 }) {
   const flyoutRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -250,10 +305,37 @@ export function ModelPickerPopover({
 
   const query = search.trim().toLowerCase();
   const selectable = useMemo(
-    () => options.filter((option) => modelAvailableForMode(mode, option)),
-    [mode, options],
+    () =>
+      options.filter(
+        (option) =>
+          modelAvailableForMode(mode, option) &&
+          // With the Auto section shown, the toggle is the router's one home;
+          // keep the catalog's Auto entry out of the lists so it doesn't
+          // double up as a row.
+          !(onCostQualityChange && option.id === AUTO_MODEL_ID),
+      ),
+    [mode, onCostQualityChange, options],
   );
   const suggested = useMemo(() => suggestedModelsForMode(mode, selectable), [mode, selectable]);
+  const autoEnabled = onCostQualityChange !== undefined && model?.id === AUTO_MODEL_ID;
+  const autoPreference = autoPreferenceFromCostQuality(costQuality ?? 100);
+  // Toggling stays inside the popover: turning Auto off lands on the leading
+  // suggested pick (the default generation model) so the next step — choosing
+  // an explicit model — is right there, one row away.
+  const toggleAuto = useCallback(
+    (on: boolean) => {
+      onFlyoutChange(null);
+      if (on) {
+        onSelect(AUTO_MODEL_ID, undefined, { keepOpen: true });
+        return;
+      }
+      const fallback =
+        suggested.find((item) => item.model.id !== AUTO_MODEL_ID)?.model.id ??
+        selectable.find((option) => option.id !== AUTO_MODEL_ID)?.id;
+      if (fallback) onSelect(fallback, undefined, { keepOpen: true });
+    },
+    [onFlyoutChange, onSelect, selectable, suggested],
+  );
   const privacyFiltered = privateOnly ? selectable.filter(modelIsPrivate) : selectable;
   const filteredOptions = query
     ? privacyFiltered.filter((option) => modelMatchesQuery(option, query))
@@ -428,6 +510,57 @@ export function ModelPickerPopover({
       }}
     >
       <p className="agent-composer-model-title">{title}</p>
+      {onCostQualityChange ? (
+        <div className="agent-composer-model-auto">
+          <div className="agent-composer-model-filter agent-composer-model-auto-toggle">
+            <span>Auto</span>
+            <Switch
+              checked={autoEnabled}
+              onCheckedChange={toggleAuto}
+              aria-label="Choose the model automatically"
+            />
+          </div>
+          {autoEnabled ? (
+            <button
+              type="button"
+              className="agent-composer-model-row agent-composer-model-auto-row"
+              aria-haspopup="true"
+              aria-expanded={flyout?.kind === "auto"}
+              data-active={flyout?.kind === "auto" || undefined}
+              onMouseEnter={() => {
+                if (modelBridge.isActive()) {
+                  return;
+                }
+                const open = () => onFlyoutChange({ kind: "auto" });
+                if (flyout) {
+                  cancelHoverIntent();
+                  open();
+                } else {
+                  hoverIntent(open);
+                }
+              }}
+              onFocus={() => {
+                cancelHoverIntent();
+                onFlyoutChange({ kind: "auto" });
+              }}
+              onClick={() => {
+                cancelHoverIntent();
+                onFlyoutChange({ kind: "auto" });
+              }}
+            >
+              <span className="agent-composer-model-row-name">Preference</span>
+              <span className="agent-composer-model-auto-value">
+                {AUTO_PREFERENCE_DETAILS.find((option) => option.value === autoPreference)?.label}
+              </span>
+              <IconChevronRightSmall
+                size={16}
+                aria-hidden
+                className="agent-composer-model-row-chevron"
+              />
+            </button>
+          ) : null}
+        </div>
+      ) : null}
       <div className="agent-composer-model-menu" role="listbox" aria-label={suggestedListLabel}>
         {suggested.length ? (
           suggested.map(({ key, model: option, costQuality: presetCostQuality }) => (
@@ -550,6 +683,43 @@ export function ModelPickerPopover({
           }}
         >
           <div className="agent-composer-model-surface">{catalogList(allModelsLabel)}</div>
+        </div>
+      ) : null}
+      {onCostQualityChange && flyout?.kind === "auto" ? (
+        <div
+          ref={flyoutRef}
+          className="agent-composer-model-flyout agent-composer-model-auto-panel"
+          role="group"
+          aria-label="Auto preference"
+          onPointerLeave={() => {
+            cancelHoverIntent();
+            setBridging(false);
+          }}
+        >
+          <div className="agent-composer-model-surface">
+            {AUTO_PREFERENCE_DETAILS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className="agent-composer-model-row agent-composer-model-pref-option"
+                role="menuitemradio"
+                aria-checked={option.value === autoPreference}
+                onClick={() => onCostQualityChange(AUTO_PREFERENCE_VALUES[option.value])}
+              >
+                <span className="agent-composer-model-pref-copy">
+                  <span className="agent-composer-model-row-name">{option.label}</span>
+                  <span className="agent-composer-model-pref-desc">{option.description}</span>
+                </span>
+                {option.value === autoPreference ? (
+                  <IconCheckmark2Small
+                    size={14}
+                    aria-hidden
+                    className="agent-composer-model-row-check"
+                  />
+                ) : null}
+              </button>
+            ))}
+          </div>
         </div>
       ) : null}
       {flyout?.kind === "all" && catalogHover && portalTarget

--- a/src/components/ui/useModelHoverBridge.ts
+++ b/src/components/ui/useModelHoverBridge.ts
@@ -11,8 +11,14 @@ import {
 
 // The picker flyout state, shared verbatim by the composer and settings pickers
 // (both declare a structurally identical alias). A row's detail card is open
-// when `kind === "model"`; the searchable catalog when `kind === "all"`.
-export type ModelHoverFlyout = { kind: "model"; id: string } | { kind: "all" } | null;
+// when `kind === "model"`; the searchable catalog when `kind === "all"`; the
+// Auto preference panel when `kind === "auto"` (the bridge itself only ever
+// traverses to "model" cards, so it ignores that kind).
+export type ModelHoverFlyout =
+  | { kind: "model"; id: string }
+  | { kind: "all" }
+  | { kind: "auto" }
+  | null;
 
 // Reports whether a safe-polygon traversal is currently anchored, so the rows
 // can suppress their own hover-intent while the pointer is bridging to a card.

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -131,12 +131,6 @@ export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
   ],
 };
 
-// The Auto toggle's last-resort landing when the catalog is empty or still
-// loading: the leading curated pick, which mirrors DEFAULT_GENERATION_MODEL
-// in the Rust providers module. Selecting it while absent from the catalog is
-// safe — the pill renders a name-only stub until the catalog arrives.
-export const DEFAULT_GENERATION_SUGGESTION_ID = SUGGESTED_MODELS.generation[0].id;
-
 /**
  * The model June switches to when the user attaches an image while a
  * non-vision model is active. The switch must land on a model that can both

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -36,9 +36,20 @@ export function autoPillDesignation(costQuality: number | undefined): string | u
  * is zero-retention privacy, so every text pick here is a "private" catalog
  * model that supports tools).
  *
- * Text suggestions are the three useful ways to run Auto. Auto selects the
- * best currently available private model for each request; these presets tune
- * that routing decision without making people understand the provider catalog.
+ * Auto lives in the picker's pinned toggle section, not in these rows: the
+ * suggested rows stay concrete models so they double as the landing spots
+ * when Auto is switched off (the first pick is the toggle-off fallback).
+ *
+ * Curation snapshot (June 2026), from the live Venice catalog plus public
+ * benchmarks (SWE-bench agentic coding, Artificial Analysis intelligence
+ * index):
+ * - GLM 5.2: latest GLM flagship and June's default text model, with
+ *   reasoning effort controls, tool use, 200K context, $1.75/$5.50 per 1M
+ *   tokens.
+ * - Kimi K2.6: leads the open-weights intelligence rankings, built for long
+ *   agentic tool runs, 256K context, $0.85/$4.66.
+ * - GLM 5.1: previous GLM flagship, top-tier agentic coding and tool use
+ *   among open models, 200K context, $1.75/$5.50 per 1M tokens.
  * - Parakeet: fast, accurate everyday dictation at the lowest price tier.
  * - Whisper Large v3: best multilingual accuracy at the same low price.
  *
@@ -52,22 +63,19 @@ export function autoPillDesignation(costQuality: number | undefined): string | u
 export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
   generation: [
     {
-      id: "open-software/auto",
-      label: "Auto · Higher Quality",
-      costQuality: 100,
-      reason: "Best for complex questions and important work where response quality matters most.",
+      id: "zai-org-glm-5-2",
+      reason:
+        "Default pick: latest GLM flagship with strong reasoning, tool use, structured output, and zero data retention.",
     },
     {
-      id: "open-software/auto",
-      label: "Auto · Balanced",
-      costQuality: 50,
-      reason: "Best for everyday work when you want a practical balance of quality and credit use.",
+      id: "kimi-k2-6",
+      reason:
+        "Best alternate: leads independent intelligence rankings and excels at long tool-driven tasks, with zero data retention.",
     },
     {
-      id: "open-software/auto",
-      label: "Auto · Lower Cost",
-      costQuality: 20,
-      reason: "Best for quick or routine tasks when minimizing credit use matters most.",
+      id: "zai-org-glm-5-1",
+      reason:
+        "Stable GLM alternate: previous GLM flagship with top-tier agentic coding, tool use, and zero data retention.",
     },
   ],
   transcription: [

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -131,6 +131,12 @@ export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
   ],
 };
 
+// The Auto toggle's last-resort landing when the catalog is empty or still
+// loading: the leading curated pick, which mirrors DEFAULT_GENERATION_MODEL
+// in the Rust providers module. Selecting it while absent from the catalog is
+// safe — the pill renders a name-only stub until the catalog arrives.
+export const DEFAULT_GENERATION_SUGGESTION_ID = SUGGESTED_MODELS.generation[0].id;
+
 /**
  * The model June switches to when the user attaches an image while a
  * non-vision model is active. The switch must land on a model that can both

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6536,6 +6536,74 @@ input:focus-visible,
   line-height: 1.3;
 }
 
+/* Automatic-routing section pinned above the suggested rows in the root
+ * popover: the Auto label + switch on the shared content gutter, and the
+ * Preference drill-in row underneath while Auto is on. The hairline splits
+ * the section from the model list, running the popover's full width. */
+.agent-composer-model-auto {
+  display: flex;
+  flex-direction: column;
+  margin: 0 calc(-1 * var(--sp-2)) var(--sp-1);
+  padding: 0 var(--sp-2) var(--sp-1);
+  border-bottom: 1px solid color-mix(in oklch, var(--border-subtle) 50%, transparent);
+}
+
+/* The filter recipe's bleed/padding are tuned for the flyout surface; re-seat
+ * the toggle row on the root popover's gutter (title text at --sp-3, switch on
+ * the rows' --sp-2 inset) and drop the recipe's own hairline — the section
+ * draws one for the whole block. */
+.agent-composer-model-auto .agent-composer-model-auto-toggle {
+  margin: 0;
+  padding: 0 var(--sp-2) 0 var(--sp-3);
+  border-bottom: 0;
+}
+
+/* The Preference drill-in row while Auto is on: label left, the active preset
+ * as a quiet value beside the chevron. The auto margin sits on the value, so
+ * the chevron's own auto margin has to stand down or the pair splits apart. */
+.agent-composer-model-auto-value {
+  min-width: 0;
+  margin-left: auto;
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-composer-model-auto-row .agent-composer-model-row-chevron {
+  margin-left: 0;
+}
+
+/* The preference flyout hangs off the popover's top edge (its trigger row
+ * lives in the pinned Auto section) instead of the bottom like the catalog. */
+.agent-composer-model-flyout.agent-composer-model-auto-panel {
+  top: -1px;
+  bottom: auto;
+  width: 248px;
+}
+
+/* Same inset as the catalog panel: an --sp-1 gutter between the surface
+ * border and the option rows, so hover fills never touch the edge. */
+.agent-composer-model-auto-panel .agent-composer-model-surface {
+  gap: 0;
+  width: 248px;
+  padding: var(--sp-1);
+}
+
+.agent-composer-model-pref-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.agent-composer-model-pref-desc {
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.35;
+  white-space: normal;
+}
+
 /* Catalog list scroller. Fades come from the shared `.scroll-fade` primitive
  * (contained overlays, WKWebView-safe for this popover); only the fade size is
  * tuned here so rows melt into the popover surface at the boundary. */

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3675,7 +3675,7 @@ describe("AgentWorkspace", () => {
     });
   });
 
-  it("offers the three Auto presets and persists the selected routing preference", async () => {
+  it("switches Auto on from the picker toggle and persists the drilled-in preference", async () => {
     mocks.listAgentTasks.mockResolvedValue({ items: [] });
     mocks.listHermesSessions.mockResolvedValue([]);
     mocks.setVeniceModel.mockImplementation(async () => {
@@ -3688,22 +3688,42 @@ describe("AgentWorkspace", () => {
       mocks.providerModelSettings.mockResolvedValue({ settings });
       return settings;
     });
+    mocks.setCostQuality.mockImplementation(async (costQuality: number) => {
+      const settings = {
+        transcriptionProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "open-software/auto",
+        costQuality,
+      };
+      mocks.providerModelSettings.mockResolvedValue({ settings });
+      return settings;
+    });
     const user = userEvent.setup();
 
     render(<AgentWorkspace />);
 
     await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
     const dialog = await screen.findByRole("dialog", { name: "Choose text model" });
-    expect(within(dialog).getByRole("option", { name: /Auto · Higher Quality/ })).toBeVisible();
-    expect(within(dialog).getByRole("option", { name: /Auto · Balanced/ })).toBeVisible();
-    expect(within(dialog).getByRole("option", { name: /Auto · Lower Cost/ })).toBeVisible();
+    // Suggested rows stay concrete models; Auto lives in the pinned toggle.
+    expect(within(dialog).getByRole("option", { name: /GLM 5\.2/ })).toBeVisible();
+    const autoSwitch = within(dialog).getByRole("switch", {
+      name: "Choose the model automatically",
+    });
+    expect(autoSwitch).not.toBeChecked();
 
-    await user.click(within(dialog).getByRole("option", { name: /Auto · Lower Cost/ }));
-
-    await waitFor(() => expect(mocks.setCostQuality).toHaveBeenCalledWith(20));
-    expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "open-software/auto");
+    // Toggling on selects the router and keeps the popover open.
+    await user.click(autoSwitch);
+    await waitFor(() =>
+      expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "open-software/auto"),
+    );
     // The pill ghosts the active preset designation beside the model name.
     expect(await screen.findByRole("button", { name: "Model: Auto (Lower)" })).toBeInTheDocument();
+
+    // The Preference drill-in persists a new preset and updates the pill.
+    await user.click(within(dialog).getByRole("button", { name: /Preference/ }));
+    await user.click(await screen.findByRole("menuitemradio", { name: /Higher quality/ }));
+    await waitFor(() => expect(mocks.setCostQuality).toHaveBeenCalledWith(100));
+    expect(await screen.findByRole("button", { name: "Model: Auto (Higher)" })).toBeInTheDocument();
   });
 
   it("ignores a stale pending New Session marker left over from a reload", async () => {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -3215,22 +3215,20 @@ describe("AppSettings", () => {
     await user.click(await screen.findByRole("button", { name: "Change text model" }));
 
     // Suggested is the default view: only the curated picks present in the
-    // catalog show in the compact root menu.
-    expect(
-      await screen.findByRole("option", { name: /Auto · Higher Quality/ }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: /Auto · Balanced/ })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: /Auto · Lower Cost/ })).toBeInTheDocument();
+    // catalog show in the compact root menu. Auto lives in the pinned toggle
+    // section, not the suggested rows.
+    expect(await screen.findByRole("option", { name: /GLM 5\.2/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /GLM 5\.1/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Kimi K2\.6/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Auto/ })).not.toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /Venice Uncensored/ })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "All models" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("option", { name: /Auto · Balanced/ }));
-    await waitFor(() => expect(mocks.setCostQuality).toHaveBeenCalledWith(50));
+    // The toggle selects the router and keeps the popover open.
+    await user.click(screen.getByRole("switch", { name: "Choose the model automatically" }));
     await waitFor(() =>
       expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "open-software/auto"),
     );
-
-    await user.click(await screen.findByRole("button", { name: "Change text model" }));
 
     // All models shows the full available catalog in the flyout.
     await user.click(screen.getByRole("button", { name: "All models" }));

--- a/src/test/suggested-models.test.ts
+++ b/src/test/suggested-models.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { preferredVisionFallbackModel, suggestedModelsForMode } from "../lib/suggested-models";
+import {
+  autoPillDesignation,
+  preferredVisionFallbackModel,
+  suggestedModelsForMode,
+} from "../lib/suggested-models";
 import type { VeniceModelDto } from "../lib/tauri";
 
 const model = (id: string, name: string, capabilities: string[]): VeniceModelDto => ({
@@ -53,39 +57,27 @@ describe("preferredVisionFallbackModel", () => {
 });
 
 describe("suggestedModelsForMode", () => {
-  it("replaces Auto's generic catalog description with preset-specific guidance", () => {
-    const auto = {
-      ...model("open-software/auto", "Auto", ["supportsFunctionCalling"]),
-      description: "Automatically selects an eligible private model",
-    };
+  it("returns the curated concrete picks present in the catalog, in curated order", () => {
+    // Auto is not a suggested row — it lives in the picker's pinned toggle
+    // section — so the catalog's Auto entry never surfaces here.
+    const auto = model("open-software/auto", "Auto", ["supportsFunctionCalling"]);
+    const suggestions = suggestedModelsForMode("generation", [auto, kimi, glm52]);
 
-    const suggestions = suggestedModelsForMode("generation", [auto]);
-
-    expect(
-      suggestions.map(({ model: suggestion, costQuality }) => ({
-        name: suggestion.name,
-        description: suggestion.description,
-        costQuality,
-      })),
-    ).toEqual([
-      {
-        name: "Auto · Higher Quality",
-        description:
-          "Best for complex questions and important work where response quality matters most.",
-        costQuality: 100,
-      },
-      {
-        name: "Auto · Balanced",
-        description:
-          "Best for everyday work when you want a practical balance of quality and credit use.",
-        costQuality: 50,
-      },
-      {
-        name: "Auto · Lower Cost",
-        description: "Best for quick or routine tasks when minimizing credit use matters most.",
-        costQuality: 20,
-      },
+    expect(suggestions.map(({ model: suggestion }) => suggestion.id)).toEqual([
+      "zai-org-glm-5-2",
+      "kimi-k2-6",
     ]);
-    expect(suggestions.every(({ model: suggestion }) => suggestion.id === auto.id)).toBe(true);
+  });
+});
+
+describe("autoPillDesignation", () => {
+  it("buckets the persisted cost-to-quality value onto the preset designations", () => {
+    expect(autoPillDesignation(20)).toBe("Lower");
+    expect(autoPillDesignation(50)).toBe("Balanced");
+    expect(autoPillDesignation(100)).toBe("Higher");
+    // Off-preset values (a hand-edited settings file) land on the nearest tier.
+    expect(autoPillDesignation(0)).toBe("Lower");
+    expect(autoPillDesignation(67)).toBe("Higher");
+    expect(autoPillDesignation(undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Replaces the three "Auto · …" preset suggested rows (#726, #730 copy) with the **Auto toggle design** (product decision by @andrewwashuta): suggested rows return to concrete models (GLM 5.2 / Kimi K2.6 / GLM 5.1), and Auto lives in a pinned section above them.
- **The toggle** selects `open-software/auto` while keeping the popover open; toggling off lands on the leading suggested pick (GLM 5.2). Present in the workspace composer picker and Settings → Models. The catalog's Auto entry is filtered out of the suggested/All-models lists so the toggle is the router's one home.
- **The Preference drill-in**: while Auto is on, a "Preference · Higher quality ›" row opens a side flyout with the three cost-to-quality presets as rows (one-line explanation each, checkmark on the active one). Writes persist via `set_cost_quality` and dispatch the settings-changed event so the note-chat pill designation stays in sync (mirror of the sync shipped in #728).
- Composes with what already merged: the pill designation readback and picker border fixes (#728) and the Auto branding/spec-hiding (#730) are untouched and keep working with the toggle.

## Validation

- `pnpm typecheck`, Biome clean; 359 tests pass across seven suites, including #730's Auto-branding tests and rewritten coverage: toggling Auto on from the picker (popover stays open), drilling into the preference flyout, the pill tracking the persisted preset, and `suggestedModelsForMode` never surfacing Auto as a row.

- [x] Tested visually where it matters (toggle, drill-in, and flyout inset were iterated live in the dev app during design review).
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- frontend-only -->

## Out of scope

- The note chat panel's own picker popover (duplicated component) doesn't render the Auto toggle section yet — its pill shows the designation and stays in sync, but preference editing happens from the workspace picker or Settings.
- Shifting the Auto preference for in-flight work (preference is read per request today).

## Followups

- JUN-306: backend contract for changing the Auto routing preference while work is in flight.
- Consolidate `ComposerModelPopover` (note chat) with the shared `ModelPickerPopover` so the Auto section exists in one place.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786571253&installation_id=144203540&pr_number=732&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F732&signature=833a251b7c50b9426bb30881ced66829bff23a85b7e3b02cc066de30b66157dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->