### PR TITLE
Prevent duplicate generated media blocks

### DIFF
--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -691,9 +691,7 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
   }, []);
 
   const turns = useMemo(() => {
-    const built = buildHermesSessionChatTurns(messages, liveEvents);
-    if (!pendingUserTurns.length) return built;
-    return [...built, ...pendingUserTurns].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    return buildHermesSessionChatTurns(messages, liveEvents, pendingUserTurns);
   }, [messages, liveEvents, pendingUserTurns]);
 
   return {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -364,13 +364,13 @@ export function buildHermesSessionChatTurns(
     }
   }
 
-  appendLiveHermesEvents(turns, liveEvents);
   turns.push(
     ...syntheticTurns.map((turn) => ({
       ...turn,
       parts: [...turn.parts],
     })),
   );
+  appendLiveHermesEvents(turns, liveEvents);
   const sortedTurns = sortAgentChatTurns(turns);
   deduplicateGeneratedMediaWithinAgentRuns(sortedTurns);
   return sortedTurns.filter((turn) =>
@@ -948,13 +948,16 @@ function sameImagePart(left: AgentChatImagePart, right: AgentChatImagePart) {
   if (left.path && right.path && left.path === right.path) return true;
   const leftName = left.name ?? (left.path ? filenameFromPath(left.path) : undefined);
   const rightName = right.name ?? (right.path ? filenameFromPath(right.path) : undefined);
+  const hasBarePath =
+    (left.path && left.path === leftName) || (right.path && right.path === rightName);
   return Boolean(
     leftName &&
       rightName &&
       leftName === rightName &&
       // Equal display names bridge an inline MCP image to its trailing MEDIA
-      // reference, but never collapse two distinct inline byte payloads.
-      (!left.dataUrl || !right.dataUrl),
+      // reference, but never collapse distinct inline payloads or absolute paths.
+      ((!left.dataUrl && !right.dataUrl && hasBarePath) ||
+        Boolean(left.dataUrl) !== Boolean(right.dataUrl)),
   );
 }
 

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -262,6 +262,7 @@ export function buildAgentChatTurns(
 export function buildHermesSessionChatTurns(
   messages: HermesSessionMessage[],
   liveEvents: JuneHermesEvent[] = [],
+  syntheticTurns: AgentChatTurn[] = [],
 ): AgentChatTurn[] {
   const turns: AgentChatTurn[] = [];
   const toolResults = new Map<string, HermesSessionMessage>();
@@ -364,6 +365,12 @@ export function buildHermesSessionChatTurns(
   }
 
   appendLiveHermesEvents(turns, liveEvents);
+  turns.push(
+    ...syntheticTurns.map((turn) => ({
+      ...turn,
+      parts: [...turn.parts],
+    })),
+  );
   const sortedTurns = sortAgentChatTurns(turns);
   deduplicateGeneratedMediaWithinAgentRuns(sortedTurns);
   return sortedTurns.filter((turn) =>
@@ -937,15 +944,26 @@ function appendVideoParts(parts: AgentChatPart[], videos: AgentChatVideoPart[]) 
 }
 
 function sameImagePart(left: AgentChatImagePart, right: AgentChatImagePart) {
+  if (left.dataUrl && right.dataUrl) return left.dataUrl === right.dataUrl;
+  if (left.path && right.path && left.path === right.path) return true;
+  const leftName = left.name ?? (left.path ? filenameFromPath(left.path) : undefined);
+  const rightName = right.name ?? (right.path ? filenameFromPath(right.path) : undefined);
   return Boolean(
-    (left.path && left.path === right.path) ||
-      (left.dataUrl && left.dataUrl === right.dataUrl) ||
-      (left.name && left.name === right.name),
+    leftName &&
+      rightName &&
+      leftName === rightName &&
+      // Equal display names bridge an inline MCP image to its trailing MEDIA
+      // reference, but never collapse two distinct inline byte payloads.
+      (!left.dataUrl || !right.dataUrl),
   );
 }
 
 function sameVideoPart(left: AgentChatVideoPart, right: AgentChatVideoPart) {
-  return Boolean(left.path && left.path === right.path);
+  return Boolean(
+    left.path &&
+      right.path &&
+      (left.path === right.path || filenameFromPath(left.path) === filenameFromPath(right.path)),
+  );
 }
 
 /** Live tool output and the assistant's trailing MEDIA reference share one

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -364,13 +364,7 @@ export function buildHermesSessionChatTurns(
     }
   }
 
-  turns.push(
-    ...syntheticTurns.map((turn) => ({
-      ...turn,
-      parts: [...turn.parts],
-    })),
-  );
-  appendLiveHermesEvents(turns, liveEvents);
+  appendLiveHermesEvents(turns, liveEvents, syntheticTurns);
   const sortedTurns = sortAgentChatTurns(turns);
   deduplicateGeneratedMediaWithinAgentRuns(sortedTurns);
   return sortedTurns.filter((turn) =>
@@ -515,11 +509,28 @@ function assistantTurnForTimestamp(turns: AgentChatTurn[], createdAt: string | u
   return undefined;
 }
 
-function appendLiveHermesEvents(turns: AgentChatTurn[], events: JuneHermesEvent[]) {
+function appendLiveHermesEvents(
+  turns: AgentChatTurn[],
+  events: JuneHermesEvent[],
+  syntheticTurns: AgentChatTurn[] = [],
+) {
   let currentAssistant: AgentChatTurn | null = null;
   const toolCreatedTurns = new Set<AgentChatTurn>();
+  const pendingSyntheticTurns = sortAgentChatTurns(
+    syntheticTurns.map((turn) => ({
+      ...turn,
+      parts: [...turn.parts],
+    })),
+  );
 
   for (const event of events) {
+    while (pendingSyntheticTurns[0] && pendingSyntheticTurns[0].createdAt <= event.receivedAt) {
+      const syntheticTurn = pendingSyntheticTurns.shift();
+      if (!syntheticTurn) break;
+      turns.push(syntheticTurn);
+      if (syntheticTurn.role !== "assistant") currentAssistant = null;
+    }
+
     switch (event.kind) {
       case "steering": {
         // A user instruction steered into the running turn (feature 06). It is
@@ -820,6 +831,8 @@ function appendLiveHermesEvents(turns: AgentChatTurn[], events: JuneHermesEvent[
         break;
     }
   }
+
+  turns.push(...pendingSyntheticTurns);
 }
 
 function createAssistantTurn(turns: AgentChatTurn[], createdAt: string) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -959,11 +959,11 @@ function sameImagePart(left: AgentChatImagePart, right: AgentChatImagePart) {
 }
 
 function sameVideoPart(left: AgentChatVideoPart, right: AgentChatVideoPart) {
-  return Boolean(
-    left.path &&
-      right.path &&
-      (left.path === right.path || filenameFromPath(left.path) === filenameFromPath(right.path)),
-  );
+  if (!left.path || !right.path) return false;
+  if (left.path === right.path) return true;
+  const leftName = filenameFromPath(left.path);
+  const rightName = filenameFromPath(right.path);
+  return leftName === rightName && (left.path === leftName || right.path === rightName);
 }
 
 /** Live tool output and the assistant's trailing MEDIA reference share one

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -282,12 +282,8 @@ export function buildHermesSessionChatTurns(
       // Media tool results render inline so they show in-thread instead of
       // being lost to the collapsed tool row. Image base64 and MEDIA refs are
       // stripped from the tool text above.
-      for (const imagePart of imagePartsFromHermesContent(message.content)) {
-        turn.parts.push(imagePart);
-      }
-      for (const videoPart of videoPartsFromHermesContent(message.content)) {
-        turn.parts.push(videoPart);
-      }
+      appendImageParts(turn.parts, imagePartsFromHermesContent(message.content));
+      appendVideoParts(turn.parts, videoPartsFromHermesContent(message.content));
       turn.status = "complete";
       continue;
     }
@@ -368,10 +364,10 @@ export function buildHermesSessionChatTurns(
   }
 
   appendLiveHermesEvents(turns, liveEvents);
-  return sortAgentChatTurns(
-    turns.filter((turn) =>
-      turn.parts.some((part) => part.type === "tool" || partText(part).trim()),
-    ),
+  const sortedTurns = sortAgentChatTurns(turns);
+  deduplicateGeneratedMediaWithinAgentRuns(sortedTurns);
+  return sortedTurns.filter((turn) =>
+    turn.parts.some((part) => part.type === "tool" || partText(part).trim()),
   );
 }
 
@@ -928,23 +924,54 @@ function removeAssistantTextParts(parts: AgentChatPart[]) {
 
 function appendImageParts(parts: AgentChatPart[], images: AgentChatImagePart[]) {
   for (const image of images) {
-    const exists = parts.some(
-      (part) =>
-        part.type === "image" &&
-        ((image.path && part.path === image.path) ||
-          (image.dataUrl && part.dataUrl === image.dataUrl) ||
-          (image.name && part.name === image.name)),
-    );
+    const exists = parts.some((part) => part.type === "image" && sameImagePart(part, image));
     if (!exists) parts.push(image);
   }
 }
 
 function appendVideoParts(parts: AgentChatPart[], videos: AgentChatVideoPart[]) {
   for (const video of videos) {
-    const exists = parts.some(
-      (part) => part.type === "video" && video.path && part.path === video.path,
-    );
+    const exists = parts.some((part) => part.type === "video" && sameVideoPart(part, video));
     if (!exists) parts.push(video);
+  }
+}
+
+function sameImagePart(left: AgentChatImagePart, right: AgentChatImagePart) {
+  return Boolean(
+    (left.path && left.path === right.path) ||
+      (left.dataUrl && left.dataUrl === right.dataUrl) ||
+      (left.name && left.name === right.name),
+  );
+}
+
+function sameVideoPart(left: AgentChatVideoPart, right: AgentChatVideoPart) {
+  return Boolean(left.path && left.path === right.path);
+}
+
+/** Live tool output and the assistant's trailing MEDIA reference share one
+ * turn, but Hermes persists them as consecutive assistant messages. Keep one
+ * inline block per generated file until the next user/system turn so reloading
+ * history matches the live transcript. */
+function deduplicateGeneratedMediaWithinAgentRuns(turns: AgentChatTurn[]) {
+  let images: AgentChatImagePart[] = [];
+  let videos: AgentChatVideoPart[] = [];
+
+  for (const turn of turns) {
+    if (turn.role !== "assistant") {
+      images = [];
+      videos = [];
+      continue;
+    }
+    turn.parts = turn.parts.filter((part) => {
+      if (part.type === "image") {
+        if (images.some((image) => sameImagePart(image, part))) return false;
+        images.push(part);
+      } else if (part.type === "video") {
+        if (videos.some((video) => sameVideoPart(video, part))) return false;
+        videos.push(part);
+      }
+      return true;
+    });
   }
 }
 

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -1707,6 +1707,90 @@ describe("Agent chat runtime", () => {
     ).toHaveLength(2);
   });
 
+  it("treats an optimistic user turn as a generated-media boundary", () => {
+    const media = "MEDIA:generated-image-abc.png";
+    const turns = buildHermesSessionChatTurns(
+      [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: media,
+          timestamp: "2026-06-04T10:00:00.000Z",
+        },
+      ],
+      [
+        transcriptEvent({
+          delta: media,
+          complete: true,
+          receivedAt: "2026-06-04T10:01:01.000Z",
+        }),
+      ],
+      [
+        {
+          id: "pending-user-1",
+          role: "user",
+          createdAt: "2026-06-04T10:01:00.000Z",
+          status: "complete",
+          parts: [{ type: "text", text: "Show me that image again.", status: "complete" }],
+        },
+      ],
+    );
+
+    expect(
+      turns.flatMap((turn) => turn.parts.filter((part) => part.type === "image")),
+    ).toHaveLength(2);
+  });
+
+  it("keeps distinct inline images that share a display name", () => {
+    const imageContent = (data: string) => [
+      { type: "image", data, mimeType: "image/png" },
+      {
+        type: "text",
+        text: JSON.stringify({ filename: "generated-image.png", label: "Generated image" }),
+      },
+    ];
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: imageContent("Zmlyc3Q="),
+        timestamp: "2026-06-04T10:00:00.000Z",
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        content: imageContent("c2Vjb25k"),
+        timestamp: "2026-06-04T10:00:01.000Z",
+      },
+    ]);
+
+    expect(
+      turns.flatMap((turn) => turn.parts.filter((part) => part.type === "image")),
+    ).toHaveLength(2);
+  });
+
+  it("deduplicates bare and absolute references to the same generated video", () => {
+    const name = "generated-video-ab12.mp4";
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: `MEDIA:${name}`,
+        timestamp: "2026-06-04T10:00:00.000Z",
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        content: `MEDIA:/tmp/generated-videos/${name}`,
+        timestamp: "2026-06-04T10:00:01.000Z",
+      },
+    ]);
+
+    expect(
+      turns.flatMap((turn) => turn.parts.filter((part) => part.type === "video")),
+    ).toHaveLength(1);
+  });
+
   it("renders live june_image tool results inline from tool.complete content", () => {
     const turns = buildHermesSessionChatTurns(
       [],

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -1791,6 +1791,27 @@ describe("Agent chat runtime", () => {
     ).toHaveLength(1);
   });
 
+  it("keeps distinct absolute video paths that share a filename", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "MEDIA:/tmp/run-a/output.mp4",
+        timestamp: "2026-06-04T10:00:00.000Z",
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        content: "MEDIA:/tmp/run-b/output.mp4",
+        timestamp: "2026-06-04T10:00:01.000Z",
+      },
+    ]);
+
+    expect(
+      turns.flatMap((turn) => turn.parts.filter((part) => part.type === "video")),
+    ).toHaveLength(2);
+  });
+
   it("renders live june_image tool results inline from tool.complete content", () => {
     const turns = buildHermesSessionChatTurns(
       [],

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -1618,9 +1618,10 @@ describe("Agent chat runtime", () => {
 
   it("renders an MCP image tool result as an inline image part (JUN-171 Phase B)", () => {
     // The june_image MCP returns an image content block plus a JSON text block
-    // carrying the filename/label. The image must render in-thread (so it also
-    // enters the model's context) and its base64 must NOT leak into the
-    // collapsed tool row's text.
+    // carrying the filename/label. Hermes may then persist the assistant's
+    // MEDIA reference as a separate message. Both representations belong to
+    // one agent run and must render as one image block, while the base64 stays
+    // out of the collapsed tool row's text.
     const turns = buildHermesSessionChatTurns([
       {
         id: "assistant-1",
@@ -1655,9 +1656,17 @@ describe("Agent chat runtime", () => {
         ],
         timestamp: "2026-06-04T10:00:01.000Z",
       },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        content: "Done.\n\nMEDIA:generated-image-abc.png",
+        timestamp: "2026-06-04T10:00:02.000Z",
+      },
     ]);
 
-    const image = turns[0]?.parts.find((part) => part.type === "image");
+    const images = turns.flatMap((turn) => turn.parts.filter((part) => part.type === "image"));
+    expect(images).toHaveLength(1);
+    const image = images[0];
     expect(image).toMatchObject({
       type: "image",
       status: "complete",
@@ -1668,6 +1677,34 @@ describe("Agent chat runtime", () => {
     const tool = turns[0]?.parts.find((part) => part.type === "tool");
     expect(tool).toMatchObject({ media: "image" });
     expect(tool?.type === "tool" ? tool.text : "").not.toContain("aGVsbG8=");
+  });
+
+  it("allows a generated image to be shown again after a new user turn", () => {
+    const media = "MEDIA:generated-image-abc.png";
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: media,
+        timestamp: "2026-06-04T10:00:00.000Z",
+      },
+      {
+        id: "user-1",
+        role: "user",
+        content: "Show me that image again.",
+        timestamp: "2026-06-04T10:01:00.000Z",
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        content: media,
+        timestamp: "2026-06-04T10:01:01.000Z",
+      },
+    ]);
+
+    expect(
+      turns.flatMap((turn) => turn.parts.filter((part) => part.type === "image")),
+    ).toHaveLength(2);
   });
 
   it("renders live june_image tool results inline from tool.complete content", () => {

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -1729,7 +1729,7 @@ describe("Agent chat runtime", () => {
         {
           id: "pending-user-1",
           role: "user",
-          createdAt: "2026-06-04T10:01:00.000Z",
+          createdAt: "2026-06-04T10:01:01.000Z",
           status: "complete",
           parts: [{ type: "text", text: "Show me that image again.", status: "complete" }],
         },
@@ -1760,6 +1760,27 @@ describe("Agent chat runtime", () => {
         id: "assistant-2",
         role: "assistant",
         content: imageContent("c2Vjb25k"),
+        timestamp: "2026-06-04T10:00:01.000Z",
+      },
+    ]);
+
+    expect(
+      turns.flatMap((turn) => turn.parts.filter((part) => part.type === "image")),
+    ).toHaveLength(2);
+  });
+
+  it("keeps distinct absolute image paths that share a filename", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "MEDIA:/tmp/run-a/output.png",
+        timestamp: "2026-06-04T10:00:00.000Z",
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        content: "MEDIA:/tmp/run-b/output.png",
         timestamp: "2026-06-04T10:00:01.000Z",
       },
     ]);

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -1741,6 +1741,41 @@ describe("Agent chat runtime", () => {
     ).toHaveLength(2);
   });
 
+  it("keeps an older buffered reply before a newer optimistic user turn", () => {
+    const media = "MEDIA:generated-image-abc.png";
+    const pendingTurn = (id: string, text: string, createdAt: string) => ({
+      id,
+      role: "user" as const,
+      createdAt,
+      status: "complete" as const,
+      parts: [{ type: "text" as const, text, status: "complete" as const }],
+    });
+    const turns = buildHermesSessionChatTurns(
+      [],
+      [
+        transcriptEvent({
+          delta: media,
+          complete: true,
+          receivedAt: "2026-06-04T10:00:01.000Z",
+        }),
+        transcriptEvent({
+          delta: media,
+          complete: true,
+          receivedAt: "2026-06-04T10:00:03.000Z",
+        }),
+      ],
+      [
+        pendingTurn("pending-user-1", "Create the image.", "2026-06-04T10:00:00.000Z"),
+        pendingTurn("pending-user-2", "Show it again.", "2026-06-04T10:00:02.000Z"),
+      ],
+    );
+
+    expect(turns.map((turn) => turn.role)).toEqual(["user", "assistant", "user", "assistant"]);
+    expect(
+      turns.flatMap((turn) => turn.parts.filter((part) => part.type === "image")),
+    ).toHaveLength(2);
+  });
+
   it("keeps distinct inline images that share a display name", () => {
     const imageContent = (data: string) => [
       { type: "image", data, mimeType: "image/png" },


### PR DESCRIPTION
## Summary

- Deduplicate inline image and video tool output from trailing media references during session-history reconstruction.
- Keep intentional redisplay working after a new user or system turn.
- Route persisted media results through the same append helpers used by live events.

## Root cause

Live image-tool output and the assistant's trailing `MEDIA:<filename>` reference share one assistant turn and are deduplicated. Hermes persists those representations as consecutive assistant messages, and the history reconstruction path only deduplicated within each message. After history refreshed, June rendered both representations as separate media blocks.

## Validation

- `pnpm test` - 2,620 passed, 2 skipped.
- `pnpm typecheck` - passed.
- `pnpm check` - passed with the existing warning baseline.
- `pnpm exec biome check src/lib/agent-chat-runtime.ts src/test/agent-chat-runtime.test.ts` - passed.
- `git diff --check` - passed.

- [ ] Tested visually where it matters. Not manually tested; the persisted and live event shapes are covered by regression tests.
- [ ] Needs a June API deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Image or video generation APIs and billing.
- Generated-media styling or animations.
- Changes to Hermes persistence formats.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] No security-sensitive behavior changed.
- [x] Workflow action references are unchanged.
- [x] Desktop signing, updater, entitlement, capability, and release behavior are unchanged.
- [x] Backend auth, billing, metering, CORS, rate limit, and logging behavior are unchanged.
- [x] No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786641851&installation_id=144203540&pr_number=752&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F752&signature=43f72a63e1f95624cd5dcfb813e2a9a6d9988842b263bbdf4fedc912d475b83f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->