### PR TITLE
Open notification clicks in the relevant completed chat

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub mod macos_menu_icons;
 pub mod meeting_detection;
 pub mod meeting_hud;
 pub mod menu_bar;
+pub mod notifications;
 pub mod os_accounts;
 pub mod p3a;
 pub mod providers;
@@ -259,6 +260,8 @@ pub fn run() {
             agent_hud::agent_hud_hide,
             agent_hud::agent_hud_set_layout,
             agent_hud::agent_hud_open_agent,
+            notifications::send_app_notification,
+            notifications::agent_open_ready,
             meeting_hud::meeting_hud_latest_status,
             meeting_hud::meeting_hud_reopen,
             providers::provider_model_settings,
@@ -324,6 +327,7 @@ pub fn run() {
             updates::setup(app);
             dictation::setup(app);
             agent_hud::setup(app);
+            notifications::setup(app);
             meeting_detection::setup(app);
             repair_agent_task_statuses_on_app_start(app);
             hermes_bridge::start_on_app_start(app);

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -1,0 +1,410 @@
+//! App notifications with click-through navigation.
+//!
+//! The notification plugin's desktop backend (`notify_rust` over
+//! `mac-notification-sys`) installs its own throwaway delegate on the shared
+//! `NSUserNotificationCenter` on every send and never reports clicks, so a
+//! notification could only ever reopen the app generally (JUN-327). On macOS
+//! this module owns the posting path instead: June installs one permanent
+//! center delegate, posts agent/recording notifications itself with the
+//! session id in `userInfo`, and on click focuses the main window and routes
+//! the session id to the webview via the existing `june:agent:open` event.
+//!
+//! Clicks can arrive before the webview has listeners (app launched by the
+//! click), so activation goes through a ready/pending handshake: the frontend
+//! calls `agent_open_ready` once its listeners are registered and receives
+//! any session id that was clicked while it could not listen.
+//!
+//! Outside macOS, and in unbundled dev runs where the notification center is
+//! unavailable, sends fall back to the notification plugin: same visuals, no
+//! click-through (the plugin cannot deliver clicks there anyway).
+
+use serde::Deserialize;
+use std::sync::{Mutex, OnceLock};
+use tauri::{AppHandle, Manager};
+
+const MAIN_WINDOW_LABEL: &str = "main";
+#[cfg(target_os = "macos")]
+const AGENT_OPEN_EVENT: &str = "june:agent:open";
+
+// The center delegate is a static C callback with no captured state, so
+// activations reach the app through this handle (same pattern as the agent
+// HUD panel class).
+static NOTIFICATION_APP: OnceLock<AppHandle> = OnceLock::new();
+
+static AGENT_OPEN_QUEUE: Mutex<AgentOpenQueue> = Mutex::new(AgentOpenQueue::new());
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppNotificationRequest {
+    title: String,
+    body: String,
+    #[serde(default)]
+    sound: Option<String>,
+    /// Agent session to open when the user clicks the notification.
+    #[serde(default)]
+    session_id: Option<String>,
+}
+
+/// Decides whether a notification click can be delivered to the webview now
+/// or must wait for the frontend's ready handshake. Clicking a notification
+/// can launch the app, and the click then arrives before any listener exists;
+/// dropping it would strand the user on the default view.
+struct AgentOpenQueue {
+    frontend_ready: bool,
+    pending_session_id: Option<String>,
+}
+
+impl AgentOpenQueue {
+    const fn new() -> Self {
+        Self {
+            frontend_ready: false,
+            pending_session_id: None,
+        }
+    }
+
+    /// Records a notification click. Returns the session id when the frontend
+    /// can receive it immediately; otherwise queues it for `mark_ready`.
+    fn on_activation(&mut self, session_id: Option<String>) -> Option<String> {
+        let session_id = session_id?;
+        if self.frontend_ready {
+            Some(session_id)
+        } else {
+            // Last click wins: the user's most recent choice is the one to honor.
+            self.pending_session_id = Some(session_id);
+            None
+        }
+    }
+
+    /// Frontend listeners are registered; returns any click that arrived early.
+    fn mark_ready(&mut self) -> Option<String> {
+        self.frontend_ready = true;
+        self.pending_session_id.take()
+    }
+}
+
+pub fn setup(app: &tauri::App) {
+    let _ = NOTIFICATION_APP.set(app.handle().clone());
+    #[cfg(target_os = "macos")]
+    macos::install_center_delegate();
+}
+
+/// Marks the webview ready for `june:agent:open` events and returns the
+/// session id of a notification clicked before that (app launched by the
+/// click), so the frontend can navigate to it on bootstrap.
+#[tauri::command]
+pub fn agent_open_ready() -> Option<String> {
+    lock_queue().mark_ready()
+}
+
+/// Posts a notification. On macOS the native path attaches the session id so
+/// a click deep-links into the chat; elsewhere (and when the native center is
+/// unavailable) the plugin posts it without click-through.
+#[tauri::command]
+pub fn send_app_notification(
+    app: AppHandle,
+    request: AppNotificationRequest,
+) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    if macos::deliver(&request) {
+        return Ok(());
+    }
+    send_via_plugin(&app, &request)
+}
+
+fn send_via_plugin(app: &AppHandle, request: &AppNotificationRequest) -> Result<(), String> {
+    use tauri_plugin_notification::NotificationExt;
+
+    let mut builder = app
+        .notification()
+        .builder()
+        .title(&request.title)
+        .body(&request.body);
+    if let Some(sound) = &request.sound {
+        builder = builder.sound(sound);
+    }
+    builder.show().map_err(|error| error.to_string())
+}
+
+fn lock_queue() -> std::sync::MutexGuard<'static, AgentOpenQueue> {
+    AGENT_OPEN_QUEUE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Runs on a notification click: focus the app, then route the session id to
+/// the webview (or queue it until the frontend is ready). A notification
+/// without a session id keeps the old behavior of just opening the app.
+fn handle_notification_activation(session_id: Option<String>) {
+    let Some(app) = NOTIFICATION_APP.get() else {
+        return;
+    };
+    show_main_window(app);
+    if let Some(session_id) = lock_queue().on_activation(session_id) {
+        #[cfg(target_os = "macos")]
+        {
+            use tauri::Emitter;
+            let _ = app.emit_to(
+                MAIN_WINDOW_LABEL,
+                AGENT_OPEN_EVENT,
+                serde_json::json!({ "sessionId": session_id }),
+            );
+        }
+        #[cfg(not(target_os = "macos"))]
+        let _ = session_id;
+    }
+}
+
+fn show_main_window(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::{handle_notification_activation, AppNotificationRequest};
+    use objc2::msg_send;
+    use objc2::runtime::{AnyClass, AnyObject, Bool, ClassBuilder, Sel};
+    use objc2::sel;
+    use objc2_foundation::NSString;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// `userInfo` key carrying the agent session on June's own notifications.
+    const SESSION_ID_KEY: &str = "juneAgentSessionId";
+
+    /// Set once the permanent delegate is installed; the native posting path
+    /// is only trusted after that, so clicks are never silently dropped.
+    static CENTER_DELEGATE_INSTALLED: AtomicBool = AtomicBool::new(false);
+
+    /// `NSUserNotificationCenter defaultUserNotificationCenter`, which is nil
+    /// for unbundled binaries (`tauri dev` runs the raw executable).
+    unsafe fn default_center() -> Option<*mut AnyObject> {
+        let class = AnyClass::get(c"NSUserNotificationCenter")?;
+        let center: *mut AnyObject = unsafe { msg_send![class, defaultUserNotificationCenter] };
+        if center.is_null() {
+            None
+        } else {
+            Some(center)
+        }
+    }
+
+    /// Whether the process runs from a real app bundle. Without a bundle
+    /// identifier (`tauri dev` runs the raw executable) the center exists but
+    /// silently drops deliveries; the plugin fallback fakes a bundle id there,
+    /// so posting must stay on the plugin path to remain visible.
+    unsafe fn bundled() -> bool {
+        let Some(class) = AnyClass::get(c"NSBundle") else {
+            return false;
+        };
+        unsafe {
+            let bundle: *mut AnyObject = msg_send![class, mainBundle];
+            if bundle.is_null() {
+                return false;
+            }
+            let identifier: *mut AnyObject = msg_send![bundle, bundleIdentifier];
+            !identifier.is_null()
+        }
+    }
+
+    /// Installs June's permanent notification-center delegate. Called once at
+    /// setup, before any notification can be posted or clicked.
+    pub(super) fn install_center_delegate() {
+        unsafe {
+            if !bundled() {
+                return;
+            }
+            let Some(center) = default_center() else {
+                return;
+            };
+            let Some(class) = delegate_class() else {
+                return;
+            };
+            // +1 from `new`, intentionally never released: the delegate must
+            // outlive every notification, including clicks on notifications
+            // from a previous run delivered right after relaunch.
+            let delegate: *mut AnyObject = msg_send![class, new];
+            if delegate.is_null() {
+                return;
+            }
+            let _: () = msg_send![center, setDelegate: delegate];
+            CENTER_DELEGATE_INSTALLED.store(true, Ordering::Release);
+        }
+    }
+
+    /// Posts the notification natively with the session id in `userInfo`.
+    /// Returns false when the native path is unavailable so the caller can
+    /// fall back to the plugin.
+    pub(super) fn deliver(request: &AppNotificationRequest) -> bool {
+        if !CENTER_DELEGATE_INSTALLED.load(Ordering::Acquire) {
+            return false;
+        }
+        unsafe {
+            let Some(center) = default_center() else {
+                return false;
+            };
+            let Some(class) = AnyClass::get(c"NSUserNotification") else {
+                return false;
+            };
+            let notification: *mut AnyObject = msg_send![class, new];
+            if notification.is_null() {
+                return false;
+            }
+            let title = NSString::from_str(&request.title);
+            let body = NSString::from_str(&request.body);
+            let _: () = msg_send![notification, setTitle: &*title];
+            let _: () = msg_send![notification, setInformativeText: &*body];
+            if let Some(sound) = &request.sound {
+                let sound = NSString::from_str(sound);
+                let _: () = msg_send![notification, setSoundName: &*sound];
+            }
+            if let Some(session_id) = &request.session_id {
+                if let Some(dictionary_class) = AnyClass::get(c"NSDictionary") {
+                    let key = NSString::from_str(SESSION_ID_KEY);
+                    let value = NSString::from_str(session_id);
+                    let user_info: *mut AnyObject = msg_send![
+                        dictionary_class,
+                        dictionaryWithObject: &*value,
+                        forKey: &*key,
+                    ];
+                    let _: () = msg_send![notification, setUserInfo: user_info];
+                }
+            }
+            let _: () = msg_send![center, deliverNotification: notification];
+            let _: () = msg_send![notification, release];
+        }
+        true
+    }
+
+    /// Reads June's session id out of a clicked notification's `userInfo`.
+    unsafe fn notification_session_id(notification: *mut AnyObject) -> Option<String> {
+        if notification.is_null() {
+            return None;
+        }
+        unsafe {
+            let user_info: *mut AnyObject = msg_send![notification, userInfo];
+            if user_info.is_null() {
+                return None;
+            }
+            let key = NSString::from_str(SESSION_ID_KEY);
+            let value: *mut AnyObject = msg_send![user_info, objectForKey: &*key];
+            if value.is_null() {
+                return None;
+            }
+            // June only ever stores an NSString under this key; a foreign
+            // object that does not respond to UTF8String is ignored.
+            let responds: Bool = msg_send![value, respondsToSelector: sel!(UTF8String)];
+            if !responds.as_bool() {
+                return None;
+            }
+            let utf8: *const std::ffi::c_char = msg_send![value, UTF8String];
+            if utf8.is_null() {
+                return None;
+            }
+            Some(
+                std::ffi::CStr::from_ptr(utf8)
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        }
+    }
+
+    extern "C-unwind" fn should_present(
+        _this: &AnyObject,
+        _sel: Sel,
+        _center: *mut AnyObject,
+        _notification: *mut AnyObject,
+    ) -> Bool {
+        // Present even while June is frontmost, matching the previous
+        // plugin-backed behavior (its delegate also always presented).
+        Bool::YES
+    }
+
+    extern "C-unwind" fn did_activate(
+        _this: &AnyObject,
+        _sel: Sel,
+        _center: *mut AnyObject,
+        notification: *mut AnyObject,
+    ) {
+        let session_id = unsafe { notification_session_id(notification) };
+        handle_notification_activation(session_id);
+    }
+
+    fn delegate_class() -> Option<&'static AnyClass> {
+        if let Some(class) = AnyClass::get(c"JuneNotificationCenterDelegate") {
+            return Some(class);
+        }
+        let superclass = AnyClass::get(c"NSObject")?;
+        let mut builder = ClassBuilder::new(c"JuneNotificationCenterDelegate", superclass)?;
+        unsafe {
+            builder.add_method(
+                sel!(userNotificationCenter:shouldPresentNotification:),
+                should_present as extern "C-unwind" fn(_, _, _, _) -> _,
+            );
+            builder.add_method(
+                sel!(userNotificationCenter:didActivateNotification:),
+                did_activate as extern "C-unwind" fn(_, _, _, _),
+            );
+        }
+        Some(builder.register())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn activation_before_ready_is_queued_for_the_handshake() {
+        let mut queue = AgentOpenQueue::new();
+        assert_eq!(queue.on_activation(Some("session-1".to_string())), None);
+        assert_eq!(queue.mark_ready(), Some("session-1".to_string()));
+    }
+
+    #[test]
+    fn activation_after_ready_is_delivered_immediately() {
+        let mut queue = AgentOpenQueue::new();
+        assert_eq!(queue.mark_ready(), None);
+        assert_eq!(
+            queue.on_activation(Some("session-2".to_string())),
+            Some("session-2".to_string())
+        );
+    }
+
+    #[test]
+    fn later_click_replaces_a_queued_one() {
+        let mut queue = AgentOpenQueue::new();
+        assert_eq!(queue.on_activation(Some("session-old".to_string())), None);
+        assert_eq!(queue.on_activation(Some("session-new".to_string())), None);
+        assert_eq!(queue.mark_ready(), Some("session-new".to_string()));
+    }
+
+    #[test]
+    fn clicks_without_a_session_are_ignored_by_the_queue() {
+        let mut queue = AgentOpenQueue::new();
+        assert_eq!(queue.on_activation(None), None);
+        assert_eq!(queue.mark_ready(), None);
+    }
+
+    #[test]
+    fn ready_handshake_drains_the_pending_click_once() {
+        let mut queue = AgentOpenQueue::new();
+        queue.on_activation(Some("session-3".to_string()));
+        assert_eq!(queue.mark_ready(), Some("session-3".to_string()));
+        assert_eq!(queue.mark_ready(), None);
+    }
+
+    #[test]
+    fn notification_request_accepts_camel_case_session_id() {
+        let request: AppNotificationRequest = serde_json::from_value(serde_json::json!({
+            "title": "June finished",
+            "body": "Make a PDF",
+            "sound": "Ping",
+            "sessionId": "session-4"
+        }))
+        .expect("request should deserialize");
+        assert_eq!(request.session_id.as_deref(), Some("session-4"));
+        assert_eq!(request.sound.as_deref(), Some("Ping"));
+    }
+}

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -73,9 +73,11 @@ impl AgentOpenQueue {
     /// may land on no listener. The frontend drains the queue after handling
     /// an event, and the next `mark_ready` recovers anything that was lost.
     fn on_activation(&mut self, session_id: Option<String>) -> Option<String> {
+        // Last click wins, generic clicks included: a click without a session
+        // (recording notifications) must clear a stale queued agent open so
+        // the next ready handshake cannot hijack it into an unrelated chat.
+        self.pending_session_id = session_id.clone();
         let session_id = session_id?;
-        // Last click wins: the user's most recent choice is the one to honor.
-        self.pending_session_id = Some(session_id.clone());
         self.frontend_ready.then_some(session_id)
     }
 
@@ -404,6 +406,14 @@ mod tests {
     #[test]
     fn clicks_without_a_session_are_ignored_by_the_queue() {
         let mut queue = AgentOpenQueue::new();
+        assert_eq!(queue.on_activation(None), None);
+        assert_eq!(queue.mark_ready(), None);
+    }
+
+    #[test]
+    fn generic_click_clears_a_stale_queued_agent_open() {
+        let mut queue = AgentOpenQueue::new();
+        assert_eq!(queue.on_activation(Some("session-old".to_string())), None);
         assert_eq!(queue.on_activation(None), None);
         assert_eq!(queue.mark_ready(), None);
     }

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -40,6 +40,10 @@ pub struct AppNotificationRequest {
     body: String,
     #[serde(default)]
     sound: Option<String>,
+    /// Per-session grouping, honored by the plugin fallback (the macOS
+    /// native path has no NSUserNotification equivalent).
+    #[serde(default)]
+    group: Option<String>,
     /// Agent session to open when the user clicks the notification.
     #[serde(default)]
     session_id: Option<String>,
@@ -63,16 +67,16 @@ impl AgentOpenQueue {
     }
 
     /// Records a notification click. Returns the session id when the frontend
-    /// can receive it immediately; otherwise queues it for `mark_ready`.
+    /// can receive it immediately. The click stays queued either way: the
+    /// ready flag can outlive the listeners it describes (webview reload
+    /// tears them down without telling the native side), so an emitted event
+    /// may land on no listener. The frontend drains the queue after handling
+    /// an event, and the next `mark_ready` recovers anything that was lost.
     fn on_activation(&mut self, session_id: Option<String>) -> Option<String> {
         let session_id = session_id?;
-        if self.frontend_ready {
-            Some(session_id)
-        } else {
-            // Last click wins: the user's most recent choice is the one to honor.
-            self.pending_session_id = Some(session_id);
-            None
-        }
+        // Last click wins: the user's most recent choice is the one to honor.
+        self.pending_session_id = Some(session_id.clone());
+        self.frontend_ready.then_some(session_id)
     }
 
     /// Frontend listeners are registered; returns any click that arrived early.
@@ -121,6 +125,9 @@ fn send_via_plugin(app: &AppHandle, request: &AppNotificationRequest) -> Result<
         .body(&request.body);
     if let Some(sound) = &request.sound {
         builder = builder.sound(sound);
+    }
+    if let Some(group) = &request.group {
+        builder = builder.group(group);
     }
     builder.show().map_err(|error| error.to_string())
 }
@@ -373,6 +380,20 @@ mod tests {
     }
 
     #[test]
+    fn delivered_click_stays_queued_until_drained() {
+        // The ready flag can be stale across a webview reload, so an emitted
+        // click must remain recoverable by the next ready handshake.
+        let mut queue = AgentOpenQueue::new();
+        queue.mark_ready();
+        assert_eq!(
+            queue.on_activation(Some("session-2".to_string())),
+            Some("session-2".to_string())
+        );
+        assert_eq!(queue.mark_ready(), Some("session-2".to_string()));
+        assert_eq!(queue.mark_ready(), None);
+    }
+
+    #[test]
     fn later_click_replaces_a_queued_one() {
         let mut queue = AgentOpenQueue::new();
         assert_eq!(queue.on_activation(Some("session-old".to_string())), None);
@@ -401,10 +422,12 @@ mod tests {
             "title": "June finished",
             "body": "Make a PDF",
             "sound": "Ping",
+            "group": "june-agent-session-4",
             "sessionId": "session-4"
         }))
         .expect("request should deserialize");
         assert_eq!(request.session_id.as_deref(), Some("session-4"));
         assert_eq!(request.sound.as_deref(), Some("Ping"));
+        assert_eq!(request.group.as_deref(), Some("june-agent-session-4"));
     }
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -93,6 +93,7 @@ import {
   updateNote,
   agentHudHide,
   agentHudShow,
+  agentOpenReady,
   type LiveTranscriptEventDto,
 } from "../lib/tauri";
 import { playRecordingSound, preloadRecordingSounds } from "../lib/recording-sounds";
@@ -1620,26 +1621,64 @@ export function App() {
   }, [openSettings]);
 
   useEffect(() => {
+    let aborted = false;
+
     function openAgentWorkspace(session?: HermesSessionInfo) {
       setAgentOrigin(undefined);
       setActiveAgentSession(session);
       setActiveView("agent");
     }
 
-    function handleOpenEvent(event: Event) {
-      const detail = (event as CustomEvent<{ session?: HermesSessionInfo }>).detail;
-      openAgentWorkspace(detail?.session);
+    // Notification clicks carry only a session id (the session may have
+    // changed since the notification was posted). Resolve it against the
+    // known sessions, refreshing from the bridge when it is not cached; a
+    // session that no longer exists still opens the agent workspace rather
+    // than dropping the click on an unrelated view.
+    async function openAgentSessionById(sessionId: string) {
+      const cached = agentMenuBarSessionsRef.current.find((session) => session.id === sessionId);
+      if (cached) {
+        openAgentWorkspace(cached);
+        return;
+      }
+      const sessions = await listHermesSessions({}).catch(() => []);
+      if (aborted) return;
+      openAgentWorkspace(sessions.find((session) => session.id === sessionId));
     }
 
-    let aborted = false;
+    function handleOpenPayload(payload?: { session?: HermesSessionInfo; sessionId?: string }) {
+      if (payload?.session) {
+        openAgentWorkspace(payload.session);
+        return;
+      }
+      if (payload?.sessionId) {
+        void openAgentSessionById(payload.sessionId);
+        return;
+      }
+      openAgentWorkspace(undefined);
+    }
+
+    function handleOpenEvent(event: Event) {
+      handleOpenPayload(
+        (event as CustomEvent<{ session?: HermesSessionInfo; sessionId?: string }>).detail,
+      );
+    }
+
     let unlisten: (() => void) | undefined;
     window.addEventListener(AGENT_OPEN_EVENT, handleOpenEvent);
-    void listen<{ session?: HermesSessionInfo }>(AGENT_OPEN_EVENT, (event) => {
-      openAgentWorkspace(event.payload?.session);
+    void listen<{ session?: HermesSessionInfo; sessionId?: string }>(AGENT_OPEN_EVENT, (event) => {
+      handleOpenPayload(event.payload);
     }).then((cleanup) => {
       if (aborted) cleanup();
       else unlisten = cleanup;
     });
+
+    // Listeners are registered; drain a notification click that launched the
+    // app before the webview could hear the open event.
+    void agentOpenReady()
+      .then((sessionId) => {
+        if (!aborted && sessionId) void openAgentSessionById(sessionId);
+      })
+      .catch(() => {});
 
     return () => {
       aborted = true;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1633,15 +1633,19 @@ export function App() {
     // changed since the notification was posted). Resolve it against the
     // known sessions, refreshing from the bridge when it is not cached; a
     // session that no longer exists still opens the agent workspace rather
-    // than dropping the click on an unrelated view.
+    // than dropping the click on an unrelated view. The sequence counter
+    // keeps a slow lookup for an older click from overriding a newer one.
+    let openSequence = 0;
     async function openAgentSessionById(sessionId: string) {
+      openSequence += 1;
+      const sequence = openSequence;
       const cached = agentMenuBarSessionsRef.current.find((session) => session.id === sessionId);
       if (cached) {
         openAgentWorkspace(cached);
         return;
       }
       const sessions = await listHermesSessions({}).catch(() => []);
-      if (aborted) return;
+      if (aborted || sequence !== openSequence) return;
       openAgentWorkspace(sessions.find((session) => session.id === sessionId));
     }
 
@@ -1652,6 +1656,9 @@ export function App() {
       }
       if (payload?.sessionId) {
         void openAgentSessionById(payload.sessionId);
+        // The backend keeps the clicked session queued in case the emit
+        // raced a webview reload; this event was received, so drain it.
+        void agentOpenReady().catch(() => {});
         return;
       }
       openAgentWorkspace(undefined);

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1631,10 +1631,16 @@ export function App() {
 
     // Notification clicks carry only a session id (the session may have
     // changed since the notification was posted). Resolve it against the
-    // known sessions, refreshing from the bridge when it is not cached; a
-    // session that no longer exists still opens the agent workspace rather
-    // than dropping the click on an unrelated view. The sequence counter
-    // keeps a slow lookup for an older click from overriding a newer one.
+    // known sessions, refreshing from the bridge when it is not cached. The
+    // workspace opens immediately for feedback and upgrades to the chat when
+    // the lookup lands; a session that no longer exists stays on the agent
+    // view rather than dropping the click on an unrelated one. The sequence
+    // counter keeps a slow lookup for an older click from overriding a newer
+    // one. A cold start can reach this before the Hermes bridge is up, so a
+    // failed listing (as opposed to a successful listing that lacks the id)
+    // retries while the bridge boots instead of eating the click.
+    const sessionLookupAttempts = 20;
+    const sessionLookupRetryMs = 1_000;
     let openSequence = 0;
     async function openAgentSessionById(sessionId: string) {
       openSequence += 1;
@@ -1644,9 +1650,21 @@ export function App() {
         openAgentWorkspace(cached);
         return;
       }
-      const sessions = await listHermesSessions({}).catch(() => []);
-      if (aborted || sequence !== openSequence) return;
-      openAgentWorkspace(sessions.find((session) => session.id === sessionId));
+      openAgentWorkspace(undefined);
+      for (let attempt = 0; attempt < sessionLookupAttempts; attempt += 1) {
+        let sessions: HermesSessionInfo[];
+        try {
+          sessions = await listHermesSessions({});
+        } catch {
+          await new Promise((resolve) => window.setTimeout(resolve, sessionLookupRetryMs));
+          if (aborted || sequence !== openSequence) return;
+          continue;
+        }
+        if (aborted || sequence !== openSequence) return;
+        const session = sessions.find((candidate) => candidate.id === sessionId);
+        if (session) openAgentWorkspace(session);
+        return;
+      }
     }
 
     function handleOpenPayload(payload?: { session?: HermesSessionInfo; sessionId?: string }) {

--- a/src/lib/agent-notifications.ts
+++ b/src/lib/agent-notifications.ts
@@ -4,6 +4,7 @@ import {
   sendNotification,
 } from "@tauri-apps/plugin-notification";
 import type { AgentSessionStatusDetail, AgentSessionStatusKind } from "./agent-events";
+import { sendAppNotification } from "./tauri";
 
 type NotificationCopy = {
   title: string;
@@ -56,12 +57,25 @@ export async function notifyAgentSessionStatus(detail: AgentSessionStatusDetail)
   // so a permission denial does not swallow the next legitimate notification.
   recent.set(dedupeKey, now);
 
-  sendNotification({
-    title: copy.title,
-    body: copy.body,
-    group,
-    sound: NOTIFICATION_SOUND,
-  });
+  // The backend command owns delivery so clicking the notification can
+  // deep-link into the session (JUN-327). The plugin path stays as a
+  // fallback for environments without the command (it cannot deliver
+  // clicks, so those notifications just open the app).
+  try {
+    await sendAppNotification({
+      title: copy.title,
+      body: copy.body,
+      sound: NOTIFICATION_SOUND,
+      sessionId: detail.sessionId,
+    });
+  } catch {
+    sendNotification({
+      title: copy.title,
+      body: copy.body,
+      group,
+      sound: NOTIFICATION_SOUND,
+    });
+  }
   playAgentNotificationTone(detail.status);
   return true;
 }

--- a/src/lib/agent-notifications.ts
+++ b/src/lib/agent-notifications.ts
@@ -66,6 +66,7 @@ export async function notifyAgentSessionStatus(detail: AgentSessionStatusDetail)
       title: copy.title,
       body: copy.body,
       sound: NOTIFICATION_SOUND,
+      group,
       sessionId: detail.sessionId,
     });
   } catch {

--- a/src/lib/recording-notifications.ts
+++ b/src/lib/recording-notifications.ts
@@ -24,11 +24,7 @@ async function canNotify() {
 // (JUN-327). No sessionId here; clicking still just opens the app.
 async function deliver(notification: { title: string; body: string; group: string }) {
   try {
-    await sendAppNotification({
-      title: notification.title,
-      body: notification.body,
-      sound: NOTIFICATION_SOUND,
-    });
+    await sendAppNotification({ ...notification, sound: NOTIFICATION_SOUND });
   } catch {
     await sendNotification({ ...notification, sound: NOTIFICATION_SOUND });
   }

--- a/src/lib/recording-notifications.ts
+++ b/src/lib/recording-notifications.ts
@@ -4,6 +4,7 @@ import {
   sendNotification,
 } from "@tauri-apps/plugin-notification";
 import { RECORDING_INACTIVITY_RESPONSE_MS } from "./recording-inactivity";
+import { sendAppNotification } from "./tauri";
 
 const NOTIFICATION_SOUND = "Ping";
 const RESPONSE_SECONDS = Math.round(RECORDING_INACTIVITY_RESPONSE_MS / 1000);
@@ -17,14 +18,29 @@ async function canNotify() {
   return granted;
 }
 
+// Recording notifications go through the same backend command as agent ones:
+// the plugin's desktop sender replaces the notification-center delegate on
+// every send, which would break click deep-linking for agent notifications
+// (JUN-327). No sessionId here; clicking still just opens the app.
+async function deliver(notification: { title: string; body: string; group: string }) {
+  try {
+    await sendAppNotification({
+      title: notification.title,
+      body: notification.body,
+      sound: NOTIFICATION_SOUND,
+    });
+  } catch {
+    await sendNotification({ ...notification, sound: NOTIFICATION_SOUND });
+  }
+}
+
 export async function notifyRecordingStillMeetingPrompt(sessionId: string) {
   if (!(await canNotify())) return false;
   try {
-    await sendNotification({
+    await deliver({
       title: "Still in a meeting?",
       body: `June will pause the recording in ${RESPONSE_SECONDS} seconds if you do not answer.`,
       group: `june-recording-${sessionId}`,
-      sound: NOTIFICATION_SOUND,
     });
     return true;
   } catch {
@@ -35,11 +51,10 @@ export async function notifyRecordingStillMeetingPrompt(sessionId: string) {
 export async function notifyRecordingAutoPaused(sessionId: string) {
   if (!(await canNotify())) return false;
   try {
-    await sendNotification({
+    await deliver({
       title: "June paused recording",
       body: "No meeting audio was detected. Open June to resume or finish.",
       group: `june-recording-${sessionId}`,
-      sound: NOTIFICATION_SOUND,
     });
     return true;
   } catch {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -861,6 +861,24 @@ export async function agentHudOpenAgent(session?: HermesSessionInfo) {
   return invoke<void>("agent_hud_open_agent", { session });
 }
 
+export async function sendAppNotification(input: {
+  title: string;
+  body: string;
+  sound?: string;
+  sessionId?: string;
+}) {
+  return invoke<void>("send_app_notification", { request: input });
+}
+
+/**
+ * Tells the backend the webview can receive "june:agent:open" events and
+ * returns the session id of a notification clicked before that (the click
+ * launched the app), so bootstrap can navigate straight to it.
+ */
+export async function agentOpenReady() {
+  return invoke<string | null>("agent_open_ready");
+}
+
 export async function createAgentTask(input: {
   prompt: string;
   title?: string;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -865,6 +865,7 @@ export async function sendAppNotification(input: {
   title: string;
   body: string;
   sound?: string;
+  group?: string;
   sessionId?: string;
 }) {
   return invoke<void>("send_app_notification", { request: input });

--- a/src/test/agent-notifications.test.ts
+++ b/src/test/agent-notifications.test.ts
@@ -6,7 +6,12 @@ const notificationMocks = vi.hoisted(() => ({
   sendNotification: vi.fn(),
 }));
 
+const tauriMocks = vi.hoisted(() => ({
+  sendAppNotification: vi.fn(),
+}));
+
 vi.mock("@tauri-apps/plugin-notification", () => notificationMocks);
+vi.mock("../lib/tauri", () => tauriMocks);
 
 import { agentNotificationCopy, notifyAgentSessionStatus } from "../lib/agent-notifications";
 
@@ -53,8 +58,9 @@ describe("agent notifications", () => {
     expect(notificationMocks.sendNotification).not.toHaveBeenCalled();
   });
 
-  it("sends notifications for user attention and completion", async () => {
+  it("sends notifications for user attention and completion with the session id", async () => {
     notificationMocks.isPermissionGranted.mockResolvedValue(true);
+    tauriMocks.sendAppNotification.mockResolvedValue(undefined);
 
     await expect(
       notifyAgentSessionStatus({
@@ -65,17 +71,19 @@ describe("agent notifications", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(notificationMocks.sendNotification).toHaveBeenCalledWith({
+    expect(tauriMocks.sendAppNotification).toHaveBeenCalledWith({
       title: "June needs your input",
       body: "Approve execute_code.",
-      group: "june-agent-session-1",
       sound: "Ping",
+      sessionId: "session-1",
     });
+    expect(notificationMocks.sendNotification).not.toHaveBeenCalled();
   });
 
   it("requests native notification permission when needed", async () => {
     notificationMocks.isPermissionGranted.mockResolvedValue(false);
     notificationMocks.requestPermission.mockResolvedValue("granted");
+    tauriMocks.sendAppNotification.mockResolvedValue(undefined);
 
     await expect(
       notifyAgentSessionStatus({
@@ -86,16 +94,37 @@ describe("agent notifications", () => {
     ).resolves.toBe(true);
 
     expect(notificationMocks.requestPermission).toHaveBeenCalledOnce();
+    expect(tauriMocks.sendAppNotification).toHaveBeenCalledWith({
+      title: "June finished",
+      body: "Make a PDF",
+      sound: "Ping",
+      sessionId: "session-2",
+    });
+  });
+
+  it("falls back to the plugin when the backend command is unavailable", async () => {
+    notificationMocks.isPermissionGranted.mockResolvedValue(true);
+    tauriMocks.sendAppNotification.mockRejectedValue(new Error("unknown command"));
+
+    await expect(
+      notifyAgentSessionStatus({
+        sessionId: "session-fallback",
+        status: "completed",
+        title: "Make a PDF",
+      }),
+    ).resolves.toBe(true);
+
     expect(notificationMocks.sendNotification).toHaveBeenCalledWith({
       title: "June finished",
       body: "Make a PDF",
-      group: "june-agent-session-2",
+      group: "june-agent-session-fallback",
       sound: "Ping",
     });
   });
 
   it("dedupes duplicate status notifications", async () => {
     notificationMocks.isPermissionGranted.mockResolvedValue(true);
+    tauriMocks.sendAppNotification.mockResolvedValue(undefined);
 
     await notifyAgentSessionStatus({
       sessionId: "session-3",
@@ -108,12 +137,13 @@ describe("agent notifications", () => {
       title: "Make a PDF",
     });
 
-    expect(notificationMocks.sendNotification).toHaveBeenCalledOnce();
+    expect(tauriMocks.sendAppNotification).toHaveBeenCalledOnce();
   });
 
   it("does not consume the dedupe slot when permission is not granted", async () => {
     notificationMocks.isPermissionGranted.mockResolvedValue(false);
     notificationMocks.requestPermission.mockResolvedValue("denied");
+    tauriMocks.sendAppNotification.mockResolvedValue(undefined);
 
     await expect(
       notifyAgentSessionStatus({
@@ -122,7 +152,7 @@ describe("agent notifications", () => {
         title: "Make a PDF",
       }),
     ).resolves.toBe(false);
-    expect(notificationMocks.sendNotification).not.toHaveBeenCalled();
+    expect(tauriMocks.sendAppNotification).not.toHaveBeenCalled();
 
     notificationMocks.isPermissionGranted.mockResolvedValue(true);
 
@@ -133,13 +163,14 @@ describe("agent notifications", () => {
         title: "Make a PDF",
       }),
     ).resolves.toBe(true);
-    expect(notificationMocks.sendNotification).toHaveBeenCalledOnce();
+    expect(tauriMocks.sendAppNotification).toHaveBeenCalledOnce();
   });
 
   it("prunes dedupe entries older than the window", async () => {
     vi.useFakeTimers();
     try {
       notificationMocks.isPermissionGranted.mockResolvedValue(true);
+      tauriMocks.sendAppNotification.mockResolvedValue(undefined);
 
       await notifyAgentSessionStatus({
         sessionId: "session-5",
@@ -153,7 +184,7 @@ describe("agent notifications", () => {
         title: "Second",
       });
 
-      expect(notificationMocks.sendNotification).toHaveBeenCalledTimes(2);
+      expect(tauriMocks.sendAppNotification).toHaveBeenCalledTimes(2);
       const recent = (
         globalThis as typeof globalThis & {
           __juneAgentNotificationTimes?: Map<string, number>;

--- a/src/test/agent-notifications.test.ts
+++ b/src/test/agent-notifications.test.ts
@@ -75,6 +75,7 @@ describe("agent notifications", () => {
       title: "June needs your input",
       body: "Approve execute_code.",
       sound: "Ping",
+      group: "june-agent-session-1",
       sessionId: "session-1",
     });
     expect(notificationMocks.sendNotification).not.toHaveBeenCalled();
@@ -98,6 +99,7 @@ describe("agent notifications", () => {
       title: "June finished",
       body: "Make a PDF",
       sound: "Ping",
+      group: "june-agent-session-2",
       sessionId: "session-2",
     });
   });

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -42,6 +42,7 @@ const mocks = vi.hoisted(() => ({
   osAccountsLogout: vi.fn(),
   osAccountsUpgrade: vi.fn(),
   agentHudShow: vi.fn(),
+  agentOpenReady: vi.fn().mockResolvedValue(null),
   agentHudHide: vi.fn(),
   playRecordingSound: vi.fn(),
   preloadRecordingSounds: vi.fn(),
@@ -107,6 +108,7 @@ vi.mock("../lib/tauri", () => ({
   osAccountsLogout: mocks.osAccountsLogout,
   osAccountsUpgrade: mocks.osAccountsUpgrade,
   agentHudShow: mocks.agentHudShow,
+  agentOpenReady: mocks.agentOpenReady,
   agentHudHide: mocks.agentHudHide,
   // The agent workspace mounts at launch; a quiet, not-running bridge keeps
   // these tests focused on the meetings surfaces.

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -62,6 +62,7 @@ const mocks = vi.hoisted(() => ({
   osAccountsUpgradeSession: vi.fn(),
   osAccountsChangePlan: vi.fn(),
   agentHudShow: vi.fn(),
+  agentOpenReady: vi.fn().mockResolvedValue(null),
   agentHudHide: vi.fn(),
   playRecordingSound: vi.fn(),
   preloadRecordingSounds: vi.fn(),
@@ -133,6 +134,7 @@ vi.mock("../lib/tauri", () => ({
   osAccountsUpgradeSession: mocks.osAccountsUpgradeSession,
   osAccountsChangePlan: mocks.osAccountsChangePlan,
   agentHudShow: mocks.agentHudShow,
+  agentOpenReady: mocks.agentOpenReady,
   agentHudHide: mocks.agentHudHide,
   // The agent workspace mounts at launch; a quiet, not-running bridge keeps
   // these tests focused on the meetings surfaces.

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -1555,4 +1555,27 @@ describe("App shortcuts", () => {
 
     expect(await screen.findByRole("button", { name: "Send message" })).toBeInTheDocument();
   });
+
+  it("retries the notified-chat lookup while the Hermes bridge is still starting", async () => {
+    mocks.agentOpenReady.mockResolvedValue("session-9");
+    let sessionListCalls = 0;
+    mocks.listHermesSessions.mockImplementation(async () => {
+      sessionListCalls += 1;
+      if (sessionListCalls <= 2) throw new Error("hermes_bridge_not_running");
+      return [
+        {
+          id: "session-9",
+          title: "Notified session",
+          preview: "Notified session preview",
+          last_active: now,
+        },
+      ];
+    });
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole("button", { name: "Send message" }, { timeout: 8_000 }),
+    ).toBeInTheDocument();
+  }, 15_000);
 });

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
 import { HERO_GREETINGS } from "../components/agent/AgentWorkspace";
 import { MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
-import { AGENT_NEW_SESSION_EVENT, AGENT_SESSIONS_CHANGED_EVENT } from "../lib/agent-events";
+import {
+  AGENT_NEW_SESSION_EVENT,
+  AGENT_OPEN_EVENT,
+  AGENT_SESSIONS_CHANGED_EVENT,
+} from "../lib/agent-events";
 import { CLOSE_TAB_EVENT, OPEN_SETTINGS_EVENT } from "../lib/menu-bar";
 import type {
   AccountStatus,
@@ -76,6 +80,7 @@ const mocks = vi.hoisted(() => ({
   osAccountsLogout: vi.fn(),
   osAccountsUpgrade: vi.fn(),
   agentHudShow: vi.fn(),
+  agentOpenReady: vi.fn().mockResolvedValue(null),
   agentHudHide: vi.fn(),
   ensureHermesBridgeSession: vi.fn(),
   finalizeHermesBridgeBranch: vi.fn(),
@@ -194,6 +199,7 @@ vi.mock("../lib/tauri", () => ({
   osAccountsLogout: mocks.osAccountsLogout,
   osAccountsUpgrade: mocks.osAccountsUpgrade,
   agentHudShow: mocks.agentHudShow,
+  agentOpenReady: mocks.agentOpenReady,
   agentHudHide: mocks.agentHudHide,
   ensureHermesBridgeSession: mocks.ensureHermesBridgeSession,
   finalizeHermesBridgeBranch: mocks.finalizeHermesBridgeBranch,
@@ -354,6 +360,7 @@ describe("App shortcuts", () => {
     mocks.hermesBridgeStatus.mockResolvedValue({
       running: false,
     });
+    mocks.agentOpenReady.mockResolvedValue(null);
     mocks.listAgentTasks.mockResolvedValue({ items: [] });
     mocks.listHermesSessionMessages.mockResolvedValue([]);
     mocks.listHermesSessions.mockResolvedValue([]);
@@ -1493,5 +1500,59 @@ describe("App shortcuts", () => {
     expect(await screen.findByRole("heading", { name: HERO_GREETING })).toBeInTheDocument();
     expect(mocks.bootstrapApp).toHaveBeenCalledOnce();
     expect(screen.queryByRole("button", { name: "Continue with OpenSoftware" })).toBeNull();
+  });
+
+  it("opens the chat for a notification click carrying a session id", async () => {
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-9",
+        title: "Notified session",
+        preview: "Notified session preview",
+        last_active: now,
+      },
+    ]);
+
+    render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_OPEN_EVENT, { detail: { sessionId: "session-9" } }),
+      );
+    });
+
+    expect(await screen.findByRole("button", { name: "Send message" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: HERO_GREETING })).not.toBeInTheDocument();
+  });
+
+  it("falls back to the agent view when the notified chat is missing", async () => {
+    mocks.listHermesSessions.mockResolvedValue([]);
+
+    render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_OPEN_EVENT, { detail: { sessionId: "session-gone" } }),
+      );
+    });
+
+    expect(await screen.findByRole("heading", { name: HERO_GREETING })).toBeInTheDocument();
+  });
+
+  it("navigates to the chat of a notification clicked before the webview was ready", async () => {
+    mocks.agentOpenReady.mockResolvedValue("session-9");
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-9",
+        title: "Notified session",
+        preview: "Notified session preview",
+        last_active: now,
+      },
+    ]);
+
+    render(<App />);
+
+    expect(await screen.findByRole("button", { name: "Send message" })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What changed

Closes JUN-327.

Clicking a June notification for an agent session (completed, failed, cancelled, needs input) now opens that session's chat instead of just activating the app.

- **June owns macOS notification posting** (`src-tauri/src/notifications.rs`). The notification plugin's desktop backend (`mac-notification-sys`) installs a throwaway delegate on the shared `NSUserNotificationCenter` on every send and never reports clicks, so click-through was impossible while it posted. June now installs one permanent center delegate at setup and posts agent/recording notifications itself, carrying the agent session id in `userInfo`.
- **Click routing**: the delegate focuses the main window and emits the existing `june:agent:open` event with `{ sessionId }`. `App.tsx` resolves the id against cached sessions, refreshes from the Hermes bridge when missing, and falls back to the agent view (not an unrelated view) when the session no longer exists.
- **Cold start**: a click can launch the app before the webview has listeners, so activations go through a ready/pending handshake: the frontend calls `agent_open_ready` once listeners are registered and receives any session id clicked while it could not listen. Last click wins.
- **Recording notifications** route through the same backend command (without a session id) so plugin sends cannot replace the delegate and silently break agent click-through.
- **Fallbacks**: non-macOS platforms and unbundled dev runs (no bundle id, where the center drops deliveries) keep the plugin path: same visuals, no click-through, matching today's behavior.

## Why

Completion notifications opened the app generally and users had to find the finished conversation manually. The wire for session-scoped navigation already existed (`june:agent:open` from the agent HUD); notifications just had no way to deliver a click.

## Validation

- `pnpm exec biome check --diagnostic-level=error`: clean.
- `pnpm test`: 2634 passed, 2 skipped. Includes new coverage: notification payload carries the session id, plugin fallback on command failure, and three App-level tests (open event with a known session id opens that chat; unknown id falls back to the agent view; a pending pre-webview click navigates on bootstrap).
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`: full suite green, including new unit tests for the ready/pending activation queue and request deserialization.
- `cargo clippy` and `cargo fmt --check` on src-tauri: clean.
- `pnpm tauri build --debug` produces a working bundle; the QA instance booted in an isolated profile, created an agent session, and posted through the native path.

## Live walkthrough

Partially run, then intentionally cut short: the bundled QA app booted in a scratch profile and an agent session was driven live, but the walkthrough needs foreground desktop automation (clicking a real macOS notification banner) and the user asked for that to stop because it interrupted their active work. The native click path is covered by the delegate unit tests, the handshake tests, and the App-level navigation tests above. Happy to record the banner-click demo later on request.

## Known gaps

- `NSUserNotification` is deprecated (no replacement wired for `UNUserNotificationCenter`, which requires signed-bundle entitlements and a different permission model); it is the same API the plugin already used, so runtime behavior is unchanged.
- Windows/Linux keep plugin behavior (click focuses the app, no deep link); Windows toast activation would be a separate change.
- Unbundled `tauri dev` keeps plugin behavior by design (the center drops deliveries without a bundle id), so the deep link is only exercisable in a bundled build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786649207&installation_id=144203540&pr_number=758&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F758&signature=127faf6b55f08d0a7449dffef5dada7dca1ed3f3d0e1efd601d4424765b3297b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->