### PR TITLE
Prompt with an actionable notice when mic permission blocks recording

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1996,14 +1996,11 @@ export function App() {
     if (!accessibilityBlocked) setAccessibilityBannerDismissed(false);
   }, [accessibilityBlocked]);
 
-  // The Rust readiness check probes mic via cpal, which doesn't reflect
-  // TCC denial. Trust the dictation helper's AVCaptureDevice status
-  // instead — that's the authoritative macOS API for the mic privacy
-  // entry.
   // recordNoticesMicOverride is the dev __recordNoticesDemo hook parking the
   // mic-blocked notice; it is always null in production (the state never leaves
   // its initial value), so real behavior is untouched.
-  const microphoneBlocked = recordNoticesMicOverride ?? isDeniedPermission(microphoneStatus);
+  const microphoneBlocked =
+    recordNoticesMicOverride ?? isMicrophoneRecordingBlocked(microphoneStatus, sourceReadiness);
 
   const refreshPermissionStatuses = useCallback(() => {
     void dictationHelperCommand({ type: "get_permission_status" }).catch(() => undefined);
@@ -2825,6 +2822,17 @@ export function App() {
         setRecordingNote(undefined);
         recordingStatusRef.current = undefined;
         dispatch({ type: "recordingStatusCleared" });
+        // A TCC denial resolved inside start_recording (the first-run prompt
+        // declined, or the grant revoked after the readiness probe): re-probe
+        // so the persistent mic-blocked notice appears with its Enable action,
+        // not just this transient error (JUN-319).
+        if (errorCode(err) === "microphone_permission_missing") {
+          void checkRecordingSourceReadiness(requestedSourceMode)
+            .then((readiness) =>
+              setSourceReadiness((previous) => mergeSourceReadiness(previous, readiness)),
+            )
+            .catch(() => undefined);
+        }
         setError(messageFromError(err));
         return false;
       } finally {
@@ -4408,6 +4416,24 @@ function handleTitlebarPointerDown(event: ReactPointerEvent<HTMLDivElement>) {
 
 function isDeniedPermission(state?: string) {
   return state === "denied" || state === "restricted";
+}
+
+// TCC grants are bundle-scoped, so the two microphone signals cover different
+// bundles: the dictation helper reports its own grant, while the Rust
+// readiness probe (AVCaptureDevice in recording_source_readiness) reads the
+// main app's — the one recording actually uses. Either reporting a denial
+// means Record would start a take with no audio, so either flips the
+// actionable mic-blocked notice before a doomed recording can start (JUN-319).
+// `not_determined` stays startable: the start path fires the main app's own
+// TCC prompt.
+export function isMicrophoneRecordingBlocked(
+  helperStatus: string | undefined,
+  readiness: RecordingSourceReadinessDto | undefined,
+) {
+  const readinessState = readiness?.sources.find(
+    (source) => source.source === "microphone",
+  )?.permissionState;
+  return isDeniedPermission(helperStatus) || isDeniedPermission(readinessState);
 }
 
 // Accessibility is a plain bool from the helper (AXIsProcessTrusted),

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -218,8 +218,9 @@ export function NoteEditor({
   // offered; only the recovery copy differs.
   const systemLocked = systemAvailability === "denied" || systemAvailability === "unavailable";
   const showRecordingOptions = isMacLikePlatform();
-  // Mic denial is sourced from App via the dictation helper, not from
-  // sourceReadiness — the Rust cpal-based check can't see TCC denials.
+  // Mic denial is sourced from App, which combines the dictation helper's
+  // grant with the Rust readiness probe of the main app's own TCC grant —
+  // recording uses the latter, so either denial blocks the record button.
   const micDenied = microphoneBlocked;
 
   // Auto-close the options panel whenever a recording starts so the

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11934,6 +11934,15 @@ input:focus-visible,
   font-size: var(--fs-md);
 }
 
+/* The app-shell banners render as the first children of .main-panel-body,
+ * which has no top padding (each workspace row brings its own). Without a
+ * top margin the banner sits flush against the card's top edge. Scoped to
+ * direct children so mid-content usages (routines) keep their geometry. */
+.main-panel-body > .error-banner,
+.main-panel-body > .notice-banner {
+  margin-top: var(--sp-4);
+}
+
 .routines-error-banner {
   display: flex;
   align-items: center;

--- a/src/test/app-permissions.test.ts
+++ b/src/test/app-permissions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { isAccessibilityBlocked } from "../app/App";
+import { isAccessibilityBlocked, isMicrophoneRecordingBlocked } from "../app/App";
+import type { RecordingSourceReadinessDto, SourceReadinessDto } from "../lib/tauri";
 
 // Regression: the dictation helper reports Accessibility as "granted" |
 // "missing" (AXIsProcessTrusted), not the microphone's denied/restricted
@@ -38,5 +39,57 @@ describe("accessibility banner across proactive status changes", () => {
     expect(isAccessibilityBlocked("missing")).toBe(true);
     // Re-granted (next change event): banner clears.
     expect(isAccessibilityBlocked("granted")).toBe(false);
+  });
+});
+
+// JUN-319: TCC grants are bundle-scoped, so the dictation helper can hold a
+// mic grant while the main app (the bundle that records) is denied. The
+// record button must block on either signal; before this, a denial only the
+// readiness probe could see left Record clickable and the take failed with a
+// bare error string.
+function readinessWithMicPermission(
+  permissionState: SourceReadinessDto["permissionState"],
+): RecordingSourceReadinessDto {
+  const microphone: SourceReadinessDto = {
+    source: "microphone",
+    required: true,
+    ready: permissionState === "granted",
+    permissionState,
+    deviceAvailable: true,
+    captureAvailable: permissionState === "granted",
+  };
+  return { sourceMode: "microphoneOnly", ready: microphone.ready, sources: [microphone] };
+}
+
+describe("isMicrophoneRecordingBlocked", () => {
+  it("blocks when the readiness probe sees the main app's grant denied", () => {
+    expect(isMicrophoneRecordingBlocked("granted", readinessWithMicPermission("denied"))).toBe(
+      true,
+    );
+    expect(isMicrophoneRecordingBlocked(undefined, readinessWithMicPermission("restricted"))).toBe(
+      true,
+    );
+  });
+
+  it("blocks when the dictation helper reports a denial", () => {
+    expect(isMicrophoneRecordingBlocked("denied", undefined)).toBe(true);
+    expect(isMicrophoneRecordingBlocked("restricted", readinessWithMicPermission("granted"))).toBe(
+      true,
+    );
+  });
+
+  it("does not block when both signals are granted", () => {
+    expect(isMicrophoneRecordingBlocked("granted", readinessWithMicPermission("granted"))).toBe(
+      false,
+    );
+  });
+
+  it("keeps a fresh install startable so the TCC prompt can fire", () => {
+    // `unknown` covers the Rust probe's not_determined mapping; the start
+    // path resolves it with the main app's own TCC prompt.
+    expect(isMicrophoneRecordingBlocked(undefined, readinessWithMicPermission("unknown"))).toBe(
+      false,
+    );
+    expect(isMicrophoneRecordingBlocked(undefined, undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes JUN-319

- The record button's mic-blocked notice ("Microphone access is blocked. You can still write notes here." + Enable) now also flips on the Rust source-readiness probe, which reads the main app's own TCC grant, instead of only the dictation helper's status.
- A `microphone_permission_missing` failure from `start_recording` (the first-run TCC prompt declined, or the grant revoked after the readiness probe) re-probes readiness, so the click lands on the same persistent, actionable notice rather than only a transient error banner.
- Enable opens the microphone privacy pane in System Settings; granting access and returning to June restores the record button via the existing focus-refresh probe, so the user can retry immediately.

## Root cause

TCC grants are bundle-scoped. The mic-blocked notice was keyed only on the dictation helper's grant (`co.opensoftware.june.dictation-helper`), while recording runs in the main app bundle, whose grant is read by the readiness probe. With the helper granted but the main app denied, Record stayed clickable and the click died with a bare error string that offered no way to grant permission and retry. (The specific screenshot attached to JUN-319 shows `authorization_denied`, which traces to the credit-hold cascade fixed separately in #751; the permission preflight this issue requests is implemented here.)

## Validation

- `pnpm test`: 160 files, 2634 passed. New unit tests cover `isMicrophoneRecordingBlocked` (helper denial, readiness denial, both granted, fresh-install `unknown` staying startable so the TCC prompt can fire).
- `pnpm check` (Biome) and `pnpm typecheck` clean.
- No Rust changes; the existing backend preflight (`recording_source_readiness` + `request_microphone_permission_blocking`) is untouched, so cargo suites were not run.
- Live walkthrough (agent-driven, real app shell in the Vite web preview with a Tauri shim reporting a denied main-app grant): Record visible while permission looks available; clicking Record does not start a recording and surfaces the actionable notice; Enable invokes `open_privacy_settings` with the microphone pane; simulating the grant plus window refocus restores the record button. All 7 scripted checks passed; video to follow as a PR comment. Native TCC itself cannot be driven from automation, so the macOS prompt/System Settings hop is exercised through the command boundary.

## Out of scope

- The meeting HUD and dictation surfaces keep their existing permission flows; this PR covers the in-app record path the issue describes.
- No copy changes to the existing notice.

## Followups

- None planned.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786648440&installation_id=144203540&pr_number=755&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F755&signature=29b86c2ea4bef127cd6d00dc40fe5d33fd5f206a35f6b9610ee49683b36dd1f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->