### PR TITLE
Surface Auto mode billing when a Venice API key is saved (JUN-329)

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2646,6 +2646,10 @@ export function AgentWorkspace({
   // shows as a name-only stub so the pill never goes blank while configured.
   const [defaultGenerationModelId, setDefaultGenerationModelId] = useState("");
   const [generationCostQuality, setGenerationCostQuality] = useState<number | undefined>();
+  // Mirrors the saved Venice API key's presence so the model picker's Auto
+  // section can show its billing note (Auto meters June credits, never the
+  // key). Refreshed with every provider-settings read.
+  const [veniceApiKeyConfigured, setVeniceApiKeyConfigured] = useState(false);
   // Preference saves from the picker's drill-in: writes are chained so they
   // persist in click order, and versioned so only the newest call's outcome
   // touches the UI (mirrors Settings' saveCostQuality discipline). Rollback
@@ -3768,6 +3772,7 @@ export function AgentWorkspace({
       confirmedCostQualityRef.current = settings.costQuality;
       generationCostQualityRef.current = settings.costQuality;
       setGenerationCostQuality(settings.costQuality);
+      setVeniceApiKeyConfigured(settings.veniceApiKeyConfigured);
       return selectedModelId;
     },
     [],
@@ -10573,6 +10578,7 @@ export function AgentWorkspace({
             model={generationModel}
             options={modelOptions(generationModelOptions, generationModel?.id ?? "")}
             costQuality={activeGenerationCostQuality}
+            veniceApiKeyConfigured={veniceApiKeyConfigured}
             search={modelSearch}
             popoverRef={composerModelPopoverRef}
             searchRef={composerModelSearchRef}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -3784,10 +3784,17 @@ export function AgentWorkspace({
   const loadGenerationModel = useCallback(async () => {
     const requestId = ++generationModelRequestSequence.current;
     try {
-      const [settingsResponse, modelsResponse] = await Promise.all([
-        providerModelSettings(),
-        listVeniceModels("generation"),
-      ]);
+      const settingsPromise = providerModelSettings();
+      const modelsPromise = listVeniceModels("generation");
+      // Surfaced before the catalog await: the settings read is local IPC, so
+      // key-presence state (the Auto billing note) refreshes even when the
+      // remote catalog fetch fails.
+      modelsPromise.catch(() => {});
+      const settingsResponse = await settingsPromise;
+      if (requestId === generationModelRequestSequence.current) {
+        setVeniceApiKeyConfigured(settingsResponse.settings.veniceApiKeyConfigured);
+      }
+      const modelsResponse = await modelsPromise;
       const selectedModelId = generationSelectionId(
         settingsResponse.settings,
         modelsResponse.selectedModel,

--- a/src/components/agent/composer/ModelPicker.tsx
+++ b/src/components/agent/composer/ModelPicker.tsx
@@ -19,6 +19,7 @@ import { useCatalogHoverBridge, useModelDetailHoverBridge } from "../../ui/useMo
 import { HoverTip } from "../../ui/HoverTip";
 import { ModelPrivacyChip, ModelRowPrivacyBadge } from "../../ui/ModelPrivacyChip";
 import { Switch } from "../../ui/Switch";
+import { AUTO_MODEL_ID } from "../../settings/ModelPickerDialog";
 import { ModelPickerCardContent } from "../../settings/ModelPickerPopover";
 
 /** The composer's model picker: the trigger pill and its two-layer popover
@@ -102,6 +103,7 @@ export function ComposerModelPopover({
   search,
   popoverRef,
   searchRef,
+  veniceApiKeyConfigured = false,
   onFlyoutChange,
   onSearchChange,
   onSelect,
@@ -113,6 +115,12 @@ export function ComposerModelPopover({
   search: string;
   popoverRef: RefObject<HTMLDivElement>;
   searchRef: RefObject<HTMLInputElement>;
+  /** With a Venice API key saved and Auto as the active selection, the
+   * popover leads with the billing note from the settings picker: Auto is a
+   * June-managed route, so it meters June credits and never uses the key.
+   * This popover has no Auto section, so the note is the only billing signal
+   * on this surface (JUN-329). */
+  veniceApiKeyConfigured?: boolean;
   onFlyoutChange: (flyout: ComposerModelFlyout) => void;
   onSearchChange: (value: string) => void;
   onSelect: (modelId: string, costQuality?: number) => void;
@@ -401,6 +409,11 @@ export function ComposerModelPopover({
       }}
     >
       <p className="agent-composer-model-title">Suggested</p>
+      {veniceApiKeyConfigured && model.id === AUTO_MODEL_ID ? (
+        <p className="agent-composer-model-auto-note">
+          Auto is billed to June credits and does not use your Venice API key.
+        </p>
+      ) : null}
       <div className="agent-composer-model-menu" role="listbox" aria-label="Suggested text models">
         {suggested.length ? (
           suggested.map(({ key, model: option, costQuality: presetCostQuality }) => (

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -283,6 +283,9 @@ export function NoteChatPanel({
   });
   const [modelId, setModelId] = useState("");
   const [costQuality, setCostQualityState] = useState<number | undefined>();
+  // Mirrors the saved Venice API key's presence so the model popover can show
+  // its Auto billing note (Auto meters June credits, never the key).
+  const [veniceApiKeyConfigured, setVeniceApiKeyConfigured] = useState(false);
   const [modelOpen, setModelOpen] = useState(false);
   const [modelFlyout, setModelFlyout] = useState<ComposerModelFlyout>(null);
   const [modelSearch, setModelSearch] = useState("");
@@ -312,6 +315,7 @@ export function NoteChatPanel({
         apiKey: "",
       };
       setLocalGeneration(local);
+      setVeniceApiKeyConfigured(settings.settings.veniceApiKeyConfigured);
       setModels(withLocalGenerationOption(catalog.models, local));
       const fallbackModelId =
         settings.settings.generationProvider === "local" && local.modelId.trim()
@@ -771,6 +775,7 @@ export function NoteChatPanel({
               search={modelSearch}
               popoverRef={modelPopoverRef}
               searchRef={modelSearchRef}
+              veniceApiKeyConfigured={veniceApiKeyConfigured}
               onFlyoutChange={setModelFlyout}
               onSearchChange={setModelSearch}
               onSelect={(nextModelId, nextCostQuality) =>

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -96,7 +96,12 @@ import {
   withLocalGenerationOption,
 } from "../../lib/local-generation";
 import { ProviderLogo } from "./ProviderLogo";
-import { modelOptions, selectedModel } from "./ModelPickerDialog";
+import { AUTO_MODEL_ID, modelOptions, selectedModel } from "./ModelPickerDialog";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
+import {
+  DEFAULT_GENERATION_SUGGESTION_ID,
+  suggestedModelsForMode,
+} from "../../lib/suggested-models";
 import {
   AUTO_PREFERENCE_VALUES,
   autoPreferenceFromCostQuality,
@@ -484,6 +489,10 @@ export function AppSettings({
   const latestCostQualitySaveRef = useRef(0);
   const confirmedCostQualityRef = useRef(DEFAULT_PROVIDER_MODELS.costQuality);
   const [veniceApiKeyDraft, setVeniceApiKeyDraft] = useState("");
+  // Saving a Venice key while Auto is the text model would silently keep
+  // billing June credits (Auto never uses the key), so the save surfaces an
+  // explicit billing choice: switch to a Venice model or knowingly keep Auto.
+  const [veniceKeyAutoBillingChoiceOpen, setVeniceKeyAutoBillingChoiceOpen] = useState(false);
   const [showMoreModelOptions, setShowMoreModelOptions] = useState(false);
   const [showMoreImageOptions, setShowMoreImageOptions] = useState(false);
   const [localModelSetupVisible, setLocalModelSetupVisible] = useState(false);
@@ -1220,6 +1229,12 @@ export function AppSettings({
       setProviderSettings(next);
       setVeniceApiKeyDraft("");
       setStatus("Venice API key saved.");
+      // The workspace's model picker shows a billing note while a key is
+      // saved, so let it refresh its provider settings snapshot.
+      dispatchProviderModelSettingsChanged({ mode: "generation", modelId: next.generationModel });
+      if (next.generationModel === AUTO_MODEL_ID) {
+        setVeniceKeyAutoBillingChoiceOpen(true);
+      }
     } catch (error) {
       setStatus(messageFromError(error));
     }
@@ -1253,6 +1268,7 @@ export function AppSettings({
       setProviderSettings(next);
       setVeniceApiKeyDraft("");
       setStatus("Venice API key removed.");
+      dispatchProviderModelSettingsChanged({ mode: "generation", modelId: next.generationModel });
     } catch (error) {
       setStatus(messageFromError(error));
     }
@@ -1320,6 +1336,12 @@ export function AppSettings({
   // prepend a bare duplicate entry that persisted the local id as the remote
   // model when clicked.
   const generationOptions = modelOptions(generationCatalog, modelValueForMode("generation"));
+  // Where the billing-choice dialog lands when the user opts out of Auto to
+  // use their Venice key: the leading suggested pick, mirroring the Auto
+  // toggle's own off-target in the model picker.
+  const veniceKeySwitchTarget = suggestedModelsForMode("generation", generationOptions).find(
+    (item) => item.model.id !== AUTO_MODEL_ID,
+  )?.model;
   const imageOptions = IMAGE_GENERATION_ENABLED
     ? modelOptions(IMAGE_MODELS, providerSettings.imageModel)
     : [];
@@ -1947,6 +1969,7 @@ export function AppSettings({
                     value={modelValueForMode("generation")}
                     options={generationOptions}
                     costQuality={providerSettings.costQuality}
+                    veniceApiKeyConfigured={providerSettings.veniceApiKeyConfigured}
                     open={pickerMode === "generation"}
                     summarySuppressed={pickerMode !== undefined}
                     flyout={modelPickerFlyout}
@@ -2159,6 +2182,21 @@ export function AppSettings({
                 </div>
               </div>
             </section>
+
+            <ConfirmDialog
+              open={veniceKeyAutoBillingChoiceOpen}
+              onClose={() => setVeniceKeyAutoBillingChoiceOpen(false)}
+              onConfirm={() =>
+                selectVeniceModel(
+                  "generation",
+                  veniceKeySwitchTarget?.id ?? DEFAULT_GENERATION_SUGGESTION_ID,
+                )
+              }
+              title="Auto does not use your Venice API key"
+              description={`Notes and chat are billed to June credits while Auto is selected. Switch to ${veniceKeySwitchTarget?.name ?? "a Venice model"} to use your key for notes and new chats.`}
+              confirmLabel={`Use ${veniceKeySwitchTarget?.name ?? "a Venice model"}`}
+              cancelLabel="Keep Auto"
+            />
 
             {IMAGE_GENERATION_ENABLED || VIDEO_GENERATION_ENABLED ? (
               <section
@@ -2689,6 +2727,7 @@ function ModelRow({
   value,
   options,
   costQuality,
+  veniceApiKeyConfigured,
   open,
   flyout,
   search,
@@ -2708,6 +2747,7 @@ function ModelRow({
   value: string;
   options: VeniceModelDto[];
   costQuality?: number;
+  veniceApiKeyConfigured?: boolean;
   open: boolean;
   flyout: ModelPickerFlyout;
   search: string;
@@ -2761,6 +2801,7 @@ function ModelRow({
             model={model}
             options={options}
             costQuality={costQuality}
+            veniceApiKeyConfigured={veniceApiKeyConfigured}
             search={search}
             popoverRef={popoverRef}
             searchRef={searchRef}

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -89,7 +89,10 @@ import {
 } from "../../lib/platform";
 import { systemAudioAvailability } from "../../lib/source-readiness";
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
-import { dispatchProviderModelSettingsChanged } from "../../lib/model-privacy";
+import {
+  dispatchProviderModelSettingsChanged,
+  modelAvailableForMode,
+} from "../../lib/model-privacy";
 import {
   isLoopbackUrl,
   localGenerationOptionId,
@@ -1342,13 +1345,19 @@ export function AppSettings({
   const generationOptions = modelOptions(generationCatalog, modelValueForMode("generation"));
   // Where the billing-choice dialog lands when the user opts out of Auto to
   // use their Venice key: the leading suggested pick, else the first Venice
-  // catalog model, mirroring the Auto toggle's own off-target in the model
-  // picker (the factory default stays the last resort for an empty catalog).
+  // catalog model, drawn from the same selectable list as the model picker so
+  // the dialog can never persist a model the picker would exclude (the factory
+  // default stays the last resort for an empty catalog).
+  const selectableGenerationOptions = generationOptions.filter((option) =>
+    modelAvailableForMode("generation", option),
+  );
   const veniceKeySwitchTarget =
-    suggestedModelsForMode("generation", generationOptions).find(
+    suggestedModelsForMode("generation", selectableGenerationOptions).find(
       (item) => item.model.id !== AUTO_MODEL_ID,
     )?.model ??
-    generationOptions.find((option) => option.provider === "venice" && option.id !== AUTO_MODEL_ID);
+    selectableGenerationOptions.find(
+      (option) => option.provider === "venice" && option.id !== AUTO_MODEL_ID,
+    );
   const imageOptions = IMAGE_GENERATION_ENABLED
     ? modelOptions(IMAGE_MODELS, providerSettings.imageModel)
     : [];

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1348,9 +1348,7 @@ export function AppSettings({
     suggestedModelsForMode("generation", generationOptions).find(
       (item) => item.model.id !== AUTO_MODEL_ID,
     )?.model ??
-    generationOptions.find(
-      (option) => option.provider === "venice" && option.id !== AUTO_MODEL_ID,
-    );
+    generationOptions.find((option) => option.provider === "venice" && option.id !== AUTO_MODEL_ID);
   const imageOptions = IMAGE_GENERATION_ENABLED
     ? modelOptions(IMAGE_MODELS, providerSettings.imageModel)
     : [];

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1021,7 +1021,9 @@ export function AppSettings({
     }
   }
 
-  async function selectVeniceModel(mode: ProviderModelMode, modelId: string) {
+  // Returns whether the switch persisted, so confirmation flows (the Venice
+  // key billing choice) can stay open instead of closing over a failed save.
+  async function selectVeniceModel(mode: ProviderModelMode, modelId: string): Promise<boolean> {
     try {
       const next = await setVeniceModel(mode, modelId);
       setProviderSettings(next);
@@ -1035,8 +1037,10 @@ export function AppSettings({
               ? "Video model updated."
               : "Text model updated.",
       );
+      return true;
     } catch (error) {
       setStatus(messageFromError(error));
+      return false;
     }
   }
 
@@ -1337,11 +1341,16 @@ export function AppSettings({
   // model when clicked.
   const generationOptions = modelOptions(generationCatalog, modelValueForMode("generation"));
   // Where the billing-choice dialog lands when the user opts out of Auto to
-  // use their Venice key: the leading suggested pick, mirroring the Auto
-  // toggle's own off-target in the model picker.
-  const veniceKeySwitchTarget = suggestedModelsForMode("generation", generationOptions).find(
-    (item) => item.model.id !== AUTO_MODEL_ID,
-  )?.model;
+  // use their Venice key: the leading suggested pick, else the first Venice
+  // catalog model, mirroring the Auto toggle's own off-target in the model
+  // picker (the factory default stays the last resort for an empty catalog).
+  const veniceKeySwitchTarget =
+    suggestedModelsForMode("generation", generationOptions).find(
+      (item) => item.model.id !== AUTO_MODEL_ID,
+    )?.model ??
+    generationOptions.find(
+      (option) => option.provider === "venice" && option.id !== AUTO_MODEL_ID,
+    );
   const imageOptions = IMAGE_GENERATION_ENABLED
     ? modelOptions(IMAGE_MODELS, providerSettings.imageModel)
     : [];
@@ -2186,12 +2195,15 @@ export function AppSettings({
             <ConfirmDialog
               open={veniceKeyAutoBillingChoiceOpen}
               onClose={() => setVeniceKeyAutoBillingChoiceOpen(false)}
-              onConfirm={() =>
-                selectVeniceModel(
+              onConfirm={async () => {
+                const switched = await selectVeniceModel(
                   "generation",
                   veniceKeySwitchTarget?.id ?? DEFAULT_GENERATION_SUGGESTION_ID,
-                )
-              }
+                );
+                // Keep the dialog open over a failed save so the choice is
+                // never silently dropped; the status line carries the error.
+                if (!switched) throw new Error("venice_model_switch_failed");
+              }}
               title="Auto does not use your Venice API key"
               description={`Notes and chat are billed to June credits while Auto is selected. Switch to ${veniceKeySwitchTarget?.name ?? "a Venice model"} to use your key for notes and new chats.`}
               confirmLabel={`Use ${veniceKeySwitchTarget?.name ?? "a Venice model"}`}

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -97,6 +97,7 @@ export function ModelPickerPopover({
   ariaLabel = `Choose ${modelModeLabel(mode)} model`,
   suggestedListLabel = `Suggested ${modelModeLabel(mode)} models`,
   allModelsLabel = `All ${modelModeLabel(mode)} models`,
+  veniceApiKeyConfigured = false,
   onFlyoutChange,
   onSearchChange,
   onSelect,
@@ -115,6 +116,11 @@ export function ModelPickerPopover({
   ariaLabel?: string;
   suggestedListLabel?: string;
   allModelsLabel?: string;
+  /** With a Venice API key saved, the pinned Auto section carries a billing
+   * note: Auto is a June-managed route, so it meters June credits and never
+   * uses the key. The note keeps that visible at the moment Auto could be
+   * switched on (JUN-329). */
+  veniceApiKeyConfigured?: boolean;
   onFlyoutChange: (flyout: ModelPickerFlyout) => void;
   onSearchChange: (value: string) => void;
   /** `keepOpen` asks the host to leave the popover mounted (used by the Auto
@@ -528,6 +534,11 @@ export function ModelPickerPopover({
               aria-label="Choose the model automatically"
             />
           </div>
+          {veniceApiKeyConfigured ? (
+            <p className="agent-composer-model-auto-note">
+              Auto is billed to June credits and does not use your Venice API key.
+            </p>
+          ) : null}
           {autoEnabled ? (
             <button
               type="button"

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6700,6 +6700,17 @@ input:focus-visible,
   border-bottom: 0;
 }
 
+/* Billing note under the Auto toggle while a Venice API key is saved: Auto
+ * never uses the key, so the credits impact stays visible right where Auto
+ * gets switched on. Quiet caption on the same gutter as the toggle label. */
+.agent-composer-model-auto-note {
+  margin: 0;
+  padding: 0 var(--sp-2) var(--sp-1) var(--sp-3);
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+}
+
 /* The Preference drill-in row while Auto is on: label left, the active preset
  * as a quiet value beside the chevron. The auto margin sits on the value, so
  * the chevron's own auto margin has to stand down or the pair splits apart. */

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -3302,6 +3302,151 @@ describe("AppSettings", () => {
     ).toBeInTheDocument();
   });
 
+  it("asks for a billing choice when a Venice key is saved while Auto is selected", async () => {
+    const user = userEvent.setup();
+    mocks.providerModelSettings.mockResolvedValueOnce({
+      settings: {
+        ...buildProviderSettings(),
+        generationModel: "open-software/auto",
+        remoteGenerationModel: "open-software/auto",
+      },
+    });
+    mocks.setVeniceApiKey.mockResolvedValue({
+      ...buildProviderSettings(),
+      generationModel: "open-software/auto",
+      remoteGenerationModel: "open-software/auto",
+      veniceApiKeyConfigured: true,
+    });
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Models" }));
+    await user.click(screen.getByRole("button", { name: "More options for AI models" }));
+    await user.type(await screen.findByLabelText("Venice API key"), "vc_test_key");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    // The save lands, but Auto would keep billing June credits, so the
+    // explicit choice dialog appears with the leading suggested Venice model.
+    expect(await screen.findByText("Auto does not use your Venice API key")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Use GLM 5.2" }));
+    await waitFor(() =>
+      expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "zai-org-glm-5-2"),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("Auto does not use your Venice API key")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("keeps Auto when the billing choice dialog is declined", async () => {
+    const user = userEvent.setup();
+    mocks.providerModelSettings.mockResolvedValueOnce({
+      settings: {
+        ...buildProviderSettings(),
+        generationModel: "open-software/auto",
+        remoteGenerationModel: "open-software/auto",
+      },
+    });
+    mocks.setVeniceApiKey.mockResolvedValue({
+      ...buildProviderSettings(),
+      generationModel: "open-software/auto",
+      remoteGenerationModel: "open-software/auto",
+      veniceApiKeyConfigured: true,
+    });
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Models" }));
+    await user.click(screen.getByRole("button", { name: "More options for AI models" }));
+    await user.type(await screen.findByLabelText("Venice API key"), "vc_test_key");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("Auto does not use your Venice API key")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Keep Auto" }));
+    await waitFor(() =>
+      expect(screen.queryByText("Auto does not use your Venice API key")).not.toBeInTheDocument(),
+    );
+    expect(mocks.setVeniceModel).not.toHaveBeenCalled();
+  });
+
+  it("does not ask for a billing choice when a concrete model is selected", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Models" }));
+    await user.click(screen.getByRole("button", { name: "More options for AI models" }));
+    await user.type(await screen.findByLabelText("Venice API key"), "vc_test_key");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("Key saved.")).toBeInTheDocument();
+    expect(screen.queryByText("Auto does not use your Venice API key")).not.toBeInTheDocument();
+  });
+
+  it("shows the Auto billing note in the model picker while a Venice key is saved", async () => {
+    const user = userEvent.setup();
+    mocks.providerModelSettings.mockResolvedValueOnce({
+      settings: {
+        ...buildProviderSettings(),
+        veniceApiKeyConfigured: true,
+      },
+    });
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Models" }));
+    await user.click(await screen.findByRole("button", { name: "Change text model" }));
+
+    expect(
+      await screen.findByText(
+        "Auto is billed to June credits and does not use your Venice API key.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("defaults the model picker to curated suggestions", async () => {
     const user = userEvent.setup();
     render(

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -3348,6 +3348,54 @@ describe("AppSettings", () => {
     );
   });
 
+  it("keeps the billing choice dialog open when the model switch fails", async () => {
+    const user = userEvent.setup();
+    mocks.providerModelSettings.mockResolvedValueOnce({
+      settings: {
+        ...buildProviderSettings(),
+        generationModel: "open-software/auto",
+        remoteGenerationModel: "open-software/auto",
+      },
+    });
+    mocks.setVeniceApiKey.mockResolvedValue({
+      ...buildProviderSettings(),
+      generationModel: "open-software/auto",
+      remoteGenerationModel: "open-software/auto",
+      veniceApiKeyConfigured: true,
+    });
+    mocks.setVeniceModel.mockRejectedValueOnce(new Error("switch failed"));
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Models" }));
+    await user.click(screen.getByRole("button", { name: "More options for AI models" }));
+    await user.type(await screen.findByLabelText("Venice API key"), "vc_test_key");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("Auto does not use your Venice API key")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Use GLM 5.2" }));
+
+    // The failed save must not read as a completed switch: the dialog stays
+    // open for a retry or an explicit Keep Auto.
+    expect(await screen.findByText("Auto does not use your Venice API key")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Use GLM 5.2" }));
+    await waitFor(() =>
+      expect(screen.queryByText("Auto does not use your Venice API key")).not.toBeInTheDocument(),
+    );
+    expect(mocks.setVeniceModel).toHaveBeenLastCalledWith("generation", "zai-org-glm-5-2");
+  });
+
   it("keeps Auto when the billing choice dialog is declined", async () => {
     const user = userEvent.setup();
     mocks.providerModelSettings.mockResolvedValueOnce({

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -400,6 +400,43 @@ describe("note chat session map", () => {
     window.removeEventListener(PROVIDER_MODEL_SETTINGS_CHANGED_EVENT, settingsChanged);
   });
 
+  it("shows the Auto billing note in the picker while a Venice key is saved", async () => {
+    const user = userEvent.setup();
+    mocks.providerModelSettings.mockResolvedValue({
+      settings: {
+        transcriptionProvider: "venice",
+        generationProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: autoModel.id,
+        remoteGenerationModel: autoModel.id,
+        costQuality: 100,
+        imageModel: "venice-sd35",
+        videoModel: "wan-2.2-a14b-text-to-video",
+        veniceApiKeyConfigured: true,
+        localGeneration: { baseUrl: "", modelId: "", apiKey: "" },
+        imageSafeMode: true,
+        imageSafeModePromptDismissed: false,
+      },
+    });
+
+    render(
+      createElement(NoteChatPanel, {
+        note: { id: "note-1", title: "Launch planning" },
+        chat: noteChat(),
+        onClose: vi.fn(),
+        onOpenInAgent: vi.fn(),
+      }),
+    );
+
+    await user.click(await screen.findByRole("button", { name: /^Model: Auto/ }));
+    const picker = screen.getByRole("dialog", { name: "Choose text model" });
+    expect(
+      within(picker).getByText(
+        "Auto is billed to June credits and does not use your Venice API key.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("keeps a first-run picker change session-local while session creation is pending", async () => {
     const user = userEvent.setup();
     const chat = noteChat({


### PR DESCRIPTION
Closes JUN-329 (https://app.opensoftware.co/june/issues/JUN-329).

## What changed

A user who saves a Venice API key while `open-software/auto` is the text model (the shipped default) kept silently burning June credits: Auto is a June-managed route, so both the desktop client and june-api strip the key from Auto requests by design. The reporter ran out of credits while their Venice usage stayed at zero.

This makes that billing path an explicit, informed choice, client-side only:

- **Explicit billing choice on key save** (`AppSettings.tsx`): saving a Venice key while Auto is the text model opens a dialog stating that notes and chat are billed to June credits while Auto is selected, with two buttons: "Use GLM 5.2" (switches to the leading suggested Venice model so the key applies) or "Keep Auto" (knowingly stays on June credits).
- **Billing note in the model picker's Auto section** (`ModelPickerPopover.tsx`): while a key is saved, the pinned Auto toggle carries "Auto is billed to June credits and does not use your Venice API key." This renders in both surfaces that share the popover: the Settings text-model row and the agent composer's session-bar model pill, so the billing source is visible before inference and at the moment Auto could be switched on.
- **Workspace sync** (`AgentWorkspace.tsx`): the workspace now mirrors `veniceApiKeyConfigured` from provider settings, and key save/remove dispatches the provider-settings-changed event so the composer picker refreshes without an app restart.

## Why not route Auto through the key

Auto's model choice happens upstream (os-api compat gateway) under June's service key; there is no route today that can bill an Auto request to a user's Venice key, and api.venice.ai does not accept `open-software/auto` as a model. The issue's acceptance criteria allow either honoring the key **or** requiring an explicit fallback choice with clear billing impact; this implements the latter. Server-side guardrails (key stripped for Auto, `venice_api_key_model_unavailable` on non-Venice resolutions) are unchanged and already covered by june-api tests. If a BYOK-compatible Auto route ships later, this UX collapses naturally into a smaller note.

## Validation

- `npx vitest run` - 160 files, 2634 passed (includes 4 new tests: dialog switch path, keep-Auto path, no dialog for concrete models, picker billing note).
- `tsc --noEmit` - clean.
- `biome check` on changed files - clean.
- No Rust changes, so no cargo suites were run.

## Live walkthrough

Recorded against the real `AppSettings` component served by Vite with a stateful Tauri-invoke shim (the Rust bridge is not exercised; its behavior is covered by existing june-api/src-tauri tests). The video shows: Models tab with Auto selected, the picker without the note before any key exists, saving a key, the billing choice dialog, "Keep Auto", the picker now showing the billing note, saving again and choosing "Use GLM 5.2", and the text model landing on GLM 5.2. QA video will be attached as a PR comment.

## Review follow-ups

- Greptile P1: a failed model save no longer closes the billing choice dialog as if it succeeded (`selectVeniceModel` reports success; the dialog stays open for retry).
- Greptile P2: the switch target now falls back to the first Venice model in the live catalog before the factory default.
- Codex P2: the composer refreshes `veniceApiKeyConfigured` from the local settings read even when the remote catalog fetch fails.
- Codex P2: the note chat panel's model popover (which has no Auto section) now leads with the billing note while Auto is the active selection and a key is saved.

## Known gaps

- The billing choice dialog only triggers on key save. Users already in the Auto + key state see the Settings substatus (pre-existing) and the new picker note, but are not interrupted with a dialog.
- The composer picker note was verified through the shared `ModelPickerPopover` component in Settings; the workspace wiring is covered by typecheck and the shared component tests, not a separate live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786648877&installation_id=144203540&pr_number=757&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F757&signature=835e6c2bbd904749edf8b51290b4a60db758d1bfee28afd81562a7a7f52be8a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
