### PR TITLE
JUN-309: Document June's top 10 plugin portfolio

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -257,6 +257,14 @@ group; an MCP server is an external tool provider (June ships `june_context`,
 servers `june_gmail`/`june_gcal` plus their `*_actions` counterparts).
 _Avoid_: using "tool" for all three.
 
+**Plugin**:
+A user-facing capability bundle in June's Plugins area. A plugin may combine
+Skills, Toolsets, app-owned MCP servers, routine templates, and optional
+Connectors around one job. Enabling or installing the bundle is distinct from
+connecting a third-party account and from choosing a routine's trust mode.
+_Avoid_: connector (unless specifically naming its third-party account path),
+integration (too broad), plugin for a Tauri framework package.
+
 ### Connectors
 
 **Connector**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -262,6 +262,8 @@ A user-facing capability bundle in June's Plugins area. A plugin may combine
 Skills, Toolsets, app-owned MCP servers, routine templates, and optional
 Connectors around one job. Enabling or installing the bundle is distinct from
 connecting a third-party account and from choosing a routine's trust mode.
+The ranked portfolio and shared product contract live in
+[docs/plugins/portfolio.md](docs/plugins/portfolio.md).
 _Avoid_: connector (unless specifically naming its third-party account path),
 integration (too broad), plugin for a Tauri framework package.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,17 @@ Per-repo config the engineering skills read before acting (see the
 - [hermes-architecture.md](hermes-architecture.md) — the agent runtime: bridge, gateway, control plane, sessions, models
 - [hermes-gateway-gotchas.md](hermes-gateway-gotchas.md) — integration gotchas: restart discipline, config contract, MCP OAuth, event types, upstream tool-schema quirks
 - [browser-computer-use-prd.md](browser-computer-use-prd.md) — PRD: Browser use + Computer use plugins (JUN-278); extension in the user's browser + routines-only managed browser, phase-2 computer use
+- [plugins/portfolio.md](plugins/portfolio.md) — JUN-309 portfolio: current ChatGPT plugin surface inventory, ranking rubric, June's top 10, shared product contract, sequencing, metrics, and explicit deferrals
+  - [Google Workspace](plugins/google-workspace-prd.md) — [implementation plan](plugins/google-workspace-implementation-plan.md)
+  - [Browser use](plugins/browser-use-prd.md) — [implementation plan](plugins/browser-use-implementation-plan.md)
+  - [Slack](plugins/slack-prd.md) — [implementation plan](plugins/slack-implementation-plan.md)
+  - [Microsoft 365](plugins/microsoft-365-prd.md) — [implementation plan](plugins/microsoft-365-implementation-plan.md)
+  - [Computer use](plugins/computer-use-prd.md) — [implementation plan](plugins/computer-use-implementation-plan.md)
+  - [Notion](plugins/notion-prd.md) — [implementation plan](plugins/notion-implementation-plan.md)
+  - [GitHub](plugins/github-prd.md) — [implementation plan](plugins/github-implementation-plan.md)
+  - [Linear](plugins/linear-prd.md) — [implementation plan](plugins/linear-implementation-plan.md)
+  - [Documents](plugins/documents-prd.md) — [implementation plan](plugins/documents-implementation-plan.md)
+  - [Spreadsheets](plugins/spreadsheets-prd.md) — [implementation plan](plugins/spreadsheets-implementation-plan.md)
 - [audio-pipeline.md](audio-pipeline.md) — capture → source separation → turns → transcription → note
 - [june-api-prd.md](june-api-prd.md) — June API: upstream proxy + OS Accounts authorize/charge (the canonical backend spec)
 - [telemetry.md](telemetry.md) — public overview of June telemetry, current behavior, and policies

--- a/docs/plugins/browser-use-implementation-plan.md
+++ b/docs/plugins/browser-use-implementation-plan.md
@@ -1,0 +1,117 @@
+# Implementation plan: Browser use plugin
+
+- **Mode:** CTO
+- **Date:** 2026-07-13
+- **Status:** Accepted workstream; implementation active
+- **PRD:** [browser-use-prd.md](browser-use-prd.md)
+- **Decision:** [ADR-0017](../adr/0017-browser-use-via-june-extension.md)
+
+## Technical objective
+
+Expose one app-owned `june_browser` MCP contract through a Rust policy broker
+with two transports: the user's explicitly bounded browser for attended tasks,
+and a fresh public-web-only profile for sandboxed routines.
+
+This plan is a portfolio summary. The detailed tool, transport, policy,
+distribution, and test decisions remain canonical in
+[browser-computer-use-prd.md](../browser-computer-use-prd.md) and the JUN-286
+through JUN-299 implementation Issues.
+
+## Architecture
+
+```text
+Hermes -> june_browser MCP -> authenticated loopback -> Rust browser broker
+                                                    |-> native shim -> MV3 extension -> task tabs
+                                                    `-> headless system Chromium -> ephemeral profile
+```
+
+The broker owns the stored grant, session leases, URL policy, task-tab scope,
+reference expiry, consequential-action classification, approval journal,
+artifact references, and teardown. The extension and headless driver execute
+commands but do not decide policy.
+
+## MCP contract
+
+- Session: `start_session`, `close_session`.
+- Navigation: `navigate`, `back`.
+- Perception: `snapshot`, `screenshot`.
+- Interaction: `click`, `fill`, `press`.
+- Tabs: `list_tabs`, `open_tab`, `switch_tab`, `close_tab`,
+  `accept_shared_tab`.
+
+Interactive references expire after navigation or relevant page mutation. A
+fresh snapshot follows every action. Large screenshots and snapshots return
+workspace file references rather than native-messaging payloads.
+
+## Attended transport
+
+- TypeScript MV3 extension with a pinned id and protocol version.
+- Per-tab debugger control only for June-created task tabs and explicitly
+  shared tabs.
+- Signed native-messaging shim inside the app bundle; authenticated local
+  socket to the broker.
+- Browser-owned debugging banner plus June tab grouping as visible indicators.
+- Extension detaches and clears state on broker/native-host loss.
+
+## Routine transport
+
+- Detect Chrome, Edge, Brave, then Chromium.
+- Launch headless with a fresh temp profile per run.
+- Resolve, validate, and pin public destinations; reject private, loopback,
+  link-local, non-HTTP, and rebinding targets, including after redirects.
+- Hard-block consequential actions because no user is present to approve.
+- Require an explicit per-routine opt-in.
+
+## Action safety
+
+- Park consequential actions before execution with a stable action id.
+- Allow "approve all on this site for this task" only for an exact normalized
+  origin and only in broker memory.
+- Never automate password, one-time code, or payment fields.
+- Retried turns resume a parked action and do not replay completed work.
+- Revoke in order: refuse commands, detach tabs, invalidate credentials and
+  approvals, stop sessions, delete ephemeral profiles.
+
+## Delivery map
+
+| Slice | Issue | Exit |
+| --- | --- | --- |
+| Grant and MCP skeleton | JUN-286 | Disabled/enabled contract and broker lease |
+| Extension pairing | JUN-287 | Versioned native-messaging round trip |
+| Managed read browser | JUN-289 | Navigate, snapshot, screenshot under URL policy |
+| In-chat request | JUN-290 | Grant request card and safe turn retry |
+| Attended read browser | JUN-291 | Task tabs only |
+| Distribution | JUN-292 | Store listing and reproducible zip |
+| Managed interactions | JUN-294 | Reference actions and redirect policy |
+| Shared tab | JUN-295 | Explicit handoff and revoke |
+| Attended approvals | JUN-297 | Parked consequential actions |
+| Routine opt-in | JUN-298 | Anonymous per-routine lease |
+| Plugin tile | JUN-299 | Guided connect and disconnect |
+
+## Verification
+
+- Rust policy tests for grants, exact-origin allows, action classes,
+  idempotency, URL resolution, redirects, and revoke ordering.
+- Cross-language protocol fixtures for framing, version mismatch, reconnect,
+  and file-reference payloads.
+- Extension integration tests against hostile fixture pages and navigation
+  races.
+- MCP schema fixtures plus pinned-runtime live smoke.
+- Live macOS walkthrough: install, pair, create task tab, share one tab, approve
+  an action, deny an action, human takeover, stop, disconnect, and crash the
+  broker while attached.
+- Security test that unrelated tabs, local network targets, and sensitive
+  fields stay unreachable.
+
+## Rollout
+
+Dogfood with unpacked builds, then rc through the Chrome Web Store, then stable
+after store/update compatibility and two weeks of action approval telemetry.
+Keep one remote kill switch for the attended transport and one for the managed
+transport. Do not log URLs, page text, screenshots, or field values.
+
+## Open gate
+
+Public release depends on publisher verification and store approval. The
+implementation direction itself requires no new ADR unless the work departs
+from ADR-0017.

--- a/docs/plugins/browser-use-prd.md
+++ b/docs/plugins/browser-use-prd.md
@@ -1,0 +1,97 @@
+# PRD: Browser use plugin
+
+- **Mode:** CEO
+- **Rank:** 2 of 10
+- **Score:** 91/100
+- **Date:** 2026-07-13
+- **Status:** Accepted direction in JUN-278
+- **Canonical detailed spec:** [../browser-computer-use-prd.md](../browser-computer-use-prd.md)
+
+## Thesis
+
+Browser use is June's universal adapter for web work that does not yet have a
+first-party connector. It turns June from an assistant that explains what to
+do into one that can do the work in visible, bounded tabs while the user keeps
+control of consequential actions.
+
+It ranks second because it multiplies every other plugin and prevents the
+portfolio from becoming a race to build one provider at a time. It does not
+replace connectors: connectors offer narrower scopes, structured data, safer
+actions, and routine support; Browser use covers the long tail and signed-in
+web flows.
+
+## Customer and problem
+
+June can search and fetch web pages, but users still perform interactive work:
+open a site, navigate stateful pages, fill a form, attach a file, or complete a
+workflow inside an existing login. Giving an agent an unrestricted browser
+profile would solve the capability problem by creating a larger trust problem.
+
+## Product promise
+
+June works only in clearly marked tabs it creates or a tab the user explicitly
+shares. It pauses before sending, submitting, publishing, purchasing, deleting,
+or making another consequential change. Disconnect means the browser is no
+longer under June's control.
+
+## V1 experience
+
+- The Plugins tile guides installation and pairing of the June browser
+  extension.
+- June opens task-owned tabs in a visible group and can use the user's existing
+  signed-in session there.
+- The user may share one existing tab explicitly; all other existing tabs are
+  out of bounds.
+- June shows screenshots and progress in chat.
+- Sensitive fields for passwords, one-time codes, and payment data always
+  require human takeover.
+- Sandboxed routines use a separate anonymous, ephemeral managed browser for
+  public sites, never the user's profile.
+- Stop and disconnect are always visible and immediate.
+
+## Scope boundaries
+
+Launch on Chromium-family browsers on macOS. Do not bundle a browser engine,
+automate credentials or payment fields, create persistent per-site autonomy,
+or expose signed-in sessions to unattended routines. Computer use is a
+separate plugin and grant.
+
+## Privacy and trust
+
+Page content needed for reasoning follows the user's selected inference path.
+The extension, native shim, and Rust broker stay on-device. June does not send
+the user's browsing history or unrelated tabs to OpenSoftware. Policy lives in
+the broker, not in a prompt.
+
+## Business model
+
+Attended Browser use should be available on Hobby during launch to maximize
+trust feedback. Routine browsing and higher automation limits are Pro. There
+is no provider API fee; model and support costs determine final packaging.
+
+## Success measures
+
+| Metric | Target |
+| --- | ---: |
+| Users completing pairing after opening the tile | 70% |
+| Browser tasks reaching the requested outcome | 75% |
+| Consequential actions executed without a valid approval | 0 |
+| Sessions touching an unshared pre-existing tab | 0 |
+| Median time from access request to first snapshot | under 90 seconds |
+| Users disconnecting because behavior surprised them | under 2% |
+
+## Strategic risks
+
+- Extension-store approval and independent update cadence are release risks.
+- Browser DOMs change constantly; recovery quality matters more than demo-path
+  success.
+- Signed-in pages contain prompt injection and high-value actions. Structural
+  tab isolation and broker approvals are mandatory.
+- The plugin must never become an excuse to skip a safer structured connector
+  for high-frequency workflows.
+
+## Decision
+
+The direction is already accepted. Ship Browser use before Computer use, keep
+the user's profile attended-only, and treat the browser broker as a reusable
+policy boundary for the portfolio.

--- a/docs/plugins/browser-use-prd.md
+++ b/docs/plugins/browser-use-prd.md
@@ -74,10 +74,14 @@ is no provider API fee; model and support costs determine final packaging.
 | Metric | Target |
 | --- | ---: |
 | Users completing pairing after opening the tile | 70% |
-| Browser tasks reaching the requested outcome | 75% |
+| Browser tasks with a user-confirmed or predeclared broker-verifiable outcome | 75% |
 | Consequential actions executed without a valid approval | 0 |
 | Sessions touching an unshared pre-existing tab | 0 |
 | Median time from access request to first snapshot | under 90 seconds |
+
+A verifiable outcome is defined before execution and recorded by the broker,
+such as reaching a target state, producing the requested artifact, or receiving
+an action receipt. Agent self-reported completion does not count.
 | Users disconnecting because behavior surprised them | under 2% |
 
 ## Strategic risks

--- a/docs/plugins/computer-use-implementation-plan.md
+++ b/docs/plugins/computer-use-implementation-plan.md
@@ -1,0 +1,100 @@
+# Implementation plan: Computer use plugin
+
+- **Mode:** CTO
+- **Date:** 2026-07-13
+- **Status:** Accepted phase 2; spike active
+- **PRD:** [computer-use-prd.md](computer-use-prd.md)
+- **Decision:** [ADR-0017](../adr/0017-browser-use-via-june-extension.md)
+
+## Technical objective
+
+Productize the pinned runtime's existing computer-use toolset behind a June
+grant, a pinned signed `cua-driver`, TCC onboarding, model-capability gating,
+and June-native approval cards.
+
+## Phase 0: sandbox spike
+
+JUN-288 must prove on a signed app build:
+
+- the bundled driver launches from app resources;
+- private-interface lookup works under the current Seatbelt profile, or the
+  broker can spawn a narrowly scoped helper outside the write jail;
+- Accessibility and Screen recording attach to the intended bundle identity;
+- background input does not steal cursor, focus, or Space;
+- capture and action approval hooks match the pinned runtime contract;
+- stop/revoke terminates the driver and invalidates pending actions.
+
+If the driver requires a new helper trust boundary, record an ADR addendum or a
+new ADR before hardening the plan.
+
+## Packaging
+
+- Pin the driver source/version and expected hash in the repo.
+- Build or fetch it only in controlled release tooling; never at runtime.
+- Sign it with the app release identity and include it as a Tauri resource.
+- Point the runtime at the exact binary with supported path/version overrides.
+- Add SBOM/provenance and a release test that starts, handshakes, captures a
+  fixture app, and exits.
+
+## Grant and TCC state
+
+One Computer use grant is represented in Plugins, Settings, and the runtime
+config. Granting does not fabricate macOS permission. The state machine is:
+
+`off -> grant_on_permission_missing -> permission_prompted -> ready -> error`
+
+Poll the OS permission state after an explanatory screen. Distinguish
+Accessibility from Screen recording and provide direct System Settings help.
+Revoking the June grant disables the toolset immediately even if macOS
+permission remains; removing TCC access is an explicit user follow-up.
+
+## Runtime and approvals
+
+- Keep the upstream toolset absent unless the grant is ready and the selected
+  model has authoritative vision capability.
+- Route every runtime approval hook into the June event seam and approval card.
+- Park with a stable action id, target application identity, action summary,
+  relevant capture reference, and expiry.
+- Never offer approve-all or autonomous mode in v1.
+- Block password, one-time code, payment, permission/security settings, keychain,
+  terminal privilege escalation, and destructive system actions.
+
+## Delivery slices
+
+1. **Driver spike (JUN-288).** Go/no-go and trust-boundary decision.
+2. **Pinned bundle (JUN-293, 1-2 weeks).** Reproducible resource, handshake,
+   version failure, release self-test.
+3. **TCC + tile (JUN-296, 2 weeks).** State machine, education, model gate,
+   grant/revoke.
+4. **Approval bridge (JUN-296, 1-2 weeks).** Runtime approval events to June
+   cards, stop and timeout semantics.
+5. **Hardening (2 weeks).** Target-app isolation, sensitive-action denylist,
+   crash recovery, signed-build matrix.
+
+## Verification
+
+- Unit tests for grant/TCC/model state and approval event normalization.
+- Contract fixture against the pinned runtime and driver handshake.
+- Signed-build tests on the oldest and newest supported macOS releases.
+- Fixture applications for text fields, menus, lists, scrolling, modal dialogs,
+  multiple windows, app quit, target movement, and capture change races.
+- Proof that background actions do not move cursor, change focus, or switch
+  Space.
+- Security tests for denied apps/fields/actions and stale capture references.
+- Manual walkthrough of first permission, denial, later grant, task action,
+  approve, deny, stop, revoke, OS update simulation, and driver crash.
+
+## Rollout
+
+Developer-only, internal signed builds, rc opt-in, then Pro stable. Maintain a
+remote driver kill switch keyed by June version and macOS version. The release
+self-test blocks promotion if capture or background input fails. Telemetry is
+content-free: OS version bucket, driver version, operation class, latency,
+approval outcome, failure class.
+
+## Exit criteria
+
+- Two weeks of internal use with no focus theft or unapproved mutation.
+- Release self-test green on the support matrix.
+- Security review of capture handling and denied action classes.
+- Support runbook for TCC, driver mismatch, model mismatch, and OS regression.

--- a/docs/plugins/computer-use-prd.md
+++ b/docs/plugins/computer-use-prd.md
@@ -1,0 +1,84 @@
+# PRD: Computer use plugin
+
+- **Mode:** CEO
+- **Rank:** 5 of 10
+- **Score:** 81/100
+- **Date:** 2026-07-13
+- **Status:** Accepted phase 2 in JUN-278
+- **Canonical detailed spec:** [../browser-computer-use-prd.md](../browser-computer-use-prd.md)
+
+## Thesis
+
+Computer use is June's universal adapter for Mac work that has no safe API or
+browser path. It lets June operate another app in the background without
+stealing the user's cursor, keyboard focus, or active Space. It is strategically
+powerful and technically risky, which is why it ranks behind Browser use and
+the two dominant work ecosystems.
+
+## Customer and problem
+
+Important follow-through still happens in desktop apps: legacy practice tools,
+local files, native communication apps, and proprietary workflows. The user
+cannot delegate these jobs to June today. Traditional screen-driving agents
+also take over the desktop, expose unrelated content, and make silent mistakes.
+
+## Product promise
+
+Grant access deliberately, see every mutating step before it runs, keep using
+the Mac while June works in the background, and revoke the capability at any
+time.
+
+## V1 experience
+
+- The plugin tile explains Accessibility and Screen recording before macOS
+  prompts appear.
+- June reports whether the selected model can use the capability.
+- The user chooses a target app/task; June captures a bounded representation
+  and proposes actions.
+- Every mutating action requires approval in chat.
+- The user sees progress and can stop immediately.
+- Disconnect removes June's runtime grant; macOS permissions can also be
+  revoked from System Settings.
+
+## Scope
+
+Phase 2 is macOS-only, attended sessions only, vision-capable models only, and
+uses the pinned runtime's computer-use toolset with a June-bundled driver.
+Routines, credential entry, payment entry, security settings, destructive
+system operations, and Windows support are out of scope.
+
+## Privacy and trust
+
+Screen captures needed for reasoning follow the user's selected inference path.
+June must never imply that Screen recording means captures stay local when the
+selected model is remote. The driver is pinned and signed; the upstream network
+installer never runs. Mutating actions are gated structurally, not by a prompt.
+
+## Business model
+
+Launch as Pro because of support burden, model requirements, and risk. Revisit
+after reliability and cost data. Permission education and the ability to revoke
+are available regardless of plan.
+
+## Success measures
+
+| Metric | Target |
+| --- | ---: |
+| Eligible users completing TCC setup | 60% |
+| Supported tasks completed without user takeover | 65% |
+| Mutating actions without a June approval | 0 |
+| Cursor/focus theft incidents | 0 |
+| Driver crash rate per task | under 1% |
+| Median user corrections per completed task | under 1 |
+
+## Risks and gates
+
+- The driver uses private macOS interfaces and may break on OS updates.
+- Screen capture has a larger privacy blast radius than structured connectors.
+- Model visual mistakes can target the wrong element.
+- App sandbox and TCC behavior must be proven on signed release builds.
+
+## Decision
+
+The direction is accepted, but phase 2 stays gated on the driver-under-sandbox
+spike and a release self-test. Do not expand it to routines at launch.

--- a/docs/plugins/documents-implementation-plan.md
+++ b/docs/plugins/documents-implementation-plan.md
@@ -1,0 +1,116 @@
+# Implementation plan: Documents plugin
+
+- **Mode:** CTO
+- **Date:** 2026-07-13
+- **Status:** Proposed; artifact-engine spike required
+- **PRD:** [documents-prd.md](documents-prd.md)
+
+## Technical objective
+
+Create a brokered, versioned document pipeline inside the agent workspace. The
+model supplies structured intent; deterministic code creates, inspects, renders,
+validates, and exports artifacts. The model never constructs opaque binary data
+or chooses an arbitrary filesystem destination.
+
+## Phase 0: artifact-engine spike
+
+Timebox two weeks to compare:
+
+1. A Rust-native OOXML subset using ZIP/XML libraries and a June-owned document
+   intermediate representation.
+2. A pinned app-owned worker using audited document libraries, isolated from
+   Hermes and packaged with reproducible wheels/binaries.
+3. macOS Quick Look or another supported rendering path for visual preview,
+   including behavior in a signed sandboxed build.
+
+Measure fidelity, package size, cold start, supported structures, licensing,
+sandbox behavior, malformed-input safety, and reproducibility. The exit artifact
+is an accepted engine choice, support matrix, and threat model. Adding a large
+runtime or privileged helper meets the ADR threshold.
+
+## Architecture
+
+```text
+Hermes -> june_documents MCP -> Rust artifact broker -> document engine
+                                          |-> versioned workspace artifacts
+                                          |-> preview images/HTML
+                                          `-> validation report
+June UI -> native save dialog -> explicit export copy
+```
+
+Use one June-owned intermediate representation (IR) for the supported subset:
+document metadata, sections, block nodes, inline runs, styles, tables, images,
+links, headers/footers, and source references. MCP inputs and outputs use this
+IR; the engine owns OOXML.
+
+## Proposed tools
+
+| Tool | Behavior |
+| --- | --- |
+| `inspect_document` | Parse supported structure, metadata, warnings, and active-content findings |
+| `create_document` | Create a new version from structured blocks and template id |
+| `revise_document` | Apply typed operations to a prior version |
+| `render_document` | Produce bounded preview artifacts |
+| `validate_document` | Re-open output and check structural/semantic invariants |
+| `compare_document_versions` | Return semantic changes and preview refs |
+| `export_document` | Request a June UI export handoff, never an arbitrary path |
+
+`revise_document` accepts typed operations such as replace block, insert after,
+delete block, set style, and update table cell. It does not accept raw XML.
+
+## Files and versions
+
+- Import through `import_hermes_bridge_file`; treat the imported copy as source.
+- Store artifacts under a per-session workspace `artifacts/documents/<id>/` with
+  immutable versions, manifest, source refs, preview refs, and validation.
+- Use content hashes and atomic rename for completed versions.
+- Enforce file count, uncompressed ZIP size, XML depth, image bytes, page/block
+  count, and total operation bounds.
+- Strip or reject macros, OLE objects, external templates, remote images, and
+  unsafe relationships.
+
+## Rendering and validation
+
+Validation has three levels:
+
+1. Container: safe ZIP, required parts, relationship targets, content types.
+2. Semantic: all IR nodes round-trip, links/images resolve locally, headings and
+   tables match requested content, no unexpected active content.
+3. Visual: render supported pages, check non-empty bounds and obvious clipping,
+   and show the actual preview to the user.
+
+The UI labels unsupported or approximate layout. It never claims pixel parity.
+
+## Export boundary
+
+The broker emits an export-ready artifact id. Tauri opens the native save dialog
+and copies the validated version. The agent cannot supply a path outside its
+workspace. Existing destination replacement requires native confirmation.
+
+## Delivery slices after Phase 0
+
+1. **Artifact broker + IR (2 weeks).** Version store, bounds, MCP skeleton.
+2. **Markdown/text (1 week).** Create/read/revise/export and baseline UI.
+3. **DOCX create (2 weeks).** Supported structures, templates, validation.
+4. **DOCX inspect/revise (2 weeks).** Copy-on-edit and unsupported warnings.
+5. **Preview/compare (1-2 weeks).** Visual artifacts and semantic diff.
+6. **Skills + rc (1 week).** Templates, dogfood corpus, runbook.
+
+## Verification
+
+- Golden files opened in at least Microsoft Word, Apple Pages, and LibreOffice
+  during release qualification; automated structural validation remains the CI
+  gate.
+- Fuzz/malformed corpus for ZIP bombs, XML entity expansion, relationship path
+  traversal, corrupt images, macros, OLE, and external references.
+- Round-trip property tests for every IR node and style.
+- Snapshot previews across supported fonts/page sizes.
+- Export tests proving the agent cannot choose or overwrite arbitrary paths.
+- Prompt-injection corpus in document text, metadata, links, comments, alt text,
+  and hidden/unsupported structures.
+
+## Rollout
+
+Developer templates, internal docs, rc opt-in, stable. Keep a format/engine kill
+switch and content-free operation telemetry. Publish the support matrix in the
+plugin detail and preserve artifacts when rendering fails so users can recover.

--- a/docs/plugins/documents-prd.md
+++ b/docs/plugins/documents-prd.md
@@ -1,0 +1,116 @@
+# PRD: Documents plugin
+
+- **Mode:** CEO
+- **Rank:** 9 of 10
+- **Score:** 67/100
+- **Date:** 2026-07-13
+- **Status:** Proposed
+
+## Thesis
+
+Documents turns June's strongest raw material - conversations, transcripts,
+notes, and connected context - into a finished local artifact. It should create
+and revise professional documents without requiring a cloud document service
+and without overwriting the user's original.
+
+It ranks ninth because the value is broad and highly aligned with local-first
+privacy, but high-fidelity office formats and rendering require a new artifact
+foundation. That foundation should be proven before presentations or richer
+design outputs.
+
+## Customer and problem
+
+June users leave meetings with the information needed for a brief, proposal,
+memo, decision record, or client follow-up, but still assemble the document by
+hand. Generic chat output is not a finished deliverable: it lacks structure,
+consistent styles, page-aware verification, editable format, and source links.
+
+## Product promise
+
+Ask June for a finished document. It builds an editable local artifact from the
+sources you chose, shows a preview and validation report, and exports only when
+you approve the destination.
+
+## V1 experience
+
+- Start from a June note, selected local files, or connected sources.
+- Choose a template or describe the document: memo, brief, proposal, decision
+  record, agenda, or meeting recap.
+- June creates a versioned artifact in its workspace and shows a rendered
+  preview plus outline, page/section count, and warnings.
+- Ask for revisions in chat; every revision creates a recoverable version.
+- Export DOCX, Markdown, or plain text through a native save dialog.
+- Import an existing supported document, edit a copy, and compare the new
+  version without changing the original.
+
+## Scope
+
+### V1
+
+- Create and read Markdown, plain text, and a supported DOCX subset.
+- Supported DOCX structures: paragraphs, headings, lists, tables, links,
+  images, headers/footers, page breaks, and basic styles.
+- Semantic validation and an honest rendered preview for supported structures.
+- Version history, source references, templates, and native export.
+
+### Later
+
+- PDF export, comments, tracked changes/redlines, footnotes, fields, complex
+  pagination, collaborative cloud publishing, and presentations.
+
+## Non-goals
+
+- Replacing a full word processor.
+- Pixel-perfect round-trip editing of arbitrary DOCX files.
+- Running macros, embedded objects, or external links automatically.
+- Overwriting the imported original.
+- Uploading documents to June API for storage.
+
+## Packaging
+
+- No connector is required.
+- App-owned toolset: document inspect, create, revise, render, validate, export.
+- Skills: executive memo, client brief, proposal, decision record, agenda,
+  meeting recap.
+- Optional connectors provide source context or a later publication target.
+
+## Privacy and trust
+
+Artifact storage and transformation stay on-device. Content needed for drafting
+still follows the selected inference path. The plugin listing must distinguish
+local file transformation from model inference. Imported content is untrusted,
+and external relationships, macros, and active content are disabled.
+
+Exports use a user-selected destination. Existing files require an explicit
+replace confirmation from the native dialog; the normal path creates a new file.
+
+## Business model
+
+Core creation and export are Hobby. Larger documents, premium template packs,
+and high-frequency cross-plugin artifact routines can be Pro. Model usage is
+already metered; local render/validation should not add a billing slug.
+
+## Success measures
+
+| Metric | Target |
+| --- | ---: |
+| Started documents reaching export | 45% |
+| Exports opened successfully in a reference editor | 99% |
+| Exported documents requiring structural repair | under 5% |
+| Users creating a second document within 30 days | 35% |
+| Original source files overwritten without explicit confirmation | 0 |
+
+## Risks and gates
+
+- Office formats contain far more features than V1 supports; silent loss is
+  worse than an explicit unsupported warning.
+- Visual layout can differ across editors and fonts.
+- A converter or rendering sidecar adds binary size, licensing, sandbox, and
+  supply-chain risk.
+- Source documents can contain prompt injection and active content.
+
+## Decision requested
+
+Approve a supported-subset, versioned Documents plugin with DOCX/Markdown/text
+creation and copy-on-edit. Gate implementation on the artifact-engine spike and
+defer redlines and PDF export.

--- a/docs/plugins/github-implementation-plan.md
+++ b/docs/plugins/github-implementation-plan.md
@@ -31,7 +31,7 @@ user, and the existing approval broker.
 
 | Server | Tools |
 | --- | --- |
-| `june_github` | `list_repositories`, `search_code`, `read_file`, `list_commits`, `list_issues`, `get_issue`, `list_pull_requests`, `get_pull_request`, `get_pull_request_diff`, `list_checks` |
+| `june_github` | `list_repositories`, `search_code`, `read_file`, `list_commits`, `list_issues`, `get_issue`, `list_pull_requests`, `get_pull_request`, `get_pull_request_diff`, `list_checks`, `list_discussions`, `get_discussion` |
 | `june_github_actions` | `create_issue`, `comment_on_issue`, `comment_on_pull_request`, `submit_review` |
 
 Each result includes owner, repository, stable node/database id, number or SHA,
@@ -51,8 +51,10 @@ and support explicit continuation.
 
 - Every write parks with exact repository, object, title/body or review diff,
   and source note references.
-- Issue/comment creation uses a stable local action id and provider response
-  journal to avoid duplicates.
+- Issue/comment creation uses a stable local action id and response journal.
+  Because that journal cannot make GitHub mutations idempotent, an ambiguous
+  timeout blocks automatic replay until June reconciles a stable fingerprint
+  against recent provider objects or the user explicitly approves another try.
 - Review submission revalidates pull-request head SHA before commit.
 - Merge, close, branch, content, workflow, release, secret, and administration
   operations do not exist in the server schema.
@@ -64,7 +66,8 @@ and support explicit continuation.
    selected-repository lifecycle.
 2. **Connection shell (1 week):** installation state, Keychain, health,
    repository selection updates, revoke.
-3. **Delivery reads (2 weeks):** issues, PRs, diffs, commits, checks.
+3. **Delivery reads (2 weeks):** issues, PRs, diffs, commits, checks, and
+   discussions.
 4. **Code reads (1 week):** search/file content bounds and binary handling.
 5. **Approved writes (1 week):** issue, comment, review with journal/preflight.
 6. **Skills and rc (1 week):** standup, risk, release notes, pilot.

--- a/docs/plugins/github-implementation-plan.md
+++ b/docs/plugins/github-implementation-plan.md
@@ -1,0 +1,94 @@
+# Implementation plan: GitHub plugin
+
+- **Mode:** CTO
+- **Date:** 2026-07-13
+- **Status:** Proposed
+- **PRD:** [github-prd.md](github-prd.md)
+- **Issue:** JUN-285
+
+## Technical objective
+
+Replace personal-token-style setup with a first-party GitHub App path that
+binds every tool call to an installation, selected repositories, the connected
+user, and the existing approval broker.
+
+## Phase 0: app/auth spike
+
+- Register a development GitHub App with read-only repository metadata,
+  contents, issues, pull requests, and checks; narrowly scoped issue/comment
+  writes for the action phase.
+- Verify the desktop user authorization flow with PKCE or device flow, GitHub
+  App installation selection, short-lived token refresh, revoke events, and
+  selected-repository changes.
+- Determine whether any app private key is required for the user-scoped V1
+  flows and where it can safely live. A reusable private key cannot ship in the
+  desktop binary.
+- Decide whether installation-token minting requires a TEE signer. If it does,
+  record that credential boundary in an ADR while keeping provider content
+  calls on-device.
+
+## Proposed servers
+
+| Server | Tools |
+| --- | --- |
+| `june_github` | `list_repositories`, `search_code`, `read_file`, `list_commits`, `list_issues`, `get_issue`, `list_pull_requests`, `get_pull_request`, `get_pull_request_diff`, `list_checks` |
+| `june_github_actions` | `create_issue`, `comment_on_issue`, `comment_on_pull_request`, `submit_review` |
+
+Each result includes owner, repository, stable node/database id, number or SHA,
+URL, and permission/installation context. Diffs and files are byte/line bounded
+and support explicit continuation.
+
+## State and binding
+
+- Keychain user refresh/access material where applicable.
+- Non-secret GitHub user id, installation id, selected repositories, granted
+  permissions, health, and last refresh in SQLite.
+- Server-side route resolves installation and repository from the bound grant;
+  model-supplied owner/repo is validated against it.
+- No repository clone or source index in v1. Reads are live and bounded.
+
+## Action safety
+
+- Every write parks with exact repository, object, title/body or review diff,
+  and source note references.
+- Issue/comment creation uses a stable local action id and provider response
+  journal to avoid duplicates.
+- Review submission revalidates pull-request head SHA before commit.
+- Merge, close, branch, content, workflow, release, secret, and administration
+  operations do not exist in the server schema.
+- Autonomous mode is deferred.
+
+## Delivery slices
+
+1. **App registration spike (1 week):** credential boundary, permission matrix,
+   selected-repository lifecycle.
+2. **Connection shell (1 week):** installation state, Keychain, health,
+   repository selection updates, revoke.
+3. **Delivery reads (2 weeks):** issues, PRs, diffs, commits, checks.
+4. **Code reads (1 week):** search/file content bounds and binary handling.
+5. **Approved writes (1 week):** issue, comment, review with journal/preflight.
+6. **Skills and rc (1 week):** standup, risk, release notes, pilot.
+
+## Verification
+
+- Auth/install matrix: personal/org repository, all/selected repositories,
+  owner denial, SSO, selection change, suspension, revoke, token refresh.
+- Rust tests for installation and repository binding on every route.
+- Pagination, secondary rate limits, diff truncation, renamed/deleted refs,
+  force-push/stale SHA, and partial permission fixtures.
+- Injection corpus in repository instructions, source, issues, PR bodies,
+  comments, review threads, check output, and filenames.
+- Action retry/idempotency and approval preflight tests.
+- Live walkthrough on a dedicated organization and private repository.
+
+## Rollout
+
+Developer org, internal repos, selected open-source pilot, rc, stable. Content-
+free telemetry and per-operation kill switches. Document exact GitHub App
+permissions and why each is needed.
+
+## ADR threshold
+
+If a backend signer holds a GitHub App private key, that is a hard-to-reverse
+credential boundary and requires an ADR. Provider repository content should
+still travel device to GitHub unless a separately accepted design says otherwise.

--- a/docs/plugins/github-prd.md
+++ b/docs/plugins/github-prd.md
@@ -1,0 +1,113 @@
+# PRD: GitHub plugin
+
+- **Mode:** CEO
+- **Rank:** 7 of 10
+- **Score:** 73/100
+- **Date:** 2026-07-13
+- **Status:** Proposed; tracked by JUN-285
+
+## Thesis
+
+GitHub turns June's meeting memory into software delivery follow-through. The
+plugin should prepare engineering meetings from repositories and pull requests,
+connect decisions to code, draft issues or review comments, and summarize what
+changed since the conversation.
+
+It ranks seventh because it is extremely valuable for June's technical early
+adopters but narrower than the cross-role plugins above it. It can ship with
+high confidence because GitHub Apps provide fine-grained repository permissions
+and short-lived tokens.
+
+## Customer and problem
+
+Engineering teams discuss architecture, bugs, and priorities in meetings, then
+reconstruct the same context in GitHub. Product and customer decisions rarely
+stay linked to the pull requests that implement them. Broad personal access
+tokens are easy to create and hard to justify.
+
+## Product promise
+
+Choose repositories during GitHub App installation. June can read and explain
+those repositories and draft bounded delivery actions, while GitHub and the
+user's own permissions remain the authority.
+
+## V1 experience
+
+- Install the June GitHub App on selected repositories.
+- Ask June to prepare a standup/review from issues, pull requests, commits, and
+  relevant code.
+- Link a June note to a repository, issue, or pull request.
+- Draft an issue, issue comment, pull-request review, or status summary.
+- Review and approve every GitHub write.
+- Repositories removed from the installation disappear from June immediately.
+
+## Scope
+
+### V1
+
+- Repository metadata, code/file search and bounded read, commits, issues,
+  pull requests, reviews, checks, and discussions needed for the core flows.
+- Draft/create issues and comments; submit review comments behind approval.
+- Engineering standup, PR risk brief, release note, and decision-to-issue skills.
+
+### Later
+
+- Enterprise Server, organization administration, workflow dispatch, merge,
+  branch/file writes, secrets, deployments, and webhook-triggered routines.
+
+## Non-goals
+
+- A coding agent or local git replacement.
+- Repository write access at launch.
+- Merge, close, delete, workflow dispatch, or release publication.
+- Broad classic personal access tokens as the primary setup.
+- Reading repositories outside the installation selection.
+
+## Packaging
+
+- Required connector: GitHub App installation.
+- Skills: standup, PR risk, release notes, issue drafting, implementation trace.
+- Templates: weekly engineering update, stale review queue, meeting decisions to
+  issues.
+- Composition: Linear and Slack are optional destinations/sources.
+
+## Privacy and trust
+
+Prefer a GitHub App with selected repositories and minimum permissions. User
+access tokens are short-lived and refreshed from Keychain-held material; calls
+originate on-device where GitHub's auth model permits. GitHub source is
+untrusted input, especially issue bodies, comments, and repository instruction
+files. Writes require approval in v1.
+
+## Business model
+
+Read and approved issue/comment flows are Hobby. Recurring cross-repository
+briefings and cross-plugin routines are Pro.
+
+## Success measures
+
+| Metric | Target |
+| --- | ---: |
+| Installs selecting at least one repository | 90% |
+| Weekly connected users running a delivery brief | 35% |
+| Drafted GitHub actions approved | 55% |
+| Writes targeting the wrong repository/object | 0 |
+| Reads outside installation repository selection | 0 successful |
+
+## Risks and gates
+
+- GitHub App manifest, user authorization, and installation authorization are
+  distinct states.
+- Large repositories and diffs require strict retrieval bounds.
+- Repository content can contain adversarial instructions.
+- Enterprise Server needs host-specific security and is not v1 parity.
+
+## Decision requested
+
+Approve a selected-repository GitHub App, read-rich but write-narrow, with all
+writes approved and merge/repository mutations deferred.
+
+## Sources
+
+- [Choosing GitHub App permissions](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/choosing-permissions-for-a-github-app)
+- [GitHub user access tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app)

--- a/docs/plugins/google-workspace-implementation-plan.md
+++ b/docs/plugins/google-workspace-implementation-plan.md
@@ -30,7 +30,7 @@ Add app-owned servers behind the connector token:
 | Server | Tools |
 | --- | --- |
 | `june_gdrive` | `search_files`, `get_file_metadata`, `read_file`, `list_recent_files`, `get_activity` |
-| `june_gdrive_actions` | `create_document`, `update_document`, `create_spreadsheet`, `update_range`, `move_file`, `share_file` |
+| `june_gdrive_actions` | `create_document`, `update_document`, `create_spreadsheet`, `update_range` |
 | `june_google_people` | `search_contacts`, `get_contact` |
 | `june_google_meet` | `get_meeting_space`, `list_recordings`, `list_transcripts`, `read_transcript` |
 
@@ -90,8 +90,7 @@ handle it.
 - `approval`: Drive/Docs/Sheets action calls park before the provider request.
 - `autonomous`: only explicitly granted tools and account may bypass parking
   after earned autonomy.
-- Sharing, deleting, moving across shared drives, and broad permission changes
-  remain approval-only in v1 even under autonomous mode.
+- Sharing, deleting, moving, and permission changes are not exposed in v1.
 - Send/update actions journal `pending`, `committed`, or `ambiguous`. Automatic
   retry requires a provider-supported idempotency key. After a response-loss
   timeout, June reconciles a stable action fingerprint against provider state;

--- a/docs/plugins/google-workspace-implementation-plan.md
+++ b/docs/plugins/google-workspace-implementation-plan.md
@@ -92,8 +92,10 @@ handle it.
   after earned autonomy.
 - Sharing, deleting, moving across shared drives, and broad permission changes
   remain approval-only in v1 even under autonomous mode.
-- Send/update retries resume from the stable pending action id. They never
-  blindly replay a completed mutation.
+- Send/update actions journal `pending`, `committed`, or `ambiguous`. Automatic
+  retry requires a provider-supported idempotency key. After a response-loss
+  timeout, June reconciles a stable action fingerprint against provider state;
+  if it cannot prove the result, it blocks replay until the user confirms.
 
 ## Delivery slices
 

--- a/docs/plugins/google-workspace-implementation-plan.md
+++ b/docs/plugins/google-workspace-implementation-plan.md
@@ -7,7 +7,8 @@
 
 ## Technical objective
 
-Extend the shipped Gmail + Calendar connector without weakening ADR-0016.
+Extend the shipped Gmail + Calendar connector while preserving its implemented
+local-mode security properties and resolving ADR-0016's proposed status.
 Drive, Contacts, Docs, Sheets, and Meet calls must reuse Keychain custody, the
 on-device provider proxy, the read/action MCP split, explicit account binding,
 trust modes, and the approval journal.
@@ -152,5 +153,6 @@ latency, approval, denial, and provider error buckets.
 
 - Google OAuth verification and test Workspace tenant.
 - A settled scope expansion behavior from Slice 0.
-- No new ADR if the work follows ADR-0016. A new ADR is required before any
-  cloud index, domain-wide delegation, or backend-held provider credential.
+- Resolve ADR-0016's proposed status before treating its local-mode shape as an
+  accepted constraint. A new or superseding ADR is required before any cloud
+  index, domain-wide delegation, or backend-held provider credential.

--- a/docs/plugins/google-workspace-implementation-plan.md
+++ b/docs/plugins/google-workspace-implementation-plan.md
@@ -1,0 +1,156 @@
+# Implementation plan: Google Workspace plugin
+
+- **Mode:** CTO
+- **Date:** 2026-07-13
+- **Status:** Proposed expansion of shipped local mode
+- **PRD:** [google-workspace-prd.md](google-workspace-prd.md)
+
+## Technical objective
+
+Extend the shipped Gmail + Calendar connector without weakening ADR-0016.
+Drive, Contacts, Docs, Sheets, and Meet calls must reuse Keychain custody, the
+on-device provider proxy, the read/action MCP split, explicit account binding,
+trust modes, and the approval journal.
+
+## Existing foundation
+
+- `src-tauri/src/connectors/` owns Google OAuth, account state, Keychain access,
+  provider calls, triggers, and trust enforcement.
+- `june_gmail*` and `june_gcal*` establish the base/action server convention.
+- The connector approval tray, runtime config merge, restart discipline, and
+  live schema fixtures already exist.
+- The current local mode supports one Google account. This plan does not smuggle
+  multi-account routing into the expansion.
+
+## Proposed runtime surface
+
+Add app-owned servers behind the connector token:
+
+| Server | Tools |
+| --- | --- |
+| `june_gdrive` | `search_files`, `get_file_metadata`, `read_file`, `list_recent_files`, `get_activity` |
+| `june_gdrive_actions` | `create_document`, `update_document`, `create_spreadsheet`, `update_range`, `move_file`, `share_file` |
+| `june_google_people` | `search_contacts`, `get_contact` |
+| `june_google_meet` | `get_meeting_space`, `list_recordings`, `list_transcripts`, `read_transcript` |
+
+Keep one job per tool, stable provider ids in every result, compact structured
+summaries, bounded pagination, and explicit MIME/export metadata. File reads
+must return imported file references when content exceeds the inline bound.
+
+## Data model
+
+Add only provider-neutral records unless a Google field is genuinely unique:
+
+- `connector_capability_grants`: account, capability, granted scopes, state,
+  last verified timestamp.
+- `connector_resource_refs`: provider, account, resource kind, provider id,
+  canonical URL, display name, ETag/version, last accessed timestamp.
+- Extend the existing pending action record with provider idempotency material
+  for Docs/Sheets mutations.
+
+Do not persist file bodies, email bodies, Meet transcripts, or access tokens in
+SQLite. Imported artifacts follow the existing workspace file lifecycle.
+
+## OAuth and scopes
+
+1. Inventory the exact least-privilege scope for every launch tool.
+2. Run a release-blocking spike against consumer Gmail and managed Workspace
+   accounts to establish whether capability expansion can add scopes to the
+   existing native grant or must reconnect the complete requested set.
+3. Store the scopes actually returned, not merely those requested.
+4. Render partial grants honestly and hide tools whose scopes are absent.
+5. Complete Google verification and any restricted-scope assessment before
+   stable rollout.
+
+The system browser, PKCE S256, random loopback port, state validation, and
+Keychain service remain unchanged.
+
+## Provider proxy
+
+Introduce route families under the existing connector proxy rather than new
+listeners. Each route declares:
+
+- required capability and scopes;
+- read or action classification;
+- accepted account binding;
+- request/response size bounds;
+- timeout and retry policy;
+- redaction policy for logs and issue reports;
+- idempotency behavior.
+
+Export Google Docs/Sheets to bounded representations for model reads. Do not
+send arbitrary Drive downloads inline through MCP. The proxy imports a file to
+the agent workspace, returns a reference, and lets the existing attachment path
+handle it.
+
+## Trust and action policy
+
+- `read_only`: only base servers are visible.
+- `approval`: Drive/Docs/Sheets action calls park before the provider request.
+- `autonomous`: only explicitly granted tools and account may bypass parking
+  after earned autonomy.
+- Sharing, deleting, moving across shared drives, and broad permission changes
+  remain approval-only in v1 even under autonomous mode.
+- Send/update retries resume from the stable pending action id. They never
+  blindly replay a completed mutation.
+
+## Delivery slices
+
+### Slice 0: scope and API spike (3-5 days)
+
+- Validate native grant expansion, Meet artifact availability, export limits,
+  idempotency options, and provider quotas.
+- Produce a scope-to-tool matrix and Google verification checklist.
+
+### Slice 1: capability shell (1 week)
+
+- Capability-grant model, plugin detail states, health checks, reconnect and
+  disconnect behavior.
+- No new provider tools yet.
+
+### Slice 2: Drive read path (2 weeks)
+
+- Metadata search, recent files, explicit read/export, imported file refs.
+- Injection fixtures and large-file bounds.
+
+### Slice 3: Meet + Contacts read path (1-2 weeks)
+
+- Attendee resolution and available meeting artifact reads.
+- Expected-unavailable states by account edition and organizer permissions.
+
+### Slice 4: Docs/Sheets actions (2 weeks)
+
+- Create and narrowly update operations behind the approval journal.
+- Shared-drive and permission-changing operations excluded or always parked.
+
+### Slice 5: skills, routines, and rollout (1 week)
+
+- Meeting prep/follow-up skills, template routines, metrics, rc dogfood, and
+  support runbook.
+
+## Verification
+
+- Rust unit tests for scope gating, account binding, route classification,
+  result bounds, ETag/version handling, and idempotent action resume.
+- MCP schema fixtures and pinned-runtime live smoke tests for every server.
+- OAuth matrix: first connect, partial grant, reconnect, token refresh,
+  `invalid_grant`, disconnect, server-side revoke, and managed-admin denial.
+- Live account matrix for consumer and Workspace accounts, plus Meet artifact
+  present/absent cases.
+- Prompt-injection corpus in Docs, Sheets cells, filenames, comments, and Meet
+  transcripts.
+- Sandbox proof that the agent cannot read the Keychain item while Rust can.
+
+## Rollout and operations
+
+Ship behind per-capability rc flags. Drive read can reach stable before write
+actions if verification permits. Add provider kill switches and quota/error
+dashboards without content telemetry. Record only coarse activation, success,
+latency, approval, denial, and provider error buckets.
+
+## Dependencies and decisions
+
+- Google OAuth verification and test Workspace tenant.
+- A settled scope expansion behavior from Slice 0.
+- No new ADR if the work follows ADR-0016. A new ADR is required before any
+  cloud index, domain-wide delegation, or backend-held provider credential.

--- a/docs/plugins/google-workspace-prd.md
+++ b/docs/plugins/google-workspace-prd.md
@@ -1,0 +1,146 @@
+# PRD: Google Workspace plugin
+
+- **Mode:** CEO
+- **Rank:** 1 of 10
+- **Score:** 94/100
+- **Date:** 2026-07-13
+- **Status:** Gmail + Calendar local mode shipped; expansion proposed
+- **Related:** JUN-277, ADR-0016
+
+## Thesis
+
+Google Workspace should be June's default work graph. The existing Gmail and
+Calendar connector proves the private architecture. The plugin should now turn
+that connection into a complete meeting loop: prepare from mail, calendar,
+files, and prior notes; capture the conversation; then draft the follow-up,
+update the source document, and schedule the next step.
+
+This is the highest-priority plugin because it combines broad adoption, daily
+frequency, meeting adjacency, and an already-shipped foundation. It is also the
+clearest demonstration of June's positioning: the account grant stays on the
+Mac and provider calls originate on-device.
+
+## Customer and problem
+
+The primary customer runs their work from Gmail, Calendar, Drive, Docs, and
+Meet. Context is scattered across threads, invitations, documents, and meeting
+artifacts. Before a meeting they reconstruct history manually. Afterward they
+copy action items into replies, documents, and events. Existing assistants can
+index this corpus in the cloud, but that is unacceptable for the confidential
+prosumer June is built for.
+
+## Product promise
+
+Connect Google once, choose the parts June may use, and move from meeting
+context to completed follow-through without giving OpenSoftware a credential
+that can read the account.
+
+## V1 experience
+
+1. The user opens Google Workspace in Plugins and sees Gmail and Calendar as
+   connected, plus optional Drive and Meet capabilities.
+2. Each capability explains its requested access before the system browser
+   opens Google's consent flow.
+3. June can prepare a briefing from relevant threads, attendees, calendar
+   context, Drive files, prior notes, and available Meet transcripts.
+4. During or after the meeting, June can cite source items and create a local
+   note with stable provider references.
+5. June can draft a reply, create or update an event, and create a new Docs or
+   Sheets artifact. Every outward action follows the routine's trust mode.
+6. The user can disconnect one Google account and verify that every Google
+   capability is off.
+
+## Scope
+
+### Launch expansion
+
+- Preserve shipped Gmail search/read/draft/send and Calendar read/event flows.
+- Add Drive metadata search, explicit file read/export, and file references.
+- Add Docs creation and targeted edit operations.
+- Add Sheets creation and range-level updates; rich spreadsheet work remains
+  the separate Spreadsheets plugin.
+- Add Contacts lookup for attendee resolution.
+- Add Meet space, recording, and transcript discovery where the account and
+  edition expose them.
+- Add meeting-prep and follow-up skills plus gallery routine templates.
+
+### Later
+
+- Slides generation after the artifact foundation exists.
+- BigQuery, admin-wide deployment, multi-account routing, and away-mode events.
+- Proactive Drive change triggers after the event architecture is approved.
+
+## Non-goals
+
+- Mirroring the user's Google corpus into OpenSoftware infrastructure.
+- Replacing Google editors with June-native collaboration.
+- Domain-wide delegation or an administrator grant in v1.
+- Silently broadening the scopes of already-connected accounts.
+- Treating Google sign-in as June identity; OS Accounts remains June identity.
+
+## Packaging
+
+The plugin contains:
+
+- Required connector capability: none. Users may enable any one Google family.
+- Optional connector capabilities: Gmail, Calendar, Drive, Contacts, Meet.
+- Skills: meeting prep, follow-up, inbox-to-note, agenda builder, decision log.
+- Templates: morning briefing, next-meeting brief, promised follow-ups, weekly
+  relationship recap.
+
+The listing remains one Google Workspace plugin instead of separate Gmail,
+Calendar, Drive, Docs, and Sheets tiles. Capability-level grants stay visible
+inside it.
+
+## Privacy and trust
+
+ADR-0016 remains binding. Refresh tokens live in the Keychain. Google API calls
+go from the device to Google through the Rust provider proxy. June API is not
+in the connector data path. Model inference remains a separate path and the
+consent copy says so.
+
+Provider content is untrusted. Full email bodies and file contents are fetched
+only when needed. Mutating tools live in separate action servers. Approval and
+earned autonomy are enforced in Rust.
+
+## Business model
+
+Local Google capabilities are available on Hobby. Event-triggered and
+multi-step routines are Pro. Existing agent usage meters model calls; Google
+API calls do not create a new June credit action.
+
+## Success measures
+
+| Metric | Target |
+| --- | ---: |
+| Connected Google users enabling Drive within 30 days | 35% |
+| Weekly connected users running a meeting brief | 30% |
+| Briefs followed by at least one completed follow-up action | 25% |
+| Median first successful Google read after opening the tile | under 2 minutes |
+| Google actions completed without correction | at least 97% |
+| Token-material incidents | 0 |
+
+## Risks and gates
+
+- Google verification for sensitive or restricted scopes is the external
+  release gate. Scope expansion cannot hide behind the existing approval.
+- Google's installed-app guidance currently says incremental authorization is
+  not supported for installed apps, while its broader OAuth guidance recommends
+  requesting access at the moment it is needed. Engineering must validate the
+  exact consent behavior before promising add-one-capability upgrades.
+- Meet artifacts depend on workspace edition, recording policy, and organizer
+  access. Missing artifacts are an expected state, not an error.
+- Large Drive files can exhaust model context. Metadata-first search and bounded
+  extraction are launch requirements.
+
+## Decision requested
+
+Approve one Google Workspace plugin with capability-level grants; prioritize
+Drive + meeting artifacts next; keep local connection free and routine
+automation Pro.
+
+## Sources
+
+- [Google OAuth for desktop apps](https://developers.google.com/identity/protocols/oauth2/native-app)
+- [Google OAuth policies](https://developers.google.com/identity/protocols/oauth2/policies)
+- [Google app data controls in ChatGPT](https://help.openai.com/en/articles/10408842)

--- a/docs/plugins/google-workspace-prd.md
+++ b/docs/plugins/google-workspace-prd.md
@@ -94,10 +94,10 @@ inside it.
 
 ## Privacy and trust
 
-ADR-0016 remains binding. Refresh tokens live in the Keychain. Google API calls
-go from the device to Google through the Rust provider proxy. June API is not
-in the connector data path. Model inference remains a separate path and the
-consent copy says so.
+The shipped Google path implements the local-mode design proposed in ADR-0016.
+Refresh tokens live in the Keychain. Google API calls go from the device to
+Google through the Rust provider proxy. June API is not in the connector data
+path. Model inference remains a separate path and the consent copy says so.
 
 Provider content is untrusted. Full email bodies and file contents are fetched
 only when needed. Mutating tools live in separate action servers. Approval and

--- a/docs/plugins/linear-implementation-plan.md
+++ b/docs/plugins/linear-implementation-plan.md
@@ -28,7 +28,7 @@ mutations.
 
 | Server | Tools |
 | --- | --- |
-| `june_linear` | `list_teams`, `list_projects`, `list_cycles`, `list_initiatives`, `search_issues`, `get_issue`, `list_project_updates` |
+| `june_linear` | `list_teams`, `list_users`, `list_projects`, `list_cycles`, `list_initiatives`, `search_issues`, `get_issue`, `list_issue_comments`, `list_project_updates` |
 | `june_linear_actions` | `create_issue`, `update_issue`, `add_comment`, `create_project_update` |
 
 Generate fixed GraphQL documents in Rust. Do not accept arbitrary GraphQL from
@@ -46,7 +46,9 @@ priority, assignee, timestamps, and bounded text.
 ## Action safety
 
 - `create_issue`: exact team and optional project preview; stable local action
-  id and post-response journal.
+  id and response journal. If Linear does not accept a provider idempotency
+  key, an ambiguous timeout blocks automatic replay until a recent-object
+  fingerprint reconciles the mutation or the user approves another attempt.
 - `update_issue`: allow only title, description, status, priority, assignee,
   project, and cycle in V1; approval shows field diff.
 - `add_comment` and `create_project_update`: rendered content preview.
@@ -64,8 +66,8 @@ delivery id, then fetch current state rather than trusting payload content.
 
 1. **Connection + teams (1 week).** OAuth, Keychain, selected teams, health,
    revoke.
-2. **Planning reads (1-2 weeks).** Projects, cycles, initiatives, issue search
-   and detail.
+2. **Planning reads (1-2 weeks).** Users, projects, cycles, initiatives, issue
+   search/detail/comments, and project updates.
 3. **Approved issue flow (1 week).** Create/update/comment with conflict and
    idempotency handling.
 4. **Project updates (1 week).** Read/create status updates.
@@ -91,5 +93,6 @@ to the current provider API.
 
 ## ADR threshold
 
-Local token custody/direct API calls can extend ADR-0016. A confidential token
+Local token custody/direct API calls can extend the local-mode pattern proposed
+by ADR-0016 once that decision is accepted or superseded. A confidential token
 exchange, app credential, or webhook relay requires an explicit ADR.

--- a/docs/plugins/linear-implementation-plan.md
+++ b/docs/plugins/linear-implementation-plan.md
@@ -1,0 +1,95 @@
+# Implementation plan: Linear plugin
+
+- **Mode:** CTO
+- **Date:** 2026-07-13
+- **Status:** Proposed; auth spike required
+- **PRD:** [linear-prd.md](linear-prd.md)
+- **Issue:** JUN-284
+
+## Technical objective
+
+Build a first-party Linear connector with selected-team enforcement, bounded
+GraphQL operations, rotated refresh tokens in Keychain, and approval-journaled
+mutations.
+
+## Phase 0: OAuth and API spike
+
+- Confirm whether Linear's public OAuth authorization-code flow supports PKCE
+  and a public desktop client without an embedded client secret.
+- Verify current refresh-token rotation, revoke, workspace/app actor behavior,
+  and scope semantics.
+- Compare user actor versus app actor. Use user actor for V1 unless app actor is
+  necessary and its visible attribution is product-approved.
+- Record an ADR if a confidential exchange or backend credential is required.
+- Establish GraphQL complexity, pagination, rate-limit, and idempotency behavior
+  for the exact launch operations.
+
+## Proposed servers
+
+| Server | Tools |
+| --- | --- |
+| `june_linear` | `list_teams`, `list_projects`, `list_cycles`, `list_initiatives`, `search_issues`, `get_issue`, `list_project_updates` |
+| `june_linear_actions` | `create_issue`, `update_issue`, `add_comment`, `create_project_update` |
+
+Generate fixed GraphQL documents in Rust. Do not accept arbitrary GraphQL from
+the model. Return stable ids, identifiers, URLs, team/project/cycle ids, status,
+priority, assignee, timestamps, and bounded text.
+
+## State and binding
+
+- Keychain rotated refresh/access material if Phase 0 proves local custody.
+- Workspace id, user/app actor id, selected team ids, scopes, health, and cursors
+  in SQLite.
+- Provider proxy overwrites/validates workspace and team from the bound account.
+- No issue corpus or GraphQL response cache beyond an active task.
+
+## Action safety
+
+- `create_issue`: exact team and optional project preview; stable local action
+  id and post-response journal.
+- `update_issue`: allow only title, description, status, priority, assignee,
+  project, and cycle in V1; approval shows field diff.
+- `add_comment` and `create_project_update`: rendered content preview.
+- Re-read target and updated-at value before commit; stale changes conflict.
+- Delete/archive/admin mutations do not exist. Autonomous mode is deferred.
+
+## Events
+
+Use live reads and bounded local polling for followed issues/projects while the
+Mac is awake. Linear webhooks require public HTTPS and are reserved for an
+away-mode relay. If later added, verify HMAC signature and timestamp, dedupe by
+delivery id, then fetch current state rather than trusting payload content.
+
+## Delivery slices after Phase 0
+
+1. **Connection + teams (1 week).** OAuth, Keychain, selected teams, health,
+   revoke.
+2. **Planning reads (1-2 weeks).** Projects, cycles, initiatives, issue search
+   and detail.
+3. **Approved issue flow (1 week).** Create/update/comment with conflict and
+   idempotency handling.
+4. **Project updates (1 week).** Read/create status updates.
+5. **Skills + rc (1 week).** Planning, standup, weekly status, GitHub composition.
+
+## Verification
+
+- OAuth rotation/reuse/revoke, workspace removal, selected-team change, missing
+  scopes, and actor attribution.
+- GraphQL fixtures for pagination, partial errors, deprecated fields, rate
+  limits, schema drift, and bounded selection sets.
+- Rust tests that forged workspace/team ids cannot escape the grant.
+- Action conflict, timeout, retry, batch partial-success, and idempotency tests.
+- Injection corpus in issues, comments, project updates, documents, labels, and
+  user/team names.
+- Live workspace walkthrough across two teams with different access.
+
+## Rollout
+
+Internal workspace, design partners, rc, stable. Use provider kill switch and
+content-free telemetry. Monitor schema deprecations and pin contract fixtures
+to the current provider API.
+
+## ADR threshold
+
+Local token custody/direct API calls can extend ADR-0016. A confidential token
+exchange, app credential, or webhook relay requires an explicit ADR.

--- a/docs/plugins/linear-prd.md
+++ b/docs/plugins/linear-prd.md
@@ -1,0 +1,105 @@
+# PRD: Linear plugin
+
+- **Mode:** CEO
+- **Rank:** 8 of 10
+- **Score:** 69/100
+- **Date:** 2026-07-13
+- **Status:** Proposed; tracked by JUN-284
+
+## Thesis
+
+Linear is the cleanest bridge from meeting decisions to product execution.
+June should prepare reviews from projects and issues, then draft the concrete
+issues, updates, and comments a team needs after the meeting.
+
+It ranks below GitHub because the audience is narrower and much of the value
+composes with GitHub, but it has a well-defined GraphQL/OAuth surface and a
+high-value action loop.
+
+## Customer and problem
+
+Product and engineering teams discuss work in meetings, then manually recreate
+decisions in Linear. Issues lack the rationale in the note; notes lack the live
+delivery state in Linear. Status reporting becomes repeated synthesis.
+
+## Product promise
+
+Connect a Linear workspace and let June turn selected meeting outcomes into
+reviewed issues and updates, with the workspace, team, project, and exact change
+visible before anything is written.
+
+## V1 experience
+
+- Connect a workspace and select allowed teams.
+- Prepare a planning or status meeting from projects, cycles, issues, and recent
+  updates.
+- Turn action items into draft issues with team/project, title, description,
+  assignee suggestion, and source note reference.
+- Approve issue creation, comments, and project updates individually or as a
+  clearly previewed batch.
+- Link June notes to Linear objects and refresh status on demand.
+
+## Scope
+
+### V1
+
+- Read teams, users, projects, cycles, initiatives, issues, comments, and project
+  updates within selected teams.
+- Create issue, update a narrow issue field set, add comment, create project
+  update behind approval.
+- Planning brief, standup, issue drafting, and weekly project-status skills.
+
+### Later
+
+- Customers, customer requests, releases, SLA, documents, agent sessions,
+  webhook routines, and autonomous triage.
+
+## Non-goals
+
+- Replacing Linear's planning UI.
+- Bulk reprioritization, deletion, archive, workspace administration, or team
+  configuration.
+- Full workspace indexing.
+- Autonomous issue mutation at launch.
+
+## Privacy and trust
+
+Use Linear OAuth with refresh-token rotation and store token material in the
+Keychain if the public client flow supports a desktop-safe exchange. Calls
+originate on-device. Team selection is enforced in Rust. Issue/comment content
+is untrusted. Every write is approved in v1.
+
+## Business model
+
+Local reads and approved writes are Hobby. Recurring status routines and
+cross-plugin GitHub/Slack workflows are Pro.
+
+## Success measures
+
+| Metric | Target |
+| --- | ---: |
+| Connections selecting at least one team | 90% |
+| Weekly connected users running a planning/status brief | 35% |
+| Draft issues approved | 60% |
+| Created issues needing team/project correction | under 2% |
+| Reads/writes outside selected teams | 0 successful |
+
+## Risks and gates
+
+- OAuth flow and refresh-token rotation changed in 2026; implementation must
+  follow current provider behavior.
+- Webhooks require public HTTPS and therefore away mode.
+- GraphQL makes over-fetching easy; every operation needs bounded selections.
+- Model-generated priority/assignee choices can look authoritative when they
+  are suggestions.
+
+## Decision requested
+
+Approve selected-team read access and approved narrow writes; pair the product
+launch with GitHub composition but do not block either plugin on the other.
+
+## Sources
+
+- [Linear OAuth 2.0](https://linear.app/developers/oauth-2-0-authentication)
+- [Linear webhooks](https://linear.app/developers/webhooks)
+- [Linear developer platform](https://linear.app/developers)

--- a/docs/plugins/microsoft-365-implementation-plan.md
+++ b/docs/plugins/microsoft-365-implementation-plan.md
@@ -35,7 +35,7 @@ must be generated from that table rather than assuming all capabilities.
 | `june_outlook` | `search_mail`, `read_thread`, `list_calendars`, `list_events`, `find_meeting_times` |
 | `june_outlook_actions` | `create_draft`, `send_draft`, `create_event`, `update_event` |
 | `june_m365_files` | `search_files`, `get_file_metadata`, `read_file` |
-| `june_m365_files_actions` | `create_file`, `update_file`, `move_file`, `share_file` |
+| `june_m365_files_actions` | `create_file`, `update_file` |
 | `june_teams` | limited read tools established by the spike |
 
 Do not expose one kitchen-sink Graph server. Tool visibility follows granted
@@ -71,8 +71,9 @@ and drive/site ids so updates target the exact source.
 - Action servers park before the Graph request in `approval`.
 - Autonomous mode is deferred until provider-specific idempotency and earned
   autonomy are proven.
-- External recipient mail, send, event cancellation, sharing, permission
-  change, move across drives/sites, and deletion remain approval-only.
+- External recipient mail, send, and event cancellation remain approval-only.
+  Sharing, permission changes, moves across drives/sites, and deletion are not
+  exposed in v1.
 - Tenant and account ids are server-bound and ignored if supplied by the model.
 
 ## Delivery slices

--- a/docs/plugins/microsoft-365-implementation-plan.md
+++ b/docs/plugins/microsoft-365-implementation-plan.md
@@ -112,6 +112,7 @@ matrix and conditional-access troubleshooting runbook.
 
 ## ADR threshold
 
-Delegated tokens on-device and direct Graph calls extend ADR-0016's pattern. An
+Delegated tokens on-device and direct Graph calls can extend the local-mode
+pattern proposed by ADR-0016 once that decision is accepted or superseded. An
 ADR is required before application permissions, a public webhook relay, tenant-
 wide deployment, or backend-held Microsoft credentials.

--- a/docs/plugins/microsoft-365-implementation-plan.md
+++ b/docs/plugins/microsoft-365-implementation-plan.md
@@ -1,0 +1,117 @@
+# Implementation plan: Microsoft 365 plugin
+
+- **Mode:** CTO
+- **Date:** 2026-07-13
+- **Status:** Proposed; API and tenant spike required
+- **PRD:** [microsoft-365-prd.md](microsoft-365-prd.md)
+
+## Technical objective
+
+Add a provider-neutral connector implementation for Microsoft Graph using
+delegated authorization code + PKCE, Keychain token custody, on-device Graph
+calls, explicit capability grants, and the existing trust/approval system.
+
+## Phase 0: Graph feasibility matrix
+
+Before defining launch parity, test a personal Microsoft account and two
+Entra tenants (standard and admin-restricted):
+
+- native desktop redirect and PKCE behavior;
+- refresh and conditional-access failure behavior;
+- delegated scopes for mail, calendar, OneDrive/SharePoint, and selected Teams
+  reads/actions;
+- tenant-admin consent requirements;
+- delta-query support, pagination, throttling, and resource ids;
+- file download/export bounds and sensitivity-label signals;
+- shared/delegated resources as explicit out-of-scope cases.
+
+Exit with a scope-to-tool matrix and supported account/tenant table. The UI
+must be generated from that table rather than assuming all capabilities.
+
+## Proposed servers
+
+| Server | Tools |
+| --- | --- |
+| `june_outlook` | `search_mail`, `read_thread`, `list_calendars`, `list_events`, `find_meeting_times` |
+| `june_outlook_actions` | `create_draft`, `send_draft`, `create_event`, `update_event` |
+| `june_m365_files` | `search_files`, `get_file_metadata`, `read_file` |
+| `june_m365_files_actions` | `create_file`, `update_file`, `move_file`, `share_file` |
+| `june_teams` | limited read tools established by the spike |
+
+Do not expose one kitchen-sink Graph server. Tool visibility follows granted
+capabilities, account binding, runtime mode, and trust mode.
+
+## Auth and account state
+
+- Register June as a public native client and use the system browser, PKCE S256,
+  state, nonce, and the supported loopback/custom redirect established by the
+  spike.
+- Store refresh/access material in a dedicated Keychain service per tenant and
+  account. Persist only tenant id, account id, email, capability/scopes, status,
+  cloud, and diagnostic timestamps.
+- Treat `interaction_required`, admin denial, conditional-access challenge,
+  tenant policy, expired refresh, and revoked grant as distinct UI states.
+- V1 supports one selected Microsoft account/tenant at a time.
+
+## Provider proxy and resource policy
+
+All Graph calls pass through connector-token routes in Rust. Route metadata
+declares scopes, capability, read/action class, account, timeout, response
+bound, retry class, and redaction. Use delta queries where available for local
+awake polling. Do not create Graph webhook subscriptions in local mode because
+they require a public endpoint and ongoing renewal.
+
+Imported files return workspace references. Avoid retaining bodies or files in
+SQLite. Preserve Graph resource ids, web URLs, ETags/change keys, tenant ids,
+and drive/site ids so updates target the exact source.
+
+## Trust policy
+
+- Base servers are read-only.
+- Action servers park before the Graph request in `approval`.
+- Autonomous mode is deferred until provider-specific idempotency and earned
+  autonomy are proven.
+- External recipient mail, send, event cancellation, sharing, permission
+  change, move across drives/sites, and deletion remain approval-only.
+- Tenant and account ids are server-bound and ignored if supplied by the model.
+
+## Delivery slices
+
+1. **Spike and registration (1-2 weeks).** Capability matrix, app registration,
+   consent copy, tenant test fixtures.
+2. **Auth shell (1 week).** Account state, Keychain, connect/reconnect/revoke,
+   diagnostics.
+3. **Outlook + Calendar reads (2 weeks).** Search/read, events, availability,
+   delta state.
+4. **Outlook + Calendar actions (1-2 weeks).** Draft/send and event updates with
+   action journal.
+5. **Files (2 weeks).** OneDrive/SharePoint search, read/import, bounded writes.
+6. **Teams read slice (1-2 weeks).** Only verified stable delegated surface.
+7. **Skills and rc (1 week).** Meeting flows, metrics, runbook, pilot.
+
+## Verification
+
+- OAuth/tenant matrix across personal, standard work/school, admin-restricted,
+  conditional-access, revoke, and reconnect cases.
+- Contract tests for Graph pagination, throttling and `Retry-After`, delta
+  tokens, ETags/change keys, partial errors, and national-cloud base URLs.
+- Rust account/tenant binding, route classification, result bounds, and action
+  idempotency tests.
+- Injection corpus across HTML mail, calendar bodies, filenames, documents,
+  Teams messages, and link previews.
+- Live permission tests proving June never exceeds the authorizing user's
+  source permissions.
+- Sandbox test that Hermes cannot read the Keychain item.
+
+## Rollout
+
+Internal tenant, invited design partners, rc, then stable. Expose capability
+availability and admin requirements before auth. Use per-family kill switches
+and content-free error/latency telemetry. Publish a supported tenant/account
+matrix and conditional-access troubleshooting runbook.
+
+## ADR threshold
+
+Delegated tokens on-device and direct Graph calls extend ADR-0016's pattern. An
+ADR is required before application permissions, a public webhook relay, tenant-
+wide deployment, or backend-held Microsoft credentials.

--- a/docs/plugins/microsoft-365-prd.md
+++ b/docs/plugins/microsoft-365-prd.md
@@ -1,0 +1,133 @@
+# PRD: Microsoft 365 plugin
+
+- **Mode:** CEO
+- **Rank:** 4 of 10
+- **Score:** 84/100
+- **Date:** 2026-07-13
+- **Status:** Proposed
+
+## Thesis
+
+Microsoft 365 is the enterprise counterpart to Google Workspace and the
+largest remaining gap in June's work graph. One plugin should cover Outlook
+mail and calendar, OneDrive and SharePoint files, and selected Teams context
+through Microsoft Graph. The product outcome is not "connect Microsoft"; it is
+private meeting preparation and follow-through for users whose organizations
+standardize on Microsoft.
+
+It ranks below Slack because enterprise tenant approval and Graph permission
+complexity slow activation, but it ranks above narrower knowledge and software
+delivery apps because it unlocks an entire work ecosystem.
+
+## Customer and problem
+
+Consultants, attorneys, accountants, recruiters, and enterprise operators live
+in Outlook, Teams, OneDrive, and SharePoint. Their meeting history, documents,
+and follow-ups are distributed across tenant-controlled systems. They need a
+personal assistant but cannot authorize a cloud service to create an
+unbounded secondary index of that work.
+
+## Product promise
+
+Connect a Microsoft account with delegated access, keep the refresh grant on
+the Mac, and let June prepare and act only within the scopes and resources the
+user and tenant have approved.
+
+## V1 experience
+
+- One Microsoft 365 tile with capability states for Outlook mail, Calendar,
+  Files, and Teams.
+- System-browser authorization with clear personal-account versus work/school
+  account and admin-consent outcomes.
+- Meeting brief from invite, attendees, recent mail, relevant files, Teams
+  context exposed by supported delegated APIs, and local June notes.
+- Draft mail, create/update a calendar event, and create or update a bounded
+  file with approval.
+- Stable links and source labels in June output.
+- Disconnect locally and handle tenant-side revoke or conditional-access
+  failure without partial phantom connection states.
+
+## Scope
+
+### V1
+
+- Outlook mail search/read/draft/send.
+- Calendar read, availability, event create/update.
+- OneDrive and SharePoint file metadata search and explicit read.
+- Selected Teams/channel context only where stable delegated Graph APIs and
+  tenant policy permit it.
+- Meeting prep and follow-up skills.
+
+### Later
+
+- Shared/delegated mailboxes and calendars, Planner/To Do, Teams meeting
+  transcripts/recordings, sensitivity labels, multiple tenants, sovereign
+  clouds, and away-mode change notifications.
+
+## Non-goals
+
+- Application permissions, domain-wide admin impersonation, or tenant-wide
+  indexing.
+- Replacing Microsoft Purview, retention, or eDiscovery controls.
+- Promising every Teams resource is available through one user grant.
+- Storing Microsoft content in June API.
+- Hiding admin-consent or conditional-access requirements from users.
+
+## Packaging
+
+- Required connector: none; each capability is optional within one plugin.
+- Skills: Outlook meeting prep, client follow-up, file brief, Teams recap.
+- Templates: tomorrow's meetings, unanswered client mail, weekly commitments.
+- Composition: Documents and Spreadsheets can produce local files; Microsoft
+  actions may publish an approved copy to the user's drive.
+
+## Privacy and trust
+
+Use delegated user permissions, not application permissions. Tokens stay in
+Keychain and Graph calls originate on-device. Resource permissions and tenant
+policy remain authoritative. June must state that inference follows the
+selected model path even though OpenSoftware is outside the connector path.
+
+Mail, files, and Teams messages are untrusted input. Write operations park in
+the Rust approval broker. Sharing, deletion, external recipients, and changes
+to broadly visible resources remain approval-only.
+
+## Business model
+
+Local read and approved actions are available on Hobby. Cross-capability
+routines and event-driven workflows are Pro. Enterprise admin deployment and
+policy are future products, not prerequisites for personal delegated access.
+
+## Success measures
+
+| Metric | Target |
+| --- | ---: |
+| Users completing auth after opening the tile | 55% |
+| Connected users with at least two capabilities working | 60% |
+| Weekly connected users running a meeting brief | 30% |
+| Completed follow-up action after a brief | 20% |
+| Support cases with an unexplained admin-consent failure | under 5% of connects |
+| Cross-tenant or permission-boundary incidents | 0 |
+
+## Risks and gates
+
+- Entra admin consent, conditional access, tenant policy, account type, and
+  sovereign cloud produce a large state matrix.
+- Graph webhook subscriptions require a public HTTPS endpoint and renewal;
+  local v1 should poll or use delta queries while awake.
+- Teams APIs and permissions are uneven. V1 must be scoped from verified Graph
+  support, not parity marketing.
+- Enterprise sensitivity labels and retention obligations may constrain file
+  content and caching.
+
+## Decision requested
+
+Approve one Microsoft 365 plugin built on delegated Graph access, with Outlook
+and Calendar first, Files second, and Teams only after an API/permission spike.
+
+## Sources
+
+- [Microsoft authorization code flow with PKCE](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow)
+- [Microsoft Graph mail overview](https://learn.microsoft.com/en-us/graph/api/resources/mail-api-overview)
+- [Microsoft Graph calendar overview](https://learn.microsoft.com/en-us/graph/api/resources/calendar-overview)
+- [Microsoft Graph Teams overview](https://learn.microsoft.com/en-us/graph/api/resources/teams-api-overview)

--- a/docs/plugins/notion-implementation-plan.md
+++ b/docs/plugins/notion-implementation-plan.md
@@ -1,0 +1,102 @@
+# Implementation plan: Notion plugin
+
+- **Mode:** CTO
+- **Date:** 2026-07-13
+- **Status:** Proposed; auth spike required
+- **PRD:** [notion-prd.md](notion-prd.md)
+- **Issue:** JUN-283
+
+## Technical objective
+
+Expose selected Notion content through read and action MCP servers, with the
+authorized page graph enforced in Rust and all writes parked for approval.
+
+## Phase 0: auth boundary
+
+Notion's documented public OAuth flow requires HTTP Basic authentication with
+a client id and client secret during code exchange. A desktop binary cannot
+protect that secret. Before implementation:
+
+1. Confirm whether Notion supports PKCE or another public-client flow for
+   distributed desktop apps.
+2. Confirm whether the authorized access token can be returned to and stored
+   only on the device after a narrowly scoped confidential exchange.
+3. Reject an embedded secret and a generic OpenSoftware token vault.
+4. If a TEE exchange, user-created internal connection, or other compromise is
+   chosen, document the credential/data boundary in an ADR and consent copy.
+
+Exit with a supported auth design, revoke flow, Marketplace/review requirements,
+and an honest privacy claim.
+
+## Proposed servers
+
+| Server | Tools |
+| --- | --- |
+| `june_notion` | `search_pages`, `get_page`, `list_data_source`, `query_data_source`, `list_comments` |
+| `june_notion_actions` | `create_page`, `update_page_properties`, `append_blocks`, `update_block` |
+
+Tool results preserve page/block/data-source ids, parent ids, canonical URLs,
+last-edited time, property schema, pagination cursor, and a compact content
+representation. Full block trees are bounded by depth, count, and bytes.
+
+## Authorization boundary
+
+Notion's page picker and API permissions determine the maximum accessible
+graph. Rust keeps a non-secret index of authorized root ids returned at connect
+time and treats provider 403/404 as permission outcomes. It never infers access
+from a cached path alone. Writes additionally require an approved parent within
+the current accessible graph.
+
+## State and events
+
+- Keychain token if the Phase 0 design preserves device custody.
+- Workspace/account id, bot id, authorized roots, capabilities, and health in
+  SQLite.
+- No page bodies or database row corpus at rest.
+- V1 freshness is live fetch plus optional bounded polling of user-followed
+  pages. Provider webhooks require public HTTPS and belong to away mode.
+
+## Write model
+
+- Create is preferred over broad in-place transformation.
+- Updates operate on explicit page/block ids and include last-edited/version
+  material where available.
+- Approval shows workspace, destination breadcrumb, operation, property diff,
+  and rendered content preview.
+- A preflight re-reads destination state before commit. Stale state returns a
+  conflict instead of overwriting.
+- Autonomous mode is deferred.
+
+## Delivery slices after Phase 0
+
+1. **Connection shell (1 week):** workspace state, authorized roots, revoke,
+   health, plugin detail.
+2. **Read path (2 weeks):** search, page/block read, data-source query, comments,
+   limits and pagination.
+3. **Approved create (1 week):** create page with exact-parent approval.
+4. **Targeted update (1-2 weeks):** properties and bounded block operations with
+   conflict preflight.
+5. **Skills and rc (1 week):** decision/project templates, metrics, runbook.
+
+## Verification
+
+- Auth, reconnect, revoke, removed-page-access, workspace removal, and partial
+  capability matrix.
+- Block-tree property tests for depth, pagination, unsupported types, mentions,
+  embeds, equations, and files.
+- Boundary tests that forged page/parent ids cannot escape authorized access.
+- Conflict/idempotency tests for create and update around retries and restarts.
+- Injection corpus in page title, rich text, comments, URLs, code blocks,
+  database properties, and embedded content.
+- Live workspace walkthrough with private/shared pages and schema changes.
+
+## Rollout
+
+Internal workspace, selected external workspaces, rc, stable. Use a provider
+kill switch and content-free telemetry. Publish supported block/property types
+and render unsupported content explicitly instead of dropping it.
+
+## ADR threshold
+
+Any backend-held secret or token, public webhook intake, or provider content
+relay is a new trust boundary and requires an ADR before shipping.

--- a/docs/plugins/notion-prd.md
+++ b/docs/plugins/notion-prd.md
@@ -1,0 +1,119 @@
+# PRD: Notion plugin
+
+- **Mode:** CEO
+- **Rank:** 6 of 10
+- **Score:** 77/100
+- **Date:** 2026-07-13
+- **Status:** Proposed; tracked by JUN-283
+
+## Thesis
+
+Notion is the strongest knowledge-base complement to June's private note graph.
+The plugin should bridge ephemeral meeting context and durable team knowledge:
+prepare from selected pages and databases, then publish a reviewed decision
+record, project update, or action list back to the right location.
+
+It ranks below the universal and ecosystem plugins because many users do not
+use Notion and its OAuth/token exchange creates a privacy-architecture question.
+It ranks above software delivery tools because its workflows apply across roles.
+
+## Customer and problem
+
+Teams intend Notion to be the source of truth, but meeting outcomes arrive late,
+inconsistently, or not at all. Before a meeting, people search pages manually.
+Afterward, they translate notes into a page or database row and lose source
+traceability. Broad workspace indexing solves search by increasing data copies.
+
+## Product promise
+
+Choose the Notion pages June may use. Prepare and publish from those bounded
+sources while local June notes remain private unless the user explicitly sends
+content to Notion.
+
+## V1 experience
+
+- Connect from Plugins and use Notion's page picker to select accessible roots.
+- Search selected pages/data sources and read a page on demand.
+- Link a June note to a Notion page without copying the entire note.
+- Draft a decision record, project update, or action database entry from a
+  meeting.
+- Preview the destination, parent, properties, and content before creation or
+  update.
+- Disconnect and remove every Notion capability from the runtime.
+
+## Scope
+
+### V1
+
+- Search, page/data-source metadata, bounded page/block read, comments read.
+- Create a page under an approved parent.
+- Append/update a narrowly targeted block range or database properties.
+- Meeting brief, decision record, and project-update skills.
+- Local polling while awake for explicitly followed pages if feasible.
+
+### Later
+
+- Multiple workspaces, broad sync, comments/actions, files, team-wide install,
+  and webhook-triggered routines through an approved away-mode relay.
+
+## Non-goals
+
+- Replacing Notion search or editing UI.
+- Mirroring an entire workspace into June or OpenSoftware.
+- Accessing pages outside the Notion authorization/page picker.
+- Autonomous publishing at launch.
+- Treating every database schema as a generic spreadsheet.
+
+## Packaging
+
+- Required connector: Notion.
+- Skills: meeting-to-decision, project update, research brief, page maintenance.
+- Templates: decision log, weekly project status, customer meeting recap.
+- Composition: Google/Microsoft calendar and Slack context can feed a draft;
+  Notion remains the explicit publication destination.
+
+## Privacy and trust
+
+Notion public connections use OAuth and a client secret for token exchange. The
+implementation must resolve whether a public desktop distribution can keep the
+user token on-device without embedding a reusable secret. Until then, the PRD
+does not make the Google local-mode credential claim.
+
+Notion content is untrusted input. The user-selected page set and provider
+permissions form a hard boundary. All creates and updates require approval in
+v1, with exact destination and diff visible.
+
+## Business model
+
+Local reads and approved publishing are Hobby if the auth design preserves the
+privacy baseline. Triggered routines and cross-plugin publishing flows are Pro.
+
+## Success measures
+
+| Metric | Target |
+| --- | ---: |
+| Connections selecting at least one page root | 85% |
+| Weekly connected users reading or publishing | 30% |
+| Drafts approved and published | 60% |
+| Published pages requiring a manual structural repair | under 5% |
+| Reads outside authorized page roots | 0 successful |
+
+## Risks and gates
+
+- Confidential-client OAuth is the first gate.
+- Notion APIs expose block trees and evolving data-source schemas; lossless
+  editing is not a credible v1 promise.
+- Webhooks require a public endpoint and can arrive out of order; local v1 does
+  not quietly depend on them.
+- Page content can instruct the model to publish or disclose unrelated data.
+
+## Decision requested
+
+Approve a bounded-page Notion plugin with read-on-demand and approved publish;
+require the auth spike before implementation and defer webhook routines.
+
+## Sources
+
+- [Notion public connection authorization](https://developers.notion.com/guides/get-started/authorization)
+- [Notion public connections](https://developers.notion.com/guides/get-started/public-connections)
+- [Notion webhooks](https://developers.notion.com/reference/webhooks)

--- a/docs/plugins/portfolio.md
+++ b/docs/plugins/portfolio.md
@@ -153,6 +153,7 @@ top-ten decision without first changing the family's assumptions.
 | Salesforce | 19 | 9 | 13 | 11 | 8 | 2 | 62 |
 | Asana | 17 | 10 | 11 | 10 | 8 | 5 | 61 |
 | Box | 16 | 11 | 8 | 9 | 9 | 7 | 60 |
+| GitLab Issues | 17 | 9 | 10 | 10 | 8 | 6 | 60 |
 | ClickUp | 16 | 10 | 11 | 9 | 8 | 5 | 59 |
 | Dropbox | 15 | 11 | 8 | 9 | 9 | 7 | 59 |
 | Pipedrive | 17 | 8 | 12 | 9 | 8 | 5 | 59 |
@@ -183,6 +184,10 @@ skills and app integrations already represented by the capability candidates;
 including them would double-count the same value. They remain an important
 packaging pattern for future June skill collections, not a distinct connector
 or execution capability competing for an implementation slot.
+
+Provider deployment variants such as the GitHub Enterprise app template are
+folded into the parent capability score. They affect delivery and rollout, but
+do not represent an additional user job or portfolio slot.
 
 ## Sequencing
 

--- a/docs/plugins/portfolio.md
+++ b/docs/plugins/portfolio.md
@@ -1,0 +1,243 @@
+# June plugin portfolio: top 10
+
+- **Owner:** CEO + CTO
+- **Date:** 2026-07-13
+- **Status:** Proposed portfolio for JUN-309
+- **Related:** JUN-275, JUN-278, JUN-283, JUN-284, JUN-285
+
+## Executive decision
+
+June should launch a deliberately small, first-party plugin portfolio that
+turns meeting context into completed work. The first ten plugins should be:
+
+| Rank | Plugin | Score | Portfolio role | Current state |
+| ---: | --- | ---: | --- | --- |
+| 1 | Google Workspace | 94 | Default personal work graph | Gmail + Calendar shipped; expansion proposed |
+| 2 | Browser use | 91 | Universal fallback for web work | Accepted in JUN-278; implementation active |
+| 3 | Slack | 86 | Team context and follow-through | Proposed in the connector roadmap |
+| 4 | Microsoft 365 | 84 | Enterprise work graph | New proposal |
+| 5 | Computer use | 81 | Universal fallback for Mac work | Accepted phase 2 in JUN-278 |
+| 6 | Notion | 77 | Durable team knowledge | Tracked by JUN-283 |
+| 7 | GitHub | 73 | Software delivery context and action | Tracked by JUN-285 |
+| 8 | Linear | 69 | Product execution context and action | Tracked by JUN-284 |
+| 9 | Documents | 67 | Local-first finished written artifacts | New proposal |
+| 10 | Spreadsheets | 64 | Local-first structured analysis | New proposal |
+
+This ordering is a portfolio priority, not an instruction to stop work already
+in flight. Google remains the release baseline. Browser use can ship before
+Computer use because the latter still has a driver and macOS sandbox spike.
+Provider review, store review, or OAuth verification can move one workstream
+around another without changing the strategic ranking.
+
+## What changed in the benchmark
+
+The current ChatGPT feature is not the legacy 2023 plugin manifest model. As
+of 2026-07-09, OpenAI describes a plugin as a workflow package that can contain
+skills, apps, and app templates. The underlying app supplies external data,
+actions, interactive UI, search, sync, or deep research; installation policy
+and app permission policy remain separate. The directory is available across
+ChatGPT web, desktop, Work, and Codex.
+
+That model maps cleanly to June if June keeps its own canonical terms:
+
+- A **plugin** is the user-facing capability bundle in the Plugins area.
+- A **Skill** provides reusable workflow guidance.
+- A **Toolset** groups runtime tools.
+- An **MCP server** exposes tools to the embedded runtime.
+- A **connector** is specifically the private-by-architecture path to a
+  third-party account. A connector may be one component of a plugin, but the
+  words are not interchangeable.
+
+June should adopt the useful product layering without adopting cloud indexing
+as the default. A plugin can be installed while its optional connector is not
+connected. Connecting an account grants only provider scopes. A plugin's
+trust mode decides how June governs outward actions. None of those controls
+override permissions in the source system.
+
+## Surface inventory
+
+The benchmark exposes six capability families:
+
+| Family | Current benchmark behavior | June interpretation |
+| --- | --- | --- |
+| Workflow packaging | Skills, apps, and app templates can ship together | First-party plugin bundles with a manifest, bundled skills, toolsets, and optional connectors |
+| Discovery | Directory, search, categories, featured listings, installed state | The JUN-275 Plugins area plus contextual suggestions in chat |
+| Invocation | Explicit selection, `@` mention, or model discovery | Plugin chips, slash/mention entry points, and a visible suggestion card |
+| Data access | Live search and optional pre-indexed sync | Live, metadata-first local connector reads; no provider corpus copied to OpenSoftware |
+| Action control | Read, routine write, important write, and admin policy | Existing `read_only -> approval -> autonomous` trust modes and broker-enforced approvals |
+| Administration | Role availability, app setup, action controls, domains, disconnect | Personal v1 connection controls; team policy only after June has an organization model |
+
+Interactive third-party widgets and cloud-wide pre-indexing are not launch
+requirements for June. June's local desktop surface, note graph, routines, and
+approval cards already cover the higher-value parts of the job.
+
+### Candidate census reviewed
+
+The directory is dynamic and varies by plan, workspace, role, region, and
+supported surface. This census covers every candidate family named by the
+current official directory, plugin use-case guide, app help, and workspace
+release notes available during the 2026-07-13 review. It is not a claim that
+every account sees every listing.
+
+| Candidate family | Named current examples reviewed | Portfolio disposition |
+| --- | --- | --- |
+| Google work graph | Gmail, Calendar, Drive, Docs, Sheets, Slides, Meet, Contacts, BigQuery | Google Workspace selected; BigQuery and Slides deferred |
+| Microsoft work graph | Outlook Email, Outlook Calendar, OneDrive, SharePoint, Teams | Microsoft 365 selected as one capability-granular plugin |
+| Team communication and knowledge | Slack, Notion, Asana, Intercom | Slack and Notion selected; Asana and Intercom deferred |
+| Software delivery | GitHub, GitHub Enterprise template, Linear, Replit, Lovable | GitHub and Linear selected; hosted builders deferred |
+| File stores | Dropbox, Box | Deferred behind ecosystem file access and local artifacts |
+| CRM, structured data, and warehouses | HubSpot, Airtable, Databricks template, Snowflake template | Deferred for narrower ICP and admin/away-mode complexity |
+| Creative work | Adobe, Canva, Figma | Deferred until the local artifact foundation proves itself |
+| Consumer and lifestyle | AllTrails, Apple Music, Booking.com, Expedia, Instacart, Spotify, Target, Tripadvisor, Zillow | Outside June's private work focus |
+| Agent execution | Browser interaction and computer interaction | Browser use and Computer use selected |
+| Local work products | Documents, spreadsheets, PDFs, presentations, visualizations, sites | Documents and Spreadsheets selected; adjacent formats follow the shared artifact broker |
+
+The census also reviewed the cross-cutting surfaces around each listing:
+directory discovery, search and categories, explicit and model-suggested
+invocation, interactive UI, live search, deep research, pre-indexed sync, write
+actions, per-action confirmation, role access, domain restriction, connection,
+disconnect, developer-mode custom apps, public review, and app templates. June's
+shared product contract below records which of those surfaces it should adopt.
+
+## Ranking method
+
+Each candidate was scored out of 100. The rubric intentionally rewards June's
+core loop and private architecture over directory visibility.
+
+| Criterion | Weight | Question |
+| --- | ---: | --- |
+| Core-loop fit | 25 | Does it improve capture -> understand -> act? |
+| ICP frequency | 20 | How often does June's confidential prosumer encounter the job? |
+| Action leverage | 15 | Can June complete work, not only retrieve context? |
+| Retention and composition | 15 | Does it create recurring use and combine with notes, routines, and other plugins? |
+| Privacy differentiation | 15 | Does local execution make June meaningfully more trustworthy or useful? |
+| Delivery confidence | 10 | Can the team ship a narrow, reliable v1 with known APIs and review paths? |
+
+Scores reflect evidence available on 2026-07-13, not permanent market facts.
+They should be revisited after 30-day activation, weekly use, approval, and
+task-completion data exist.
+
+## Sequencing
+
+### Wave 0: finish the foundation
+
+1. Preserve the shipped Google Gmail + Calendar path and Plugins foundation.
+2. Ship Browser use v1 and finish the Computer use driver spike.
+3. Extract a provider-neutral connector kit from the Google implementation:
+   token custody, account index, provider proxy, read/action server split,
+   trust enforcement, approval journal, and health diagnostics.
+
+### Wave 1: cover the two work ecosystems
+
+4. Add Slack local mode.
+5. Expand Google Workspace with Drive and Meet artifacts.
+6. Build Microsoft 365 on the provider-neutral connector kit.
+
+### Wave 2: make context operational
+
+7. Add Notion.
+8. Add GitHub.
+9. Add Linear.
+
+### Wave 3: create finished local artifacts
+
+10. Ship Documents, then Spreadsheets, on one artifact broker and shared
+    render-and-verify pipeline.
+11. Re-run the portfolio score before starting the next candidate.
+
+The waves permit parallel engineering where provider registration, external
+review, and local implementation have independent critical paths. They do not
+permit shipping multiple one-off OAuth stacks.
+
+## Shared product contract
+
+Every launch plugin must satisfy the same contract:
+
+1. The listing states what the plugin can read, what it can change, what leaves
+   the device for inference, and whether OpenSoftware is in the connector data
+   path.
+2. Install, connect, grant, trust mode, and runtime mode are separate states.
+3. The Plugins tile, Settings control, and contextual in-chat suggestion point
+   to one source of truth.
+4. Read tools return compact structured summaries first. Full bodies or files
+   are fetched only when the task requires them.
+5. Mutating tools are separate from read tools and enforced in Rust, not by
+   prompting the model.
+6. Disconnect revokes provider access where supported, removes Keychain
+   material, disables the runtime surface, ends active leases, and verifies the
+   disconnected state.
+7. Provider content is untrusted input. Tool descriptions and the June soul
+   carry injection warnings, while the broker remains the enforcement point.
+8. Routines receive explicit toolsets and an explicit account binding. No
+   routine silently selects the first account.
+9. Every action has a stable idempotency key or a local action journal before
+   retries are allowed.
+10. No plugin introduces an upstream provider key into the desktop binary or
+    routes provider content through June API unless a separately approved
+    away-mode design requires it.
+
+## Business model
+
+The private connection itself should remain available on Hobby. Privacy is not
+the upsell. Pro value comes from high-frequency automation: event-triggered
+routines, multi-step cross-plugin workflows, unattended execution where the
+provider permits it, and higher run limits. Computer use can remain Pro while
+its cost and support burden are measured. Local Documents and Spreadsheets
+should be broadly available, with model calls charged through existing agent
+usage.
+
+## Portfolio success metrics
+
+| Metric | 90-day target | Why it matters |
+| --- | ---: | --- |
+| Weekly active users with at least one enabled plugin | 50% | Plugins become a core product surface |
+| Enabled-plugin users completing one plugin-backed task per week | 40% | Measures work completed, not connections |
+| Median time from tile open to first successful read | under 3 minutes | Setup is not the product |
+| Approved actions completed without correction | at least 95% | Trust must precede autonomy |
+| Connector-derived security or token incidents | 0 | Non-negotiable |
+| 30-day retention lift for plugin users | at least 15 points | Validates portfolio value |
+
+Provider-specific PRDs add activation and outcome measures without replacing
+these shared metrics.
+
+## Explicit deferrals
+
+- **Dropbox, Box, OneDrive-only, and SharePoint-only plugins:** valuable file
+  access, but Google Workspace, Microsoft 365, Notion, and local Documents cover
+  the dominant jobs first. Provider-specific file stores remain candidates.
+- **HubSpot and other CRMs:** strong meeting follow-through but narrower than
+  the first ten and likely to need an away-mode webhook path for the best
+  proactive experience.
+- **Figma, Canva, and presentation creation:** compelling output, but June
+  should prove the shared artifact broker with Documents and Spreadsheets
+  before adding remote design surfaces or a presentation renderer.
+- **Airtable and databases:** overlap with Spreadsheets, Notion, and Linear.
+- **Travel, shopping, real estate, education, music, and lifestyle:** visible
+  in the public app directory but outside June's private work focus.
+- **A third-party plugin marketplace:** the security, signing, update, and
+  policy model is a separate product. The first ten are first-party bundles.
+- **Cloud sync of entire provider corpora:** conflicts with the local-mode
+  trust story. Live, scoped reads come first; away mode requires its own
+  accepted threat model.
+
+## Source snapshot
+
+The source snapshot is intentionally dated because the ecosystem changed four
+days before this document was written.
+
+- [Plugins in ChatGPT and Codex](https://help.openai.com/en/articles/20001256-plugins-in-chatgpt-and-codex) - package model, directory, installation policy, app permissions, and surfaces.
+- [Apps in ChatGPT](https://help.openai.com/en/articles/11487775-connectors-in-chatgpt) - interactive UI, search, deep research, sync, write actions, and admin controls.
+- [Plugin use cases and prompts](https://help.openai.com/en/articles/12084614-app-use-cases-and-prompts) - current work categories and supported app examples.
+- [ChatGPT release notes](https://help.openai.com/en/articles/6825453-chatgpt-release-notes) - current Google, Microsoft, Box, Dropbox, Notion, and Linear action expansion.
+- [ChatGPT Business release notes](https://help.openai.com/en/articles/11391654) - current Slack, Asana, Intercom, Google, Microsoft, and workspace plugin changes.
+- [ChatGPT public app directory](https://chatgpt.com/apps/) - public featured, productivity, and lifestyle inventory.
+- [Apps SDK tool design](https://developers.openai.com/apps-sdk/plan/tools) - focused tools, predictable structured output, read/write separation, and discovery metadata.
+- [Apps SDK guidelines](https://developers.openai.com/apps-sdk/app-guidelines) - action annotations, data minimization, reliability, and review expectations.
+
+## Companion documents
+
+Each ranked plugin has a CEO-mode PRD and CTO-mode implementation plan in this
+directory. These documents are proposals unless their status says an existing
+June decision is already accepted. An implementation plan does not by itself
+authorize a provider registration, a new permission, an external deploy, or a
+change to an accepted ADR.

--- a/docs/plugins/portfolio.md
+++ b/docs/plugins/portfolio.md
@@ -131,9 +131,11 @@ task-completion data exist.
 ### Reproducible scorecard
 
 Values are weighted points, not unweighted ratings. Each row sums to its total,
-so a reviewer can change one assumption without reconstructing the model.
-Grouped deferred rows use the highest-scoring member of that family, giving an
-omitted family its strongest reasonable case.
+so a reviewer can change one assumption without reconstructing the model. Every
+omitted candidate within ten points of the cutoff is scored individually. The
+remaining grouped rows are conservative family ceilings: their best member is
+at least 13 points below the cutoff, so member-level variance cannot change the
+top-ten decision without first changing the family's assumptions.
 
 | Candidate | Core /25 | Frequency /20 | Action /15 | Retention /15 | Privacy /15 | Delivery /10 | Total |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -147,24 +149,40 @@ omitted family its strongest reasonable case.
 | Linear | 18 | 12 | 13 | 11 | 8 | 7 | **69** |
 | Documents | 18 | 15 | 11 | 9 | 10 | 4 | **67** |
 | Spreadsheets | 17 | 13 | 12 | 9 | 8 | 5 | **64** |
-| CRM and sales: Salesforce, HubSpot, Pipedrive, Zoho CRM, Clay | 19 | 10 | 13 | 11 | 8 | 2 | 63 |
-| Project management: Aha!, Asana, Azure Boards, Basecamp, ClickUp, Teamwork.com | 17 | 10 | 11 | 10 | 8 | 5 | 61 |
-| File stores: Box, Dropbox | 16 | 11 | 8 | 9 | 9 | 7 | 60 |
-| Creative and design: Adobe, Canva, Figma | 14 | 8 | 12 | 9 | 7 | 6 | 56 |
-| Data and warehouses: Airtable, BigQuery, Databricks, Hex, Snowflake | 12 | 7 | 11 | 8 | 8 | 5 | 51 |
-| Support: Intercom, Help Scout, Zoho Desk | 14 | 7 | 10 | 8 | 7 | 4 | 50 |
-| Hosted sites and builders: Sites, Replit, Lovable | 12 | 6 | 13 | 8 | 5 | 4 | 48 |
+| HubSpot | 19 | 10 | 13 | 11 | 8 | 2 | 63 |
+| Salesforce | 19 | 9 | 13 | 11 | 8 | 2 | 62 |
+| Asana | 17 | 10 | 11 | 10 | 8 | 5 | 61 |
+| Box | 16 | 11 | 8 | 9 | 9 | 7 | 60 |
+| ClickUp | 16 | 10 | 11 | 9 | 8 | 5 | 59 |
+| Dropbox | 15 | 11 | 8 | 9 | 9 | 7 | 59 |
+| Pipedrive | 17 | 8 | 12 | 9 | 8 | 5 | 59 |
+| Azure Boards | 16 | 9 | 11 | 9 | 7 | 5 | 57 |
+| Canva | 14 | 8 | 12 | 9 | 7 | 6 | 56 |
+| Zoho CRM | 16 | 8 | 11 | 9 | 8 | 4 | 56 |
+| Aha! | 15 | 9 | 10 | 10 | 7 | 4 | 55 |
+| Basecamp | 15 | 9 | 10 | 9 | 7 | 5 | 55 |
+| Figma | 14 | 8 | 11 | 9 | 7 | 6 | 55 |
+| Teamwork.com | 14 | 8 | 10 | 9 | 7 | 6 | 54 |
+| Adobe | 13 | 8 | 11 | 8 | 7 | 6 | 53 |
+| Clay | 14 | 7 | 11 | 9 | 7 | 4 | 52 |
+| Data and warehouses family ceiling | 12 | 7 | 11 | 8 | 8 | 5 | 51 |
+| Support family ceiling | 14 | 7 | 10 | 8 | 7 | 4 | 50 |
+| Hosted sites and builders family ceiling | 12 | 6 | 13 | 8 | 5 | 4 | 48 |
 | Presentations and visualizations | 12 | 8 | 10 | 7 | 6 | 4 | 47 |
-| Role packages: six current role-specific bundles | 11 | 7 | 9 | 8 | 6 | 5 | 46 |
 | Remote infrastructure: DigitalOcean and remote workspaces | 8 | 4 | 11 | 6 | 4 | 4 | 37 |
 | Consumer and lifestyle directory apps | 5 | 4 | 8 | 4 | 3 | 6 | 30 |
 
-The closest omission is CRM and sales at 63, one point below Spreadsheets.
-Its meeting follow-through is strong, but June's current ICP encounters it less
-often, its best proactive workflows need administrator setup or away-mode
-events, and Salesforce-class distribution adds a difficult credential and
-review path. Customer evidence can change that decision; the threshold is now
-explicit.
+The closest omission is HubSpot at 63, one point below Spreadsheets. CRM meeting
+follow-through is strong, but June's current ICP encounters it less often, its
+best proactive workflows need administrator setup or away-mode events, and
+distribution adds a difficult credential and review path. Customer evidence
+can change that decision; the threshold is now explicit.
+
+The six role-specific plugins are not independently scored because they bundle
+skills and app integrations already represented by the capability candidates;
+including them would double-count the same value. They remain an important
+packaging pattern for future June skill collections, not a distinct connector
+or execution capability competing for an implementation slot.
 
 ## Sequencing
 

--- a/docs/plugins/portfolio.md
+++ b/docs/plugins/portfolio.md
@@ -74,30 +74,41 @@ approval cards already cover the higher-value parts of the job.
 ### Candidate census reviewed
 
 The directory is dynamic and varies by plan, workspace, role, region, and
-supported surface. This census covers every candidate family named by the
-current official directory, plugin use-case guide, app help, and workspace
-release notes available during the 2026-07-13 review. It is not a claim that
+supported surface. This census covers the complete product surface and every
+candidate or family specifically named by the official directory, sync
+catalog, plugin use-case guide, app help, and workspace release notes available
+during the 2026-07-13 review. OpenAI describes 66 single-app plugins without
+publishing one stable, account-independent list, so this is not a claim that
 every account sees every listing.
 
 | Candidate family | Named current examples reviewed | Portfolio disposition |
 | --- | --- | --- |
 | Google work graph | Gmail, Calendar, Drive, Docs, Sheets, Slides, Meet, Contacts, BigQuery | Google Workspace selected; BigQuery and Slides deferred |
 | Microsoft work graph | Outlook Email, Outlook Calendar, OneDrive, SharePoint, Teams | Microsoft 365 selected as one capability-granular plugin |
-| Team communication and knowledge | Slack, Notion, Asana, Intercom | Slack and Notion selected; Asana and Intercom deferred |
-| Software delivery | GitHub, GitHub Enterprise template, Linear, Replit, Lovable | GitHub and Linear selected; hosted builders deferred |
+| Team communication and knowledge | Slack, Notion | Slack and Notion selected |
+| Project and product management | Aha!, Asana, Azure Boards, Basecamp, ClickUp, Linear, Teamwork.com | Linear selected; the rest scored as alternatives |
+| Software delivery | GitHub, GitHub Enterprise template, GitLab Issues, Replit, Lovable | GitHub selected; GitLab and hosted builders deferred |
 | File stores | Dropbox, Box | Deferred behind ecosystem file access and local artifacts |
-| CRM, structured data, and warehouses | HubSpot, Airtable, Databricks template, Snowflake template | Deferred for narrower ICP and admin/away-mode complexity |
+| CRM and sales | Salesforce, HubSpot, Pipedrive, Zoho CRM, Clay | Scored below the top ten; revisit when sales workflows are a primary ICP |
+| Customer support | Intercom, Help Scout, Zoho Desk | Scored below the top ten; narrower than June's current ICP |
+| Structured data and warehouses | Airtable, Databricks, Hex, Snowflake, BigQuery | Deferred for narrower ICP and admin/data-model complexity |
 | Creative work | Adobe, Canva, Figma | Deferred until the local artifact foundation proves itself |
 | Consumer and lifestyle | AllTrails, Apple Music, Booking.com, Expedia, Instacart, Spotify, Target, Tripadvisor, Zillow | Outside June's private work focus |
 | Agent execution | Browser interaction and computer interaction | Browser use and Computer use selected |
 | Local work products | Documents, spreadsheets, PDFs, presentations, visualizations, sites | Documents and Spreadsheets selected; adjacent formats follow the shared artifact broker |
+| Hosted and remote execution | ChatGPT Sites, DigitalOcean Droplet Workspace, Codex Remote | Deferred; June should first prove local artifacts and execution |
+| Role packages | Sales, Data Analytics, Product Design, Creative Production, Investment Banking, Public Equity Investing | Evaluated as packaging patterns; the underlying jobs score below the first ten |
 
 The census also reviewed the cross-cutting surfaces around each listing:
 directory discovery, search and categories, explicit and model-suggested
 invocation, interactive UI, live search, deep research, pre-indexed sync, write
 actions, per-action confirmation, role access, domain restriction, connection,
-disconnect, developer-mode custom apps, public review, and app templates. June's
-shared product contract below records which of those surfaces it should adopt.
+disconnect, developer-mode custom apps, public review, app templates, locally
+built plugins, workspace sharing, role packages, Sites, remote workspaces,
+record-and-replay skill creation, RBAC, analytics, and organization policy.
+June's shared product contract below records which of those surfaces it should
+adopt. Local-plugin sharing and a third-party marketplace are platform choices,
+not candidates in the end-user top-ten ranking.
 
 ## Ranking method
 
@@ -116,6 +127,44 @@ core loop and private architecture over directory visibility.
 Scores reflect evidence available on 2026-07-13, not permanent market facts.
 They should be revisited after 30-day activation, weekly use, approval, and
 task-completion data exist.
+
+### Reproducible scorecard
+
+Values are weighted points, not unweighted ratings. Each row sums to its total,
+so a reviewer can change one assumption without reconstructing the model.
+Grouped deferred rows use the highest-scoring member of that family, giving an
+omitted family its strongest reasonable case.
+
+| Candidate | Core /25 | Frequency /20 | Action /15 | Retention /15 | Privacy /15 | Delivery /10 | Total |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Google Workspace | 24 | 20 | 14 | 14 | 14 | 8 | **94** |
+| Browser use | 23 | 18 | 15 | 15 | 12 | 8 | **91** |
+| Slack | 22 | 18 | 14 | 14 | 12 | 6 | **86** |
+| Microsoft 365 | 23 | 18 | 13 | 13 | 12 | 5 | **84** |
+| Computer use | 22 | 17 | 15 | 14 | 10 | 3 | **81** |
+| Notion | 20 | 15 | 12 | 13 | 11 | 6 | **77** |
+| GitHub | 19 | 13 | 13 | 12 | 9 | 7 | **73** |
+| Linear | 18 | 12 | 13 | 11 | 8 | 7 | **69** |
+| Documents | 18 | 15 | 11 | 9 | 10 | 4 | **67** |
+| Spreadsheets | 17 | 13 | 12 | 9 | 8 | 5 | **64** |
+| CRM and sales: Salesforce, HubSpot, Pipedrive, Zoho CRM, Clay | 19 | 10 | 13 | 11 | 8 | 2 | 63 |
+| Project management: Aha!, Asana, Azure Boards, Basecamp, ClickUp, Teamwork.com | 17 | 10 | 11 | 10 | 8 | 5 | 61 |
+| File stores: Box, Dropbox | 16 | 11 | 8 | 9 | 9 | 7 | 60 |
+| Creative and design: Adobe, Canva, Figma | 14 | 8 | 12 | 9 | 7 | 6 | 56 |
+| Data and warehouses: Airtable, BigQuery, Databricks, Hex, Snowflake | 12 | 7 | 11 | 8 | 8 | 5 | 51 |
+| Support: Intercom, Help Scout, Zoho Desk | 14 | 7 | 10 | 8 | 7 | 4 | 50 |
+| Hosted sites and builders: Sites, Replit, Lovable | 12 | 6 | 13 | 8 | 5 | 4 | 48 |
+| Presentations and visualizations | 12 | 8 | 10 | 7 | 6 | 4 | 47 |
+| Role packages: six current role-specific bundles | 11 | 7 | 9 | 8 | 6 | 5 | 46 |
+| Remote infrastructure: DigitalOcean and remote workspaces | 8 | 4 | 11 | 6 | 4 | 4 | 37 |
+| Consumer and lifestyle directory apps | 5 | 4 | 8 | 4 | 3 | 6 | 30 |
+
+The closest omission is CRM and sales at 63, one point below Spreadsheets.
+Its meeting follow-through is strong, but June's current ICP encounters it less
+often, its best proactive workflows need administrator setup or away-mode
+events, and Salesforce-class distribution adds a difficult credential and
+review path. Customer evidence can change that decision; the threshold is now
+explicit.
 
 ## Sequencing
 
@@ -153,9 +202,12 @@ permit shipping multiple one-off OAuth stacks.
 
 Every launch plugin must satisfy the same contract:
 
-1. The listing states what the plugin can read, what it can change, what leaves
-   the device for inference, and whether OpenSoftware is in the connector data
-   path.
+1. The listing states what the plugin can read and change; which June note,
+   conversation, memory, device, IP-address, and approximate-location context
+   can reach the provider; what leaves the device for inference; whether
+   OpenSoftware is in the connector data path; and links the provider's privacy
+   and retention policy. The approval preview identifies the June-originated
+   content disclosed by that specific action.
 2. Install, connect, grant, trust mode, and runtime mode are separate states.
 3. The Plugins tile, Settings control, and contextual in-chat suggestion point
    to one source of truth.
@@ -170,8 +222,11 @@ Every launch plugin must satisfy the same contract:
    carry injection warnings, while the broker remains the enforcement point.
 8. Routines receive explicit toolsets and an explicit account binding. No
    routine silently selects the first account.
-9. Every action has a stable idempotency key or a local action journal before
-   retries are allowed.
+9. Automatic write retries require a provider-supported idempotency key. A
+   local journal records `pending`, `committed`, or `ambiguous`, but cannot by
+   itself make a provider mutation idempotent. After an ambiguous timeout June
+   must reconcile provider state using a stable action fingerprint, or block
+   replay and ask the user to confirm.
 10. No plugin introduces an upstream provider key into the desktop binary or
     routes provider content through June API unless a separately approved
     away-mode design requires it.
@@ -205,9 +260,15 @@ these shared metrics.
 - **Dropbox, Box, OneDrive-only, and SharePoint-only plugins:** valuable file
   access, but Google Workspace, Microsoft 365, Notion, and local Documents cover
   the dominant jobs first. Provider-specific file stores remain candidates.
-- **HubSpot and other CRMs:** strong meeting follow-through but narrower than
-  the first ten and likely to need an away-mode webhook path for the best
-  proactive experience.
+- **Salesforce, HubSpot, Pipedrive, Zoho CRM, Clay, and other CRM/sales tools:**
+  strong meeting follow-through and the closest ranked omission, but narrower
+  than the first ten and likely to need admin setup or an away-mode webhook
+  path for the best proactive experience.
+- **Aha!, Asana, Azure Boards, Basecamp, ClickUp, GitLab Issues, and
+  Teamwork.com:** credible planning alternatives, but Linear and GitHub cover
+  the first product/engineering wedge without multiplying overlapping setup.
+- **Intercom, Help Scout, and Zoho Desk:** useful support context, deferred
+  until support teams are a validated primary segment.
 - **Figma, Canva, and presentation creation:** compelling output, but June
   should prove the shared artifact broker with Documents and Spreadsheets
   before adding remote design surfaces or a presentation renderer.
@@ -216,6 +277,10 @@ these shared metrics.
   in the public app directory but outside June's private work focus.
 - **A third-party plugin marketplace:** the security, signing, update, and
   policy model is a separate product. The first ten are first-party bundles.
+- **Role-specific plugin packs, local-plugin sharing, and ChatGPT Sites:** useful
+  packaging and platform benchmarks, but not additional account connectors.
+  June should revisit them after the first-party manifest, artifact broker,
+  and organization model exist.
 - **Cloud sync of entire provider corpora:** conflicts with the local-mode
   trust story. Live, scoped reads come first; away mode requires its own
   accepted threat model.
@@ -230,6 +295,7 @@ days before this document was written.
 - [Plugin use cases and prompts](https://help.openai.com/en/articles/12084614-app-use-cases-and-prompts) - current work categories and supported app examples.
 - [ChatGPT release notes](https://help.openai.com/en/articles/6825453-chatgpt-release-notes) - current Google, Microsoft, Box, Dropbox, Notion, and Linear action expansion.
 - [ChatGPT Business release notes](https://help.openai.com/en/articles/11391654) - current Slack, Asana, Intercom, Google, Microsoft, and workspace plugin changes.
+- [Apps with sync](https://help.openai.com/en/collections/15507678-apps-with-sync) - current named sync catalog across knowledge, planning, code, CRM, and support tools.
 - [ChatGPT public app directory](https://chatgpt.com/apps/) - public featured, productivity, and lifestyle inventory.
 - [Apps SDK tool design](https://developers.openai.com/apps-sdk/plan/tools) - focused tools, predictable structured output, read/write separation, and discovery metadata.
 - [Apps SDK guidelines](https://developers.openai.com/apps-sdk/app-guidelines) - action annotations, data minimization, reliability, and review expectations.

--- a/docs/plugins/slack-implementation-plan.md
+++ b/docs/plugins/slack-implementation-plan.md
@@ -1,0 +1,111 @@
+# Implementation plan: Slack plugin
+
+- **Mode:** CTO
+- **Date:** 2026-07-13
+- **Status:** Proposed; auth spike required
+- **PRD:** [slack-prd.md](slack-prd.md)
+
+## Technical objective
+
+Build Slack on the provider-neutral connector kit, keeping token custody and
+provider calls on-device if Slack's public distribution model permits it.
+Enforce channel selection and action approval in Rust.
+
+## Phase 0: release-blocking auth spike
+
+Slack's OAuth v2 authorization-code exchange uses a client secret. A shipped
+desktop app cannot protect a reusable confidential secret. Before coding the
+connector:
+
+1. Confirm with Slack's current distribution requirements whether a public app
+   can use a desktop-safe PKCE flow or another supported non-confidential flow.
+2. Evaluate Socket Mode and OAuth separately; Socket Mode avoids a public
+   Events API URL but does not by itself solve installation secret custody.
+3. Reject embedding the secret, proxying all Slack tokens through June API, or
+   using a shared static user token.
+4. If no local-safe public install exists, write an ADR for the chosen boundary
+   before implementation. Options are a TEE token exchange with explicit copy,
+   a bring-your-own Slack app for technical users, or deferral until away mode.
+
+Exit: one supported, reviewable auth design and verified disconnect/revoke
+path. No downstream estimate is a commitment until this passes.
+
+## Proposed connector surface
+
+Subject to the spike, add:
+
+| Server | Tools |
+| --- | --- |
+| `june_slack` | `list_channels`, `search_messages`, `read_thread`, `list_mentions`, `get_message` |
+| `june_slack_actions` | `post_message`, `reply_to_thread` |
+
+All read tools require an account-bound channel allowlist checked in Rust after
+provider resolution. Search results return message id, channel id, author,
+timestamp, compact text, and canonical link. Full threads require an explicit
+call. Bots and edited/deleted messages are represented, not silently flattened.
+
+## Local state
+
+- Keychain token material if the auth design allows local custody.
+- Non-secret workspace/account index and selected channel ids in SQLite.
+- Per-channel polling cursor and backoff state.
+- Existing pending action journal for posts/replies, including stable client
+  message id where Slack accepts it.
+- No message corpus, channel transcript, or file body cache.
+
+## Events
+
+V1 local mode uses one of two on-device approaches selected by the spike:
+
+- Socket Mode while June is running, if public distribution and token custody
+  are compatible; or
+- bounded polling of mentions and selected conversations with persisted cursors.
+
+HTTP Events API webhooks require a public endpoint and therefore belong to an
+away-mode design, not a quiet exception in local mode.
+
+## Trust policy
+
+- `read_only`: `june_slack` only.
+- `approval`: action server visible; every post/reply parks.
+- `autonomous`: deferred. The first release does not permit unattended posts.
+- Channel allowlist applies in every mode and cannot be widened by tool input.
+- Cross-workspace and Slack Connect channel identity is explicit in approvals.
+
+## Delivery slices after Phase 0
+
+1. **Account and channel grant (1 week):** connection state, channel picker,
+   allowlist enforcement, revoke and health checks.
+2. **Read path (2 weeks):** channel list, search, message/thread reads, links,
+   pagination, rate-limit handling.
+3. **Approved actions (1 week):** draft/post/reply through the approval journal.
+4. **Local events (1 week):** mentions/selected-channel wakeups while awake.
+5. **Skills and rollout (1 week):** recap and standup templates, rc dogfood,
+   support and kill switch.
+
+## Verification
+
+- Auth matrix: first install, workspace-admin denial, token rotation, restart,
+  revoke at Slack, disconnect in June, and reauthorization.
+- Rust tests that provider-resolved channel ids cannot escape the allowlist.
+- Pagination, rate-limit, deleted-message, edited-message, thread, bot, and
+  Slack Connect fixtures.
+- Prompt-injection corpus in message text, usernames, link unfurls, attachments,
+  and channel topics.
+- Action-journal tests for timeout, retry, duplicate acknowledgement, and app
+  restart.
+- Live workspace walkthrough with public/private channels and denied scopes.
+- Sandbox proof for Keychain material if local custody ships.
+
+## Rollout and operations
+
+Use an internal Slack workspace, then a small external pilot with explicit
+admin consent, then rc. Collect coarse operation, rate-limit, latency, approval,
+and error buckets only. A provider kill switch disables calls and event intake
+without deleting the user's local notes.
+
+## Architecture decision gate
+
+Following ADR-0016 without a backend credential or event path needs no new ADR.
+Any exception to local token custody or on-device provider calls satisfies the
+repo's ADR threshold and must be recorded before implementation.

--- a/docs/plugins/slack-implementation-plan.md
+++ b/docs/plugins/slack-implementation-plan.md
@@ -71,6 +71,10 @@ away-mode design, not a quiet exception in local mode.
 - `autonomous`: deferred. The first release does not permit unattended posts.
 - Channel allowlist applies in every mode and cannot be widened by tool input.
 - Cross-workspace and Slack Connect channel identity is explicit in approvals.
+- Automatic retry is enabled only where Slack honors the stable client message
+  id as an idempotency key. Otherwise an ambiguous timeout is reconciled
+  against recent channel history by action fingerprint, or replay is blocked
+  until the user confirms; the local journal alone is insufficient.
 
 ## Delivery slices after Phase 0
 
@@ -106,6 +110,7 @@ without deleting the user's local notes.
 
 ## Architecture decision gate
 
-Following ADR-0016 without a backend credential or event path needs no new ADR.
-Any exception to local token custody or on-device provider calls satisfies the
-repo's ADR threshold and must be recorded before implementation.
+The local-mode shape proposed by ADR-0016 is the starting hypothesis, not an
+accepted decision while that ADR remains proposed. Accept or supersede it
+before implementation depends on the boundary. Any backend credential or event
+path independently satisfies the repo's ADR threshold and must be recorded.

--- a/docs/plugins/slack-prd.md
+++ b/docs/plugins/slack-prd.md
@@ -1,0 +1,127 @@
+# PRD: Slack plugin
+
+- **Mode:** CEO
+- **Rank:** 3 of 10
+- **Score:** 86/100
+- **Date:** 2026-07-13
+- **Status:** Proposed; anticipated by the connector roadmap
+
+## Thesis
+
+Slack is where meeting decisions become team commitments and where those
+commitments are later lost. A June Slack plugin should let users prepare from
+relevant conversations, publish a reviewed meeting recap, answer follow-up
+questions from the local note graph, and turn messages into routines without
+copying the workspace into OpenSoftware infrastructure.
+
+Slack ranks third because it adds team distribution to June's private local
+context. The combination is more valuable than a generic chat bot: June can
+connect a channel thread to the actual meeting note and transcript on the
+user's Mac.
+
+## Customer and problem
+
+Small teams use Slack as their operating memory, but important context is split
+between channels, DMs, meeting notes, and individual recollection. People
+rewrite status updates, lose decisions, and answer questions without the
+source meeting in view. Cloud assistants often solve retrieval by ingesting the
+workspace. June's customer wants the utility without creating another copy.
+
+## Product promise
+
+Connect one Slack workspace, choose the channels June may read, and let June
+prepare or publish bounded team updates with every outward action visible and
+governed.
+
+## V1 experience
+
+- Connect from the plugin tile in the system browser.
+- Choose a small allowlist of channels. DMs and private channels are excluded
+  until explicitly added and supported by the granted scopes.
+- Ask June to summarize a thread, prepare for a meeting, or find prior context.
+- From a June note, draft a channel recap with decisions, owners, and links.
+- Review and approve every post or reply before it leaves the Mac.
+- Use templates for daily standup, meeting recap, unanswered mentions, and
+  promised follow-ups.
+- Disconnect and verify that reads, posts, triggers, and cached metadata stop.
+
+## Scope
+
+### V1
+
+- Workspace identity and channel picker.
+- Search/read messages and threads only within selected channels.
+- Read mentions involving the connected user where scopes permit it.
+- Draft and post a message or thread reply behind approval.
+- Stable Slack links in June responses and notes.
+- On-device polling while awake for mentions and selected-channel changes.
+
+### Later
+
+- Slack Connect edge cases, multiple workspaces, file upload, reactions,
+  canvases, workflow steps, and an app users can message from inside Slack.
+- Away-mode mention triggers after the relay threat model is accepted.
+
+## Non-goals
+
+- Full-workspace indexing or retention in June.
+- Reading every channel the authorizing user can see by default.
+- Posting as if June were the human without visible attribution.
+- Autonomous posting at launch.
+- Making Slack identity the source of June identity or team membership.
+
+## Packaging
+
+- Required connector: Slack.
+- Skills: meeting recap, standup synthesis, decision follow-up, thread brief.
+- Templates: morning mentions, daily team recap, post-meeting actions.
+- Optional composition: Google/Microsoft calendar, GitHub, Linear, and local
+  June notes.
+
+## Privacy and trust
+
+The OAuth token belongs in the Keychain and provider calls should originate
+on-device. Slack's OAuth token exchange requires an app client secret, so the
+technical spike must prove a distributable desktop pattern that does not embed
+a reusable secret. If Slack requires a confidential backend for public app
+installation, the plugin cannot claim the same local-mode credential boundary
+as Google until a separately approved design exists.
+
+Messages are untrusted input. Channel selection is an enforced provider-proxy
+allowlist. Posts and replies are `approval` only in v1.
+
+## Business model
+
+Local Slack read and approved posting are available on Hobby. Triggered team
+briefings and cross-plugin routines are Pro. Slack API calls are not separately
+metered; model work uses existing agent billing.
+
+## Success measures
+
+| Metric | Target |
+| --- | ---: |
+| Connectors selecting at least one channel | 80% |
+| Weekly connected users producing a recap or brief | 35% |
+| Approved posts requiring an edit after publication | under 3% |
+| Read attempts outside the selected channel set | 0 successful |
+| Median connect-to-first-thread-summary time | under 3 minutes |
+
+## Risks and gates
+
+- OAuth client-secret custody and marketplace distribution must be resolved
+  before product copy promises local mode.
+- Slack scopes, workspace-admin approval, retention policy, and enterprise
+  restrictions vary.
+- Channel messages are a high-risk prompt-injection surface.
+- Polling provides local privacy but not true away-mode responsiveness.
+
+## Decision requested
+
+Approve Slack as the first new provider after the shared connector kit, with a
+channel allowlist, approved posting only, and an auth feasibility gate before
+implementation hardens.
+
+## Sources
+
+- [Slack OAuth v2](https://api.slack.com/authentication/oauth-v2)
+- [Slack Events API](https://api.slack.com/apis/connections/events-api)

--- a/docs/plugins/spreadsheets-implementation-plan.md
+++ b/docs/plugins/spreadsheets-implementation-plan.md
@@ -77,8 +77,10 @@ No arbitrary code, SQL, formula language extensions, macros, or raw OOXML.
   charts, operations, and preview size.
 - Large analysis uses local streaming/profile operations and sends only selected
   ranges/statistics to the model.
-- Detect formula injection when exporting CSV/TSV and neutralize only when the
-  user chooses a safe-text export mode; otherwise warn without corrupting data.
+- CSV/TSV export defaults to safe text: neutralize cells beginning with `=`,
+  `+`, `-`, or `@` using the documented target-compatible escape. Raw formula
+  export is a separate explicit override with a warning and native confirmation;
+  it is never selected implicitly or reused from a prior export.
 
 ## Version and export model
 

--- a/docs/plugins/spreadsheets-implementation-plan.md
+++ b/docs/plugins/spreadsheets-implementation-plan.md
@@ -1,0 +1,116 @@
+# Implementation plan: Spreadsheets plugin
+
+- **Mode:** CTO
+- **Date:** 2026-07-13
+- **Status:** Proposed; depends on the artifact broker
+- **PRD:** [spreadsheets-prd.md](spreadsheets-prd.md)
+
+## Technical objective
+
+Extend the shared artifact broker with a typed workbook IR and deterministic
+CSV/TSV/XLSX adapters. Keep binary generation and validation out of model text,
+bound every read/write, never execute active content, and export only through
+the June UI.
+
+## Dependencies
+
+- Documents Phase 0 selects the shared artifact worker/broker pattern.
+- The package-security spec governs any new Rust crate, Python wheel, binary,
+  and build script.
+- A formula-engine spike must establish exactly which functions June can
+  calculate versus preserve without calculation.
+
+## Phase 0: workbook engine spike
+
+Compare a Rust-native path (for example, a safe XLSX reader plus deterministic
+writer) with an isolated pinned worker. Evaluate:
+
+- cell types, shared strings, styles, merges, formulas, cached results, dates,
+  errors, names, filters, hidden rows/sheets, charts, and conditional formats;
+- formula calculation coverage and compatibility;
+- malformed ZIP/XML safety, memory bounds, package size, sandbox behavior,
+  licensing, and reproducibility;
+- render strategy for table and chart previews.
+
+Exit with a supported feature/function matrix. Unsupported formulas are
+preserved and labeled "not recalculated" or rejected for a requested edit; June
+never invents a cached value.
+
+## Architecture
+
+```text
+Hermes -> june_spreadsheets MCP -> Rust artifact broker -> workbook engine
+                                             |-> immutable workbook versions
+                                             |-> table/chart previews
+                                             `-> validation + calculation report
+June UI -> native save dialog -> explicit export copy
+```
+
+Workbook IR includes workbook metadata, sheet properties, cells with typed
+value/formula/style, ranges, names, merges, filters, panes, conditional rules,
+and supported charts. All operations target stable sheet ids and A1 ranges.
+
+## Proposed tools
+
+| Tool | Behavior |
+| --- | --- |
+| `inspect_workbook` | Sheets, dimensions, names, formulas, links, active-content findings, warnings |
+| `read_range` | Bounded typed cells with formula and displayed/cached value |
+| `profile_range` | Local summary statistics and type/null/error profile |
+| `create_workbook` | New immutable version from structured sheets |
+| `revise_workbook` | Typed cell/range/sheet/style operations |
+| `calculate_workbook` | Supported-function calculation report |
+| `render_workbook` | Bounded table/chart preview artifacts |
+| `compare_workbook_versions` | Cell/formula/structure diff |
+| `export_workbook` | UI handoff only |
+
+No arbitrary code, SQL, formula language extensions, macros, or raw OOXML.
+
+## Safety and bounds
+
+- Reject macros, OLE, external data connections, DDE, remote images, and unsafe
+  relationships. Preserve a clean imported copy only when the support matrix
+  permits it.
+- Record hidden rows/columns/sheets and comments in inspection; do not silently
+  omit them from prompt-injection review.
+- Bound compressed/uncompressed bytes, sheets, cells, formulas, styles, images,
+  charts, operations, and preview size.
+- Large analysis uses local streaming/profile operations and sends only selected
+  ranges/statistics to the model.
+- Detect formula injection when exporting CSV/TSV and neutralize only when the
+  user chooses a safe-text export mode; otherwise warn without corrupting data.
+
+## Version and export model
+
+Reuse `artifacts/spreadsheets/<id>/` immutable manifests, content hashes,
+atomic completion, source refs, previews, and validation. Import never grants a
+write path to the original. Tauri owns native export and replace confirmation.
+
+## Delivery slices after Phase 0
+
+1. **Workbook IR + CSV/TSV (1-2 weeks).** Inspect/read/create/revise/export.
+2. **XLSX reads (2 weeks).** Types, formulas, styles, structure, safety findings.
+3. **XLSX create/revise (2 weeks).** Supported subset and immutable versions.
+4. **Calculation + validation (2 weeks).** Function corpus and honest status.
+5. **Preview + diff (1 week).** Table/chart artifacts and semantic changes.
+6. **Skills + rc (1 week).** Analysis/cleanup templates and dogfood corpus.
+
+## Verification
+
+- Conformance corpus produced by Excel, Google Sheets export, Apple Numbers,
+  and LibreOffice; automated CI checks structural/semantic invariants.
+- Formula golden corpus for every supported function, types, error propagation,
+  date systems, locale-independent storage, and circular references.
+- Fuzz/malformed tests for ZIP bombs, XML attacks, shared-string abuse, style
+  explosion, broken relationships, and oversized dimensions.
+- Injection corpus in cells, formulas, comments, names, hidden content, links,
+  metadata, and CSV-leading formula characters.
+- Export-boundary tests and reference-editor smoke qualification.
+- Memory/time benchmarks at each published workbook limit.
+
+## Rollout
+
+CSV/TSV first, then XLSX rc behind a format flag. Publish the exact workbook and
+formula support matrix. Keep format/engine kill switches and content-free size,
+latency, validation, and error telemetry. Preserve the source and last valid
+version on every failure.

--- a/docs/plugins/spreadsheets-prd.md
+++ b/docs/plugins/spreadsheets-prd.md
@@ -1,0 +1,114 @@
+# PRD: Spreadsheets plugin
+
+- **Mode:** CEO
+- **Rank:** 10 of 10
+- **Score:** 64/100
+- **Date:** 2026-07-13
+- **Status:** Proposed
+
+## Thesis
+
+Spreadsheets gives June a local, inspectable way to turn meeting data and files
+into structured analysis. It should analyze an imported workbook, explain its
+logic, build or revise a safe copy, verify formulas and shape, and export an
+editable XLSX or CSV without relying on a cloud spreadsheet service.
+
+It ranks tenth because it is valuable and already appears in June's product
+story, but high-quality spreadsheet work needs deterministic calculation,
+formula safety, and visual verification. The shared artifact broker should land
+with Documents first.
+
+## Customer and problem
+
+Operators receive spreadsheets before and after meetings, but understanding
+them is slow and error-prone. Chat can explain pasted cells, yet cannot reliably
+preserve workbook structure, formulas, types, sheets, and charts. Cloud upload
+is often unacceptable for financial, client, or personnel data.
+
+## Product promise
+
+Work from a local copy, see what June changed, validate the workbook, and export
+only the version you approve. No macro execution and no silent overwrite.
+
+## V1 experience
+
+- Import CSV, TSV, or XLSX into the June workspace.
+- Ask questions about sheets, ranges, formulas, anomalies, and summaries.
+- See a compact table preview and cited cell/range references.
+- Ask June to clean data, add a derived column, create a summary sheet, or build
+  a new workbook from meeting data.
+- Review a typed change summary, recalculation status, warnings, and preview.
+- Export a validated XLSX/CSV through the native save dialog.
+
+## Scope
+
+### V1
+
+- Read/write CSV, TSV, and non-macro XLSX.
+- Values, types, formulas in a supported subset, styles, merged cells, frozen
+  panes, filters, basic conditional formatting, and basic charts if the chosen
+  engine can verify them.
+- Typed range operations, immutable versions, semantic diff, validation, and
+  preview.
+- Analysis, cleanup, forecast-input, action tracker, and status-report skills.
+
+### Later
+
+- XLSM/macros, external data connections, pivot tables, Power Query, full chart
+  parity, live collaboration, Google Sheets/Excel publication, and large-data
+  engines.
+
+## Non-goals
+
+- Executing macros or external links.
+- Claiming formula parity with Excel for unsupported functions.
+- Overwriting the imported workbook.
+- Acting as an accounting system or making financial decisions for the user.
+- Full BI/dashboard replacement.
+
+## Packaging
+
+- No connector is required.
+- App-owned toolset: inspect, read ranges, create, revise, calculate/validate,
+  render, compare, export.
+- Skills: data cleanup, meeting action tracker, budget variance, pipeline review,
+  experiment analysis.
+- Optional Google/Microsoft capabilities can publish an approved exported copy.
+
+## Privacy and trust
+
+Parsing, transformation, storage, and preview stay on-device. Selected workbook
+content used for reasoning follows the selected inference path. Formula text,
+sheet names, comments, hidden cells, links, and metadata are untrusted input.
+Macros and external connections are disabled.
+
+## Business model
+
+Core analysis and export are Hobby. Larger workbook limits, repeated monitoring,
+and cross-plugin reporting routines are Pro. Local compute does not add a new
+credit action; model usage remains metered normally.
+
+## Success measures
+
+| Metric | Target |
+| --- | ---: |
+| Imported workbooks reaching a useful answer or export | 60% |
+| Exported workbooks opening without repair | 99% |
+| Supported formulas changing result unexpectedly | 0 in conformance corpus |
+| Exports needing structural repair | under 3% |
+| Original workbook overwritten without explicit confirmation | 0 |
+
+## Risks and gates
+
+- Formula engines differ, and writing cached results without real recalculation
+  can mislead users.
+- Hidden sheets/cells and external links can conceal instructions or data.
+- Large workbooks can exhaust memory and model context.
+- Spreadsheet outputs can influence consequential financial or operational
+  decisions; validation and uncertainty must be visible.
+
+## Decision requested
+
+Approve CSV/TSV/XLSX with a supported formula subset, immutable versions, and
+no macro execution. Build after the shared artifact broker and publish a strict
+format/function support matrix.


### PR DESCRIPTION
## Summary

- Inventory the current official plugin surface, including packaged workflows,
  apps, sync, actions, administration, role bundles, sharing, Sites, browser and
  computer use, and the named provider catalog.
- Rank June's top 10 with a reproducible weighted scorecard: Google Workspace,
  Browser use, Slack, Microsoft 365, Computer use, Notion, GitHub, Linear,
  Documents, and Spreadsheets.
- Add a CEO-mode PRD and CTO-mode implementation plan for each selection, plus
  a shared privacy, trust, retry, sequencing, and measurement contract.
- Add the canonical Plugin term to `CONTEXT.md` and index all new documents.

Closes JUN-309.

## Validation

- `make local-ci` (frontend and macOS Rust signoffs correctly reported not
  applicable for this docs-only diff)
- `git diff origin/main...HEAD --check`
- Local Markdown link resolution check across `docs/**/*.md` and `CONTEXT.md`
- Verified 10 unique PRD ranks, 10 PRDs, 10 implementation plans, and all 33
  scorecard row totals
- Independent adversarial review converged with no remaining High/Medium issues
- Live UI walkthrough skipped because this PR changes documentation only

- [ ] Tested visually where it matters (not applicable: no UI changes).
- [ ] Needs a June API (backend) deploy before it works end to end. No deploy is
  required; this PR contains proposals only.

## Out of scope

- Implementing any plugin or changing current plugin ownership/work in flight
- Provider app registration, OAuth approval, external review, or credentials
- A third-party marketplace, organization policy model, or provider-corpus
  cloud sync
- Accepting ADR-0016; plans explicitly require resolving its proposed status
  before treating it as an accepted constraint

## Followups

- Continue Browser/Computer execution under JUN-278.
- Use the relevant briefs for the existing Notion (JUN-283), Linear (JUN-284),
  and GitHub (JUN-285) workstreams without disturbing current owners.
- Run the provider auth and artifact-engine spikes before committing delivery
  dates for the corresponding plugins.
- Re-score the portfolio after real 30-day activation and task-completion data.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary and shared plugin contract.
- [ ] Workflow action references are pinned to full-length commit SHAs (not applicable: no workflow changes).
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable).
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable).
- [x] User-facing copy follows the repo UI conventions (no user-facing UI copy changed).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786575236&installation_id=144203540&pr_number=735&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F735&signature=4174879b3f4d3da2104eb212e3465cd9714ffcda5297a80952008413d53679a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->