### PR TITLE
Move recorder notices into the funding-notice card family

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -36,6 +36,7 @@ import { NoteChatPanel } from "../components/note-chat/NoteChatPanel";
 import { useNoteChat } from "../components/note-chat/useNoteChat";
 import { GlobalRecorderPill } from "../components/recorder/GlobalRecorderPill";
 import type { GlobalRecorderDemoApi } from "../lib/global-recorder-demo";
+import type { RecordNoticesDemoApi } from "../lib/record-notices-demo";
 import type { UpdateCardDemoApi } from "../lib/update-card-demo";
 import { NotesList, type NotesListHandle } from "../components/notes-list/NotesList";
 import { PermissionBanner } from "../components/permissions/PermissionBanner";
@@ -198,7 +199,11 @@ import {
 } from "../lib/max-upgrade";
 import { ConfirmDialog } from "../components/ui/ConfirmDialog";
 import { checkJuneUpdate, reconcileToStable, relaunchJune, type JuneUpdate } from "../lib/updater";
-import { PROCESSING_DEMO_NOTE_ID, shouldPollProcessingStatus } from "./processing-polling";
+import {
+  PROCESSING_DEMO_NOTE_ID,
+  RECORD_NOTICES_DEMO_SESSION_ID,
+  shouldPollProcessingStatus,
+} from "./processing-polling";
 import { attachScrollThumbFade } from "../lib/scroll-thumb-fade";
 import { createInitialState, notesReducer } from "./state/app-state";
 import { handleSidebarResizeStart } from "./sidebar-resize";
@@ -542,6 +547,46 @@ export function App() {
       dispose?.();
     };
   }, []);
+  // Dev-only console driver (window.__recordNoticesDemo) that parks the
+  // recorder-area notices (consent reminder, source warning, mic-blocked) on the
+  // selected note without a real recording, so their styling can be inspected.
+  // The synthetic status runs under RECORD_NOTICES_DEMO_SESSION_ID, which the
+  // status poll and the pause/resume/finish handlers skip so no backend call
+  // fires; consent pinning bypasses the recorder bar's reveal/auto-hide timers.
+  const [recordNoticesConsentPinned, setRecordNoticesConsentPinned] = useState(false);
+  const [recordNoticesMicOverride, setRecordNoticesMicOverride] = useState<boolean | null>(null);
+  const recordNoticesDemoRef = useRef<RecordNoticesDemoApi | null>(null);
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    let cancelled = false;
+    void import("../lib/record-notices-demo").then(({ registerRecordNoticesDemo }) => {
+      if (cancelled) return;
+      recordNoticesDemoRef.current = registerRecordNoticesDemo({
+        seedNote: (note) => {
+          dispatch({ type: "noteLoaded", note });
+          setActiveView("meetings");
+        },
+        setStatus: (status) => {
+          if (status) {
+            dispatch({ type: "recordingStatusChanged", status });
+            setRecordingNote(status.noteId);
+          } else {
+            dispatch({ type: "recordingStatusCleared" });
+            setRecordingNote(undefined);
+            setLiveTranscriptEvents([]);
+          }
+        },
+        setConsentPinned: setRecordNoticesConsentPinned,
+        setMicOverride: setRecordNoticesMicOverride,
+        getSelectedNoteId: () => selectedNoteIdRef.current,
+      });
+    });
+    return () => {
+      cancelled = true;
+      recordNoticesDemoRef.current?.dispose();
+      recordNoticesDemoRef.current = null;
+    };
+  }, [setRecordingNote]);
   // The referral delight nudge (bottom-left card). Real shows come from the
   // trigger layer (useReferralNudgeTriggers below); the dev console driver
   // (window.__referralNudge) parks the card without touching the persisted
@@ -1947,7 +1992,10 @@ export function App() {
   // TCC denial. Trust the dictation helper's AVCaptureDevice status
   // instead — that's the authoritative macOS API for the mic privacy
   // entry.
-  const microphoneBlocked = isDeniedPermission(microphoneStatus);
+  // recordNoticesMicOverride is the dev __recordNoticesDemo hook parking the
+  // mic-blocked notice; it is always null in production (the state never leaves
+  // its initial value), so real behavior is untouched.
+  const microphoneBlocked = recordNoticesMicOverride ?? isDeniedPermission(microphoneStatus);
 
   const refreshPermissionStatuses = useCallback(() => {
     void dictationHelperCommand({ type: "get_permission_status" }).catch(() => undefined);
@@ -2120,6 +2168,13 @@ export function App() {
       return;
     }
     const sessionId = state.recordingStatus.sessionId;
+    // The dev __recordNoticesDemo session lives only in the reducer — there is
+    // no backend recording to poll, and getRecordingStatus would clear the
+    // synthetic bar with a "recording not found". Stripped from production via
+    // import.meta.env.DEV. See lib/record-notices-demo.ts.
+    if (import.meta.env.DEV && sessionId === RECORD_NOTICES_DEMO_SESSION_ID) {
+      return;
+    }
     // Drops in-flight responses once this effect is torn down. Without it, a
     // poll that was already in flight when the user hit stop resolves after
     // recordingStatusCleared and resurrects the recorder bar with a stale
@@ -3035,6 +3090,13 @@ export function App() {
   }, []);
 
   async function handleFinishRecording(sessionId: string, options: { rethrow?: boolean } = {}) {
+    // The dev __recordNoticesDemo session has no backend recording — stopping it
+    // just tears the demo down (clears the synthetic status and pins) instead of
+    // calling finishRecording, which would fail with "recording not found".
+    if (import.meta.env.DEV && sessionId === RECORD_NOTICES_DEMO_SESSION_ID) {
+      recordNoticesDemoRef.current?.clear();
+      return;
+    }
     // The recorder bar stays mounted (and clickable) for the duration of its
     // exit animation after the first stop click, so a fast double-click would
     // fire finishRecording twice — the second call fails with a scary
@@ -3088,6 +3150,12 @@ export function App() {
   }
 
   const handlePauseRecording = useCallback(async (sessionId: string) => {
+    // The dev __recordNoticesDemo session has no backend recording; report
+    // success without a pauseRecording IPC round-trip. Its own ticker keeps the
+    // bar live, so pause is a visual no-op here.
+    if (import.meta.env.DEV && sessionId === RECORD_NOTICES_DEMO_SESSION_ID) {
+      return true;
+    }
     try {
       const status = await pauseRecording(sessionId);
       dispatch({ type: "recordingStatusChanged", status });
@@ -3100,6 +3168,11 @@ export function App() {
   }, []);
 
   async function handleResumeRecording(sessionId: string) {
+    // The dev __recordNoticesDemo session has no backend recording; its ticker
+    // already keeps the bar in the recording state, so resume is a no-op.
+    if (import.meta.env.DEV && sessionId === RECORD_NOTICES_DEMO_SESSION_ID) {
+      return;
+    }
     playRecordingSound("start");
     try {
       const status = await resumeRecording(sessionId);
@@ -3877,6 +3950,11 @@ export function App() {
                       onEnableSystemAudio={handleEnableSystemAudio}
                       onEnableMicrophone={handleEnableMicrophone}
                       microphoneBlocked={microphoneBlocked}
+                      consentReminderPinned={
+                        import.meta.env.DEV &&
+                        recordNoticesConsentPinned &&
+                        selectedNoteId === recordingNoteId
+                      }
                       onTabChange={(activeTab) =>
                         void updateNote({
                           noteId: selectedNote.id,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -567,6 +567,10 @@ export function App() {
           setActiveView("meetings");
         },
         setStatus: (status) => {
+          // Defense in depth: never let the demo's synthetic status stomp a real
+          // recording, even if the driver's hasRealRecording check somehow raced.
+          const active = recordingStatusRef.current;
+          if (active && active.sessionId !== RECORD_NOTICES_DEMO_SESSION_ID) return;
           if (status) {
             dispatch({ type: "recordingStatusChanged", status });
             setRecordingNote(status.noteId);
@@ -579,6 +583,10 @@ export function App() {
         setConsentPinned: setRecordNoticesConsentPinned,
         setMicOverride: setRecordNoticesMicOverride,
         getSelectedNoteId: () => selectedNoteIdRef.current,
+        hasRealRecording: () => {
+          const active = recordingStatusRef.current;
+          return !!active && active.sessionId !== RECORD_NOTICES_DEMO_SESSION_ID;
+        },
       });
     });
     return () => {

--- a/src/app/processing-polling.ts
+++ b/src/app/processing-polling.ts
@@ -9,3 +9,10 @@ export function shouldPollProcessingStatus(status: ProcessingStatus) {
  * backend row — so the processing-status poll skips it. See
  * lib/processing-progress-demo.ts. */
 export const PROCESSING_DEMO_NOTE_ID = "dev-processing-demo-note";
+
+/** Sentinel session id for the dev-only recorder-notices demo
+ * (window.__recordNoticesDemo). Its recording status lives only in the reducer
+ * — there is no backend recording — so the recording-status poll and the
+ * pause/resume/finish handlers skip it instead of calling Tauri. See
+ * lib/record-notices-demo.ts. */
+export const RECORD_NOTICES_DEMO_SESSION_ID = "dev-record-notices-demo-session";

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -64,6 +64,10 @@ type NoteEditorProps = {
   onEnableSystemAudio: () => void;
   onEnableMicrophone: () => void;
   microphoneBlocked: boolean;
+  /** Dev-only: pin the consent reminder open past its reveal/auto-hide timers so
+   * the dev console driver (window.__recordNoticesDemo) can park it for styling
+   * review. Undefined in production, so the recorder timers run untouched. */
+  consentReminderPinned?: boolean;
   onStartRecording: () => void;
   onPauseRecording: (sessionId: string) => void;
   onResumeRecording: (sessionId: string) => void;
@@ -148,6 +152,7 @@ export function NoteEditor({
   onEnableSystemAudio,
   onEnableMicrophone,
   microphoneBlocked,
+  consentReminderPinned,
   onStartRecording,
   onPauseRecording,
   onResumeRecording,
@@ -224,6 +229,14 @@ export function NoteEditor({
   }, [recordingForNote]);
   const consentEdgeRef = useRef({ noteId: note.id, recording: false });
   useEffect(() => {
+    // Dev driver (window.__recordNoticesDemo): show the reminder immediately and
+    // skip the reveal timer so it can be parked for styling review. The edge ref
+    // is still synced so releasing the pin resumes normal behavior cleanly.
+    if (consentReminderPinned) {
+      consentEdgeRef.current = { noteId: note.id, recording: recordingActive };
+      setConsentReminderVisible(true);
+      return;
+    }
     const prev = consentEdgeRef.current;
     const shouldReveal =
       prev.noteId !== note.id ? recordingActive : recordingActive && !prev.recording;
@@ -252,16 +265,18 @@ export function NoteEditor({
       window.clearTimeout(timer);
       restoreEdge();
     };
-  }, [note.id, recordingActive]);
+  }, [note.id, recordingActive, consentReminderPinned]);
 
   useEffect(() => {
-    if (!consentReminderVisible) return;
+    // A pinned reminder (dev driver) is held until "clear" or Dismiss, never
+    // auto-hidden.
+    if (!consentReminderVisible || consentReminderPinned) return;
     const timer = window.setTimeout(
       () => setConsentReminderVisible(false),
       RECORD_CONSENT_AUTO_HIDE_MS,
     );
     return () => window.clearTimeout(timer);
-  }, [consentReminderVisible]);
+  }, [consentReminderVisible, consentReminderPinned]);
   const processingStatus = processingStageStatus(note.processingStatus);
   const processingLock = processingStatus !== null;
   const recordButtonDisabled = recordingDisabled || Boolean(recordingBlockedReason);
@@ -469,7 +484,7 @@ export function NoteEditor({
                 aria-label="Recording needs credits"
                 body={recordingBlockedReason}
                 actions={
-                  <button type="button" className="primary-action" onClick={onTopUp}>
+                  <button type="button" className="btn btn-secondary" onClick={onTopUp}>
                     {topUpLabel ?? "Upgrade"}
                   </button>
                 }

--- a/src/lib/record-notices-demo.ts
+++ b/src/lib/record-notices-demo.ts
@@ -1,0 +1,233 @@
+// Dev-only console driver for the recorder-area notices that appear inside a
+// meeting note while it is recording:
+//
+//   window.__recordNoticesDemo("consent")          park the consent reminder
+//   window.__recordNoticesDemo("warning")          park a recording source warning
+//   window.__recordNoticesDemo("warning", "…")     ...with a custom warning message
+//   window.__recordNoticesDemo("mic")              park the mic-blocked notice (no recording)
+//   window.__recordNoticesDemo("clear")            tear the demo down, back to real state
+//
+// The consent reminder and the recording source warning normally sit behind the
+// recorder bar's reveal/auto-hide timers, so there is no way to hold them on
+// screen for styling review without a real recording. This driver pushes a
+// synthetic recording status straight into the reducer (under a sentinel
+// session id the status poll and the pause/resume/finish handlers skip, so no
+// backend call fires) and pins the consent reminder past its timers, so the
+// notices — just restyled to match the chat funding-notice chrome — can be
+// inspected in the browser sandbox or `pnpm tauri:dev`. It parks on the
+// selected note, seeding a minimal in-memory note when none is selected.
+//
+// The out-of-credits editor-footer notice is a separate surface: drive it with
+// __fundingDemo("free"). Mirrors the sibling dev drivers in
+// lib/processing-progress-demo.ts and lib/global-recorder-demo.ts.
+//
+// Never bundled in production: App gates the dynamic import on
+// import.meta.env.DEV.
+
+import { RECORD_NOTICES_DEMO_SESSION_ID } from "../app/processing-polling";
+import type { NoteDto, RecordingStatusDto } from "./tauri";
+
+const DEMO_NOTE_ID = "dev-record-notices-demo-note";
+
+// Mirrors the real microphone stall warning (src-tauri audio/capture.rs) so the
+// parked notice reads exactly like production.
+const DEFAULT_WARNING_MESSAGE =
+  "Microphone input stopped unexpectedly. Audio after this point may be missing.";
+
+// Push cadence for the waveform + elapsed clock, matching global-recorder-demo:
+// fast enough to keep the recorder bar looking alive without pinning a core.
+const TICK_MS = 90;
+
+type Variant = "consent" | "warning";
+
+export type RecordNoticesDemoApi = {
+  /** Tear down timers and remove the window hook. */
+  dispose: () => void;
+  /** Tear the demo down and restore real recorder state (also used when the
+   * recorder bar's finish button is pressed on the demo session). */
+  clear: () => void;
+};
+
+const HELP = [
+  "Recorder notices demo (meeting note recorder bar):",
+  '  __recordNoticesDemo("consent")        park the consent reminder',
+  '  __recordNoticesDemo("warning")        park a recording source warning',
+  '  __recordNoticesDemo("warning", "…")   ...with a custom warning message',
+  '  __recordNoticesDemo("mic")            park the mic-blocked notice (no recording)',
+  '  __recordNoticesDemo("clear")          tear the demo down, back to real state',
+  "",
+  "Parks the recorder notices without a real recording, on the selected note",
+  "(seeds one if none is selected). The out-of-credits editor-footer notice is",
+  'a separate surface: drive it with __fundingDemo("free"). Dev only.',
+].join("\n");
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+// A minimal in-memory note to park on when nothing is selected. "recording"
+// keeps the processing poll away (it only polls transcribing/generating) and
+// reads truthfully for a note being recorded.
+function buildDemoNote(): NoteDto {
+  const timestamp = "2026-06-30T15:04:00.000Z";
+  return {
+    id: DEMO_NOTE_ID,
+    title: "Weekly product sync",
+    preview: "Recording in progress",
+    processingStatus: "recording",
+    folderIds: [],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    activeTab: "notes",
+  };
+}
+
+export function registerRecordNoticesDemo({
+  seedNote,
+  setStatus,
+  setConsentPinned,
+  setMicOverride,
+  getSelectedNoteId,
+}: {
+  /** Add the minimal demo note and select it on the meeting-notes view. */
+  seedNote: (note: NoteDto) => void;
+  /** Push (or clear) the synthetic recording status the recorder bar reads. */
+  setStatus: (status: RecordingStatusDto | null) => void;
+  /** Pin the consent reminder past its reveal/auto-hide timers. */
+  setConsentPinned: (pinned: boolean) => void;
+  /** Force (or release) the mic-blocked notice, independent of real TCC state. */
+  setMicOverride: (blocked: boolean | null) => void;
+  /** The id of the currently selected note, or undefined if none. */
+  getSelectedNoteId: () => string | undefined;
+}): RecordNoticesDemoApi {
+  let timer: number | undefined;
+  let phase = 0;
+  let elapsedMs = 0;
+  let noteId = DEMO_NOTE_ID;
+  let variant: Variant = "consent";
+  let warningMessage = DEFAULT_WARNING_MESSAGE;
+
+  function stopTicker() {
+    if (timer !== undefined) {
+      window.clearInterval(timer);
+      timer = undefined;
+    }
+  }
+
+  // Resolve the note to park on: the selected note, or a seeded in-memory one.
+  function resolveTargetNote(): string {
+    const selected = getSelectedNoteId();
+    if (selected) return selected;
+    seedNote(buildDemoNote());
+    return DEMO_NOTE_ID;
+  }
+
+  function buildStatus(level: number): RecordingStatusDto {
+    // recentPeaks feeds the waveform's coalescing tail; a slight per-entry
+    // falloff reads as a freshest-first window like the real poll.
+    const recentPeaks = Array.from({ length: 6 }, (_, i) =>
+      clamp01(level + (Math.random() - 0.5) * 0.2 - i * 0.02),
+    );
+    return {
+      sessionId: RECORD_NOTICES_DEMO_SESSION_ID,
+      noteId,
+      sourceMode: "microphonePlusSystem",
+      state: "recording",
+      elapsedMs,
+      level: { peak: level, rms: level * 0.7, recentPeaks },
+      silenceWarning: false,
+      bytesWritten: 0,
+      warnings:
+        variant === "warning"
+          ? [
+              {
+                source: "microphone",
+                code: "microphone_stream_stalled",
+                message: warningMessage,
+              },
+            ]
+          : undefined,
+    };
+  }
+
+  function pushStatus() {
+    const carrier = 0.42 + 0.3 * Math.sin(phase * 0.18);
+    const jitter = (Math.random() - 0.5) * 0.22;
+    setStatus(buildStatus(clamp01(carrier + jitter)));
+  }
+
+  // Keep the recorder bar alive: advance the elapsed clock and repaint the
+  // waveform on a steady tick, exactly like a real recording poll.
+  function startTicker() {
+    stopTicker();
+    pushStatus();
+    timer = window.setInterval(() => {
+      phase += 1;
+      elapsedMs += TICK_MS;
+      pushStatus();
+    }, TICK_MS);
+  }
+
+  function parkRecording(next: Variant, message?: string) {
+    phase = 0;
+    elapsedMs = 0;
+    variant = next;
+    warningMessage = message ?? DEFAULT_WARNING_MESSAGE;
+    setMicOverride(null);
+    // The consent reminder only renders when there are no warnings, so pinning
+    // it for the warning variant is harmless — but keep it off for clarity.
+    setConsentPinned(next === "consent");
+    noteId = resolveTargetNote();
+    startTicker();
+  }
+
+  function parkMic() {
+    stopTicker();
+    phase = 0;
+    elapsedMs = 0;
+    // The mic-blocked notice and the recorder bar are mutually exclusive in the
+    // UI (micDenied && !recordingForNote), so clear any demo recording first.
+    setStatus(null);
+    setConsentPinned(false);
+    // Ensure a note is on screen to host the editor footer.
+    if (!getSelectedNoteId()) seedNote(buildDemoNote());
+    setMicOverride(true);
+  }
+
+  function clear() {
+    stopTicker();
+    phase = 0;
+    elapsedMs = 0;
+    setStatus(null);
+    setConsentPinned(false);
+    setMicOverride(null);
+  }
+
+  const hook = (command?: string, arg?: string) => {
+    switch (command) {
+      case "consent":
+        parkRecording("consent");
+        return 'Parked the consent reminder. __recordNoticesDemo("clear") to finish.';
+      case "warning":
+        parkRecording("warning", typeof arg === "string" ? arg : undefined);
+        return 'Parked a recording source warning. __recordNoticesDemo("clear") to finish.';
+      case "mic":
+        parkMic();
+        return 'Parked the mic-blocked notice. __recordNoticesDemo("clear") to finish.';
+      case "clear":
+        clear();
+        return "Recorder notices demo cleared; back to real state.";
+      default:
+        return HELP;
+    }
+  };
+
+  (window as unknown as Record<string, unknown>).__recordNoticesDemo = hook;
+
+  function dispose() {
+    stopTicker();
+    delete (window as unknown as Record<string, unknown>).__recordNoticesDemo;
+  }
+
+  return { dispose, clear };
+}

--- a/src/lib/record-notices-demo.ts
+++ b/src/lib/record-notices-demo.ts
@@ -17,6 +17,10 @@
 // inspected in the browser sandbox or `pnpm tauri:dev`. It parks on the
 // selected note, seeding a minimal in-memory note when none is selected.
 //
+// Because it drives the same reducer recording status, every state-mutating
+// command refuses while a real recording is live, rather than stomping it and
+// stranding the backend recording with no pause/resume/finish controls.
+//
 // The out-of-credits editor-footer notice is a separate surface: drive it with
 // __fundingDemo("free"). Mirrors the sibling dev drivers in
 // lib/processing-progress-demo.ts and lib/global-recorder-demo.ts.
@@ -61,6 +65,12 @@ const HELP = [
   'a separate surface: drive it with __fundingDemo("free"). Dev only.',
 ].join("\n");
 
+// Shown when a command that would mutate recorder state runs while a real
+// recording is live: the driver refuses rather than stomping the reducer's
+// recording status (which would strand the backend recording with no controls).
+const REAL_RECORDING_REFUSAL =
+  "A real recording is in progress. Finish it before running the demo.";
+
 function clamp01(value: number): number {
   return Math.max(0, Math.min(1, value));
 }
@@ -88,6 +98,7 @@ export function registerRecordNoticesDemo({
   setConsentPinned,
   setMicOverride,
   getSelectedNoteId,
+  hasRealRecording,
 }: {
   /** Add the minimal demo note and select it on the meeting-notes view. */
   seedNote: (note: NoteDto) => void;
@@ -99,6 +110,9 @@ export function registerRecordNoticesDemo({
   setMicOverride: (blocked: boolean | null) => void;
   /** The id of the currently selected note, or undefined if none. */
   getSelectedNoteId: () => string | undefined;
+  /** True when a real (non-sentinel) recording is live; guards the driver from
+   * stomping the reducer's recording status out from under the backend. */
+  hasRealRecording: () => boolean;
 }): RecordNoticesDemoApi {
   let timer: number | undefined;
   let phase = 0;
@@ -204,6 +218,18 @@ export function registerRecordNoticesDemo({
   }
 
   const hook = (command?: string, arg?: string) => {
+    // Every state-mutating command refuses while a real recording is live: the
+    // demo drives the same reducer status, so parking or clearing here would
+    // strand the backend recording with no pause/resume/finish controls.
+    if (
+      (command === "consent" ||
+        command === "warning" ||
+        command === "mic" ||
+        command === "clear") &&
+      hasRealRecording()
+    ) {
+      return REAL_RECORDING_REFUSAL;
+    }
     switch (command) {
       case "consent":
         parkRecording("consent");

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4899,8 +4899,9 @@ input:focus-visible,
  * where the user just acted, and clears itself when the turn finishes. A
  * content-sized pill (not another full-width box, which read as a second
  * composer) with the rolling dot spinner tying it to the working state. Same
- * surface recipe as the recording-consent note and the "Generating notes…"
- * pill so the app's status messages read as one family. */
+ * surface recipe as the "Generating notes…" pill so the app's progress
+ * statuses read as one family. (The recording-consent note left this family
+ * for the funding-notice card chrome — it asks, it doesn't report progress.) */
 .agent-composer-notice {
   pointer-events: auto;
   display: inline-flex;
@@ -11170,42 +11171,48 @@ input:focus-visible,
 
 /* Scoped to .record-dock to outrank the later, equal-specificity base
  * .inline-notice rule, which would otherwise win on background/border/padding. */
-/* Matches the "Generating notes…" pill's padding/height/radius/surface so the
- * two status messages read as the same family. */
+/* Same surface recipe as the chat funding notice (.funding-notice): card,
+ * ring-in-shadow, --shadow-md, --r-xl — notices docked on the composer and on
+ * the recorder read as one family. Move them together. */
 .record-dock .record-consent-note-surface {
+  align-items: center;
   gap: var(--sp-3);
-  padding: var(--sp-2) var(--sp-3);
+  padding: var(--sp-2) var(--sp-4);
   border-color: transparent;
-  border-radius: var(--r-md);
-  background: color-mix(in oklch, var(--muted) 68%, var(--card));
-  color: var(--muted-foreground);
-  box-shadow: none;
+  border-radius: var(--r-xl);
+  background: var(--card);
+  box-shadow:
+    var(--shadow-md),
+    0 0 0 1px color-mix(in oklch, var(--border-subtle) 60%, transparent);
+}
+
+/* The Dismiss button hugs the corner radius like the funding notice's CTA. */
+.record-dock .record-consent-note-surface:has(.inline-notice-actions) {
+  padding-right: var(--sp-2);
 }
 
 .record-dock .record-consent-note-surface .inline-notice-message {
   flex-wrap: nowrap;
   font-size: var(--fs-md);
-  font-weight: 400;
-  line-height: 1;
   white-space: nowrap;
 }
 
-/* Dismiss reads as a quiet text link, not a button — no underline, just a
- * medium-weight label in the app's link color (matching .agent-markdown a)
- * that deepens to foreground on hover. line-height matches the message so the
- * two text runs share a baseline. */
-.record-dock .record-consent-note-surface .inline-notice-actions .btn {
-  height: auto;
-  padding: 0;
-  border: 0;
-  background: none;
-  color: var(--primary);
-  font-weight: 400;
-  line-height: 1;
+/* The warning-only variant has no button to set the row's control height, so
+ * the text alone must reach it. */
+.record-dock .record-consent-note-surface .inline-notice-body {
+  min-height: var(--control-md);
+  display: inline-flex;
+  align-items: center;
+  color: color-mix(in oklch, var(--foreground) 72%, var(--muted-foreground));
 }
 
-.record-dock .record-consent-note-surface .inline-notice-actions .btn:hover {
-  background: none;
+/* Quiet secondary action, recolored like the funding notice's ghost buttons
+ * ("Or go Max", reopen links). */
+.record-dock .record-consent-note-surface .inline-notice-actions .btn-ghost {
+  color: var(--muted-foreground);
+}
+
+.record-dock .record-consent-note-surface .inline-notice-actions .btn-ghost:hover {
   color: var(--foreground);
 }
 
@@ -11300,16 +11307,33 @@ input:focus-visible,
   background: color-mix(in oklch, var(--warm-strong) 12%, transparent);
 }
 
-/* Mic-blocked strip — persistent inline notice that sits above the
- * chevron popover when microphone access is denied. Mirrors the
- * .record-options-row shape so it feels like part of the same family
- * of inline status surfaces. */
+/* Mic-blocked and needs-credits notices — persistent inline notices that sit
+ * above the record pill. They occupy the same footer slot the FundingNotice
+ * renders into, so they wear the same chrome (card, ring-in-shadow,
+ * --shadow-md, --r-xl, content-max column) — see .funding-notice; move them
+ * together. Scoped to .editor-footer to outrank the later, equal-specificity
+ * base .inline-notice rule. */
 /* Inline notice layout slot for the editor footer — forces the notice
  * onto its own row so the recorder shell (if rendered) sits below. */
-.record-mic-blocked,
-.record-funding-blocked {
+.editor-footer .record-mic-blocked,
+.editor-footer .record-funding-blocked {
   flex: 0 0 100%;
   width: 100%;
+  max-width: var(--content-max);
+  margin: 0 auto;
+  align-items: center;
+  padding: var(--sp-2) var(--sp-2) var(--sp-2) var(--sp-4);
+  border-color: transparent;
+  border-radius: var(--r-xl);
+  background: var(--card);
+  box-shadow:
+    var(--shadow-md),
+    0 0 0 1px color-mix(in oklch, var(--border-subtle) 60%, transparent);
+}
+
+.editor-footer .record-mic-blocked .inline-notice-body,
+.editor-footer .record-funding-blocked .inline-notice-body {
+  color: color-mix(in oklch, var(--foreground) 72%, var(--muted-foreground));
 }
 
 /* The out-of-credits notice in the editor footer sits on its own row above

--- a/src/test/record-notices-demo.test.tsx
+++ b/src/test/record-notices-demo.test.tsx
@@ -49,7 +49,7 @@ const editorProps = {
 // A harness that stands in for App's side of the driver: it records the latest
 // synthetic status / pins so tests can feed them into a real NoteEditor, just
 // as App does. getSelectedNoteId returns a note by default so no seeding fires.
-function setup(options: { selectedNoteId?: string | undefined } = {}) {
+function setup(options: { selectedNoteId?: string | undefined; hasRealRecording?: boolean } = {}) {
   const seedNote = vi.fn<(note: NoteDto) => void>();
   const setConsentPinned = vi.fn<(pinned: boolean) => void>();
   const setMicOverride = vi.fn<(blocked: boolean | null) => void>();
@@ -63,6 +63,7 @@ function setup(options: { selectedNoteId?: string | undefined } = {}) {
     setConsentPinned,
     setMicOverride,
     getSelectedNoteId: () => ("selectedNoteId" in options ? options.selectedNoteId : "note-1"),
+    hasRealRecording: () => options.hasRealRecording ?? false,
   });
   const invoke = (command?: string, arg?: string) =>
     (window as unknown as Record<string, (c?: string, a?: string) => string>).__recordNoticesDemo(
@@ -194,6 +195,38 @@ describe("registerRecordNoticesDemo", () => {
     expect(setStatus).toHaveBeenLastCalledWith(null);
     expect(setConsentPinned).toHaveBeenLastCalledWith(false);
     expect(setMicOverride).toHaveBeenLastCalledWith(null);
+    api.dispose();
+  });
+
+  it("refuses state-mutating commands while a real recording is active", () => {
+    const { api, invoke, setStatus, setConsentPinned, setMicOverride, latestStatus } = setup({
+      hasRealRecording: true,
+    });
+
+    const refusal = "A real recording is in progress. Finish it before running the demo.";
+    for (const command of ["consent", "warning", "mic"] as const) {
+      expect(invoke(command)).toBe(refusal);
+    }
+
+    // None of them touched the reducer status, consent pin, or mic override.
+    expect(setStatus).not.toHaveBeenCalled();
+    expect(setConsentPinned).not.toHaveBeenCalled();
+    expect(setMicOverride).not.toHaveBeenCalled();
+    expect(latestStatus()).toBeNull();
+    api.dispose();
+  });
+
+  it("clear does not clear a real recording", () => {
+    const { api, invoke, setStatus, setConsentPinned, setMicOverride } = setup({
+      hasRealRecording: true,
+    });
+
+    expect(invoke("clear")).toBe(
+      "A real recording is in progress. Finish it before running the demo.",
+    );
+    expect(setStatus).not.toHaveBeenCalled();
+    expect(setConsentPinned).not.toHaveBeenCalled();
+    expect(setMicOverride).not.toHaveBeenCalled();
     api.dispose();
   });
 

--- a/src/test/record-notices-demo.test.tsx
+++ b/src/test/record-notices-demo.test.tsx
@@ -1,0 +1,213 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RECORD_NOTICES_DEMO_SESSION_ID } from "../app/processing-polling";
+import { NoteEditor } from "../components/note-editor/NoteEditor";
+import { type RecordNoticesDemoApi, registerRecordNoticesDemo } from "../lib/record-notices-demo";
+import type { NoteDto, RecordingStatusDto } from "../lib/tauri";
+
+const now = "2026-05-19T10:00:00Z";
+
+function note(overrides: Partial<NoteDto> = {}): NoteDto {
+  return {
+    id: "note-1",
+    title: "Generated note",
+    preview: "Preview",
+    processingStatus: "ready",
+    folderIds: [],
+    createdAt: now,
+    updatedAt: now,
+    generatedContent: "## Section one\n\n- First point",
+    activeTab: "notes",
+    ...overrides,
+  };
+}
+
+const editorProps = {
+  folders: [],
+  sourceMode: "microphonePlusSystem" as const,
+  onTitleChange: vi.fn(),
+  onContentChange: vi.fn(),
+  onSourceModeChange: vi.fn(),
+  onEnableSystemAudio: vi.fn(),
+  onEnableMicrophone: vi.fn(),
+  microphoneBlocked: false,
+  onStartRecording: vi.fn(),
+  onPauseRecording: vi.fn(),
+  onResumeRecording: vi.fn(),
+  onFinishRecording: vi.fn(),
+  onRetry: vi.fn(),
+  onTopUp: vi.fn(),
+  onRecoverRecording: vi.fn(),
+  onDiscardRecording: vi.fn(),
+  onAssignFolder: vi.fn(),
+  onRemoveFolder: vi.fn(),
+  onCreateAndAssignFolder: vi.fn(),
+  onNavigateToFolder: vi.fn(),
+  onTabChange: vi.fn(),
+};
+
+// A harness that stands in for App's side of the driver: it records the latest
+// synthetic status / pins so tests can feed them into a real NoteEditor, just
+// as App does. getSelectedNoteId returns a note by default so no seeding fires.
+function setup(options: { selectedNoteId?: string | undefined } = {}) {
+  const seedNote = vi.fn<(note: NoteDto) => void>();
+  const setConsentPinned = vi.fn<(pinned: boolean) => void>();
+  const setMicOverride = vi.fn<(blocked: boolean | null) => void>();
+  let status: RecordingStatusDto | null = null;
+  const setStatus = vi.fn((next: RecordingStatusDto | null) => {
+    status = next;
+  });
+  const api: RecordNoticesDemoApi = registerRecordNoticesDemo({
+    seedNote,
+    setStatus,
+    setConsentPinned,
+    setMicOverride,
+    getSelectedNoteId: () => ("selectedNoteId" in options ? options.selectedNoteId : "note-1"),
+  });
+  const invoke = (command?: string, arg?: string) =>
+    (window as unknown as Record<string, (c?: string, a?: string) => string>).__recordNoticesDemo(
+      command,
+      arg,
+    );
+  return {
+    api,
+    invoke,
+    seedNote,
+    setConsentPinned,
+    setMicOverride,
+    setStatus,
+    latestStatus: () => status,
+  };
+}
+
+describe("registerRecordNoticesDemo", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as Record<string, unknown>).__recordNoticesDemo;
+  });
+
+  it("returns help for no or unknown command", () => {
+    const { api, invoke } = setup();
+    expect(invoke()).toContain("Recorder notices demo");
+    expect(invoke("bogus")).toContain('__recordNoticesDemo("consent")');
+    // The help points at the separate driver for the out-of-credits notice.
+    expect(invoke()).toContain('__fundingDemo("free")');
+    api.dispose();
+  });
+
+  it("parks the consent reminder under the sentinel session the poll skips", () => {
+    vi.useFakeTimers();
+    const { api, invoke, setConsentPinned, setMicOverride, latestStatus } = setup();
+
+    invoke("consent");
+
+    // Pinned open, mic notice off, and a live recording status with no warnings.
+    expect(setConsentPinned).toHaveBeenLastCalledWith(true);
+    expect(setMicOverride).toHaveBeenLastCalledWith(null);
+    const status = latestStatus();
+    expect(status).not.toBeNull();
+    // The exact sentinel App's status poll and pause/finish handlers skip, so no
+    // backend call fires for the demo session.
+    expect(status?.sessionId).toBe(RECORD_NOTICES_DEMO_SESSION_ID);
+    expect(status?.warnings ?? []).toHaveLength(0);
+
+    // The reminder shows immediately when pinned — no reveal timer to advance.
+    render(
+      <NoteEditor
+        {...editorProps}
+        note={note()}
+        recordingStatus={status ?? undefined}
+        consentReminderPinned
+      />,
+    );
+    expect(screen.getByRole("status", { name: "Recording consent reminder" })).toBeInTheDocument();
+
+    // ...and it is never auto-hidden while pinned.
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+    expect(screen.getByRole("status", { name: "Recording consent reminder" })).toBeInTheDocument();
+    api.dispose();
+  });
+
+  it("parks a source warning that suppresses the consent reminder", () => {
+    const { api, invoke, setConsentPinned, latestStatus } = setup();
+
+    invoke("warning");
+
+    expect(setConsentPinned).toHaveBeenLastCalledWith(false);
+    const status = latestStatus();
+    expect(status?.warnings).toHaveLength(1);
+    expect(status?.warnings?.[0].message).toContain("Microphone input stopped unexpectedly");
+
+    render(<NoteEditor {...editorProps} note={note()} recordingStatus={status ?? undefined} />);
+    expect(screen.getByText(/Microphone input stopped unexpectedly/)).toBeInTheDocument();
+    expect(
+      screen.queryByText("Make sure everyone has agreed to be recorded."),
+    ).not.toBeInTheDocument();
+    api.dispose();
+  });
+
+  it("overrides the warning message from the second argument", () => {
+    const { api, invoke, latestStatus } = setup();
+    invoke("warning", "System audio capture stopped unexpectedly.");
+    expect(latestStatus()?.warnings?.[0].message).toBe(
+      "System audio capture stopped unexpectedly.",
+    );
+    api.dispose();
+  });
+
+  it("parks the mic-blocked notice with no active recording", () => {
+    const { api, invoke, setStatus, setMicOverride, setConsentPinned } = setup();
+
+    invoke("mic");
+
+    // No recording is pushed (mutually exclusive with the mic notice), the mic
+    // override is forced on, and consent pinning is released.
+    expect(setStatus).toHaveBeenLastCalledWith(null);
+    expect(setMicOverride).toHaveBeenLastCalledWith(true);
+    expect(setConsentPinned).toHaveBeenLastCalledWith(false);
+
+    render(
+      <NoteEditor {...editorProps} note={note()} microphoneBlocked recordingStatus={undefined} />,
+    );
+    expect(screen.getByText(/Microphone access is blocked/)).toBeInTheDocument();
+    api.dispose();
+  });
+
+  it("seeds a note when none is selected", () => {
+    const { api, invoke, seedNote } = setup({ selectedNoteId: undefined });
+    invoke("consent");
+    expect(seedNote).toHaveBeenCalledTimes(1);
+    expect(seedNote.mock.calls[0][0].processingStatus).toBe("recording");
+    api.dispose();
+  });
+
+  it("clear restores real state", () => {
+    const { api, invoke, setStatus, setConsentPinned, setMicOverride } = setup();
+    invoke("consent");
+    setStatus.mockClear();
+    setConsentPinned.mockClear();
+    setMicOverride.mockClear();
+
+    expect(invoke("clear")).toContain("back to real state");
+    expect(setStatus).toHaveBeenLastCalledWith(null);
+    expect(setConsentPinned).toHaveBeenLastCalledWith(false);
+    expect(setMicOverride).toHaveBeenLastCalledWith(null);
+    api.dispose();
+  });
+
+  it("dispose removes the window hook and stops the ticker", () => {
+    vi.useFakeTimers();
+    const { api, invoke, setStatus } = setup();
+    invoke("consent");
+    api.dispose();
+    setStatus.mockClear();
+    // The ticker interval must be cleared on dispose — no further status pushes.
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(setStatus).not.toHaveBeenCalled();
+    expect((window as unknown as Record<string, unknown>).__recordNoticesDemo).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- The recording consent reminder ("Make sure everyone has agreed to be recorded") and the recording source warning wore a one-off grey pill; the footer's mic-blocked and needs-credits notices used the flat base inline-notice card. All four now wear the same chrome as the out-of-credits notices above the chat composers (card surface, ring-in-shadow, `--r-xl`, same body color), so notices that ask something of the user read as one family across chat and notes.
- The needs-credits CTA in the editor footer swaps `primary-action` for the funding family's `btn btn-secondary`; the consent Dismiss becomes a quiet ghost button recolored like the funding notice's secondary actions.
- Adds a dev-only `__recordNoticesDemo` console driver (consent / warning / mic / clear) that parks these states on the selected note for styling review, mirroring the existing `__processingDemo` pattern. Its synthetic recording uses a sentinel session id that the status poll and the pause/resume/finish handlers skip, so no backend calls fire; NoteEditor gains an optional dev-only `consentReminderPinned` prop to bypass the reveal/auto-hide timers (production behavior unchanged when absent).

## Validation

- `pnpm typecheck`, Biome (0 errors on touched files), vitest: `record-notices-demo` (8 tests), `note-editor` (37), `funding-notice` (23) all pass.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- The "Generating notes..." pill and the chat composer's rejected-send pill stay in the quiet grey progress-status family on purpose; they report progress rather than asking for action. Their CSS cross-reference comments were updated to document the family split.
- `record-funding-blocked` remains shadowed by `FundingNotice` in App's wiring (`fundingNotice ?? recordingBlockedReason`); this PR restyles it but does not change when it renders.

## Followups

- None planned.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786598267&installation_id=144203540&pr_number=741&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F741&signature=c22faf0ecef8190060ee4af2dceb1c99c1d9f80b61def29daff320583fcdbde7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->