### PR TITLE
Add text zoom keyboard shortcuts

### DIFF
--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -72,8 +72,8 @@ import { getStoredTheme, setStoredTheme, type ThemePreference } from "../../lib/
 import { BRAND_PRESETS, getStoredBrand, setStoredBrand, type BrandId } from "../../lib/brand";
 import {
   FONT_SCALE_PRESETS,
-  getStoredFontScale,
   setStoredFontScale,
+  useFontScaleId,
   type FontScaleId,
 } from "../../lib/font-scale";
 import {
@@ -457,7 +457,7 @@ export function AppSettings({
   const [micOpen, setMicOpen] = useState(false);
   const [theme, setTheme] = useState<ThemePreference>(() => getStoredTheme());
   const [brand, setBrand] = useState<BrandId>(() => getStoredBrand());
-  const [fontScale, setFontScale] = useState<FontScaleId>(() => getStoredFontScale());
+  const fontScale = useFontScaleId();
   const [dateFormat, setDateFormat] = useState<DateFormatPreference>(() => getStoredDateFormat());
   const [releaseChannel, setReleaseChannelValue] = useState<ReleaseChannel>("stable");
   // Set only when a leave-rc switch turns up an installable stable, so the
@@ -488,6 +488,7 @@ export function AppSettings({
   const [micTestStartedAt, setMicTestStartedAt] = useState<number>();
   const [micTestElapsedMs, setMicTestElapsedMs] = useState(0);
   const [micTestSampleSrc, setMicTestSampleSrc] = useState<string>();
+
   const [micTestError, setMicTestError] = useState<string>();
   const [micTestPlaying, setMicTestPlaying] = useState(false);
   const controlled = controlledTab !== undefined && onTabChange !== undefined;
@@ -1517,10 +1518,7 @@ export function AppSettings({
                       aria-label="Text size"
                       value={fontScale}
                       options={FONT_SCALE_OPTIONS}
-                      onValueChange={(next) => {
-                        setFontScale(next);
-                        setStoredFontScale(next);
-                      }}
+                      onValueChange={setStoredFontScale}
                     />
                   </div>
                 </div>

--- a/src/lib/font-scale.ts
+++ b/src/lib/font-scale.ts
@@ -32,7 +32,8 @@ const STORAGE_KEY = "os-june:font-scale";
 export const FONT_SCALE_CHANGED_EVENT = "june://font-scale-change";
 export const DEFAULT_FONT_SCALE: FontScaleId = "default";
 let sessionFontScale: FontScaleId = DEFAULT_FONT_SCALE;
-let storageUnavailable = false;
+let storageWriteFailed = false;
+let storageReadFailed = false;
 
 function presetFor(id: string | null) {
   // Unknown ids (including a stored "small" from the dropped preset) resolve
@@ -45,13 +46,17 @@ function presetFor(id: string | null) {
 }
 
 export function getStoredFontScale(): FontScaleId {
-  if (storageUnavailable) return sessionFontScale;
+  if (storageWriteFailed) return sessionFontScale;
   try {
-    sessionFontScale = presetFor(localStorage.getItem(STORAGE_KEY)).id;
+    const next = presetFor(localStorage.getItem(STORAGE_KEY)).id;
+    const recoveredFromReadFailure = storageReadFailed;
+    storageReadFailed = false;
+    sessionFontScale = next;
+    if (recoveredFromReadFailure) applyFontScale(next);
     return sessionFontScale;
   } catch {
-    // localStorage can throw in sandboxed contexts.
-    storageUnavailable = true;
+    // A transient read failure should not prevent a later snapshot from retrying.
+    storageReadFailed = true;
     return sessionFontScale;
   }
 }
@@ -65,17 +70,19 @@ export function setStoredFontScale(id: FontScaleId) {
   sessionFontScale = next;
   try {
     localStorage.setItem(STORAGE_KEY, next);
-    storageUnavailable = false;
+    storageWriteFailed = false;
+    storageReadFailed = false;
   } catch {
     // The in-memory value keeps stepping and reset working for this session.
-    storageUnavailable = true;
+    storageWriteFailed = true;
   }
   applyFontScale(next);
   window.dispatchEvent(new CustomEvent<FontScaleId>(FONT_SCALE_CHANGED_EVENT, { detail: next }));
 }
 
 export function initFontScale() {
-  storageUnavailable = false;
+  storageWriteFailed = false;
+  storageReadFailed = false;
   applyFontScale(getStoredFontScale());
 }
 
@@ -105,8 +112,11 @@ function shortcutAction(event: KeyboardEvent): "increase" | "decrease" | "reset"
   if (!hasPrimaryModifier) return undefined;
 
   if (event.key === "+" || event.key === "=") return "increase";
-  if (!event.shiftKey && event.key === "-") return "decrease";
-  if (!event.shiftKey && event.key === "0") return "reset";
+  if (event.key === "-") return "decrease";
+  if (event.key === "0") return "reset";
+  if (event.code === "Equal" || event.code === "NumpadAdd") return "increase";
+  if (event.code === "Minus" || event.code === "NumpadSubtract") return "decrease";
+  if (event.code === "Digit0" || event.code === "Numpad0") return "reset";
   return undefined;
 }
 

--- a/src/lib/font-scale.ts
+++ b/src/lib/font-scale.ts
@@ -10,6 +10,9 @@
 // runs so a non-default size doesn't flash the base scale first. Keep the
 // storage key and the id->multiplier map in sync with that bootstrap.
 
+import { useSyncExternalStore } from "react";
+import { isMacLikePlatform } from "./platform";
+
 export type FontScaleId = "default" | "large" | "larger";
 
 // Up-only ladder: June is a reading app, so there's no "denser" step — the two
@@ -26,6 +29,7 @@ export const FONT_SCALE_PRESETS: {
 ];
 
 const STORAGE_KEY = "os-june:font-scale";
+export const FONT_SCALE_CHANGED_EVENT = "june://font-scale-change";
 export const DEFAULT_FONT_SCALE: FontScaleId = "default";
 
 function presetFor(id: string | null) {
@@ -52,14 +56,78 @@ export function applyFontScale(id: FontScaleId) {
 }
 
 export function setStoredFontScale(id: FontScaleId) {
+  const next = presetFor(id).id;
   try {
-    localStorage.setItem(STORAGE_KEY, id);
+    localStorage.setItem(STORAGE_KEY, next);
   } catch {
     // Apply still works for this session.
   }
-  applyFontScale(id);
+  applyFontScale(next);
+  window.dispatchEvent(new CustomEvent<FontScaleId>(FONT_SCALE_CHANGED_EVENT, { detail: next }));
 }
 
 export function initFontScale() {
   applyFontScale(getStoredFontScale());
+}
+
+function subscribeFontScale(onChange: () => void) {
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === STORAGE_KEY || event.key === null) onChange();
+  };
+  window.addEventListener(FONT_SCALE_CHANGED_EVENT, onChange);
+  window.addEventListener("storage", onStorage);
+  return () => {
+    window.removeEventListener(FONT_SCALE_CHANGED_EVENT, onChange);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+export function useFontScaleId() {
+  return useSyncExternalStore(subscribeFontScale, getStoredFontScale, () => DEFAULT_FONT_SCALE);
+}
+
+function stepStoredFontScale(delta: -1 | 1) {
+  const current = getStoredFontScale();
+  const currentIndex = FONT_SCALE_PRESETS.findIndex((preset) => preset.id === current);
+  const nextIndex = Math.min(FONT_SCALE_PRESETS.length - 1, Math.max(0, currentIndex + delta));
+  const next = FONT_SCALE_PRESETS[nextIndex]?.id ?? DEFAULT_FONT_SCALE;
+  if (next !== current) setStoredFontScale(next);
+}
+
+function shortcutAction(event: KeyboardEvent): "increase" | "decrease" | "reset" | undefined {
+  if (event.altKey) return undefined;
+
+  const hasPrimaryModifier = isMacLikePlatform()
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey;
+  if (!hasPrimaryModifier) return undefined;
+
+  if (event.key === "+" || event.key === "=") return "increase";
+  if (!event.shiftKey && event.key === "-") return "decrease";
+  if (!event.shiftKey && event.key === "0") return "reset";
+  return undefined;
+}
+
+/**
+ * Installs the standard desktop text zoom shortcuts. June's scale is
+ * intentionally up-only, so zooming out reverses a prior zoom-in and stops at
+ * the default size.
+ */
+export function installFontScaleShortcuts() {
+  const onKeyDown = (event: KeyboardEvent) => {
+    const action = shortcutAction(event);
+    if (!action) return;
+
+    event.preventDefault();
+    if (action === "increase") {
+      stepStoredFontScale(1);
+    } else if (action === "decrease") {
+      stepStoredFontScale(-1);
+    } else if (getStoredFontScale() !== DEFAULT_FONT_SCALE) {
+      setStoredFontScale(DEFAULT_FONT_SCALE);
+    }
+  };
+
+  window.addEventListener("keydown", onKeyDown);
+  return () => window.removeEventListener("keydown", onKeyDown);
 }

--- a/src/lib/font-scale.ts
+++ b/src/lib/font-scale.ts
@@ -31,6 +31,8 @@ export const FONT_SCALE_PRESETS: {
 const STORAGE_KEY = "os-june:font-scale";
 export const FONT_SCALE_CHANGED_EVENT = "june://font-scale-change";
 export const DEFAULT_FONT_SCALE: FontScaleId = "default";
+let sessionFontScale: FontScaleId = DEFAULT_FONT_SCALE;
+let storageUnavailable = false;
 
 function presetFor(id: string | null) {
   // Unknown ids (including a stored "small" from the dropped preset) resolve
@@ -43,11 +45,14 @@ function presetFor(id: string | null) {
 }
 
 export function getStoredFontScale(): FontScaleId {
+  if (storageUnavailable) return sessionFontScale;
   try {
-    return presetFor(localStorage.getItem(STORAGE_KEY)).id;
+    sessionFontScale = presetFor(localStorage.getItem(STORAGE_KEY)).id;
+    return sessionFontScale;
   } catch {
     // localStorage can throw in sandboxed contexts.
-    return DEFAULT_FONT_SCALE;
+    storageUnavailable = true;
+    return sessionFontScale;
   }
 }
 
@@ -57,29 +62,26 @@ export function applyFontScale(id: FontScaleId) {
 
 export function setStoredFontScale(id: FontScaleId) {
   const next = presetFor(id).id;
+  sessionFontScale = next;
   try {
     localStorage.setItem(STORAGE_KEY, next);
+    storageUnavailable = false;
   } catch {
-    // Apply still works for this session.
+    // The in-memory value keeps stepping and reset working for this session.
+    storageUnavailable = true;
   }
   applyFontScale(next);
   window.dispatchEvent(new CustomEvent<FontScaleId>(FONT_SCALE_CHANGED_EVENT, { detail: next }));
 }
 
 export function initFontScale() {
+  storageUnavailable = false;
   applyFontScale(getStoredFontScale());
 }
 
 function subscribeFontScale(onChange: () => void) {
-  const onStorage = (event: StorageEvent) => {
-    if (event.key === STORAGE_KEY || event.key === null) onChange();
-  };
   window.addEventListener(FONT_SCALE_CHANGED_EVENT, onChange);
-  window.addEventListener("storage", onStorage);
-  return () => {
-    window.removeEventListener(FONT_SCALE_CHANGED_EVENT, onChange);
-    window.removeEventListener("storage", onStorage);
-  };
+  return () => window.removeEventListener(FONT_SCALE_CHANGED_EVENT, onChange);
 }
 
 export function useFontScaleId() {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import { installNativeContextMenuGuard } from "./lib/native-context-menu";
 import { replayOnboarding } from "./lib/onboarding";
 import { initTheme } from "./lib/theme";
 import { initBrand } from "./lib/brand";
-import { initFontScale } from "./lib/font-scale";
+import { initFontScale, installFontScaleShortcuts } from "./lib/font-scale";
 import { installExternalLinkOpener } from "./lib/external-links";
 import "./styles/app.css";
 
@@ -27,6 +27,7 @@ if (import.meta.env.DEV) {
 initTheme();
 initBrand();
 initFontScale();
+installFontScaleShortcuts();
 installExternalLinkOpener();
 installNativeContextMenuGuard();
 

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -10,6 +10,7 @@ import { MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS } from "../lib/hermes-messaging";
 import { PROVIDER_MODEL_SETTINGS_CHANGED_EVENT } from "../lib/model-privacy";
 import { TELEMETRY_INFO_URL } from "../lib/p3a";
 import { DATE_FORMAT_STORAGE_KEY } from "../lib/date-format";
+import { setStoredFontScale } from "../lib/font-scale";
 
 const mocks = vi.hoisted(() => ({
   dictationSettings: vi.fn(),
@@ -729,6 +730,34 @@ describe("AppSettings", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("keeps the appearance text-size control in sync with zoom shortcuts", () => {
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Appearance" }));
+    expect(screen.getByRole("button", { name: "Default text size" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    act(() => setStoredFontScale("large"));
+
+    expect(screen.getByRole("button", { name: "Large text size" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 
   it("changes the sidebar date format through the appearance picker", () => {

--- a/src/test/font-scale.test.ts
+++ b/src/test/font-scale.test.ts
@@ -69,7 +69,19 @@ describe("font scale shortcuts", () => {
   it("ignores chords that are not standard zoom shortcuts", () => {
     fireEvent.keyDown(window, { key: "+", ctrlKey: true, shiftKey: true });
     fireEvent.keyDown(window, { key: "+", metaKey: true, altKey: true, shiftKey: true });
-    fireEvent.keyDown(window, { key: "0", metaKey: true, shiftKey: true });
+    fireEvent.keyDown(window, { key: "z", code: "KeyZ", metaKey: true, shiftKey: true });
+    expect(getStoredFontScale()).toBe("default");
+  });
+
+  it("recognizes physical zoom keys across keyboard layouts", () => {
+    fireEvent.keyDown(window, { key: "´", code: "Equal", metaKey: true });
+    expect(getStoredFontScale()).toBe("large");
+
+    fireEvent.keyDown(window, { key: "à", code: "Digit0", metaKey: true, shiftKey: true });
+    expect(getStoredFontScale()).toBe("default");
+
+    fireEvent.keyDown(window, { key: "´", code: "Equal", metaKey: true });
+    fireEvent.keyDown(window, { key: "/", code: "Minus", metaKey: true, shiftKey: true });
     expect(getStoredFontScale()).toBe("default");
   });
 
@@ -113,6 +125,23 @@ describe("font scale shortcuts", () => {
       expect(document.documentElement.style.getPropertyValue("--font-scale")).toBe("1");
     } finally {
       setItem.mockRestore();
+    }
+  });
+
+  it("retries snapshots after a transient storage read failure", () => {
+    const getItem = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementationOnce(() => {
+        throw new DOMException("Storage temporarily unavailable", "SecurityError");
+      })
+      .mockImplementation(() => "large");
+
+    try {
+      expect(getStoredFontScale()).toBe("default");
+      expect(getStoredFontScale()).toBe("large");
+      expect(document.documentElement.style.getPropertyValue("--font-scale")).toBe("1.1");
+    } finally {
+      getItem.mockRestore();
     }
   });
 });

--- a/src/test/font-scale.test.ts
+++ b/src/test/font-scale.test.ts
@@ -1,0 +1,94 @@
+import { fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  FONT_SCALE_CHANGED_EVENT,
+  getStoredFontScale,
+  installFontScaleShortcuts,
+} from "../lib/font-scale";
+
+describe("font scale shortcuts", () => {
+  let uninstall: (() => void) | undefined;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.style.removeProperty("--font-scale");
+    uninstall = installFontScaleShortcuts();
+  });
+
+  afterEach(() => {
+    uninstall?.();
+  });
+
+  it("zooms in through the supported text sizes with Command plus", () => {
+    fireEvent.keyDown(window, { key: "+", code: "Equal", metaKey: true, shiftKey: true });
+    expect(getStoredFontScale()).toBe("large");
+    expect(document.documentElement.style.getPropertyValue("--font-scale")).toBe("1.1");
+
+    fireEvent.keyDown(window, { key: "=", code: "Equal", metaKey: true });
+    expect(getStoredFontScale()).toBe("larger");
+    expect(document.documentElement.style.getPropertyValue("--font-scale")).toBe("1.2");
+
+    fireEvent.keyDown(window, { key: "+", code: "Equal", metaKey: true, shiftKey: true });
+    expect(getStoredFontScale()).toBe("larger");
+  });
+
+  it("zooms back out to the default and resets with Command zero", () => {
+    fireEvent.keyDown(window, { key: "+", metaKey: true, shiftKey: true });
+    fireEvent.keyDown(window, { key: "+", metaKey: true, shiftKey: true });
+    fireEvent.keyDown(window, { key: "-", metaKey: true });
+    expect(getStoredFontScale()).toBe("large");
+
+    fireEvent.keyDown(window, { key: "0", metaKey: true });
+    expect(getStoredFontScale()).toBe("default");
+    expect(document.documentElement.style.getPropertyValue("--font-scale")).toBe("1");
+
+    fireEvent.keyDown(window, { key: "-", metaKey: true });
+    expect(getStoredFontScale()).toBe("default");
+  });
+
+  it("prevents the webview default and announces scale changes", () => {
+    const changes: string[] = [];
+    const onChange = (event: Event) => changes.push((event as CustomEvent<string>).detail);
+    window.addEventListener(FONT_SCALE_CHANGED_EVENT, onChange);
+
+    const zoomIn = new KeyboardEvent("keydown", {
+      key: "+",
+      metaKey: true,
+      shiftKey: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(zoomIn);
+
+    expect(zoomIn.defaultPrevented).toBe(true);
+    expect(changes).toEqual(["large"]);
+    window.removeEventListener(FONT_SCALE_CHANGED_EVENT, onChange);
+  });
+
+  it("ignores chords that are not standard zoom shortcuts", () => {
+    fireEvent.keyDown(window, { key: "+", ctrlKey: true, shiftKey: true });
+    fireEvent.keyDown(window, { key: "+", metaKey: true, altKey: true, shiftKey: true });
+    fireEvent.keyDown(window, { key: "0", metaKey: true, shiftKey: true });
+    expect(getStoredFontScale()).toBe("default");
+  });
+
+  it("uses Control instead of Command on Windows", () => {
+    const platform = Object.getOwnPropertyDescriptor(navigator, "platform");
+    const userAgent = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+    Object.defineProperty(navigator, "platform", { configurable: true, get: () => "Win32" });
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      get: () => "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    });
+
+    try {
+      fireEvent.keyDown(window, { key: "+", metaKey: true, shiftKey: true });
+      expect(getStoredFontScale()).toBe("default");
+
+      fireEvent.keyDown(window, { key: "+", ctrlKey: true, shiftKey: true });
+      expect(getStoredFontScale()).toBe("large");
+    } finally {
+      if (platform) Object.defineProperty(navigator, "platform", platform);
+      if (userAgent) Object.defineProperty(navigator, "userAgent", userAgent);
+    }
+  });
+});

--- a/src/test/font-scale.test.ts
+++ b/src/test/font-scale.test.ts
@@ -1,8 +1,9 @@
 import { fireEvent } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   FONT_SCALE_CHANGED_EVENT,
   getStoredFontScale,
+  initFontScale,
   installFontScaleShortcuts,
 } from "../lib/font-scale";
 
@@ -12,6 +13,7 @@ describe("font scale shortcuts", () => {
   beforeEach(() => {
     localStorage.clear();
     document.documentElement.style.removeProperty("--font-scale");
+    initFontScale();
     uninstall = installFontScaleShortcuts();
   });
 
@@ -89,6 +91,28 @@ describe("font scale shortcuts", () => {
     } finally {
       if (platform) Object.defineProperty(navigator, "platform", platform);
       if (userAgent) Object.defineProperty(navigator, "userAgent", userAgent);
+    }
+  });
+
+  it("keeps stepping and reset working when persistence fails", () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage quota exceeded", "QuotaExceededError");
+    });
+
+    try {
+      fireEvent.keyDown(window, { key: "+", metaKey: true, shiftKey: true });
+      expect(getStoredFontScale()).toBe("large");
+      expect(document.documentElement.style.getPropertyValue("--font-scale")).toBe("1.1");
+
+      fireEvent.keyDown(window, { key: "+", metaKey: true, shiftKey: true });
+      expect(getStoredFontScale()).toBe("larger");
+      expect(document.documentElement.style.getPropertyValue("--font-scale")).toBe("1.2");
+
+      fireEvent.keyDown(window, { key: "0", metaKey: true });
+      expect(getStoredFontScale()).toBe("default");
+      expect(document.documentElement.style.getPropertyValue("--font-scale")).toBe("1");
+    } finally {
+      setItem.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Summary

- Add Command-Plus/Equal to increase the app text size through the existing presets.
- Add Command-Minus to step back toward default and Command-Zero to reset.
- Keep the Appearance text-size control synchronized with keyboard changes, including when persistent storage is unavailable.

## Validation

- `make local-ci` - passed and posted frontend and Rust macOS signoffs for `6b11fc99`.
- 159 frontend test files passed: 2,595 tests passed and 2 skipped.
- `pnpm typecheck` and Biome checks passed with the existing repository warning baseline.
- Live web-preview walkthrough verified Default -> Large -> Larger -> Large -> Default, with the settings control and persisted value synchronized and no console errors.
- Standard-sized review battery: independent adversarial convergence review approved; final standards and product-spec reviews were clean.

- [x] Tested visually where it matters. A local recording and screenshots were captured during the walkthrough.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed; this is desktop-only.

## Out of scope

- HUD windows remain at their existing fixed 1x scale.
- Native webview zoom and a below-default text-size preset are unchanged.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. None.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786595981&installation_id=144203540&pr_number=739&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F739&signature=6b92fe4cb47da144083e46289406df86ce1214d89bfe44288ac17cdb9cb22515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->