### PR TITLE
Loosen the connector approvals logo stack

### DIFF
--- a/src/components/connectors/ConnectorApprovalsTray.tsx
+++ b/src/components/connectors/ConnectorApprovalsTray.tsx
@@ -146,6 +146,21 @@ export function ConnectorApprovalsTray() {
     ),
   ].slice(0, 3);
 
+  // Dev-only: only Google ships today, so a real queue only ever stacks one
+  // mark. The demo driver sets window.__connectorApprovalsStack to preview the
+  // overlapping-logo treatment with 2 to 3 marks; production ignores it and
+  // shows one mark per distinct provider (guarded on import.meta.env.DEV).
+  const demoStackCount =
+    import.meta.env.DEV && stackProviders.length > 0
+      ? Number(
+          (window as unknown as { __connectorApprovalsStack?: number }).__connectorApprovalsStack,
+        ) || 0
+      : 0;
+  const stackMarks =
+    demoStackCount > 0
+      ? Array.from({ length: Math.min(demoStackCount, 3) }, () => stackProviders[0])
+      : stackProviders;
+
   return (
     <aside
       className="connector-approvals"
@@ -162,9 +177,9 @@ export function ConnectorApprovalsTray() {
           onClick={() => setCollapsed((current) => !current)}
         >
           <span className="connector-approvals-stack" aria-hidden>
-            {stackProviders.length > 0 ? (
-              stackProviders.map((provider) => (
-                <span key={provider} className="connector-approvals-stack-mark">
+            {stackMarks.length > 0 ? (
+              stackMarks.map((provider, index) => (
+                <span key={`${provider}-${index}`} className="connector-approvals-stack-mark">
                   <ConnectorProviderIcon provider={provider} size={10} />
                 </span>
               ))

--- a/src/lib/connector-approvals-demo.ts
+++ b/src/lib/connector-approvals-demo.ts
@@ -94,10 +94,17 @@ export function registerConnectorApprovalsDemo({
 }: {
   setPending: (items: PendingConnectorApproval[]) => void;
 }): ConnectorApprovalsDemoApi {
+  const win = window as unknown as Record<string, unknown>;
+
   function park(count: number) {
     const now = Date.now();
+    const parked = Math.max(1, Math.min(count, SAMPLES.length));
+    // Only Google ships today, so the real header stack never shows more than
+    // one mark. Preview the overlapping-logo treatment by asking the tray to
+    // repeat the mark up to 3 times (it honors this only in DEV).
+    win.__connectorApprovalsStack = Math.min(parked, 3);
     setPending(
-      Array.from({ length: Math.max(1, Math.min(count, SAMPLES.length)) }, (_, index) => ({
+      Array.from({ length: parked }, (_, index) => ({
         ...SAMPLES[index % SAMPLES.length],
         approvalId: `demo-${index}`,
         requestedAtMs: now - index * 45_000,

--- a/src/lib/connector-approvals-demo.ts
+++ b/src/lib/connector-approvals-demo.ts
@@ -130,6 +130,9 @@ export function registerConnectorApprovalsDemo({
       case "clear":
       case "stop":
         setPending([]);
+        // Drop the preview override so a stale count can't leak into a later
+        // real approvals refresh in the same dev session.
+        delete win.__connectorApprovalsStack;
         return "Approvals tray dismissed.";
       default:
         return HELP;
@@ -139,7 +142,8 @@ export function registerConnectorApprovalsDemo({
   (window as unknown as Record<string, unknown>).__connectorApprovals = hook;
 
   function dispose() {
-    delete (window as unknown as Record<string, unknown>).__connectorApprovals;
+    delete win.__connectorApprovals;
+    delete win.__connectorApprovalsStack;
   }
 
   return { dispose };

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -25979,15 +25979,15 @@ input:focus-visible,
 }
 
 .connector-approvals-stack-mark + .connector-approvals-stack-mark {
-  margin-left: -5px;
+  margin-left: -2px;
 }
 
-/* The next mark sits 3px right of this tile's right edge center (16px tile,
- * -5px overlap → its center lands at x=19px); carving a 10px circle there
+/* The next mark sits 6px right of this tile's right edge center (16px tile,
+ * -2px overlap → its center lands at x=22px); carving a 10px circle there
  * leaves a 2px see-through gap around the overlapping mark. */
 .connector-approvals-stack-mark:not(:last-child) {
-  -webkit-mask: radial-gradient(circle 10px at 19px 50%, transparent 98%, #000 100%);
-  mask: radial-gradient(circle 10px at 19px 50%, transparent 98%, #000 100%);
+  -webkit-mask: radial-gradient(circle 10px at 22px 50%, transparent 98%, #000 100%);
+  mask: radial-gradient(circle 10px at 22px 50%, transparent 98%, #000 100%);
 }
 
 .connector-approvals-header-actions {


### PR DESCRIPTION
## Summary

- Reduce the overlap in the connector approvals tray's header logo stack so each provider mark reads as its own chip rather than colliding. Marks now overlap by `2px` instead of `5px`, and the transparent cutout that separates overlapping marks moves to match (mask circle re-centered from x=19px to x=22px). Tile size, icon size, and the cutout-vs-painted-ring approach are unchanged.
- The overlap treatment is only visible with 2+ marks, but only Google ships today so a real queue only ever stacks one mark. The dev-only demo driver (`window.__connectorApprovals`) now sets `window.__connectorApprovalsStack`, and the tray repeats the mark up to 3 times to preview the treatment. Production ignores this (guarded on `import.meta.env.DEV`) and still renders one mark per distinct provider — ready for real multi-provider stacks once more connectors land.

## Validation

- `pnpm typecheck`, `pnpm check` (Biome, 0 errors), and the `connectors` / `connector-approvals-tray` vitest suites all pass.
- Preview in dev: `__connectorApprovals(3)` shows 3 overlapping marks, `__connectorApprovals("one")` shows 1, `__connectorApprovals("long")` caps at 3, `__connectorApprovals("clear")` dismisses.

- [x] Tested visually where it matters (UI change; previewed via the dev demo driver).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- No new providers are added. The provider mapping (`providerFromServer`) and the shared `ConnectorProviderIcon` stay Google-only; teaching them additional brands is deferred to when those connectors actually ship.

## Followups

- When additional connectors (e.g. Notion, Linear, Slack) land, widen `providerFromServer` + `ConnectorProviderIcon` so the header stacks real distinct provider logos, and drop the dev-only `__connectorApprovalsStack` preview shim.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786600469&installation_id=144203540&pr_number=742&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F742&signature=c5fd3748f1e3dadb42df318aba502b7afbf07910e82e2b293e9262c029c657b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->