### PR TITLE
Register generated images in the Files panel

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -15904,8 +15904,8 @@ function surfacedArtifactsFromTurns(
       if (part.type !== "image" || part.status !== "complete") continue;
       const imagePath = part.path?.trim();
       if (!imagePath) continue;
-      const alias = generatedImagePathAlias(imagePath, part.name);
-      if (alias && surfacedImageAliases.has(alias)) continue;
+      const aliases = generatedImagePathAliases(imagePath, part.name);
+      if (aliases.some((alias) => surfacedImageAliases.has(alias))) continue;
       const matchingArtifacts = availableArtifacts.filter(
         (artifact) => artifact.path === imagePath,
       );
@@ -15919,20 +15919,29 @@ function surfacedArtifactsFromTurns(
           rootLabel: "Workspace",
         });
       }
-      if (alias) surfacedImageAliases.add(alias);
+      for (const alias of aliases) surfacedImageAliases.add(alias);
     }
   }
 
   return surfaced;
 }
 
-function generatedImagePathAlias(path: string, displayName?: string): string | undefined {
+export function generatedImagePathAliases(path: string, displayName?: string): string[] {
   const normalized = path.replaceAll("\\", "/");
   const isBare = !normalized.includes("/");
-  if (!isBare && !/\/(?:image_cache|images)\//i.test(normalized)) return undefined;
-  return (displayName?.trim() || normalized.split("/").at(-1))
-    ?.replace(/\.june-source-[^.]+(?=\.[^.]+$)/i, "")
-    .toLowerCase();
+  if (!isBare && !/\/(?:image_cache|images)\//i.test(normalized)) return [];
+  const aliases = new Set<string>();
+  const pathName = normalized.split("/").at(-1);
+  if (pathName) aliases.add(normalizedGeneratedImageName(pathName));
+  const name = displayName?.trim();
+  if (name && (/\.june-source-[^.]+(?=\.[^.]+$)/i.test(name) || /^generated-image-/i.test(name))) {
+    aliases.add(normalizedGeneratedImageName(name));
+  }
+  return [...aliases];
+}
+
+function normalizedGeneratedImageName(name: string): string {
+  return name.replace(/\.june-source-[^.]+(?=\.[^.]+$)/i, "").toLowerCase();
 }
 
 function includesQuery(value: unknown, query: string) {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -9689,6 +9689,11 @@ export function AgentWorkspace({
     selectedHermesSessionId ? hermesTurns : taskTurns,
     chatArtifacts,
   );
+  const surfacedConversationArtifacts = surfacedArtifactsFromTurns(
+    selectedHermesSessionId ? hermesTurns : taskTurns,
+    turnArtifacts,
+    chatArtifacts,
+  );
   const activeThinkingKey = selectedHermesSessionId
     ? `session:${selectedHermesSessionId}:active`
     : selectedTask
@@ -9705,7 +9710,7 @@ export function AgentWorkspace({
   }, []);
   // Every file the conversation has surfaced, in turn order — the session
   // bar's files button keeps them reachable after their cards scroll away.
-  const surfacedArtifacts = [...turnArtifacts.values()].flat().concat(devArtifacts);
+  const surfacedArtifacts = surfacedConversationArtifacts.concat(devArtifacts);
   const downloadPathBackedArtifact = (path: string, displayName: string) => {
     const requestSessionId = selectedHermesSessionIdRef.current;
     void downloadHermesBridgeFile(path)
@@ -15871,6 +15876,63 @@ function assignArtifactsToTurns(
     if (mentioned.length) byTurn.set(turn.id, mentioned);
   }
   return byTurn;
+}
+
+// The inline media renderer owns generated-image cards, so
+// assignArtifactsToTurns deliberately excludes their workspace files. The
+// Files panel still needs those path-backed images: collect them beside the
+// ordinary per-turn artifacts, preserving conversation order and listing each
+// file once.
+function surfacedArtifactsFromTurns(
+  turns: AgentChatTurn[],
+  artifactsByTurn: Map<string, AgentArtifact[]>,
+  availableArtifacts: AgentArtifact[],
+): AgentArtifact[] {
+  const surfaced: AgentArtifact[] = [];
+  const surfacedPaths = new Set<string>();
+  const surfacedImageAliases = new Set<string>();
+
+  function addArtifact(artifact: AgentArtifact) {
+    if (surfacedPaths.has(artifact.path)) return;
+    surfacedPaths.add(artifact.path);
+    surfaced.push(artifact);
+  }
+
+  for (const turn of turns) {
+    for (const artifact of artifactsByTurn.get(turn.id) ?? []) addArtifact(artifact);
+    for (const part of turn.parts) {
+      if (part.type !== "image" || part.status !== "complete") continue;
+      const imagePath = part.path?.trim();
+      if (!imagePath) continue;
+      const alias = generatedImagePathAlias(imagePath, part.name);
+      if (alias && surfacedImageAliases.has(alias)) continue;
+      const matchingArtifacts = availableArtifacts.filter(
+        (artifact) => artifact.path === imagePath,
+      );
+      const matchedArtifact = matchingArtifacts.length === 1 ? matchingArtifacts[0] : undefined;
+      if (matchedArtifact) {
+        addArtifact(matchedArtifact);
+      } else {
+        addArtifact({
+          name: part.name?.trim() || "Generated image",
+          path: imagePath,
+          rootLabel: "Workspace",
+        });
+      }
+      if (alias) surfacedImageAliases.add(alias);
+    }
+  }
+
+  return surfaced;
+}
+
+function generatedImagePathAlias(path: string, displayName?: string): string | undefined {
+  const normalized = path.replaceAll("\\", "/");
+  const isBare = !normalized.includes("/");
+  if (!isBare && !/\/(?:image_cache|images)\//i.test(normalized)) return undefined;
+  return (displayName?.trim() || normalized.split("/").at(-1))
+    ?.replace(/\.june-source-[^.]+(?=\.[^.]+$)/i, "")
+    .toLowerCase();
 }
 
 function includesQuery(value: unknown, query: string) {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -11,6 +11,7 @@ import {
   HERO_GREETINGS,
   SkillsToolsPanel,
   composerInSteerStateFor,
+  generatedImagePathAliases,
   projectAgentActivityLevels,
   resetAgentSessionContinuity,
   seedAgentComposerDraftForTest,
@@ -9795,6 +9796,11 @@ describe("AgentWorkspace", () => {
   it("deduplicates absolute and signed bare references to the same generated image", async () => {
     const absolutePath = "/Users/alex/.hermes/image_cache/img_cff5d542a4d2.png";
     const signedName = "generated-image-abc.june-source-deadbeef.png";
+    expect(generatedImagePathAliases(absolutePath, signedName)).toEqual([
+      "img_cff5d542a4d2.png",
+      "generated-image-abc.png",
+    ]);
+    expect(generatedImagePathAliases(signedName, signedName)).toEqual(["generated-image-abc.png"]);
     const envelope = {
       result: `MEDIA:${absolutePath}\n${JSON.stringify({ filename: signedName })}`,
       structuredContent: { filename: signedName, mimeType: "image/png" },
@@ -9842,6 +9848,16 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
 
     expect(await screen.findByRole("button", { name: "View files (1)" })).toBeInTheDocument();
+  });
+
+  it("keeps distinct cache images that share a generic display name", () => {
+    const firstPath = "/Users/alex/.hermes/image_cache/img_first.png";
+    const secondPath = "/Users/alex/.hermes/image_cache/img_second.png";
+    expect(generatedImagePathAliases(firstPath, "output.png")).toEqual(["img_first.png"]);
+    expect(generatedImagePathAliases(secondPath, "output.png")).toEqual(["img_second.png"]);
+    expect(generatedImagePathAliases(firstPath, "output.png")).not.toEqual(
+      generatedImagePathAliases(secondPath, "output.png"),
+    );
   });
 
   it("does not register a pathless MCP image block by filename", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -9238,6 +9238,8 @@ describe("AgentWorkspace", () => {
     expect(
       screen.queryByRole("button", { name: "Download generated-image-abc.png" }),
     ).not.toBeInTheDocument();
+
+    expect(screen.queryByRole("button", { name: /View files/ })).not.toBeInTheDocument();
   });
 
   it("opens a markdown artifact in the viewer panel with rendered content", async () => {
@@ -9666,6 +9668,7 @@ describe("AgentWorkspace", () => {
   });
 
   it("renders Hermes MEDIA image references as inline generated images", async () => {
+    const user = userEvent.setup();
     const mediaPath =
       "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/image_cache/img_ce347dc6e27a.png";
     mocks.listHermesSessionMessages.mockResolvedValue([
@@ -9690,9 +9693,17 @@ describe("AgentWorkspace", () => {
     expect(image).toHaveAttribute("src", "data:image/png;base64,cHJldmlldw==");
     expect(screen.queryByText(/MEDIA:/)).not.toBeInTheDocument();
     expect(mocks.hermesBridgeFilePreview).toHaveBeenCalledWith(mediaPath);
+
+    const openImage = image.closest("button");
+    expect(openImage).not.toBeNull();
+    await user.click(openImage as HTMLButtonElement);
+    const panel = await screen.findByRole("complementary", { name: "Files" });
+    await user.click(within(panel).getByRole("button", { name: "All files" }));
+    expect(within(panel).getByText("img_ce347dc6e27a.png")).toBeInTheDocument();
   });
 
   it("renders bare-filename MEDIA references as inline generated images", async () => {
+    const user = userEvent.setup();
     // The june_image tool returns a plain `filename`, and the model echoes it as
     // `MEDIA:<filename>` rather than an absolute path. The bare reference must
     // still render inline (the backend resolves it against the image roots)
@@ -9715,6 +9726,169 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByText(/MEDIA:/)).not.toBeInTheDocument();
     // The bare filename is passed through to the bridge, which resolves it.
     expect(mocks.hermesBridgeFilePreview).toHaveBeenCalledWith(mediaName);
+
+    const openImage = image.closest("button");
+    expect(openImage).not.toBeNull();
+    await user.click(openImage as HTMLButtonElement);
+    const panel = await screen.findByRole("complementary", { name: "Files" });
+    await user.click(within(panel).getByRole("button", { name: "All files" }));
+    expect(within(panel).getByText(mediaName)).toBeInTheDocument();
+  });
+
+  it("does not remap a bare-filename MEDIA image to a same-named Workspace file", async () => {
+    const user = userEvent.setup();
+    const mediaName = "img_ae9ed1ffc669.png";
+    const workspacePath =
+      "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/workspace/img_ae9ed1ffc669.png";
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/workspace",
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: mediaName,
+              path: workspacePath,
+              kind: "file",
+              size: 2048,
+              modifiedAt: "2026-06-04T18:39:00Z",
+            },
+          ],
+        },
+        {
+          id: "memory",
+          label: "Memory",
+          path: "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/memory",
+          description: "Hermes memory files.",
+          entries: [
+            {
+              name: mediaName,
+              path: `/Users/alex/Library/Application Support/co.opensoftware.june/hermes/memory/${mediaName}`,
+              kind: "file",
+              size: 2048,
+              modifiedAt: "2026-06-04T18:39:00Z",
+            },
+          ],
+        },
+      ],
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content: `MEDIA:${mediaName}`,
+        timestamp: "2026-06-04T18:39:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    await screen.findByRole("img", { name: "Generated image" });
+    await user.click(screen.getByRole("button", { name: "View files (1)" }));
+    const panel = await screen.findByRole("complementary", { name: "Files" });
+    await user.click(within(panel).getByText(mediaName));
+    expect(mocks.hermesBridgeFilePreview).not.toHaveBeenCalledWith(workspacePath);
+  });
+
+  it("deduplicates absolute and signed bare references to the same generated image", async () => {
+    const absolutePath = "/Users/alex/.hermes/image_cache/img_cff5d542a4d2.png";
+    const signedName = "generated-image-abc.june-source-deadbeef.png";
+    const envelope = {
+      result: `MEDIA:${absolutePath}\n${JSON.stringify({ filename: signedName })}`,
+      structuredContent: { filename: signedName, mimeType: "image/png" },
+    };
+    const wrappedResult = [
+      '<untrusted_tool_result source="mcp_june_image_generate_image">',
+      JSON.stringify(envelope),
+      "</untrusted_tool_result>",
+    ].join("\n");
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content: "",
+        timestamp: "2026-06-04T18:39:00Z",
+        tool_calls: JSON.stringify([
+          {
+            id: "call-1",
+            function: { name: "mcp_june_image_generate_image", arguments: {} },
+          },
+        ]),
+      },
+      {
+        id: "message-2",
+        role: "tool",
+        tool_call_id: "call-1",
+        tool_name: "mcp_june_image_generate_image",
+        content: wrappedResult,
+        timestamp: "2026-06-04T18:39:01Z",
+      },
+      {
+        id: "message-3",
+        role: "user",
+        content: "Show that image again.",
+        timestamp: "2026-06-04T18:40:00Z",
+      },
+      {
+        id: "message-4",
+        role: "assistant",
+        content: `MEDIA:${signedName}`,
+        timestamp: "2026-06-04T18:41:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByRole("button", { name: "View files (1)" })).toBeInTheDocument();
+  });
+
+  it("does not register a pathless MCP image block by filename", async () => {
+    const mediaName = "output.png";
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: "/workspace",
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: mediaName,
+              path: `/workspace/first/${mediaName}`,
+              kind: "file",
+              size: 2048,
+              modifiedAt: "2026-06-04T18:39:00Z",
+            },
+            {
+              name: mediaName,
+              path: `/workspace/second/${mediaName}`,
+              kind: "file",
+              size: 2048,
+              modifiedAt: "2026-06-04T18:39:00Z",
+            },
+          ],
+        },
+      ],
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "tool",
+        tool_name: "generate_image",
+        content: [
+          { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+          { type: "text", text: JSON.stringify({ filename: mediaName }) },
+        ],
+        timestamp: "2026-06-04T18:39:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    await screen.findByRole("img", { name: "Generated image" });
+    expect(screen.queryByRole("button", { name: /View files/ })).not.toBeInTheDocument();
   });
 
   it("imports dropped files into the Hermes workspace before submitting", async () => {


### PR DESCRIPTION
## Summary

- register path-backed generated images in the session Files panel
- preserve absolute and bare generated-image identities used by the existing preview and download flows
- deduplicate cache-path and signed-filename aliases for the same generated image
- keep pathless inline image blocks out of Files until they have trustworthy file provenance

Closes JUN-332

## Root cause

The conversation artifact assignment intentionally excluded files already rendered as inline media so duplicate download cards would not appear in the thread. The Files panel reused that filtered assignment, so the same generated image could open in the right-panel preview but disappeared when navigating back to the parent file list.

## Validation

- `make local-ci` (160 test files, 2,655 tests passed, 2 skipped; frontend and Rust macOS signoffs recorded)
- focused generated-image Files regressions (6 passed)
- `pnpm typecheck`
- `pnpm check`
- independent standards, spec, and adversarial reviews

## Visual testing

Yes. Tested the image preview -> back arrow -> Files flow in the browser preview. The generated image remains listed and can be reopened. A local screenshot and recording were captured during QA.

## June API deploy

No. This is a desktop frontend-only change.

## Out of scope

- generated non-image behavior
- registering inline image blocks that do not carry a trustworthy file path
- backend or wire-contract changes

## Followups

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786655361&installation_id=144203540&pr_number=765&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F765&signature=7753233a24ef65ed0f64eeef5baaaeda086352509c8b866c7b4eacb070dd10b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->