### PR TITLE
Give the image-gen mark a clean, theme-aware clay twinkle

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -13439,20 +13439,21 @@ const GENERATED_MEDIA_FIELD = {
   rippleGlow: 0.4,
   ripplePaintMix: 0.95,
   /* Mark sparkle: each logo dot glints on its own deterministic cadence - a
-   * brief flash of brightness with a whisper of the theme accent, never size.
-   * The glint is luminance-led on purpose: `--brand` is a mid-tone, so mixing
-   * a dot fully to it (as an earlier, higher sparkMix did) *darkens* the
-   * near-white mark in dark mode - a glint that dims instead of catching light
-   * - and muddies it to salmon in light mode. Keeping the mix low leaves the
-   * glint reading as light on the dot with only a warm cast; the ripple keeps
-   * the bold, fully-accent burst (ripplePaintMix) for a deliberate press. The
-   * exponent keeps each glint a short flash out of a slow cycle, so only a few
-   * dots shine at any moment. */
-  sparkMinRadPerSec: 0.5,
-  sparkSpanRadPerSec: 0.7,
-  sparkExponent: 10,
-  sparkMix: 0.3,
-  sparkAlphaBoost: 0.32,
+   * brief flash of clay brightness, never size. The glint is clay-tinted
+   * (sparkMix) rather than gray so the mark reads as warm, but the tint only
+   * lands clean because --brand-bright is a *luminous* clay (fixed high
+   * lightness + healthy chroma); a duller white-mixed clay turns to mud over
+   * the light dot field. The pulse uses a near-instant attack and a longer
+   * release, matching the clean snap of a light catching an edge instead of a
+   * soft sine-wave throb. The staggered cadence keeps the mark alive without
+   * making every dot pulse at once; the press ripple keeps the fuller accent
+   * burst (ripplePaintMix) for a deliberate tap. */
+  sparkMinRadPerSec: 1.6,
+  sparkSpanRadPerSec: 1.2,
+  sparkAttackRatio: 0.025,
+  sparkDecayRatio: 0.1,
+  sparkMix: 0.72,
+  sparkAlphaBoost: 0.52,
   /* The dot field thins out over this many px at the canvas bottom, into the
    * card-surface gradient the CSS background lands on. */
   bottomFadePx: 56,
@@ -13602,11 +13603,20 @@ function GeneratedMediaDotField() {
           dx += (rx / dist) * F.ripplePush * band;
           dy += (ry / dist) * F.ripplePush * band;
         }
-        // The glint: a brief accent flash out of each logo dot's slow cycle.
+        // The glint: a quick accent strike with a slightly longer fade, out of
+        // each logo dot's staggered cycle.
         let spark = 0;
         if (animated && dot.mark > 0) {
-          const wave = 0.5 + 0.5 * Math.sin(seconds * dot.sparkOmega + dot.sparkPhase);
-          spark = wave ** F.sparkExponent * dot.mark;
+          const cycle =
+            ((seconds * dot.sparkOmega + dot.sparkPhase) % (Math.PI * 2)) / (Math.PI * 2);
+          if (cycle < F.sparkAttackRatio) {
+            const progress = cycle / F.sparkAttackRatio;
+            spark = progress * progress * (3 - 2 * progress);
+          } else if (cycle < F.sparkAttackRatio + F.sparkDecayRatio) {
+            const progress = (cycle - F.sparkAttackRatio) / F.sparkDecayRatio;
+            spark = 1 - progress * progress * (3 - 2 * progress);
+          }
+          spark *= dot.mark;
         }
         // Partial glyph coverage blends the dot between field and mark, so
         // the mark's rounded corners and bevels stay soft on the lattice.

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -13438,14 +13438,20 @@ const GENERATED_MEDIA_FIELD = {
   ripplePush: 5,
   rippleGlow: 0.4,
   ripplePaintMix: 0.95,
-  /* Mark sparkle: each logo dot glints on its own deterministic cadence -
-   * a twinkle of color and brightness only, never size. The exponent keeps
-   * the glint to a short flash out of each slow cycle, so only a few dots
-   * shine at any moment. */
+  /* Mark sparkle: each logo dot glints on its own deterministic cadence - a
+   * brief flash of brightness with a whisper of the theme accent, never size.
+   * The glint is luminance-led on purpose: `--brand` is a mid-tone, so mixing
+   * a dot fully to it (as an earlier, higher sparkMix did) *darkens* the
+   * near-white mark in dark mode - a glint that dims instead of catching light
+   * - and muddies it to salmon in light mode. Keeping the mix low leaves the
+   * glint reading as light on the dot with only a warm cast; the ripple keeps
+   * the bold, fully-accent burst (ripplePaintMix) for a deliberate press. The
+   * exponent keeps each glint a short flash out of a slow cycle, so only a few
+   * dots shine at any moment. */
   sparkMinRadPerSec: 0.5,
   sparkSpanRadPerSec: 0.7,
   sparkExponent: 10,
-  sparkMix: 0.95,
+  sparkMix: 0.3,
   sparkAlphaBoost: 0.32,
   /* The dot field thins out over this many px at the canvas bottom, into the
    * card-surface gradient the CSS background lands on. */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3112,7 +3112,11 @@ input:focus-visible,
   /* The gray canvas itself gradates into the card surface at the bottom (and
    * the dot field thins out over the same run), so the footer transition is
    * owned by the background rather than an overlay fading in on top. */
-  background: linear-gradient(to bottom, var(--secondary) 62%, var(--card));
+  background: linear-gradient(
+    to bottom,
+    color-mix(in oklch, var(--secondary) 97%, var(--foreground)) 62%,
+    var(--card)
+  );
   color: var(--muted-foreground);
 }
 
@@ -3171,9 +3175,11 @@ input:focus-visible,
   display: block;
   width: 100%;
   height: 100%;
-  /* The theme accent for the mark's glints and the press ripple's wash; the
-   * canvas reads the computed value (accent-color paints nothing here). */
-  accent-color: var(--brand);
+  /* The luminous clay accent for the mark's glints and the press ripple's
+   * wash; a plain lightness lift would read as mud over the light field, so
+   * --brand-bright pins chroma too. The canvas reads the computed value
+   * (accent-color paints nothing here). */
+  accent-color: var(--brand-bright);
 }
 
 /* The label sits on the card surface the canvas gradient lands on - no

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -292,6 +292,14 @@
    * neutrals mix from this so clay's high chroma doesn't over-cream the greys;
    * the Appearance picker overrides both --brand and --brand-wash together. */
   --brand-wash: #976851;
+  /* Luminous accent for brief clay details (the image-gen mark's glint and its
+   * press ripple). Mixing --brand with white lifts lightness but drops chroma,
+   * which reads as dusty *mud* the moment it's painted over the light dot
+   * field. So the real value (below, under @supports) pins the glint to a fixed
+   * high lightness AND healthy chroma via relative color syntax, keeping only
+   * the active brand's hue - a clean, warm, saturated spark in either theme.
+   * This color-mix is the graceful fallback for engines without oklch(from). */
+  --brand-bright: color-mix(in oklch, var(--brand) 72%, var(--on-solid));
 
   --record: oklch(60% 0.22 27);
   /* Soft dusty tint of the brand, for quiet button backdrops and hovers
@@ -356,6 +364,26 @@
     0 1px 2px oklch(24% 0.002 84.59 / 4%), 0 2px 6px oklch(24% 0.002 84.59 / 5%),
     0 8px 16px oklch(24% 0.002 84.59 / 4%), 0 18px 40px oklch(24% 0.002 84.59 / 8%);
   --shadow-inset: 0 0 0 1px oklch(0% 0 none / 4%);
+}
+
+/* The luminous clay glint (see --brand-bright above), inheriting only the
+ * active brand's hue so it stays themed across every Appearance preset. The
+ * spark reads differently against each theme's field, so lightness and chroma
+ * are tuned per theme rather than shared:
+ *
+ * - Light: the dots sit on a near-white field and the neutral gray has almost
+ *   no chroma, so a pale clay collapses into it. You can't out-brighten white,
+ *   so the pop is driven by CHROMA - a vivid, slightly deeper clay separates
+ *   cleanly from the gray - not by lightness (which would only wash it out).
+ * - Dark: a lifted, high-lightness clay glows against the dark field, so keep
+ *   lightness high and chroma moderate. */
+@supports (color: oklch(from red l c h)) {
+  :root {
+    --brand-bright: oklch(from var(--brand) 0.7 0.19 h);
+  }
+  [data-theme="dark"] {
+    --brand-bright: oklch(from var(--brand) 0.72 0.15 h);
+  }
 }
 
 :root[data-brand-transition="true"],


### PR DESCRIPTION
## What

Refines the generating-media dot field's logo glint and press ripple so the clay reads as a deliberate, warm sparkle instead of muddy residue.

- **Snappier twinkle** — a near-instant smoothstep attack + short fade replaces the slow sine glow, so each glint reads as a clean flash (a light catching an edge) rather than a soft throb.
- **Clean clay tint** — the glint stays clay-tinted (not gray), but the tint only lands clean because `--brand-bright` is now a *luminous* clay. Mixing `--brand` with white lifts lightness but drops chroma, which turns to dusty mud over the light dot field; the new value pins both lightness and chroma via relative color syntax (`oklch(from …)`), inheriting only the active brand hue so it stays themed across every Appearance preset.
- **Theme-aware accent** — `--brand-bright` is tuned per theme: light mode drives the pop with **chroma** (you can't out-brighten a near-white field), dark mode keeps a lifted, high-lightness glow. A `color-mix` fallback covers engines without `oklch(from …)`, mirroring `shimmer.css`.
- **Press keeps its burst** — the pointer ripple keeps its fuller accent wash for a deliberate tap.
- **Backdrop** — the light-mode canvas backdrop is darkened ~2% so the field reads as a surface, not faint residue.

`--brand-bright` is a new token used only by the placeholder's `accent-color`, so there are no side effects elsewhere.

## Root cause (the muddiness)

The glint was painted with a clay derived by mixing `--brand` toward white. In OKLCH that raises lightness but *lowers chroma*, landing at a dusty, low-saturation brown. Painted at partial opacity over the light, near-zero-chroma gray dot field, it blended into the gray and read as mud — worst in light mode, where you can't create separation with lightness. Fix: stop deriving the spark by lightness alone; pin chroma too, and tune the lightness/chroma balance per theme to match how each field renders a glint.

## Tested visually

Yes — tuned live in the browser against a side-by-side comparison harness (main vs. iterations, light/dark, click-to-ripple) and verified by hand in both themes. No screenshots attached; this is a subtle motion/color change best judged live. Canvas render logic is unchanged in structure (only the field constants, the spark easing, and the accent token changed).

## Needs a June API deploy?

No — frontend/CSS only.

## Out of scope

- The dot-field geometry, sweep, ripple physics, and mark lattice are unchanged.
- No change to the reduced-motion static frame or the theme-flip repaint path.

## Followups

None. Two clean tuning dials remain if design wants to nudge the light-mode spark later: chroma (`0.19`) for punch and lightness (`0.70`) for bright-vs-deep.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786685156&installation_id=144203540&pr_number=773&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F773&signature=0d7afa482bb0a9373baaf219c7f258a59587221583692ee0c673047cbd5ab8af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->