### PR TITLE
Release credit holds when metered work fails

### DIFF
--- a/june-api/crates/services/src/agent_chat.rs
+++ b/june-api/crates/services/src/agent_chat.rs
@@ -1,7 +1,7 @@
 use crate::{
     charge_flow::{
-        AuthorizeParams, ChargeParams, authorize_or_deny, charge, clamp_to_cap, log_settled,
-        new_charge_operation_id, zero_receipt,
+        AuthorizeParams, ChargeParams, ReleaseHoldParams, authorize_or_deny, charge, clamp_to_cap,
+        log_settled, new_charge_operation_id, release_hold, zero_receipt,
     },
     error::ServiceError,
     metering::{log_skipped_user_venice_key, uses_user_venice_key_for_model},
@@ -75,7 +75,7 @@ impl AgentChatService {
         })
         .await?;
         let idempotency_key = idempotency_key(&params.user_id, &params.body);
-        let completion = self
+        let completion = match self
             .chat_completer
             .complete(AgentChatRequest {
                 body: params.body,
@@ -83,7 +83,19 @@ impl AgentChatService {
                 provider_credentials: params.provider_credentials.clone(),
                 unmetered: false,
             })
-            .await?;
+            .await
+        {
+            Ok(completion) => completion,
+            Err(error) => {
+                release_hold(ReleaseHoldParams {
+                    os_accounts: self.os_accounts.as_ref(),
+                    action: ActionSlug::AgentChat,
+                    action_token: authorization.action_token,
+                })
+                .await;
+                return Err(error.into());
+            }
+        };
         let actual = self
             .pricing
             .price_token_usage(&params.model_id.0, completion.usage)?;
@@ -148,7 +160,7 @@ impl AgentChatService {
         })
         .await?;
         let idempotency_key = idempotency_key(&params.user_id, &params.body);
-        let stream = self
+        let stream = match self
             .chat_completer
             .complete_stream(AgentChatRequest {
                 body: params.body,
@@ -156,7 +168,19 @@ impl AgentChatService {
                 provider_credentials: params.provider_credentials.clone(),
                 unmetered: false,
             })
-            .await?;
+            .await
+        {
+            Ok(stream) => stream,
+            Err(error) => {
+                release_hold(ReleaseHoldParams {
+                    os_accounts: self.os_accounts.as_ref(),
+                    action: ActionSlug::AgentChat,
+                    action_token: authorization.action_token,
+                })
+                .await;
+                return Err(error.into());
+            }
+        };
         spawn_stream_settlement(StreamSettlement {
             pricing: self.pricing.clone(),
             os_accounts: self.os_accounts.clone(),
@@ -270,8 +294,14 @@ async fn settle_stream_charge(params: StreamSettlement) {
                 user_id = %params.user_id.0,
                 action = ActionSlug::AgentChat.as_str(),
                 model = %params.model_id.0,
-                "agent chat stream failed mid-transport; leaving hold unsettled"
+                "agent chat stream failed mid-transport; releasing hold"
             );
+            release_hold(ReleaseHoldParams {
+                os_accounts: params.os_accounts.as_ref(),
+                action: ActionSlug::AgentChat,
+                action_token: params.action_token,
+            })
+            .await;
             return;
         }
     };

--- a/june-api/crates/services/src/charge_flow.rs
+++ b/june-api/crates/services/src/charge_flow.rs
@@ -1,4 +1,5 @@
 use crate::error::ServiceError;
+use crate::util::sha256_hex;
 use june_domain::{
     ActionSlug, Authorization, AuthorizeRequest, ChargeRequest, Credits, OsAccountsClient, Receipt,
     UserId,
@@ -135,6 +136,49 @@ pub(crate) async fn charge(params: ChargeParams<'_>) -> Result<Receipt, ServiceE
         })
         .await
         .map_err(ServiceError::from)
+}
+
+pub(crate) struct ReleaseHoldParams<'a> {
+    pub os_accounts: &'a dyn OsAccountsClient,
+    pub action: ActionSlug,
+    pub action_token: String,
+}
+
+/// Best-effort release of a Hold whose metered work failed: settles the grant
+/// at zero credits (os-accounts ADR-0032) so it stops counting against the
+/// user's concurrency cap and available balance. Before the release primitive,
+/// failed work stranded its hold until TTL + sweep — enough failures in one
+/// burst saturated the 10-open-grant cap and denied every following authorize
+/// (the 2026-07-14 lost-transcript incident). Errors are logged, never
+/// propagated: the caller is already returning the provider failure, and an
+/// unreleased hold degrades to the old TTL-expiry behavior.
+pub(crate) async fn release_hold(params: ReleaseHoldParams<'_>) {
+    // Grant-scoped key (token digest): a release can never collide with a
+    // later charge of the same logical work under a fresh grant, and a
+    // replayed release of the same grant settles idempotently.
+    let idempotency_key = format!(
+        "release:{}:{}",
+        params.action.as_str(),
+        &sha256_hex(params.action_token.as_bytes())[..32],
+    );
+    match charge(ChargeParams {
+        os_accounts: params.os_accounts,
+        action_token: params.action_token,
+        credits: Credits(0),
+        idempotency_key,
+    })
+    .await
+    {
+        Ok(_) => tracing::info!(
+            action = params.action.as_str(),
+            "released unused hold after failed metered work"
+        ),
+        Err(error) => tracing::warn!(
+            %error,
+            action = params.action.as_str(),
+            "failed to release unused hold; it expires via TTL"
+        ),
+    }
 }
 
 pub(crate) struct AsyncChargeParams {

--- a/june-api/crates/services/src/dictate.rs
+++ b/june-api/crates/services/src/dictate.rs
@@ -1,7 +1,7 @@
 use crate::{
     charge_flow::{
-        AsyncChargeParams, AuthorizeParams, authorize_or_deny, clamp_to_cap, spawn_charge,
-        zero_receipt,
+        AsyncChargeParams, AuthorizeParams, ReleaseHoldParams, authorize_or_deny, clamp_to_cap,
+        release_hold, spawn_charge, zero_receipt,
     },
     error::ServiceError,
     language::fill_missing_language,
@@ -106,7 +106,7 @@ impl DictateService {
             hold_ttl_seconds: self.transcribe_hold_ttl_seconds,
         })
         .await?;
-        let transcript = self
+        let transcript = match self
             .transcriber
             .transcribe(TranscriptionRequest {
                 audio: params.audio,
@@ -117,7 +117,18 @@ impl DictateService {
                 provider_credentials: params.provider_credentials.clone(),
             })
             .await
-            .map_err(ServiceError::from)?;
+        {
+            Ok(transcript) => transcript,
+            Err(error) => {
+                release_hold(ReleaseHoldParams {
+                    os_accounts: self.os_accounts.as_ref(),
+                    action: ActionSlug::DictateTranscribe,
+                    action_token: authorization.action_token,
+                })
+                .await;
+                return Err(ServiceError::from(error));
+            }
+        };
         let transcript = fill_missing_language(transcript, requested_language.as_deref());
         let charge_credits = clamp_to_cap(actual, authorization.cap_credits);
         let idempotency_key = format!(
@@ -181,7 +192,7 @@ impl DictateService {
             hold_ttl_seconds: self.cleanup_hold_ttl_seconds,
         })
         .await?;
-        let cleaned = self
+        let cleaned = match self
             .cleaner
             .cleanup(CleanupRequest {
                 text: params.text,
@@ -192,7 +203,19 @@ impl DictateService {
                 system_prompt: prompts::DICTATE_CLEANUP.to_string(),
                 provider_credentials: params.provider_credentials.clone(),
             })
-            .await?;
+            .await
+        {
+            Ok(cleaned) => cleaned,
+            Err(error) => {
+                release_hold(ReleaseHoldParams {
+                    os_accounts: self.os_accounts.as_ref(),
+                    action: ActionSlug::DictateCleanup,
+                    action_token: authorization.action_token,
+                })
+                .await;
+                return Err(error.into());
+            }
+        };
         let actual = self
             .pricing
             .price_token_usage(&params.model_id.0, cleaned.usage)?;

--- a/june-api/crates/services/src/image.rs
+++ b/june-api/crates/services/src/image.rs
@@ -1,7 +1,7 @@
 use crate::{
     charge_flow::{
-        AuthorizeParams, ChargeParams, authorize_or_deny, charge, clamp_to_cap, log_settled,
-        new_charge_operation_id, zero_receipt,
+        AuthorizeParams, ChargeParams, ReleaseHoldParams, authorize_or_deny, charge, clamp_to_cap,
+        log_settled, new_charge_operation_id, release_hold, zero_receipt,
     },
     error::ServiceError,
     metering::{log_skipped_user_venice_key, uses_user_venice_key},
@@ -171,8 +171,9 @@ impl ImageService {
         let charge_created_at = Instant::now();
         let operation_id = new_charge_operation_id();
         // A failed/rejected generation returns the error WITHOUT charging; the
-        // wallet hold simply expires (same as the web and agent chat paths).
-        let image = self
+        // wallet hold is released so it stops counting against the user's
+        // concurrency cap (same as the web and agent chat paths).
+        let image = match self
             .generator
             .generate(ImageGenerationRequest {
                 prompt: params.prompt.clone(),
@@ -182,7 +183,19 @@ impl ImageService {
                 safe_mode: params.safe_mode,
                 provider_credentials: params.provider_credentials.clone(),
             })
-            .await?;
+            .await
+        {
+            Ok(image) => image,
+            Err(error) => {
+                release_hold(ReleaseHoldParams {
+                    os_accounts: self.os_accounts.as_ref(),
+                    action: ActionSlug::ImageGenerate,
+                    action_token: authorization.action_token,
+                })
+                .await;
+                return Err(error.into());
+            }
+        };
         let charge_credits = clamp_to_cap(estimate, authorization.cap_credits);
         Ok(PendingImageCharge {
             action: ActionSlug::ImageGenerate,
@@ -200,7 +213,7 @@ impl ImageService {
     /// model (requests name none, so the default governs), reject an unpriced
     /// model before any wallet/Venice call, authorize a hold, edit, then charge
     /// the flat edit price under a unique key. A failed/rejected edit returns the
-    /// error WITHOUT charging (the hold expires).
+    /// error WITHOUT charging (the hold is released).
     pub async fn edit(&self, params: ImageEditParams) -> Result<ImageGenerateOutput, ServiceError> {
         let model = params
             .model
@@ -284,7 +297,7 @@ impl ImageService {
         .await?;
         let charge_created_at = Instant::now();
         let operation_id = new_charge_operation_id();
-        let image = self
+        let image = match self
             .editor
             .edit(ImageEditRequest {
                 image_base64: params.image_base64.clone(),
@@ -294,7 +307,19 @@ impl ImageService {
                 safe_mode: params.safe_mode,
                 provider_credentials: params.provider_credentials.clone(),
             })
-            .await?;
+            .await
+        {
+            Ok(image) => image,
+            Err(error) => {
+                release_hold(ReleaseHoldParams {
+                    os_accounts: self.os_accounts.as_ref(),
+                    action: ActionSlug::ImageEdit,
+                    action_token: authorization.action_token,
+                })
+                .await;
+                return Err(error.into());
+            }
+        };
         let charge_credits = clamp_to_cap(estimate, authorization.cap_credits);
         Ok(PendingImageCharge {
             action: ActionSlug::ImageEdit,
@@ -1715,19 +1740,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failed_generation_authorizes_but_never_charges() {
+    async fn failed_generation_authorizes_but_never_bills() {
         let os_accounts = Arc::new(RecordingOsAccounts::new(true));
         let result = service(os_accounts.clone(), Arc::new(FailingGenerator))
             .generate(params("venice-sd35"))
             .await;
 
         assert!(matches!(result, Err(crate::ServiceError::UpstreamProvider)));
+        // The hold is released at zero credits instead of stranding until TTL.
         assert_eq!(
             os_accounts.events(),
-            vec![Call::Authorize {
-                action: "image_generate".to_string(),
-                estimate: 20,
-            }]
+            vec![
+                Call::Authorize {
+                    action: "image_generate".to_string(),
+                    estimate: 20,
+                },
+                Call::Charge {
+                    credits: 0,
+                    idempotency_key: format!(
+                        "release:image_generate:{}",
+                        &crate::util::sha256_hex("agt_test".as_bytes())[..32],
+                    ),
+                },
+            ]
         );
     }
 

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -774,7 +774,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn note_transcribe_preview_failure_still_settles_hold() {
+    async fn note_transcribe_preview_failure_releases_hold_without_billing() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
             pricing: Arc::new(PricingTable::new(models([(
@@ -806,6 +806,8 @@ mod tests {
             .await;
 
         assert!(matches!(result, Err(ServiceError::UpstreamProvider)));
+        // Failed previews used to bill the full audio price just to close the
+        // hold; a zero-credit release closes it without charging.
         assert_eq!(
             os_accounts.events(),
             vec![
@@ -815,15 +817,70 @@ mod tests {
                     estimate: 1024,
                     hold_ttl: 60,
                 },
-                RecordedCall::Charge {
-                    action_token: "agt_test".to_string(),
-                    credits: 4,
-                    idempotency_key: concat!(
-                        "note_transcribe_preview:usr_123:live-preview-session-1:",
-                        "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
-                    )
-                    .to_string(),
+                release_charge_event("note_transcribe"),
+            ]
+        );
+    }
+
+    /// The grant-scoped release key: never collides with a later successful
+    /// charge of the same work under a fresh grant.
+    fn release_charge_event(action: &str) -> RecordedCall {
+        RecordedCall::Charge {
+            action_token: "agt_test".to_string(),
+            credits: 0,
+            idempotency_key: format!(
+                "release:{action}:{}",
+                &crate::util::sha256_hex("agt_test".as_bytes())[..32],
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn note_transcribe_failure_releases_hold() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: Arc::new(FailingTranscriber),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let result = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "note-1-turn-4-chunk-0".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "turn.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: false,
+                provider_credentials: ProviderCredentials::default(),
+            })
+            .await;
+
+        // The provider failure propagates, but the hold is settled at zero:
+        // stranded holds from failed turns are what saturated the concurrency
+        // cap and denied every later authorize in the 2026-07-14 incident.
+        assert!(matches!(result, Err(ServiceError::UpstreamProvider)));
+        assert_eq!(
+            os_accounts.events(),
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 1024,
+                    hold_ttl: 60,
                 },
+                release_charge_event("note_transcribe"),
             ]
         );
     }
@@ -1228,18 +1285,21 @@ mod tests {
             .await
             .expect("stream starts");
         while output.chunks.recv().await.is_some() {}
-        // The settle task returns without charging on a transport failure;
-        // yield so it runs to completion before asserting absence.
+        // The settle task releases the hold (zero-credit charge) on a
+        // transport failure; yield so it runs to completion before asserting.
         for _ in 0..20 {
             tokio::task::yield_now().await;
         }
 
-        assert!(
-            !os_accounts
-                .events()
-                .into_iter()
-                .any(|event| matches!(event, RecordedCall::Charge { .. })),
-            "a transport-failed stream must leave the hold unsettled (buffered-path parity)"
+        let charges = os_accounts
+            .events()
+            .into_iter()
+            .filter(|event| matches!(event, RecordedCall::Charge { .. }))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            charges,
+            vec![release_charge_event("agent_chat")],
+            "a transport-failed stream must release the hold without billing"
         );
     }
 

--- a/june-api/crates/services/src/note_generate.rs
+++ b/june-api/crates/services/src/note_generate.rs
@@ -1,7 +1,7 @@
 use crate::{
     charge_flow::{
-        AuthorizeParams, ChargeParams, authorize_or_deny, charge, clamp_to_cap, log_settled,
-        zero_receipt,
+        AuthorizeParams, ChargeParams, ReleaseHoldParams, authorize_or_deny, charge, clamp_to_cap,
+        log_settled, release_hold, zero_receipt,
     },
     error::ServiceError,
     metering::{log_skipped_user_venice_key, uses_user_venice_key_for_model},
@@ -92,7 +92,7 @@ impl NoteGenerateService {
             hold_ttl_seconds: self.hold_ttl_seconds,
         })
         .await?;
-        let generated = self
+        let generated = match self
             .generator
             .generate(GenerationRequest {
                 title: params.title,
@@ -107,7 +107,19 @@ impl NoteGenerateService {
                 provider_credentials: params.provider_credentials.clone(),
                 unmetered: false,
             })
-            .await?;
+            .await
+        {
+            Ok(generated) => generated,
+            Err(error) => {
+                release_hold(ReleaseHoldParams {
+                    os_accounts: self.os_accounts.as_ref(),
+                    action: ActionSlug::NoteGenerate,
+                    action_token: authorization.action_token,
+                })
+                .await;
+                return Err(error.into());
+            }
+        };
         let actual = self
             .pricing
             .price_token_usage(&params.model_id.0, generated.usage)?;

--- a/june-api/crates/services/src/note_transcribe.rs
+++ b/june-api/crates/services/src/note_transcribe.rs
@@ -1,7 +1,7 @@
 use crate::{
     charge_flow::{
-        AuthorizeParams, ChargeParams, authorize_or_deny, charge, clamp_to_cap, log_settled,
-        zero_receipt,
+        AuthorizeParams, ChargeParams, ReleaseHoldParams, authorize_or_deny, charge, clamp_to_cap,
+        log_settled, release_hold, zero_receipt,
     },
     error::ServiceError,
     metering::{log_skipped_user_venice_key, uses_user_venice_key_for_model},
@@ -180,7 +180,7 @@ impl NoteTranscribeService {
             "note_transcribe: preview request authorized"
         );
         let audio_digest = sha256_hex(&params.audio);
-        let transcript_result = self
+        let transcript = match self
             .transcriber
             .transcribe(TranscriptionRequest {
                 audio: params.audio,
@@ -190,7 +190,21 @@ impl NoteTranscribeService {
                 model: params.model_id.clone(),
                 provider_credentials: params.provider_credentials.clone(),
             })
-            .await;
+            .await
+        {
+            Ok(transcript) => transcript,
+            Err(error) => {
+                // Failed previews used to settle at the full audio price just
+                // to avoid stranding the hold; release bills nothing instead.
+                release_hold(ReleaseHoldParams {
+                    os_accounts: self.os_accounts.as_ref(),
+                    action: ActionSlug::NoteTranscribe,
+                    action_token: authorization.action_token,
+                })
+                .await;
+                return Err(error.into());
+            }
+        };
         let charge_credits = clamp_to_cap(actual, authorization.cap_credits);
         let idempotency_key = format!(
             "note_transcribe_preview:{}:{}:{}",
@@ -208,7 +222,6 @@ impl NoteTranscribeService {
             credits_charged = receipt.credits_charged.0,
             "note_transcribe: preview hold settled"
         );
-        let transcript = transcript_result?;
         Ok(NoteTranscribeOutput {
             transcript,
             receipt,
@@ -244,7 +257,7 @@ impl NoteTranscribeService {
             model = %params.model_id.0,
             "note_transcribe: calling transcriber"
         );
-        let transcript = self
+        let transcript = match self
             .transcriber
             .transcribe(TranscriptionRequest {
                 audio: params.audio,
@@ -254,7 +267,19 @@ impl NoteTranscribeService {
                 model: params.model_id.clone(),
                 provider_credentials: params.provider_credentials.clone(),
             })
-            .await?;
+            .await
+        {
+            Ok(transcript) => transcript,
+            Err(error) => {
+                release_hold(ReleaseHoldParams {
+                    os_accounts: self.os_accounts.as_ref(),
+                    action: ActionSlug::NoteTranscribe,
+                    action_token: authorization.action_token,
+                })
+                .await;
+                return Err(error.into());
+            }
+        };
         tracing::info!(
             note_id = %params.note_id,
             text_len = transcript.text.len(),

--- a/june-api/crates/services/src/video.rs
+++ b/june-api/crates/services/src/video.rs
@@ -23,7 +23,8 @@
 
 use crate::{
     charge_flow::{
-        AuthorizeParams, ChargeParams, authorize_or_deny, charge, clamp_to_cap, log_settled,
+        AuthorizeParams, ChargeParams, ReleaseHoldParams, authorize_or_deny, charge, clamp_to_cap,
+        log_settled, release_hold,
     },
     error::ServiceError,
     util::sha256_hex,
@@ -227,7 +228,7 @@ impl VideoService {
     }
 
     /// The paid work behind a create: quote -> ceiling -> authorize -> mint the
-    /// settlement key -> queue. On a queue failure the hold simply expires (no
+    /// settlement key -> queue. On a queue failure the hold is released (no
     /// charge). Video is always June-metered for this first cut.
     async fn run_create(&self, inputs: &CreateJobInputs) -> Result<VideoJob, ServiceError> {
         let estimate = self.quote_to_credits(inputs).await?;
@@ -249,10 +250,18 @@ impl VideoService {
             Uuid::now_v7(),
             inputs.shape_hash,
         );
-        let queued = self
-            .queue(&inputs.queue)
-            .await
-            .map_err(translate_upstream_error)?;
+        let queued = match self.queue(&inputs.queue).await {
+            Ok(queued) => queued,
+            Err(error) => {
+                release_hold(ReleaseHoldParams {
+                    os_accounts: self.os_accounts.as_ref(),
+                    action: inputs.action,
+                    action_token: authorization.action_token,
+                })
+                .await;
+                return Err(translate_upstream_error(error));
+            }
+        };
         let charge_credits = clamp_to_cap(estimate, authorization.cap_credits);
         Ok(Self::build_job(
             inputs,
@@ -362,8 +371,10 @@ impl VideoService {
                                 // Venice reported COMPLETED but returned no usable media:
                                 // terminal, no charge (we never entered Charging). Retrying
                                 // will not help.
-                                self.registry
+                                let released = self
+                                    .registry
                                     .mark_failed(&job_id, "video_media_unavailable");
+                                self.release_failed_job_hold(released).await;
                                 return Ok(VideoStatusOutput::Failed {
                                     reason: "video_media_unavailable".to_string(),
                                 });
@@ -378,7 +389,7 @@ impl VideoService {
                             }
                         }
                         Err(error) => {
-                            return self.handle_retrieve_error(&job_id, &error);
+                            return self.handle_retrieve_error(&job_id, &error).await;
                         }
                     }
                 }
@@ -439,20 +450,22 @@ impl VideoService {
         }
     }
 
-    fn handle_retrieve_error(
+    async fn handle_retrieve_error(
         &self,
         job_id: &JobId,
         error: &DomainError,
     ) -> Result<VideoStatusOutput, ServiceError> {
         match classify_retrieve_error(error) {
             RetrieveOutcome::ContentRejected { reason } => {
-                // Content policy discovered mid-job: mark Failed, no charge (the
-                // hold expires).
-                self.registry.mark_failed(job_id, &reason);
+                // Content policy discovered mid-job: mark Failed, no charge,
+                // and release the hold.
+                let released = self.registry.mark_failed(job_id, &reason);
+                self.release_failed_job_hold(released).await;
                 Ok(VideoStatusOutput::Failed { reason })
             }
             RetrieveOutcome::MediaExpired => {
-                self.registry.mark_failed(job_id, "media_expired");
+                let released = self.registry.mark_failed(job_id, "media_expired");
+                self.release_failed_job_hold(released).await;
                 Err(ServiceError::JobNotFound)
             }
             RetrieveOutcome::Transient => {
@@ -461,6 +474,19 @@ impl VideoService {
                 Ok(self.registry.processing_snapshot(job_id))
             }
             RetrieveOutcome::Fatal => Err(ServiceError::UpstreamProvider),
+        }
+    }
+
+    /// Releases the hold handed back by `mark_failed`: a Failed job can never
+    /// charge, so its unused grant must not keep pinning the user's wallet.
+    async fn release_failed_job_hold(&self, released: Option<(ActionSlug, VideoCharge)>) {
+        if let Some((action, charge)) = released {
+            release_hold(ReleaseHoldParams {
+                os_accounts: self.os_accounts.as_ref(),
+                action,
+                action_token: charge.action_token,
+            })
+            .await;
         }
     }
 }
@@ -1106,26 +1132,27 @@ impl VideoJobRegistry {
         }
     }
 
-    fn mark_failed(&self, job_id: &JobId, reason: &str) {
-        {
-            let mut state = self.state();
-            let Some(job) = state.jobs.get_mut(job_id) else {
-                return;
-            };
-            // A job already Charging/Delivered must not be flipped to Failed by a
-            // stray retrieve error; only a non-terminal job fails.
-            match &job.state {
-                VideoJobState::Charging { .. }
-                | VideoJobState::Delivered
-                | VideoJobState::Failed { .. } => return,
-                VideoJobState::Queued
-                | VideoJobState::Processing { .. }
-                | VideoJobState::ChargePending => {}
-            }
-            job.state = VideoJobState::Failed {
-                reason: reason.to_string(),
-            };
+    /// Fails a non-terminal job and hands back its unused charge (if any) so
+    /// the caller can release the hold — a Failed job never enters Charging
+    /// (`next_charge_claim` treats Failed as terminal), so the token is dead
+    /// weight that would otherwise pin the user's wallet until TTL.
+    fn mark_failed(&self, job_id: &JobId, reason: &str) -> Option<(ActionSlug, VideoCharge)> {
+        let mut state = self.state();
+        let job = state.jobs.get_mut(job_id)?;
+        // A job already Charging/Delivered must not be flipped to Failed by a
+        // stray retrieve error; only a non-terminal job fails.
+        match &job.state {
+            VideoJobState::Charging { .. }
+            | VideoJobState::Delivered
+            | VideoJobState::Failed { .. } => return None,
+            VideoJobState::Queued
+            | VideoJobState::Processing { .. }
+            | VideoJobState::ChargePending => {}
         }
+        job.state = VideoJobState::Failed {
+            reason: reason.to_string(),
+        };
+        job.charge.take().map(|charge| (job.action, charge))
     }
 
     fn processing_snapshot(&self, job_id: &JobId) -> VideoStatusOutput {

--- a/june-api/crates/services/src/video/tests.rs
+++ b/june-api/crates/services/src/video/tests.rs
@@ -379,6 +379,18 @@ fn authorize_count(events: &[Call]) -> usize {
         .count()
 }
 
+/// The zero-credit release settling a failed job's hold (grant-scoped key,
+/// derived from the mock's fixed `agt_test` token).
+fn release_call() -> (u64, String) {
+    (
+        0,
+        format!(
+            "release:video_generate:{}",
+            &crate::util::sha256_hex("agt_test".as_bytes())[..32],
+        ),
+    )
+}
+
 // --- credits_from_quote ------------------------------------------------------
 
 #[test]
@@ -599,9 +611,9 @@ async fn content_violation_on_queue_rejects_without_charging() {
         result,
         Err(ServiceError::ContentRejected { reason }) if reason == "content_violation"
     ));
-    // The hold was taken (authorize) but never charged.
+    // The hold was taken (authorize) and released at zero credits.
     assert_eq!(authorize_count(&os.events()), 1);
-    assert_eq!(charge_calls(&os.events()).len(), 0);
+    assert_eq!(charge_calls(&os.events()), vec![release_call()]);
 }
 
 #[tokio::test]
@@ -639,7 +651,7 @@ async fn content_violation_on_status_fails_without_charging() {
             reason: "content_violation".to_string(),
         }
     );
-    assert_eq!(charge_calls(&os.events()).len(), 0);
+    assert_eq!(charge_calls(&os.events()), vec![release_call()]);
 }
 
 #[tokio::test]
@@ -675,7 +687,7 @@ async fn oversized_video_on_status_fails_without_charging() {
             reason: "video_too_large".to_string(),
         }
     );
-    assert_eq!(charge_calls(&os.events()).len(), 0);
+    assert_eq!(charge_calls(&os.events()), vec![release_call()]);
 }
 
 #[tokio::test]
@@ -688,9 +700,9 @@ async fn queue_capacity_maps_to_metering_and_does_not_charge() {
         .await;
 
     assert!(matches!(result, Err(ServiceError::MeteringProvider)));
-    // Authorized (hold taken) but never charged; the hold expires.
+    // Authorized (hold taken), never billed: released at zero credits.
     assert_eq!(authorize_count(&os.events()), 1);
-    assert_eq!(charge_calls(&os.events()).len(), 0);
+    assert_eq!(charge_calls(&os.events()), vec![release_call()]);
 }
 
 #[tokio::test]
@@ -703,7 +715,7 @@ async fn queue_upstream_failure_maps_to_upstream_and_does_not_charge() {
         .await;
 
     assert!(matches!(result, Err(ServiceError::UpstreamProvider)));
-    assert_eq!(charge_calls(&os.events()).len(), 0);
+    assert_eq!(charge_calls(&os.events()), vec![release_call()]);
 }
 
 #[tokio::test]
@@ -752,7 +764,7 @@ async fn expired_media_on_status_is_not_found() {
 
     let result = service.status(usr("usr_1"), handle.job_id).await;
     assert!(matches!(result, Err(ServiceError::JobNotFound)));
-    assert_eq!(charge_calls(&os.events()).len(), 0);
+    assert_eq!(charge_calls(&os.events()), vec![release_call()]);
 }
 
 // --- charge failure re-poll --------------------------------------------------
@@ -1082,7 +1094,7 @@ async fn completed_url_without_usable_media_fails_terminally_without_charging() 
             reason: "video_media_unavailable".to_string(),
         }
     );
-    assert_eq!(charge_calls(&os.events()).len(), 0);
+    assert_eq!(charge_calls(&os.events()), vec![release_call()]);
 }
 
 // --- registry eviction / ttl -------------------------------------------------

--- a/june-api/crates/services/src/web_augment.rs
+++ b/june-api/crates/services/src/web_augment.rs
@@ -1,7 +1,7 @@
 use crate::{
     charge_flow::{
-        AuthorizeParams, ChargeParams, authorize_or_deny, charge, clamp_to_cap, log_settled,
-        zero_receipt,
+        AuthorizeParams, ChargeParams, ReleaseHoldParams, authorize_or_deny, charge, clamp_to_cap,
+        log_settled, release_hold, zero_receipt,
     },
     error::ServiceError,
     metering::{log_skipped_user_venice_key, uses_user_venice_key},
@@ -75,7 +75,7 @@ impl WebAugmentService {
             hold_ttl_seconds: self.hold_ttl_seconds,
         })
         .await?;
-        let results = self
+        let results = match self
             .searcher
             .search(WebSearchRequest {
                 query: params.query.clone(),
@@ -83,7 +83,19 @@ impl WebAugmentService {
                 provider: params.provider,
                 provider_credentials: params.provider_credentials.clone(),
             })
-            .await?;
+            .await
+        {
+            Ok(results) => results,
+            Err(error) => {
+                release_hold(ReleaseHoldParams {
+                    os_accounts: self.os_accounts.as_ref(),
+                    action: ActionSlug::WebSearch,
+                    action_token: authorization.action_token,
+                })
+                .await;
+                return Err(error.into());
+            }
+        };
         let charge_credits = clamp_to_cap(estimate, authorization.cap_credits);
         let receipt = charge(ChargeParams {
             os_accounts: self.os_accounts.as_ref(),
@@ -131,13 +143,25 @@ impl WebAugmentService {
             hold_ttl_seconds: self.hold_ttl_seconds,
         })
         .await?;
-        let result = self
+        let result = match self
             .fetcher
             .fetch(WebFetchRequest {
                 url: params.url.clone(),
                 provider_credentials: params.provider_credentials.clone(),
             })
-            .await?;
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => {
+                release_hold(ReleaseHoldParams {
+                    os_accounts: self.os_accounts.as_ref(),
+                    action: ActionSlug::WebFetch,
+                    action_token: authorization.action_token,
+                })
+                .await;
+                return Err(error.into());
+            }
+        };
         let charge_credits = clamp_to_cap(estimate, authorization.cap_credits);
         let receipt = charge(ChargeParams {
             os_accounts: self.os_accounts.as_ref(),
@@ -482,13 +506,23 @@ mod tests {
             result,
             Err(crate::ServiceError::InvalidInput { .. })
         ));
-        // Authorized (hold taken, expires via TTL) but never charged.
+        // Authorized, never billed: the hold is released at zero credits
+        // instead of stranding until TTL.
         assert_eq!(
             os_accounts.events(),
-            vec![Call::Authorize {
-                action: "web_fetch".to_string(),
-                estimate: 25,
-            }]
+            vec![
+                Call::Authorize {
+                    action: "web_fetch".to_string(),
+                    estimate: 25,
+                },
+                Call::Charge {
+                    credits: 0,
+                    idempotency_key: format!(
+                        "release:web_fetch:{}",
+                        &crate::util::sha256_hex("agt_test".as_bytes())[..32],
+                    ),
+                },
+            ]
         );
     }
 

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -2094,6 +2094,12 @@ fn user_facing_transcription_failure_message(
     {
         return "The transcription provider could not process this audio.".to_string();
     }
+    // A transient metering denial (concurrency cap, rate limit): the account
+    // is fine and a retry after a short wait usually clears it. Never show
+    // the raw reason string.
+    if normalized_message.contains("authorization_denied") {
+        return "The service is busy right now. Wait a minute, then retry.".to_string();
+    }
     message.trim().to_string()
 }
 
@@ -2951,6 +2957,17 @@ mod tests {
                 "microphone",
             ),
             "Billing is temporarily unavailable. Please try again in a moment."
+        );
+        // Regression (2026-07-14): the raw deny reason leaked into the failure
+        // banner as "authorization_denied".
+        assert_eq!(
+            user_facing_transcription_failure_message(
+                "june_request_failed",
+                "authorization_denied",
+                false,
+                "microphone",
+            ),
+            "The service is busy right now. Wait a minute, then retry."
         );
     }
 


### PR DESCRIPTION
## Why

2026-07-14 incident: a 30-minute recording lost most of its transcript, and Retry could never recover it. Root cause chain (verified against the prod OS Accounts database):

1. Every metered flow does authorize -> provider call -> charge. A provider failure propagated with `?`, stranding the 250-credit hold until TTL + sweep.
2. Stranded holds count toward the OS Accounts 10-open-grants concurrency cap, so a burst of turn failures denied every following authorize (`authorization_denied` on turns 9-20).
3. Retry re-transcribes already-charged chunks; their work-scoped idempotency keys collide under a fresh grant, which strands another hold per chunk — every retry pass re-saturated the cap deterministically (9 strands at 15:47Z, 9 more at 16:06Z).

Companion PR open-software-network/os-accounts#98 (ADR-0032) adds the two server-side primitives: `/charge` with `credits = 0` as a release, and cross-grant idempotency replays that release the redundant grant.

## What changed

- `charge_flow::release_hold`: best-effort zero-credit settle of a hold whose work failed, under a grant-scoped key (`release:<action>:<token digest>`), so it can never collide with a later successful retry. Errors are logged, never propagated — until the os-accounts PR deploys, a failed release degrades to today's TTL-expiry behavior, so deploy order does not matter.
- Applied on the provider-failure path of every metered flow: note transcribe (charged and preview), note generate, agent chat (buffered and streaming, including the mid-stream failure that previously "left the hold unsettled" by design), dictate transcribe + cleanup, web search + fetch, image generate + edit, and video (queue failure plus every `mark_failed` transition — `mark_failed` now hands back the unused charge for release since Failed is charge-terminal).
- Preview transcription no longer bills the full audio price for a FAILED preview (it used to charge just to close the hold); it releases instead.
- Client copy: `authorization_denied` now renders as "The service is busy right now. Wait a minute, then retry." instead of leaking the raw reason into the failure banner.

## Validation

- `cargo +1.95.0 test --manifest-path june-api/Cargo.toml --all-targets --all-features --locked`: all green (141 june-services tests; new coverage: `note_transcribe_failure_releases_hold`, `note_transcribe_preview_failure_releases_hold_without_billing`; updated the nine "never charges on failure" tests across image/video/web/agent-chat to expect the zero-credit release).
- `cargo +1.95.0 fmt --check` and `clippy --all-targets --all-features` clean.
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`: 686 passed (includes the new `authorization_denied` copy regression test).
- No live app walkthrough: the change is billing settlement semantics with no reachable UI state without forcing a prod provider failure; the one user-visible string is covered by a unit test.

## Notes

- Works standalone: releases fail gracefully (WARN log, hold expires via TTL) until os-accounts#98 deploys; after it deploys, failed work frees its hold immediately and retries stop stranding grants.
- Client-to-june-api API surface unchanged (no contract fixture changes needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786641611&installation_id=144203540&pr_number=751&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F751&signature=935b827c4f80e29c8c8b147005d8291bccd40458ee3cd9963edbff475eb28729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->