### PR TITLE
Verify the attested Open Software API

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ verifiable.
 3. **Minimal retention.** Open Software's services store account, login, and
    billing records. Prompts, audio, transcripts, and files are not among them.
 4. **Verifiable, not promised.** June API runs in an Intel TDX confidential VM
-   on Phala Cloud, and its trust chain has three public anchors:
+   on Phala Cloud. Its model routing service runs in Google Confidential Space on
+   Intel TDX. Both services are open source and independently attested. June's
+   trust chain starts with three public anchors:
    - **Source:** this repository. The production image records its source
      commit in the OCI `org.opencontainers.image.revision` label.
    - **Image:** [`build-june-api.yml`](.github/workflows/build-june-api.yml)
@@ -117,9 +119,12 @@ verifiable.
      proves that image is what actually runs inside the TEE.
 
    Every deployment serves a self-contained walkthrough at
-   [`/verify`](https://june-api.opensoftware.co/verify). The chain proves the
-   code running in the confidential VM, not what upstream model providers do
-   with what they receive, which is why zero-retention routing is the default.
+   [`/verify`](https://june-api.opensoftware.co/verify). It also generates a
+   fresh browser nonce, verifies Google's os-api signature and workload claims,
+   and compares the running service to the exact approved image digest. The
+   chain proves the June and routing-service code. Model privacy and attestation remain
+   explicit provider evidence, which is why zero-retention private routing is
+   the default.
 
 ## Download
 

--- a/docs/adr/0023-attested-os-api-service-chain.md
+++ b/docs/adr/0023-attested-os-api-service-chain.md
@@ -1,0 +1,52 @@
+---
+status: accepted
+date: 2026-07-14
+---
+
+# June verifies an attested Open Software API before service-managed inference
+
+## Context
+
+June API is open source and remotely attested, but moving its inference traffic
+from a model provider directly to os-api adds another plaintext policy and
+routing hop. Open sourcing os-api makes its behavior inspectable, but source
+availability alone does not prove which code is running or prevent an ordinary
+deployment from receiving provider keys.
+
+## Decision
+
+The production inference chain is:
+
+```text
+June -> attested June API -> attested Open Software API -> private or attested model
+```
+
+- os-api runs as a Google Cloud Confidential Space workload on Intel TDX.
+- Google Cloud Attestation releases os-api's runtime identity and Secret Manager
+  access only to a stable, non-debug workload running an exact approved image
+  digest.
+- os-api publishes a public nonce-bound Google attestation token at
+  `POST /v1/gateway/attestation` and fails closed outside Confidential Space.
+- June API verifies Google's signature, issuer, audience, expiration, caller
+  nonce, software identity, debug state, hardware model, stable support status,
+  and exact os-api image digest.
+- Production June API refuses to start if the proof is invalid. Service-managed
+  text inference refreshes the proof on a bounded cache and fails closed when
+  it cannot be refreshed. User-provided Venice keys continue to route directly
+  to Venice and do not depend on os-api.
+- June's public `/verify` page shows both deployment policies and includes a
+  browser-side fresh proof verifier.
+
+## Consequences
+
+- A source commit or container tag is insufficient for promotion. The immutable
+  os-api digest must be stamped into both Google workload identity policy and
+  June configuration.
+- Digest rotation is a coordinated two-repository release. A mismatch causes
+  downtime for service-managed inference by design.
+- Google Cloud Attestation, Intel TDX, the June image, the os-api image, and the
+  selected model provider remain explicit trust dependencies.
+- This proves the model routing service workload identity and makes secret release
+  enforceable. It does not by itself prove every upstream model's implementation;
+  os-api inference receipts remain the source for model privacy and attestation
+  evidence.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,8 @@ raw Tauri app config directory are unaffected.
 
 Non-secret (usually left to `config.toml`): `JUNE__SERVER__HOST` / `PORT`,
 `JUNE__OS_ACCOUNTS__API_URL`, `JUNE__LOCAL_DEV__ENABLED` / `BEARER_TOKEN` /
-`USER_ID`, `JUNE__UPSTREAMS__*__BASE_URL`.
+`USER_ID`, `JUNE__UPSTREAMS__*__BASE_URL`, and the
+`JUNE__GATEWAY_ATTESTATION__*` policy fields.
 
 ## Backend knobs (`june-api/config.toml`)
 
@@ -69,4 +70,8 @@ Non-secret (usually left to `config.toml`): `JUNE__SERVER__HOST` / `PORT`,
 - **Preview cap:** `note_transcribe_preview_max_audio_secs` 30.
 - **OS Accounts token contract:** `iss` `https://accounts.opensoftware.co`, `aud` `open-software-apps`, `jwks_refresh_secs` 300, `jwks_miss_min_backoff_secs` 5.
 - **Pricing:** one `[pricing."<model_id>"]` table per priced model (unit, credits, provider, model_type, capabilities, ...). A model with no pricing entry is rejected at the boundary; the live Venice catalog extends this at boot (see [ADR-0007](adr/0007-model-capability-source-of-truth.md)).
-- **Attestation / issue reports:** the TEE trust-center URL + the fixed os-platform destination (`open-software` / `june`).
+- **Attestation / issue reports:** the June TEE trust-center URL, the os-api
+  Confidential Space proof URL/audience/exact image digest/cache policy, and
+  the fixed os-platform destination (`open-software` / `june`). Production sets
+  `gateway_attestation.required = true`; invalid or unavailable proof stops
+  startup and service-managed text inference.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ decision. See "When to add an ADR" in [AGENTS.md](../AGENTS.md).
 - [adr/0020](adr/0020-windows-dictation-keyboard-hook.md) — Windows shortcuts combine `RegisterHotKey` with a narrow keyboard hook
 - [adr/0021](adr/0021-june-api-v1-compatibility-policy.md) — `/v1` is additive-only for shipped app versions: per-version contract fixtures gate CI and production promotes, clients send `x-june-app-version`, error codes never renumber
 - [adr/0022](adr/0022-venice-private-first-model-routing.md) — service-managed text uses Venice private zero-retention first with Phala TEE fallback; existing `/v1` provider semantics stay compatible and pricing is fallback-safe
+- [adr/0023](adr/0023-attested-os-api-service-chain.md) — June verifies a nonce-bound, digest-pinned Confidential Space proof for the Open Software API before service-managed inference
 
 ## Enforceable rules (spec/)
 

--- a/june-api/.env.example
+++ b/june-api/.env.example
@@ -50,6 +50,13 @@ JUNE__UPSTREAMS__VENICE__API_KEY=VENICE_API_KEY_REPLACE_ME
 # JUNE__UPSTREAMS__VENICE__BASE_URL=https://api.venice.ai/api/v1
 # OpenSoftware private-router canary: https://api.opensoftware.co/v1
 
+# Production only: require a fresh Google Confidential Space proof for the
+# Open Software API model routing service and pin it to the exact promoted container digest. Local mode
+# inherits required=false from config.toml.
+# JUNE__GATEWAY_ATTESTATION__REQUIRED=true
+# JUNE__GATEWAY_ATTESTATION__URL=https://api.opensoftware.co/v1/gateway/attestation
+# JUNE__GATEWAY_ATTESTATION__EXPECTED_IMAGE_DIGEST=sha256:<64-hex-digest>
+
 # --- Issue reports ----------------------------------------------------------
 # Optional. The destination is fixed in config.toml: the `june` project in the
 # `open-software` org on os-platform. Set the bot user's fellow API key to file

--- a/june-api/config.toml
+++ b/june-api/config.toml
@@ -16,6 +16,17 @@ source_repo_url = "https://github.com/open-software-network/os-june"
 image_repo = "ghcr.io/open-software-network/june-api"
 trust_center_url = "https://trust.phala.com/app/6514acb0e08dc4825e2b6e22a46f0ed0ff455b54"
 
+# Production sets required=true and stamps the exact deployed os-api digest.
+# June refuses to start, and service-managed text inference fails closed, when
+# the nonce-bound Google Confidential Space proof does not match these values.
+[gateway_attestation]
+required = false
+url = "https://api.opensoftware.co/v1/gateway/attestation"
+expected_image_digest = ""
+audience = "https://june-api.opensoftware.co/os-api-gateway"
+jwks_url = "https://www.googleapis.com/service_accounts/v1/metadata/jwk/signer@confidentialspace-sign.iam.gserviceaccount.com"
+cache_secs = 300
+
 [issue_reports]
 # User-submitted issue reports are filed as os-platform Issues in the June
 # project. The only per-environment value is the bot user's fellow API key

--- a/june-api/crates/api/src/handlers/verify.rs
+++ b/june-api/crates/api/src/handlers/verify.rs
@@ -37,6 +37,17 @@ fn render_page(info: &AttestationInfo) -> String {
     let repo_url = escape_html(&info.source_repo_url);
     let image_repo = escape_html(&info.image_repo);
     let trust_center_url = escape_html(&info.trust_center_url);
+    let gateway_url = escape_html(&info.gateway_attestation_url);
+    let gateway_digest = escape_html(&info.gateway_image_digest);
+    let gateway_status = if info.gateway_attestation_required {
+        "required and verified before startup"
+    } else {
+        "not required in this deployment"
+    };
+    let gateway_url_json =
+        serde_json::to_string(&info.gateway_attestation_url).unwrap_or_else(|_| "\"\"".to_string());
+    let gateway_digest_json =
+        serde_json::to_string(&info.gateway_image_digest).unwrap_or_else(|_| "\"\"".to_string());
 
     let (commit_value, short_sha) = match short_commit(&info.source_commit) {
         Some(short) => {
@@ -63,6 +74,11 @@ fn render_page(info: &AttestationInfo) -> String {
         .replace("@REPO_URL@", &repo_url)
         .replace("@IMAGE_REPO@", &image_repo)
         .replace("@TRUST_CENTER_URL@", &trust_center_url)
+        .replace("@GATEWAY_STATUS@", gateway_status)
+        .replace("@GATEWAY_URL@", &gateway_url)
+        .replace("@GATEWAY_DIGEST@", &gateway_digest)
+        .replace("@GATEWAY_URL_JSON@", &gateway_url_json)
+        .replace("@GATEWAY_DIGEST_JSON@", &gateway_digest_json)
 }
 
 const PAGE_TEMPLATE: &str = r#"<!doctype html>
@@ -153,6 +169,17 @@ const PAGE_TEMPLATE: &str = r#"<!doctype html>
     color: var(--muted);
     margin-bottom: 1.25rem;
   }
+  button {
+    border: 0;
+    border-radius: 8px;
+    padding: 0.65rem 0.9rem;
+    background: var(--accent);
+    color: var(--bg);
+    font: inherit;
+    cursor: pointer;
+  }
+  button:disabled { cursor: wait; opacity: 0.65; }
+  #gateway-result { overflow-wrap: anywhere; }
   footer {
     margin-top: 3.5rem;
     padding-top: 1.25rem;
@@ -178,7 +205,16 @@ const PAGE_TEMPLATE: &str = r#"<!doctype html>
   <div><dt>Source code</dt><dd><a href="@REPO_URL@">@REPO_URL@</a></dd></div>
   <div><dt>Image</dt><dd><code>@IMAGE_REPO@:@SHORT_SHA@</code></dd></div>
   <div><dt>Attestation</dt><dd><a href="@TRUST_CENTER_URL@">Phala Trust Center report</a></dd></div>
+  <div><dt>os-api policy</dt><dd>@GATEWAY_STATUS@</dd></div>
+  <div><dt>os-api image</dt><dd><code>@GATEWAY_DIGEST@</code></dd></div>
 </dl>
+
+<h2>Verify the Open Software API now</h2>
+<p>Generate a fresh nonce and verify the model routing service's Google Confidential Space
+signature and workload claims in your browser. The proof must name a stable,
+non-debug Intel TDX workload running the exact image digest above.</p>
+<p><button id="verify-gateway" type="button">Verify model routing</button></p>
+<p id="gateway-result" class="muted">No proof checked in this browser yet.</p>
 
 <h2>Why this matters</h2>
 <p>Audio, transcripts, and notes pass through this server. Because the running
@@ -222,19 +258,85 @@ and recorded for that commit. Bit-for-bit reproducible rebuilds (regenerating
 the digest yourself instead of trusting our CI) are in progress; see
 <a href="@REPO_URL@/blob/main/docs/reproducible-builds.md">docs/reproducible-builds.md</a>.</p>
 
-<h2>What this does not cover</h2>
-<p>The chain verifies the <strong>code</strong> running in the confidential VM,
-not what upstream providers do. Everything leaving the TEE for model inference
-(audio for transcription, prompts and context for note generation and the
-agent) goes through Venice. By default it runs on Venice private models: zero
-data retention, no training. If you select an anonymized model not run by
-Venice, the request is still routed and anonymized by Venice, but the
-underlying model provider may retain data under its own privacy policy.
-End-to-end private inference is a separate workstream.</p>
+<h2>The complete inference chain</h2>
+<p>June verifies the model routing proof before startup and refreshes it for
+service-managed text inference. A missing, expired, debug, wrong-hardware, or
+wrong-image proof fails closed. The service can receive its provider keys only
+when Google verifies that same workload policy. The final model privacy and
+attestation evidence remains visible in each os-api inference receipt.</p>
 
 <footer>
   <p>Open Software · <a href="@REPO_URL@">source</a> · <a href="@TRUST_CENTER_URL@">attestation</a></p>
 </footer>
+<script>
+const gatewayUrl = @GATEWAY_URL_JSON@;
+const expectedDigest = @GATEWAY_DIGEST_JSON@;
+const expectedAudience = "https://june-api.opensoftware.co/os-api-gateway";
+const issuer = "https://confidentialcomputing.googleapis.com";
+const jwksUrl = "https://www.googleapis.com/service_accounts/v1/metadata/jwk/signer@confidentialspace-sign.iam.gserviceaccount.com";
+const decodePart = value => JSON.parse(new TextDecoder().decode(base64url(value)));
+function base64url(value) {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "="));
+  return Uint8Array.from(binary, character => character.charCodeAt(0));
+}
+function has(value, expected) {
+  return Array.isArray(value) ? value.includes(expected) : value === expected;
+}
+async function verifyGateway() {
+  const button = document.getElementById("verify-gateway");
+  const result = document.getElementById("gateway-result");
+  button.disabled = true;
+  result.textContent = "Checking a fresh nonce-bound proof...";
+  try {
+    if (!gatewayUrl || !expectedDigest) throw new Error("model routing policy is not enabled here");
+    const nonceBytes = crypto.getRandomValues(new Uint8Array(24));
+    const nonce = Array.from(nonceBytes, byte => byte.toString(16).padStart(2, "0")).join("");
+    const response = await fetch(gatewayUrl, {method: "POST", body: JSON.stringify({nonce})});
+    if (!response.ok) throw new Error(`model routing service returned HTTP ${response.status}`);
+    const envelope = await response.json();
+    if (envelope.nonce !== nonce || envelope.audience !== expectedAudience) {
+      throw new Error("response is not bound to this browser's nonce and audience");
+    }
+    const parts = envelope.token.split(".");
+    if (parts.length !== 3) throw new Error("proof is not a JWT");
+    const header = decodePart(parts[0]);
+    const claims = decodePart(parts[1]);
+    const jwks = await (await fetch(jwksUrl)).json();
+    const jwk = jwks.keys.find(key => key.kid === header.kid);
+    if (!jwk) throw new Error("Google signing key was not found");
+    if (header.alg !== "RS256") throw new Error("unsupported Google signing algorithm");
+    const importAlgorithm = {name: "RSASSA-PKCS1-v1_5", hash: "SHA-256"};
+    const verifyAlgorithm = {name: "RSASSA-PKCS1-v1_5"};
+    const key = await crypto.subtle.importKey("jwk", jwk, importAlgorithm, false, ["verify"]);
+    const validSignature = await crypto.subtle.verify(
+      verifyAlgorithm,
+      key,
+      base64url(parts[2]),
+      new TextEncoder().encode(`${parts[0]}.${parts[1]}`)
+    );
+    const stable = claims.submods?.confidential_space?.support_attributes || [];
+    const digest = claims.submods?.container?.image_digest;
+    const validClaims = validSignature
+      && claims.iss === issuer
+      && has(claims.aud, expectedAudience)
+      && has(claims.eat_nonce, nonce)
+      && Number(claims.exp) > Date.now() / 1000
+      && claims.swname === "CONFIDENTIAL_SPACE"
+      && claims.dbgstat === "disabled-since-boot"
+      && claims.hwmodel === "GCP_INTEL_TDX"
+      && stable.includes("STABLE")
+      && has(digest, expectedDigest);
+    if (!validClaims) throw new Error("signature is valid but workload claims do not match policy");
+    result.textContent = `Verified now: Google signed ${expectedDigest} on stable Intel TDX, bound to this browser's nonce.`;
+  } catch (error) {
+    result.textContent = `Verification failed closed: ${error.message}`;
+  } finally {
+    button.disabled = false;
+  }
+}
+document.getElementById("verify-gateway").addEventListener("click", verifyGateway);
+</script>
 </body>
 </html>
 "#;
@@ -250,6 +352,10 @@ mod tests {
             source_repo_url: "https://github.com/open-software-network/os-june".to_string(),
             image_repo: "ghcr.io/open-software-network/june-api".to_string(),
             trust_center_url: "https://trust.phala.com/app/15f8d2fd".to_string(),
+            gateway_attestation_required: true,
+            gateway_attestation_url: "https://api.opensoftware.co/v1/gateway/attestation"
+                .to_string(),
+            gateway_image_digest: format!("sha256:{}", "a".repeat(64)),
         }
     }
 
@@ -287,6 +393,9 @@ mod tests {
         ));
         assert!(html.contains("ghcr.io/open-software-network/june-api:0123abc"));
         assert!(html.contains("https://trust.phala.com/app/15f8d2fd"));
+        assert!(html.contains("required and verified before startup"));
+        assert!(html.contains(&format!("sha256:{}", "a".repeat(64))));
+        assert!(html.contains("Verify the Open Software API now"));
         assert!(!html.contains("@SHORT_SHA@"));
     }
 

--- a/june-api/crates/api/src/handlers/verify.rs
+++ b/june-api/crates/api/src/handlers/verify.rs
@@ -292,7 +292,11 @@ async function verifyGateway() {
     if (!gatewayUrl || !expectedDigest) throw new Error("model routing policy is not enabled here");
     const nonceBytes = crypto.getRandomValues(new Uint8Array(24));
     const nonce = Array.from(nonceBytes, byte => byte.toString(16).padStart(2, "0")).join("");
-    const response = await fetch(gatewayUrl, {method: "POST", body: JSON.stringify({nonce})});
+    const response = await fetch(gatewayUrl, {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({nonce})
+    });
     if (!response.ok) throw new Error(`model routing service returned HTTP ${response.status}`);
     const envelope = await response.json();
     if (envelope.nonce !== nonce || envelope.audience !== expectedAudience) {
@@ -396,6 +400,7 @@ mod tests {
         assert!(html.contains("required and verified before startup"));
         assert!(html.contains(&format!("sha256:{}", "a".repeat(64))));
         assert!(html.contains("Verify the Open Software API now"));
+        assert!(html.contains("headers: {\"Content-Type\": \"application/json\"}"));
         assert!(!html.contains("@SHORT_SHA@"));
     }
 

--- a/june-api/crates/api/src/state.rs
+++ b/june-api/crates/api/src/state.rs
@@ -82,6 +82,9 @@ pub struct AttestationInfo {
     pub source_repo_url: String,
     pub image_repo: String,
     pub trust_center_url: String,
+    pub gateway_attestation_required: bool,
+    pub gateway_attestation_url: String,
+    pub gateway_image_digest: String,
 }
 
 pub struct ApiStateParams {

--- a/june-api/crates/api/tests/support/mod.rs
+++ b/june-api/crates/api/tests/support/mod.rs
@@ -54,6 +54,9 @@ pub(crate) fn test_attestation() -> AttestationInfo {
         source_repo_url: "https://github.com/open-software-network/os-june".to_string(),
         image_repo: "ghcr.io/open-software-network/june-api".to_string(),
         trust_center_url: "https://trust.phala.com/app/test-app-id".to_string(),
+        gateway_attestation_required: true,
+        gateway_attestation_url: "https://api.opensoftware.co/v1/gateway/attestation".to_string(),
+        gateway_image_digest: format!("sha256:{}", "a".repeat(64)),
     }
 }
 

--- a/june-api/crates/app/src/main.rs
+++ b/june-api/crates/app/src/main.rs
@@ -5,11 +5,12 @@ use june_config::{
     VENICE_API_KEY_PLACEHOLDER, image_client_timeout_secs,
 };
 use june_providers::{
-    JwksTokenVerifier, LocalDevOsAccountsClient, LocalDevTokenVerifier, LogIssueReportSink,
-    LogP3aSink, MultiFormatDurationProbe, OsAccountsHttpClient, OsAccountsP3aSink,
-    OsPlatformIssueReportSink, RoutingTranscriber, VeniceAgentChat, VeniceAugment, VeniceCleaner,
-    VeniceGenerator, VeniceImageEditor, VeniceImageGenerator, VeniceModelCatalog,
-    VeniceVideoProvider, client_with_timeout, default_client, issue_report_client, jwks_client,
+    GatewayAttestationVerifier, JwksTokenVerifier, LocalDevOsAccountsClient, LocalDevTokenVerifier,
+    LogIssueReportSink, LogP3aSink, MultiFormatDurationProbe, OsAccountsHttpClient,
+    OsAccountsP3aSink, OsPlatformIssueReportSink, RoutingTranscriber, VeniceAgentChat,
+    VeniceAugment, VeniceCleaner, VeniceGenerator, VeniceImageEditor, VeniceImageGenerator,
+    VeniceModelCatalog, VeniceVideoProvider, client_with_timeout, default_client,
+    issue_report_client, jwks_client,
 };
 use june_services::{
     AgentChatService, AgentChatServiceDeps, DictateService, DictateServiceDeps, ImageModelPrice,
@@ -62,6 +63,10 @@ async fn serve() -> anyhow::Result<()> {
     // file and Issue creation POSTs are not idempotent.
     let issue_report_http =
         issue_report_client(Duration::from_secs(config.server.request_timeout_secs))?;
+    GatewayAttestationVerifier::new(upstream_http.clone(), &config.gateway_attestation)
+        .verify(&config.upstreams.venice.api_key)
+        .await
+        .map_err(|_| anyhow::anyhow!("os-api gateway attestation failed closed"))?;
     let pricing = load_pricing(&config, upstream_http.clone()).await;
     let clients = HttpClients {
         default: &http,
@@ -167,20 +172,25 @@ fn build_router(
     // would let a 300-600s call reach `charge` after its hold expired.
     // Unmetered (user-Venice-key) requests have no hold to protect and keep
     // the full-route client — see AgentChatRequest::unmetered.
-    let generator: Arc<dyn june_domain::Generator> = Arc::new(VeniceGenerator::from_config(
-        clients.metered_inference.clone(),
-        clients.upstream.clone(),
-        &config.upstreams.venice,
-    ));
-    let cleaner: Arc<dyn june_domain::Cleaner> = Arc::new(VeniceCleaner::from_config(
-        clients.upstream.clone(),
-        &config.upstreams.venice,
-    ));
-    let agent_chat_completer: Arc<dyn june_domain::AgentChatCompleter> =
-        Arc::new(VeniceAgentChat::from_config(
+    let generator: Arc<dyn june_domain::Generator> =
+        Arc::new(VeniceGenerator::from_config_with_gateway_attestation(
             clients.metered_inference.clone(),
             clients.upstream.clone(),
             &config.upstreams.venice,
+            &config.gateway_attestation,
+        ));
+    let cleaner: Arc<dyn june_domain::Cleaner> =
+        Arc::new(VeniceCleaner::from_config_with_gateway_attestation(
+            clients.upstream.clone(),
+            &config.upstreams.venice,
+            &config.gateway_attestation,
+        ));
+    let agent_chat_completer: Arc<dyn june_domain::AgentChatCompleter> =
+        Arc::new(VeniceAgentChat::from_config_with_gateway_attestation(
+            clients.metered_inference.clone(),
+            clients.upstream.clone(),
+            &config.upstreams.venice,
+            &config.gateway_attestation,
         ));
     // One client backs both web traits (search + fetch) over the same Venice
     // credential and base URL.
@@ -328,6 +338,9 @@ fn build_router(
             source_repo_url: config.attestation.source_repo_url.clone(),
             image_repo: config.attestation.image_repo.clone(),
             trust_center_url: config.attestation.trust_center_url.clone(),
+            gateway_attestation_required: config.gateway_attestation.required,
+            gateway_attestation_url: config.gateway_attestation.url.clone(),
+            gateway_image_digest: config.gateway_attestation.expected_image_digest.clone(),
         },
     });
     june_api::router(state)

--- a/june-api/crates/app/src/main.rs
+++ b/june-api/crates/app/src/main.rs
@@ -63,7 +63,9 @@ async fn serve() -> anyhow::Result<()> {
     // file and Issue creation POSTs are not idempotent.
     let issue_report_http =
         issue_report_client(Duration::from_secs(config.server.request_timeout_secs))?;
-    GatewayAttestationVerifier::new(upstream_http.clone(), &config.gateway_attestation)
+    let gateway_attestation =
+        GatewayAttestationVerifier::new(upstream_http.clone(), &config.gateway_attestation);
+    gateway_attestation
         .verify(&config.upstreams.venice.api_key)
         .await
         .map_err(|_| anyhow::anyhow!("os-api gateway attestation failed closed"))?;
@@ -74,7 +76,7 @@ async fn serve() -> anyhow::Result<()> {
         metered_inference: &metered_inference_http,
         issue_reports: &issue_report_http,
     };
-    let app = build_router(&config, clients, pricing);
+    let app = build_router(&config, clients, pricing, gateway_attestation);
     let listener = tokio::net::TcpListener::bind(address).await?;
     tracing::info!(%address, "june-api listening");
     axum::serve(listener, app).await?;
@@ -146,6 +148,7 @@ fn build_router(
     config: &AppConfig,
     clients: HttpClients<'_>,
     mut pricing_config: BTreeMap<String, ModelPriceConfig>,
+    gateway_attestation: GatewayAttestationVerifier,
 ) -> axum::Router {
     if config.local_dev.enabled {
         pricing_config = filter_unconfigured_provider_models(config, pricing_config);
@@ -177,20 +180,20 @@ fn build_router(
             clients.metered_inference.clone(),
             clients.upstream.clone(),
             &config.upstreams.venice,
-            &config.gateway_attestation,
+            gateway_attestation.clone(),
         ));
     let cleaner: Arc<dyn june_domain::Cleaner> =
         Arc::new(VeniceCleaner::from_config_with_gateway_attestation(
             clients.upstream.clone(),
             &config.upstreams.venice,
-            &config.gateway_attestation,
+            gateway_attestation.clone(),
         ));
     let agent_chat_completer: Arc<dyn june_domain::AgentChatCompleter> =
         Arc::new(VeniceAgentChat::from_config_with_gateway_attestation(
             clients.metered_inference.clone(),
             clients.upstream.clone(),
             &config.upstreams.venice,
-            &config.gateway_attestation,
+            gateway_attestation,
         ));
     // One client backs both web traits (search + fetch) over the same Venice
     // credential and base URL.

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -135,6 +135,8 @@ pub struct AppConfig {
     pub upstreams: UpstreamsConfig,
     pub attestation: AttestationConfig,
     #[serde(default)]
+    pub gateway_attestation: GatewayAttestationConfig,
+    #[serde(default)]
     pub issue_reports: IssueReportsConfig,
     pub pricing: BTreeMap<String, ModelPriceConfig>,
     /// Flat credits charged per generated image, keyed by image model id. Kept
@@ -197,6 +199,7 @@ impl Debug for AppConfig {
             .field("os_accounts", &self.os_accounts)
             .field("upstreams", &self.upstreams)
             .field("attestation", &self.attestation)
+            .field("gateway_attestation", &self.gateway_attestation)
             .field("issue_reports", &self.issue_reports)
             .field("pricing", &self.pricing)
             .field("image_pricing", &self.image_pricing)
@@ -340,6 +343,47 @@ pub struct AttestationConfig {
     pub source_repo_url: String,
     pub image_repo: String,
     pub trust_center_url: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GatewayAttestationConfig {
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub url: String,
+    #[serde(default)]
+    pub expected_image_digest: String,
+    #[serde(default = "default_gateway_attestation_audience")]
+    pub audience: String,
+    #[serde(default = "default_gateway_attestation_jwks_url")]
+    pub jwks_url: String,
+    #[serde(default = "default_gateway_attestation_cache_secs")]
+    pub cache_secs: u64,
+}
+
+impl Default for GatewayAttestationConfig {
+    fn default() -> Self {
+        Self {
+            required: false,
+            url: String::new(),
+            expected_image_digest: String::new(),
+            audience: default_gateway_attestation_audience(),
+            jwks_url: default_gateway_attestation_jwks_url(),
+            cache_secs: default_gateway_attestation_cache_secs(),
+        }
+    }
+}
+
+fn default_gateway_attestation_audience() -> String {
+    "https://june-api.opensoftware.co/os-api-gateway".to_string()
+}
+
+fn default_gateway_attestation_jwks_url() -> String {
+    "https://www.googleapis.com/service_accounts/v1/metadata/jwk/signer@confidentialspace-sign.iam.gserviceaccount.com".to_string()
+}
+
+const fn default_gateway_attestation_cache_secs() -> u64 {
+    300
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -937,6 +981,7 @@ impl Default for AppConfig {
                     "https://trust.phala.com/app/6514acb0e08dc4825e2b6e22a46f0ed0ff455b54"
                         .to_string(),
             },
+            gateway_attestation: GatewayAttestationConfig::default(),
             issue_reports: IssueReportsConfig::default(),
             pricing: default_pricing(),
             image_pricing: default_image_pricing(),
@@ -1014,6 +1059,7 @@ fn validate(config: &AppConfig) -> Result<(), ConfigError> {
     }
     validate_request_limits(config)?;
     validate_issue_report_diagnosis(config)?;
+    validate_gateway_attestation(config)?;
 
     let uses_openai = config
         .pricing
@@ -1090,6 +1136,30 @@ fn validate(config: &AppConfig) -> Result<(), ConfigError> {
     }
     validate_image_pricing(config)?;
     validate_video_pricing(config)?;
+    Ok(())
+}
+
+fn validate_gateway_attestation(config: &AppConfig) -> Result<(), ConfigError> {
+    let gateway = &config.gateway_attestation;
+    if !gateway.required {
+        return Ok(());
+    }
+    validate_absolute_http_url("gateway_attestation.url", &gateway.url)?;
+    validate_absolute_http_url("gateway_attestation.jwks_url", &gateway.jwks_url)?;
+    validate_required_text("gateway_attestation.audience", &gateway.audience)?;
+    validate_positive_config("gateway_attestation.cache_secs", gateway.cache_secs)?;
+    let digest = gateway.expected_image_digest.trim();
+    if digest.len() != 71
+        || !digest.starts_with("sha256:")
+        || !digest[7..]
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+    {
+        return Err(ConfigError::InvalidRequired {
+            field: "gateway_attestation.expected_image_digest",
+            reason: "must be an exact sha256:<64 hex characters> image digest",
+        });
+    }
     Ok(())
 }
 
@@ -1436,6 +1506,26 @@ mod tests {
         config.upstreams.openai.api_key = "sk-test".to_string();
         config.upstreams.venice.api_key = "venice-test".to_string();
         config
+    }
+
+    #[test]
+    fn validate_requires_exact_gateway_policy_when_enabled() {
+        let mut config = valid_config();
+        config.gateway_attestation.required = true;
+        config.gateway_attestation.url =
+            "https://api.opensoftware.co/v1/gateway/attestation".to_string();
+        config.gateway_attestation.expected_image_digest = format!("sha256:{}", "a".repeat(64));
+
+        assert!(validate(&config).is_ok());
+
+        config.gateway_attestation.expected_image_digest = "sha256:latest".to_string();
+        assert!(matches!(
+            validate(&config),
+            Err(ConfigError::InvalidRequired {
+                field: "gateway_attestation.expected_image_digest",
+                ..
+            })
+        ));
     }
 
     fn packaged_config_toml() -> AppConfig {

--- a/june-api/crates/providers/src/gateway_attestation.rs
+++ b/june-api/crates/providers/src/gateway_attestation.rs
@@ -203,9 +203,11 @@ impl OneOrMany {
 #[cfg(test)]
 mod tests {
     use super::{
-        Claims, ConfidentialSpaceClaims, ContainerClaims, OneOrMany, Submods, workload_claims_match,
+        Claims, ConfidentialSpaceClaims, ContainerClaims, GatewayAttestationVerifier, OneOrMany,
+        Submods, workload_claims_match,
     };
     use june_config::GatewayAttestationConfig;
+    use std::sync::Arc;
 
     fn config() -> GatewayAttestationConfig {
         GatewayAttestationConfig {
@@ -230,6 +232,14 @@ mod tests {
                 },
             },
         }
+    }
+
+    #[test]
+    fn clones_share_the_verification_cache_and_refresh_lock() {
+        let verifier = GatewayAttestationVerifier::new(reqwest::Client::new(), &config());
+        let clone = verifier.clone();
+
+        assert!(Arc::ptr_eq(&verifier.inner, &clone.inner));
     }
 
     #[test]

--- a/june-api/crates/providers/src/gateway_attestation.rs
+++ b/june-api/crates/providers/src/gateway_attestation.rs
@@ -1,0 +1,260 @@
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header, jwk::JwkSet};
+use june_config::GatewayAttestationConfig;
+use june_domain::DomainError;
+use serde::Deserialize;
+use std::{
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+use tokio::sync::Mutex as AsyncMutex;
+
+static NONCE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone)]
+pub struct GatewayAttestationVerifier {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    http: reqwest::Client,
+    config: GatewayAttestationConfig,
+    verified_at: Mutex<Option<Instant>>,
+    verification_lock: AsyncMutex<()>,
+}
+
+impl GatewayAttestationVerifier {
+    pub fn new(http: reqwest::Client, config: &GatewayAttestationConfig) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                http,
+                config: config.clone(),
+                verified_at: Mutex::new(None),
+                verification_lock: AsyncMutex::new(()),
+            }),
+        }
+    }
+
+    pub async fn verify(&self, api_key: &str) -> Result<(), DomainError> {
+        if !self.inner.config.required || self.is_fresh()? {
+            return Ok(());
+        }
+        let _guard = self.inner.verification_lock.lock().await;
+        if self.is_fresh()? {
+            return Ok(());
+        }
+        self.verify_fresh(api_key).await.map_err(|reason| {
+            tracing::error!(%reason, "os-api gateway attestation failed closed");
+            DomainError::UpstreamProvider
+        })?;
+        *self
+            .inner
+            .verified_at
+            .lock()
+            .map_err(|_| DomainError::UpstreamProvider)? = Some(Instant::now());
+        Ok(())
+    }
+
+    fn is_fresh(&self) -> Result<bool, DomainError> {
+        Ok(self
+            .inner
+            .verified_at
+            .lock()
+            .map_err(|_| DomainError::UpstreamProvider)?
+            .is_some_and(|verified| {
+                verified.elapsed() < Duration::from_secs(self.inner.config.cache_secs.max(1))
+            }))
+    }
+
+    async fn verify_fresh(&self, api_key: &str) -> Result<(), &'static str> {
+        let nonce = nonce();
+        let response = self
+            .inner
+            .http
+            .post(&self.inner.config.url)
+            .bearer_auth(api_key)
+            .json(&serde_json::json!({"nonce": nonce}))
+            .send()
+            .await
+            .map_err(|_| "attestation request failed")?
+            .error_for_status()
+            .map_err(|_| "attestation endpoint rejected request")?;
+        let envelope = response
+            .json::<AttestationEnvelope>()
+            .await
+            .map_err(|_| "invalid attestation response")?;
+        if envelope.format != "confidential-space.oidc"
+            || envelope.audience != self.inner.config.audience
+            || envelope.nonce != nonce
+        {
+            return Err("attestation response binding mismatch");
+        }
+        let header = decode_header(&envelope.token).map_err(|_| "invalid attestation token")?;
+        if header.alg != Algorithm::RS256 {
+            return Err("unsupported attestation signing algorithm");
+        }
+        let kid = header.kid.ok_or("attestation token has no key id")?;
+        let jwks = self
+            .inner
+            .http
+            .get(&self.inner.config.jwks_url)
+            .send()
+            .await
+            .map_err(|_| "attestation JWKS request failed")?
+            .error_for_status()
+            .map_err(|_| "attestation JWKS endpoint rejected request")?
+            .json::<JwkSet>()
+            .await
+            .map_err(|_| "invalid attestation JWKS")?;
+        let key = jwks.find(&kid).ok_or("attestation signing key not found")?;
+        let decoding_key = DecodingKey::from_jwk(key).map_err(|_| "invalid attestation key")?;
+        let mut validation = Validation::new(header.alg);
+        validation.set_issuer(&["https://confidentialcomputing.googleapis.com"]);
+        validation.set_audience(&[self.inner.config.audience.as_str()]);
+        validation.set_required_spec_claims(&["exp", "iss", "aud", "eat_nonce"]);
+        let claims = decode::<Claims>(&envelope.token, &decoding_key, &validation)
+            .map_err(|_| "attestation signature or registered claims are invalid")?
+            .claims;
+        if !workload_claims_match(&claims, &self.inner.config, &nonce) {
+            return Err("attestation workload claims do not match policy");
+        }
+        Ok(())
+    }
+}
+
+fn workload_claims_match(claims: &Claims, config: &GatewayAttestationConfig, nonce: &str) -> bool {
+    claims.eat_nonce.contains(nonce)
+        && claims.swname == "CONFIDENTIAL_SPACE"
+        && claims.dbgstat == "disabled-since-boot"
+        && claims.hwmodel == "GCP_INTEL_TDX"
+        && claims
+            .submods
+            .confidential_space
+            .support_attributes
+            .iter()
+            .any(|value| value == "STABLE")
+        && claims
+            .submods
+            .container
+            .image_digest
+            .contains(&config.expected_image_digest)
+}
+
+fn nonce() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let counter = NONCE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("june-{now:x}-{counter:x}")
+}
+
+#[derive(Deserialize)]
+struct AttestationEnvelope {
+    format: String,
+    token: String,
+    audience: String,
+    nonce: String,
+}
+
+#[derive(Deserialize)]
+struct Claims {
+    eat_nonce: OneOrMany,
+    swname: String,
+    dbgstat: String,
+    hwmodel: String,
+    submods: Submods,
+}
+
+#[derive(Deserialize)]
+struct Submods {
+    container: ContainerClaims,
+    confidential_space: ConfidentialSpaceClaims,
+}
+
+#[derive(Deserialize)]
+struct ContainerClaims {
+    image_digest: OneOrMany,
+}
+
+#[derive(Deserialize)]
+struct ConfidentialSpaceClaims {
+    support_attributes: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum OneOrMany {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl OneOrMany {
+    fn contains(&self, expected: &str) -> bool {
+        match self {
+            Self::One(value) => value == expected,
+            Self::Many(values) => values.iter().any(|value| value == expected),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Claims, ConfidentialSpaceClaims, ContainerClaims, OneOrMany, Submods, workload_claims_match,
+    };
+    use june_config::GatewayAttestationConfig;
+
+    fn config() -> GatewayAttestationConfig {
+        GatewayAttestationConfig {
+            required: true,
+            expected_image_digest: format!("sha256:{}", "a".repeat(64)),
+            ..GatewayAttestationConfig::default()
+        }
+    }
+
+    fn claims() -> Claims {
+        Claims {
+            eat_nonce: OneOrMany::Many(vec!["fresh-nonce".to_string()]),
+            swname: "CONFIDENTIAL_SPACE".to_string(),
+            dbgstat: "disabled-since-boot".to_string(),
+            hwmodel: "GCP_INTEL_TDX".to_string(),
+            submods: Submods {
+                container: ContainerClaims {
+                    image_digest: OneOrMany::One(format!("sha256:{}", "a".repeat(64))),
+                },
+                confidential_space: ConfidentialSpaceClaims {
+                    support_attributes: vec!["STABLE".to_string()],
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn accepts_exact_nonce_hardware_stability_and_digest_policy() {
+        assert!(workload_claims_match(&claims(), &config(), "fresh-nonce"));
+    }
+
+    #[test]
+    fn rejects_replayed_nonce() {
+        assert!(!workload_claims_match(&claims(), &config(), "other-nonce"));
+    }
+
+    #[test]
+    fn rejects_debug_or_wrong_image_workload() {
+        let mut debug = claims();
+        debug.dbgstat = "enabled".to_string();
+        assert!(!workload_claims_match(&debug, &config(), "fresh-nonce"));
+
+        let mut wrong_image = claims();
+        wrong_image.submods.container.image_digest =
+            OneOrMany::One(format!("sha256:{}", "b".repeat(64)));
+        assert!(!workload_claims_match(
+            &wrong_image,
+            &config(),
+            "fresh-nonce"
+        ));
+    }
+}

--- a/june-api/crates/providers/src/lib.rs
+++ b/june-api/crates/providers/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used, clippy::panic))]
 
 pub mod audio_probe;
+pub mod gateway_attestation;
 pub mod http;
 pub mod issue_reports;
 pub mod jwks;
@@ -21,6 +22,7 @@ mod retry;
 mod transcription;
 
 pub use audio_probe::MultiFormatDurationProbe;
+pub use gateway_attestation::GatewayAttestationVerifier;
 pub use http::{client_with_timeout, default_client, issue_report_client, jwks_client};
 pub use issue_reports::{LogIssueReportSink, OsPlatformIssueReportSink};
 pub use jwks::{JwksTokenVerifier, JwksTokenVerifierParams};

--- a/june-api/crates/providers/src/venice.rs
+++ b/june-api/crates/providers/src/venice.rs
@@ -1,7 +1,10 @@
+use crate::gateway_attestation::GatewayAttestationVerifier;
 use crate::retry::{self, UpstreamAttemptError};
 use crate::transcription::TranscriptionWireResponse;
 use async_trait::async_trait;
-use june_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit, UpstreamConfig};
+use june_config::{
+    GatewayAttestationConfig, ModelPriceConfig, ModelProvider, ModelType, PriceUnit, UpstreamConfig,
+};
 use june_domain::{
     AgentChatCompleter, AgentChatCompletion, AgentChatRequest, AgentChatStream,
     AgentChatStreamOutcome, CleanedText, Cleaner, CleanupRequest, DomainError, GeneratedNote,
@@ -295,6 +298,22 @@ impl VeniceGenerator {
             chat: VeniceChat::with_unmetered(http, unmetered_http, config),
         }
     }
+
+    pub fn from_config_with_gateway_attestation(
+        http: reqwest::Client,
+        unmetered_http: reqwest::Client,
+        config: &UpstreamConfig,
+        gateway_attestation: &GatewayAttestationConfig,
+    ) -> Self {
+        Self {
+            chat: VeniceChat::with_unmetered_and_gateway_attestation(
+                http,
+                unmetered_http,
+                config,
+                gateway_attestation,
+            ),
+        }
+    }
 }
 
 #[async_trait]
@@ -386,6 +405,22 @@ impl VeniceAgentChat {
             chat: VeniceChat::with_unmetered(http, unmetered_http, config),
         }
     }
+
+    pub fn from_config_with_gateway_attestation(
+        http: reqwest::Client,
+        unmetered_http: reqwest::Client,
+        config: &UpstreamConfig,
+        gateway_attestation: &GatewayAttestationConfig,
+    ) -> Self {
+        Self {
+            chat: VeniceChat::with_unmetered_and_gateway_attestation(
+                http,
+                unmetered_http,
+                config,
+                gateway_attestation,
+            ),
+        }
+    }
 }
 
 #[async_trait]
@@ -427,6 +462,16 @@ impl VeniceCleaner {
     pub fn from_config(http: reqwest::Client, config: &UpstreamConfig) -> Self {
         Self {
             chat: VeniceChat::new(http, config),
+        }
+    }
+
+    pub fn from_config_with_gateway_attestation(
+        http: reqwest::Client,
+        config: &UpstreamConfig,
+        gateway_attestation: &GatewayAttestationConfig,
+    ) -> Self {
+        Self {
+            chat: VeniceChat::new_with_gateway_attestation(http, config, gateway_attestation),
         }
     }
 }
@@ -503,6 +548,7 @@ struct VeniceChat {
     api_key: String,
     base_url: String,
     byok_base_url: String,
+    gateway_attestation: Option<GatewayAttestationVerifier>,
 }
 
 impl VeniceChat {
@@ -513,6 +559,7 @@ impl VeniceChat {
             api_key: config.api_key.clone(),
             base_url: config.base_url.trim_end_matches('/').to_string(),
             byok_base_url: byok_base_url(config),
+            gateway_attestation: None,
         }
     }
 
@@ -525,6 +572,42 @@ impl VeniceChat {
             unmetered_http: Some(unmetered_http),
             ..Self::new(http, config)
         }
+    }
+
+    fn new_with_gateway_attestation(
+        http: reqwest::Client,
+        config: &UpstreamConfig,
+        gateway_attestation: &GatewayAttestationConfig,
+    ) -> Self {
+        Self {
+            gateway_attestation: Some(GatewayAttestationVerifier::new(
+                http.clone(),
+                gateway_attestation,
+            )),
+            ..Self::new(http, config)
+        }
+    }
+
+    fn with_unmetered_and_gateway_attestation(
+        http: reqwest::Client,
+        unmetered_http: reqwest::Client,
+        config: &UpstreamConfig,
+        gateway_attestation: &GatewayAttestationConfig,
+    ) -> Self {
+        Self {
+            unmetered_http: Some(unmetered_http),
+            ..Self::new_with_gateway_attestation(http, config, gateway_attestation)
+        }
+    }
+
+    async fn verify_gateway(&self, auth: ChatCallAuth<'_>) -> Result<(), DomainError> {
+        if auth.provider_credentials.has_venice_api_key() {
+            return Ok(());
+        }
+        if let Some(verifier) = &self.gateway_attestation {
+            verifier.verify(&self.api_key).await?;
+        }
+        Ok(())
     }
 
     fn client(&self, unmetered: bool) -> &reqwest::Client {
@@ -545,6 +628,7 @@ impl VeniceChat {
         mut body: ChatCompletionRequest,
         auth: ChatCallAuth<'_>,
     ) -> Result<RoutedChatCompletion, DomainError> {
+        self.verify_gateway(auth).await?;
         body.messages.insert(0, ChatMessage::safety_context());
         let url = self.chat_completions_url(auth.provider_credentials);
         // Bounded retry on transient failures — same rationale as the
@@ -627,6 +711,7 @@ impl VeniceChat {
         model: june_domain::ModelId,
         auth: ChatCallAuth<'_>,
     ) -> Result<AgentChatCompletion, DomainError> {
+        self.verify_gateway(auth).await?;
         let body = prepare_agent_chat_body(body, &model)?;
         let url = self.chat_completions_url(auth.provider_credentials);
         let request = self
@@ -685,6 +770,7 @@ impl VeniceChat {
         model: june_domain::ModelId,
         auth: ChatCallAuth<'_>,
     ) -> Result<AgentChatStream, DomainError> {
+        self.verify_gateway(auth).await?;
         let body = prepare_agent_chat_body(body, &model)?;
         let url = self.chat_completions_url(auth.provider_credentials);
         let request = self

--- a/june-api/crates/providers/src/venice.rs
+++ b/june-api/crates/providers/src/venice.rs
@@ -2,9 +2,7 @@ use crate::gateway_attestation::GatewayAttestationVerifier;
 use crate::retry::{self, UpstreamAttemptError};
 use crate::transcription::TranscriptionWireResponse;
 use async_trait::async_trait;
-use june_config::{
-    GatewayAttestationConfig, ModelPriceConfig, ModelProvider, ModelType, PriceUnit, UpstreamConfig,
-};
+use june_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit, UpstreamConfig};
 use june_domain::{
     AgentChatCompleter, AgentChatCompletion, AgentChatRequest, AgentChatStream,
     AgentChatStreamOutcome, CleanedText, Cleaner, CleanupRequest, DomainError, GeneratedNote,
@@ -303,7 +301,7 @@ impl VeniceGenerator {
         http: reqwest::Client,
         unmetered_http: reqwest::Client,
         config: &UpstreamConfig,
-        gateway_attestation: &GatewayAttestationConfig,
+        gateway_attestation: GatewayAttestationVerifier,
     ) -> Self {
         Self {
             chat: VeniceChat::with_unmetered_and_gateway_attestation(
@@ -410,7 +408,7 @@ impl VeniceAgentChat {
         http: reqwest::Client,
         unmetered_http: reqwest::Client,
         config: &UpstreamConfig,
-        gateway_attestation: &GatewayAttestationConfig,
+        gateway_attestation: GatewayAttestationVerifier,
     ) -> Self {
         Self {
             chat: VeniceChat::with_unmetered_and_gateway_attestation(
@@ -468,7 +466,7 @@ impl VeniceCleaner {
     pub fn from_config_with_gateway_attestation(
         http: reqwest::Client,
         config: &UpstreamConfig,
-        gateway_attestation: &GatewayAttestationConfig,
+        gateway_attestation: GatewayAttestationVerifier,
     ) -> Self {
         Self {
             chat: VeniceChat::new_with_gateway_attestation(http, config, gateway_attestation),
@@ -577,13 +575,10 @@ impl VeniceChat {
     fn new_with_gateway_attestation(
         http: reqwest::Client,
         config: &UpstreamConfig,
-        gateway_attestation: &GatewayAttestationConfig,
+        gateway_attestation: GatewayAttestationVerifier,
     ) -> Self {
         Self {
-            gateway_attestation: Some(GatewayAttestationVerifier::new(
-                http.clone(),
-                gateway_attestation,
-            )),
+            gateway_attestation: Some(gateway_attestation),
             ..Self::new(http, config)
         }
     }
@@ -592,7 +587,7 @@ impl VeniceChat {
         http: reqwest::Client,
         unmetered_http: reqwest::Client,
         config: &UpstreamConfig,
-        gateway_attestation: &GatewayAttestationConfig,
+        gateway_attestation: GatewayAttestationVerifier,
     ) -> Self {
         Self {
             unmetered_http: Some(unmetered_http),


### PR DESCRIPTION
## What changed

- verify a fresh Google Confidential Space OIDC proof for the Open Software API at startup
- refresh and fail closed before service-managed text inference while preserving direct user-provided Venice-key routing
- share one verification cache and refresh lock across generation, cleanup, and agent chat
- pin issuer, audience, nonce, expiration, RS256 signature, stable/non-debug Intel TDX claims, and the exact approved os-api digest
- extend `/verify` with the routing policy and a one-click browser verifier
- document the coordinated trust chain in ADR 0023 and configuration guidance

## Why

Moving from June API directly to the Open Software API introduces another plaintext routing hop. This makes that hop independently verifiable and rejects inference when its running workload does not match the approved public image.

## Coordinated change

- os-api infrastructure and proof endpoint: https://github.com/open-software-network/os-api/pull/24

## Rollout and scope

This change needs a June API deployment and the coordinated os-api deployment to work end to end. Production rollout must stamp the same immutable os-api digest into both repositories. This PR does not deploy either service or change production traffic.

Visual testing: not manually tested in a browser; the generated `/verify` page and verification request are covered by unit and HTTP integration tests.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`