### PR TITLE
Hide internal continuation prompts from agent chat

### DIFF
--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -1373,10 +1373,23 @@ function resolveHermesMessageText(message: HermesSessionMessage) {
 function displayContentForHermesMessage(message: HermesSessionMessage) {
   const content = resolveHermesMessageText(message);
   if (message.role !== "user") return content.trim();
+  // Hermes appends this as a synthetic user message when an assistant response
+  // reaches the provider's output cap. It belongs in the model's continuation
+  // context, but never in June's transcript as something the user said.
+  if (isHermesOutputLengthContinuationPrompt(content)) return "";
   // Scheduled runs lead with the cron delivery preamble; show the routine's
   // own instructions, not the machine scaffolding.
   return displayedUserPromptText(
     stripImageAnalysisFailureNotice(stripScheduledRunPreamble(stripHermesContextMarkers(content))),
+  );
+}
+
+function isHermesOutputLengthContinuationPrompt(content: string) {
+  return (
+    content.trim() ===
+    "[System: Your previous response was truncated by the output length limit. " +
+      "Continue exactly where you left off. Do not restart or repeat prior text. " +
+      "Finish the answer directly.]"
   );
 }
 

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -398,6 +398,41 @@ describe("Agent chat runtime", () => {
     ]);
   });
 
+  it("hides Hermes' persisted output-length continuation prompt", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "1",
+        role: "user",
+        content: "Create an image of a desert at sunrise.",
+        timestamp: "2026-07-14T20:00:00.000Z",
+      },
+      {
+        id: "2",
+        role: "assistant",
+        content: "MEDIA:generated-image.png",
+        timestamp: "2026-07-14T20:00:01.000Z",
+      },
+      {
+        id: "3",
+        role: "user",
+        content:
+          "[System: Your previous response was truncated by the output length limit. " +
+          "Continue exactly where you left off. Do not restart or repeat prior text. " +
+          "Finish the answer directly.]",
+        timestamp: "2026-07-14T20:00:02.000Z",
+      },
+      {
+        id: "4",
+        role: "assistant",
+        content: "Here it is.",
+        timestamp: "2026-07-14T20:00:03.000Z",
+      },
+    ]);
+
+    expect(turns.map((turn) => turn.id)).toEqual(["1", "2", "4"]);
+    expect(turns.map((turn) => turn.role)).toEqual(["user", "assistant", "assistant"]);
+  });
+
   it("preserves same-timestamp Hermes user-before-assistant source order", () => {
     const createdAt = "2026-06-11T12:00:00.000Z";
     const turns = buildHermesSessionChatTurns([


### PR DESCRIPTION
## Summary

- Hide Hermes' output-limit continuation instruction when persisted history is rendered in agent chat.
- Keep the instruction in Hermes' model context so automatic continuation behavior is unchanged.
- Cover the generated-image transcript sequence with a regression test.

## Root cause

When a model response reached its output limit, Hermes appended an internal continuation instruction to its message list with the `user` role. Hermes later persisted that message, and June rendered every persisted user-role message as user-authored chat content.

## Validation

- `pnpm exec vitest run src/test/agent-chat-runtime.test.ts`
- `pnpm test` (160 files, 2,653 passed, 2 skipped)
- `pnpm typecheck`
- `pnpm exec biome check src/lib/agent-chat-runtime.ts src/test/agent-chat-runtime.test.ts`
- `git diff --check`

- [ ] Tested visually where it matters (the attached lower-environment screenshot is captured in the regression fixture; the patched app was not manually retested).
- [ ] Needs a June API (backend) deploy before it works end to end. No - this is a desktop-only transcript display change.

## Out of scope

- Changing Hermes' output-limit retry or persistence behavior.
- Hiding other runtime-authored message variants.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. No security-sensitive behavior changed.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such changes.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend changes.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy was added.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786654466&installation_id=144203540&pr_number=764&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F764&signature=89b5a1b898a551de41a1ee2a8ac8a07ad4cf13e5324c6742367a2ce802eb4bf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->