### PR TITLE
Keep chat visible above queued steers

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2820,9 +2820,11 @@ export function AgentWorkspace({
   const titleSuggestionInFlightSessionIdsRef = useRef<Set<string>>(new Set());
   const listRef = useRef<HTMLDivElement | null>(null);
   const agentScrollRef = useRef<HTMLDivElement | null>(null);
+  const composerRef = useRef<HTMLFormElement | null>(null);
   const composerEditorRef = useRef<ComposerEditorHandle | null>(null);
   const composerTiptapEditorRef = useRef<TiptapEditor | null>(null);
   const composerBoxRef = useRef<HTMLDivElement | null>(null);
+  const [composerClearance, setComposerClearance] = useState(0);
   // A note reference to seed once the editor is ready, set by startNewTask for
   // note-level "Ask June" entry points.
   const pendingSeedNoteRefRef = useRef<{
@@ -3608,6 +3610,36 @@ export function AgentWorkspace({
     if (!el || el.scrollHeight <= el.clientHeight + 1) return;
     return attachScrollThumbFade(el);
   }, [hasFollowUps, steerQueueOpen, selectedFollowUpCount]);
+
+  // The composer is fixed over the conversation, so it contributes no layout
+  // height of its own. Reserve its live overlap in the scroller instead. A
+  // ResizeObserver catches queue rows draining, collapse/expand, wrapped copy,
+  // draft growth, and viewport changes without coupling the chat to any one
+  // queue-row height.
+  useLayoutEffect(() => {
+    const scroller = agentScrollRef.current;
+    const composer = composerRef.current;
+    if (heroMode || activePanel !== "chat" || !scroller || !composer) {
+      setComposerClearance(0);
+      return;
+    }
+    const measure = () => {
+      const next = agentComposerClearance(
+        scroller.getBoundingClientRect().bottom,
+        composer.getBoundingClientRect().top,
+      );
+      setComposerClearance((current) => (current === next ? current : next));
+    };
+    measure();
+    const observer = typeof ResizeObserver === "function" ? new ResizeObserver(measure) : undefined;
+    observer?.observe(scroller);
+    observer?.observe(composer);
+    window.addEventListener("resize", measure);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [activePanel, heroMode, selectedFollowUpCount, steerQueueOpen]);
 
   // Updates the task list without touching the selection — a late poll
   // response must not re-select a task the user already navigated away from.
@@ -9873,7 +9905,13 @@ export function AgentWorkspace({
       behavior: settled ? "smooth" : "auto",
     });
     transcriptShouldStickToBottomRef.current = true;
-  }, [renderedTurnsSignature, selectedHermesSessionId, selectedHistoryLoaded, selectedTaskId]);
+  }, [
+    composerClearance,
+    renderedTurnsSignature,
+    selectedHermesSessionId,
+    selectedHistoryLoaded,
+    selectedTaskId,
+  ]);
 
   // Jump back to the live edge from the floating pill. Glide the same way the
   // auto-scroll effect does — arm the programmatic-scroll ref + timeout so the
@@ -10032,6 +10070,7 @@ export function AgentWorkspace({
   const composer =
     activePanel === "chat" ? (
       <form
+        ref={composerRef}
         className="agent-composer"
         data-hero={heroMode ? "true" : undefined}
         data-drop-active={dropActive ? "true" : undefined}
@@ -11046,7 +11085,15 @@ export function AgentWorkspace({
         </section>
       ) : (
         <>
-          <div ref={agentScrollRef} className="agent-scroll">
+          <div
+            ref={agentScrollRef}
+            className="agent-scroll"
+            style={
+              {
+                "--agent-composer-clearance": `${composerClearance}px`,
+              } as CSSProperties
+            }
+          >
             <section className="agent-main" aria-label="Agent task details">
               {galleryErrors ? (
                 <AgentErrorBanner
@@ -12354,6 +12401,10 @@ function chatTurnsSignature(turns: AgentChatTurn[]) {
 const TURN_ACTION_TIP_DELAY_MS = 550;
 
 const AGENT_TRANSCRIPT_BOTTOM_THRESHOLD_PX = 48;
+
+export function agentComposerClearance(scrollerBottom: number, composerTop: number) {
+  return Math.max(0, Math.ceil(scrollerBottom - composerTop));
+}
 
 function isAgentTranscriptNearBottom(scroller: HTMLElement) {
   return (

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -534,7 +534,10 @@ input:focus-visible,
   overflow-y: auto;
   overscroll-behavior: contain;
   margin: calc(-1 * var(--detail-bar-h)) calc(-1 * var(--sp-8)) 0;
-  padding: var(--detail-bar-h) var(--sp-8) var(--sp-5);
+  /* The fixed composer is outside layout. Its measured overlap grows with the
+   * Up next queue and shrinks as rows drain; the final gap keeps the last chat
+   * item visibly separated from the top of that floating surface. */
+  padding: var(--detail-bar-h) var(--sp-8) calc(var(--agent-composer-clearance, 0px) + var(--sp-5));
   /* Center the thread column from the LEFT GUTTER, not margin:auto inside the
    * scroller: the classic scrollbar steals an engine-specific slice of the
    * content box (8px custom in Chrome, wider native in WKWebView), and auto
@@ -741,9 +744,11 @@ input:focus-visible,
   /* Align the thread rail with the composer's text line, not its outer
    * border: 1px box border + sp-1 box padding + sp-5 textarea padding.
    * User turns stay right-aligned inside this rail. */
-  /* Bottom padding clears the fixed composer so the last turn can scroll fully
-   * clear of it instead of hiding underneath. */
-  padding: var(--sp-2) calc(1px + var(--sp-1) + var(--sp-5)) 148px;
+  /* The outer scroller owns the live clearance for the fixed composer. Keep
+   * only the final turn's out-of-flow action row in this rail's tail so its
+   * copy/branch/timestamp controls also remain above that surface. */
+  padding: var(--sp-2) calc(1px + var(--sp-1) + var(--sp-5))
+    calc(var(--agent-turn-actions-h) + var(--sp-2));
 }
 
 /* Dev-tools response gallery (window.__agentGallery): a labeled catalog of every

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5913,6 +5913,9 @@ input:focus-visible,
   gap: var(--sp-2);
   min-height: var(--control-md);
   padding: var(--sp-1) var(--sp-2);
+  /* Match the composer text line: queue frame (sp-2) + this sp-4 inset equals
+   * composer frame (sp-1) + editor inset (sp-5). */
+  padding-inline-start: var(--sp-4);
   border: 0;
   border-radius: var(--r-md);
   background: transparent;

--- a/src/test/agent-scroll-to-latest-css.test.ts
+++ b/src/test/agent-scroll-to-latest-css.test.ts
@@ -26,6 +26,10 @@ describe("agent scroll-to-latest styles", () => {
     );
   });
 
+  it("aligns the Up next label with the composer text line", () => {
+    expect(cssRuleFor(".agent-steer-queue-trigger")).toContain("padding-inline-start: var(--sp-4)");
+  });
+
   it("floats the pill absolutely (never fixed) above the composer", () => {
     const rule = cssRuleFor(".agent-scroll-to-latest");
     // WKWebView clips composited fixed elements to the overflow-hidden card.

--- a/src/test/agent-scroll-to-latest-css.test.ts
+++ b/src/test/agent-scroll-to-latest-css.test.ts
@@ -18,6 +18,14 @@ function cssRuleFor(selector: string) {
 }
 
 describe("agent scroll-to-latest styles", () => {
+  it("reserves the measured fixed-composer overlap below the conversation", () => {
+    expect(appCss).toContain("calc(var(--agent-composer-clearance, 0px) + var(--sp-5))");
+    expect(cssRuleFor(".agent-timeline")).not.toContain("148px");
+    expect(cssRuleFor(".agent-timeline")).toContain(
+      "calc(var(--agent-turn-actions-h) + var(--sp-2))",
+    );
+  });
+
   it("floats the pill absolutely (never fixed) above the composer", () => {
     const rule = cssRuleFor(".agent-scroll-to-latest");
     // WKWebView clips composited fixed elements to the overflow-hidden card.

--- a/src/test/agent-scroll-to-latest.test.tsx
+++ b/src/test/agent-scroll-to-latest.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { createRef } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { AgentScrollToLatestButton } from "../components/agent/AgentWorkspace";
+import {
+  AgentScrollToLatestButton,
+  agentComposerClearance,
+} from "../components/agent/AgentWorkspace";
 
 // jsdom reports zero scroll metrics, so a scroller looks pinned to the bottom
 // by default. Force the geometry to model a user parked up-thread.
@@ -73,5 +76,16 @@ describe("AgentScrollToLatestButton", () => {
     stubScrollGeometry(scroller, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
     fireEvent.scroll(scroller);
     expect(button.getAttribute("data-visible")).toBeNull();
+  });
+});
+
+describe("agentComposerClearance", () => {
+  it("tracks the fixed composer's overlap as the Up next queue grows and drains", () => {
+    expect(agentComposerClearance(900, 520)).toBe(380);
+    expect(agentComposerClearance(900, 690)).toBe(210);
+  });
+
+  it("never reserves negative clearance when the composer does not overlap", () => {
+    expect(agentComposerClearance(900, 920)).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- Measure the fixed composer surface and reserve its live overlap below the conversation.
- Grow the clearance as queued text, image, or file messages are added, then shrink it as they send, are removed, collapse, or disappear.
- Preserve the final completed turn and its copy/branch/timestamp actions above the floating surface.
- Align the Up next label with the composer text line using the shared spacing scale.

Closes JUN-328

## Root cause

The composer and Up next queue are fixed over the conversation, so their height does not participate in the scroll layout. The transcript relied on a fixed 148px spacer, which could not grow with the queue and could leave either covered content or excessive empty space.

## Validation

- `make local-ci` (typecheck and all 160 frontend test files: 2,623 passed, 2 skipped)
- Focused scroll-clearance/alignment tests: 9 passed
- Independent standards, spec, and adversarial reviews: passed
- Live browser walkthrough at 1180 x 780 across 4, 3, and 2 queued rows, collapsed, and absent states. Clearance changed 291 -> 255 -> 219 -> 147 -> 99px as rows drained; the final completed turn retained about 44px and its action row about 18px above the composer.
- Focused reference comparison measured the Up next label and composer text at the same x-coordinate (0px delta) with no browser errors.

- [x] Tested visually where it matters (UI changes: local screenshots and recording captured in the QA evidence directory).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Changes to Up next queue content, ordering, delivery, or appearance.
- Backend or protocol changes.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. No security-sensitive behavior changed.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow files changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No related files changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend files changed.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.
