### PR TITLE
Polish agent shimmer contrast and cadence

### DIFF
--- a/src/components/agent/AgentThinking.tsx
+++ b/src/components/agent/AgentThinking.tsx
@@ -1,0 +1,37 @@
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+
+// Framer transforms require same-shape numeric values, so this mirrors the
+// 2px --sp-px token rather than passing that CSS variable into the mixer.
+const AGENT_THINKING_OFFSET_PX = 2;
+
+/**
+ * Bottom-of-timeline responding affordance. The presence host stays mounted
+ * while runtime events have no visible output, preserving the shimmer phase;
+ * once output arrives, the label gets a brief handoff instead of disappearing.
+ */
+export function AgentThinking({ visible }: { visible: boolean }) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <AnimatePresence initial={false} mode="popLayout">
+      {visible ? (
+        <motion.div
+          key="agent-thinking"
+          className="agent-thinking"
+          role="status"
+          aria-live="polite"
+          initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: AGENT_THINKING_OFFSET_PX }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -AGENT_THINKING_OFFSET_PX }}
+          transition={{
+            // Framer Motion takes seconds; these mirror --t-fast/--t-med.
+            duration: reduceMotion ? 0.1 : 0.16,
+            ease: [0.22, 1, 0.36, 1],
+          }}
+        >
+          <span className="text-shimmer shimmer agent-thinking-label">Thinking…</span>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -25,7 +25,7 @@ import { IconStopCircle } from "central-icons/IconStopCircle";
 import { IconToolbox } from "central-icons/IconToolbox";
 import { IconTrashCan } from "central-icons/IconTrashCan";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { createPortal } from "react-dom";
 import { IconArrowCornerDownRight } from "central-icons/IconArrowCornerDownRight";
 import { IconArrowUp } from "central-icons/IconArrowUp";
@@ -215,6 +215,7 @@ import {
   // `AgentArtifact` (the file-viewer card), so alias it.
   type AgentArtifact as TimelineArtifact,
 } from "../../lib/hermes-artifact-store";
+import { AgentThinking } from "./AgentThinking";
 import { SessionUsagePanel } from "./SessionUsagePanel";
 import { useUsagePanelDemo } from "../../lib/usage-panel-demo";
 import { AgentActivityDrawer, AgentArtifactsSection } from "./AgentActivityDrawer";
@@ -9737,9 +9738,11 @@ export function AgentWorkspace({
           branchingMessageId={branchingMessageId}
         />
       ))}
-      {workingSessionIds.has(selectedHermesSessionId) && hermesTurns.at(-1)?.role === "user" ? (
-        <AgentThinking />
-      ) : null}
+      <AgentThinking
+        visible={
+          workingSessionIds.has(selectedHermesSessionId) && hermesTurns.at(-1)?.role === "user"
+        }
+      />
     </div>
   ) : !newSessionMode && selectedTask ? (
     <>
@@ -9842,9 +9845,9 @@ export function AgentWorkspace({
             }}
           />
         ))}
-        {workingTaskIds.has(selectedTask.id) && taskTurns.at(-1)?.role === "user" ? (
-          <AgentThinking />
-        ) : null}
+        <AgentThinking
+          visible={workingTaskIds.has(selectedTask.id) && taskTurns.at(-1)?.role === "user"}
+        />
       </div>
     </>
   ) : null;
@@ -11448,6 +11451,36 @@ function mergeThinkingTurns(turns: AgentChatTurn[]): AgentChatTurn[] {
 // stable across renders.
 const galleryNoop = () => {};
 
+const SHIMMER_GALLERY_SAMPLES = [
+  { length: "Short", text: "Thinking…" },
+  { length: "Medium", text: "Generating image…" },
+  { length: "Long", text: "Generating video, this can take a minute" },
+] as const;
+
+function AgentShimmerGallerySection() {
+  return (
+    <section className="agent-gallery-section agent-gallery-shimmer-section">
+      <header className="agent-gallery-section-header">
+        <h3>Shimmer text lengths</h3>
+        <p>
+          Each sample uses the production color, spread, and 1.6-second cadence. Compare perceived
+          speed and contrast across text lengths in the active theme.
+        </p>
+      </header>
+      <dl className="agent-gallery-shimmer-list">
+        {SHIMMER_GALLERY_SAMPLES.map((sample) => (
+          <div key={sample.length} className="agent-gallery-shimmer-sample">
+            <dt>{sample.length}</dt>
+            <dd>
+              <span className="text-shimmer shimmer agent-gallery-shimmer-text">{sample.text}</span>
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
 function AgentResponseGallery({
   sections,
   errors,
@@ -11487,6 +11520,7 @@ function AgentResponseGallery({
           <IconCrossMedium size={15} />
         </button>
       </div>
+      {errors ? null : <AgentShimmerGallerySection />}
       {sections.map((section) => (
         <section key={section.label} className="agent-gallery-section">
           <header className="agent-gallery-section-header">
@@ -12333,7 +12367,7 @@ function AgentGeneratedVideo({
     return (
       <div className="agent-generated-video" data-status="running" role="status" aria-live="polite">
         <div className="agent-generated-video-placeholder">
-          <span className="text-shimmer">Generating video, this can take a minute</span>
+          <span className="text-shimmer shimmer">Generating video, this can take a minute</span>
           {progress ? <span className="agent-generated-video-progress">{progress}</span> : null}
         </div>
       </div>
@@ -12369,7 +12403,9 @@ function AgentGeneratedVideo({
         {src ? (
           <video controls src={src} poster={part.posterDataUrl} preload="metadata" />
         ) : (
-          <span className="agent-generated-image-loading text-shimmer">Loading video...</span>
+          <span className="agent-generated-image-loading text-shimmer shimmer">
+            Loading video...
+          </span>
         )}
       </div>
       <figcaption className="agent-generated-image-bar">
@@ -13416,6 +13452,7 @@ function AgentThinkingGroup({
   reasoning: Extract<AgentChatPart, { type: "reasoning" }>[];
   running: boolean;
 }) {
+  const reduceMotion = useReducedMotion();
   // Collapsed by default to a short label — "Thinking" while it works, "Thought"
   // once done (terracotta while live). Expanding reveals only the reasoning
   // prose; tool/action rows render outside this disclosure.
@@ -13430,9 +13467,24 @@ function AgentThinkingGroup({
       open={open}
       onToggle={(event) => onOpenChange(event.currentTarget.open)}
     >
-      <summary>
-        <span className={running ? "text-shimmer shimmer" : undefined}>
-          {running ? "Thinking" : "Thought"}
+      <summary aria-label={running ? "Thinking" : "Thought"}>
+        <span className="agent-reasoning-label-swap" aria-hidden="true">
+          <AnimatePresence initial={false}>
+            <motion.span
+              key={running ? "thinking" : "thought"}
+              className={running ? "text-shimmer shimmer" : undefined}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{
+                // Framer Motion takes seconds; these mirror --t-fast/--t-med.
+                duration: reduceMotion ? 0.1 : 0.16,
+                ease: [0.22, 1, 0.36, 1],
+              }}
+            >
+              {running ? "Thinking" : "Thought"}
+            </motion.span>
+          </AnimatePresence>
         </span>
         <IconChevronDownSmall size={14} className="agent-disclosure-chevron" />
       </summary>
@@ -14670,18 +14722,6 @@ function ActivityIndicator({
       <span aria-hidden="true" />
       {status === "waitingForUser" ? "Needs you" : "Working"}
     </span>
-  );
-}
-
-// Bottom-of-timeline "responding" affordance: a shimmering label, painted by
-// the same shared .shimmer utility the recorder uses while transcribing. Lives
-// in the timeline (not the header) so it reads like the agent is actively
-// composing the next turn.
-function AgentThinking() {
-  return (
-    <div className="agent-thinking" role="status" aria-live="polite">
-      <span className="text-shimmer shimmer agent-thinking-label">Thinking…</span>
-    </div>
   );
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -803,6 +803,39 @@ input:focus-visible,
   line-height: 1.35;
 }
 
+.agent-gallery-shimmer-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  margin: 0;
+}
+
+.agent-gallery-shimmer-sample {
+  display: grid;
+  grid-template-columns: calc(var(--sp-12) + var(--sp-2)) minmax(0, 1fr);
+  align-items: baseline;
+  gap: var(--sp-4);
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--r-md);
+  background: var(--surface-subtle);
+}
+
+.agent-gallery-shimmer-sample dt {
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+}
+
+.agent-gallery-shimmer-sample dd {
+  min-width: 0;
+  margin: 0;
+}
+
+.agent-gallery-shimmer-text {
+  display: inline-block;
+  max-width: 100%;
+  vertical-align: bottom;
+}
+
 .agent-management-panel {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
@@ -4560,6 +4593,17 @@ input:focus-visible,
 
 .agent-reasoning > summary span {
   font-weight: 400;
+}
+
+/* Thinking -> Thought crossfades in one grid cell. Keeping both keyed labels
+ * in flow avoids popLayout's absolute-positioned inline clone, which can paint
+ * a clipped-text gradient outside its glyph bounds in some browser engines. */
+.agent-reasoning-label-swap {
+  display: inline-grid;
+}
+
+.agent-reasoning .agent-reasoning-label-swap > span {
+  grid-area: 1 / 1;
 }
 
 .agent-reasoning[open] > summary p {
@@ -10731,16 +10775,15 @@ input:focus-visible,
 
 /* Truncation layout plus the shimmer base color for the agent-chat working
  * labels. Pairs with the shared .shimmer utility in markup, which owns the
- * sweep; here we only keep the ellipsis clamp and the base color it sweeps. The
- * agent shimmer runs quicker than the 2s default — the slower cadence read
- * sluggish in the chat — so it sets a shorter --shimmer-duration. */
+ * sweep and theme contrast; here we keep the ellipsis clamp, base color, and
+ * agent-chat cadence between the old abrupt 1.2s and the shared 2s default. */
 .text-shimmer {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--muted-foreground);
-  --shimmer-duration: 1200ms;
+  --shimmer-duration: 1600ms;
 }
 
 /* Count chip — how many follow-up recordings are queued behind the one

--- a/src/test/agent-thinking.test.tsx
+++ b/src/test/agent-thinking.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { MotionGlobalConfig } from "framer-motion";
+import { expect, it } from "vitest";
+import { AgentThinking } from "../components/agent/AgentThinking";
+
+it("keeps the thinking status mounted for its exit handoff", () => {
+  const skipAnimations = MotionGlobalConfig.skipAnimations;
+  MotionGlobalConfig.skipAnimations = false;
+
+  const { rerender, unmount } = render(<AgentThinking visible />);
+  try {
+    const indicator = screen.getByText("Thinking…");
+
+    rerender(<AgentThinking visible />);
+    expect(screen.getByText("Thinking…")).toBe(indicator);
+
+    rerender(<AgentThinking visible={false} />);
+    expect(indicator).toBeInTheDocument();
+  } finally {
+    MotionGlobalConfig.skipAnimations = skipAnimations;
+    unmount();
+  }
+});

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6543,6 +6543,53 @@ describe("AgentWorkspace", () => {
     expect(mocks.gatewayEventHandlers.size).toBe(0);
   });
 
+  it("keeps one thinking shimmer mounted until visible response content arrives", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "summarize the current page",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "summarize the current page",
+      }),
+    );
+    const indicator = await screen.findByText("Thinking…");
+    expect(indicator).toHaveClass("text-shimmer", "shimmer");
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "message.start",
+          session_id: "runtime-session-2",
+          payload: { message_id: "live-response" },
+        });
+      }
+    });
+
+    expect(screen.getAllByText("Thinking…")).toHaveLength(1);
+    expect(screen.getByText("Thinking…")).toBe(indicator);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "message.delta",
+          session_id: "runtime-session-2",
+          payload: { delta: "Here is the summary." },
+        });
+      }
+    });
+
+    expect(screen.getByText("Here is the summary.")).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText("Thinking…")).toBeNull());
+  });
+
   it("keeps an opened thinking disclosure open while reasoning streams", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
@@ -6574,6 +6621,9 @@ describe("AgentWorkspace", () => {
     const label = await screen.findByText("Thinking");
     const details = label.closest("details");
     expect(details).not.toHaveAttribute("open");
+    expect(label.parentElement).toHaveClass("agent-reasoning-label-swap");
+    expect(label.parentElement).toHaveAttribute("aria-hidden", "true");
+    expect(details?.querySelector("summary")).toHaveAttribute("aria-label", "Thinking");
 
     await user.click(label);
     await waitFor(() => expect(details).toHaveAttribute("open"));
@@ -6602,6 +6652,9 @@ describe("AgentWorkspace", () => {
     });
 
     expect(await screen.findByText("Thought")).toBeInTheDocument();
+    expect(screen.getByText("Thought").parentElement).toHaveClass("agent-reasoning-label-swap");
+    expect(screen.getByText("Thought").parentElement).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByText("Thought").closest("summary")).toHaveAttribute("aria-label", "Thought");
     expect(screen.getByText("Thought").closest("details")).toHaveAttribute("open");
 
     await user.type(screen.getByRole("textbox"), "next request");
@@ -9572,6 +9625,12 @@ describe("AgentWorkspace", () => {
     vi.useFakeTimers();
     try {
       fireEvent.submit(document.querySelector(".agent-composer") as HTMLFormElement);
+      await settleUnderFakeTimers(() =>
+        expect(screen.getByText("Generating video, this can take a minute")).toHaveClass(
+          "text-shimmer",
+          "shimmer",
+        ),
+      );
       await act(async () => {
         await vi.advanceTimersByTimeAsync(900_000);
       });
@@ -11438,12 +11497,47 @@ describe("AgentWorkspace", () => {
           selector: ".agent-composer-notice",
         }),
       ).toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: "Shimmer text lengths" })).toBeNull();
     } finally {
       // Always reset the module-level desired state — a failure here must not
       // leave the gallery on and cascade into later workspace mounts.
       act(() => void agentErrors(false));
     }
     await waitFor(() => expect(screen.queryByText("Agent error gallery")).toBeNull());
+  });
+
+  it("shows production shimmer across text lengths via the __agentGallery() dev handle", async () => {
+    const agentGallery = (window as unknown as { __agentGallery: (show?: boolean) => string })
+      .__agentGallery;
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    act(() => void agentGallery());
+
+    try {
+      expect(await screen.findByText("Agent response gallery")).toBeInTheDocument();
+      const heading = screen.getByRole("heading", { name: "Shimmer text lengths" });
+      const section = heading.closest("section");
+      expect(section).not.toBeNull();
+
+      const samples = Array.from(section?.querySelectorAll(".text-shimmer.shimmer") ?? []);
+      const sampleTexts = [
+        "Thinking…",
+        "Generating image…",
+        "Generating video, this can take a minute",
+      ];
+      expect(samples.map((sample) => sample.textContent)).toEqual(sampleTexts);
+      for (const text of sampleTexts) {
+        expect(within(section as HTMLElement).getByText(text)).toHaveClass(
+          "text-shimmer",
+          "shimmer",
+        );
+      }
+      expect(section?.querySelector('[role="status"], [aria-live]')).toBeNull();
+    } finally {
+      act(() => void agentGallery(false));
+    }
+    await waitFor(() => expect(screen.queryByText("Agent response gallery")).toBeNull());
   });
 
   it("does not let a stale message fetch erase a newer follow-up", async () => {

--- a/src/test/shimmer-system.test.ts
+++ b/src/test/shimmer-system.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import appCss from "../styles/app.css?raw";
+import shimmerCss from "../styles/shimmer.css?raw";
+
+function cssRuleFor(css: string, selector: string) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`${escaped}\\s*\\{`).exec(css);
+  if (!match) throw new Error(`Missing CSS rule for ${selector}`);
+  const openIndex = match.index + match[0].length - 1;
+  let depth = 0;
+  for (let index = openIndex; index < css.length; index += 1) {
+    if (css[index] === "{") depth += 1;
+    if (css[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return css.slice(openIndex + 1, index);
+    }
+  }
+  throw new Error(`Unclosed CSS rule for ${selector}`);
+}
+
+describe("shimmer system", () => {
+  it("uses the shared theme contrast and tuned cadence for agent working text", () => {
+    const agentShimmer = cssRuleFor(appCss, ".text-shimmer");
+    expect(agentShimmer).toContain("--shimmer-duration: 1600ms;");
+    expect(agentShimmer).not.toContain("--shimmer-color");
+    expect(appCss).not.toContain('[data-theme="dark"] .text-shimmer');
+    expect(shimmerCss).toContain(
+      "--_highlight: var(--shimmer-color, oklch(from currentColor l c h / calc(alpha * 0.2)));",
+    );
+    expect(cssRuleFor(shimmerCss, '[data-theme="dark"] .shimmer')).toContain(
+      "oklch(from currentColor max(0.8, calc(l + 0.4)) c h / calc(alpha + 0.4))",
+    );
+    expect(shimmerCss).toContain(
+      "animation: tw-shimmer var(--shimmer-duration, 2s) linear infinite;",
+    );
+  });
+
+  it("overlaps reasoning labels in flow during the completion crossfade", () => {
+    expect(cssRuleFor(appCss, ".agent-reasoning-label-swap")).toContain("display: inline-grid;");
+    expect(cssRuleFor(appCss, ".agent-reasoning .agent-reasoning-label-swap > span")).toContain(
+      "grid-area: 1 / 1;",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Keep agent working text on June's vendored plain-CSS port of the shadcn shimmer recipe, using its shared light and dark contrast rather than app-level color overrides.
- Tune agent shimmer cadence from the original 1.2 seconds to 1.6 seconds. This lands between the abrupt baseline and the too-slow 2-second first pass.
- Preserve the bottom-of-timeline `Thinking…` indicator across runtime event boundaries, then hand it off with a short reduced-motion-aware exit instead of abruptly removing it. Crossfade `Thinking` to `Thought` in the reasoning disclosure as well.
- Apply the actual shimmer paint class to video generation/loading states that previously had only the layout class.
- Add a development gallery section with the production short, medium, and long strings so contrast and perceived speed can be compared in either theme with `__agentGallery(true)`.

## Root cause

The original agent shimmer combined a fast 1.2-second pass with conditional mounts at runtime event boundaries. That restarted or removed the sweep while June was still working, which made the system feel abrupt and inconsistent. Two video states also carried `.text-shimmer` without `.shimmer`, so they never painted the shared sweep.

The first tuning pass corrected the lifecycle but over-corrected the visual treatment: it used the shared 2-second default and introduced quieter per-theme `--shimmer-color` values. In dark mode, the override mixed 80% muted text with only 20% foreground, moving the peak from OKLCH L 0.709 to about 0.764. That was only a 0.055 lift, roughly 19% of the shared dark recipe's contrast, and the gradient shoulders halved it again. Light mode was similarly too restrained.

The final state removes those contrast overrides entirely, restores the shared theme-aware recipe, and keeps only a 1.6-second agent-specific cadence.

| Stage | Cadence | Contrast | Runtime behavior |
|---|---:|---|---|
| Baseline | 1.2s | Shared theme recipe | Restarts/disappears at event boundaries; some video states do not animate |
| First pass | 2.0s | Custom low-contrast overrides | Stable, but too slow and too faint in both themes |
| Final | 1.6s | Shared theme recipe | Stable presence with short enter/exit and completion crossfades |

## Validation

- `make local-ci` passed on the final pushed commit: typecheck passed; 155 frontend test files passed; 2,516 tests passed and 2 skipped; `signoff/frontend` and the not-applicable `signoff/rust-macos` status were posted successfully.
- After merging current `main`, the focused agent workspace/shimmer suites also passed independently: 267 tests passed and 2 skipped.
- Biome error-level check passed on all six changed files. Existing warning-level diagnostics in `AgentWorkspace.tsx` are unchanged.
- `git diff --check origin/main...HEAD` passed.
- Independent diff review found no blockers or material regressions.
- Greptile reviewed the final commit at 5/5 confidence with no blocking issues and marked it safe to merge. Octopus completed at 4/5 with no actionable finding.
- Browser QA exercised several live cycles of all three production text lengths in light and dark mode, confirmed the computed 1.6-second linear cadence, and reported no console errors.

### Visual evidence

[Light and dark shimmer gallery recording](https://app.opensoftware.co/api/v1/files/fil_QaKru4dRxinZ/download)

- [x] Tested visually where it matters (browser recording above; production CSS/classes, both themes, three text lengths).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is required; this is frontend-only.

## Out of scope

- Changing the shared shimmer recipe or its default cadence for recorder and other non-agent surfaces.
- Length-dependent animation timing. The gallery now makes that option easy to evaluate later without coupling cadence to copy length in this pass.
- Native, backend, billing, identity, or model-runtime behavior.

## Followups

- None required. Revisit spread or length-aware timing only if the production gallery reveals a new issue after broader use.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. No security-sensitive behavior changed.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such changes are present.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend changes are present.
- [x] User-facing copy follows the repo UI conventions.
