### PR TITLE
Align usage skeleton with system bars and make the wordmark squircle solid brand

### DIFF
--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -96,11 +96,19 @@ warnings use `InlineNotice` (`src/components/ui/InlineNotice.tsx`) with
 `data-tone="warning"` or `"destructive"`; full-width banners are a separate
 treatment.
 
+First-load skeleton bars are quiet and static: flat `var(--surface-subtle)`
+blocks with `var(--r-sm)` radius, sized to the line they stand in for, on an
+`aria-hidden` (or `aria-busy`) container — no sweep, no pulse (the settings
+sections and the session usage panel are the reference call sites). Don't
+hand-roll an animated gradient for a skeleton; `.shimmer` below is for working
+*text*, not placeholder blocks.
+
 ## Shimmer
 
 `.shimmer` (`src/styles/shimmer.css`, imported by `app.css`) is the canonical
 sweep for "this text is working" states: thinking labels, image-generation and
-transcription progress, first-load skeleton bars. It is a vendored plain-CSS
+transcription progress. It clips to glyphs, so it never applies to block
+placeholders (see the skeleton-bar rule above). It is a vendored plain-CSS
 port of the shadcn shimmer utility, kept API-compatible with upstream, so its
 knobs (`--shimmer-duration`, `--shimmer-spread`, `--shimmer-angle`,
 `--shimmer-color`) tune per call site.

--- a/src/components/agent/SessionUsagePanel.tsx
+++ b/src/components/agent/SessionUsagePanel.tsx
@@ -22,12 +22,12 @@ import { ModelPrivacyChip } from "../ui/ModelPrivacyChip";
  *
  * Missing fields drop their row rather than showing a placeholder; a payload
  * with nothing usable shows a single empty-state line. The very first load
- * renders the REAL structure with placeholder content — a shimmer bar where the
- * model name lands, the real 60-segment meter track sitting empty (unlit), and
- * two shimmer bars where the legend reading and percent land — so nothing jumps
- * when data arrives: the text placeholders cross-fade to real copy in place and
- * the live track starts from a pixel-identical empty state before lighting up
- * with its eased sweep.
+ * renders the REAL structure with placeholder content — a skeleton bar where
+ * the model name lands, the real 60-segment meter track sitting empty (unlit),
+ * and two skeleton bars where the legend reading and percent land — so nothing
+ * jumps when data arrives: the text placeholders cross-fade to real copy in
+ * place and the live track starts from a pixel-identical empty state before
+ * lighting up with its eased sweep.
  *
  * Decoupled from the gateway on purpose: it takes a `fetchUsage(sessionId)`
  * function that already normalizes the raw `session.usage` result into a
@@ -140,9 +140,9 @@ export function SessionUsagePanel({
       ) : firstLoad ? (
         // First load: render the real structure with placeholder content. The
         // layout is known before data arrives, so we mount the same body
-        // container with a shimmer bar for the model name, the real (empty) meter
-        // track, and two shimmer bars for the legend — nothing jumps when the
-        // payload lands and the placeholders swap to real content in place.
+        // container with a skeleton bar for the model name, the real (empty)
+        // meter track, and two skeleton bars for the legend — nothing jumps when
+        // the payload lands and the placeholders swap to real content in place.
         <div className="agent-usage-body" aria-busy="true">
           <UsageSkeleton />
         </div>
@@ -416,12 +416,13 @@ function MeterTrack({
   );
 }
 
-/** First-load placeholder: the real body structure with shimmer bars standing in
- * for the model name and the legend reading/percent, wrapped around the real
- * (empty) meter track. Because it shares the body container, vertical rhythm,
- * and {@link MeterTrack} markup with the loaded content, the swap to real data
- * is seamless: the text cross-fades and the live track starts from the same
- * empty frame before lighting up. */
+/** First-load placeholder: the real body structure with static skeleton bars
+ * (the app-wide quiet-bar treatment) standing in for the model name and the
+ * legend reading/percent, wrapped around the real (empty) meter track. Because
+ * it shares the body container, vertical rhythm, and {@link MeterTrack} markup
+ * with the loaded content, the swap to real data is seamless: the text
+ * cross-fades and the live track starts from the same empty frame before
+ * lighting up. */
 function UsageSkeleton() {
   return (
     <>

--- a/src/components/agent/SessionUsagePanel.tsx
+++ b/src/components/agent/SessionUsagePanel.tsx
@@ -143,7 +143,10 @@ export function SessionUsagePanel({
         // container with a skeleton bar for the model name, the real (empty)
         // meter track, and two skeleton bars for the legend — nothing jumps when
         // the payload lands and the placeholders swap to real content in place.
-        <div className="agent-usage-body" aria-busy="true">
+        // aria-busy is honest here, but data-first-load exempts this body from
+        // the refresh dim so the quiet skeleton bars stay at full strength (a
+        // refresh dims stale content; the first-load skeleton must not dim).
+        <div className="agent-usage-body" aria-busy="true" data-first-load>
           <UsageSkeleton />
         </div>
       ) : (

--- a/src/components/brand/JuneWordmark.tsx
+++ b/src/components/brand/JuneWordmark.tsx
@@ -1,17 +1,14 @@
-import { useId } from "react";
-
 /**
  * The "June" wordmark + squircle mark, inlined so it follows the live theme:
  * the lettering paints in `currentColor` (set by the caller to the right
- * foreground per light/dark) and the mark's squircle gradient derives from
- * --brand, so picking a new accent recolors the logo everywhere it renders
- * (sidebar header, etc.). Replaces the static /os-june-light.svg + dark pair,
- * which couldn't read CSS variables through an <img>.
+ * foreground per light/dark) and the mark's squircle fills with the solid
+ * --brand accent, so picking a new accent recolors the logo everywhere it
+ * renders (sidebar header, etc.). Replaces the static /os-june-light.svg +
+ * dark pair, which couldn't read CSS variables through an <img>.
  *
  * Geometry traced 1:1 from public/os-june-light.svg (61x18).
  */
 export function JuneWordmark({ className }: { className?: string }) {
-  const gradientId = `june-wordmark-${useId().replace(/:/g, "")}`;
   return (
     <svg
       className={className}
@@ -29,18 +26,12 @@ export function JuneWordmark({ className }: { className?: string }) {
         <path d="M35.9509 15.788C34.0609 15.788 32.8189 14.582 32.8189 12.314V7.616C32.8189 6.914 33.1609 6.536 33.7549 6.536C34.3309 6.536 34.6909 6.914 34.6909 7.616V11.99C34.6909 13.43 35.2489 14.312 36.4909 14.312C37.7509 14.312 38.5429 13.358 38.5429 11.774V7.616C38.5429 6.914 38.8849 6.536 39.4789 6.536C40.0549 6.536 40.4149 6.914 40.4149 7.616V14.654C40.4149 15.338 40.0549 15.734 39.4969 15.734C38.9389 15.734 38.5969 15.356 38.5969 14.726C38.5969 14.564 38.5969 14.42 38.6149 14.294C38.1829 15.176 37.2649 15.788 35.9509 15.788Z" />
         <path d="M26.676 15.788C24.372 15.788 23.256 14.546 22.878 13.088C22.554 11.918 23.058 11.306 23.76 11.306C24.318 11.306 24.642 11.648 24.768 12.332C24.948 13.34 25.452 14.114 26.73 14.114C28.314 14.114 28.818 13.016 28.818 11.486V3.818C28.818 3.08 29.196 2.666 29.826 2.666C30.456 2.666 30.834 3.08 30.834 3.818V11.72C30.834 14.33 29.196 15.788 26.676 15.788Z" />
       </g>
-      {/* Squircle mark — gradient derives from the selected accent. */}
-      <rect width="18" height="18" rx="4" fill={`url(#${gradientId})`} />
+      {/* Squircle mark — solid fill in the selected accent. */}
+      <rect width="18" height="18" rx="4" fill="var(--brand)" />
       <g fill="white">
         <path d="M14.0417 8.53571C14.2948 8.53571 14.5 8.74358 14.5 9V10.3929C14.5 10.6493 14.2948 10.8571 14.0417 10.8571H13.0462C12.9247 10.8572 12.8081 10.9061 12.7222 10.9932L12.3426 11.3777C12.2567 11.4647 12.2084 11.5828 12.2083 11.7059V12.7143C12.2083 12.9707 12.0031 13.1786 11.75 13.1786H6.62956C6.50802 13.1786 6.39144 13.2275 6.3055 13.3146L5.92594 13.6991C5.84001 13.7861 5.79169 13.9042 5.79167 14.0273V15.0357C5.79167 15.2921 5.58646 15.5 5.33333 15.5H3.95833C3.7052 15.5 3.5 15.2921 3.5 15.0357V13.6429C3.5 13.3864 3.7052 13.1786 3.95833 13.1786H4.95378C5.07531 13.1786 5.19189 13.1296 5.27783 13.0426L5.65739 12.6581C5.74333 12.571 5.79165 12.4529 5.79167 12.3298V11.3214C5.79167 11.065 5.99687 10.8571 6.25 10.8571H11.3704C11.492 10.8571 11.6086 10.8082 11.6945 10.7211L12.0741 10.3366C12.16 10.2496 12.2083 10.1315 12.2083 10.0084V9C12.2083 8.74358 12.4135 8.53571 12.6667 8.53571H14.0417Z" />
         <path d="M14.0417 2.5C14.2948 2.5 14.5 2.70787 14.5 2.96429V4.35714C14.5 4.61356 14.2948 4.82143 14.0417 4.82143H13.0462C12.9247 4.82145 12.8081 4.8704 12.7222 4.95745L12.3426 5.34194C12.2567 5.42899 12.2084 5.54709 12.2083 5.6702V6.67857C12.2083 6.93499 12.0031 7.14286 11.75 7.14286H6.62956C6.50802 7.14288 6.39144 7.19182 6.3055 7.27888L5.92594 7.66336C5.84001 7.75042 5.79169 7.86852 5.79167 7.99163V9C5.79167 9.25642 5.58646 9.46429 5.33333 9.46429H3.95833C3.7052 9.46429 3.5 9.25642 3.5 9V7.60714C3.5 7.35072 3.7052 7.14286 3.95833 7.14286H4.95378C5.07531 7.14284 5.19189 7.09389 5.27783 7.00684L5.65739 6.62235C5.74333 6.5353 5.79165 6.4172 5.79167 6.29408V5.28571C5.79167 5.0293 5.99687 4.82143 6.25 4.82143H11.3704C11.492 4.82141 11.6086 4.77246 11.6945 4.68541L12.0741 4.30092C12.16 4.21387 12.2083 4.09577 12.2083 3.97266V2.96429C12.2083 2.70787 12.4135 2.5 12.6667 2.5H14.0417Z" />
       </g>
-      <defs>
-        <linearGradient id={gradientId} x1="9" y1="0" x2="9" y2="18" gradientUnits="userSpaceOnUse">
-          <stop style={{ stopColor: "color-mix(in oklch, var(--brand) 55%, white)" }} />
-          <stop offset="1" style={{ stopColor: "var(--brand)" }} />
-        </linearGradient>
-      </defs>
     </svg>
   );
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3694,7 +3694,12 @@ input:focus-visible,
   overflow-y: auto;
 }
 
-.agent-usage-body[aria-busy="true"] {
+/* A refresh dims the stale card so it reads as reloading while the prior data
+   stays visible. The first-load body is aria-busy too (its skeleton is genuinely
+   busy), but must NOT dim — the static --surface-subtle skeleton bars already
+   sit close to the popover background, so a 60% dim would render them nearly
+   invisible. [data-first-load] carries that exemption. */
+.agent-usage-body[aria-busy="true"]:not([data-first-load]) {
   opacity: 0.6;
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3698,37 +3698,19 @@ input:focus-visible,
   opacity: 0.6;
 }
 
-/* First-load skeleton bars: block-shaped shimmer standing in for the model name
-   and the legend reading/percent while the real meter track renders empty
+/* First-load skeleton bars: quiet static placeholders standing in for the model
+   name and the legend reading/percent while the real meter track renders empty
    beneath. The body structure is shared with the loaded content, and the live
    track starts from a pixel-identical empty frame before lighting up, so the
-   swap has no visible jump. The bars run their own background-position sweep on
-   a wide muted gradient — a block sweep, not a text-clip, so it is independent
-   of the shared .shimmer text utility (which clips to glyphs). Muted base, pill
-   radius; sizes come from spacing tokens with a small local width var. */
+   swap has no visible jump. Same treatment as the other first-load skeletons
+   (settings sections, messaging detail): a flat --surface-subtle bar with the
+   small radius — no sweep. Bars stay 1em tall so they occupy exactly the line
+   the real text will. */
 .agent-usage-skeleton {
   display: inline-block;
   height: 1em;
-  border-radius: var(--r-pill);
-  background: linear-gradient(
-    90deg,
-    var(--muted) 0%,
-    var(--muted) 35%,
-    var(--muted-foreground) 50%,
-    var(--muted) 65%,
-    var(--muted) 100%
-  );
-  background-size: 200% 100%;
-  animation: usage-skeleton-sweep 1.6s linear infinite;
-}
-
-@keyframes usage-skeleton-sweep {
-  0% {
-    background-position: 150% 0;
-  }
-  100% {
-    background-position: -50% 0;
-  }
+  border-radius: var(--r-sm);
+  background: var(--surface-subtle);
 }
 
 .agent-usage-skeleton-model {
@@ -3986,12 +3968,6 @@ input:focus-visible,
   .agent-usage-panel,
   .agent-usage-model-row,
   .agent-usage-meter-legend {
-    animation: none;
-  }
-
-  /* Static shimmer bars: no sweep, a flat muted fill. */
-  .agent-usage-skeleton {
-    background: var(--muted);
     animation: none;
   }
 

--- a/src/test/hermes-session-usage.test.tsx
+++ b/src/test/hermes-session-usage.test.tsx
@@ -221,6 +221,9 @@ describe("SessionUsagePanel", () => {
     const body = container.querySelector(".agent-usage-body");
     expect(body).not.toBeNull();
     expect(body).toHaveAttribute("aria-busy", "true");
+    // data-first-load exempts the busy first-load body from the refresh dim so
+    // the quiet skeleton bars stay at full strength.
+    expect(body).toHaveAttribute("data-first-load");
     expect(container.querySelectorAll(".agent-usage-skeleton")).toHaveLength(3);
     expect(container.querySelectorAll(".agent-usage-meter-segment")).toHaveLength(60);
     expect(container.querySelectorAll('.agent-usage-meter-segment[data-lit="true"]')).toHaveLength(


### PR DESCRIPTION
## Summary

- The session usage panel's first-load skeleton (chat overflow menu → Usage) now uses the app-wide skeleton treatment: quiet static bars of `--surface-subtle` with `--r-sm` radius, matching the settings sections and messaging detail. It previously ran a bespoke infinite gradient sweep with pill radius whose highlight was `--muted-foreground` (a text color), flashing with far more contrast than any other skeleton in the app. The bars keep their widths and 1em height, so the no-jump handoff to real data is unchanged; the bespoke keyframes and their reduced-motion special case are deleted.
- The sidebar June wordmark's squircle mark now fills with solid `var(--brand)` instead of the light-to-brand vertical gradient, so the theme accent reads directly in the top-left. The welcome-screen glass mark and app icon are untouched.
- Documented the skeleton convention in `docs/design/components.md` (static `--surface-subtle` bars for placeholders; `.shimmer` is glyph-clipped and only for working *text*), so the next skeleton doesn't hand-roll a new treatment.

## Validation

- `pnpm typecheck`, `pnpm check`, and the full vitest suite pass (155 files / 2527 tests at time of the rebase; usage-panel suite 29/29 keeps asserting the skeleton → live handoff).

- [x] Tested visually where it matters (verified in the running app during the session).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- The sidebar header layout itself (whether the wordmark should be replaced by a bare mark + compact search trigger) — an exploration of that lives on `andrewwashuta/sidebar-header-exploration` and is deliberately not part of this PR.
- The tab context menu's "Close other tabs" on a lone tab: main already ships the identical fix, so this branch carries nothing for it.

## Followups

- Decide on the sidebar header exploration (bare brand mark, search trigger in the header row, full-width search row removed) parked on `andrewwashuta/sidebar-header-exploration`.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. <!-- none -->
- [x] Workflow action references are pinned to full-length commit SHAs. <!-- no workflow changes -->
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. <!-- none -->
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. <!-- none -->
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786597968&installation_id=144203540&pr_number=740&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F740&signature=e307a70b9b9e28df927ee5b2fe32a814fcb916e00ac49e0f077cf6222a7d6c6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->