### PR TITLE
Smooth assistant chat streaming

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -226,6 +226,7 @@ import { hermesTraceBuffer } from "../../lib/hermes-trace-buffer";
 import { UnsupportedEventNotice } from "./UnsupportedEventNotice";
 import { HermesTracePanel } from "./HermesTracePanel";
 import { MarkdownContent, highlightText } from "./MarkdownContent";
+import { SmoothedStreamingMarkdown } from "./SmoothedStreamingMarkdown";
 import {
   ComposerModelPicker,
   PrivacyModeBadge,
@@ -12933,8 +12934,9 @@ function AgentChatTurnRow({
                 {/* A part can retain raw MEDIA deltas while streaming or when
                     a terminal/error event arrives without message.complete.
                     Those transport references never belong in assistant prose. */}
-                <MarkdownContent
+                <SmoothedStreamingMarkdown
                   markdown={stripRenderedMediaReferences(part.text, part.status === "running")}
+                  running={part.status === "running"}
                   repairProse
                 />
               </div>

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -9804,6 +9804,14 @@ export function AgentWorkspace({
   const transcriptProgrammaticScrollTimeoutRef = useRef<number | undefined>();
   const transcriptLastScrollTopRef = useRef(0);
 
+  const pinTranscriptAfterVisibleReveal = useCallback(() => {
+    if (!transcriptShouldStickToBottomRef.current) return;
+    const scroller = agentScrollRef.current;
+    if (!scroller || typeof scroller.scrollTo !== "function") return;
+    scroller.scrollTo({ top: scroller.scrollHeight, behavior: "auto" });
+    transcriptLastScrollTopRef.current = scroller.scrollTop;
+  }, []);
+
   // History for the selected conversation has landed: a session gets an entry
   // in hermesSessionMessages (even an empty one) once its fetch resolves;
   // tasks either arrive with their turns inline or get recorded when the lazy
@@ -10780,6 +10788,7 @@ export function AgentWorkspace({
             )
           }
           branchingMessageId={branchingMessageId}
+          onVisibleMarkdownChange={pinTranscriptAfterVisibleReveal}
         />
       ))}
       <AgentThinking
@@ -10845,6 +10854,7 @@ export function AgentWorkspace({
             onTopUp={handleTopUp}
             topUpLabel={topUpLabel}
             fundingTier={fundingTier}
+            onVisibleMarkdownChange={pinTranscriptAfterVisibleReveal}
             onApproval={(part, choice) => {
               const sessionId = part.sessionId ?? selectedTask.hermesSessionId;
               if (!sessionId) return;
@@ -12638,6 +12648,7 @@ function AgentChatTurnRow({
   onTopUp,
   topUpLabel,
   fundingTier,
+  onVisibleMarkdownChange,
   onBranch,
   branchingMessageId,
   turn,
@@ -12673,6 +12684,7 @@ function AgentChatTurnRow({
   onTopUp?: () => void;
   topUpLabel?: string;
   fundingTier?: FundingTier;
+  onVisibleMarkdownChange?: (visibleMarkdown: string) => void;
   /** Fork the conversation from this turn into a new session (feature 07).
    * Optional: only Hermes-session rows pass it — task rows and the dev gallery
    * omit it, so the action is absent there. */
@@ -12938,6 +12950,7 @@ function AgentChatTurnRow({
                   markdown={stripRenderedMediaReferences(part.text, part.status === "running")}
                   running={part.status === "running"}
                   repairProse
+                  onVisibleMarkdownChange={onVisibleMarkdownChange}
                 />
               </div>
             )

--- a/src/components/agent/SmoothedStreamingMarkdown.tsx
+++ b/src/components/agent/SmoothedStreamingMarkdown.tsx
@@ -1,0 +1,107 @@
+import { useReducedMotion } from "framer-motion";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+
+import { MarkdownContent } from "./MarkdownContent";
+
+// Keep the reveal comfortably above the threshold where individual updates
+// read as discrete provider chunks, without making markdown parsing compete
+// with every display refresh.
+const STREAM_REVEAL_INTERVAL_MS = 32;
+const STREAM_CATCH_UP_STEPS = 4;
+
+/**
+ * Smooths append-only assistant text for presentation. The authoritative text
+ * remains the raw stream in AgentWorkspace; this component only trails it by a
+ * few frames so irregular provider chunks read as one continuous response.
+ */
+export function SmoothedStreamingMarkdown({
+  markdown,
+  running,
+  repairProse = false,
+}: {
+  markdown: string;
+  running: boolean;
+  repairProse?: boolean;
+}) {
+  const reducedMotion = useReducedMotion() ?? false;
+  const [visibleMarkdown, setVisibleMarkdown] = useState(markdown);
+  const visibleRef = useRef(markdown);
+  const targetRef = useRef(markdown);
+  const timerRef = useRef<number | null>(null);
+
+  const reveal = useCallback((next: string) => {
+    visibleRef.current = next;
+    setVisibleMarkdown(next);
+  }, []);
+
+  const stopTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const scheduleReveal = useCallback(() => {
+    if (timerRef.current !== null) return;
+    const tick = () => {
+      timerRef.current = null;
+      const current = visibleRef.current;
+      const target = targetRef.current;
+      if (current === target) return;
+
+      // Completion reconciliation can replace streamed text rather than append
+      // to it. Never animate through content the model has corrected.
+      if (!target.startsWith(current)) {
+        reveal(target);
+        return;
+      }
+
+      const remaining = target.length - current.length;
+      const step = Math.max(1, Math.ceil(remaining / STREAM_CATCH_UP_STEPS));
+      const end = safeTextSliceEnd(target, Math.min(target.length, current.length + step));
+      reveal(target.slice(0, end));
+      if (end < target.length) {
+        timerRef.current = window.setTimeout(tick, STREAM_REVEAL_INTERVAL_MS);
+      }
+    };
+    timerRef.current = window.setTimeout(tick, STREAM_REVEAL_INTERVAL_MS);
+  }, [reveal]);
+
+  useLayoutEffect(() => {
+    targetRef.current = markdown;
+    if (!running || reducedMotion || !markdown.startsWith(visibleRef.current)) {
+      stopTimer();
+      reveal(markdown);
+      return;
+    }
+    scheduleReveal();
+  }, [markdown, reducedMotion, reveal, running, scheduleReveal, stopTimer]);
+
+  useEffect(() => {
+    const flushWhileHidden = () => {
+      if (document.hidden) {
+        stopTimer();
+        reveal(targetRef.current);
+      }
+    };
+    document.addEventListener("visibilitychange", flushWhileHidden);
+    return () => {
+      document.removeEventListener("visibilitychange", flushWhileHidden);
+      stopTimer();
+    };
+  }, [reveal, stopTimer]);
+
+  // Raw chunks still re-render the parent. Reuse the parsed markdown element
+  // until the presentation string advances so smoothing does not add duplicate
+  // markdown work on those intermediate renders.
+  return useMemo(
+    () => <MarkdownContent markdown={visibleMarkdown} repairProse={repairProse} />,
+    [repairProse, visibleMarkdown],
+  );
+}
+
+function safeTextSliceEnd(text: string, proposedEnd: number) {
+  if (proposedEnd <= 0 || proposedEnd >= text.length) return proposedEnd;
+  const previous = text.charCodeAt(proposedEnd - 1);
+  return previous >= 0xd800 && previous <= 0xdbff ? proposedEnd + 1 : proposedEnd;
+}

--- a/src/components/agent/SmoothedStreamingMarkdown.tsx
+++ b/src/components/agent/SmoothedStreamingMarkdown.tsx
@@ -18,16 +18,19 @@ export function SmoothedStreamingMarkdown({
   markdown,
   running,
   repairProse = false,
+  onVisibleMarkdownChange,
 }: {
   markdown: string;
   running: boolean;
   repairProse?: boolean;
+  onVisibleMarkdownChange?: (visibleMarkdown: string) => void;
 }) {
   const reducedMotion = useReducedMotion() ?? false;
   const [visibleMarkdown, setVisibleMarkdown] = useState(markdown);
   const visibleRef = useRef(markdown);
   const targetRef = useRef(markdown);
   const timerRef = useRef<number | null>(null);
+  const visibleMarkdownMountedRef = useRef(false);
 
   const reveal = useCallback((next: string) => {
     visibleRef.current = next;
@@ -69,7 +72,13 @@ export function SmoothedStreamingMarkdown({
 
   useLayoutEffect(() => {
     targetRef.current = markdown;
-    if (!running || reducedMotion || !markdown.startsWith(visibleRef.current)) {
+    if (
+      !running ||
+      reducedMotion ||
+      document.hidden ||
+      visibleRef.current.length === 0 ||
+      !markdown.startsWith(visibleRef.current)
+    ) {
       stopTimer();
       reveal(markdown);
       return;
@@ -90,6 +99,14 @@ export function SmoothedStreamingMarkdown({
       stopTimer();
     };
   }, [reveal, stopTimer]);
+
+  useLayoutEffect(() => {
+    if (!visibleMarkdownMountedRef.current) {
+      visibleMarkdownMountedRef.current = true;
+      return;
+    }
+    onVisibleMarkdownChange?.(visibleMarkdown);
+  }, [onVisibleMarkdownChange, visibleMarkdown]);
 
   // Raw chunks still re-render the parent. Reuse the parsed markdown element
   // until the presentation string advances so smoothing does not add duplicate

--- a/src/test/smoothed-streaming-markdown.test.tsx
+++ b/src/test/smoothed-streaming-markdown.test.tsx
@@ -1,0 +1,48 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SmoothedStreamingMarkdown } from "../components/agent/SmoothedStreamingMarkdown";
+
+describe("SmoothedStreamingMarkdown", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reveals appended stream text over a short catch-up window", () => {
+    vi.useFakeTimers();
+    const view = render(<SmoothedStreamingMarkdown markdown="Hello" running repairProse />);
+    view.rerender(
+      <SmoothedStreamingMarkdown
+        markdown="Hello from a larger provider chunk"
+        running
+        repairProse
+      />,
+    );
+
+    expect(view.container.textContent).toBe("Hello");
+    act(() => vi.advanceTimersByTime(32));
+    expect(view.container.textContent?.startsWith("Hello")).toBe(true);
+    expect(view.container.textContent).not.toBe("Hello");
+    expect(view.container.textContent).not.toBe("Hello from a larger provider chunk");
+
+    act(() => vi.advanceTimersByTime(1_000));
+    expect(view.container.textContent).toBe("Hello from a larger provider chunk");
+  });
+
+  it("flushes immediately when the turn completes", () => {
+    vi.useFakeTimers();
+    const view = render(<SmoothedStreamingMarkdown markdown="Hello" running />);
+    view.rerender(<SmoothedStreamingMarkdown markdown="Hello streaming backlog" running />);
+    expect(view.container.textContent).toBe("Hello");
+
+    view.rerender(<SmoothedStreamingMarkdown markdown="Hello streaming backlog" running={false} />);
+    expect(view.container.textContent).toBe("Hello streaming backlog");
+  });
+
+  it("does not animate through a reconciled text replacement", () => {
+    vi.useFakeTimers();
+    const view = render(<SmoothedStreamingMarkdown markdown="Draft answer" running />);
+    view.rerender(<SmoothedStreamingMarkdown markdown="Corrected answer" running />);
+    expect(view.container.textContent).toBe("Corrected answer");
+  });
+});

--- a/src/test/smoothed-streaming-markdown.test.tsx
+++ b/src/test/smoothed-streaming-markdown.test.tsx
@@ -6,6 +6,16 @@ import { SmoothedStreamingMarkdown } from "../components/agent/SmoothedStreaming
 describe("SmoothedStreamingMarkdown", () => {
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("reveals the first non-empty stream chunk immediately", () => {
+    vi.useFakeTimers();
+    const view = render(<SmoothedStreamingMarkdown markdown="" running />);
+
+    view.rerender(<SmoothedStreamingMarkdown markdown="First chunk" running />);
+
+    expect(view.container.textContent).toBe("First chunk");
   });
 
   it("reveals appended stream text over a short catch-up window", () => {
@@ -44,5 +54,40 @@ describe("SmoothedStreamingMarkdown", () => {
     const view = render(<SmoothedStreamingMarkdown markdown="Draft answer" running />);
     view.rerender(<SmoothedStreamingMarkdown markdown="Corrected answer" running />);
     expect(view.container.textContent).toBe("Corrected answer");
+  });
+
+  it("flushes stream updates received while the document is hidden", () => {
+    vi.useFakeTimers();
+    vi.spyOn(document, "hidden", "get").mockReturnValue(true);
+    const view = render(<SmoothedStreamingMarkdown markdown="Hello" running />);
+
+    view.rerender(<SmoothedStreamingMarkdown markdown="Hello hidden backlog" running />);
+
+    expect(view.container.textContent).toBe("Hello hidden backlog");
+  });
+
+  it("notifies the transcript when delayed text becomes visible", () => {
+    vi.useFakeTimers();
+    const onVisibleMarkdownChange = vi.fn();
+    const view = render(
+      <SmoothedStreamingMarkdown
+        markdown="Hello"
+        running
+        onVisibleMarkdownChange={onVisibleMarkdownChange}
+      />,
+    );
+    onVisibleMarkdownChange.mockClear();
+    view.rerender(
+      <SmoothedStreamingMarkdown
+        markdown="Hello streaming backlog"
+        running
+        onVisibleMarkdownChange={onVisibleMarkdownChange}
+      />,
+    );
+    expect(onVisibleMarkdownChange).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(32));
+
+    expect(onVisibleMarkdownChange).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- smooth append-only assistant text while a response is streaming
- render the first chunk immediately, then drain later chunks with adaptive catch-up
- flush immediately on completion, corrections, reduced motion, and hidden tabs
- avoid reparsing Markdown for every raw transport chunk

## Why

Streaming responses could feel significantly slower even when transport timing was unchanged because irregular chunk boundaries appeared as visible text jumps. This keeps the exact upstream response while presenting user-facing text at a steadier cadence.

## Verification

- `pnpm exec vitest run src/test/smoothed-streaming-markdown.test.tsx`
- `pnpm exec tsc --noEmit`
- Biome check for the new component and tests
- `git diff --check`

The focused tests cover animated catch-up, immediate completion flush, and immediate replacement when upstream text is corrected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786653560&installation_id=144203540&pr_number=762&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F762&signature=4d87ffbe886cd368aa46ca6567fa084a7bb4854e96ef8519b621d428cdf23378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->