### PR TITLE
Fix ⌘K command prompt not firing while sidebar is collapsed

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -54,6 +54,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import {
   AGENT_SESSION_RENAMED_EVENT,
   markAgentNewSessionPending,
@@ -1767,7 +1768,12 @@ function CommandPrompt({
 
   let itemIndex = 0;
 
-  return (
+  // Portal to the document body so the prompt renders above the whole app,
+  // never trapped inside the sidebar's DOM subtree. The collapsed sidebar is
+  // `display: none` (see .app-shell[data-sidebar="collapsed"] .sidebar), which
+  // would otherwise hide this overlay along with it — so ⌘K must open a prompt
+  // that lives outside the sidebar to fire regardless of the sidebar state.
+  return createPortal(
     <div
       className="command-prompt-backdrop"
       role="presentation"
@@ -1842,7 +1848,8 @@ function CommandPrompt({
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -182,6 +182,37 @@ describe("Sidebar primary navigation", () => {
     expect(screen.queryByRole("dialog", { name: "Search" })).toBeNull();
   });
 
+  it("opens the command prompt with Command-K while the sidebar is collapsed", async () => {
+    const { container } = render(
+      <Sidebar
+        notes={notes}
+        activeView="notes"
+        collapsed
+        onChangeView={vi.fn()}
+        onSelectNote={vi.fn()}
+        onDeleteNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onRemoveNoteFromFolder={vi.fn()}
+        onNewAgentSession={vi.fn()}
+        onRenameAgentSession={vi.fn()}
+        onSelectAgentSession={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+
+    const prompt = screen.getByRole("dialog", { name: "Search" });
+    const search = within(prompt).getByRole("textbox", { name: "Search" });
+    await waitFor(() => expect(search).toHaveFocus());
+
+    // The collapsed sidebar is `display: none`, so the prompt must live outside
+    // the sidebar subtree (portaled to the body) to stay visible.
+    const sidebar = container.querySelector(".sidebar");
+    expect(sidebar).not.toBeNull();
+    expect(sidebar?.contains(prompt)).toBe(false);
+    expect(document.body.contains(prompt)).toBe(true);
+  });
+
   it("closes the command prompt on Escape even when a result row is focused", async () => {
     render(
       <Sidebar


### PR DESCRIPTION
The command prompt overlay was rendered as a child of the sidebar aside.
A collapsed sidebar is `display: none`, which hid the whole subtree,
so ⌘K set the open state but the prompt never appeared. Portal the
CommandPrompt to the document body so it renders above the app
regardless of sidebar collapsed/settings state.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013XRsaJzRqMN6CWbpArnA9F

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786659131&installation_id=144203540&pr_number=767&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F767&signature=253ff2e739ea13743dd97653397357bbef276f6af875df29e580f2f00c5d2ab0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->