### PR TITLE
Isolate debug model settings and harden local Auto

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,10 +39,11 @@ Dev-only toggles also read in code: `OS_JUNE_ENABLE_DEV_SINGLE_INSTANCE`,
 `OS_JUNE_USE_PROD_ACCOUNTS_TOKENS`, `OS_JUNE_USE_PROD_DATA_DIR`,
 `JUNE_HERMES_DISABLE_SANDBOX`.
 
-`OS_JUNE_USE_PROD_DATA_DIR` opts a debug build into both the production app
-data directory and the production app config directory that stores
-`provider-settings.json`. Without it, both directories use the debug-only
-`-dev` suffix.
+When set to `1`, `true`, `yes`, or `on`, `OS_JUNE_USE_PROD_DATA_DIR` opts a
+debug build into the production app data directory and the production
+`provider-settings.json` location. Otherwise, app data and provider settings
+use debug-only paths with the `-dev` suffix. Other files read directly from the
+raw Tauri app config directory are unaffected.
 
 ## June API backend (`june-api/.env`, `JUNE__…`)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,11 @@ Dev-only toggles also read in code: `OS_JUNE_ENABLE_DEV_SINGLE_INSTANCE`,
 `OS_JUNE_USE_PROD_ACCOUNTS_TOKENS`, `OS_JUNE_USE_PROD_DATA_DIR`,
 `JUNE_HERMES_DISABLE_SANDBOX`.
 
+`OS_JUNE_USE_PROD_DATA_DIR` opts a debug build into both the production app
+data directory and the production app config directory that stores
+`provider-settings.json`. Without it, both directories use the debug-only
+`-dev` suffix.
+
 ## June API backend (`june-api/.env`, `JUNE__…`)
 
 **Secrets — env only, never in `config.toml` or the client `.env`:**

--- a/june-api/crates/api/src/handlers/agent.rs
+++ b/june-api/crates/api/src/handlers/agent.rs
@@ -95,10 +95,7 @@ struct AgentModelRequirements {
 impl AgentModelRequirements {
     fn from_body(body: &serde_json::Value) -> Self {
         Self {
-            vision: ["messages", "input"]
-                .into_iter()
-                .filter_map(|key| body.get(key))
-                .any(chat_items_contain_image),
+            vision: body.get("messages").is_some_and(chat_items_contain_image),
             tools: body
                 .get("tools")
                 .and_then(serde_json::Value::as_array)
@@ -161,7 +158,7 @@ fn chat_items_contain_image(value: &serde_json::Value) -> bool {
         serde_json::Value::Object(object) => {
             matches!(
                 object.get("type").and_then(serde_json::Value::as_str),
-                Some("image_url" | "input_image")
+                Some("image_url")
             ) || object.get("content").is_some_and(chat_items_contain_image)
         }
         _ => false,
@@ -196,7 +193,7 @@ fn has_capability(capabilities: &[String], expected: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentModelRequirements, chat_items_contain_image, has_capability};
+    use super::{AgentModelRequirements, has_capability};
 
     #[test]
     fn infers_image_and_tool_requirements_from_chat_content() {
@@ -221,31 +218,15 @@ mod tests {
     }
 
     #[test]
-    fn infers_input_image_without_inventing_a_tool_requirement() {
-        let body = serde_json::json!({
-            "messages": [{
-                "role": "user",
-                "content": [{ "type": "input_image", "image_url": "data:image/png;base64,eA==" }]
-            }]
-        });
-
-        assert!(chat_items_contain_image(&body["messages"]));
-        assert_eq!(
-            AgentModelRequirements::from_body(&body),
-            AgentModelRequirements {
-                vision: true,
-                tools: false,
-            }
-        );
-    }
-
-    #[test]
-    fn ignores_image_like_metadata_outside_message_content() {
+    fn ignores_image_like_content_outside_supported_message_content() {
         let body = serde_json::json!({
             "messages": [{
                 "role": "user",
                 "content": "hello",
                 "metadata": { "type": "image_url" }
+            }],
+            "input": [{
+                "content": [{ "type": "image_url", "image_url": "unsupported-here" }]
             }]
         });
 

--- a/june-api/crates/api/src/handlers/agent.rs
+++ b/june-api/crates/api/src/handlers/agent.rs
@@ -12,9 +12,11 @@ use axum::{
     http::{HeaderMap, StatusCode, header::CONTENT_TYPE},
     response::{IntoResponse, Response},
 };
-use june_domain::ModelId;
-use june_services::AgentChatParams;
+use june_domain::{ModelId, ModelKind};
+use june_services::{AgentChatParams, PricingTable};
 use tokio_stream::wrappers::UnboundedReceiverStream;
+
+const PREFERRED_VISION_TEXT_MODEL: &str = "kimi-k2-6";
 
 pub(crate) async fn chat_completions(
     State(state): State<ApiState>,
@@ -32,7 +34,7 @@ pub(crate) async fn chat_completions(
         .to_string();
     validation::validate_text_len("model", &requested_model_id, validation::MAX_MODEL_CHARS)?;
     validation::validate_agent_chat_body(&body)?;
-    let model_id = resolve_priced_text_model(&state, &requested_model_id)?;
+    let model_id = resolve_priced_agent_text_model(&state, &requested_model_id, &body)?;
     let provider_credentials = credentials_for_resolved_model(
         provider_credentials,
         &requested_model_id,
@@ -82,4 +84,186 @@ pub(crate) async fn chat_completions(
         output.completion.body,
     )
         .into_response())
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct AgentModelRequirements {
+    vision: bool,
+    tools: bool,
+}
+
+impl AgentModelRequirements {
+    fn from_body(body: &serde_json::Value) -> Self {
+        Self {
+            vision: ["messages", "input"]
+                .into_iter()
+                .filter_map(|key| body.get(key))
+                .any(chat_items_contain_image),
+            tools: body
+                .get("tools")
+                .and_then(serde_json::Value::as_array)
+                .is_some_and(|tools| !tools.is_empty()),
+        }
+    }
+
+    fn is_empty(self) -> bool {
+        !self.vision && !self.tools
+    }
+}
+
+fn resolve_priced_agent_text_model(
+    state: &ApiState,
+    requested_model_id: &str,
+    body: &serde_json::Value,
+) -> Result<String, ApiError> {
+    let resolved_model_id = resolve_priced_text_model(state, requested_model_id)?;
+    let requirements = AgentModelRequirements::from_body(body);
+    if resolved_model_id == AUTO_TEXT_MODEL
+        || resolved_model_id == requested_model_id
+        || requirements.is_empty()
+        || model_supports_requirements(state.pricing(), &resolved_model_id, requirements)
+    {
+        return Ok(resolved_model_id);
+    }
+
+    [PREFERRED_VISION_TEXT_MODEL]
+        .into_iter()
+        .filter(|model_id| {
+            state
+                .pricing()
+                .ensure_model_kind(model_id, ModelKind::Text)
+                .is_ok()
+        })
+        .find(|model_id| model_supports_requirements(state.pricing(), model_id, requirements))
+        .map(str::to_string)
+        .or_else(|| {
+            state
+                .pricing()
+                .priced_models(Some(ModelKind::Text))
+                .into_iter()
+                .map(|(model_id, _)| model_id)
+                .filter(|model_id| *model_id != AUTO_TEXT_MODEL)
+                .find(|model_id| {
+                    state
+                        .pricing()
+                        .ensure_model_kind(model_id, ModelKind::Text)
+                        .is_ok()
+                        && model_supports_requirements(state.pricing(), model_id, requirements)
+                })
+                .cloned()
+        })
+        .ok_or_else(|| ApiError::unprocessable("model_not_priced"))
+}
+
+fn chat_items_contain_image(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Array(values) => values.iter().any(chat_items_contain_image),
+        serde_json::Value::Object(object) => {
+            matches!(
+                object.get("type").and_then(serde_json::Value::as_str),
+                Some("image_url" | "input_image")
+            ) || object.get("content").is_some_and(chat_items_contain_image)
+        }
+        _ => false,
+    }
+}
+
+fn model_supports_requirements(
+    pricing: &PricingTable,
+    model_id: &str,
+    requirements: AgentModelRequirements,
+) -> bool {
+    pricing
+        .iter()
+        .find(|(candidate_id, _)| candidate_id.as_str() == model_id)
+        .is_some_and(|(_, model)| {
+            (!requirements.vision || has_capability(&model.capabilities, "supportsvision"))
+                && (!requirements.tools
+                    || has_capability(&model.capabilities, "supportsfunctioncalling"))
+        })
+}
+
+fn has_capability(capabilities: &[String], expected: &str) -> bool {
+    capabilities.iter().any(|capability| {
+        capability
+            .chars()
+            .filter(char::is_ascii_alphabetic)
+            .map(|character| character.to_ascii_lowercase())
+            .collect::<String>()
+            == expected
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AgentModelRequirements, chat_items_contain_image, has_capability};
+
+    #[test]
+    fn infers_image_and_tool_requirements_from_chat_content() {
+        let body = serde_json::json!({
+            "messages": [{
+                "role": "user",
+                "content": [{
+                    "type": "image_url",
+                    "image_url": { "url": "https://example.com/image.png" }
+                }]
+            }],
+            "tools": [{ "type": "function" }]
+        });
+
+        assert_eq!(
+            AgentModelRequirements::from_body(&body),
+            AgentModelRequirements {
+                vision: true,
+                tools: true,
+            }
+        );
+    }
+
+    #[test]
+    fn infers_input_image_without_inventing_a_tool_requirement() {
+        let body = serde_json::json!({
+            "messages": [{
+                "role": "user",
+                "content": [{ "type": "input_image", "image_url": "data:image/png;base64,eA==" }]
+            }]
+        });
+
+        assert!(chat_items_contain_image(&body["messages"]));
+        assert_eq!(
+            AgentModelRequirements::from_body(&body),
+            AgentModelRequirements {
+                vision: true,
+                tools: false,
+            }
+        );
+    }
+
+    #[test]
+    fn ignores_image_like_metadata_outside_message_content() {
+        let body = serde_json::json!({
+            "messages": [{
+                "role": "user",
+                "content": "hello",
+                "metadata": { "type": "image_url" }
+            }]
+        });
+
+        assert_eq!(
+            AgentModelRequirements::from_body(&body),
+            AgentModelRequirements::default()
+        );
+    }
+
+    #[test]
+    fn capability_matching_uses_the_catalog_names_normalized() {
+        assert!(has_capability(
+            &["supports_vision".to_string()],
+            "supportsvision"
+        ));
+        assert!(!has_capability(
+            &["supportsVision".to_string()],
+            "supportsfunctioncalling"
+        ));
+    }
 }

--- a/june-api/crates/api/src/handlers/agent.rs
+++ b/june-api/crates/api/src/handlers/agent.rs
@@ -1,7 +1,7 @@
 use crate::{
     auth::{authenticated_user, provider_credentials},
     error::ApiError,
-    handlers::notes::{credentials_for_resolved_model, resolve_priced_text_model},
+    handlers::notes::{AUTO_TEXT_MODEL, credentials_for_resolved_model, resolve_priced_text_model},
     state::ApiState,
     validation,
 };
@@ -40,6 +40,9 @@ pub(crate) async fn chat_completions(
         state.pricing().is_venice_model(&model_id),
     )?;
     if let Some(object) = body.as_object_mut() {
+        if model_id != AUTO_TEXT_MODEL {
+            object.remove("auto");
+        }
         object.insert(
             "model".to_string(),
             serde_json::Value::String(model_id.clone()),

--- a/june-api/crates/api/src/handlers/agent.rs
+++ b/june-api/crates/api/src/handlers/agent.rs
@@ -35,6 +35,13 @@ pub(crate) async fn chat_completions(
     validation::validate_text_len("model", &requested_model_id, validation::MAX_MODEL_CHARS)?;
     validation::validate_agent_chat_body(&body)?;
     let model_id = resolve_priced_agent_text_model(&state, &requested_model_id, &body)?;
+    if state.local_dev_enabled() && model_id != AUTO_TEXT_MODEL && model_id != requested_model_id {
+        tracing::warn!(
+            requested_model = %requested_model_id,
+            resolved_model = %model_id,
+            "local dev substituted a concrete text model for unavailable Auto"
+        );
+    }
     let provider_credentials = credentials_for_resolved_model(
         provider_credentials,
         &requested_model_id,

--- a/june-api/crates/api/src/handlers/agent.rs
+++ b/june-api/crates/api/src/handlers/agent.rs
@@ -130,7 +130,7 @@ fn resolve_priced_agent_text_model(
         return Ok(resolved_model_id);
     }
 
-    [PREFERRED_VISION_TEXT_MODEL]
+    let compatible_model = [PREFERRED_VISION_TEXT_MODEL]
         .into_iter()
         .filter(|model_id| {
             state
@@ -155,8 +155,18 @@ fn resolve_priced_agent_text_model(
                         && model_supports_requirements(state.pricing(), model_id, requirements)
                 })
                 .cloned()
-        })
-        .ok_or_else(|| ApiError::unprocessable("model_not_priced"))
+        });
+
+    if compatible_model.is_none() {
+        tracing::warn!(
+            requested_model = %requested_model_id,
+            vision_required = requirements.vision,
+            tools_required = requirements.tools,
+            "no priced text model satisfies the agent request capabilities"
+        );
+    }
+
+    compatible_model.ok_or_else(|| ApiError::unprocessable("model_capability_unavailable"))
 }
 
 fn chat_items_contain_image(value: &serde_json::Value) -> bool {
@@ -183,7 +193,8 @@ fn model_supports_requirements(
         .is_some_and(|(_, model)| {
             (!requirements.vision || has_capability(&model.capabilities, "supportsvision"))
                 && (!requirements.tools
-                    || has_capability(&model.capabilities, "supportsfunctioncalling"))
+                    || has_capability(&model.capabilities, "functioncalling")
+                    || has_capability(&model.capabilities, "toolcalling"))
         })
 }
 
@@ -194,7 +205,7 @@ fn has_capability(capabilities: &[String], expected: &str) -> bool {
             .filter(char::is_ascii_alphabetic)
             .map(|character| character.to_ascii_lowercase())
             .collect::<String>()
-            == expected
+            .contains(expected)
     })
 }
 
@@ -247,6 +258,10 @@ mod tests {
     fn capability_matching_uses_the_catalog_names_normalized() {
         assert!(has_capability(
             &["supports_vision".to_string()],
+            "supportsvision"
+        ));
+        assert!(has_capability(
+            &["parent.supportsVision".to_string()],
             "supportsvision"
         ));
         assert!(!has_capability(

--- a/june-api/crates/api/src/handlers/notes.rs
+++ b/june-api/crates/api/src/handlers/notes.rs
@@ -99,6 +99,13 @@ pub(crate) async fn generate(
     let requested_model_id = required(request.model, "model_required")?;
     validation::validate_text_len("model", &requested_model_id, validation::MAX_MODEL_CHARS)?;
     let model_id = resolve_priced_text_model(&state, &requested_model_id)?;
+    if state.local_dev_enabled() && model_id != AUTO_TEXT_MODEL && model_id != requested_model_id {
+        tracing::warn!(
+            requested_model = %requested_model_id,
+            resolved_model = %model_id,
+            "local dev substituted a concrete text model for unavailable Auto"
+        );
+    }
     let cost_quality = if model_id == AUTO_TEXT_MODEL {
         request.cost_quality
     } else {
@@ -369,7 +376,11 @@ pub(crate) fn resolve_priced_text_model(
     state: &ApiState,
     requested_model_id: &str,
 ) -> Result<String, ApiError> {
-    resolve_priced_text_model_kind(state.pricing(), requested_model_id)
+    resolve_priced_text_model_kind(
+        state.pricing(),
+        requested_model_id,
+        state.local_dev_enabled(),
+    )
 }
 
 /// Auto is a June-managed route. Strip BYOK from an explicit Auto selection,
@@ -401,17 +412,25 @@ pub(crate) fn credentials_for_resolved_model(
 fn resolve_priced_text_model_kind(
     pricing: &PricingTable,
     requested_model_id: &str,
+    allow_concrete_fallback: bool,
 ) -> Result<String, ApiError> {
     match pricing.ensure_model_kind(requested_model_id, ModelKind::Text) {
         Ok(()) => Ok(requested_model_id.to_string()),
         Err(PricingError::NotPriced | PricingError::MissingRate) => {
-            for fallback_model_id in [AUTO_TEXT_MODEL, DEFAULT_TEXT_MODEL] {
-                if pricing
-                    .ensure_model_kind(fallback_model_id, ModelKind::Text)
-                    .is_ok()
-                {
-                    return Ok(fallback_model_id.to_string());
-                }
+            if pricing
+                .ensure_model_kind(AUTO_TEXT_MODEL, ModelKind::Text)
+                .is_ok()
+            {
+                return Ok(AUTO_TEXT_MODEL.to_string());
+            }
+            if !allow_concrete_fallback {
+                return Err(ApiError::unprocessable("model_not_priced"));
+            }
+            if pricing
+                .ensure_model_kind(DEFAULT_TEXT_MODEL, ModelKind::Text)
+                .is_ok()
+            {
+                return Ok(DEFAULT_TEXT_MODEL.to_string());
             }
             pricing
                 .priced_models(Some(ModelKind::Text))
@@ -539,8 +558,9 @@ mod tests {
 
     #[test]
     fn stale_text_model_falls_back_to_auto() {
-        let resolved = resolve_priced_text_model_kind(&pricing_table(), "retired-venice-model")
-            .expect("stale model should remain usable through Auto");
+        let resolved =
+            resolve_priced_text_model_kind(&pricing_table(), "retired-venice-model", false)
+                .expect("stale model should remain usable through Auto");
         assert_eq!(resolved, AUTO_TEXT_MODEL);
     }
 
@@ -556,10 +576,29 @@ mod tests {
             .expect("text model should exist");
         models.insert(DEFAULT_TEXT_MODEL.to_string(), text_model);
 
-        let resolved = resolve_priced_text_model_kind(&PricingTable::new(models), AUTO_TEXT_MODEL)
-            .expect("local Auto should resolve to the built-in concrete default");
+        let resolved =
+            resolve_priced_text_model_kind(&PricingTable::new(models), AUTO_TEXT_MODEL, true)
+                .expect("local Auto should resolve to the built-in concrete default");
 
         assert_eq!(resolved, DEFAULT_TEXT_MODEL);
+    }
+
+    #[test]
+    fn non_local_auto_without_auto_pricing_fails_loudly() {
+        let mut models = pricing_table()
+            .iter()
+            .map(|(model_id, model)| (model_id.clone(), model.clone()))
+            .collect::<BTreeMap<_, _>>();
+        models.remove(AUTO_TEXT_MODEL);
+
+        let error =
+            resolve_priced_text_model_kind(&PricingTable::new(models), AUTO_TEXT_MODEL, false)
+                .expect_err("production must not silently substitute a concrete model");
+
+        assert!(matches!(
+            error,
+            ApiError::Unprocessable { message, .. } if message == "model_not_priced"
+        ));
     }
 
     #[test]
@@ -570,8 +609,9 @@ mod tests {
             .collect::<BTreeMap<_, _>>();
         models.remove(AUTO_TEXT_MODEL);
 
-        let resolved = resolve_priced_text_model_kind(&PricingTable::new(models), "retired-model")
-            .expect("a remaining priced text model should be used");
+        let resolved =
+            resolve_priced_text_model_kind(&PricingTable::new(models), "retired-model", true)
+                .expect("a remaining priced text model should be used");
 
         assert_eq!(resolved, "text-model");
     }
@@ -663,7 +703,7 @@ mod tests {
 
     #[test]
     fn priced_text_model_is_preserved() {
-        let resolved = resolve_priced_text_model_kind(&pricing_table(), "text-model")
+        let resolved = resolve_priced_text_model_kind(&pricing_table(), "text-model", false)
             .expect("priced text model should remain explicit");
         assert_eq!(resolved, "text-model");
     }

--- a/june-api/crates/api/src/handlers/notes.rs
+++ b/june-api/crates/api/src/handlers/notes.rs
@@ -99,6 +99,11 @@ pub(crate) async fn generate(
     let requested_model_id = required(request.model, "model_required")?;
     validation::validate_text_len("model", &requested_model_id, validation::MAX_MODEL_CHARS)?;
     let model_id = resolve_priced_text_model(&state, &requested_model_id)?;
+    let cost_quality = if model_id == AUTO_TEXT_MODEL {
+        request.cost_quality
+    } else {
+        None
+    };
     let provider_credentials = credentials_for_resolved_model(
         provider_credentials,
         &requested_model_id,
@@ -119,7 +124,7 @@ pub(crate) async fn generate(
         existing_generated_note: request.existing_generated_note,
         model_id: ModelId(model_id),
         provider_credentials,
-        cost_quality: request.cost_quality,
+        cost_quality,
     };
 
     if stream {
@@ -351,12 +356,15 @@ pub(crate) fn required(value: Option<String>, message: &str) -> Result<String, A
         .ok_or_else(|| ApiError::bad_request(message))
 }
 
-const AUTO_TEXT_MODEL: &str = "open-software/auto";
+pub(crate) const AUTO_TEXT_MODEL: &str = "open-software/auto";
+const DEFAULT_TEXT_MODEL: &str = "zai-org-glm-5-2";
 const DEFAULT_ASR_MODEL: &str = "nvidia/parakeet-tdt-0.6b-v3";
 
 /// Older June clients may retain a Venice model that disappeared when the
 /// production catalog moved behind os-api. Preserve those sessions by routing
-/// an unpriced text selection through Auto; wrong-kind models still fail.
+/// an unpriced text selection through Auto when available, or through a
+/// concrete priced text model in local environments where Auto is unavailable.
+/// Wrong-kind models still fail.
 pub(crate) fn resolve_priced_text_model(
     state: &ApiState,
     requested_model_id: &str,
@@ -374,6 +382,10 @@ pub(crate) fn credentials_for_resolved_model(
     resolved_model_id: &str,
     resolved_supports_venice_byok: bool,
 ) -> Result<ProviderCredentials, ApiError> {
+    if requested_model_id == AUTO_TEXT_MODEL {
+        credentials.venice_api_key = None;
+        return Ok(credentials);
+    }
     if credentials.has_venice_api_key()
         && ((resolved_model_id == AUTO_TEXT_MODEL && requested_model_id != AUTO_TEXT_MODEL)
             || (resolved_model_id != AUTO_TEXT_MODEL && !resolved_supports_venice_byok))
@@ -393,8 +405,21 @@ fn resolve_priced_text_model_kind(
     match pricing.ensure_model_kind(requested_model_id, ModelKind::Text) {
         Ok(()) => Ok(requested_model_id.to_string()),
         Err(PricingError::NotPriced | PricingError::MissingRate) => {
-            require_priced_model_kind(pricing, AUTO_TEXT_MODEL, ModelKind::Text)?;
-            Ok(AUTO_TEXT_MODEL.to_string())
+            for fallback_model_id in [AUTO_TEXT_MODEL, DEFAULT_TEXT_MODEL] {
+                if pricing
+                    .ensure_model_kind(fallback_model_id, ModelKind::Text)
+                    .is_ok()
+                {
+                    return Ok(fallback_model_id.to_string());
+                }
+            }
+            pricing
+                .priced_models(Some(ModelKind::Text))
+                .into_iter()
+                .map(|(model_id, _)| model_id)
+                .find(|model_id| pricing.ensure_model_kind(model_id, ModelKind::Text).is_ok())
+                .cloned()
+                .ok_or_else(|| ApiError::unprocessable("model_not_priced"))
         }
         Err(PricingError::WrongUnit) => Err(ApiError::unprocessable("model_type_invalid")),
         Err(PricingError::Overflow) => Err(ApiError::unprocessable("price_overflow")),
@@ -437,21 +462,6 @@ fn resolve_priced_asr_model_kind(
     }
 }
 
-fn require_priced_model_kind(
-    pricing: &PricingTable,
-    model_id: &str,
-    kind: ModelKind,
-) -> Result<(), ApiError> {
-    match pricing.ensure_model_kind(model_id, kind) {
-        Ok(()) => Ok(()),
-        Err(PricingError::WrongUnit) => Err(ApiError::unprocessable("model_type_invalid")),
-        Err(PricingError::NotPriced | PricingError::MissingRate) => {
-            Err(ApiError::unprocessable("model_not_priced"))
-        }
-        Err(PricingError::Overflow) => Err(ApiError::unprocessable("price_overflow")),
-    }
-}
-
 fn parse_preview_flag(value: Option<&str>) -> bool {
     value.is_some_and(|value| matches!(value, "true" | "1"))
 }
@@ -459,12 +469,12 @@ fn parse_preview_flag(value: Option<&str>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        AUTO_TEXT_MODEL, credentials_for_resolved_model, parse_preview_flag,
-        require_priced_model_kind, resolve_priced_asr_model_kind, resolve_priced_text_model_kind,
+        AUTO_TEXT_MODEL, DEFAULT_TEXT_MODEL, credentials_for_resolved_model, parse_preview_flag,
+        resolve_priced_asr_model_kind, resolve_priced_text_model_kind,
     };
     use crate::ApiError;
     use june_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
-    use june_domain::{ModelKind, ProviderCredentials};
+    use june_domain::ProviderCredentials;
     use june_services::PricingTable;
     use std::collections::BTreeMap;
 
@@ -535,6 +545,38 @@ mod tests {
     }
 
     #[test]
+    fn auto_falls_back_to_the_concrete_default_when_auto_is_not_priced() {
+        let mut models = pricing_table()
+            .iter()
+            .map(|(model_id, model)| (model_id.clone(), model.clone()))
+            .collect::<BTreeMap<_, _>>();
+        models.remove(AUTO_TEXT_MODEL);
+        let text_model = models
+            .remove("text-model")
+            .expect("text model should exist");
+        models.insert(DEFAULT_TEXT_MODEL.to_string(), text_model);
+
+        let resolved = resolve_priced_text_model_kind(&PricingTable::new(models), AUTO_TEXT_MODEL)
+            .expect("local Auto should resolve to the built-in concrete default");
+
+        assert_eq!(resolved, DEFAULT_TEXT_MODEL);
+    }
+
+    #[test]
+    fn unpriced_text_falls_back_to_another_priced_text_model_without_auto_or_default() {
+        let mut models = pricing_table()
+            .iter()
+            .map(|(model_id, model)| (model_id.clone(), model.clone()))
+            .collect::<BTreeMap<_, _>>();
+        models.remove(AUTO_TEXT_MODEL);
+
+        let resolved = resolve_priced_text_model_kind(&PricingTable::new(models), "retired-model")
+            .expect("a remaining priced text model should be used");
+
+        assert_eq!(resolved, "text-model");
+    }
+
+    #[test]
     fn byok_rejects_retired_asr_fallback_to_non_venice_model() {
         let credentials = ProviderCredentials {
             venice_api_key: Some("opaque-user-key".to_string()),
@@ -581,6 +623,19 @@ mod tests {
         let credentials =
             credentials_for_resolved_model(credentials, AUTO_TEXT_MODEL, AUTO_TEXT_MODEL, false)
                 .expect("explicit Auto remains a June-managed request");
+
+        assert!(!credentials.has_venice_api_key());
+    }
+
+    #[test]
+    fn explicit_auto_strips_byok_after_resolving_to_a_concrete_model() {
+        let credentials = ProviderCredentials {
+            venice_api_key: Some("opaque-user-key".to_string()),
+        };
+
+        let credentials =
+            credentials_for_resolved_model(credentials, AUTO_TEXT_MODEL, DEFAULT_TEXT_MODEL, true)
+                .expect("explicit Auto remains June-managed after a local fallback");
 
         assert!(!credentials.has_venice_api_key());
     }
@@ -634,40 +689,6 @@ mod tests {
         assert!(matches!(
             error,
             ApiError::Unprocessable { message, .. } if message == "model_type_invalid"
-        ));
-    }
-
-    #[test]
-    fn require_priced_model_kind_accepts_matching_model_type() {
-        let pricing = pricing_table();
-
-        assert!(require_priced_model_kind(&pricing, "asr-model", ModelKind::Asr).is_ok());
-        assert!(require_priced_model_kind(&pricing, "text-model", ModelKind::Text).is_ok());
-    }
-
-    #[test]
-    fn require_priced_model_kind_rejects_wrong_endpoint_model_type() {
-        let pricing = pricing_table();
-
-        let error = require_priced_model_kind(&pricing, "asr-model", ModelKind::Text)
-            .expect_err("ASR model must not be accepted for text generation");
-
-        assert!(matches!(
-            error,
-            ApiError::Unprocessable { message, .. } if message == "model_type_invalid"
-        ));
-    }
-
-    #[test]
-    fn require_priced_model_kind_keeps_missing_model_error() {
-        let pricing = pricing_table();
-
-        let error = require_priced_model_kind(&pricing, "missing", ModelKind::Text)
-            .expect_err("missing model should be rejected");
-
-        assert!(matches!(
-            error,
-            ApiError::Unprocessable { message, .. } if message == "model_not_priced"
         ));
     }
 

--- a/june-api/crates/api/src/state.rs
+++ b/june-api/crates/api/src/state.rs
@@ -43,6 +43,7 @@ pub struct ApiState {
 
 struct ApiStateInner {
     pricing: Arc<PricingTable>,
+    local_dev_enabled: bool,
     token_verifier: Arc<dyn TokenVerifier>,
     note_transcribe: Arc<NoteTranscribeService>,
     note_generate: Arc<NoteGenerateService>,
@@ -85,6 +86,7 @@ pub struct AttestationInfo {
 
 pub struct ApiStateParams {
     pub pricing: Arc<PricingTable>,
+    pub local_dev_enabled: bool,
     pub token_verifier: Arc<dyn TokenVerifier>,
     pub note_transcribe: Arc<NoteTranscribeService>,
     pub note_generate: Arc<NoteGenerateService>,
@@ -104,6 +106,7 @@ impl ApiState {
         Self {
             inner: Arc::new(ApiStateInner {
                 pricing: params.pricing,
+                local_dev_enabled: params.local_dev_enabled,
                 token_verifier: params.token_verifier,
                 note_transcribe: params.note_transcribe,
                 note_generate: params.note_generate,
@@ -123,6 +126,10 @@ impl ApiState {
 
     pub(crate) fn pricing(&self) -> &PricingTable {
         &self.inner.pricing
+    }
+
+    pub(crate) fn local_dev_enabled(&self) -> bool {
+        self.inner.local_dev_enabled
     }
 
     pub(crate) fn token_verifier(&self) -> &dyn TokenVerifier {

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -331,6 +331,80 @@ async fn integration_agent_chat_routes_stale_model_through_auto() -> Result<(), 
 }
 
 #[tokio::test]
+async fn integration_agent_chat_local_auto_fallback_strips_auto_policy()
+-> Result<(), Box<dyn Error>> {
+    let completer = Arc::new(RecordingChatCompleter::default());
+    let app = router(test_state_with_local_text_pricing(
+        Arc::new(FakeGenerator),
+        completer.clone(),
+    ));
+    let response = match app
+        .oneshot(json_request(
+            "/v1/chat/completions",
+            &serde_json::json!({
+                "model": "open-software/auto",
+                "auto": { "cost_quality": 0.75 },
+                "messages": [{ "role": "user", "content": "hello" }]
+            }),
+            Some(AUTHORIZATION),
+        )?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let requests = completer
+        .requests
+        .lock()
+        .map_err(|_| "chat request mutex poisoned")?;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].model.0, "zai-org-glm-5-2");
+    assert!(requests[0].body.get("auto").is_none());
+    assert!(!requests[0].body.to_string().contains("cost_quality"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_note_generate_local_auto_fallback_omits_cost_quality()
+-> Result<(), Box<dyn Error>> {
+    let generator = Arc::new(RecordingGenerator::default());
+    let app = router(test_state_with_local_text_pricing(
+        generator.clone(),
+        Arc::new(FakeChatCompleter),
+    ));
+    let response = match app
+        .oneshot(json_request(
+            "/v1/notes/generate",
+            &serde_json::json!({
+                "noteId": "note-local-auto",
+                "promptVersion": "prompt-v1",
+                "title": "Planning",
+                "transcript": "System: launch is Friday",
+                "model": "open-software/auto",
+                "costQuality": 0.75
+            }),
+            Some(AUTHORIZATION),
+        )?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let requests = generator
+        .requests
+        .lock()
+        .map_err(|_| "generation request mutex poisoned")?;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].model.0, "zai-org-glm-5-2");
+    assert_eq!(requests[0].cost_quality, None);
+    Ok(())
+}
+
+#[tokio::test]
 async fn integration_agent_chat_rejects_byok_when_stale_model_would_fallback()
 -> Result<(), Box<dyn Error>> {
     let response = send(json_request_with_venice_api_key(
@@ -1663,10 +1737,12 @@ fn test_state_with_issue_sink_and_timeout(
     request_timeout_secs: u64,
 ) -> ApiState {
     test_state_from_deps(TestStateDeps {
+        pricing: models(),
         issue_reports: test_issue_report_service(issue_reports),
         attestation,
         transcriber: Arc::new(FakeTranscriber),
         generator: Arc::new(FakeGenerator),
+        chat_completer: Arc::new(FakeChatCompleter),
         request_timeout_secs,
         p3a_sink: Arc::new(RecordingP3aSink::default()),
     })
@@ -1693,10 +1769,12 @@ fn test_state_with_sinks_and_transcriber(
     transcriber: Arc<dyn Transcriber>,
 ) -> ApiState {
     test_state_from_deps(TestStateDeps {
+        pricing: models(),
         issue_reports,
         attestation,
         transcriber,
         generator: Arc::new(FakeGenerator),
+        chat_completer: Arc::new(FakeChatCompleter),
         request_timeout_secs: 5,
         p3a_sink: Arc::new(RecordingP3aSink::default()),
     })
@@ -1707,10 +1785,12 @@ fn test_state_with_generator_and_timeout(
     request_timeout_secs: u64,
 ) -> ApiState {
     test_state_from_deps(TestStateDeps {
+        pricing: models(),
         issue_reports: test_issue_report_service(Arc::new(RecordingIssueReportSink::default())),
         attestation: test_attestation(),
         transcriber: Arc::new(FakeTranscriber),
         generator,
+        chat_completer: Arc::new(FakeChatCompleter),
         request_timeout_secs,
         p3a_sink: Arc::new(RecordingP3aSink::default()),
     })
@@ -1718,30 +1798,69 @@ fn test_state_with_generator_and_timeout(
 
 fn test_state_with_p3a_sink(p3a_sink: Arc<dyn P3aSink>) -> ApiState {
     test_state_from_deps(TestStateDeps {
+        pricing: models(),
         issue_reports: test_issue_report_service(Arc::new(RecordingIssueReportSink::default())),
         attestation: test_attestation(),
         transcriber: Arc::new(FakeTranscriber),
         generator: Arc::new(FakeGenerator),
+        chat_completer: Arc::new(FakeChatCompleter),
         request_timeout_secs: 5,
         p3a_sink,
     })
 }
 
+fn test_state_with_local_text_pricing(
+    generator: Arc<dyn Generator>,
+    chat_completer: Arc<dyn AgentChatCompleter>,
+) -> ApiState {
+    let mut pricing = models();
+    pricing.remove("open-software/auto");
+    pricing.insert(
+        "zai-org-glm-5-2".to_string(),
+        ModelPriceConfig {
+            unit: PriceUnit::Tokens,
+            credits_per_million_seconds: None,
+            input_credits_per_million_tokens: Some(500),
+            output_credits_per_million_tokens: Some(500),
+            provider: ModelProvider::Venice,
+            model_type: ModelType::Text,
+            display_name: "GLM 5.2".to_string(),
+            description: None,
+            privacy: None,
+            pricing: None,
+            context_tokens: None,
+            traits: Vec::new(),
+            capabilities: Vec::new(),
+        },
+    );
+    test_state_from_deps(TestStateDeps {
+        pricing,
+        issue_reports: test_issue_report_service(Arc::new(RecordingIssueReportSink::default())),
+        attestation: test_attestation(),
+        transcriber: Arc::new(FakeTranscriber),
+        generator,
+        chat_completer,
+        request_timeout_secs: 5,
+        p3a_sink: Arc::new(RecordingP3aSink::default()),
+    })
+}
+
 struct TestStateDeps {
+    pricing: BTreeMap<String, ModelPriceConfig>,
     issue_reports: Arc<IssueReportService>,
     attestation: AttestationInfo,
     transcriber: Arc<dyn Transcriber>,
     generator: Arc<dyn Generator>,
+    chat_completer: Arc<dyn AgentChatCompleter>,
     request_timeout_secs: u64,
     p3a_sink: Arc<dyn P3aSink>,
 }
 
 fn test_state_from_deps(deps: TestStateDeps) -> ApiState {
-    let pricing = Arc::new(PricingTable::new(models()));
+    let pricing = Arc::new(PricingTable::new(deps.pricing));
     let os_accounts = Arc::new(FakeOsAccounts);
     let cleaner = Arc::new(FakeCleaner);
     let duration_probe = Arc::new(FakeDurationProbe);
-    let chat_completer = Arc::new(FakeChatCompleter);
     let image = Arc::new(ImageService::new(ImageServiceDeps {
         os_accounts: os_accounts.clone(),
         generator: Arc::new(FakeImageGenerator),
@@ -1792,7 +1911,7 @@ fn test_state_from_deps(deps: TestStateDeps) -> ApiState {
         agent_chat: Arc::new(AgentChatService::new(AgentChatServiceDeps {
             pricing: pricing.clone(),
             os_accounts: os_accounts.clone(),
-            chat_completer,
+            chat_completer: deps.chat_completer,
             hold_ttl_seconds: 30,
             flat_estimate_credits: 1_000,
         })),
@@ -2410,6 +2529,22 @@ impl Generator for FakeGenerator {
     }
 }
 
+#[derive(Default)]
+struct RecordingGenerator {
+    requests: Mutex<Vec<GenerationRequest>>,
+}
+
+#[async_trait]
+impl Generator for RecordingGenerator {
+    async fn generate(&self, request: GenerationRequest) -> Result<GeneratedNote, DomainError> {
+        self.requests
+            .lock()
+            .map_err(|_| DomainError::UpstreamProvider)?
+            .push(request.clone());
+        FakeGenerator.generate(request).await
+    }
+}
+
 struct SlowGenerator;
 
 #[async_trait]
@@ -2479,6 +2614,36 @@ impl AgentChatCompleter for FakeChatCompleter {
             chunks: chunks_rx,
             outcome: outcome_rx,
         })
+    }
+}
+
+#[derive(Default)]
+struct RecordingChatCompleter {
+    requests: Mutex<Vec<AgentChatRequest>>,
+}
+
+#[async_trait]
+impl AgentChatCompleter for RecordingChatCompleter {
+    async fn complete(
+        &self,
+        request: AgentChatRequest,
+    ) -> Result<AgentChatCompletion, DomainError> {
+        self.requests
+            .lock()
+            .map_err(|_| DomainError::UpstreamProvider)?
+            .push(request.clone());
+        FakeChatCompleter.complete(request).await
+    }
+
+    async fn complete_stream(
+        &self,
+        request: AgentChatRequest,
+    ) -> Result<AgentChatStream, DomainError> {
+        self.requests
+            .lock()
+            .map_err(|_| DomainError::UpstreamProvider)?
+            .push(request.clone());
+        FakeChatCompleter.complete_stream(request).await
     }
 }
 

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -419,48 +419,6 @@ async fn integration_agent_chat_local_auto_image_and_tools_falls_back_to_compati
 }
 
 #[tokio::test]
-async fn integration_agent_chat_local_auto_input_image_falls_back_to_vision_model()
--> Result<(), Box<dyn Error>> {
-    let completer = Arc::new(RecordingChatCompleter::default());
-    let app = router(test_state_with_local_text_pricing(
-        Arc::new(FakeGenerator),
-        completer.clone(),
-    ));
-    let response = match app
-        .oneshot(json_request(
-            "/v1/chat/completions",
-            &serde_json::json!({
-                "model": "open-software/auto",
-                "auto": { "cost_quality": 0.25 },
-                "messages": [{
-                    "role": "user",
-                    "content": [{
-                        "type": "input_image",
-                        "image_url": "data:image/png;base64,eA=="
-                    }]
-                }]
-            }),
-            Some(AUTHORIZATION),
-        )?)
-        .await
-    {
-        Ok(response) => response,
-        Err(error) => match error {},
-    };
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let requests = completer
-        .requests
-        .lock()
-        .map_err(|_| "chat request mutex poisoned")?;
-    assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0].model.0, "kimi-k2-6");
-    assert!(requests[0].body.get("auto").is_none());
-    assert!(requests[0].body.get("tools").is_none());
-    Ok(())
-}
-
-#[tokio::test]
 async fn integration_note_generate_local_auto_fallback_omits_cost_quality()
 -> Result<(), Box<dyn Error>> {
     let generator = Arc::new(RecordingGenerator::default());

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -367,6 +367,100 @@ async fn integration_agent_chat_local_auto_fallback_strips_auto_policy()
 }
 
 #[tokio::test]
+async fn integration_agent_chat_local_auto_image_and_tools_falls_back_to_compatible_model()
+-> Result<(), Box<dyn Error>> {
+    let completer = Arc::new(RecordingChatCompleter::default());
+    let app = router(test_state_with_local_text_pricing(
+        Arc::new(FakeGenerator),
+        completer.clone(),
+    ));
+    let response = match app
+        .oneshot(json_request(
+            "/v1/chat/completions",
+            &serde_json::json!({
+                "model": "open-software/auto",
+                "auto": { "cost_quality": 0.75 },
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        { "type": "text", "text": "describe this image" },
+                        {
+                            "type": "image_url",
+                            "image_url": { "url": "https://example.com/image.png" }
+                        }
+                    ]
+                }],
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": "save_description",
+                        "parameters": { "type": "object" }
+                    }
+                }]
+            }),
+            Some(AUTHORIZATION),
+        )?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let requests = completer
+        .requests
+        .lock()
+        .map_err(|_| "chat request mutex poisoned")?;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].model.0, "kimi-k2-6");
+    assert!(requests[0].body.get("auto").is_none());
+    assert!(requests[0].body.get("tools").is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_agent_chat_local_auto_input_image_falls_back_to_vision_model()
+-> Result<(), Box<dyn Error>> {
+    let completer = Arc::new(RecordingChatCompleter::default());
+    let app = router(test_state_with_local_text_pricing(
+        Arc::new(FakeGenerator),
+        completer.clone(),
+    ));
+    let response = match app
+        .oneshot(json_request(
+            "/v1/chat/completions",
+            &serde_json::json!({
+                "model": "open-software/auto",
+                "auto": { "cost_quality": 0.25 },
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "input_image",
+                        "image_url": "data:image/png;base64,eA=="
+                    }]
+                }]
+            }),
+            Some(AUTHORIZATION),
+        )?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let requests = completer
+        .requests
+        .lock()
+        .map_err(|_| "chat request mutex poisoned")?;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].model.0, "kimi-k2-6");
+    assert!(requests[0].body.get("auto").is_none());
+    assert!(requests[0].body.get("tools").is_none());
+    Ok(())
+}
+
+#[tokio::test]
 async fn integration_note_generate_local_auto_fallback_omits_cost_quality()
 -> Result<(), Box<dyn Error>> {
     let generator = Arc::new(RecordingGenerator::default());
@@ -1831,6 +1925,27 @@ fn test_state_with_local_text_pricing(
             context_tokens: None,
             traits: Vec::new(),
             capabilities: Vec::new(),
+        },
+    );
+    pricing.insert(
+        "kimi-k2-6".to_string(),
+        ModelPriceConfig {
+            unit: PriceUnit::Tokens,
+            credits_per_million_seconds: None,
+            input_credits_per_million_tokens: Some(500),
+            output_credits_per_million_tokens: Some(500),
+            provider: ModelProvider::Venice,
+            model_type: ModelType::Text,
+            display_name: "Kimi K2.6".to_string(),
+            description: None,
+            privacy: None,
+            pricing: None,
+            context_tokens: None,
+            traits: Vec::new(),
+            capabilities: vec![
+                "supportsFunctionCalling".to_string(),
+                "supportsVision".to_string(),
+            ],
         },
     );
     test_state_from_deps(TestStateDeps {

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -448,6 +448,51 @@ async fn integration_agent_chat_local_auto_image_and_tools_falls_back_to_compati
 }
 
 #[tokio::test]
+async fn integration_agent_chat_local_auto_rejects_when_capabilities_are_unavailable()
+-> Result<(), Box<dyn Error>> {
+    let app = router(
+        test_state_with_text_pricing_without_auto_and_kimi_capabilities(
+            true,
+            Arc::new(FakeGenerator),
+            Arc::new(FakeChatCompleter),
+            vec!["supportsVision".to_string()],
+        ),
+    );
+    let response = match app
+        .oneshot(json_request(
+            "/v1/chat/completions",
+            &serde_json::json!({
+                "model": "open-software/auto",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "image_url",
+                        "image_url": { "url": "https://example.com/image.png" }
+                    }]
+                }],
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": "save_description",
+                        "parameters": { "type": "object" }
+                    }
+                }]
+            }),
+            Some(AUTHORIZATION),
+        )?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let body = response_json(response).await?;
+    assert_eq!(body["message"], "model_capability_unavailable");
+    Ok(())
+}
+
+#[tokio::test]
 async fn integration_note_generate_local_auto_fallback_omits_cost_quality()
 -> Result<(), Box<dyn Error>> {
     let generator = Arc::new(RecordingGenerator::default());
@@ -1906,6 +1951,23 @@ fn test_state_with_text_pricing_without_auto(
     generator: Arc<dyn Generator>,
     chat_completer: Arc<dyn AgentChatCompleter>,
 ) -> ApiState {
+    test_state_with_text_pricing_without_auto_and_kimi_capabilities(
+        local_dev_enabled,
+        generator,
+        chat_completer,
+        vec![
+            "supportsFunctionCalling".to_string(),
+            "supportsVision".to_string(),
+        ],
+    )
+}
+
+fn test_state_with_text_pricing_without_auto_and_kimi_capabilities(
+    local_dev_enabled: bool,
+    generator: Arc<dyn Generator>,
+    chat_completer: Arc<dyn AgentChatCompleter>,
+    kimi_capabilities: Vec<String>,
+) -> ApiState {
     let mut pricing = models();
     pricing.remove("open-software/auto");
     pricing.insert(
@@ -1941,10 +2003,7 @@ fn test_state_with_text_pricing_without_auto(
             pricing: None,
             context_tokens: None,
             traits: Vec::new(),
-            capabilities: vec![
-                "supportsFunctionCalling".to_string(),
-                "supportsVision".to_string(),
-            ],
+            capabilities: kimi_capabilities,
         },
     );
     test_state_from_deps(TestStateDeps {

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -367,6 +367,35 @@ async fn integration_agent_chat_local_auto_fallback_strips_auto_policy()
 }
 
 #[tokio::test]
+async fn integration_agent_chat_non_local_missing_auto_fails_loudly() -> Result<(), Box<dyn Error>>
+{
+    let app = router(test_state_with_text_pricing_without_auto(
+        false,
+        Arc::new(FakeGenerator),
+        Arc::new(FakeChatCompleter),
+    ));
+    let response = match app
+        .oneshot(json_request(
+            "/v1/chat/completions",
+            &serde_json::json!({
+                "model": "open-software/auto",
+                "messages": [{ "role": "user", "content": "hello" }]
+            }),
+            Some(AUTHORIZATION),
+        )?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let body = response_json(response).await?;
+    assert_eq!(body["message"], "model_not_priced");
+    Ok(())
+}
+
+#[tokio::test]
 async fn integration_agent_chat_local_auto_image_and_tools_falls_back_to_compatible_model()
 -> Result<(), Box<dyn Error>> {
     let completer = Arc::new(RecordingChatCompleter::default());
@@ -1790,6 +1819,7 @@ fn test_state_with_issue_sink_and_timeout(
 ) -> ApiState {
     test_state_from_deps(TestStateDeps {
         pricing: models(),
+        local_dev_enabled: false,
         issue_reports: test_issue_report_service(issue_reports),
         attestation,
         transcriber: Arc::new(FakeTranscriber),
@@ -1822,6 +1852,7 @@ fn test_state_with_sinks_and_transcriber(
 ) -> ApiState {
     test_state_from_deps(TestStateDeps {
         pricing: models(),
+        local_dev_enabled: false,
         issue_reports,
         attestation,
         transcriber,
@@ -1838,6 +1869,7 @@ fn test_state_with_generator_and_timeout(
 ) -> ApiState {
     test_state_from_deps(TestStateDeps {
         pricing: models(),
+        local_dev_enabled: false,
         issue_reports: test_issue_report_service(Arc::new(RecordingIssueReportSink::default())),
         attestation: test_attestation(),
         transcriber: Arc::new(FakeTranscriber),
@@ -1851,6 +1883,7 @@ fn test_state_with_generator_and_timeout(
 fn test_state_with_p3a_sink(p3a_sink: Arc<dyn P3aSink>) -> ApiState {
     test_state_from_deps(TestStateDeps {
         pricing: models(),
+        local_dev_enabled: false,
         issue_reports: test_issue_report_service(Arc::new(RecordingIssueReportSink::default())),
         attestation: test_attestation(),
         transcriber: Arc::new(FakeTranscriber),
@@ -1862,6 +1895,14 @@ fn test_state_with_p3a_sink(p3a_sink: Arc<dyn P3aSink>) -> ApiState {
 }
 
 fn test_state_with_local_text_pricing(
+    generator: Arc<dyn Generator>,
+    chat_completer: Arc<dyn AgentChatCompleter>,
+) -> ApiState {
+    test_state_with_text_pricing_without_auto(true, generator, chat_completer)
+}
+
+fn test_state_with_text_pricing_without_auto(
+    local_dev_enabled: bool,
     generator: Arc<dyn Generator>,
     chat_completer: Arc<dyn AgentChatCompleter>,
 ) -> ApiState {
@@ -1908,6 +1949,7 @@ fn test_state_with_local_text_pricing(
     );
     test_state_from_deps(TestStateDeps {
         pricing,
+        local_dev_enabled,
         issue_reports: test_issue_report_service(Arc::new(RecordingIssueReportSink::default())),
         attestation: test_attestation(),
         transcriber: Arc::new(FakeTranscriber),
@@ -1920,6 +1962,7 @@ fn test_state_with_local_text_pricing(
 
 struct TestStateDeps {
     pricing: BTreeMap<String, ModelPriceConfig>,
+    local_dev_enabled: bool,
     issue_reports: Arc<IssueReportService>,
     attestation: AttestationInfo,
     transcriber: Arc<dyn Transcriber>,
@@ -1964,6 +2007,7 @@ fn test_state_from_deps(deps: TestStateDeps) -> ApiState {
 
     ApiState::new(ApiStateParams {
         pricing: pricing.clone(),
+        local_dev_enabled: deps.local_dev_enabled,
         token_verifier: Arc::new(FakeTokenVerifier),
         note_transcribe: Arc::new(NoteTranscribeService::new(NoteTranscribeServiceDeps {
             pricing: pricing.clone(),

--- a/june-api/crates/app/src/main.rs
+++ b/june-api/crates/app/src/main.rs
@@ -274,6 +274,7 @@ fn build_router(
 
     let state = ApiState::new(ApiStateParams {
         pricing,
+        local_dev_enabled: config.local_dev.enabled,
         token_verifier,
         note_transcribe,
         note_generate,

--- a/src-tauri/src/app_paths.rs
+++ b/src-tauri/src/app_paths.rs
@@ -64,23 +64,45 @@ pub fn app_data_dir(app: &AppHandle) -> Result<PathBuf, tauri::Error> {
     })
 }
 
+pub fn app_config_dir(app: &AppHandle) -> Result<PathBuf, tauri::Error> {
+    app.path().app_config_dir().map(|config_dir| {
+        app_config_dir_for_build(config_dir, cfg!(debug_assertions), use_prod_data_dir())
+    })
+}
+
 fn use_prod_data_dir() -> bool {
     std::env::var_os(USE_PROD_DATA_DIR_ENV).is_some()
 }
 
 fn app_data_dir_for_build(data_dir: PathBuf, debug_assertions: bool, use_prod: bool) -> PathBuf {
+    isolated_app_dir_for_build(data_dir, debug_assertions, use_prod)
+}
+
+fn app_config_dir_for_build(
+    config_dir: PathBuf,
+    debug_assertions: bool,
+    use_prod: bool,
+) -> PathBuf {
+    isolated_app_dir_for_build(config_dir, debug_assertions, use_prod)
+}
+
+fn isolated_app_dir_for_build(
+    directory: PathBuf,
+    debug_assertions: bool,
+    use_prod: bool,
+) -> PathBuf {
     if !debug_assertions || use_prod {
-        return data_dir;
+        return directory;
     }
 
-    data_dir
+    directory
         .file_name()
         .map(|name| {
             let mut dev_name = name.to_os_string();
             dev_name.push("-dev");
-            data_dir.with_file_name(dev_name)
+            directory.with_file_name(dev_name)
         })
-        .unwrap_or_else(|| data_dir.join("dev"))
+        .unwrap_or_else(|| directory.join("dev"))
 }
 
 fn validate_recording_component(field: &'static str, value: &str) -> std::io::Result<()> {
@@ -103,7 +125,7 @@ fn validate_recording_component(field: &'static str, value: &str) -> std::io::Re
 
 #[cfg(test)]
 mod tests {
-    use super::{app_data_dir_for_build, AppPaths};
+    use super::{app_config_dir_for_build, app_data_dir_for_build, AppPaths};
     use std::path::PathBuf;
 
     #[test]
@@ -164,6 +186,36 @@ mod tests {
         assert_eq!(
             app_data_dir_for_build(data_dir.clone(), true, true),
             data_dir
+        );
+    }
+
+    #[test]
+    fn release_builds_use_the_configured_config_dir() {
+        let config_dir = PathBuf::from("/tmp/co.opensoftware.june");
+
+        assert_eq!(
+            app_config_dir_for_build(config_dir.clone(), false, false),
+            config_dir
+        );
+    }
+
+    #[test]
+    fn debug_builds_use_a_separate_dev_config_dir_by_default() {
+        let config_dir = PathBuf::from("/tmp/co.opensoftware.june");
+
+        assert_eq!(
+            app_config_dir_for_build(config_dir, true, false),
+            PathBuf::from("/tmp/co.opensoftware.june-dev")
+        );
+    }
+
+    #[test]
+    fn debug_builds_can_opt_into_the_configured_config_dir() {
+        let config_dir = PathBuf::from("/tmp/co.opensoftware.june");
+
+        assert_eq!(
+            app_config_dir_for_build(config_dir.clone(), true, true),
+            config_dir
         );
     }
 }

--- a/src-tauri/src/app_paths.rs
+++ b/src-tauri/src/app_paths.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::OsStr,
     io::{Error, ErrorKind},
     path::{Component, Path, PathBuf},
 };
@@ -71,7 +72,17 @@ pub fn app_config_dir(app: &AppHandle) -> Result<PathBuf, tauri::Error> {
 }
 
 fn use_prod_data_dir() -> bool {
-    std::env::var_os(USE_PROD_DATA_DIR_ENV).is_some()
+    let value = std::env::var_os(USE_PROD_DATA_DIR_ENV);
+    env_value_truthy(value.as_deref())
+}
+
+fn env_value_truthy(value: Option<&OsStr>) -> bool {
+    value.and_then(OsStr::to_str).is_some_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
 }
 
 fn app_data_dir_for_build(data_dir: PathBuf, debug_assertions: bool, use_prod: bool) -> PathBuf {
@@ -125,8 +136,20 @@ fn validate_recording_component(field: &'static str, value: &str) -> std::io::Re
 
 #[cfg(test)]
 mod tests {
-    use super::{app_config_dir_for_build, app_data_dir_for_build, AppPaths};
-    use std::path::PathBuf;
+    use super::{app_config_dir_for_build, app_data_dir_for_build, env_value_truthy, AppPaths};
+    use std::{ffi::OsStr, path::PathBuf};
+
+    #[test]
+    fn production_data_override_accepts_only_truthy_values() {
+        for value in ["1", "true", "TRUE", " yes ", "on"] {
+            assert!(env_value_truthy(Some(OsStr::new(value))), "{value:?}");
+        }
+
+        for value in ["", "0", "false", "no", "off", "unexpected"] {
+            assert!(!env_value_truthy(Some(OsStr::new(value))), "{value:?}");
+        }
+        assert!(!env_value_truthy(None));
+    }
 
     #[test]
     fn recording_session_dir_rejects_path_traversal_components() {

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -1111,10 +1111,13 @@ fn default_image_safe_mode() -> bool {
 }
 
 fn provider_settings_path(app: &AppHandle) -> Option<PathBuf> {
-    app.path()
-        .app_config_dir()
+    crate::app_paths::app_config_dir(app)
         .ok()
-        .map(|directory| directory.join("provider-settings.json"))
+        .map(provider_settings_path_from_config_dir)
+}
+
+fn provider_settings_path_from_config_dir(directory: PathBuf) -> PathBuf {
+    directory.join("provider-settings.json")
 }
 
 fn load_settings_from_disk(app: &AppHandle) -> ProviderModelSettings {
@@ -1433,6 +1436,16 @@ impl ModelMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn provider_settings_path_derives_from_the_isolated_config_dir() {
+        let isolated_config_dir = PathBuf::from("/tmp/co.opensoftware.june-dev");
+
+        assert_eq!(
+            provider_settings_path_from_config_dir(isolated_config_dir),
+            PathBuf::from("/tmp/co.opensoftware.june-dev/provider-settings.json")
+        );
+    }
 
     #[test]
     fn legacy_settings_default_cost_quality_to_higher_quality() {

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -21,6 +21,7 @@ pub const PROVIDER_LOCAL: &str = "local";
 pub const DEFAULT_TRANSCRIPTION_MODEL: &str = "nvidia/parakeet-tdt-0.6b-v3";
 pub const DEFAULT_GENERATION_MODEL: &str = "zai-org-glm-5-2";
 pub const AUTO_GENERATION_MODEL: &str = "open-software/auto";
+const LOCAL_AUTO_VISION_FALLBACK_MODEL: &str = "kimi-k2-6";
 pub const DEFAULT_COST_QUALITY: u8 = 100;
 pub const DEFAULT_IMAGE_MODEL: &str = "venice-sd35";
 pub const DEFAULT_VIDEO_MODEL: &str = "wan-2.2-a14b-text-to-video";
@@ -390,8 +391,10 @@ fn context_tokens_cache() -> &'static Mutex<Option<(String, i64)>> {
 /// proxy is `provider: custom`, so that override is the only signal, and the
 /// spawn path resolves it here (see `render_hermes_config`). Returns `false`
 /// when the catalog is unreachable (offline, signed out) or the model reports no
-/// vision capability — the conservative default keeps the prior behavior, where
-/// Hermes falls back to its (unconfigured) auxiliary vision LLM.
+/// vision capability. In local dev, a persisted Auto selection can use the same
+/// catalog-backed Kimi fallback as June API when Auto is absent. The conservative
+/// default keeps the prior behavior, where Hermes falls back to its
+/// (unconfigured) auxiliary vision LLM.
 pub async fn generation_model_supports_vision() -> bool {
     if generation_provider() == PROVIDER_LOCAL {
         return false;
@@ -400,10 +403,33 @@ pub async fn generation_model_supports_vision() -> bool {
     let Ok(models) = crate::june_api::list_models(ModelMode::Generation.api_type()).await else {
         return false;
     };
-    models
-        .into_iter()
-        .find(|model| model.id == model_id)
-        .is_some_and(|model| capabilities_include_vision(&model.capabilities))
+    generation_model_supports_vision_from_catalog(
+        &model_id,
+        crate::os_accounts::local_dev_enabled(),
+        models
+            .iter()
+            .map(|model| (model.id.as_str(), model.capabilities.as_slice())),
+    )
+}
+
+fn generation_model_supports_vision_from_catalog<'a>(
+    model_id: &str,
+    local_dev_enabled: bool,
+    models: impl IntoIterator<Item = (&'a str, &'a [String])>,
+) -> bool {
+    let use_local_auto_fallback = local_dev_enabled && model_id == AUTO_GENERATION_MODEL;
+    let mut local_auto_fallback_supports_vision = false;
+
+    for (catalog_model_id, capabilities) in models {
+        if catalog_model_id == model_id {
+            return capabilities_include_vision(capabilities);
+        }
+        if use_local_auto_fallback && catalog_model_id == LOCAL_AUTO_VISION_FALLBACK_MODEL {
+            local_auto_fallback_supports_vision = capabilities_include_vision(capabilities);
+        }
+    }
+
+    local_auto_fallback_supports_vision
 }
 
 /// Mirrors the frontend `modelSupportsImageInput`: key off the authoritative
@@ -1466,6 +1492,74 @@ mod tests {
         ]));
         assert!(!capabilities_include_vision(&["supportsTools".to_string()]));
         assert!(!capabilities_include_vision(&[]));
+    }
+
+    #[test]
+    fn generation_vision_uses_selected_catalog_model() {
+        let vision = vec!["supportsVision".to_string()];
+
+        assert!(generation_model_supports_vision_from_catalog(
+            "vision-model",
+            false,
+            [("vision-model", vision.as_slice())],
+        ));
+    }
+
+    #[test]
+    fn generation_vision_local_auto_uses_catalog_backed_kimi_when_auto_is_absent() {
+        let vision = vec!["supportsVision".to_string()];
+
+        assert!(generation_model_supports_vision_from_catalog(
+            AUTO_GENERATION_MODEL,
+            true,
+            [(LOCAL_AUTO_VISION_FALLBACK_MODEL, vision.as_slice())],
+        ));
+    }
+
+    #[test]
+    fn generation_vision_non_local_auto_does_not_use_kimi_fallback() {
+        let vision = vec!["supportsVision".to_string()];
+
+        assert!(!generation_model_supports_vision_from_catalog(
+            AUTO_GENERATION_MODEL,
+            false,
+            [(LOCAL_AUTO_VISION_FALLBACK_MODEL, vision.as_slice())],
+        ));
+    }
+
+    #[test]
+    fn generation_vision_local_auto_without_catalog_fallback_is_false() {
+        assert!(!generation_model_supports_vision_from_catalog(
+            AUTO_GENERATION_MODEL,
+            true,
+            std::iter::empty(),
+        ));
+    }
+
+    #[test]
+    fn generation_vision_present_auto_wins_over_local_kimi_fallback() {
+        let vision = vec!["supportsVision".to_string()];
+        let no_capabilities = Vec::new();
+
+        assert!(!generation_model_supports_vision_from_catalog(
+            AUTO_GENERATION_MODEL,
+            true,
+            [
+                (LOCAL_AUTO_VISION_FALLBACK_MODEL, vision.as_slice()),
+                (AUTO_GENERATION_MODEL, no_capabilities.as_slice()),
+            ],
+        ));
+    }
+
+    #[test]
+    fn generation_vision_local_auto_requires_kimi_vision_capability() {
+        let no_capabilities = Vec::new();
+
+        assert!(!generation_model_supports_vision_from_catalog(
+            AUTO_GENERATION_MODEL,
+            true,
+            [(LOCAL_AUTO_VISION_FALLBACK_MODEL, no_capabilities.as_slice(),)],
+        ));
     }
 
     #[test]

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -392,9 +392,9 @@ fn context_tokens_cache() -> &'static Mutex<Option<(String, i64)>> {
 /// spawn path resolves it here (see `render_hermes_config`). Returns `false`
 /// when the catalog is unreachable (offline, signed out) or the model reports no
 /// vision capability. In local dev, a persisted Auto selection can use the same
-/// catalog-backed Kimi fallback as June API when Auto is absent. The conservative
-/// default keeps the prior behavior, where Hermes falls back to its
-/// (unconfigured) auxiliary vision LLM.
+/// catalog-backed capability fallback as June API when Auto is absent. The
+/// conservative default keeps the prior behavior, where Hermes falls back to
+/// its (unconfigured) auxiliary vision LLM.
 pub async fn generation_model_supports_vision() -> bool {
     if generation_provider() == PROVIDER_LOCAL {
         return false;
@@ -418,31 +418,46 @@ fn generation_model_supports_vision_from_catalog<'a>(
     models: impl IntoIterator<Item = (&'a str, &'a [String])>,
 ) -> bool {
     let use_local_auto_fallback = local_dev_enabled && model_id == AUTO_GENERATION_MODEL;
-    let mut local_auto_fallback_supports_vision = false;
+    let mut preferred_fallback_is_compatible = false;
+    let mut alternate_fallback_is_compatible = false;
 
     for (catalog_model_id, capabilities) in models {
         if catalog_model_id == model_id {
             return capabilities_include_vision(capabilities);
         }
-        if use_local_auto_fallback && catalog_model_id == LOCAL_AUTO_VISION_FALLBACK_MODEL {
-            local_auto_fallback_supports_vision = capabilities_include_vision(capabilities);
+        if use_local_auto_fallback && capabilities_support_agent_images(capabilities) {
+            if catalog_model_id == LOCAL_AUTO_VISION_FALLBACK_MODEL {
+                preferred_fallback_is_compatible = true;
+            } else {
+                alternate_fallback_is_compatible = true;
+            }
         }
     }
 
-    local_auto_fallback_supports_vision
+    preferred_fallback_is_compatible || alternate_fallback_is_compatible
 }
 
 /// Mirrors the frontend `modelSupportsImageInput`: key off the authoritative
 /// `capabilities` list (never `traits`), matching the normalized `supportsVision`
 /// name so a rename to snake_case still resolves.
 fn capabilities_include_vision(capabilities: &[String]) -> bool {
+    capabilities_include(capabilities, "supportsvision")
+}
+
+fn capabilities_support_agent_images(capabilities: &[String]) -> bool {
+    capabilities_include_vision(capabilities)
+        && (capabilities_include(capabilities, "functioncalling")
+            || capabilities_include(capabilities, "toolcalling"))
+}
+
+fn capabilities_include(capabilities: &[String], expected: &str) -> bool {
     capabilities.iter().any(|capability| {
         let normalized: String = capability
             .chars()
             .filter(char::is_ascii_alphabetic)
             .map(|ch| ch.to_ascii_lowercase())
             .collect();
-        normalized.contains("supportsvision")
+        normalized.contains(expected)
     })
 }
 
@@ -1507,23 +1522,54 @@ mod tests {
 
     #[test]
     fn generation_vision_local_auto_uses_catalog_backed_kimi_when_auto_is_absent() {
-        let vision = vec!["supportsVision".to_string()];
+        let compatible = vec![
+            "supportsVision".to_string(),
+            "supportsFunctionCalling".to_string(),
+        ];
 
         assert!(generation_model_supports_vision_from_catalog(
             AUTO_GENERATION_MODEL,
             true,
-            [(LOCAL_AUTO_VISION_FALLBACK_MODEL, vision.as_slice())],
+            [(LOCAL_AUTO_VISION_FALLBACK_MODEL, compatible.as_slice())],
         ));
     }
 
     #[test]
     fn generation_vision_non_local_auto_does_not_use_kimi_fallback() {
-        let vision = vec!["supportsVision".to_string()];
+        let compatible = vec![
+            "supportsVision".to_string(),
+            "supportsFunctionCalling".to_string(),
+        ];
 
         assert!(!generation_model_supports_vision_from_catalog(
             AUTO_GENERATION_MODEL,
             false,
-            [(LOCAL_AUTO_VISION_FALLBACK_MODEL, vision.as_slice())],
+            [(LOCAL_AUTO_VISION_FALLBACK_MODEL, compatible.as_slice())],
+        ));
+    }
+
+    #[test]
+    fn generation_vision_local_auto_rejects_kimi_without_tool_support() {
+        let vision_only = vec!["supportsVision".to_string()];
+
+        assert!(!generation_model_supports_vision_from_catalog(
+            AUTO_GENERATION_MODEL,
+            true,
+            [(LOCAL_AUTO_VISION_FALLBACK_MODEL, vision_only.as_slice())],
+        ));
+    }
+
+    #[test]
+    fn generation_vision_local_auto_accepts_an_alternate_compatible_model() {
+        let compatible = vec![
+            "parent.supportsVision".to_string(),
+            "features.toolCalling".to_string(),
+        ];
+
+        assert!(generation_model_supports_vision_from_catalog(
+            AUTO_GENERATION_MODEL,
+            true,
+            [("replacement-model", compatible.as_slice())],
         ));
     }
 
@@ -1538,21 +1584,24 @@ mod tests {
 
     #[test]
     fn generation_vision_present_auto_wins_over_local_kimi_fallback() {
-        let vision = vec!["supportsVision".to_string()];
+        let compatible = vec![
+            "supportsVision".to_string(),
+            "supportsFunctionCalling".to_string(),
+        ];
         let no_capabilities = Vec::new();
 
         assert!(!generation_model_supports_vision_from_catalog(
             AUTO_GENERATION_MODEL,
             true,
             [
-                (LOCAL_AUTO_VISION_FALLBACK_MODEL, vision.as_slice()),
+                (LOCAL_AUTO_VISION_FALLBACK_MODEL, compatible.as_slice()),
                 (AUTO_GENERATION_MODEL, no_capabilities.as_slice()),
             ],
         ));
     }
 
     #[test]
-    fn generation_vision_local_auto_requires_kimi_vision_capability() {
+    fn generation_vision_local_auto_requires_a_compatible_catalog_model() {
         let no_capabilities = Vec::new();
 
         assert!(!generation_model_supports_vision_from_catalog(


### PR DESCRIPTION
## Summary

- isolate debug provider settings from the installed production app by default
- make the production-data override accept only explicit truthy values
- allow unavailable Auto to resolve to a concrete compatible model only in local development
- align desktop and June API vision-plus-tools capability checks so Hermes can reach the local image fallback
- keep production catalog failures loud and strip Auto-only policy and BYOK on concrete substitution

## Root cause

Debug builds reused the production `provider-settings.json`, so a production Auto selection leaked into local development. The local June API connects directly to the upstream provider and does not price the hosted `open-software/auto` route, causing `HTTP 422: model_not_priced`. The desktop and API also needed a shared catalog-backed vision-plus-tools predicate for image-bearing local Auto requests.

## Validation

- `make local-ci` - frontend not applicable; Rust/macOS signoff passed on `cabaca3e`
- June API workspace: 422 tests passed
- Tauri workspace: 783 passed, 4 ignored
- both all-target/all-feature Clippy gates passed with warnings denied
- formatting and `git diff --check` passed
- two consecutive clean independent adversarial reviews
- Not tested visually: a live image run would send content to an external provider and may authorize credits; deterministic handler and routing tests cover the failure and fixed paths.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [x] Needs a June API (backend) deploy before it works end to end. Deploy this PR's June API changes and [os-api #20](https://github.com/open-software-network/os-api/pull/20) for the complete hosted and local behavior.

## Out of scope

- Migrating production provider settings into the debug profile; that would recreate environment leakage and copy stored credentials.
- Isolating `release-settings.json`, `p3a-settings.json`, and `dictation-settings.json`; tracked in JUN-323.
- Live billed image-generation QA.

## Followups

- JUN-323 isolates the remaining raw Tauri config consumers.
- Hosted Auto capability routing and metering: [os-api #20](https://github.com/open-software-network/os-api/pull/20).

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs (not applicable; no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (local fallback and logging reviewed; metering is in os-api #20).
- [x] User-facing copy follows the repo UI conventions (not applicable; no UI copy changes).

Closes JUN-321

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786637487&installation_id=144203540&pr_number=749&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F749&signature=40e0ecb1999df7539ff37f5b0bac8890d82d50c0aeaecc9181cafc459cf1de9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->