### PR TITLE
Hide internal model switch messages

### DIFF
--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -1372,6 +1372,7 @@ function resolveHermesMessageText(message: HermesSessionMessage) {
 
 function displayContentForHermesMessage(message: HermesSessionMessage) {
   const content = resolveHermesMessageText(message);
+  if (message.role === "system") return displayedHermesSystemMessageText(content);
   if (message.role !== "user") return content.trim();
   // Hermes appends this as a synthetic user message when an assistant response
   // reaches the provider's output cap. It belongs in the model's continuation
@@ -1382,6 +1383,29 @@ function displayContentForHermesMessage(message: HermesSessionMessage) {
   return displayedUserPromptText(
     stripImageAnalysisFailureNotice(stripScheduledRunPreamble(stripHermesContextMarkers(content))),
   );
+}
+
+// Hermes persists model switches as a system instruction containing internal
+// provider metadata. That instruction is useful to the model, but the raw
+// routing id and the directive that follows it are implementation details and
+// must not leak into the transcript.
+function displayedHermesSystemMessageText(content: string) {
+  const text = content.trim();
+  const match = text.match(
+    /^(?:\[System:\s*)?The active model for this chat has changed to\s+(.+?)\s+via provider\s+\S+\./i,
+  );
+  if (!match?.[1]) return text;
+  return `Model changed to ${displayNameForHermesModel(match[1])}.`;
+}
+
+function displayNameForHermesModel(modelId: string) {
+  const auto = /^__june_auto_generation__:(\d+(?:\.\d+)?)$/i.exec(modelId.trim());
+  if (!auto?.[1]) return modelId.trim();
+
+  const qualityPreference = Number(auto[1]);
+  if (qualityPreference >= 67) return "Auto Higher";
+  if (qualityPreference <= 33) return "Auto Lower";
+  return "Auto Balanced";
 }
 
 function isHermesOutputLengthContinuationPrompt(content: string) {

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -398,6 +398,50 @@ describe("Agent chat runtime", () => {
     ]);
   });
 
+  it("replaces internal Hermes model-change instructions with a short label", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "model-change-1",
+        role: "system",
+        content:
+          "[System: The active model for this chat has changed to " +
+          "__june_auto_generation__:100 via provider custom. From this point " +
+          "forward, use this runtime metadata when answering questions about " +
+          "what model/provider is active.]",
+        timestamp: "2026-07-14T22:57:11.000Z",
+      },
+    ]);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.role).toBe("system");
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "text",
+        text: "Model changed to Auto Higher.",
+        status: "complete",
+      },
+    ]);
+  });
+
+  it("leaves unrelated Hermes system messages unchanged", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "system-1",
+        role: "system",
+        content: "A useful system notice.",
+        timestamp: "2026-07-14T22:57:11.000Z",
+      },
+    ]);
+
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "text",
+        text: "A useful system notice.",
+        status: "complete",
+      },
+    ]);
+  });
+
   it("hides Hermes' persisted output-length continuation prompt", () => {
     const turns = buildHermesSessionChatTurns([
       {


### PR DESCRIPTION
## Summary

- replace persisted Hermes model-switch system instructions with concise user-facing transcript copy
- translate internal Auto routing preferences into Auto Lower, Auto Balanced, or Auto Higher labels
- preserve unrelated system messages unchanged

## Why

Hermes stores model changes as system instructions so the runtime can answer questions about the active model. June rendered those instructions verbatim, exposing internal routing IDs and provider metadata in the conversation. This keeps the runtime metadata intact while sanitizing only its display representation, including existing conversations.

## User impact

A switch to `__june_auto_generation__:100` now appears as `Model changed to Auto Higher.` instead of the full internal system instruction.

## Validation

- `pnpm exec vitest run src/test/agent-chat-runtime.test.ts` (103 tests passed)
- `pnpm exec biome check src/lib/agent-chat-runtime.ts src/test/agent-chat-runtime.test.ts`
- `pnpm run typecheck`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786663632&installation_id=144203540&pr_number=770&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F770&signature=35d5821d381794b1724d4e5f2142c01edb8e30d57c0d77db0b63895f63e537d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->