### PR TITLE
Route BYOK Venice requests direct to Venice's public API

### DIFF
--- a/june-api/config.toml
+++ b/june-api/config.toml
@@ -74,6 +74,11 @@ base_url = "https://api.openai.com/v1"
 
 [upstreams.venice]
 base_url = "https://api.venice.ai/api/v1"
+# Requests carrying a user-supplied (BYOK) Venice key go to `byok_base_url`
+# instead of `base_url`, because `base_url` may point at a June-managed
+# gateway that only accepts June's own service key. Unset, it defaults to
+# Venice's public API (https://api.venice.ai/api/v1).
+# byok_base_url = "https://api.venice.ai/api/v1"
 
 # Usage credit prices include June's 1.2x retail multiplier over upstream cost.
 # OpenAI lists ASR prices per MINUTE of audio ($0.003/min mini, $0.006/min 4o);

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -531,6 +531,12 @@ pub struct UpstreamConfig {
     #[serde(default)]
     pub api_key: String,
     pub base_url: String,
+    /// Base URL for requests authenticated with a user-supplied (BYOK) key.
+    /// `base_url` may point at a June-managed gateway that only accepts
+    /// June's own service key; a user's key must be presented to the provider
+    /// that issued it. `None` falls back to the provider's public API URL.
+    #[serde(default)]
+    pub byok_base_url: Option<String>,
 }
 
 impl Debug for UpstreamConfig {
@@ -539,6 +545,7 @@ impl Debug for UpstreamConfig {
             .debug_struct("UpstreamConfig")
             .field("api_key", &REDACTED)
             .field("base_url", &self.base_url)
+            .field("byok_base_url", &self.byok_base_url)
             .finish()
     }
 }
@@ -914,10 +921,12 @@ impl Default for AppConfig {
                 openai: UpstreamConfig {
                     api_key: String::new(),
                     base_url: "https://api.openai.com/v1".to_string(),
+                    byok_base_url: None,
                 },
                 venice: UpstreamConfig {
                     api_key: String::new(),
                     base_url: "https://api.venice.ai/api/v1".to_string(),
+                    byok_base_url: None,
                 },
             },
             attestation: AttestationConfig {

--- a/june-api/crates/providers/src/openai.rs
+++ b/june-api/crates/providers/src/openai.rs
@@ -158,6 +158,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "openai_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: None,
             },
         )
     }

--- a/june-api/crates/providers/src/routing.rs
+++ b/june-api/crates/providers/src/routing.rs
@@ -67,10 +67,12 @@ mod tests {
                 openai: UpstreamConfig {
                     api_key: "openai_key".to_string(),
                     base_url: server.uri(),
+                    byok_base_url: None,
                 },
                 venice: UpstreamConfig {
                     api_key: "venice_key".to_string(),
                     base_url: server.uri(),
+                    byok_base_url: None,
                 },
             },
             ["gpt-4o-mini-transcribe".to_string()],

--- a/june-api/crates/providers/src/venice.rs
+++ b/june-api/crates/providers/src/venice.rs
@@ -28,6 +28,8 @@ pub(crate) fn byok_base_url(config: &UpstreamConfig) -> String {
     config
         .byok_base_url
         .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
         .unwrap_or(VENICE_PUBLIC_BASE_URL)
         .trim_end_matches('/')
         .to_string()
@@ -1917,12 +1919,16 @@ mod tests {
 
     #[test]
     fn byok_base_url_defaults_to_public_venice() {
-        let config = UpstreamConfig {
+        let mut config = UpstreamConfig {
             api_key: "venice_key".to_string(),
             base_url: "https://june-managed.example/v1".to_string(),
             byok_base_url: None,
         };
+        assert_eq!(super::byok_base_url(&config), super::VENICE_PUBLIC_BASE_URL);
 
+        // An explicitly blank override (e.g. an empty env var) must fall back
+        // too, not build scheme-less request URLs.
+        config.byok_base_url = Some("   ".to_string());
         assert_eq!(super::byok_base_url(&config), super::VENICE_PUBLIC_BASE_URL);
     }
 

--- a/june-api/crates/providers/src/venice.rs
+++ b/june-api/crates/providers/src/venice.rs
@@ -18,6 +18,37 @@ use tokio::sync::{mpsc, oneshot};
 
 pub const PROVIDER_NAME: &str = "venice";
 
+/// Where BYOK requests go when the config names no `byok_base_url`. The
+/// configured `base_url` may point at a June-managed gateway that only
+/// accepts June's service key; a user's own Venice key is only valid against
+/// Venice itself, so BYOK traffic must target Venice's public API directly.
+const VENICE_PUBLIC_BASE_URL: &str = "https://api.venice.ai/api/v1";
+
+pub(crate) fn byok_base_url(config: &UpstreamConfig) -> String {
+    config
+        .byok_base_url
+        .as_deref()
+        .unwrap_or(VENICE_PUBLIC_BASE_URL)
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// Picks the upstream base for one request: BYOK requests carry the user's
+/// key and must go direct to Venice; everything else uses the configured
+/// (June-managed, metered) upstream. Must stay aligned with
+/// [`venice_api_key`], which selects the bearer on the same condition.
+pub(crate) fn request_base_url<'a>(
+    base_url: &'a str,
+    byok_base_url: &'a str,
+    credentials: &ProviderCredentials,
+) -> &'a str {
+    if credentials.has_venice_api_key() {
+        byok_base_url
+    } else {
+        base_url
+    }
+}
+
 const CREDITS_PER_USD: f64 = 1_000.0;
 const RATE_SCALE: f64 = 1_000_000.0;
 #[cfg(not(test))]
@@ -116,6 +147,7 @@ pub struct VeniceTranscriber {
     http: reqwest::Client,
     api_key: String,
     base_url: String,
+    byok_base_url: String,
 }
 
 impl VeniceTranscriber {
@@ -124,6 +156,7 @@ impl VeniceTranscriber {
             http,
             api_key: config.api_key.clone(),
             base_url: config.base_url.trim_end_matches('/').to_string(),
+            byok_base_url: byok_base_url(config),
         }
     }
 }
@@ -131,7 +164,12 @@ impl VeniceTranscriber {
 #[async_trait]
 impl Transcriber for VeniceTranscriber {
     async fn transcribe(&self, request: TranscriptionRequest) -> Result<Transcript, DomainError> {
-        let url = format!("{}/audio/transcriptions", self.base_url);
+        let base_url = request_base_url(
+            &self.base_url,
+            &self.byok_base_url,
+            &request.provider_credentials,
+        );
+        let url = format!("{base_url}/audio/transcriptions");
         // Bounded retry on transient failures (connection reset, 429, 5xx).
         // Safe to replay: the metering charge only settles after this call
         // succeeds, so a retried attempt can never double-charge.
@@ -453,6 +491,7 @@ struct VeniceChat {
     unmetered_http: Option<reqwest::Client>,
     api_key: String,
     base_url: String,
+    byok_base_url: String,
 }
 
 impl VeniceChat {
@@ -462,6 +501,7 @@ impl VeniceChat {
             unmetered_http: None,
             api_key: config.api_key.clone(),
             base_url: config.base_url.trim_end_matches('/').to_string(),
+            byok_base_url: byok_base_url(config),
         }
     }
 
@@ -484,13 +524,18 @@ impl VeniceChat {
         }
     }
 
+    fn chat_completions_url(&self, credentials: &ProviderCredentials) -> String {
+        let base_url = request_base_url(&self.base_url, &self.byok_base_url, credentials);
+        format!("{base_url}/chat/completions")
+    }
+
     async fn complete(
         &self,
         mut body: ChatCompletionRequest,
         auth: ChatCallAuth<'_>,
     ) -> Result<ChatCompletionResponse, DomainError> {
         body.messages.insert(0, ChatMessage::safety_context());
-        let url = format!("{}/chat/completions", self.base_url);
+        let url = self.chat_completions_url(auth.provider_credentials);
         // Bounded retry on transient failures — same rationale as the
         // transcribers: metering settles only after success, so a replay
         // can never double-charge.
@@ -565,7 +610,7 @@ impl VeniceChat {
         auth: ChatCallAuth<'_>,
     ) -> Result<AgentChatCompletion, DomainError> {
         let body = prepare_agent_chat_body(body, &model)?;
-        let url = format!("{}/chat/completions", self.base_url);
+        let url = self.chat_completions_url(auth.provider_credentials);
         let response = self
             .client(auth.unmetered)
             .post(&url)
@@ -616,7 +661,7 @@ impl VeniceChat {
         auth: ChatCallAuth<'_>,
     ) -> Result<AgentChatStream, DomainError> {
         let body = prepare_agent_chat_body(body, &model)?;
-        let url = format!("{}/chat/completions", self.base_url);
+        let url = self.chat_completions_url(auth.provider_credentials);
         let mut response = self
             .client(auth.unmetered)
             .post(&url)
@@ -1521,6 +1566,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: None,
             },
         );
 
@@ -1579,7 +1625,9 @@ mod tests {
             http::default_client(),
             &UpstreamConfig {
                 api_key: "shared_venice_key".to_string(),
-                base_url: server.uri(),
+                // BYOK requests route to byok_base_url, never base_url.
+                base_url: "http://127.0.0.1:9".to_string(),
+                byok_base_url: Some(server.uri()),
             },
         );
 
@@ -1629,6 +1677,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: None,
             },
         );
 
@@ -1677,6 +1726,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: None,
             },
         );
 
@@ -1752,6 +1802,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: None,
             },
         );
 
@@ -1792,6 +1843,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: None,
             },
         );
 
@@ -1833,6 +1885,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: None,
             },
         );
 
@@ -1862,6 +1915,92 @@ mod tests {
         assert!(body.contains("filename=\"audio.wav\""), "body: {body}");
     }
 
+    #[test]
+    fn byok_base_url_defaults_to_public_venice() {
+        let config = UpstreamConfig {
+            api_key: "venice_key".to_string(),
+            base_url: "https://june-managed.example/v1".to_string(),
+            byok_base_url: None,
+        };
+
+        assert_eq!(super::byok_base_url(&config), super::VENICE_PUBLIC_BASE_URL);
+    }
+
+    #[tokio::test]
+    async fn byok_transcription_routes_direct_to_byok_base_url() {
+        // Regression: the configured base_url may be a June-managed gateway
+        // that rejects any bearer other than June's service key. A request
+        // carrying a user's own Venice key must go to the BYOK base instead.
+        let byok_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/audio/transcriptions"))
+            .and(header("authorization", "Bearer user_venice_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "text": "Hello" })))
+            .expect(1)
+            .mount(&byok_server)
+            .await;
+        let transcriber = super::VeniceTranscriber::from_config(
+            http::default_client(),
+            &UpstreamConfig {
+                api_key: "venice_key".to_string(),
+                base_url: "http://127.0.0.1:9".to_string(),
+                byok_base_url: Some(byok_server.uri()),
+            },
+        );
+
+        let transcript = june_domain::Transcriber::transcribe(
+            &transcriber,
+            june_domain::TranscriptionRequest {
+                audio: b"fake wav".to_vec(),
+                format: june_domain::AudioFormat::Wav,
+                context: None,
+                language: None,
+                model: ModelId("nvidia/parakeet-tdt-0.6b-v3".to_string()),
+                provider_credentials: ProviderCredentials {
+                    venice_api_key: Some("user_venice_key".to_string()),
+                },
+            },
+        )
+        .await;
+
+        assert_eq!(transcript.map(|value| value.text), Ok("Hello".to_string()));
+    }
+
+    #[tokio::test]
+    async fn metered_transcription_ignores_byok_base_url() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/audio/transcriptions"))
+            .and(header("authorization", "Bearer venice_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "text": "Hello" })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let transcriber = super::VeniceTranscriber::from_config(
+            http::default_client(),
+            &UpstreamConfig {
+                api_key: "venice_key".to_string(),
+                base_url: server.uri(),
+                byok_base_url: Some("http://127.0.0.1:9".to_string()),
+            },
+        );
+
+        let transcript = june_domain::Transcriber::transcribe(
+            &transcriber,
+            june_domain::TranscriptionRequest {
+                audio: b"fake wav".to_vec(),
+                format: june_domain::AudioFormat::Wav,
+                context: None,
+                language: None,
+                model: ModelId("nvidia/parakeet-tdt-0.6b-v3".to_string()),
+                provider_credentials: ProviderCredentials::default(),
+            },
+        )
+        .await;
+
+        assert_eq!(transcript.map(|value| value.text), Ok("Hello".to_string()));
+    }
+
     #[tokio::test]
     async fn agent_chat_replaces_non_object_stream_options() {
         // A non-object `stream_options` used to silently skip the
@@ -1883,6 +2022,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: None,
             },
         );
 
@@ -1921,7 +2061,9 @@ mod tests {
             http::default_client(),
             &UpstreamConfig {
                 api_key: "shared_venice_key".to_string(),
-                base_url: server.uri(),
+                // BYOK requests route to byok_base_url, never base_url.
+                base_url: "http://127.0.0.1:9".to_string(),
+                byok_base_url: Some(server.uri()),
             },
         );
 
@@ -2105,6 +2247,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: None,
             },
         );
 
@@ -2152,6 +2295,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: None,
             },
         );
 
@@ -2189,6 +2333,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: base_url.to_string(),
+                byok_base_url: None,
             },
         )
     }
@@ -2308,6 +2453,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: base_url.to_string(),
+                byok_base_url: None,
             },
         )
     }

--- a/june-api/crates/providers/src/venice_augment.rs
+++ b/june-api/crates/providers/src/venice_augment.rs
@@ -27,6 +27,7 @@ pub struct VeniceAugment {
     http: reqwest::Client,
     api_key: String,
     base_url: String,
+    byok_base_url: String,
 }
 
 impl VeniceAugment {
@@ -35,6 +36,7 @@ impl VeniceAugment {
             http,
             api_key: config.api_key.clone(),
             base_url: config.base_url.trim_end_matches('/').to_string(),
+            byok_base_url: crate::venice::byok_base_url(config),
         }
     }
 
@@ -57,8 +59,13 @@ impl VeniceAugment {
         B: Serialize,
         T: DeserializeOwned,
     {
+        let base_url = crate::venice::request_base_url(
+            &self.base_url,
+            &self.byok_base_url,
+            provider_credentials,
+        );
         let endpoint = ResolvedAugmentEndpoint {
-            url: format!("{}{}", self.base_url, endpoint.path),
+            url: format!("{}{}", base_url, endpoint.path),
             client_error_reason: endpoint.client_error_reason,
         };
         for attempt in 0..retry::UPSTREAM_ATTEMPTS {
@@ -299,8 +306,49 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: None,
             },
         )
+    }
+
+    #[tokio::test]
+    async fn byok_search_routes_direct_to_byok_base_url() {
+        // A request carrying a user's own Venice key must go to the BYOK base;
+        // the configured base_url may be a June-managed gateway that rejects
+        // any bearer other than June's service key.
+        let byok_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/augment/search"))
+            .and(header("authorization", "Bearer user_venice_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "query": "rust async",
+                "results": []
+            })))
+            .expect(1)
+            .mount(&byok_server)
+            .await;
+        let augment = VeniceAugment::from_config(
+            http::default_client(),
+            &UpstreamConfig {
+                api_key: "venice_key".to_string(),
+                base_url: "http://127.0.0.1:9".to_string(),
+                byok_base_url: Some(byok_server.uri()),
+            },
+        );
+
+        let results = augment
+            .search(WebSearchRequest {
+                query: "rust async".to_string(),
+                limit: Some(5),
+                provider: WebSearchProvider::Brave,
+                provider_credentials: ProviderCredentials {
+                    venice_api_key: Some("user_venice_key".to_string()),
+                },
+            })
+            .await
+            .expect("search should succeed");
+
+        assert_eq!(results.results.len(), 0);
     }
 
     #[tokio::test]

--- a/june-api/crates/providers/src/venice_image.rs
+++ b/june-api/crates/providers/src/venice_image.rs
@@ -27,6 +27,7 @@ pub struct VeniceImageGenerator {
     http: reqwest::Client,
     api_key: String,
     base_url: String,
+    byok_base_url: String,
     /// End-to-end budget for the whole generate leg INCLUDING retries; the
     /// hold TTL and route timeout arithmetic assume this bound (config lib.rs).
     leg_budget: std::time::Duration,
@@ -42,6 +43,7 @@ impl VeniceImageGenerator {
             http,
             api_key: config.api_key.clone(),
             base_url: config.base_url.trim_end_matches('/').to_string(),
+            byok_base_url: crate::venice::byok_base_url(config),
             leg_budget,
         }
     }
@@ -120,7 +122,12 @@ impl ImageGenerator for VeniceImageGenerator {
             height: request.height,
             safe_mode: request.safe_mode,
         };
-        let url = format!("{}/image/generate", self.base_url);
+        let base_url = crate::venice::request_base_url(
+            &self.base_url,
+            &self.byok_base_url,
+            &request.provider_credentials,
+        );
+        let url = format!("{base_url}/image/generate");
         // Bounded retry on transient failures (connection reset, 429, 5xx),
         // same as the chat and augment paths. The service settles at most one
         // June charge after this call returns; a retry can cost at most one
@@ -227,6 +234,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: Some(server.uri()),
             },
             std::time::Duration::from_secs(5),
         )

--- a/june-api/crates/providers/src/venice_image_edit.rs
+++ b/june-api/crates/providers/src/venice_image_edit.rs
@@ -27,6 +27,7 @@ pub struct VeniceImageEditor {
     http: reqwest::Client,
     api_key: String,
     base_url: String,
+    byok_base_url: String,
     /// End-to-end budget for the whole edit leg INCLUDING retries (see
     /// `VeniceImageGenerator::leg_budget`).
     leg_budget: std::time::Duration,
@@ -42,6 +43,7 @@ impl VeniceImageEditor {
             http,
             api_key: config.api_key.clone(),
             base_url: config.base_url.trim_end_matches('/').to_string(),
+            byok_base_url: crate::venice::byok_base_url(config),
             leg_budget,
         }
     }
@@ -130,7 +132,12 @@ impl ImageEditor for VeniceImageEditor {
             output_format: OUTPUT_FORMAT,
             safe_mode: request.safe_mode,
         };
-        let url = format!("{}/image/edit", self.base_url);
+        let base_url = crate::venice::request_base_url(
+            &self.base_url,
+            &self.byok_base_url,
+            &request.provider_credentials,
+        );
+        let url = format!("{base_url}/image/edit");
         // Bounded retry on transient failures, same as the generator. The
         // service charges once AFTER a successful edit, so a retry never
         // double-charges; at most one extra upstream edit if a completed
@@ -200,6 +207,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "test-key".to_string(),
                 base_url: base_url.to_string(),
+                byok_base_url: None,
             },
             std::time::Duration::from_secs(5),
         )

--- a/june-api/crates/providers/src/venice_video.rs
+++ b/june-api/crates/providers/src/venice_video.rs
@@ -532,6 +532,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: None,
             },
             std::time::Duration::from_secs(5),
             100 * 1024 * 1024,
@@ -544,6 +545,7 @@ mod tests {
             &UpstreamConfig {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
+                byok_base_url: None,
             },
             std::time::Duration::from_secs(5),
             max_response_bytes,


### PR DESCRIPTION
## Summary

- Requests carrying a user-supplied (BYOK) Venice key now target a dedicated `upstreams.venice.byok_base_url` (default `https://api.venice.ai/api/v1`) instead of the configured Venice `base_url`. Metered requests are unchanged.
- Applied in every provider that forwards BYOK credentials: transcription, chat/note generation, agent chat (including streaming), web augment (search/scrape), image generate, and image edit.
- `byok_base_url` is optional in config and overridable via `JUNE__UPSTREAMS__VENICE__BYOK_BASE_URL`; unset, it falls back to Venice's public API.

## Root cause

BYOK was implemented by swapping the upstream bearer from June's service key to the user's Venice key while keeping the single configured Venice base URL. Since the production Venice upstream was cut over to the June-managed gateway (2026-07-13), that gateway authenticates only June's own service keys, so every BYOK request came back 401 and surfaced to users as `venice_api_key_rejected`, even for keys Venice itself accepts (verified against `api.venice.ai` directly with a working key). A user's Venice key is only valid against Venice, so BYOK traffic must go there regardless of where metered traffic is routed.

## Validation

- `cargo test --workspace` in `june-api` passes (417 tests), including new wiremock tests that pin the routing: BYOK transcription/search hit only `byok_base_url` (with `base_url` unroutable), metered transcription hits only `base_url` (with `byok_base_url` unroutable), and the existing BYOK bearer-preference tests now run with an unroutable `base_url` to prove they never touch it.
- `cargo fmt` and `cargo clippy --workspace --all-targets` are clean.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [x] Needs a June API (backend) deploy before it works end to end. BYOK stays broken in production until this ships; no desktop change required.

## Out of scope

- Auto (`open-software/auto`) still strips BYOK and meters June credits by design; the settings warning for that shipped in #738 and rides the next desktop release.
- No change to BYOK eligibility rules (`is_venice_model`, `credentials_for_resolved_model`) or to metering.

## Followups

- Consider a contract/smoke check that exercises a BYOK-shaped request against the deployed upstream pair, so an upstream cutover cannot silently break BYOK again.
- Ship the next desktop release containing #738 (Auto BYOK warning, opaque key formats) so the client-side messaging catches up.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [ ] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786639877&installation_id=144203540&pr_number=750&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F750&signature=453772f1b52d3176ca73e82f306f674a844fbff5beb155e6030f28f573e7ac1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->