### PR TITLE
Condense running-command logs in chat (JUN-326)

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -12902,13 +12902,7 @@ function AgentChatTurnRow({
             onOpenChange={(open) => onThinkingOpenChange(thinkingKey, open)}
           />
         ) : null}
-        {visibleToolParts.length > 0 ? (
-          <div className="agent-tool-stack">
-            {visibleToolParts.map((tool) => (
-              <AgentToolPartRow key={`tool:${tool.id}`} part={tool} />
-            ))}
-          </div>
-        ) : null}
+        {visibleToolParts.length > 0 ? <AgentToolStack parts={visibleToolParts} /> : null}
         {runningMediaTools.map((tool) =>
           tool.media === "image" ? (
             <AgentGeneratedImage
@@ -15068,6 +15062,60 @@ function AgentToolPartRow({ part }: { part: Extract<AgentChatPart, { type: "tool
         ) : null
       }
     />
+  );
+}
+
+// Long tool runs stop growing the transcript a row per call: past this many
+// rows, settled (complete/failed) calls fold behind a single count line while
+// running calls stay visible below it, so what June is doing right now is
+// never hidden and failures are still called out on the fold itself.
+const AGENT_TOOL_STACK_FOLD_THRESHOLD = 3;
+
+function AgentToolStack({ parts }: { parts: Extract<AgentChatPart, { type: "tool" }>[] }) {
+  const settled = parts.filter((part) => part.status !== "running");
+  const folded = parts.length > AGENT_TOOL_STACK_FOLD_THRESHOLD && settled.length >= 2;
+  if (!folded) {
+    return (
+      <div className="agent-tool-stack">
+        {parts.map((tool) => (
+          <AgentToolPartRow key={`tool:${tool.id}`} part={tool} />
+        ))}
+      </div>
+    );
+  }
+  const running = parts.filter((part) => part.status === "running");
+  const failedCount = settled.filter((part) => part.status === "failed").length;
+  return (
+    <div className="agent-tool-stack">
+      {/* Uncontrolled like the per-row disclosures: the browser owns the open
+       * state, so rows settling into the fold don't snap it shut. */}
+      <details
+        className="agent-tool-disclosure agent-tool-fold"
+        data-status={failedCount > 0 ? "failed" : "complete"}
+      >
+        <summary>
+          <span className="agent-tool-icon">
+            <IconConsoleSimple size={15} className="agent-tool-icon-glyph" />
+            <span className="agent-tool-icon-expand">+</span>
+            <span className="agent-tool-icon-minimize">−</span>
+          </span>
+          <span className="agent-tool-name">{settled.length} actions</span>
+          {failedCount > 0 ? (
+            <span className="agent-tool-live-status" data-status="failed">
+              {failedCount} failed
+            </span>
+          ) : null}
+        </summary>
+        <div className="agent-tool-fold-body">
+          {settled.map((tool) => (
+            <AgentToolPartRow key={`tool:${tool.id}`} part={tool} />
+          ))}
+        </div>
+      </details>
+      {running.map((tool) => (
+        <AgentToolPartRow key={`tool:${tool.id}`} part={tool} />
+      ))}
+    </div>
   );
 }
 

--- a/src/lib/agent-chat-gallery.ts
+++ b/src/lib/agent-chat-gallery.ts
@@ -234,6 +234,54 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
       ],
     },
     {
+      label: "Tool stack: condensed",
+      description:
+        "Past three tool rows, settled calls fold behind one count line (failed count on the fold); the running row stays visible below it.",
+      turns: [
+        assistantTurn(
+          "tool-fold",
+          [
+            {
+              type: "tool",
+              id: "fold-1",
+              name: "Running command",
+              text: "$ git status -sb\n## main",
+              status: "complete",
+            },
+            {
+              type: "tool",
+              id: "fold-2",
+              name: "Searching files",
+              text: "$ rg -n 'recap' notes/\nnotes/monday.md:4: recap with the team",
+              status: "complete",
+            },
+            {
+              type: "tool",
+              id: "fold-3",
+              name: "Running command",
+              text: "$ pnpm test\n47 passed",
+              status: "complete",
+            },
+            {
+              type: "tool",
+              id: "fold-4",
+              name: "Fetch Url",
+              text: "Request timed out after 30s.",
+              status: "failed",
+            },
+            {
+              type: "tool",
+              id: "fold-5",
+              name: "Running command",
+              text: "",
+              status: "running",
+            },
+          ],
+          "running",
+        ),
+      ],
+    },
+    {
       label: ERROR_SECTION_LABEL,
       description: "A surfaced error renders as a failed tool row named “Error”.",
       turns: [

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2927,6 +2927,18 @@ input:focus-visible,
   background: transparent;
 }
 
+/* Condensed tool run (JUN-326): settled rows tuck behind one count line so a
+ * long command run reads as a single quiet row instead of a column of them.
+ * The fold reuses the disclosure row treatment; only the body is new — the
+ * folded rows indent under the summary label so the hierarchy is legible. */
+.agent-tool-fold-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  margin-top: var(--sp-1);
+  padding-left: calc(15px + var(--sp-2));
+}
+
 .agent-tool-output {
   overflow: auto;
   max-height: 220px;

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -7583,6 +7583,86 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("Done.")).toBeInTheDocument();
   });
 
+  it("condenses long tool runs behind a count line while running rows stay visible (JUN-326)", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "audit the project",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "audit the project",
+      }),
+    );
+
+    const emit = (type: string, payload: Record<string, unknown>) => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type, session_id: "runtime-session-2", payload });
+      }
+    };
+
+    act(() => {
+      emit("tool.start", { tool_id: "tool-1", tool_name: "read_file", path: "notes.md" });
+      emit("tool.complete", { tool_id: "tool-1", tool_name: "read_file", path: "notes.md" });
+      emit("tool.start", { tool_id: "tool-2", tool_name: "bash", command: "./scripts/build.sh" });
+      emit("tool.complete", {
+        tool_id: "tool-2",
+        tool_name: "bash",
+        command: "./scripts/build.sh",
+      });
+      emit("tool.start", { tool_id: "tool-3", tool_name: "web_search", search_query: "june" });
+      emit("tool.complete", {
+        tool_id: "tool-3",
+        tool_name: "web_search",
+        search_query: "june",
+      });
+    });
+
+    // At the threshold the stack still renders flat: three rows, no fold.
+    expect(await screen.findByText("Reading files")).toBeInTheDocument();
+    expect(screen.getByText("Running command")).toBeInTheDocument();
+    expect(screen.getByText("Searching web")).toBeInTheDocument();
+    expect(document.querySelector(".agent-tool-fold")).toBeNull();
+
+    act(() => {
+      emit("tool.start", { tool_id: "tool-4", tool_name: "fetch_url", url: "https://june.dev" });
+      emit("tool.failed", {
+        tool_id: "tool-4",
+        tool_name: "fetch_url",
+        url: "https://june.dev",
+        text: "Request timed out.",
+      });
+      emit("tool.start", { tool_id: "tool-5", tool_name: "edit_file", path: "notes.md" });
+    });
+
+    // Past the threshold, the four settled calls fold behind one count line
+    // that also carries the failed count; the fold starts collapsed.
+    const foldName = await screen.findByText("4 actions");
+    const fold = foldName.closest("details");
+    expect(fold).toHaveClass("agent-tool-fold");
+    expect(fold).not.toHaveAttribute("open");
+    expect(within(fold as HTMLElement).getByText("1 failed")).toBeInTheDocument();
+
+    // Settled rows (including the failure) live inside the fold and keep their
+    // per-row status when expanded.
+    expect(fold).toContainElement(screen.getByText("Reading files"));
+    expect(fold).toContainElement(screen.getByText("Running command"));
+    expect(fold).toContainElement(screen.getByText("Browsing"));
+    expect(fold).toContainElement(screen.getByText("Failed"));
+
+    // The running row stays outside the fold, spinner and all.
+    const runningLabel = screen.getByText("Editing files");
+    expect(fold).not.toContainElement(runningLabel);
+    expect(runningLabel.closest(".agent-tool-stack")).toBeTruthy();
+    expect(fold).not.toContainElement(screen.getByRole("status", { name: "Running" }));
+  });
+
   it("holds space with a generation placeholder while an image tool runs and never paints streamed MEDIA text", async () => {
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,


### PR DESCRIPTION
Closes JUN-326

## What changed

Long tool runs in agent chat no longer grow the transcript one row per call. Once a turn accumulates more than three tool rows, the settled (complete/failed) calls fold behind a single count line ("12 actions", plus a "2 failed" pill when any failed). Rows still running stay visible below the fold with their spinner, so what June is doing right now is never hidden.

- `AgentToolStack` in `AgentWorkspace.tsx` owns the fold; below the threshold the stack renders flat exactly as before.
- The fold reuses the existing tool-disclosure row treatment (same icon, +/- hover affordance, uncontrolled `<details>`), so a row settling into the fold cannot snap it shut and the presentation stays fluid at any width.
- Expanding the fold reveals the individual rows unchanged: each keeps its own status (Failed pill, spinner) and its own expandable command output.
- New dev-gallery section "Tool stack: condensed" so the state is easy to restyle later.

## Why

JUN-326: repeated "Running command" entries consumed too much vertical space and made active conversations hard to scan.

## Validation

- `pnpm check --diagnostic-level=error` clean, `pnpm typecheck` clean.
- `pnpm test`: 160 files, 2631 passed (includes a new test covering: flat at the threshold, fold past it, failed count on the fold, running row outside the fold).
- Live web-preview walkthrough (Playwright, dev response gallery rendered through the real `AgentChatTurnRow`): verified collapsed count line + failed pill + visible running row, expanded rows with per-row status and output. QA video comment to follow.

## Notes

- Fold copy is "N actions" (labels cover mixed tools: commands, file reads, web searches), sentence case, no dashes per repo copy rules.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786648485&installation_id=144203540&pr_number=756&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F756&signature=1d89d666551ecdc5f4e052495d2dd47ee3818d1b04f3b549f2e9815016e93b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
