### PR TITLE
Add Linear workspace connection with selected-team grants (JUN-284 slice 1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -294,13 +294,24 @@ integration (too broad), plugin for a Tauri framework package.
 
 **Connector**:
 A private-by-architecture integration between June and a third-party account
-(launch: Google Gmail + Calendar). The user authorizes the provider on their
-Mac; the grant lives in the Keychain and every provider API call originates
-on-device. June ships each connector as a read MCP server (`june_gmail`,
-`june_gcal`) plus a mutating actions server (`june_gmail_actions`,
-`june_gcal_actions`); neither holds the token, which stays in Rust behind the
-on-device provider proxy (see [ADR-0016](docs/adr/0016-private-connectors-local-mode.md)).
+(shipped: Google Gmail + Calendar; in progress: Linear). The user authorizes
+the provider on their Mac; the grant lives in the Keychain and every provider
+API call originates on-device. June ships each connector as a read MCP server
+(`june_gmail`, `june_gcal`) plus a mutating actions server
+(`june_gmail_actions`, `june_gcal_actions`); neither holds the token, which
+stays in Rust behind the on-device provider proxy (see
+[ADR-0016](docs/adr/0016-private-connectors-local-mode.md)).
 _Avoid_: integration (unqualified), plugin, the Google API.
+
+**Selected teams** (Linear):
+The June-side authorization grant limiting every Linear read and write to the
+teams the user checked at connect time (stored in SQLite, editable in
+settings, enforced in Rust). Not a provider OAuth scope: Linear's `read` and
+`write` scopes are workspace-wide, so team boundaries exist only because
+June's own proxy refuses anything outside the grant. An account with no
+selected teams is connected but inert.
+_Avoid_: team scopes (they are not OAuth scopes), team filter (it is an
+enforcement boundary, not a view preference), workspace access.
 
 **Local mode**:
 The default (and, in v1, only) connector trust model: the OAuth grant is

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ Per-repo config the engineering skills read before acting (see the
   - [Computer use](plugins/computer-use-prd.md) — [implementation plan](plugins/computer-use-implementation-plan.md)
   - [Notion](plugins/notion-prd.md) — [implementation plan](plugins/notion-implementation-plan.md)
   - [GitHub](plugins/github-prd.md) — [implementation plan](plugins/github-implementation-plan.md)
-  - [Linear](plugins/linear-prd.md) — [implementation plan](plugins/linear-implementation-plan.md)
+  - [Linear](plugins/linear-prd.md) — [implementation plan](plugins/linear-implementation-plan.md), [Phase 0 OAuth spike findings](plugins/linear-oauth-spike.md)
   - [Documents](plugins/documents-prd.md) — [implementation plan](plugins/documents-implementation-plan.md)
   - [Spreadsheets](plugins/spreadsheets-prd.md) — [implementation plan](plugins/spreadsheets-implementation-plan.md)
 - [plugins/integrations-next-ten.md](plugins/integrations-next-ten.md) - follow-on provider portfolio: ranks 11-20, auth feasibility, sequencing, and decision gates

--- a/docs/plugins/linear-implementation-plan.md
+++ b/docs/plugins/linear-implementation-plan.md
@@ -2,7 +2,9 @@
 
 - **Mode:** CTO
 - **Date:** 2026-07-13
-- **Status:** Proposed; auth spike required
+- **Status:** Proposed; Phase 0 documentation spike complete, see
+  [linear-oauth-spike.md](linear-oauth-spike.md) (live verification pending
+  OAuth app registration)
 - **PRD:** [linear-prd.md](linear-prd.md)
 - **Issue:** JUN-284
 

--- a/docs/plugins/linear-oauth-spike.md
+++ b/docs/plugins/linear-oauth-spike.md
@@ -1,0 +1,117 @@
+# Phase 0 findings: Linear OAuth and API spike
+
+- **Mode:** CTO
+- **Date:** 2026-07-15
+- **Status:** Documentation spike complete; live-workspace verification pending
+  OAuth app registration
+- **Plan:** [linear-implementation-plan.md](linear-implementation-plan.md)
+- **Issue:** JUN-284
+
+## Verdict
+
+Local token custody works. Linear's authorization-code flow supports PKCE with
+an optional client secret, a loopback redirect, rotating refresh tokens, and a
+revoke endpoint. No confidential exchange, backend credential, or June API
+involvement is needed, so the Linear connector extends the ADR-0016 local-mode
+pattern as-is and **no new ADR is required for v1**. The plan's ADR threshold
+(confidential token exchange, app credential, or webhook relay) is not
+triggered.
+
+## Question-by-question
+
+### 1. Public desktop client without an embedded secret
+
+Yes. The token exchange at `POST https://api.linear.app/oauth/token` marks
+`client_secret` optional for PKCE flows; `client_id`, `code`, `code_verifier`,
+and `redirect_uri` complete the exchange. `code_challenge_method` supports
+`plain` and `S256`; June always uses S256. PKCE is optional on Linear's side,
+so June must enforce it client-side rather than rely on the provider requiring
+it. `http://localhost:<port>/...` redirect URIs are accepted, matching the
+existing loopback flow in `connectors/oauth.rs`.
+
+### 2. Refresh-token rotation, lifetime, revoke
+
+- Access tokens live 24 hours; each refresh returns a new access token **and a
+  new refresh token** (rotation).
+- Refresh-token consumption has a 30-minute grace period for network-error
+  recovery, which tolerates the retry races that strict one-shot rotation
+  would turn into lockouts.
+- `POST https://api.linear.app/oauth/revoke` revokes (200), with
+  `token_type_hint` of `access_token` or `refresh_token`; disconnect must call
+  it and treat 400 (already revoked) as success.
+
+### 3. User actor vs app actor
+
+`actor=user` (default) creates resources as the authorizing user and inherits
+that user's team visibility. `actor=app` is for agents/service accounts, is
+issued via the client-credentials flow (which needs a secret, so it is not
+desktop-safe), and sees all public teams. **V1 uses the user actor**, per the
+plan's default; app actor would both break the no-secret constraint and widen
+visibility beyond the selected-team grant.
+
+### 4. Scopes
+
+`read` (always present), `write`, `issues:create`, `comments:create`,
+`timeSchedule:write`, `admin` (avoid). The v1 write set (`create_issue`,
+`update_issue`, `add_comment`, `create_project_update`) requires `write`
+because issue updates and project updates have no granular scope. So v1
+requests `read,write` in one consent, with every mutation still parked for
+approval in the Rust proxy. There is no teams-scoped provider grant; selected
+teams remain a June-side authorization enforced in Rust.
+
+### 5. Rate limits and GraphQL complexity
+
+- OAuth apps: 5,000 requests/user/hour and 2,000,000 complexity points/hour;
+  a single query may not exceed 10,000 points.
+- Budget headers: `X-RateLimit-Requests-Remaining`,
+  `X-RateLimit-Complexity-Remaining`, plus `*-Reset` epoch-ms headers; exceeding
+  returns HTTP 400 with the `RATELIMITED` error code.
+- Complexity is roughly 1 point/object, 0.1/property, multiplied by the
+  pagination argument on connections, so the plan's bounded selections with
+  explicit `first:` arguments fit comfortably. The proxy should surface the
+  two remaining-budget headers in health diagnostics and back off on
+  `RATELIMITED`.
+
+### 6. Pagination
+
+Relay-style cursors (`first`/`after`, `pageInfo.hasNextPage`/`endCursor`),
+default page size 50, `nodes` shorthand available, `orderBy: updatedAt` for
+recency reads. Cursors persist per the plan's SQLite state.
+
+### 7. Idempotency for mutations
+
+Provider-supported: `IssueCreateInput.id`, `CommentCreateInput.id`, and
+`ProjectUpdateCreateInput.id` each accept a client-supplied UUID v4 ("The
+identifier in UUID v4 format. If none is provided, the backend will generate
+one."). June mints the object UUID as the journal's action id, so an ambiguous
+timeout reconciles by querying that exact id: a replay with the same id cannot
+double-create. This satisfies shared-contract point 9 without the
+fingerprint-only fallback the plan reserved for a provider without idempotency
+support. `IssueUpdateInput` contains exactly the v1 allowlist fields (`title`,
+`description`, `stateId`, `priority`, `assigneeId`, `projectId`, `cycleId`);
+conflict detection re-reads `updatedAt` before commit.
+
+### 8. Webhooks (confirming the deferral)
+
+Webhooks require a public HTTPS, non-localhost URL, signed with HMAC-SHA256 in
+`Linear-Signature`, with `webhookTimestamp` replay protection and a
+`Linear-Delivery` UUID for dedupe. This confirms the plan's decision: local
+mode uses live reads plus bounded polling; webhooks stay reserved for a future
+away-mode relay with its own ADR.
+
+## Residual Phase 0 items
+
+- **OAuth app registration is a human step.** A public OAuth2 application must
+  be created in a Linear workspace (client id ships in the binary; that is fine
+  for a public client). Until then the flow cannot be exercised live.
+- **Live verification** of rotation, grace-period behavior, revoke, and scope
+  errors against a real workspace once the app exists, per the plan's
+  verification list.
+
+## Sources
+
+- [Linear OAuth 2.0 authentication](https://linear.app/developers/oauth-2-0-authentication)
+- [Linear rate limiting](https://linear.app/developers/rate-limiting)
+- [Linear pagination](https://linear.app/developers/pagination)
+- [Linear webhooks](https://linear.app/developers/webhooks)
+- [Linear SDK schema](https://github.com/linear/linear/blob/master/packages/sdk/src/schema.graphql) (`IssueCreateInput`, `CommentCreateInput`, `ProjectUpdateCreateInput`, `IssueUpdateInput`)

--- a/docs/plugins/linear-oauth-spike.md
+++ b/docs/plugins/linear-oauth-spike.md
@@ -26,8 +26,17 @@ Yes. The token exchange at `POST https://api.linear.app/oauth/token` marks
 and `redirect_uri` complete the exchange. `code_challenge_method` supports
 `plain` and `S256`; June always uses S256. PKCE is optional on Linear's side,
 so June must enforce it client-side rather than rely on the provider requiring
-it. `http://localhost:<port>/...` redirect URIs are accepted, matching the
-existing loopback flow in `connectors/oauth.rs`.
+it. `http://localhost:<port>/...` redirect URIs are accepted as registered
+callback URLs.
+
+**Redirect URI matching caveat:** unlike Google, Linear matches the redirect
+URI against the registered callback URLs exactly - it does not implement RFC
+8252's rule to ignore the port on loopback addresses (observed in the wild:
+Linear's MCP OAuth rejects ephemeral loopback ports). June therefore binds
+one of a fixed candidate port list (`44741`, `44742`, `44743`; override with
+`LINEAR_OAUTH_LOOPBACK_PORT`) and the OAuth application must register a
+`http://127.0.0.1:<port>/callback` URL for each candidate. Confirm during
+live verification.
 
 ### 2. Refresh-token rotation, lifetime, revoke
 

--- a/src-tauri/migrations/014_linear_connector.sql
+++ b/src-tauri/migrations/014_linear_connector.sql
@@ -1,0 +1,13 @@
+-- The Linear teams a connected workspace account is scoped to. A routine's
+-- Linear tools only ever see issues/projects within these teams, so a
+-- multi-team workspace does not implicitly grant access to every team in it.
+-- Replaced wholesale on every "manage teams" save (see
+-- Repositories::set_selected_teams), never diffed row by row.
+CREATE TABLE IF NOT EXISTS connector_selected_teams (
+  account_id TEXT NOT NULL,
+  team_id TEXT NOT NULL,
+  team_key TEXT NOT NULL,
+  team_name TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (account_id, team_id)
+);

--- a/src-tauri/src/connectors/commands.rs
+++ b/src-tauri/src/connectors/commands.rs
@@ -9,8 +9,8 @@ use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 
 use super::{
-    begin_connect, disconnect, list_accounts, scopes::ScopeBundle, ConnectFlow, ConnectorAccount,
-    ConnectorAccountStatus,
+    begin_connect, begin_connect_linear, disconnect, linear, list_accounts, scopes::ScopeBundle,
+    ConnectFlow, ConnectorAccount, ConnectorAccountStatus, ConnectorProvider, SelectedTeamDto,
 };
 
 /// A routine earns autonomy only after this many completed approval-mode
@@ -36,11 +36,18 @@ pub async fn connectors_list(app: tauri::AppHandle) -> Result<Vec<ConnectorAccou
 #[serde(rename_all = "camelCase")]
 pub struct ConnectorsConnectRequest {
     /// Bundle names: "gmail_read" | "gmail_draft" | "gmail_send" |
-    /// "calendar_events".
+    /// "calendar_events" | "linear_read" | "linear_write". Every bundle must
+    /// belong to the requested provider.
     pub scopes: Vec<String>,
-    /// Existing account email for incremental scope escalation.
+    /// Existing account identity for a reconnect or incremental scope
+    /// escalation: the account EMAIL for Google, the ACCOUNT ID (workspace
+    /// id) for Linear.
     #[serde(default)]
     pub login_hint: Option<String>,
+    /// "google" | "linear". Absent means "google": the field predates
+    /// multi-provider support and older frontends never send it.
+    #[serde(default)]
+    pub provider: Option<String>,
 }
 
 #[tauri::command]
@@ -49,8 +56,20 @@ pub async fn connectors_connect(
     flow: tauri::State<'_, ConnectFlow>,
     request: ConnectorsConnectRequest,
 ) -> Result<ConnectorAccount, AppError> {
+    let provider = parse_provider(request.provider.as_deref())?;
     let bundles = parse_bundles(&request.scopes)?;
-    let account = begin_connect(&app, &flow, &bundles, request.login_hint.as_deref()).await?;
+    validate_bundle_providers(&bundles, provider)?;
+    let account = match provider {
+        ConnectorProvider::Google => {
+            begin_connect(&app, &flow, &bundles, request.login_hint.as_deref()).await?
+        }
+        ConnectorProvider::Linear => {
+            begin_connect_linear(&app, &flow, &bundles, request.login_hint.as_deref()).await?
+        }
+    };
+    if provider != ConnectorProvider::Google {
+        return Ok(account);
+    }
 
     // Re-mint autonomous grants for routines that still declare autonomous
     // trust. A prior disconnect deletes an account's grants but keeps the
@@ -61,6 +80,8 @@ pub async fn connectors_connect(
     // failure must not fail the connect, and each grant is recreated with the
     // token carried over when the tool set is unchanged, so this is a no-op for
     // routines that already hold valid grants (a plain scope escalation).
+    // Google-only: the grants are Gmail/Calendar autonomy, so a Linear connect
+    // never touches them.
     let repos = crate::commands::repositories(&app).await?;
     match repos.list_routine_trust_by_mode("autonomous").await {
         Ok(records) => {
@@ -100,6 +121,101 @@ pub async fn connectors_disconnect(
     request: ConnectorsDisconnectRequest,
 ) -> Result<(), AppError> {
     disconnect(&app, &request.account_id, request.revoke).await
+}
+
+// --- Linear teams --------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectorsLinearTeamsRequest {
+    /// Linear account id (the workspace id).
+    pub account_id: String,
+}
+
+/// The workspace's teams for the selection UI, live from Linear. A rejected
+/// access token is force-refreshed once and the listing retried, matching
+/// the Google retry-once convention.
+#[tauri::command]
+pub async fn connectors_linear_teams(
+    app: tauri::AppHandle,
+    request: ConnectorsLinearTeamsRequest,
+) -> Result<Vec<SelectedTeamDto>, AppError> {
+    let repos = crate::commands::repositories(&app).await?;
+    require_linear_account(&repos, &request.account_id).await?;
+    let token = super::linear_access_token(&app, &request.account_id).await?;
+    let teams = match linear::list_teams(&token).await {
+        Ok(teams) => teams,
+        Err(linear::LinearApiError::Unauthorized) => {
+            let token = super::force_refresh_linear_access_token(&app, &request.account_id).await?;
+            linear::list_teams(&token).await.map_err(AppError::from)?
+        }
+        Err(error) => return Err(error.into()),
+    };
+    Ok(teams
+        .into_iter()
+        .map(|team| SelectedTeamDto {
+            id: team.id,
+            key: team.key,
+            name: team.name,
+        })
+        .collect())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectorsSelectedTeamsSetRequest {
+    /// Linear account id (the workspace id).
+    pub account_id: String,
+    /// The full desired team set; replaces the stored selection wholesale.
+    pub teams: Vec<SelectedTeamDto>,
+}
+
+/// Replace the account's selected-team set. The selection is June's own
+/// authorization boundary (Linear has no teams-scoped grant), so it must
+/// never be empty: an empty set would make every team query answer nothing
+/// while looking connected.
+#[tauri::command]
+pub async fn connectors_selected_teams_set(
+    app: tauri::AppHandle,
+    request: ConnectorsSelectedTeamsSetRequest,
+) -> Result<ConnectorAccount, AppError> {
+    let repos = crate::commands::repositories(&app).await?;
+    require_linear_account(&repos, &request.account_id).await?;
+    let teams = validate_selected_teams(&request.teams)?;
+    let records: Vec<crate::db::repositories::SelectedTeamRecord> = teams
+        .into_iter()
+        .map(|team| crate::db::repositories::SelectedTeamRecord {
+            team_id: team.id,
+            team_key: team.key,
+            team_name: team.name,
+        })
+        .collect();
+    repos
+        .set_selected_teams(&request.account_id, &records)
+        .await?;
+    super::emit_connectors_changed(&app);
+    let record = repos
+        .get_connector_account(&request.account_id)
+        .await?
+        .ok_or_else(linear_account_not_found)?;
+    super::account_dto(&repos, record).await
+}
+
+fn linear_account_not_found() -> AppError {
+    AppError::new(
+        "connector_account_not_found",
+        "That Linear workspace is not connected.",
+    )
+}
+
+/// The account must exist AND be a Linear row: a Google email passed as the
+/// account id must not pass the existence check and then hit Linear APIs.
+async fn require_linear_account(repos: &Repositories, account_id: &str) -> Result<(), AppError> {
+    let record = repos.get_connector_account(account_id).await?;
+    match record {
+        Some(record) if record.provider == ConnectorProvider::Linear.as_str() => Ok(()),
+        _ => Err(linear_account_not_found()),
+    }
 }
 
 // --- Routine trust modes -----------------------------------------------------
@@ -358,7 +474,13 @@ async fn first_connected_account_email(app: &tauri::AppHandle) -> String {
     match list_accounts(app).await {
         Ok(accounts) => accounts
             .into_iter()
-            .find(|account| account.status == ConnectorAccountStatus::Connected)
+            // Autonomy grants are Gmail/Calendar servers, so only a Google
+            // account can back them; a connected Linear workspace in the
+            // list must never leak its email into a Google grant.
+            .find(|account| {
+                account.provider == ConnectorProvider::Google
+                    && account.status == ConnectorAccountStatus::Connected
+            })
             .map(|account| account.email)
             .unwrap_or_default(),
         // Never fail the trust change on an account-enumeration hiccup; the
@@ -420,11 +542,16 @@ pub async fn connector_trigger_set(
 ) -> Result<ConnectorTriggerDto, AppError> {
     validate_trigger_kind(&request.kind)?;
     let repos = crate::commands::repositories(&app).await?;
-    if repos
+    // Triggers poll Gmail history and Calendar events, so the subscribed
+    // account must be a Google one: a Linear workspace id would pass a bare
+    // existence check and leave the routine silently never firing.
+    let is_google_account = repos
         .get_connector_account(&request.account_id)
         .await?
-        .is_none()
-    {
+        .is_some_and(|record| {
+            super::ConnectorProvider::from_db(&record.provider) == super::ConnectorProvider::Google
+        });
+    if !is_google_account {
         return Err(AppError::new(
             "connector_account_not_found",
             "That Google account is not connected.",
@@ -506,6 +633,78 @@ fn parse_bundles(names: &[String]) -> Result<Vec<ScopeBundle>, AppError> {
         .collect()
 }
 
+/// Parse the connect request's provider field. Absent means Google (the
+/// field predates multi-provider support); anything else must name a known
+/// provider exactly.
+fn parse_provider(value: Option<&str>) -> Result<ConnectorProvider, AppError> {
+    match value {
+        None => Ok(ConnectorProvider::Google),
+        Some(value) => match value.trim() {
+            "google" => Ok(ConnectorProvider::Google),
+            "linear" => Ok(ConnectorProvider::Linear),
+            _ => Err(AppError::new(
+                "connector_unknown_provider",
+                format!("Unknown connector provider \"{value}\"."),
+            )),
+        },
+    }
+}
+
+/// Every requested bundle must belong to the provider being connected: a
+/// mixed request would silently drop the foreign bundles' scopes from the
+/// consent screen while the caller believes they were granted.
+fn validate_bundle_providers(
+    bundles: &[ScopeBundle],
+    provider: ConnectorProvider,
+) -> Result<(), AppError> {
+    for bundle in bundles {
+        if bundle.provider() != provider {
+            return Err(AppError::new(
+                "connector_scope_provider_mismatch",
+                format!(
+                    "Scope bundle \"{}\" does not belong to the {} connector.",
+                    bundle.name(),
+                    provider.as_str()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Validate a selected-teams payload: non-empty, every field non-blank
+/// (trimmed), deduplicated by team id preserving first-seen order. Returns
+/// the cleaned (trimmed, deduped) set to persist.
+fn validate_selected_teams(teams: &[SelectedTeamDto]) -> Result<Vec<SelectedTeamDto>, AppError> {
+    if teams.is_empty() {
+        return Err(AppError::new(
+            "connector_teams_required",
+            "Select at least one team.",
+        ));
+    }
+    let mut cleaned: Vec<SelectedTeamDto> = Vec::with_capacity(teams.len());
+    for team in teams {
+        let id = team.id.trim();
+        let key = team.key.trim();
+        let name = team.name.trim();
+        if id.is_empty() || key.is_empty() || name.is_empty() {
+            return Err(AppError::new(
+                "connector_teams_invalid",
+                "Team entries need an id, key, and name.",
+            ));
+        }
+        if cleaned.iter().any(|existing| existing.id == id) {
+            continue;
+        }
+        cleaned.push(SelectedTeamDto {
+            id: id.to_string(),
+            key: key.to_string(),
+            name: name.to_string(),
+        });
+    }
+    Ok(cleaned)
+}
+
 fn validate_trust_mode(mode: &str) -> Result<(), AppError> {
     if TRUST_MODES.contains(&mode) {
         Ok(())
@@ -549,6 +748,98 @@ mod tests {
         assert_eq!(error.code, "connector_unknown_scope_bundle");
         let error = parse_bundles(&[]).unwrap_err();
         assert_eq!(error.code, "connector_unknown_scope_bundle");
+    }
+
+    #[test]
+    fn provider_parsing_defaults_to_google_and_rejects_unknown() {
+        // Absent field: requests that predate multi-provider are Google.
+        assert_eq!(parse_provider(None).unwrap(), ConnectorProvider::Google);
+        assert_eq!(
+            parse_provider(Some("google")).unwrap(),
+            ConnectorProvider::Google
+        );
+        assert_eq!(
+            parse_provider(Some("linear")).unwrap(),
+            ConnectorProvider::Linear
+        );
+        let error = parse_provider(Some("jira")).unwrap_err();
+        assert_eq!(error.code, "connector_unknown_provider");
+        assert!(error.message.contains("\"jira\""));
+        assert_eq!(
+            parse_provider(Some("")).unwrap_err().code,
+            "connector_unknown_provider"
+        );
+    }
+
+    #[test]
+    fn bundle_provider_mismatch_is_rejected_both_ways() {
+        // A Google bundle cannot ride a Linear connect...
+        let error = validate_bundle_providers(
+            &[ScopeBundle::LinearRead, ScopeBundle::GmailRead],
+            ConnectorProvider::Linear,
+        )
+        .unwrap_err();
+        assert_eq!(error.code, "connector_scope_provider_mismatch");
+        assert!(error.message.contains("\"gmail_read\""));
+        assert!(error.message.contains("linear"));
+        // ...nor a Linear bundle a Google connect.
+        let error =
+            validate_bundle_providers(&[ScopeBundle::LinearWrite], ConnectorProvider::Google)
+                .unwrap_err();
+        assert_eq!(error.code, "connector_scope_provider_mismatch");
+        // Matching sets pass for both providers.
+        assert!(validate_bundle_providers(
+            &[ScopeBundle::GmailRead, ScopeBundle::CalendarEvents],
+            ConnectorProvider::Google
+        )
+        .is_ok());
+        assert!(validate_bundle_providers(
+            &[ScopeBundle::LinearRead, ScopeBundle::LinearWrite],
+            ConnectorProvider::Linear
+        )
+        .is_ok());
+    }
+
+    fn team(id: &str, key: &str, name: &str) -> SelectedTeamDto {
+        SelectedTeamDto {
+            id: id.to_string(),
+            key: key.to_string(),
+            name: name.to_string(),
+        }
+    }
+
+    #[test]
+    fn selected_teams_payload_validation() {
+        // Empty set: the selection is June's authorization boundary and must
+        // never be cleared to nothing.
+        assert_eq!(
+            validate_selected_teams(&[]).unwrap_err().code,
+            "connector_teams_required"
+        );
+        // Blank fields (after trimming) are rejected.
+        for invalid in [
+            team(" ", "ENG", "Engineering"),
+            team("team-1", "", "Engineering"),
+            team("team-1", "ENG", "  "),
+        ] {
+            assert_eq!(
+                validate_selected_teams(&[invalid]).unwrap_err().code,
+                "connector_teams_invalid"
+            );
+        }
+        // Dedupe by id keeps the first entry and its order; fields come back
+        // trimmed.
+        let cleaned = validate_selected_teams(&[
+            team(" team-2 ", " DES ", " Design "),
+            team("team-1", "ENG", "Engineering"),
+            team("team-2", "DES2", "Design again"),
+        ])
+        .expect("valid payload");
+        assert_eq!(cleaned.len(), 2);
+        assert_eq!(cleaned[0].id, "team-2");
+        assert_eq!(cleaned[0].key, "DES");
+        assert_eq!(cleaned[0].name, "Design");
+        assert_eq!(cleaned[1].id, "team-1");
     }
 
     #[test]

--- a/src-tauri/src/connectors/commands.rs
+++ b/src-tauri/src/connectors/commands.rs
@@ -139,26 +139,40 @@ pub struct ConnectorsLinearTeamsRequest {
 pub async fn connectors_linear_teams(
     app: tauri::AppHandle,
     request: ConnectorsLinearTeamsRequest,
-) -> Result<Vec<SelectedTeamDto>, AppError> {
+) -> Result<LinearTeamsDto, AppError> {
     let repos = crate::commands::repositories(&app).await?;
     require_linear_account(&repos, &request.account_id).await?;
     let token = super::linear_access_token(&app, &request.account_id).await?;
-    let teams = match linear::list_teams(&token).await {
-        Ok(teams) => teams,
+    let listing = match linear::list_teams(&token).await {
+        Ok(listing) => listing,
         Err(linear::LinearApiError::Unauthorized) => {
             let token = super::force_refresh_linear_access_token(&app, &request.account_id).await?;
             linear::list_teams(&token).await.map_err(AppError::from)?
         }
         Err(error) => return Err(error.into()),
     };
-    Ok(teams
-        .into_iter()
-        .map(|team| SelectedTeamDto {
-            id: team.id,
-            key: team.key,
-            name: team.name,
-        })
-        .collect())
+    Ok(LinearTeamsDto {
+        teams: listing
+            .teams
+            .into_iter()
+            .map(|team| SelectedTeamDto {
+                id: team.id,
+                key: team.key,
+                name: team.name,
+            })
+            .collect(),
+        truncated: listing.truncated,
+    })
+}
+
+/// The live team listing for the selection dialog. `truncated` means the
+/// pagination cap cut the listing short, so the UI must not present it as
+/// the complete team inventory.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinearTeamsDto {
+    pub teams: Vec<SelectedTeamDto>,
+    pub truncated: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src-tauri/src/connectors/linear.rs
+++ b/src-tauri/src/connectors/linear.rs
@@ -149,9 +149,13 @@ fn build_auth_url(
     // spaces). `actor=user` is the default but stated explicitly: v1
     // deliberately authorizes as the user, never the app actor (see the
     // spike doc - app actor needs a secret and sees every public team).
+    // `prompt=consent` forces the workspace picker on every connect: after
+    // a non-revoking disconnect the old grant still exists at Linear, and
+    // without the prompt a fresh connect would silently re-authorize the
+    // previous workspace with no way to pick a different one.
     format!(
         "{AUTH_ENDPOINT}?client_id={}&redirect_uri={}&response_type=code&scope={}\
-         &state={}&code_challenge={}&code_challenge_method=S256&actor=user",
+         &state={}&code_challenge={}&code_challenge_method=S256&actor=user&prompt=consent",
         urlencoding::encode(client_id),
         urlencoding::encode(redirect_uri),
         urlencoding::encode(&scopes.join(",")),
@@ -675,6 +679,9 @@ mod tests {
         assert!(url.contains("code_challenge=challenge"));
         assert!(url.contains("code_challenge_method=S256"));
         assert!(url.contains("actor=user"));
+        // Forces the workspace picker so a lingering grant after a
+        // non-revoking disconnect cannot silently re-authorize.
+        assert!(url.contains("prompt=consent"));
         // Public client: no secret in the authorization request.
         assert!(!url.contains("client_secret"));
     }

--- a/src-tauri/src/connectors/linear.rs
+++ b/src-tauri/src/connectors/linear.rs
@@ -541,7 +541,11 @@ pub struct LinearTeam {
     pub name: String,
 }
 
-const TEAMS_QUERY: &str = "query Teams($after: String) { teams(first: 100, after: $after) \
+// Page size rides in as a variable so [`TEAMS_PAGE_SIZE`] is the single
+// source of truth; a literal here would silently diverge from the constant
+// (and its truncation-warn log) if the cap were ever tuned.
+const TEAMS_QUERY: &str = "query Teams($after: String, $first: Int!) \
+     { teams(first: $first, after: $after) \
      { nodes { id key name } pageInfo { hasNextPage endCursor } } }";
 
 #[derive(Deserialize)]
@@ -629,7 +633,7 @@ pub async fn list_teams(access_token: &str) -> Result<LinearTeamsListing, Linear
         let data: TeamsDataWire = graphql(
             access_token,
             TEAMS_QUERY,
-            serde_json::json!({ "after": after }),
+            serde_json::json!({ "after": after, "first": TEAMS_PAGE_SIZE }),
         )
         .await?;
         after = pager.absorb(data.teams);

--- a/src-tauri/src/connectors/linear.rs
+++ b/src-tauri/src/connectors/linear.rs
@@ -278,23 +278,33 @@ fn classify_refresh_failure(status: u16, error_code: Option<&str>) -> LinearRefr
 /// 400 when the token was already revoked; both leave the grant dead, so
 /// both count as success. Other failures are swallowed after logging the
 /// HTTP status: local custody removal is the real disconnect.
-pub async fn revoke(token: &str) -> bool {
+pub async fn revoke(token: &str, token_type_hint: &str) -> bool {
     match oauth::http_client()
         .post(REVOKE_ENDPOINT)
-        .form(&[("token", token)])
+        .form(&[("token", token), ("token_type_hint", token_type_hint)])
         .send()
         .await
     {
         Ok(response) => {
             let status = response.status().as_u16();
-            let ok = response.status().is_success() || status == 400;
+            let ok = response.status().is_success();
             if !ok {
-                tracing::warn!(status, "linear revoke failed");
+                // 400 can mean "already revoked" but ALSO "could not revoke"
+                // (e.g. an unidentifiable token), so it is never silently
+                // success: log the OAuth error word (never the body) so a
+                // grant surviving a revoking disconnect is diagnosable.
+                let error_code = match response.text().await {
+                    Ok(body) => serde_json::from_str::<TokenErrorBody>(&body)
+                        .ok()
+                        .and_then(|body| body.error),
+                    Err(_) => None,
+                };
+                tracing::warn!(status, token_type_hint, error_code = ?error_code, "linear revoke did not confirm");
             }
             ok
         }
         Err(_) => {
-            tracing::warn!("linear revoke request failed");
+            tracing::warn!(token_type_hint, "linear revoke request failed");
             false
         }
     }

--- a/src-tauri/src/connectors/linear.rs
+++ b/src-tauri/src/connectors/linear.rs
@@ -611,10 +611,18 @@ impl TeamsPager {
     }
 }
 
+/// A teams listing plus whether the pagination cap cut it short. The flag
+/// travels to the UI: a silently incomplete list would present itself as
+/// the complete team inventory in a very large workspace.
+pub struct LinearTeamsListing {
+    pub teams: Vec<LinearTeam>,
+    pub truncated: bool,
+}
+
 /// List the workspace's teams for the selection UI: pages of 100, hard cap
-/// [`TEAMS_MAX_PAGES`] pages (a warn is logged if the cap truncates), sorted
-/// by name case-insensitively.
-pub async fn list_teams(access_token: &str) -> Result<Vec<LinearTeam>, LinearApiError> {
+/// [`TEAMS_MAX_PAGES`] pages (a warn is logged and the listing is flagged if
+/// the cap truncates), sorted by name case-insensitively.
+pub async fn list_teams(access_token: &str) -> Result<LinearTeamsListing, LinearApiError> {
     let mut pager = TeamsPager::new();
     let mut after: Option<String> = None;
     loop {
@@ -637,7 +645,7 @@ pub async fn list_teams(access_token: &str) -> Result<Vec<LinearTeam>, LinearApi
             "linear teams listing truncated at the pagination cap"
         );
     }
-    Ok(teams)
+    Ok(LinearTeamsListing { teams, truncated })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/connectors/linear.rs
+++ b/src-tauri/src/connectors/linear.rs
@@ -112,12 +112,20 @@ pub async fn authorize(
     flow: &ConnectFlow,
     client_id: &str,
     scopes: &[&str],
+    loopback_ports: &[u16],
 ) -> Result<LinearAuthorizedGrant, AppError> {
-    let authorization =
-        oauth::loopback_authorize(flow, "Linear", |redirect_uri, code_challenge, state| {
+    // Fixed candidate ports, not an ephemeral one: Linear matches the
+    // registered callback URL exactly (port included), so the redirect URI
+    // must be one whose URL is registered on the OAuth application.
+    let authorization = oauth::loopback_authorize(
+        flow,
+        "Linear",
+        oauth::LoopbackPort::Candidates(loopback_ports.to_vec()),
+        |redirect_uri, code_challenge, state| {
             build_auth_url(client_id, redirect_uri, scopes, code_challenge, state)
-        })
-        .await?;
+        },
+    )
+    .await?;
 
     let tokens = exchange_code(
         client_id,
@@ -346,6 +354,11 @@ struct GraphqlErrorWire {
 struct GraphqlErrorExtensionsWire {
     #[serde(default)]
     code: Option<String>,
+    /// Linear also tags errors with a human category here (e.g.
+    /// "authentication error"); carried because auth failures are not
+    /// guaranteed to arrive as HTTP 401.
+    #[serde(default, rename = "type")]
+    kind: Option<String>,
 }
 
 /// Shared GraphQL POST for the identity and teams documents. HTTP 401 maps
@@ -397,6 +410,27 @@ async fn graphql<T: DeserializeOwned>(
 fn check_graphql_errors(errors: &[GraphqlErrorWire], status: u16) -> Result<(), LinearApiError> {
     if errors.is_empty() {
         return Ok(());
+    }
+    // Linear signals failures through GraphQL error codes rather than
+    // semantic HTTP statuses (rate limiting arrives as HTTP 400), so a
+    // revoked or invalid token cannot be assumed to arrive as HTTP 401
+    // either: classify an authentication-flavored code or type as
+    // Unauthorized so the callers' refresh-and-retry and the
+    // reconnect_required transition still fire.
+    let unauthorized = errors.iter().any(|error| {
+        error.extensions.as_ref().is_some_and(|extensions| {
+            extensions
+                .code
+                .as_deref()
+                .is_some_and(|code| code.to_ascii_uppercase().contains("AUTHENTICATION"))
+                || extensions
+                    .kind
+                    .as_deref()
+                    .is_some_and(|kind| kind.to_ascii_lowercase().contains("authentication"))
+        })
+    });
+    if unauthorized {
+        return Err(LinearApiError::Unauthorized);
     }
     let rate_limited = errors.iter().any(|error| {
         error
@@ -661,6 +695,37 @@ mod tests {
         );
         assert!(parse_scope_field("").is_empty());
         assert!(parse_scope_field(" , ,").is_empty());
+    }
+
+    #[test]
+    fn graphql_auth_errors_classify_as_unauthorized_at_any_status() {
+        // Linear signals failures through GraphQL error codes rather than
+        // semantic HTTP statuses, so an auth failure must classify as
+        // Unauthorized even when it arrives as HTTP 400/200.
+        let errors: Vec<GraphqlErrorWire> = serde_json::from_str(
+            r#"[{"message":"Authentication required","extensions":{"code":"AUTHENTICATION_ERROR"}}]"#,
+        )
+        .expect("errors parse");
+        assert!(matches!(
+            check_graphql_errors(&errors, 400),
+            Err(LinearApiError::Unauthorized)
+        ));
+        let errors: Vec<GraphqlErrorWire> = serde_json::from_str(
+            r#"[{"message":"boom","extensions":{"type":"authentication error"}}]"#,
+        )
+        .expect("errors parse");
+        assert!(matches!(
+            check_graphql_errors(&errors, 200),
+            Err(LinearApiError::Unauthorized)
+        ));
+        // A non-auth error at HTTP 400 still classifies as a plain API error.
+        let errors: Vec<GraphqlErrorWire> =
+            serde_json::from_str(r#"[{"message":"boom","extensions":{"code":"INTERNAL_ERROR"}}]"#)
+                .expect("errors parse");
+        assert!(matches!(
+            check_graphql_errors(&errors, 400),
+            Err(LinearApiError::Api { status: 400, .. })
+        ));
     }
 
     #[test]

--- a/src-tauri/src/connectors/linear.rs
+++ b/src-tauri/src/connectors/linear.rs
@@ -1,0 +1,851 @@
+//! Linear native-app OAuth and the fixed GraphQL documents slice 1 needs.
+//!
+//! Linear is a PKCE-only PUBLIC client: unlike Google's Desktop credential,
+//! no client secret exists anywhere in this flow - the token endpoint marks
+//! it optional for PKCE and June never sends one (see
+//! docs/plugins/linear-oauth-spike.md). The browser handoff itself is the
+//! shared [`oauth::loopback_authorize`] primitive; this module owns Linear's
+//! auth-URL shape (COMMA-joined scopes, explicit `actor=user` - v1
+//! deliberately uses the user actor so grants inherit the authorizing user's
+//! team visibility, never the app actor's all-teams view), the secretless
+//! token exchange and refresh, revocation, and the two GraphQL documents the
+//! connect flow needs: viewer/organization identity and the Teams listing.
+//!
+//! Refresh responses rotate the refresh token on every success; callers
+//! persist the rotated token when present and keep the old one otherwise
+//! (same logic as Google). Rate limiting arrives as HTTP 400 with a
+//! `RATELIMITED` error code in the GraphQL errors array, not as HTTP 429.
+//!
+//! NEVER log, print, or serialize tokens (or authorization codes) into
+//! errors. Error messages carry stable codes and short human text only.
+
+use crate::domain::types::AppError;
+use serde::{de::DeserializeOwned, Deserialize};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use super::oauth::{self, ConnectFlow};
+
+const AUTH_ENDPOINT: &str = "https://linear.app/oauth/authorize";
+const TOKEN_ENDPOINT: &str = "https://api.linear.app/oauth/token";
+const REVOKE_ENDPOINT: &str = "https://api.linear.app/oauth/revoke";
+const GRAPHQL_ENDPOINT: &str = "https://api.linear.app/graphql";
+const API_ERROR_MESSAGE_MAX_LEN: usize = 200;
+/// Teams pagination hard cap: 5 pages of 100 covers 500 teams, far beyond
+/// any workspace June plausibly serves; the cap bounds a pathological or
+/// adversarial cursor loop.
+const TEAMS_PAGE_SIZE: u32 = 100;
+const TEAMS_MAX_PAGES: usize = 5;
+
+/// Token endpoint response. Secret fields zeroize on drop.
+#[derive(Deserialize, Zeroize, ZeroizeOnDrop)]
+pub struct LinearTokenResponse {
+    pub access_token: String,
+    /// Present on the initial exchange and (rotated) on every refresh; may
+    /// be absent on a scope escalation for an already-connected workspace,
+    /// in which case callers keep the one in custody.
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    #[zeroize(skip)]
+    pub expires_in: i64,
+    /// The granted scope set. Linear's separator is not contractual, so
+    /// callers parse it with [`parse_scope_field`] (commas or whitespace).
+    #[serde(default)]
+    #[zeroize(skip)]
+    pub scope: Option<String>,
+}
+
+/// Split a token response `scope` field into individual scopes. Accepts
+/// comma- and whitespace-separated forms (and mixtures) because Linear's
+/// exact separator is not contractual; empty fragments are dropped.
+pub fn parse_scope_field(raw: &str) -> Vec<String> {
+    raw.split(|c: char| c.is_whitespace() || c == ',')
+        .filter(|part| !part.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Who authorized, and for which workspace. The workspace id keys the
+/// keychain entry and the DB index row (NOT the email: a Linear account is a
+/// workspace grant, and the email may legitimately be empty). Carries no
+/// token material, so deriving `Debug` is safe.
+#[derive(Debug, Clone)]
+pub struct LinearIdentity {
+    pub workspace_id: String,
+    pub workspace_name: String,
+    pub workspace_url_key: String,
+    pub user_id: String,
+    pub user_name: String,
+    /// Lowercased and trimmed; may be empty (kept as-is, never substituted).
+    pub user_email: String,
+}
+
+/// Outcome of the full browser handoff: granted tokens plus the identity
+/// resolved with the fresh access token.
+pub struct LinearAuthorizedGrant {
+    pub tokens: LinearTokenResponse,
+    pub identity: LinearIdentity,
+}
+
+#[derive(Deserialize)]
+struct TokenErrorBody {
+    #[serde(default)]
+    error: Option<String>,
+}
+
+/// Mirrors `oauth::RefreshOutcome`, which hard-codes the Google token type;
+/// a Linear-local enum beats contorting the Google one.
+pub enum LinearRefreshOutcome {
+    Refreshed(LinearTokenResponse),
+    /// Definitive: the grant was revoked or expired. The workspace must be
+    /// reconnected; retrying cannot help.
+    InvalidGrant,
+    /// Upstream wobble (5xx, 429, network error): worth a bounded retry.
+    Transient,
+}
+
+/// Run the full Linear authorization handoff: open the consent screen in the
+/// default browser, wait on the loopback listener for the redirect, exchange
+/// the code (no client secret), and resolve the workspace identity with the
+/// fresh access token. A thin Linear-specific wrapper over
+/// [`oauth::loopback_authorize`], parallel to the Google `oauth::authorize`.
+pub async fn authorize(
+    flow: &ConnectFlow,
+    client_id: &str,
+    scopes: &[&str],
+) -> Result<LinearAuthorizedGrant, AppError> {
+    let authorization =
+        oauth::loopback_authorize(flow, "Linear", |redirect_uri, code_challenge, state| {
+            build_auth_url(client_id, redirect_uri, scopes, code_challenge, state)
+        })
+        .await?;
+
+    let tokens = exchange_code(
+        client_id,
+        &authorization.code,
+        &authorization.verifier,
+        &authorization.redirect_uri,
+    )
+    .await?;
+    let identity = fetch_identity(&tokens.access_token).await?;
+    Ok(LinearAuthorizedGrant { tokens, identity })
+}
+
+fn build_auth_url(
+    client_id: &str,
+    redirect_uri: &str,
+    scopes: &[&str],
+    code_challenge: &str,
+    state: &str,
+) -> String {
+    // Scopes are COMMA-joined (Linear's documented form, unlike Google's
+    // spaces). `actor=user` is the default but stated explicitly: v1
+    // deliberately authorizes as the user, never the app actor (see the
+    // spike doc - app actor needs a secret and sees every public team).
+    format!(
+        "{AUTH_ENDPOINT}?client_id={}&redirect_uri={}&response_type=code&scope={}\
+         &state={}&code_challenge={}&code_challenge_method=S256&actor=user",
+        urlencoding::encode(client_id),
+        urlencoding::encode(redirect_uri),
+        urlencoding::encode(&scopes.join(",")),
+        urlencoding::encode(state),
+        urlencoding::encode(code_challenge),
+    )
+}
+
+/// Exchange the authorization code for tokens. PKCE only: the form carries
+/// NO client_secret (public client), the verifier is the whole proof.
+async fn exchange_code(
+    client_id: &str,
+    code: &str,
+    verifier: &str,
+    redirect_uri: &str,
+) -> Result<LinearTokenResponse, AppError> {
+    let response = oauth::http_client()
+        .post(TOKEN_ENDPOINT)
+        .form(&authorization_code_form(
+            client_id,
+            code,
+            verifier,
+            redirect_uri,
+        ))
+        .send()
+        .await
+        .map_err(|_| exchange_failed(None))?;
+    let status = response.status().as_u16();
+    let body = response.text().await.map_err(|_| exchange_failed(None))?;
+    if let Ok(tokens) = serde_json::from_str::<LinearTokenResponse>(&body) {
+        if !tokens.access_token.is_empty() {
+            return Ok(tokens);
+        }
+    }
+    // Never echo the body: it could carry partial token material. Surface
+    // the OAuth error code word only.
+    let error_code = serde_json::from_str::<TokenErrorBody>(&body)
+        .ok()
+        .and_then(|body| body.error);
+    tracing::warn!(status, error_code = ?error_code, "linear token exchange failed");
+    Err(exchange_failed(error_code))
+}
+
+fn authorization_code_form<'a>(
+    client_id: &'a str,
+    code: &'a str,
+    verifier: &'a str,
+    redirect_uri: &'a str,
+) -> [(&'static str, &'a str); 5] {
+    [
+        ("grant_type", "authorization_code"),
+        ("code", code),
+        ("redirect_uri", redirect_uri),
+        ("client_id", client_id),
+        ("code_verifier", verifier),
+    ]
+}
+
+fn exchange_failed(error_code: Option<String>) -> AppError {
+    let message = match error_code {
+        Some(code) => format!("Could not complete the Linear connection ({code})."),
+        None => "Could not complete the Linear connection.".to_string(),
+    };
+    AppError::new("connector_token_exchange_failed", message)
+}
+
+/// One refresh attempt. Classifies invalid_grant (definitive, the workspace
+/// must be reconnected) apart from transient upstream wobble. On success the
+/// response ALWAYS carries a rotated refresh token; the caller persists it.
+pub async fn refresh(client_id: &str, refresh_token: &str) -> LinearRefreshOutcome {
+    let response = match oauth::http_client()
+        .post(TOKEN_ENDPOINT)
+        .form(&refresh_form(client_id, refresh_token))
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        // No response at all: DNS, connection reset, timeout. Always transient.
+        Err(_) => return LinearRefreshOutcome::Transient,
+    };
+    let status = response.status().as_u16();
+    let body = match response.text().await {
+        Ok(body) => body,
+        Err(_) => return LinearRefreshOutcome::Transient,
+    };
+    if let Ok(tokens) = serde_json::from_str::<LinearTokenResponse>(&body) {
+        if !tokens.access_token.is_empty() {
+            return LinearRefreshOutcome::Refreshed(tokens);
+        }
+    }
+    let error_code = serde_json::from_str::<TokenErrorBody>(&body)
+        .ok()
+        .and_then(|body| body.error);
+    classify_refresh_failure(status, error_code.as_deref())
+}
+
+fn refresh_form<'a>(client_id: &'a str, refresh_token: &'a str) -> [(&'static str, &'a str); 3] {
+    [
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh_token),
+        ("client_id", client_id),
+    ]
+}
+
+/// `invalid_grant` is the definitive "grant revoked/expired" signal; anything
+/// else (5xx, 429, even invalid_client) is treated as transient so a config
+/// hiccup never flips a workspace into the reconnect state. Mirrors the
+/// Google classification in oauth.rs.
+fn classify_refresh_failure(status: u16, error_code: Option<&str>) -> LinearRefreshOutcome {
+    // Log status + error code word only; never the body or tokens.
+    tracing::warn!(status, error_code = ?error_code, "linear token refresh failed");
+    match error_code {
+        Some("invalid_grant") => LinearRefreshOutcome::InvalidGrant,
+        _ => LinearRefreshOutcome::Transient,
+    }
+}
+
+/// Best-effort revocation of the grant at Linear (used by
+/// `disconnect(revoke_grant = true)`). Linear answers 200 on revocation and
+/// 400 when the token was already revoked; both leave the grant dead, so
+/// both count as success. Other failures are swallowed after logging the
+/// HTTP status: local custody removal is the real disconnect.
+pub async fn revoke(token: &str) -> bool {
+    match oauth::http_client()
+        .post(REVOKE_ENDPOINT)
+        .form(&[("token", token)])
+        .send()
+        .await
+    {
+        Ok(response) => {
+            let status = response.status().as_u16();
+            let ok = response.status().is_success() || status == 400;
+            if !ok {
+                tracing::warn!(status, "linear revoke failed");
+            }
+            ok
+        }
+        Err(_) => {
+            tracing::warn!("linear revoke request failed");
+            false
+        }
+    }
+}
+
+// --- GraphQL -------------------------------------------------------------------
+
+#[derive(Debug)]
+pub enum LinearApiError {
+    /// The access token was rejected. The caller should refresh and retry
+    /// once before surfacing an error.
+    Unauthorized,
+    /// Linear's request/complexity budget is exhausted (HTTP 400 with the
+    /// `RATELIMITED` error code, per the rate-limiting docs).
+    RateLimited,
+    Api {
+        status: u16,
+        message: String,
+    },
+    Network(String),
+}
+
+impl From<LinearApiError> for AppError {
+    fn from(error: LinearApiError) -> Self {
+        match error {
+            LinearApiError::Unauthorized => AppError::new(
+                "linear_unauthorized",
+                "Linear rejected the connection's access token.",
+            ),
+            LinearApiError::RateLimited => AppError::new(
+                "linear_rate_limited",
+                "Linear is rate limiting requests. Try again in a few minutes.",
+            ),
+            LinearApiError::Api { status, message } => AppError::new(
+                "linear_api_error",
+                format!("Linear API request failed ({status}): {message}"),
+            ),
+            LinearApiError::Network(message) => AppError::new("network_error", message),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct GraphqlResponseWire<T> {
+    // Missing `data` reads as None (serde treats Option fields as optional);
+    // no `default` attribute, which would wrongly demand `T: Default`.
+    data: Option<T>,
+    #[serde(default)]
+    errors: Vec<GraphqlErrorWire>,
+}
+
+#[derive(Deserialize)]
+struct GraphqlErrorWire {
+    #[serde(default)]
+    message: String,
+    #[serde(default)]
+    extensions: Option<GraphqlErrorExtensionsWire>,
+}
+
+#[derive(Deserialize)]
+struct GraphqlErrorExtensionsWire {
+    #[serde(default)]
+    code: Option<String>,
+}
+
+/// Shared GraphQL POST for the identity and teams documents. HTTP 401 maps
+/// to `Unauthorized`; a `RATELIMITED` code anywhere in the errors array maps
+/// to `RateLimited`; any other GraphQL error surfaces the first message
+/// (bounded). Never logs or echoes the access token.
+async fn graphql<T: DeserializeOwned>(
+    access_token: &str,
+    query: &str,
+    variables: serde_json::Value,
+) -> Result<T, LinearApiError> {
+    let response = oauth::http_client()
+        .post(GRAPHQL_ENDPOINT)
+        .bearer_auth(access_token)
+        .json(&serde_json::json!({ "query": query, "variables": variables }))
+        .send()
+        .await
+        .map_err(|e| LinearApiError::Network(e.to_string()))?;
+    let status = response.status().as_u16();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| LinearApiError::Network(e.to_string()))?;
+    if status == 401 {
+        return Err(LinearApiError::Unauthorized);
+    }
+    let parsed: GraphqlResponseWire<T> =
+        serde_json::from_str(&body).map_err(|e| LinearApiError::Api {
+            status,
+            message: format!("unexpected response shape: {e}"),
+        })?;
+    check_graphql_errors(&parsed.errors, status)?;
+    if !(200..300).contains(&status) {
+        return Err(LinearApiError::Api {
+            status,
+            message: "request failed".to_string(),
+        });
+    }
+    parsed.data.ok_or(LinearApiError::Api {
+        status,
+        message: "response carried no data".to_string(),
+    })
+}
+
+/// Classify a GraphQL errors array: `RATELIMITED` (checked in both
+/// `extensions.code` and the message, since the docs only guarantee the code
+/// word appears) beats a generic API failure; the first error's message is
+/// surfaced, bounded, never the raw body.
+fn check_graphql_errors(errors: &[GraphqlErrorWire], status: u16) -> Result<(), LinearApiError> {
+    if errors.is_empty() {
+        return Ok(());
+    }
+    let rate_limited = errors.iter().any(|error| {
+        error
+            .extensions
+            .as_ref()
+            .and_then(|extensions| extensions.code.as_deref())
+            == Some("RATELIMITED")
+            || error.message.contains("RATELIMITED")
+    });
+    if rate_limited {
+        return Err(LinearApiError::RateLimited);
+    }
+    let message = errors
+        .first()
+        .map(|error| {
+            error
+                .message
+                .chars()
+                .take(API_ERROR_MESSAGE_MAX_LEN)
+                .collect()
+        })
+        .unwrap_or_else(|| "request failed".to_string());
+    Err(LinearApiError::Api { status, message })
+}
+
+// --- Identity --------------------------------------------------------------------
+
+const IDENTITY_QUERY: &str = "{ viewer { id name email } organization { id name urlKey } }";
+
+#[derive(Deserialize)]
+struct IdentityDataWire {
+    #[serde(default)]
+    viewer: Option<ViewerWire>,
+    #[serde(default)]
+    organization: Option<OrganizationWire>,
+}
+
+#[derive(Deserialize)]
+struct ViewerWire {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    email: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OrganizationWire {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    url_key: String,
+}
+
+fn identity_failed() -> AppError {
+    AppError::new(
+        "connector_identity_failed",
+        "Could not determine the Linear workspace.",
+    )
+}
+
+/// Resolve the workspace + user identity that keys custody and the DB index.
+/// Any transport or API failure maps to the identity error (mirroring how
+/// Google's email resolution reports): during a connect there is nothing
+/// more actionable to say.
+async fn fetch_identity(access_token: &str) -> Result<LinearIdentity, AppError> {
+    let data: IdentityDataWire = graphql(access_token, IDENTITY_QUERY, serde_json::json!({}))
+        .await
+        .map_err(|_| identity_failed())?;
+    identity_from_data(data)
+}
+
+/// Pure mapping from the identity document's data to [`LinearIdentity`].
+/// Workspace and viewer ids are load-bearing (custody key, actor
+/// attribution) and must be present; name/urlKey/email may be empty and are
+/// carried as-is - the email is NOT substituted with the user name, because
+/// the account is keyed by workspace id, not email.
+fn identity_from_data(data: IdentityDataWire) -> Result<LinearIdentity, AppError> {
+    let viewer = data.viewer.ok_or_else(identity_failed)?;
+    let organization = data.organization.ok_or_else(identity_failed)?;
+    if viewer.id.is_empty() || organization.id.is_empty() {
+        return Err(identity_failed());
+    }
+    Ok(LinearIdentity {
+        workspace_id: organization.id,
+        workspace_name: organization.name,
+        workspace_url_key: organization.url_key,
+        user_id: viewer.id,
+        user_name: viewer.name,
+        user_email: viewer.email.trim().to_ascii_lowercase(),
+    })
+}
+
+// --- Teams -----------------------------------------------------------------------
+
+/// One team as offered to the selection UI. The GraphQL node shape (id, key,
+/// name) deserializes directly.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct LinearTeam {
+    pub id: String,
+    #[serde(default)]
+    pub key: String,
+    #[serde(default)]
+    pub name: String,
+}
+
+const TEAMS_QUERY: &str = "query Teams($after: String) { teams(first: 100, after: $after) \
+     { nodes { id key name } pageInfo { hasNextPage endCursor } } }";
+
+#[derive(Deserialize)]
+struct TeamsDataWire {
+    teams: TeamsPageWire,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TeamsPageWire {
+    #[serde(default)]
+    nodes: Vec<LinearTeam>,
+    page_info: PageInfoWire,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PageInfoWire {
+    #[serde(default)]
+    has_next_page: bool,
+    #[serde(default)]
+    end_cursor: Option<String>,
+}
+
+/// Pure page-fold for the Teams query, so the merge, the page cap, and the
+/// final ordering are unit-testable without HTTP.
+struct TeamsPager {
+    teams: Vec<LinearTeam>,
+    pages: usize,
+    truncated: bool,
+}
+
+impl TeamsPager {
+    fn new() -> Self {
+        TeamsPager {
+            teams: Vec::new(),
+            pages: 0,
+            truncated: false,
+        }
+    }
+
+    /// Fold one page in. Returns the `after` cursor for the next request, or
+    /// `None` when pagination is complete - either no further page exists or
+    /// the hard cap was reached (recorded as truncation).
+    fn absorb(&mut self, page: TeamsPageWire) -> Option<String> {
+        self.pages += 1;
+        self.teams.extend(page.nodes);
+        if !page.page_info.has_next_page {
+            return None;
+        }
+        if self.pages >= TEAMS_MAX_PAGES {
+            self.truncated = true;
+            return None;
+        }
+        page.page_info
+            .end_cursor
+            .filter(|cursor| !cursor.is_empty())
+    }
+
+    /// The accumulated teams sorted by name, case-insensitively (stable, so
+    /// equal names keep their arrival order), plus whether the cap truncated
+    /// the listing.
+    fn finish(self) -> (Vec<LinearTeam>, bool) {
+        let mut teams = self.teams;
+        teams.sort_by_key(|team| team.name.to_lowercase());
+        (teams, self.truncated)
+    }
+}
+
+/// List the workspace's teams for the selection UI: pages of 100, hard cap
+/// [`TEAMS_MAX_PAGES`] pages (a warn is logged if the cap truncates), sorted
+/// by name case-insensitively.
+pub async fn list_teams(access_token: &str) -> Result<Vec<LinearTeam>, LinearApiError> {
+    let mut pager = TeamsPager::new();
+    let mut after: Option<String> = None;
+    loop {
+        let data: TeamsDataWire = graphql(
+            access_token,
+            TEAMS_QUERY,
+            serde_json::json!({ "after": after }),
+        )
+        .await?;
+        after = pager.absorb(data.teams);
+        if after.is_none() {
+            break;
+        }
+    }
+    let (teams, truncated) = pager.finish();
+    if truncated {
+        tracing::warn!(
+            page_cap = TEAMS_MAX_PAGES,
+            page_size = TEAMS_PAGE_SIZE,
+            "linear teams listing truncated at the pagination cap"
+        );
+    }
+    Ok(teams)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_url_carries_pkce_public_client_params() {
+        let url = build_auth_url(
+            "client-123",
+            "http://127.0.0.1:49152/callback",
+            &["read", "write"],
+            "challenge",
+            "csrf-state",
+        );
+        assert!(url.starts_with("https://linear.app/oauth/authorize?"));
+        assert!(url.contains("client_id=client-123"));
+        assert!(url.contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A49152%2Fcallback"));
+        assert!(url.contains("response_type=code"));
+        // Scopes are comma-joined (encoded comma), never space-joined.
+        assert!(url.contains("scope=read%2Cwrite"));
+        assert!(url.contains("state=csrf-state"));
+        assert!(url.contains("code_challenge=challenge"));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("actor=user"));
+        // Public client: no secret in the authorization request.
+        assert!(!url.contains("client_secret"));
+    }
+
+    #[test]
+    fn token_forms_carry_no_client_secret() {
+        let exchange = authorization_code_form(
+            "public-id",
+            "authorization-code",
+            "pkce-verifier",
+            "http://127.0.0.1:49152/callback",
+        );
+        assert!(exchange.contains(&("client_id", "public-id")));
+        assert!(exchange.contains(&("code_verifier", "pkce-verifier")));
+        assert!(exchange.iter().all(|(key, _)| *key != "client_secret"));
+
+        let refresh = refresh_form("public-id", "refresh-token");
+        assert!(refresh.contains(&("client_id", "public-id")));
+        assert!(refresh.contains(&("refresh_token", "refresh-token")));
+        assert!(refresh.iter().all(|(key, _)| *key != "client_secret"));
+    }
+
+    #[test]
+    fn parse_scope_field_accepts_commas_spaces_and_mixtures() {
+        assert_eq!(parse_scope_field("read,write"), vec!["read", "write"]);
+        assert_eq!(parse_scope_field("read write"), vec!["read", "write"]);
+        assert_eq!(
+            parse_scope_field(" read, write ,,  issues:create "),
+            vec!["read", "write", "issues:create"]
+        );
+        assert!(parse_scope_field("").is_empty());
+        assert!(parse_scope_field(" , ,").is_empty());
+    }
+
+    #[test]
+    fn refresh_failure_classification() {
+        assert!(matches!(
+            classify_refresh_failure(400, Some("invalid_grant")),
+            LinearRefreshOutcome::InvalidGrant
+        ));
+        assert!(matches!(
+            classify_refresh_failure(500, None),
+            LinearRefreshOutcome::Transient
+        ));
+        assert!(matches!(
+            classify_refresh_failure(429, Some("rate_limited")),
+            LinearRefreshOutcome::Transient
+        ));
+        assert!(matches!(
+            classify_refresh_failure(400, Some("invalid_client")),
+            LinearRefreshOutcome::Transient
+        ));
+    }
+
+    #[test]
+    fn identity_parses_and_normalizes_the_email() {
+        let data: IdentityDataWire = serde_json::from_str(
+            r#"{
+                "viewer": { "id": "user-1", "name": "Ada", "email": " Ada@Example.COM " },
+                "organization": { "id": "org-1", "name": "Acme", "urlKey": "acme" }
+            }"#,
+        )
+        .expect("fixture");
+        let identity = identity_from_data(data).expect("identity");
+        assert_eq!(identity.workspace_id, "org-1");
+        assert_eq!(identity.workspace_name, "Acme");
+        assert_eq!(identity.workspace_url_key, "acme");
+        assert_eq!(identity.user_id, "user-1");
+        assert_eq!(identity.user_name, "Ada");
+        assert_eq!(identity.user_email, "ada@example.com");
+    }
+
+    #[test]
+    fn identity_requires_workspace_and_viewer_ids_but_not_email() {
+        // Missing organization: no workspace to key custody by.
+        let data: IdentityDataWire =
+            serde_json::from_str(r#"{ "viewer": { "id": "user-1" } }"#).expect("fixture");
+        let error = identity_from_data(data).unwrap_err();
+        assert_eq!(error.code, "connector_identity_failed");
+
+        // Empty viewer id is as unusable as a missing viewer.
+        let data: IdentityDataWire = serde_json::from_str(
+            r#"{ "viewer": { "id": "" }, "organization": { "id": "org-1" } }"#,
+        )
+        .expect("fixture");
+        assert_eq!(
+            identity_from_data(data).unwrap_err().code,
+            "connector_identity_failed"
+        );
+
+        // An empty email is fine: the account is keyed by workspace id.
+        let data: IdentityDataWire = serde_json::from_str(
+            r#"{ "viewer": { "id": "user-1" }, "organization": { "id": "org-1" } }"#,
+        )
+        .expect("fixture");
+        let identity = identity_from_data(data).expect("identity");
+        assert_eq!(identity.user_email, "");
+    }
+
+    fn team(name: &str) -> LinearTeam {
+        LinearTeam {
+            id: format!("id-{name}"),
+            key: name.to_uppercase(),
+            name: name.to_string(),
+        }
+    }
+
+    fn page(names: &[&str], has_next: bool, cursor: Option<&str>) -> TeamsPageWire {
+        TeamsPageWire {
+            nodes: names.iter().map(|name| team(name)).collect(),
+            page_info: PageInfoWire {
+                has_next_page: has_next,
+                end_cursor: cursor.map(str::to_string),
+            },
+        }
+    }
+
+    #[test]
+    fn teams_pager_merges_pages_and_sorts_case_insensitively() {
+        let mut pager = TeamsPager::new();
+        assert_eq!(
+            pager.absorb(page(&["zeta", "Alpha"], true, Some("c1"))),
+            Some("c1".to_string())
+        );
+        assert_eq!(pager.absorb(page(&["beta"], false, None)), None);
+        let (teams, truncated) = pager.finish();
+        assert!(!truncated);
+        let names: Vec<&str> = teams.iter().map(|team| team.name.as_str()).collect();
+        assert_eq!(names, vec!["Alpha", "beta", "zeta"]);
+    }
+
+    #[test]
+    fn teams_pager_stops_at_the_page_cap_and_reports_truncation() {
+        let mut pager = TeamsPager::new();
+        for index in 0..TEAMS_MAX_PAGES - 1 {
+            let cursor = format!("c{index}");
+            assert_eq!(
+                pager.absorb(page(&["team"], true, Some(&cursor))),
+                Some(cursor)
+            );
+        }
+        // The capping page still claims more data, but the pager refuses.
+        assert_eq!(pager.absorb(page(&["team"], true, Some("more"))), None);
+        let (teams, truncated) = pager.finish();
+        assert!(truncated);
+        assert_eq!(teams.len(), TEAMS_MAX_PAGES);
+    }
+
+    #[test]
+    fn teams_pager_treats_a_missing_cursor_as_the_end() {
+        // hasNextPage with no cursor cannot be followed; stop rather than
+        // loop on a request that would replay the same page.
+        let mut pager = TeamsPager::new();
+        assert_eq!(pager.absorb(page(&["team"], true, None)), None);
+        let (_, truncated) = pager.finish();
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn graphql_error_classification() {
+        // Empty errors array: not an error.
+        assert!(check_graphql_errors(&[], 200).is_ok());
+
+        // RATELIMITED via extensions.code.
+        let errors: Vec<GraphqlErrorWire> = serde_json::from_str(
+            r#"[{ "message": "Rate limit exceeded", "extensions": { "code": "RATELIMITED" } }]"#,
+        )
+        .expect("fixture");
+        assert!(matches!(
+            check_graphql_errors(&errors, 400),
+            Err(LinearApiError::RateLimited)
+        ));
+
+        // RATELIMITED mentioned only in the message still classifies.
+        let errors: Vec<GraphqlErrorWire> =
+            serde_json::from_str(r#"[{ "message": "RATELIMITED: slow down" }]"#).expect("fixture");
+        assert!(matches!(
+            check_graphql_errors(&errors, 400),
+            Err(LinearApiError::RateLimited)
+        ));
+
+        // Anything else surfaces the first message, bounded to the cap.
+        let long_message = "x".repeat(API_ERROR_MESSAGE_MAX_LEN + 50);
+        let errors = vec![GraphqlErrorWire {
+            message: long_message,
+            extensions: None,
+        }];
+        match check_graphql_errors(&errors, 400) {
+            Err(LinearApiError::Api { status, message }) => {
+                assert_eq!(status, 400);
+                assert_eq!(message.len(), API_ERROR_MESSAGE_MAX_LEN);
+            }
+            other => panic!("expected Api error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn api_errors_map_to_stable_app_error_codes() {
+        assert_eq!(
+            AppError::from(LinearApiError::Unauthorized).code,
+            "linear_unauthorized"
+        );
+        assert_eq!(
+            AppError::from(LinearApiError::RateLimited).code,
+            "linear_rate_limited"
+        );
+        assert_eq!(
+            AppError::from(LinearApiError::Api {
+                status: 400,
+                message: "bad".to_string()
+            })
+            .code,
+            "linear_api_error"
+        );
+        assert_eq!(
+            AppError::from(LinearApiError::Network("down".to_string())).code,
+            "network_error"
+        );
+    }
+}

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -705,10 +705,16 @@ pub async fn begin_connect(
     // Persist the account's scopes. When Google omits the response scope field
     // on an incremental grant, this unions the requested scopes with the ones
     // the account already held, so add-access never makes the DB forget earlier
-    // grants the token still carries.
+    // grants the token still carries. Matched by provider AND email: a Linear
+    // row can carry the same email (the Linear viewer email is often the
+    // Google address), and its "read"/"write" scopes must never leak into the
+    // Google account's persisted grant.
     let existing_scopes = existing_accounts
         .iter()
-        .find(|record| record.email.eq_ignore_ascii_case(&email))
+        .find(|record| {
+            record.provider == ConnectorProvider::Google.as_str()
+                && record.email.eq_ignore_ascii_case(&email)
+        })
         .map(|record| record.scopes.as_slice());
     let granted_scopes =
         scopes::resolve_granted_scopes(grant.tokens.scope.as_deref(), &requested, existing_scopes);

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -41,12 +41,25 @@ const GOOGLE_OAUTH_CLIENT_SECRET_ENV: &str = "GOOGLE_OAUTH_CLIENT_SECRET";
 #[serde(rename_all = "snake_case")]
 pub enum ConnectorProvider {
     Google,
+    Linear,
 }
 
 impl ConnectorProvider {
     pub fn as_str(&self) -> &'static str {
         match self {
             ConnectorProvider::Google => "google",
+            ConnectorProvider::Linear => "linear",
+        }
+    }
+
+    /// Parse the `connector_accounts.provider` column. Unrecognized values
+    /// default to `Google` (mirrors `ConnectorAccountStatus::from_db`'s
+    /// defaulting style) rather than failing to load the whole account list
+    /// over a single stale or corrupt row.
+    pub fn from_db(value: &str) -> Self {
+        match value {
+            "linear" => ConnectorProvider::Linear,
+            _ => ConnectorProvider::Google,
         }
     }
 }
@@ -75,7 +88,8 @@ impl ConnectorAccountStatus {
 }
 
 /// Non-secret account descriptor returned to the frontend and used by the
-/// proxy to enumerate accounts. The account id IS the Google account email.
+/// proxy to enumerate accounts. The account id IS the Google account email
+/// for a Google row; a later Linear chunk keys it by workspace id instead.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectorAccount {
@@ -84,6 +98,37 @@ pub struct ConnectorAccount {
     pub email: String,
     pub scopes: Vec<String>,
     pub status: ConnectorAccountStatus,
+    /// Linear workspace display name, parsed from the account's `metadata`
+    /// JSON. Always `None` for Google rows.
+    pub workspace_name: Option<String>,
+    /// Linear workspace url key (the `foo` in `linear.app/foo`), parsed from
+    /// `metadata`. Always `None` for Google rows.
+    pub workspace_url_key: Option<String>,
+    /// The Linear teams this account is scoped to. Always empty for Google
+    /// rows, which have no team concept.
+    pub selected_teams: Vec<SelectedTeamDto>,
+}
+
+/// One Linear team the account is scoped to, as shown to the frontend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectedTeamDto {
+    pub id: String,
+    pub key: String,
+    pub name: String,
+}
+
+/// Non-secret metadata carried on a `connector_accounts` row, beyond the
+/// columns every provider shares (email, scopes, status). Parsed
+/// best-effort from the `metadata` JSON column; unknown or absent keys
+/// resolve to `None` rather than failing account enumeration.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConnectorAccountMetadata {
+    #[serde(default)]
+    workspace_name: Option<String>,
+    #[serde(default)]
+    workspace_url_key: Option<String>,
 }
 
 // --- Config ------------------------------------------------------------------
@@ -206,7 +251,7 @@ pub async fn google_access_token(
     app: &tauri::AppHandle,
     account_id: &str,
 ) -> Result<String, AppError> {
-    let stored = store::load_tokens(account_id)
+    let stored = store::load_tokens(ConnectorProvider::Google, account_id)
         .await?
         .ok_or_else(not_connected_error)?;
     if access_token_is_fresh(stored.expires_at_unix, now_unix()) {
@@ -243,7 +288,7 @@ async fn refresh_google_access_token_with_freshness_gate(
     let _guard = lock.lock().await;
     // Re-read inside the lock: another caller may have already refreshed
     // (and rotated the refresh token) while we waited.
-    let mut stored = store::load_tokens(account_id)
+    let mut stored = store::load_tokens(ConnectorProvider::Google, account_id)
         .await?
         .ok_or_else(not_connected_error)?;
     if accept_fresh && access_token_is_fresh(stored.expires_at_unix, now_unix()) {
@@ -272,7 +317,7 @@ async fn refresh_google_access_token_with_freshness_gate(
                     stored.refresh_token = rotated.to_string();
                 }
                 stored.expires_at_unix = now_unix() + fresh.expires_in.max(0);
-                store::store_tokens(&stored).await?;
+                store::store_tokens(ConnectorProvider::Google, account_id, &stored).await?;
                 return Ok(stored.access_token.clone());
             }
             oauth::RefreshOutcome::InvalidGrant => {
@@ -340,32 +385,55 @@ async fn mark_reconnect_required(app: &tauri::AppHandle, account_id: &str) {
 pub async fn list_accounts(app: &tauri::AppHandle) -> Result<Vec<ConnectorAccount>, AppError> {
     let repos = crate::commands::repositories(app).await?;
     let records = repos.list_connector_accounts().await?;
-    Ok(records
-        .into_iter()
-        .map(|record| ConnectorAccount {
+    let mut accounts = Vec::with_capacity(records.len());
+    for record in records {
+        // Best-effort: a malformed metadata blob degrades to "no workspace
+        // info" rather than failing the whole account list.
+        let metadata: ConnectorAccountMetadata =
+            serde_json::from_str(&record.metadata).unwrap_or_default();
+        let selected_teams = repos
+            .list_selected_teams(&record.account_id)
+            .await?
+            .into_iter()
+            .map(|team| SelectedTeamDto {
+                id: team.team_id,
+                key: team.team_key,
+                name: team.team_name,
+            })
+            .collect();
+        accounts.push(ConnectorAccount {
             account_id: record.account_id,
-            provider: ConnectorProvider::Google,
+            provider: ConnectorProvider::from_db(&record.provider),
             email: record.email,
             scopes: record.scopes,
             status: ConnectorAccountStatus::from_db(&record.status),
-        })
-        .collect())
+            workspace_name: metadata.workspace_name,
+            workspace_url_key: metadata.workspace_url_key,
+            selected_teams,
+        });
+    }
+    Ok(accounts)
 }
 
-/// The email of an already-stored account that differs from the one being
-/// connected, if any. Local mode is single-account (every connector surface
-/// resolves the one connected account), so a second, distinct account is
-/// refused to avoid a cross-account read/write mix-up. Comparison is
-/// case-insensitive, so reconnecting or adding scope to the same email returns
-/// `None` and is allowed.
+/// The email of an already-stored account, for the SAME provider, that
+/// differs from the one being connected, if any. Local mode is
+/// single-account per provider (every connector surface for a given provider
+/// resolves the one connected account for that provider), so a second,
+/// distinct account for that provider is refused to avoid a cross-account
+/// read/write mix-up. A different provider's account never conflicts: a
+/// connected Google account must not block connecting Linear, and vice versa.
+/// Comparison is case-insensitive, so reconnecting or adding scope to the
+/// same email returns `None` and is allowed.
 fn conflicting_existing_account<'a>(
-    existing_emails: impl IntoIterator<Item = &'a str>,
-    connecting: &str,
+    existing: impl IntoIterator<Item = (&'a str, &'a str)>,
+    connecting_provider: &str,
+    connecting_email: &str,
 ) -> Option<String> {
-    existing_emails
+    existing
         .into_iter()
-        .find(|email| !email.eq_ignore_ascii_case(connecting))
-        .map(str::to_string)
+        .filter(|(provider, _)| *provider == connecting_provider)
+        .find(|(_, email)| !email.eq_ignore_ascii_case(connecting_email))
+        .map(|(_, email)| email.to_string())
 }
 
 /// Run the full connect flow (browser consent, loopback callback, code
@@ -389,12 +457,27 @@ pub async fn begin_connect(
         if let Some(record) = repos.get_connector_account(&hint_lower).await? {
             let already_granted = scopes::missing_scopes(&record.scopes, bundles).is_empty();
             if already_granted && record.status == ConnectorAccountStatus::Connected.as_str() {
+                let selected_teams = repos
+                    .list_selected_teams(&record.account_id)
+                    .await?
+                    .into_iter()
+                    .map(|team| SelectedTeamDto {
+                        id: team.team_id,
+                        key: team.team_key,
+                        name: team.team_name,
+                    })
+                    .collect();
+                let metadata: ConnectorAccountMetadata =
+                    serde_json::from_str(&record.metadata).unwrap_or_default();
                 return Ok(ConnectorAccount {
                     account_id: record.account_id,
-                    provider: ConnectorProvider::Google,
+                    provider: ConnectorProvider::from_db(&record.provider),
                     email: record.email,
                     scopes: record.scopes,
                     status: ConnectorAccountStatus::Connected,
+                    workspace_name: metadata.workspace_name,
+                    workspace_url_key: metadata.workspace_url_key,
+                    selected_teams,
                 });
             }
         }
@@ -437,7 +520,10 @@ pub async fn begin_connect(
     // guard is the safety net, not the primary path.
     let existing_accounts = repos.list_connector_accounts().await?;
     if let Some(existing_email) = conflicting_existing_account(
-        existing_accounts.iter().map(|record| record.email.as_str()),
+        existing_accounts
+            .iter()
+            .map(|record| (record.provider.as_str(), record.email.as_str())),
+        ConnectorProvider::Google.as_str(),
         &email,
     ) {
         return Err(AppError::new(
@@ -468,7 +554,7 @@ pub async fn begin_connect(
         .filter(|token| !token.is_empty())
     {
         Some(token) => token.to_string(),
-        None => store::load_tokens(&email)
+        None => store::load_tokens(ConnectorProvider::Google, &email)
             .await?
             .map(|existing| existing.refresh_token.clone())
             .ok_or_else(|| {
@@ -486,7 +572,7 @@ pub async fn begin_connect(
         scopes: granted_scopes.clone(),
         email: email.clone(),
     };
-    store::store_tokens(&tokens).await?;
+    store::store_tokens(ConnectorProvider::Google, &email, &tokens).await?;
 
     repos
         .upsert_connector_account(
@@ -495,6 +581,7 @@ pub async fn begin_connect(
             &email,
             &granted_scopes,
             ConnectorAccountStatus::Connected.as_str(),
+            "{}",
         )
         .await?;
     emit_connectors_changed(app);
@@ -505,6 +592,9 @@ pub async fn begin_connect(
         email,
         scopes: granted_scopes,
         status: ConnectorAccountStatus::Connected,
+        workspace_name: None,
+        workspace_url_key: None,
+        selected_teams: Vec::new(),
     })
 }
 
@@ -522,7 +612,7 @@ pub async fn disconnect(
     revoke_grant: bool,
 ) -> Result<(), AppError> {
     if revoke_grant {
-        if let Ok(Some(stored)) = store::load_tokens(account_id).await {
+        if let Ok(Some(stored)) = store::load_tokens(ConnectorProvider::Google, account_id).await {
             // Revoking either token of the pair invalidates the whole grant;
             // prefer the refresh token.
             let token = if stored.refresh_token.is_empty() {
@@ -535,7 +625,7 @@ pub async fn disconnect(
             }
         }
     }
-    store::delete_tokens(account_id).await?;
+    store::delete_tokens(ConnectorProvider::Google, account_id).await?;
     let repos = crate::commands::repositories(app).await?;
     repos.delete_connector_account(account_id).await?;
     emit_connectors_changed(app);
@@ -553,12 +643,32 @@ mod tests {
             "\"google\""
         );
         assert_eq!(
+            serde_json::to_string(&ConnectorProvider::Linear).unwrap(),
+            "\"linear\""
+        );
+        assert_eq!(
             serde_json::to_string(&ConnectorAccountStatus::ReconnectRequired).unwrap(),
             "\"reconnect_required\""
         );
         assert_eq!(
             serde_json::from_str::<ConnectorAccountStatus>("\"connected\"").unwrap(),
             ConnectorAccountStatus::Connected
+        );
+    }
+
+    #[test]
+    fn provider_from_db_defaults_to_google() {
+        assert_eq!(
+            ConnectorProvider::from_db("google"),
+            ConnectorProvider::Google
+        );
+        assert_eq!(
+            ConnectorProvider::from_db("linear"),
+            ConnectorProvider::Linear
+        );
+        assert_eq!(
+            ConnectorProvider::from_db("unexpected"),
+            ConnectorProvider::Google
         );
     }
 
@@ -570,11 +680,39 @@ mod tests {
             email: "user@example.com".to_string(),
             scopes: vec!["openid".to_string()],
             status: ConnectorAccountStatus::Connected,
+            workspace_name: None,
+            workspace_url_key: None,
+            selected_teams: Vec::new(),
         };
         let json = serde_json::to_value(&account).unwrap();
         assert_eq!(json["accountId"], "user@example.com");
         assert_eq!(json["provider"], "google");
         assert_eq!(json["status"], "connected");
+        assert!(json["workspaceName"].is_null());
+        assert!(json["workspaceUrlKey"].is_null());
+        assert_eq!(json["selectedTeams"], serde_json::json!([]));
+
+        let linear_account = ConnectorAccount {
+            account_id: "workspace-1".to_string(),
+            provider: ConnectorProvider::Linear,
+            email: String::new(),
+            scopes: Vec::new(),
+            status: ConnectorAccountStatus::Connected,
+            workspace_name: Some("Acme".to_string()),
+            workspace_url_key: Some("acme".to_string()),
+            selected_teams: vec![SelectedTeamDto {
+                id: "team-1".to_string(),
+                key: "ENG".to_string(),
+                name: "Engineering".to_string(),
+            }],
+        };
+        let json = serde_json::to_value(&linear_account).unwrap();
+        assert_eq!(json["provider"], "linear");
+        assert_eq!(json["workspaceName"], "Acme");
+        assert_eq!(json["workspaceUrlKey"], "acme");
+        assert_eq!(json["selectedTeams"][0]["id"], "team-1");
+        assert_eq!(json["selectedTeams"][0]["key"], "ENG");
+        assert_eq!(json["selectedTeams"][0]["name"], "Engineering");
     }
 
     #[test]
@@ -604,21 +742,47 @@ mod tests {
     #[test]
     fn single_account_guard_blocks_a_different_account_only() {
         // First-ever connect: nothing stored, nothing conflicts.
-        assert_eq!(conflicting_existing_account([], "a@example.com"), None);
+        assert_eq!(
+            conflicting_existing_account([], "google", "a@example.com"),
+            None
+        );
         // Reconnect or scope-add on the same account (any casing) is allowed.
         assert_eq!(
-            conflicting_existing_account(["a@example.com"], "A@Example.com"),
+            conflicting_existing_account([("google", "a@example.com")], "google", "A@Example.com"),
             None
         );
         // A second, distinct account is refused, naming the stored one.
         assert_eq!(
-            conflicting_existing_account(["a@example.com"], "b@example.com"),
+            conflicting_existing_account([("google", "a@example.com")], "google", "b@example.com"),
             Some("a@example.com".to_string())
         );
         // The stored account is reported even when the new one is also present
         // in the list (defensive: only the differing email matters).
         assert_eq!(
-            conflicting_existing_account(["a@example.com", "b@example.com"], "b@example.com"),
+            conflicting_existing_account(
+                [("google", "a@example.com"), ("google", "b@example.com")],
+                "google",
+                "b@example.com"
+            ),
+            Some("a@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn single_account_guard_ignores_other_providers() {
+        // A connected Google account must never block connecting a Linear
+        // workspace (and vice versa): the single-account guard is scoped per
+        // provider, not global across the whole connector_accounts table.
+        assert_eq!(
+            conflicting_existing_account([("google", "a@example.com")], "linear", "workspace-1"),
+            None
+        );
+        assert_eq!(
+            conflicting_existing_account(
+                [("linear", "workspace-1"), ("google", "a@example.com")],
+                "google",
+                "b@example.com"
+            ),
             Some("a@example.com".to_string())
         );
     }

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -986,20 +986,30 @@ pub async fn disconnect(
     for &provider in providers {
         if revoke_grant {
             if let Ok(Some(stored)) = store::load_tokens(provider, account_id).await {
-                // Revoking either token of the pair invalidates the whole
-                // grant; prefer the refresh token.
-                let token = if stored.refresh_token.is_empty() {
-                    stored.access_token.clone()
-                } else {
-                    stored.refresh_token.clone()
-                };
-                if !token.is_empty() {
-                    match provider {
-                        ConnectorProvider::Google => {
+                match provider {
+                    ConnectorProvider::Google => {
+                        // Google: revoking either token of the pair
+                        // invalidates the whole grant; prefer the refresh
+                        // token.
+                        let token = if stored.refresh_token.is_empty() {
+                            stored.access_token.clone()
+                        } else {
+                            stored.refresh_token.clone()
+                        };
+                        if !token.is_empty() {
                             let _ = oauth::revoke(&token).await;
                         }
-                        ConnectorProvider::Linear => {
-                            let _ = linear::revoke(&token).await;
+                    }
+                    ConnectorProvider::Linear => {
+                        // Linear documents no cross-token cascade, so revoke
+                        // BOTH tokens: a lone refresh-token revoke can leave
+                        // the 24-hour access token alive and the app still
+                        // listed under the user's authorized applications.
+                        if !stored.refresh_token.is_empty() {
+                            let _ = linear::revoke(&stored.refresh_token, "refresh_token").await;
+                        }
+                        if !stored.access_token.is_empty() {
+                            let _ = linear::revoke(&stored.access_token, "access_token").await;
                         }
                     }
                 }

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -1,10 +1,11 @@
-//! Private Google connectors, local mode.
+//! Private connectors (Google, Linear), local mode.
 //!
 //! OAuth (PKCE + loopback), Keychain token custody, the scope registry, and
-//! the direct Google REST client. The provider proxy and the trigger daemon
+//! the direct provider clients. The provider proxy and the trigger daemon
 //! consume this module: they resolve an access token via
-//! [`google_access_token`] and call the [`google`] functions with it. June
-//! API and OpenSoftware infrastructure are never in the connector data path.
+//! [`google_access_token`] / [`linear_access_token`] and call the [`google`]
+//! / [`linear`] functions with it. June API and OpenSoftware infrastructure
+//! are never in the connector data path.
 //!
 //! Secrets live ONLY in the keychain ([`store`]); the SQLite index carries
 //! non-secret account metadata (emails, scopes, status) so accounts can be
@@ -14,6 +15,7 @@
 pub mod approvals;
 pub mod commands;
 pub mod google;
+pub mod linear;
 pub mod oauth;
 pub mod scopes;
 pub mod store;
@@ -36,6 +38,7 @@ pub use oauth::ConnectFlow;
 const ACCESS_TOKEN_EXPIRY_BUFFER_SECS: i64 = 60;
 const GOOGLE_OAUTH_CLIENT_ID_ENV: &str = "GOOGLE_OAUTH_CLIENT_ID";
 const GOOGLE_OAUTH_CLIENT_SECRET_ENV: &str = "GOOGLE_OAUTH_CLIENT_SECRET";
+const LINEAR_OAUTH_CLIENT_ID_ENV: &str = "LINEAR_OAUTH_CLIENT_ID";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -199,6 +202,29 @@ fn require_oauth_client() -> Result<GoogleOAuthClient, AppError> {
     Ok(client)
 }
 
+/// Linear public-client credential: a client id only. Linear's PKCE flow
+/// needs no secret anywhere (see docs/plugins/linear-oauth-spike.md), so
+/// unlike [`google_oauth_client`] there is no second field to ship. Runtime
+/// env overrides the build-time value for local testing.
+fn linear_oauth_client_id() -> String {
+    crate::os_accounts::load_local_env();
+    env_or_build_trimmed(
+        LINEAR_OAUTH_CLIENT_ID_ENV,
+        option_env!("LINEAR_OAUTH_CLIENT_ID"),
+    )
+}
+
+fn require_linear_client_id() -> Result<String, AppError> {
+    let client_id = linear_oauth_client_id();
+    if client_id.is_empty() {
+        return Err(AppError::new(
+            "connector_not_configured",
+            "Linear connector is not configured in this build.",
+        ));
+    }
+    Ok(client_id)
+}
+
 // --- Access tokens ----------------------------------------------------------------
 
 /// Per-account refresh serialization: refresh tokens can rotate, so two
@@ -239,6 +265,20 @@ fn reconnect_required_error() -> AppError {
     AppError::new(
         "connector_reconnect_required",
         "Google access for this account expired. Reconnect it in settings.",
+    )
+}
+
+fn linear_not_connected_error() -> AppError {
+    AppError::new(
+        "connector_not_connected",
+        "This Linear workspace is not connected.",
+    )
+}
+
+fn linear_reconnect_required_error() -> AppError {
+    AppError::new(
+        "connector_reconnect_required",
+        "Linear access for this workspace expired. Reconnect it in settings.",
     )
 }
 
@@ -338,6 +378,91 @@ async fn refresh_google_access_token_with_freshness_gate(
     }
 }
 
+/// Resolve a usable access token for the Linear workspace: the cached token
+/// when it is comfortably fresh, otherwise a refreshed one. The account id
+/// is the workspace id; it shares [`REFRESH_LOCKS`] with Google accounts
+/// (workspace ids and emails cannot collide). The refresh loop is a
+/// deliberate duplicate of the Google one with Linear types - the two flows
+/// differ in credential shape (no secret) and outcome enum, and an
+/// abstraction over both would obscure more than it saves.
+pub async fn linear_access_token(
+    app: &tauri::AppHandle,
+    account_id: &str,
+) -> Result<String, AppError> {
+    let stored = store::load_tokens(ConnectorProvider::Linear, account_id)
+        .await?
+        .ok_or_else(linear_not_connected_error)?;
+    if access_token_is_fresh(stored.expires_at_unix, now_unix()) {
+        return Ok(stored.access_token.clone());
+    }
+    refresh_linear_access_token_with_freshness_gate(app, account_id, true).await
+}
+
+/// Refresh regardless of cached freshness. Callers use this to retry once
+/// after `linear::LinearApiError::Unauthorized` (a token revoked or expired
+/// server side before its local expiry).
+pub async fn force_refresh_linear_access_token(
+    app: &tauri::AppHandle,
+    account_id: &str,
+) -> Result<String, AppError> {
+    // Skip the freshness fast path but still serialize on the account lock.
+    refresh_linear_access_token_with_freshness_gate(app, account_id, false).await
+}
+
+async fn refresh_linear_access_token_with_freshness_gate(
+    app: &tauri::AppHandle,
+    account_id: &str,
+    accept_fresh: bool,
+) -> Result<String, AppError> {
+    let client_id = require_linear_client_id()?;
+    let lock = refresh_lock_for(account_id);
+    let _guard = lock.lock().await;
+    // Re-read inside the lock: another caller may have already refreshed
+    // (and rotated the refresh token) while we waited.
+    let mut stored = store::load_tokens(ConnectorProvider::Linear, account_id)
+        .await?
+        .ok_or_else(linear_not_connected_error)?;
+    if accept_fresh && access_token_is_fresh(stored.expires_at_unix, now_unix()) {
+        return Ok(stored.access_token.clone());
+    }
+
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        match linear::refresh(&client_id, &stored.refresh_token).await {
+            linear::LinearRefreshOutcome::Refreshed(fresh) => {
+                stored.access_token = fresh.access_token.clone();
+                // Rotation: Linear issues a new refresh token on every
+                // refresh; persist it, keep the existing one if absent.
+                if let Some(rotated) = fresh
+                    .refresh_token
+                    .as_deref()
+                    .filter(|token| !token.is_empty())
+                {
+                    stored.refresh_token = rotated.to_string();
+                }
+                stored.expires_at_unix = now_unix() + fresh.expires_in.max(0);
+                store::store_tokens(ConnectorProvider::Linear, account_id, &stored).await?;
+                return Ok(stored.access_token.clone());
+            }
+            linear::LinearRefreshOutcome::InvalidGrant => {
+                mark_reconnect_required(app, account_id).await;
+                return Err(linear_reconnect_required_error());
+            }
+            linear::LinearRefreshOutcome::Transient => {
+                if attempt < oauth::REFRESH_MAX_ATTEMPTS {
+                    tokio::time::sleep(oauth::REFRESH_RETRY_BACKOFF * attempt as u32).await;
+                    continue;
+                }
+                return Err(AppError::new(
+                    "connector_refresh_unavailable",
+                    "Couldn't reach Linear to refresh access. Try again in a moment.",
+                ));
+            }
+        }
+    }
+}
+
 /// Fired whenever an account's connection state changes (connect, disconnect,
 /// or a background `reconnect_required` transition) so an open settings page
 /// refreshes without a remount. The frontend `CONNECTORS_CHANGED_EVENT`
@@ -380,6 +505,41 @@ async fn mark_reconnect_required(app: &tauri::AppHandle, account_id: &str) {
 
 // --- Account lifecycle -------------------------------------------------------------
 
+/// Build the frontend-facing DTO for one stored account row: map the
+/// provider/status columns, parse the metadata JSON, and load the selected
+/// teams. The single mapping shared by [`list_accounts`], the connect
+/// short-circuits, and the team-selection command, so the row-to-DTO
+/// translation cannot drift between call sites.
+async fn account_dto(
+    repos: &crate::db::repositories::Repositories,
+    record: crate::db::repositories::ConnectorAccountRecord,
+) -> Result<ConnectorAccount, AppError> {
+    // Best-effort: a malformed metadata blob degrades to "no workspace
+    // info" rather than failing the whole account list.
+    let metadata: ConnectorAccountMetadata =
+        serde_json::from_str(&record.metadata).unwrap_or_default();
+    let selected_teams = repos
+        .list_selected_teams(&record.account_id)
+        .await?
+        .into_iter()
+        .map(|team| SelectedTeamDto {
+            id: team.team_id,
+            key: team.team_key,
+            name: team.team_name,
+        })
+        .collect();
+    Ok(ConnectorAccount {
+        account_id: record.account_id,
+        provider: ConnectorProvider::from_db(&record.provider),
+        email: record.email,
+        scopes: record.scopes,
+        status: ConnectorAccountStatus::from_db(&record.status),
+        workspace_name: metadata.workspace_name,
+        workspace_url_key: metadata.workspace_url_key,
+        selected_teams,
+    })
+}
+
 /// Enumerate connected accounts from the non-secret DB index (no keychain
 /// access, so listing never prompts).
 pub async fn list_accounts(app: &tauri::AppHandle) -> Result<Vec<ConnectorAccount>, AppError> {
@@ -387,53 +547,32 @@ pub async fn list_accounts(app: &tauri::AppHandle) -> Result<Vec<ConnectorAccoun
     let records = repos.list_connector_accounts().await?;
     let mut accounts = Vec::with_capacity(records.len());
     for record in records {
-        // Best-effort: a malformed metadata blob degrades to "no workspace
-        // info" rather than failing the whole account list.
-        let metadata: ConnectorAccountMetadata =
-            serde_json::from_str(&record.metadata).unwrap_or_default();
-        let selected_teams = repos
-            .list_selected_teams(&record.account_id)
-            .await?
-            .into_iter()
-            .map(|team| SelectedTeamDto {
-                id: team.team_id,
-                key: team.team_key,
-                name: team.team_name,
-            })
-            .collect();
-        accounts.push(ConnectorAccount {
-            account_id: record.account_id,
-            provider: ConnectorProvider::from_db(&record.provider),
-            email: record.email,
-            scopes: record.scopes,
-            status: ConnectorAccountStatus::from_db(&record.status),
-            workspace_name: metadata.workspace_name,
-            workspace_url_key: metadata.workspace_url_key,
-            selected_teams,
-        });
+        accounts.push(account_dto(&repos, record).await?);
     }
     Ok(accounts)
 }
 
-/// The email of an already-stored account, for the SAME provider, that
-/// differs from the one being connected, if any. Local mode is
-/// single-account per provider (every connector surface for a given provider
-/// resolves the one connected account for that provider), so a second,
-/// distinct account for that provider is refused to avoid a cross-account
-/// read/write mix-up. A different provider's account never conflicts: a
-/// connected Google account must not block connecting Linear, and vice versa.
-/// Comparison is case-insensitive, so reconnecting or adding scope to the
-/// same email returns `None` and is allowed.
+/// The identity of an already-stored account, for the SAME provider, that
+/// differs from the one being connected, if any. The identity string is
+/// whatever keys that provider's accounts: the email for Google, the
+/// workspace id for Linear. Local mode is single-account per provider
+/// (every connector surface for a given provider resolves the one connected
+/// account for that provider), so a second, distinct account for that
+/// provider is refused to avoid a cross-account read/write mix-up. A
+/// different provider's account never conflicts: a connected Google account
+/// must not block connecting Linear, and vice versa. Comparison is
+/// case-insensitive, so reconnecting or adding scope to the same identity
+/// returns `None` and is allowed.
 fn conflicting_existing_account<'a>(
     existing: impl IntoIterator<Item = (&'a str, &'a str)>,
     connecting_provider: &str,
-    connecting_email: &str,
+    connecting_identity: &str,
 ) -> Option<String> {
     existing
         .into_iter()
         .filter(|(provider, _)| *provider == connecting_provider)
-        .find(|(_, email)| !email.eq_ignore_ascii_case(connecting_email))
-        .map(|(_, email)| email.to_string())
+        .find(|(_, identity)| !identity.eq_ignore_ascii_case(connecting_identity))
+        .map(|(_, identity)| identity.to_string())
 }
 
 /// Run the full connect flow (browser consent, loopback callback, code
@@ -457,28 +596,7 @@ pub async fn begin_connect(
         if let Some(record) = repos.get_connector_account(&hint_lower).await? {
             let already_granted = scopes::missing_scopes(&record.scopes, bundles).is_empty();
             if already_granted && record.status == ConnectorAccountStatus::Connected.as_str() {
-                let selected_teams = repos
-                    .list_selected_teams(&record.account_id)
-                    .await?
-                    .into_iter()
-                    .map(|team| SelectedTeamDto {
-                        id: team.team_id,
-                        key: team.team_key,
-                        name: team.team_name,
-                    })
-                    .collect();
-                let metadata: ConnectorAccountMetadata =
-                    serde_json::from_str(&record.metadata).unwrap_or_default();
-                return Ok(ConnectorAccount {
-                    account_id: record.account_id,
-                    provider: ConnectorProvider::from_db(&record.provider),
-                    email: record.email,
-                    scopes: record.scopes,
-                    status: ConnectorAccountStatus::Connected,
-                    workspace_name: metadata.workspace_name,
-                    workspace_url_key: metadata.workspace_url_key,
-                    selected_teams,
-                });
+                return account_dto(&repos, record).await;
             }
         }
     }
@@ -598,35 +716,247 @@ pub async fn begin_connect(
     })
 }
 
+/// The non-secret metadata blob persisted on a Linear account row. Keys are
+/// camelCase to match [`ConnectorAccountMetadata`]'s parse; empty-string
+/// fields are omitted rather than stored as noise.
+fn linear_account_metadata_json(identity: &linear::LinearIdentity) -> String {
+    let mut map = serde_json::Map::new();
+    for (key, value) in [
+        ("workspaceName", &identity.workspace_name),
+        ("workspaceUrlKey", &identity.workspace_url_key),
+        ("actorUserId", &identity.user_id),
+        ("actorName", &identity.user_name),
+    ] {
+        if !value.is_empty() {
+            map.insert(key.to_string(), serde_json::Value::String(value.clone()));
+        }
+    }
+    serde_json::Value::Object(map).to_string()
+}
+
+/// Run the full Linear connect flow (browser consent, loopback callback,
+/// code exchange, identity resolution, custody write, DB index upsert) for
+/// the requested scope bundles. The account is keyed by WORKSPACE id, not
+/// email: a Linear grant is a workspace grant, and `reconnect_account_id`
+/// carries that id on a reconnect or scope escalation. With a
+/// `reconnect_account_id` naming an already-connected workspace whose
+/// granted scopes cover the request, no browser round-trip happens
+/// (mirroring the Google incremental-auth short-circuit).
+pub async fn begin_connect_linear(
+    app: &tauri::AppHandle,
+    flow: &ConnectFlow,
+    bundles: &[scopes::ScopeBundle],
+    reconnect_account_id: Option<&str>,
+) -> Result<ConnectorAccount, AppError> {
+    // Defensive: the command layer validates too, but a Google bundle here
+    // would request Google scope URLs from Linear's consent screen.
+    if let Some(bundle) = bundles
+        .iter()
+        .find(|bundle| bundle.provider() != ConnectorProvider::Linear)
+    {
+        return Err(AppError::new(
+            "connector_scope_provider_mismatch",
+            format!(
+                "Scope bundle \"{}\" does not belong to the linear connector.",
+                bundle.name()
+            ),
+        ));
+    }
+    let client_id = require_linear_client_id()?;
+    let repos = crate::commands::repositories(app).await?;
+
+    let reconnect_account_id = reconnect_account_id
+        .map(str::trim)
+        .filter(|id| !id.is_empty());
+
+    // Escalation/reconnect short-circuit: an existing, healthy workspace
+    // that already holds every wanted scope needs no new consent.
+    if let Some(account_id) = reconnect_account_id {
+        if let Some(record) = repos.get_connector_account(account_id).await? {
+            let already_granted = scopes::missing_scopes(&record.scopes, bundles).is_empty();
+            if record.provider == ConnectorProvider::Linear.as_str()
+                && already_granted
+                && record.status == ConnectorAccountStatus::Connected.as_str()
+            {
+                return account_dto(&repos, record).await;
+            }
+        }
+    }
+
+    let requested = scopes::requested_linear_scopes(bundles);
+    let grant = linear::authorize(flow, &client_id, &requested).await?;
+    let identity = grant.identity;
+    let workspace_id = identity.workspace_id.clone();
+
+    // A reconnect id means the user asked to (re)connect one specific
+    // workspace. The browser can still consent for a different one; abort on
+    // mismatch rather than silently storing the wrong workspace (which would
+    // leave the intended one still flagged reconnect_required).
+    if let Some(expected) = reconnect_account_id {
+        if !workspace_id.eq_ignore_ascii_case(expected) {
+            return Err(AppError::new(
+                "connector_account_mismatch",
+                "That Linear workspace does not match the one you were reconnecting. Try again and pick that workspace.",
+            ));
+        }
+    }
+
+    // Same single-account rationale as the Google guard above, scoped to the
+    // Linear provider: every Linear surface resolves "the connected
+    // workspace", so a second, distinct workspace is refused. Compared by
+    // workspace id (the account id), never email.
+    let existing_accounts = repos.list_connector_accounts().await?;
+    if let Some(existing_id) = conflicting_existing_account(
+        existing_accounts
+            .iter()
+            .map(|record| (record.provider.as_str(), record.account_id.as_str())),
+        ConnectorProvider::Linear.as_str(),
+        &workspace_id,
+    ) {
+        // Name the stored workspace when its metadata carries a name; the
+        // raw id is a last resort that at least identifies the row.
+        let display = existing_accounts
+            .iter()
+            .find(|record| record.account_id == existing_id)
+            .and_then(|record| {
+                serde_json::from_str::<ConnectorAccountMetadata>(&record.metadata).ok()
+            })
+            .and_then(|metadata| metadata.workspace_name)
+            .filter(|name| !name.is_empty())
+            .unwrap_or(existing_id);
+        return Err(AppError::new(
+            "connector_single_account_only",
+            format!(
+                "June local mode uses one Linear workspace at a time. Disconnect {display} before connecting another."
+            ),
+        ));
+    }
+
+    // Persist the granted scopes: Linear's response scope field when it
+    // carries anything, otherwise the requested list.
+    let granted_scopes: Vec<String> = grant
+        .tokens
+        .scope
+        .as_deref()
+        .map(linear::parse_scope_field)
+        .filter(|scopes| !scopes.is_empty())
+        .unwrap_or_else(|| requested.iter().map(|scope| scope.to_string()).collect());
+
+    // Scope escalation on an existing grant can omit the refresh token; keep
+    // the one already in custody then (mirrors the Google fallback).
+    let refresh_token = match grant
+        .tokens
+        .refresh_token
+        .as_deref()
+        .filter(|token| !token.is_empty())
+    {
+        Some(token) => token.to_string(),
+        None => store::load_tokens(ConnectorProvider::Linear, &workspace_id)
+            .await?
+            .map(|existing| existing.refresh_token.clone())
+            .ok_or_else(|| {
+                AppError::new(
+                    "connector_missing_refresh_token",
+                    "Linear did not return a refresh token. Remove June's access in Linear settings and connect again.",
+                )
+            })?,
+    };
+
+    let tokens = store::StoredConnectorTokens {
+        access_token: grant.tokens.access_token.clone(),
+        refresh_token,
+        expires_at_unix: now_unix() + grant.tokens.expires_in.max(0),
+        scopes: granted_scopes.clone(),
+        // May be empty; informational only. The workspace id keys custody.
+        email: identity.user_email.clone(),
+    };
+    store::store_tokens(ConnectorProvider::Linear, &workspace_id, &tokens).await?;
+
+    let metadata_json = linear_account_metadata_json(&identity);
+    repos
+        .upsert_connector_account(
+            &workspace_id,
+            ConnectorProvider::Linear.as_str(),
+            &identity.user_email,
+            &granted_scopes,
+            ConnectorAccountStatus::Connected.as_str(),
+            &metadata_json,
+        )
+        .await?;
+    emit_connectors_changed(app);
+
+    // On a reconnect the previous team selection survives (the rows were
+    // never deleted); a fresh connect has none until the user picks teams.
+    let selected_teams = repos
+        .list_selected_teams(&workspace_id)
+        .await?
+        .into_iter()
+        .map(|team| SelectedTeamDto {
+            id: team.team_id,
+            key: team.team_key,
+            name: team.team_name,
+        })
+        .collect();
+    Ok(ConnectorAccount {
+        account_id: workspace_id,
+        provider: ConnectorProvider::Linear,
+        email: identity.user_email,
+        scopes: granted_scopes,
+        status: ConnectorAccountStatus::Connected,
+        workspace_name: Some(identity.workspace_name).filter(|name| !name.is_empty()),
+        workspace_url_key: Some(identity.workspace_url_key).filter(|key| !key.is_empty()),
+        selected_teams,
+    })
+}
+
 /// Abort an in-flight connect (drains the browser-handoff wait).
 pub fn cancel_connect(flow: &ConnectFlow) {
     flow.cancel();
 }
 
-/// Disconnect an account: optionally revoke the grant at Google
+/// Disconnect an account: optionally revoke the grant at the provider
 /// (best-effort), always remove local custody, and drop the account from
-/// the DB index along with its triggers and cursors.
+/// the DB index along with its triggers, cursors, and selected teams. The
+/// provider is read from the account row; when the row is already gone
+/// (a half-completed earlier disconnect), custody cleanup sweeps BOTH
+/// providers' keychain services so no token is ever stranded.
 pub async fn disconnect(
     app: &tauri::AppHandle,
     account_id: &str,
     revoke_grant: bool,
 ) -> Result<(), AppError> {
-    if revoke_grant {
-        if let Ok(Some(stored)) = store::load_tokens(ConnectorProvider::Google, account_id).await {
-            // Revoking either token of the pair invalidates the whole grant;
-            // prefer the refresh token.
-            let token = if stored.refresh_token.is_empty() {
-                stored.access_token.clone()
-            } else {
-                stored.refresh_token.clone()
-            };
-            if !token.is_empty() {
-                let _ = oauth::revoke(&token).await;
+    let repos = crate::commands::repositories(app).await?;
+    let providers: &[ConnectorProvider] = match repos.get_connector_account(account_id).await? {
+        Some(record) => match ConnectorProvider::from_db(&record.provider) {
+            ConnectorProvider::Google => &[ConnectorProvider::Google],
+            ConnectorProvider::Linear => &[ConnectorProvider::Linear],
+        },
+        None => &[ConnectorProvider::Google, ConnectorProvider::Linear],
+    };
+    for &provider in providers {
+        if revoke_grant {
+            if let Ok(Some(stored)) = store::load_tokens(provider, account_id).await {
+                // Revoking either token of the pair invalidates the whole
+                // grant; prefer the refresh token.
+                let token = if stored.refresh_token.is_empty() {
+                    stored.access_token.clone()
+                } else {
+                    stored.refresh_token.clone()
+                };
+                if !token.is_empty() {
+                    match provider {
+                        ConnectorProvider::Google => {
+                            let _ = oauth::revoke(&token).await;
+                        }
+                        ConnectorProvider::Linear => {
+                            let _ = linear::revoke(&token).await;
+                        }
+                    }
+                }
             }
         }
+        store::delete_tokens(provider, account_id).await?;
     }
-    store::delete_tokens(ConnectorProvider::Google, account_id).await?;
-    let repos = crate::commands::repositories(app).await?;
     repos.delete_connector_account(account_id).await?;
     emit_connectors_changed(app);
     Ok(())
@@ -766,6 +1096,29 @@ mod tests {
             ),
             Some("a@example.com".to_string())
         );
+    }
+
+    #[test]
+    fn linear_metadata_json_omits_empty_fields_and_round_trips() {
+        let identity = linear::LinearIdentity {
+            workspace_id: "org-1".to_string(),
+            workspace_name: "Acme".to_string(),
+            workspace_url_key: String::new(),
+            user_id: "user-1".to_string(),
+            user_name: String::new(),
+            user_email: "ada@example.com".to_string(),
+        };
+        let raw = linear_account_metadata_json(&identity);
+        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(json["workspaceName"], "Acme");
+        assert_eq!(json["actorUserId"], "user-1");
+        assert!(json.get("workspaceUrlKey").is_none());
+        assert!(json.get("actorName").is_none());
+        // The stored blob parses back through the account-metadata reader
+        // that list_accounts uses.
+        let metadata: ConnectorAccountMetadata = serde_json::from_str(&raw).unwrap();
+        assert_eq!(metadata.workspace_name.as_deref(), Some("Acme"));
+        assert_eq!(metadata.workspace_url_key, None);
     }
 
     #[test]

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -467,7 +467,21 @@ async fn refresh_linear_access_token_with_freshness_gate(
                     stored.refresh_token = rotated.to_string();
                 }
                 stored.expires_at_unix = now_unix() + fresh.expires_in.max(0);
-                store::store_tokens(ConnectorProvider::Linear, account_id, &stored).await?;
+                // Linear already rotated server-side, so a failed persist
+                // here strands the NEW refresh token. Recovery rides on
+                // Linear's 30-minute grace window for the consumed (old)
+                // token still in custody (spike doc): the next refresh
+                // within that window rotates again. Log distinctly so a
+                // later forced reconnect is diagnosable to this write.
+                if let Err(error) =
+                    store::store_tokens(ConnectorProvider::Linear, account_id, &stored).await
+                {
+                    tracing::error!(
+                        error_code = %error.code,
+                        "persisting rotated linear refresh token failed; grant recovers only within linear's consumption grace window"
+                    );
+                    return Err(error);
+                }
                 return Ok(stored.access_token.clone());
             }
             linear::LinearRefreshOutcome::InvalidGrant => {
@@ -543,16 +557,27 @@ async fn account_dto(
     // info" rather than failing the whole account list.
     let metadata: ConnectorAccountMetadata =
         serde_json::from_str(&record.metadata).unwrap_or_default();
-    let selected_teams = repos
-        .list_selected_teams(&record.account_id)
-        .await?
-        .into_iter()
-        .map(|team| SelectedTeamDto {
-            id: team.team_id,
-            key: team.team_key,
-            name: team.team_name,
-        })
-        .collect();
+    // Same best-effort stance for the team rows: account enumeration was
+    // infallible before selected teams existed, and callers treat an Err as
+    // "no accounts" (blanking the settings page and routine gates), so one
+    // transient DB hiccup on one row must not fail the whole list.
+    let selected_teams = match repos.list_selected_teams(&record.account_id).await {
+        Ok(teams) => teams
+            .into_iter()
+            .map(|team| SelectedTeamDto {
+                id: team.team_id,
+                key: team.team_key,
+                name: team.team_name,
+            })
+            .collect(),
+        Err(error) => {
+            tracing::warn!(
+                error_code = %AppError::from(error).code,
+                "listing selected teams failed; account enumerates with an empty team set"
+            );
+            Vec::new()
+        }
+    };
     Ok(ConnectorAccount {
         account_id: record.account_id,
         provider: ConnectorProvider::from_db(&record.provider),

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -92,7 +92,7 @@ impl ConnectorAccountStatus {
 
 /// Non-secret account descriptor returned to the frontend and used by the
 /// proxy to enumerate accounts. The account id IS the Google account email
-/// for a Google row; a later Linear chunk keys it by workspace id instead.
+/// for a Google row, and the Linear workspace id for a Linear row.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectorAccount {
@@ -223,6 +223,31 @@ fn require_linear_client_id() -> Result<String, AppError> {
         ));
     }
     Ok(client_id)
+}
+
+/// The callback ports registered on the Linear OAuth application
+/// (`http://127.0.0.1:<port>/callback`, one URL per port). Linear matches
+/// the registered callback URL exactly - it does not ignore the loopback
+/// port the way Google does (RFC 8252) - so the connect listener must bind
+/// one of exactly these. Keep this list in sync with the OAuth app's
+/// registered callback URLs.
+const LINEAR_LOOPBACK_PORTS: &[u16] = &[44741, 44742, 44743];
+const LINEAR_OAUTH_LOOPBACK_PORT_ENV: &str = "LINEAR_OAUTH_LOOPBACK_PORT";
+
+/// The candidate loopback ports for a Linear connect: the
+/// `LINEAR_OAUTH_LOOPBACK_PORT` override alone when it parses as a port
+/// (for an OAuth app registered with a custom callback URL), otherwise the
+/// registered defaults.
+fn linear_loopback_ports() -> Vec<u16> {
+    crate::os_accounts::load_local_env();
+    linear_loopback_ports_from(&env_trimmed(LINEAR_OAUTH_LOOPBACK_PORT_ENV))
+}
+
+fn linear_loopback_ports_from(override_value: &str) -> Vec<u16> {
+    match override_value.parse::<u16>() {
+        Ok(port) if port != 0 => vec![port],
+        _ => LINEAR_LOOPBACK_PORTS.to_vec(),
+    }
 }
 
 // --- Access tokens ----------------------------------------------------------------
@@ -784,7 +809,7 @@ pub async fn begin_connect_linear(
     }
 
     let requested = scopes::requested_linear_scopes(bundles);
-    let grant = linear::authorize(flow, &client_id, &requested).await?;
+    let grant = linear::authorize(flow, &client_id, &requested, &linear_loopback_ports()).await?;
     let identity = grant.identity;
     let workspace_id = identity.workspace_id.clone();
 
@@ -1119,6 +1144,21 @@ mod tests {
         let metadata: ConnectorAccountMetadata = serde_json::from_str(&raw).unwrap();
         assert_eq!(metadata.workspace_name.as_deref(), Some("Acme"));
         assert_eq!(metadata.workspace_url_key, None);
+    }
+
+    #[test]
+    fn linear_loopback_ports_prefer_a_valid_env_override_only() {
+        // A parseable non-zero override narrows the candidates to that port.
+        assert_eq!(linear_loopback_ports_from("50000"), vec![50000]);
+        // Empty, garbage, zero, and out-of-range values all fall back to the
+        // registered defaults instead of breaking the connect flow.
+        assert_eq!(linear_loopback_ports_from(""), LINEAR_LOOPBACK_PORTS);
+        assert_eq!(
+            linear_loopback_ports_from("not-a-port"),
+            LINEAR_LOOPBACK_PORTS
+        );
+        assert_eq!(linear_loopback_ports_from("0"), LINEAR_LOOPBACK_PORTS);
+        assert_eq!(linear_loopback_ports_from("70000"), LINEAR_LOOPBACK_PORTS);
     }
 
     #[test]

--- a/src-tauri/src/connectors/oauth.rs
+++ b/src-tauri/src/connectors/oauth.rs
@@ -11,8 +11,8 @@
 //! mechanics. [`loopback_authorize`] owns the PKCE/CSRF minting, the
 //! listener, and the browser handoff; [`authorize`] is Google's thin wrapper
 //! around it and owns Google's own auth-URL shape, token exchange, and email
-//! resolution. A later Linear chunk adds its own thin wrapper the same way,
-//! never touching the shared listener code.
+//! resolution. `linear::authorize` is the same kind of thin wrapper; neither
+//! touches the shared listener code.
 //!
 //! NEVER log, print, or serialize tokens (or authorization codes) into
 //! errors. Error messages carry stable codes and short human text only.
@@ -118,36 +118,74 @@ pub enum RefreshOutcome {
 /// authorization code, its PKCE verifier, and the exact `redirect_uri` the
 /// code was issued for (the token endpoint requires it echoed back
 /// byte-identical). The caller still owns the token exchange and identity
-/// resolution, which differ per provider (Google's OIDC id_token/userinfo
-/// today; Linear's own token + viewer query in a later chunk).
+/// resolution, which differ per provider (Google's OIDC id_token/userinfo;
+/// Linear's own token endpoint + viewer query).
 pub(crate) struct LoopbackAuthorization {
     pub code: String,
     pub verifier: String,
     pub redirect_uri: String,
 }
 
+/// How the loopback listener picks its port. Google ignores the loopback
+/// port when matching redirect URIs (RFC 8252 native-app behavior), so an
+/// OS-assigned ephemeral port works. Linear matches the registered callback
+/// URL exactly, port included, so its listener must bind one of the fixed
+/// ports whose callback URLs are registered on the OAuth application.
+pub(crate) enum LoopbackPort {
+    Ephemeral,
+    Candidates(Vec<u16>),
+}
+
+/// Bind the loopback listener per the port strategy. For candidates, the
+/// first free port wins; every candidate being taken is reported with the
+/// full list so the user can see which local ports the connect needs.
+async fn bind_loopback(port: &LoopbackPort) -> Result<TcpListener, AppError> {
+    let bind_failed = |detail: String| {
+        AppError::new(
+            "connector_loopback_bind_failed",
+            format!("Could not start the local connect listener: {detail}"),
+        )
+    };
+    match port {
+        LoopbackPort::Ephemeral => TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .map_err(|e| bind_failed(e.to_string())),
+        LoopbackPort::Candidates(ports) => {
+            for &candidate in ports {
+                if let Ok(listener) = TcpListener::bind(("127.0.0.1", candidate)).await {
+                    return Ok(listener);
+                }
+            }
+            let list = ports
+                .iter()
+                .map(u16::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(bind_failed(format!(
+                "ports {list} are all in use on this Mac"
+            )))
+        }
+    }
+}
+
 /// Provider-neutral half of a native-app OAuth connect: mint PKCE + CSRF
-/// state, bind an ephemeral 127.0.0.1 listener, ask `build_auth_url` to
-/// assemble the provider's consent URL from the resulting
-/// `(redirect_uri, code_challenge, state)`, open it in the system browser,
-/// and race the loopback callback against the connect timeout and the
-/// flow's cancel signal. `provider_label` names the provider in the
+/// state, bind a 127.0.0.1 listener per the port strategy, ask
+/// `build_auth_url` to assemble the provider's consent URL from the
+/// resulting `(redirect_uri, code_challenge, state)`, open it in the system
+/// browser, and race the loopback callback against the connect timeout and
+/// the flow's cancel signal. `provider_label` names the provider in the
 /// timeout/cancel/denial copy shown to the user (e.g. "Google"), so each
 /// provider's wrapper keeps producing its own exact error text.
 pub(crate) async fn loopback_authorize(
     flow: &ConnectFlow,
     provider_label: &str,
+    port: LoopbackPort,
     build_auth_url: impl FnOnce(&str, &str, &str) -> String,
 ) -> Result<LoopbackAuthorization, AppError> {
     let (verifier, challenge) = pkce();
     let csrf = random_b64url(24);
 
-    let listener = TcpListener::bind(("127.0.0.1", 0)).await.map_err(|e| {
-        AppError::new(
-            "connector_loopback_bind_failed",
-            format!("Could not start the local connect listener: {e}"),
-        )
-    })?;
+    let listener = bind_loopback(&port).await?;
     let port = listener
         .local_addr()
         .map_err(|e| AppError::new("connector_loopback_bind_failed", e.to_string()))?
@@ -200,8 +238,11 @@ pub async fn authorize(
     scopes: &[&str],
     login_hint: Option<&str>,
 ) -> Result<AuthorizedGrant, AppError> {
-    let authorization =
-        loopback_authorize(flow, "Google", |redirect_uri, code_challenge, state| {
+    let authorization = loopback_authorize(
+        flow,
+        "Google",
+        LoopbackPort::Ephemeral,
+        |redirect_uri, code_challenge, state| {
             build_auth_url(
                 client_id,
                 redirect_uri,
@@ -210,8 +251,9 @@ pub async fn authorize(
                 state,
                 login_hint,
             )
-        })
-        .await?;
+        },
+    )
+    .await?;
 
     let tokens = exchange_code(
         client_id,

--- a/src-tauri/src/connectors/oauth.rs
+++ b/src-tauri/src/connectors/oauth.rs
@@ -1,4 +1,6 @@
-//! Google native-app OAuth for private connectors.
+//! Google native-app OAuth for private connectors, plus the provider-neutral
+//! loopback primitive ([`loopback_authorize`]) every connector's OAuth flow
+//! is built on.
 //!
 //! PKCE (S256) + loopback redirect on an ephemeral 127.0.0.1 port, for BOTH
 //! debug and release builds: Google desktop-app clients use the loopback
@@ -6,7 +8,11 @@
 //! `client_secret` at its token endpoint even though an installed application
 //! cannot keep that credential confidential; PKCE remains the protection for
 //! an intercepted authorization code. Mirrors the os_accounts.rs login flow
-//! mechanics.
+//! mechanics. [`loopback_authorize`] owns the PKCE/CSRF minting, the
+//! listener, and the browser handoff; [`authorize`] is Google's thin wrapper
+//! around it and owns Google's own auth-URL shape, token exchange, and email
+//! resolution. A later Linear chunk adds its own thin wrapper the same way,
+//! never touching the shared listener code.
 //!
 //! NEVER log, print, or serialize tokens (or authorization codes) into
 //! errors. Error messages carry stable codes and short human text only.
@@ -108,16 +114,31 @@ pub enum RefreshOutcome {
     Transient,
 }
 
-/// Run the full authorization handoff: open the consent screen in the
-/// default browser, wait on a loopback listener for the redirect, exchange
-/// the code, and resolve the account email.
-pub async fn authorize(
+/// Outcome of the provider-neutral PKCE + loopback handoff: the
+/// authorization code, its PKCE verifier, and the exact `redirect_uri` the
+/// code was issued for (the token endpoint requires it echoed back
+/// byte-identical). The caller still owns the token exchange and identity
+/// resolution, which differ per provider (Google's OIDC id_token/userinfo
+/// today; Linear's own token + viewer query in a later chunk).
+pub(crate) struct LoopbackAuthorization {
+    pub code: String,
+    pub verifier: String,
+    pub redirect_uri: String,
+}
+
+/// Provider-neutral half of a native-app OAuth connect: mint PKCE + CSRF
+/// state, bind an ephemeral 127.0.0.1 listener, ask `build_auth_url` to
+/// assemble the provider's consent URL from the resulting
+/// `(redirect_uri, code_challenge, state)`, open it in the system browser,
+/// and race the loopback callback against the connect timeout and the
+/// flow's cancel signal. `provider_label` names the provider in the
+/// timeout/cancel/denial copy shown to the user (e.g. "Google"), so each
+/// provider's wrapper keeps producing its own exact error text.
+pub(crate) async fn loopback_authorize(
     flow: &ConnectFlow,
-    client_id: &str,
-    client_secret: &str,
-    scopes: &[&str],
-    login_hint: Option<&str>,
-) -> Result<AuthorizedGrant, AppError> {
+    provider_label: &str,
+    build_auth_url: impl FnOnce(&str, &str, &str) -> String,
+) -> Result<LoopbackAuthorization, AppError> {
     let (verifier, challenge) = pkce();
     let csrf = random_b64url(24);
 
@@ -132,14 +153,7 @@ pub async fn authorize(
         .map_err(|e| AppError::new("connector_loopback_bind_failed", e.to_string()))?
         .port();
     let redirect_uri = format!("http://127.0.0.1:{port}/callback");
-    let auth_url = build_auth_url(
-        client_id,
-        &redirect_uri,
-        scopes,
-        &challenge,
-        &csrf,
-        login_hint,
-    );
+    let auth_url = build_auth_url(&redirect_uri, &challenge, &csrf);
 
     crate::os_accounts::open_in_browser(&auth_url)?;
 
@@ -148,17 +162,17 @@ pub async fn authorize(
         *slot = Some(cancel_tx);
     }
     let outcome = tokio::select! {
-        result = tokio::time::timeout(CONNECT_TIMEOUT, await_callback(&listener, &csrf)) => {
+        result = tokio::time::timeout(CONNECT_TIMEOUT, await_callback(&listener, &csrf, provider_label)) => {
             result.unwrap_or_else(|_| {
                 Err(AppError::new(
                     "connector_connect_timed_out",
-                    "Connecting to Google timed out. Please try again.",
+                    format!("Connecting to {provider_label} timed out. Please try again."),
                 ))
             })
         }
         _ = cancel_rx => Err(AppError::new(
             "connector_connect_canceled",
-            "Connecting to Google was canceled.",
+            format!("Connecting to {provider_label} was canceled."),
         )),
     };
     if let Ok(mut slot) = flow.cancel.lock() {
@@ -166,7 +180,47 @@ pub async fn authorize(
     }
     let code = outcome?;
 
-    let tokens = exchange_code(client_id, client_secret, &code, &verifier, &redirect_uri).await?;
+    Ok(LoopbackAuthorization {
+        code,
+        verifier,
+        redirect_uri,
+    })
+}
+
+/// Run the full Google authorization handoff: open the consent screen in the
+/// default browser, wait on a loopback listener for the redirect, exchange
+/// the code, and resolve the account email. A thin Google-specific wrapper
+/// over [`loopback_authorize`]: it supplies Google's auth URL and owns the
+/// token exchange + email resolution the shared primitive knows nothing
+/// about.
+pub async fn authorize(
+    flow: &ConnectFlow,
+    client_id: &str,
+    client_secret: &str,
+    scopes: &[&str],
+    login_hint: Option<&str>,
+) -> Result<AuthorizedGrant, AppError> {
+    let authorization =
+        loopback_authorize(flow, "Google", |redirect_uri, code_challenge, state| {
+            build_auth_url(
+                client_id,
+                redirect_uri,
+                scopes,
+                code_challenge,
+                state,
+                login_hint,
+            )
+        })
+        .await?;
+
+    let tokens = exchange_code(
+        client_id,
+        client_secret,
+        &authorization.code,
+        &authorization.verifier,
+        &authorization.redirect_uri,
+    )
+    .await?;
     let email = resolve_email(&tokens).await?;
     Ok(AuthorizedGrant { tokens, email })
 }
@@ -231,8 +285,13 @@ const SUCCESS_BODY: &str = r##"<!doctype html>
 
 /// Accept connections until one hits `/callback` with a matching state.
 /// Every per-socket read is bounded so a slow client on the loopback port
-/// cannot stall the listener for the full connect timeout.
-async fn await_callback(listener: &TcpListener, expected_state: &str) -> Result<String, AppError> {
+/// cannot stall the listener for the full connect timeout. `provider_label`
+/// names the provider in the denial/missing-code error copy.
+async fn await_callback(
+    listener: &TcpListener,
+    expected_state: &str,
+    provider_label: &str,
+) -> Result<String, AppError> {
     loop {
         let (mut stream, _) = listener
             .accept()
@@ -265,14 +324,14 @@ async fn await_callback(listener: &TcpListener, expected_state: &str) -> Result<
                 write_http(&mut stream, "200 OK", "You can close this tab.").await;
                 return Err(AppError::new(
                     "connector_connect_denied",
-                    "Google access was declined.",
+                    format!("{provider_label} access was declined."),
                 ));
             }
             CallbackOutcome::MissingCode => {
                 write_http(&mut stream, "400 Bad Request", "Missing authorization code").await;
                 return Err(AppError::new(
                     "connector_missing_code",
-                    "Google's response was missing an authorization code.",
+                    format!("{provider_label}'s response was missing an authorization code."),
                 ));
             }
             CallbackOutcome::Code(code) => {

--- a/src-tauri/src/connectors/scopes.rs
+++ b/src-tauri/src/connectors/scopes.rs
@@ -1,9 +1,13 @@
-//! Scope registry for Google connectors: feature bundles map to the minimal
-//! Google OAuth scopes they need, plus the incremental-auth helper that
-//! decides whether a new consent round-trip is required.
+//! Scope registry for the private connectors: feature bundles map to the
+//! minimal provider OAuth scopes they need, plus the incremental-auth helper
+//! that decides whether a new consent round-trip is required. Google and
+//! Linear bundles share one registry so a connect request is a flat list of
+//! bundle names; each bundle knows which provider it belongs to.
 
-/// Baseline identity scopes requested on every connect so the granted account
-/// can be keyed by email (the id_token carries the email claim).
+use super::ConnectorProvider;
+
+/// Baseline identity scopes requested on every Google connect so the granted
+/// account can be keyed by email (the id_token carries the email claim).
 pub const OPENID: &str = "openid";
 pub const EMAIL: &str = "email";
 
@@ -17,6 +21,13 @@ pub const GMAIL_MODIFY: &str = "https://www.googleapis.com/auth/gmail.modify";
 /// write ("view and edit events"), so read-only routines must not request it.
 pub const CALENDAR_READONLY: &str = "https://www.googleapis.com/auth/calendar.readonly";
 pub const CALENDAR_EVENTS: &str = "https://www.googleapis.com/auth/calendar.events";
+
+/// Linear scopes are short names, not URLs. `read` is always granted (and
+/// always requested: identity resolution and the teams listing need it);
+/// `write` covers the v1 mutation set because Linear has no granular scope
+/// for issue updates or project updates (see the spike doc).
+pub const LINEAR_READ: &str = "read";
+pub const LINEAR_WRITE: &str = "write";
 
 pub const BASELINE_SCOPES: &[&str] = &[OPENID, EMAIL];
 
@@ -33,11 +44,13 @@ pub enum ScopeBundle {
     GmailSend,
     CalendarRead,
     CalendarEvents,
+    LinearRead,
+    LinearWrite,
 }
 
 impl ScopeBundle {
-    /// The Google scope URLs this bundle needs (baseline identity scopes are
-    /// added separately by `requested_scopes`).
+    /// The provider scope strings this bundle needs (Google's baseline
+    /// identity scopes are added separately by `requested_scopes`).
     pub fn scopes(&self) -> &'static [&'static str] {
         match self {
             ScopeBundle::GmailRead => &[GMAIL_READONLY],
@@ -46,6 +59,8 @@ impl ScopeBundle {
             ScopeBundle::GmailSend => &[GMAIL_SEND],
             ScopeBundle::CalendarRead => &[CALENDAR_READONLY],
             ScopeBundle::CalendarEvents => &[CALENDAR_EVENTS],
+            ScopeBundle::LinearRead => &[LINEAR_READ],
+            ScopeBundle::LinearWrite => &[LINEAR_WRITE],
         }
     }
 
@@ -58,6 +73,8 @@ impl ScopeBundle {
             ScopeBundle::GmailSend => "gmail_send",
             ScopeBundle::CalendarRead => "calendar_read",
             ScopeBundle::CalendarEvents => "calendar_events",
+            ScopeBundle::LinearRead => "linear_read",
+            ScopeBundle::LinearWrite => "linear_write",
         }
     }
 
@@ -69,14 +86,31 @@ impl ScopeBundle {
             "gmail_send" => Some(ScopeBundle::GmailSend),
             "calendar_read" => Some(ScopeBundle::CalendarRead),
             "calendar_events" => Some(ScopeBundle::CalendarEvents),
+            "linear_read" => Some(ScopeBundle::LinearRead),
+            "linear_write" => Some(ScopeBundle::LinearWrite),
             _ => None,
+        }
+    }
+
+    /// The provider whose consent flow grants this bundle. A connect request
+    /// must not mix providers: the command layer rejects a bundle whose
+    /// provider differs from the one being connected.
+    pub fn provider(&self) -> ConnectorProvider {
+        match self {
+            ScopeBundle::GmailRead
+            | ScopeBundle::GmailDraft
+            | ScopeBundle::GmailModify
+            | ScopeBundle::GmailSend
+            | ScopeBundle::CalendarRead
+            | ScopeBundle::CalendarEvents => ConnectorProvider::Google,
+            ScopeBundle::LinearRead | ScopeBundle::LinearWrite => ConnectorProvider::Linear,
         }
     }
 }
 
-/// Full scope set to request on the auth URL for a set of bundles: baseline
-/// identity scopes plus each bundle's feature scopes, deduplicated, in a
-/// stable order.
+/// Full scope set to request on the Google auth URL for a set of bundles:
+/// baseline identity scopes plus each bundle's feature scopes, deduplicated,
+/// in a stable order.
 pub fn requested_scopes(bundles: &[ScopeBundle]) -> Vec<&'static str> {
     let mut scopes: Vec<&'static str> = Vec::new();
     for scope in BASELINE_SCOPES {
@@ -84,6 +118,23 @@ pub fn requested_scopes(bundles: &[ScopeBundle]) -> Vec<&'static str> {
             scopes.push(scope);
         }
     }
+    for bundle in bundles {
+        for scope in bundle.scopes() {
+            if !scopes.contains(scope) {
+                scopes.push(scope);
+            }
+        }
+    }
+    scopes
+}
+
+/// Full scope set to request on the Linear auth URL for a set of bundles:
+/// `read` always leads (Linear grants it unconditionally, and identity
+/// resolution plus the teams listing need it), then each bundle's feature
+/// scopes, deduplicated, in a stable order. Linear has no openid/email
+/// baseline - identity comes from a GraphQL viewer query, not OIDC.
+pub fn requested_linear_scopes(bundles: &[ScopeBundle]) -> Vec<&'static str> {
+    let mut scopes: Vec<&'static str> = vec![LINEAR_READ];
     for bundle in bundles {
         for scope in bundle.scopes() {
             if !scopes.contains(scope) {
@@ -270,10 +321,55 @@ mod tests {
             ScopeBundle::GmailSend,
             ScopeBundle::CalendarRead,
             ScopeBundle::CalendarEvents,
+            ScopeBundle::LinearRead,
+            ScopeBundle::LinearWrite,
         ] {
             assert_eq!(ScopeBundle::from_name(bundle.name()), Some(bundle));
         }
         assert_eq!(ScopeBundle::from_name("gmail"), None);
+        assert_eq!(ScopeBundle::from_name("linear"), None);
+    }
+
+    #[test]
+    fn bundles_map_to_their_provider() {
+        for bundle in [
+            ScopeBundle::GmailRead,
+            ScopeBundle::GmailDraft,
+            ScopeBundle::GmailModify,
+            ScopeBundle::GmailSend,
+            ScopeBundle::CalendarRead,
+            ScopeBundle::CalendarEvents,
+        ] {
+            assert_eq!(bundle.provider(), ConnectorProvider::Google);
+        }
+        for bundle in [ScopeBundle::LinearRead, ScopeBundle::LinearWrite] {
+            assert_eq!(bundle.provider(), ConnectorProvider::Linear);
+        }
+    }
+
+    #[test]
+    fn requested_linear_scopes_always_lead_with_read() {
+        // Even a write-only request carries read: identity + teams need it,
+        // and Linear grants it unconditionally anyway.
+        assert_eq!(
+            requested_linear_scopes(&[ScopeBundle::LinearWrite]),
+            vec![LINEAR_READ, LINEAR_WRITE]
+        );
+        // Read-only request stays read-only, deduped.
+        assert_eq!(
+            requested_linear_scopes(&[ScopeBundle::LinearRead, ScopeBundle::LinearRead]),
+            vec![LINEAR_READ]
+        );
+        assert_eq!(requested_linear_scopes(&[]), vec![LINEAR_READ]);
+    }
+
+    #[test]
+    fn google_requested_scopes_keep_the_oidc_baseline() {
+        // The Linear registry addition must not disturb Google's baseline.
+        assert_eq!(
+            requested_scopes(&[ScopeBundle::GmailRead]),
+            vec![OPENID, EMAIL, GMAIL_READONLY]
+        );
     }
 
     #[test]

--- a/src-tauri/src/connectors/store.rs
+++ b/src-tauri/src/connectors/store.rs
@@ -1,5 +1,4 @@
-//! Connector token custody, shared by every provider (Google today, Linear
-//! in a later chunk).
+//! Connector token custody, shared by every provider (Google and Linear).
 //!
 //! Tokens live in the OS keychain, one entry per connected account (user =
 //! the caller-supplied account id: a Google account email, or a Linear
@@ -50,8 +49,8 @@ pub struct StoredConnectorTokens {
 }
 
 /// Write `tokens` to the keychain, keyed by `(provider, account_id)`.
-/// `account_id` is the caller-supplied keychain user: today always the
-/// Google account email; a later Linear chunk passes a workspace id.
+/// `account_id` is the caller-supplied keychain user: a Google account
+/// email, or a Linear workspace id.
 pub async fn store_tokens(
     provider: ConnectorProvider,
     account_id: &str,

--- a/src-tauri/src/connectors/store.rs
+++ b/src-tauri/src/connectors/store.rs
@@ -1,24 +1,39 @@
-//! Google connector token custody.
+//! Connector token custody, shared by every provider (Google today, Linear
+//! in a later chunk).
 //!
-//! Tokens live in the OS keychain, one entry per Google account (user =
-//! account email), and NEVER anywhere else: the SQLite index only carries
+//! Tokens live in the OS keychain, one entry per connected account (user =
+//! the caller-supplied account id: a Google account email, or a Linear
+//! workspace id), and NEVER anywhere else: the SQLite index only carries
 //! non-secret account metadata (emails, scopes, status) so accounts can be
-//! enumerated without touching the keychain. Debug builds use a separate
-//! keychain service, and can opt into a plaintext token file for local
-//! development via `OS_JUNE_DEV_PLAINTEXT_TOKEN_STORE=1` (also what unit
-//! tests exercise, since the Keychain is unavailable in CI).
+//! enumerated without touching the keychain. Each provider gets its own
+//! keychain SERVICE (`co.opensoftware.june.<provider>`), so two providers'
+//! tokens never collide even if they ever shared an account id. Debug builds
+//! use a separate keychain service per provider, and can opt into a
+//! plaintext token file for local development via
+//! `OS_JUNE_DEV_PLAINTEXT_TOKEN_STORE=1` (also what unit tests exercise,
+//! since the Keychain is unavailable in CI); that file is per provider too.
 
+use super::ConnectorProvider;
 use crate::domain::types::AppError;
 use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-const KEYCHAIN_SERVICE: &str = "co.opensoftware.june.google";
-const DEV_KEYCHAIN_SERVICE: &str = "co.opensoftware.june-dev.google";
+const KEYCHAIN_SERVICE_PREFIX: &str = "co.opensoftware.june";
+const DEV_KEYCHAIN_SERVICE_PREFIX: &str = "co.opensoftware.june-dev";
 #[cfg(debug_assertions)]
 const DEV_PLAINTEXT_TOKEN_STORE_ENV: &str = "OS_JUNE_DEV_PLAINTEXT_TOKEN_STORE";
-#[cfg(any(debug_assertions, test))]
-const DEV_PLAINTEXT_TOKEN_FILE: &str = "dev-google-connector-tokens.json";
 const USE_PROD_ACCOUNTS_TOKENS_ENV: &str = "OS_JUNE_USE_PROD_ACCOUNTS_TOKENS";
+
+/// The dev plaintext token file's basename for a provider (under
+/// `target/`). Kept separate per provider for the same reason the keychain
+/// service is: so a Google and a Linear dev-mode connect never share a file.
+#[cfg(any(debug_assertions, test))]
+fn dev_plaintext_token_file(provider: ConnectorProvider) -> &'static str {
+    match provider {
+        ConnectorProvider::Google => "dev-google-connector-tokens.json",
+        ConnectorProvider::Linear => "dev-linear-connector-tokens.json",
+    }
+}
 
 /// What lives in one keychain entry. Token fields zeroize on drop so rotated
 /// grants don't linger in memory (mirrors `os_accounts::TokenPair`).
@@ -34,40 +49,54 @@ pub struct StoredConnectorTokens {
     pub email: String,
 }
 
-pub async fn store_tokens(tokens: &StoredConnectorTokens) -> Result<(), AppError> {
+/// Write `tokens` to the keychain, keyed by `(provider, account_id)`.
+/// `account_id` is the caller-supplied keychain user: today always the
+/// Google account email; a later Linear chunk passes a workspace id.
+pub async fn store_tokens(
+    provider: ConnectorProvider,
+    account_id: &str,
+    tokens: &StoredConnectorTokens,
+) -> Result<(), AppError> {
     let json = serde_json::to_string(tokens)
         .map_err(|e| AppError::new("connector_token_serialize_failed", e.to_string()))?;
-    let email = tokens.email.clone();
+    let account_id = account_id.to_string();
     #[cfg(debug_assertions)]
     if use_dev_plaintext_token_store() {
-        return store_dev_plaintext_tokens(email, json).await;
+        return store_dev_plaintext_tokens(provider, account_id, json).await;
     }
-    store_platform_tokens(email, json).await
+    store_platform_tokens(provider, account_id, json).await
 }
 
 /// Load the stored tokens for one account. `Ok(None)` means "not connected"
 /// (no keychain entry); errors are real keychain failures.
-pub async fn load_tokens(account_id: &str) -> Result<Option<StoredConnectorTokens>, AppError> {
+pub async fn load_tokens(
+    provider: ConnectorProvider,
+    account_id: &str,
+) -> Result<Option<StoredConnectorTokens>, AppError> {
     #[cfg(debug_assertions)]
     if use_dev_plaintext_token_store() {
-        return load_dev_plaintext_tokens(account_id).await;
+        return load_dev_plaintext_tokens(provider, account_id).await;
     }
-    load_platform_tokens(account_id).await
+    load_platform_tokens(provider, account_id).await
 }
 
-pub async fn delete_tokens(account_id: &str) -> Result<(), AppError> {
+pub async fn delete_tokens(provider: ConnectorProvider, account_id: &str) -> Result<(), AppError> {
     #[cfg(debug_assertions)]
     if use_dev_plaintext_token_store() {
-        return delete_dev_plaintext_tokens(account_id).await;
+        return delete_dev_plaintext_tokens(provider, account_id).await;
     }
-    delete_platform_tokens(account_id).await
+    delete_platform_tokens(provider, account_id).await
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-async fn store_platform_tokens(email: String, json: String) -> Result<(), AppError> {
-    let service = keychain_service().to_string();
+async fn store_platform_tokens(
+    provider: ConnectorProvider,
+    account_id: String,
+    json: String,
+) -> Result<(), AppError> {
+    let service = keychain_service(provider);
     tokio::task::spawn_blocking(move || {
-        keyring::Entry::new(&service, &email).and_then(|entry| entry.set_password(&json))
+        keyring::Entry::new(&service, &account_id).and_then(|entry| entry.set_password(&json))
     })
     .await
     .map_err(|e| AppError::new("connector_keychain_write_failed", e.to_string()))?
@@ -75,13 +104,20 @@ async fn store_platform_tokens(email: String, json: String) -> Result<(), AppErr
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-async fn store_platform_tokens(_email: String, _json: String) -> Result<(), AppError> {
+async fn store_platform_tokens(
+    _provider: ConnectorProvider,
+    _account_id: String,
+    _json: String,
+) -> Result<(), AppError> {
     Err(secure_storage_unavailable())
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-async fn load_platform_tokens(account_id: &str) -> Result<Option<StoredConnectorTokens>, AppError> {
-    let service = keychain_service().to_string();
+async fn load_platform_tokens(
+    provider: ConnectorProvider,
+    account_id: &str,
+) -> Result<Option<StoredConnectorTokens>, AppError> {
+    let service = keychain_service(provider);
     let user = account_id.to_string();
     let raw = tokio::task::spawn_blocking(move || {
         match keyring::Entry::new(&service, &user).and_then(|entry| entry.get_password()) {
@@ -113,14 +149,18 @@ async fn load_platform_tokens(account_id: &str) -> Result<Option<StoredConnector
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 async fn load_platform_tokens(
+    _provider: ConnectorProvider,
     _account_id: &str,
 ) -> Result<Option<StoredConnectorTokens>, AppError> {
     Ok(None)
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-async fn delete_platform_tokens(account_id: &str) -> Result<(), AppError> {
-    let service = keychain_service().to_string();
+async fn delete_platform_tokens(
+    provider: ConnectorProvider,
+    account_id: &str,
+) -> Result<(), AppError> {
+    let service = keychain_service(provider);
     let user = account_id.to_string();
     tokio::task::spawn_blocking(move || {
         match keyring::Entry::new(&service, &user).and_then(|entry| entry.delete_credential()) {
@@ -136,7 +176,10 @@ async fn delete_platform_tokens(account_id: &str) -> Result<(), AppError> {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-async fn delete_platform_tokens(_account_id: &str) -> Result<(), AppError> {
+async fn delete_platform_tokens(
+    _provider: ConnectorProvider,
+    _account_id: &str,
+) -> Result<(), AppError> {
     Ok(())
 }
 
@@ -149,17 +192,26 @@ fn secure_storage_unavailable() -> AppError {
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-fn keychain_service() -> &'static str {
-    keychain_service_for_build(cfg!(debug_assertions), use_prod_connector_tokens())
+fn keychain_service(provider: ConnectorProvider) -> String {
+    keychain_service_for_build(
+        provider,
+        cfg!(debug_assertions),
+        use_prod_connector_tokens(),
+    )
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows", test))]
-fn keychain_service_for_build(debug_assertions: bool, use_prod: bool) -> &'static str {
-    if debug_assertions && !use_prod {
-        DEV_KEYCHAIN_SERVICE
+fn keychain_service_for_build(
+    provider: ConnectorProvider,
+    debug_assertions: bool,
+    use_prod: bool,
+) -> String {
+    let prefix = if debug_assertions && !use_prod {
+        DEV_KEYCHAIN_SERVICE_PREFIX
     } else {
-        KEYCHAIN_SERVICE
-    }
+        KEYCHAIN_SERVICE_PREFIX
+    };
+    format!("{prefix}.{}", provider.as_str())
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
@@ -175,41 +227,56 @@ fn use_dev_plaintext_token_store() -> bool {
 }
 
 #[cfg(any(debug_assertions, test))]
-fn dev_plaintext_token_path() -> std::path::PathBuf {
+fn dev_plaintext_token_path(provider: ConnectorProvider) -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("target")
-        .join(DEV_PLAINTEXT_TOKEN_FILE)
+        .join(dev_plaintext_token_file(provider))
 }
 
 // --- Dev plaintext file store (debug builds only) ---------------------------
 //
-// One JSON object keyed by account email. The pure `dev_file_*` helpers take
-// an explicit path so unit tests can exercise them against a temp dir without
-// mutating process env or the shared target/ file.
+// One JSON object keyed by account id, in a file scoped to the provider. The
+// pure `dev_file_*` helpers take an explicit path so unit tests can exercise
+// them against a temp dir without mutating process env or the shared
+// target/ file.
 
 #[cfg(debug_assertions)]
-async fn store_dev_plaintext_tokens(email: String, json: String) -> Result<(), AppError> {
-    tokio::task::spawn_blocking(move || dev_file_store(&dev_plaintext_token_path(), &email, &json))
-        .await
-        .map_err(|e| AppError::new("connector_dev_token_store_write_failed", e.to_string()))?
+async fn store_dev_plaintext_tokens(
+    provider: ConnectorProvider,
+    account_id: String,
+    json: String,
+) -> Result<(), AppError> {
+    tokio::task::spawn_blocking(move || {
+        dev_file_store(&dev_plaintext_token_path(provider), &account_id, &json)
+    })
+    .await
+    .map_err(|e| AppError::new("connector_dev_token_store_write_failed", e.to_string()))?
 }
 
 #[cfg(debug_assertions)]
 async fn load_dev_plaintext_tokens(
+    provider: ConnectorProvider,
     account_id: &str,
 ) -> Result<Option<StoredConnectorTokens>, AppError> {
     let account_id = account_id.to_string();
-    tokio::task::spawn_blocking(move || dev_file_load(&dev_plaintext_token_path(), &account_id))
-        .await
-        .map_err(|e| AppError::new("connector_dev_token_store_read_failed", e.to_string()))?
+    tokio::task::spawn_blocking(move || {
+        dev_file_load(&dev_plaintext_token_path(provider), &account_id)
+    })
+    .await
+    .map_err(|e| AppError::new("connector_dev_token_store_read_failed", e.to_string()))?
 }
 
 #[cfg(debug_assertions)]
-async fn delete_dev_plaintext_tokens(account_id: &str) -> Result<(), AppError> {
+async fn delete_dev_plaintext_tokens(
+    provider: ConnectorProvider,
+    account_id: &str,
+) -> Result<(), AppError> {
     let account_id = account_id.to_string();
-    tokio::task::spawn_blocking(move || dev_file_delete(&dev_plaintext_token_path(), &account_id))
-        .await
-        .map_err(|e| AppError::new("connector_dev_token_store_write_failed", e.to_string()))?
+    tokio::task::spawn_blocking(move || {
+        dev_file_delete(&dev_plaintext_token_path(provider), &account_id)
+    })
+    .await
+    .map_err(|e| AppError::new("connector_dev_token_store_write_failed", e.to_string()))?
 }
 
 #[cfg(any(debug_assertions, test))]
@@ -411,16 +478,32 @@ mod tests {
     #[test]
     fn keychain_service_separates_dev_and_release() {
         assert_eq!(
-            keychain_service_for_build(true, false),
+            keychain_service_for_build(ConnectorProvider::Google, true, false),
             "co.opensoftware.june-dev.google"
         );
         assert_eq!(
-            keychain_service_for_build(true, true),
+            keychain_service_for_build(ConnectorProvider::Google, true, true),
             "co.opensoftware.june.google"
         );
         assert_eq!(
-            keychain_service_for_build(false, false),
+            keychain_service_for_build(ConnectorProvider::Google, false, false),
             "co.opensoftware.june.google"
+        );
+    }
+
+    #[test]
+    fn keychain_service_separates_providers() {
+        assert_eq!(
+            keychain_service_for_build(ConnectorProvider::Linear, true, false),
+            "co.opensoftware.june-dev.linear"
+        );
+        assert_eq!(
+            keychain_service_for_build(ConnectorProvider::Linear, true, true),
+            "co.opensoftware.june.linear"
+        );
+        assert_eq!(
+            keychain_service_for_build(ConnectorProvider::Linear, false, false),
+            "co.opensoftware.june.linear"
         );
     }
 }

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -144,6 +144,17 @@ pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::error::Error
             query(statement).execute(_pool).await?;
         }
     }
+    // Non-secret, provider-specific account details that don't warrant their
+    // own column (Linear's workspace name/url key today; JSON so a future
+    // provider's own shape never forces another migration). Google rows keep
+    // the default empty object.
+    ensure_column(
+        _pool,
+        "connector_accounts",
+        "metadata",
+        "TEXT NOT NULL DEFAULT '{}'",
+    )
+    .await?;
     for statement in include_str!("../../migrations/012_connector_grants.sql").split(';') {
         let statement = statement.trim();
         if !statement.is_empty() {
@@ -160,6 +171,12 @@ pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::error::Error
     // crediting only counts runs that finished at or after this instant, so
     // earlier read-only runs never retroactively unlock autonomy.
     ensure_column(_pool, "routine_trust", "approval_since", "TEXT").await?;
+    for statement in include_str!("../../migrations/014_linear_connector.sql").split(';') {
+        let statement = statement.trim();
+        if !statement.is_empty() {
+            query(statement).execute(_pool).await?;
+        }
+    }
     Ok(())
 }
 

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -43,6 +43,19 @@ pub struct ConnectorAccountRecord {
     pub status: String,
     pub created_at: String,
     pub updated_at: String,
+    /// Provider-specific, non-secret details as a JSON object (e.g. Linear's
+    /// workspace name/url key). `"{}"` for providers (Google) that carry
+    /// none. The connectors layer owns parsing this; the repository treats
+    /// it as an opaque string.
+    pub metadata: String,
+}
+
+/// One Linear team a connected workspace account is scoped to.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SelectedTeamRecord {
+    pub team_id: String,
+    pub team_key: String,
+    pub team_name: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -213,7 +226,7 @@ impl Repositories {
             .collect())
     }
 
-    // --- Private connectors (Google) --------------------------------------
+    // --- Private connectors (Google, Linear) --------------------------------
     //
     // Non-secret account index only: tokens live in the OS keychain
     // (src/connectors/store.rs), never in SQLite.
@@ -225,17 +238,19 @@ impl Repositories {
         email: &str,
         scopes: &[String],
         status: &str,
+        metadata: &str,
     ) -> Result<(), sqlx::error::Error> {
         let now = timestamp();
         let scopes_json = string_vec_to_json(scopes);
         query(
-            "INSERT INTO connector_accounts (account_id, provider, email, scopes, status, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?)
+            "INSERT INTO connector_accounts (account_id, provider, email, scopes, status, metadata, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(account_id) DO UPDATE SET
                provider = excluded.provider,
                email = excluded.email,
                scopes = excluded.scopes,
                status = excluded.status,
+               metadata = excluded.metadata,
                updated_at = excluded.updated_at",
         )
         .bind(account_id)
@@ -243,6 +258,7 @@ impl Repositories {
         .bind(email)
         .bind(&scopes_json)
         .bind(status)
+        .bind(metadata)
         .bind(&now)
         .bind(&now)
         .execute(&self.pool)
@@ -254,7 +270,7 @@ impl Repositories {
         &self,
     ) -> Result<Vec<ConnectorAccountRecord>, sqlx::error::Error> {
         let rows = query(
-            "SELECT account_id, provider, email, scopes, status, created_at, updated_at
+            "SELECT account_id, provider, email, scopes, status, metadata, created_at, updated_at
              FROM connector_accounts ORDER BY created_at ASC",
         )
         .fetch_all(&self.pool)
@@ -267,13 +283,59 @@ impl Repositories {
         account_id: &str,
     ) -> Result<Option<ConnectorAccountRecord>, sqlx::error::Error> {
         let row = query(
-            "SELECT account_id, provider, email, scopes, status, created_at, updated_at
+            "SELECT account_id, provider, email, scopes, status, metadata, created_at, updated_at
              FROM connector_accounts WHERE account_id = ?",
         )
         .bind(account_id)
         .fetch_optional(&self.pool)
         .await?;
         Ok(row.map(connector_account_from_row))
+    }
+
+    /// Replace the set of Linear teams an account is scoped to. DELETE +
+    /// re-INSERT in one transaction (never diffed): "manage teams" always
+    /// submits the full desired set, and a partial failure must not leave a
+    /// mix of old and new rows. One `created_at` for the whole batch keeps
+    /// rows from the same save trivially group-able.
+    pub async fn set_selected_teams(
+        &self,
+        account_id: &str,
+        teams: &[SelectedTeamRecord],
+    ) -> Result<(), sqlx::error::Error> {
+        let now = timestamp();
+        let mut tx = self.pool.begin().await?;
+        query("DELETE FROM connector_selected_teams WHERE account_id = ?")
+            .bind(account_id)
+            .execute(&mut *tx)
+            .await?;
+        for team in teams {
+            query(
+                "INSERT INTO connector_selected_teams (account_id, team_id, team_key, team_name, created_at)
+                 VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind(account_id)
+            .bind(&team.team_id)
+            .bind(&team.team_key)
+            .bind(&team.team_name)
+            .bind(&now)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await
+    }
+
+    pub async fn list_selected_teams(
+        &self,
+        account_id: &str,
+    ) -> Result<Vec<SelectedTeamRecord>, sqlx::error::Error> {
+        let rows = query(
+            "SELECT team_id, team_key, team_name
+             FROM connector_selected_teams WHERE account_id = ? ORDER BY team_name ASC",
+        )
+        .bind(account_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(selected_team_from_row).collect())
     }
 
     pub async fn set_connector_account_status(
@@ -292,10 +354,10 @@ impl Repositories {
     }
 
     /// Remove the account row plus everything keyed to it (triggers, polling
-    /// cursors, and autonomy grants) in one transaction. Clearing the grants
-    /// matters for security: without it, reconnecting the same email would
-    /// silently revive the per-job autonomous action servers the user granted
-    /// to the old connection.
+    /// cursors, autonomy grants, and selected teams) in one transaction.
+    /// Clearing the grants matters for security: without it, reconnecting the
+    /// same email would silently revive the per-job autonomous action servers
+    /// the user granted to the old connection.
     pub async fn delete_connector_account(
         &self,
         account_id: &str,
@@ -310,6 +372,10 @@ impl Repositories {
             .execute(&mut *tx)
             .await?;
         query("DELETE FROM connector_grants WHERE account_id = ?")
+            .bind(account_id)
+            .execute(&mut *tx)
+            .await?;
+        query("DELETE FROM connector_selected_teams WHERE account_id = ?")
             .bind(account_id)
             .execute(&mut *tx)
             .await?;
@@ -3387,8 +3453,17 @@ fn connector_account_from_row(row: sqlx_sqlite::SqliteRow) -> ConnectorAccountRe
         email: row.get("email"),
         scopes: string_vec_from_json(&row.get::<String, _>("scopes")),
         status: row.get("status"),
+        metadata: row.get("metadata"),
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
+    }
+}
+
+fn selected_team_from_row(row: sqlx_sqlite::SqliteRow) -> SelectedTeamRecord {
+    SelectedTeamRecord {
+        team_id: row.get("team_id"),
+        team_key: row.get("team_key"),
+        team_name: row.get("team_name"),
     }
 }
 
@@ -3568,6 +3643,7 @@ mod tests {
                 "user@example.com",
                 &scopes(&["openid", "email"]),
                 "connected",
+                "{}",
             )
             .await
             .expect("insert account");
@@ -3577,6 +3653,7 @@ mod tests {
         assert_eq!(accounts[0].account_id, "user@example.com");
         assert_eq!(accounts[0].scopes, scopes(&["openid", "email"]));
         assert_eq!(accounts[0].status, "connected");
+        assert_eq!(accounts[0].metadata, "{}");
 
         // Upsert widens scopes without duplicating the row.
         repos
@@ -3590,6 +3667,7 @@ mod tests {
                     "https://www.googleapis.com/auth/gmail.readonly",
                 ]),
                 "connected",
+                "{}",
             )
             .await
             .expect("upsert account");
@@ -3615,7 +3693,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_connector_account_cascades_triggers_and_cursors() {
+    async fn delete_connector_account_cascades_triggers_cursors_and_teams() {
         let repos = test_repositories().await;
         repos
             .upsert_connector_account(
@@ -3624,6 +3702,7 @@ mod tests {
                 "user@example.com",
                 &scopes(&["openid"]),
                 "connected",
+                "{}",
             )
             .await
             .expect("insert account");
@@ -3649,6 +3728,17 @@ mod tests {
             )
             .await
             .expect("set grant");
+        repos
+            .set_selected_teams(
+                "user@example.com",
+                &[super::SelectedTeamRecord {
+                    team_id: "team-1".to_string(),
+                    team_key: "ENG".to_string(),
+                    team_name: "Engineering".to_string(),
+                }],
+            )
+            .await
+            .expect("set selected teams");
 
         repos
             .delete_connector_account("user@example.com")
@@ -3677,6 +3767,100 @@ mod tests {
             .await
             .expect("grants")
             .is_empty());
+        // Selected teams must not survive either: reconnecting the same
+        // workspace should require re-picking teams, not silently inherit the
+        // old scope.
+        assert!(repos
+            .list_selected_teams("user@example.com")
+            .await
+            .expect("teams")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn selected_teams_set_replaces_wholesale_and_orders_by_name() {
+        let repos = test_repositories().await;
+        assert!(repos
+            .list_selected_teams("workspace-1")
+            .await
+            .expect("list")
+            .is_empty());
+
+        repos
+            .set_selected_teams(
+                "workspace-1",
+                &[
+                    super::SelectedTeamRecord {
+                        team_id: "team-eng".to_string(),
+                        team_key: "ENG".to_string(),
+                        team_name: "Engineering".to_string(),
+                    },
+                    super::SelectedTeamRecord {
+                        team_id: "team-design".to_string(),
+                        team_key: "DES".to_string(),
+                        team_name: "Design".to_string(),
+                    },
+                ],
+            )
+            .await
+            .expect("set teams");
+        let teams = repos
+            .list_selected_teams("workspace-1")
+            .await
+            .expect("list");
+        // Ordered by team_name, not insertion order.
+        assert_eq!(teams.len(), 2);
+        assert_eq!(teams[0].team_name, "Design");
+        assert_eq!(teams[1].team_name, "Engineering");
+
+        // A second save replaces the set wholesale rather than appending: a
+        // team dropped from the picker must actually disappear.
+        repos
+            .set_selected_teams(
+                "workspace-1",
+                &[super::SelectedTeamRecord {
+                    team_id: "team-design".to_string(),
+                    team_key: "DES".to_string(),
+                    team_name: "Design".to_string(),
+                }],
+            )
+            .await
+            .expect("replace teams");
+        let teams = repos
+            .list_selected_teams("workspace-1")
+            .await
+            .expect("list after replace");
+        assert_eq!(teams.len(), 1);
+        assert_eq!(teams[0].team_id, "team-design");
+
+        // A different account's teams are untouched.
+        repos
+            .set_selected_teams(
+                "workspace-2",
+                &[super::SelectedTeamRecord {
+                    team_id: "team-other".to_string(),
+                    team_key: "OTH".to_string(),
+                    team_name: "Other".to_string(),
+                }],
+            )
+            .await
+            .expect("set other account teams");
+        assert_eq!(
+            repos
+                .list_selected_teams("workspace-1")
+                .await
+                .expect("list")
+                .len(),
+            1
+        );
+        assert_eq!(
+            repos
+                .list_selected_teams("workspace-2")
+                .await
+                .expect("list")
+                .len(),
+            1
+        );
     }
 
     // Far enough ahead that a recorded run always lands after the approval
@@ -3825,6 +4009,7 @@ mod tests {
                 "user@example.com",
                 &scopes(&["openid"]),
                 "connected",
+                "{}",
             )
             .await
             .expect("account");

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -6970,23 +6970,30 @@ fn sync_june_recorder_mcp(
 }
 
 /// Writes the four connector MCP scripts and returns their configs, but ONLY
-/// when at least one Google account is connected. v1 registers a single account
-/// context: the first connected account's email is passed to every server, and
-/// each proxy call carries it as `account_id`. Returns `None` when no account
-/// is connected, in which case the connector servers are not registered at all.
+/// when at least one Google account is connected. v1 registers a single
+/// account context: the first connected GOOGLE account's email is passed to
+/// every server, and each proxy call carries it as `account_id`. Returns
+/// `None` when no Google account is connected (a connected Linear workspace
+/// does not count), in which case the connector servers are not registered
+/// at all.
 async fn sync_june_connector_mcps(
     app: &AppHandle,
     hermes_command: &str,
 ) -> Result<Option<ConnectorMcpConfigs>, AppError> {
     // Listing reads the non-secret DB index only (no keychain prompt). v1 uses
-    // the first CONNECTED account for the base servers; multi-account is a
-    // documented follow-up. A `reconnect_required` account is skipped so a
-    // stale first account does not hand the base servers a dead email while a
-    // healthy account exists.
+    // the first CONNECTED Google account for the base servers; multi-account
+    // is a documented follow-up. The provider filter matters: the base
+    // servers are Gmail/Calendar, so a connected Linear workspace (whose
+    // email may even be empty) must never be the account they bind to. A
+    // `reconnect_required` account is skipped so a stale first account does
+    // not hand the base servers a dead email while a healthy account exists.
     let account_email = match crate::connectors::list_accounts(app).await {
         Ok(accounts) => accounts
             .into_iter()
-            .find(|account| account.status == crate::connectors::ConnectorAccountStatus::Connected)
+            .find(|account| {
+                account.provider == crate::connectors::ConnectorProvider::Google
+                    && account.status == crate::connectors::ConnectorAccountStatus::Connected
+            })
             .map(|account| account.email),
         Err(error) => {
             // A DB read failure must not wedge the whole bridge start; skip the

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -6491,13 +6491,19 @@ fn prepare_sandbox(app: &AppHandle, hermes_home: &Path, agent_cli_access: bool) 
     let config_temp_prefix = sandbox_config_temp_prefix(hermes_home);
     // Block the jailed agent from reading the connector token stores: the
     // Keychain is already denied above; add the dev plaintext connector token
-    // file (debug builds' fallback custody) explicitly.
+    // files (debug builds' fallback custody, one per provider) explicitly.
     let mut secret_read_paths = vec![image_source_key_path];
     #[cfg(debug_assertions)]
     secret_read_paths.push(
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("target")
             .join("dev-google-connector-tokens.json"),
+    );
+    #[cfg(debug_assertions)]
+    secret_read_paths.push(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("dev-linear-connector-tokens.json"),
     );
     let profile = build_sandbox_profile(
         &home,
@@ -8205,6 +8211,7 @@ fn is_sensitive_file_name(name: &str) -> bool {
                 | "credentials.json"
                 | "application_default_credentials.json"
                 | "dev-google-connector-tokens.json"
+                | "dev-linear-connector-tokens.json"
                 | "secrets"
                 | "secrets.json"
                 | "id_rsa"
@@ -12055,6 +12062,8 @@ mod tests {
             "/workspace/project/id_rsa",
             "/workspace/project/client.p12",
             "/workspace/project/application_default_credentials.json",
+            "/workspace/target/dev-google-connector-tokens.json",
+            "/workspace/target/dev-linear-connector-tokens.json",
         ] {
             assert!(is_hidden_secret_path(Path::new(path)), "{path}");
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -299,6 +299,8 @@ pub fn run() {
             connectors::commands::connectors_connect,
             connectors::commands::connectors_cancel_connect,
             connectors::commands::connectors_disconnect,
+            connectors::commands::connectors_linear_teams,
+            connectors::commands::connectors_selected_teams_set,
             connectors::commands::routine_trust_get,
             connectors::commands::routine_trust_set,
             connectors::commands::routine_trust_record_run,

--- a/src/components/connectors/ConnectorProviderIcon.tsx
+++ b/src/components/connectors/ConnectorProviderIcon.tsx
@@ -1,8 +1,21 @@
 import { IconGoogle } from "central-icons/IconGoogle";
+import { IconLinear } from "central-icons/IconLinear";
+
+const PROVIDER_ICONS = {
+  google: IconGoogle,
+  linear: IconLinear,
+} as const;
 
 /** The monochrome brand mark for a connector provider (central-icons,
  * currentColor). Shared by the Connectors settings directory and the
  * approvals tray so provider identity renders the same everywhere. */
-export function ConnectorProviderIcon({ size = 18 }: { provider: "google"; size?: number }) {
-  return <IconGoogle size={size} aria-hidden />;
+export function ConnectorProviderIcon({
+  provider,
+  size = 18,
+}: {
+  provider: "google" | "linear";
+  size?: number;
+}) {
+  const Icon = PROVIDER_ICONS[provider];
+  return <Icon size={size} aria-hidden />;
 }

--- a/src/components/routines/RoutineCreate.tsx
+++ b/src/components/routines/RoutineCreate.tsx
@@ -100,7 +100,9 @@ export function RoutineCreate({ template, creating, error, onBack, onCreate }: R
   // the scope gate must check that exact account. Checking "any account" would
   // enable Create while the routine still polls/calls Google with an account
   // that lacks the scope, silently missing triggers or failing on scope errors.
-  const connectedAccount = (accounts ?? []).find((account) => account.status === "connected");
+  const connectedAccount = (accounts ?? []).find(
+    (account) => account.provider === "google" && account.status === "connected",
+  );
   const scopeGateSatisfied =
     !requiredScopes ||
     (connectedAccount != null && scopesCoverBundles(connectedAccount.scopes, requiredScopes));

--- a/src/components/routines/RoutineDetail.tsx
+++ b/src/components/routines/RoutineDetail.tsx
@@ -257,7 +257,11 @@ export function RoutineDetail({
     let triggerAccount: ConnectorAccount | undefined;
     const switchingToEvent = triggerChanged && trigger.source !== "schedule";
     if (switchingToEvent) {
-      triggerAccount = accounts.find((entry) => entry.status === "connected");
+      // Google only: triggers poll Gmail/Calendar, so a connected Linear
+      // workspace must never be picked as the trigger account.
+      triggerAccount = accounts.find(
+        (entry) => entry.provider === "google" && entry.status === "connected",
+      );
       if (!triggerAccount) {
         toast.error("Connect a Google account before using an event trigger.");
         return;
@@ -631,10 +635,14 @@ export function RoutineDetail({
                 <TriggerPicker
                   trigger={trigger}
                   scheduleDraft={draft}
-                  hasAccount={accounts.some((entry) => entry.status === "connected")}
+                  hasAccount={accounts.some(
+                    (entry) => entry.provider === "google" && entry.status === "connected",
+                  )}
                   scopeWarning={triggerScopeWarning(
                     trigger,
-                    accounts.find((entry) => entry.status === "connected")?.scopes ?? null,
+                    accounts.find(
+                      (entry) => entry.provider === "google" && entry.status === "connected",
+                    )?.scopes ?? null,
                   )}
                   onTriggerChange={changeTrigger}
                   onScheduleChange={setDraft}

--- a/src/components/settings/ConnectorsSection.tsx
+++ b/src/components/settings/ConnectorsSection.tsx
@@ -2,9 +2,9 @@ import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useState } from "react";
 import { ConnectorProviderIcon } from "../connectors/ConnectorProviderIcon";
 import {
-  ALL_SCOPE_BUNDLES,
   BUNDLE_META,
   accountStatusMeta,
+  bundlesForProvider,
   bundlesFromScopes,
   grantedFeatureLabels,
   isConnectorNotConfiguredError,
@@ -15,9 +15,13 @@ import {
   connectorsApplyRuntime,
   connectorsConnect,
   connectorsDisconnect,
+  connectorsLinearTeams,
   connectorsList,
+  connectorsSetSelectedTeams,
   type ConnectorAccount,
+  type ConnectorProvider,
   type ConnectorScopeBundle,
+  type LinearTeam,
 } from "../../lib/tauri";
 import { Checkbox } from "../ui/Checkbox";
 import { Dialog } from "../ui/Dialog";
@@ -25,56 +29,143 @@ import { InlineNotice } from "../ui/InlineNotice";
 import { toast } from "../ui/Toaster";
 import { SettingsPageHeader } from "./AppSettings";
 
-// Read-only by default: mail read and calendar read. Write scopes (draft,
-// send, organize, manage calendar) are opt-in checkboxes, so a fresh connect
+// Read-only by default: Google gets mail read and calendar read, Linear gets
+// workspace read. Write scopes are opt-in checkboxes, so a fresh connect
 // never grants mutation authority the user did not ask for.
-const DEFAULT_CONNECT_BUNDLES: readonly ConnectorScopeBundle[] = ["gmail_read", "calendar_read"];
+const DEFAULT_CONNECT_BUNDLES = {
+  google: ["gmail_read", "calendar_read"],
+  linear: ["linear_read"],
+} satisfies Record<ConnectorProvider, readonly ConnectorScopeBundle[]>;
 
-const PROVIDER_ORDER = ["google"] as const;
+const PROVIDER_ORDER = ["google", "linear"] as const;
 
 const PROVIDER_NAMES = {
   google: "Google",
-} as const;
+  linear: "Linear",
+} satisfies Record<ConnectorProvider, string>;
 
 /** One-line capability blurb shown while a provider is not connected: what
  * connecting it lets June do, in the provider directory row. */
 const PROVIDER_BLURBS = {
   google: "Mail and calendar for briefings, triage, and meeting prep.",
-} as const;
+  linear: "Projects, cycles, and issues for planning briefs and status updates.",
+} satisfies Record<ConnectorProvider, string>;
+
+const CONNECT_TITLES = {
+  google: { connect: "Connect Google account", add: "Add Google access" },
+  linear: { connect: "Connect Linear workspace", add: "Add Linear access" },
+} satisfies Record<ConnectorProvider, { connect: string; add: string }>;
+
+const CONNECT_TOASTS = {
+  google: {
+    connect: "Google account connected",
+    add: "Google access updated",
+    reconnect: "Google reconnected",
+  },
+  linear: {
+    connect: "Linear workspace connected",
+    add: "Linear access updated",
+    reconnect: "Linear reconnected",
+  },
+} satisfies Record<ConnectorProvider, { connect: string; add: string; reconnect: string }>;
+
+/** True once an account holds every feature bundle its provider offers —
+ * nothing left to add. */
+function allBundlesGranted(account: ConnectorAccount): boolean {
+  return (
+    bundlesFromScopes(account.scopes, account.provider).length >=
+    bundlesForProvider(account.provider).length
+  );
+}
+
+/** The name to show for an account outside its row (dialog titles, toasts):
+ * the workspace name for Linear, falling back to the signed-in user's email
+ * and then a generic label; the email for Google. */
+function accountDisplayName(account: ConnectorAccount): string {
+  if (account.provider === "linear") {
+    return account.workspaceName || account.email || "Linear workspace";
+  }
+  return account.email;
+}
+
+/** The login hint the connect flow escalates on: a Google email, or the
+ * Linear workspace's account id (Linear escalates by workspace, not by
+ * user email). */
+function loginHintFor(account: ConnectorAccount): string {
+  return account.provider === "linear" ? account.accountId : account.email;
+}
 
 function featureSummary(account: ConnectorAccount): string {
-  const features = grantedFeatureLabels(account.scopes);
+  const features = grantedFeatureLabels(account.scopes, account.provider);
   return features.length > 0 ? `Can ${features.join(", ").toLowerCase()}.` : "";
 }
 
-/** The connected row's one-liner: who is connected, then what June may do. */
+/** The connected row's one-liner: who is connected, then what June may do,
+ * then (Linear only) how many teams are selected. */
 function accountSubtitle(account: ConnectorAccount): string {
+  const parts = [accountDisplayName(account)];
   const summary = featureSummary(account);
-  return summary ? `${account.email} · ${summary}` : account.email;
+  if (summary) parts.push(summary);
+  if (account.provider === "linear" && account.selectedTeams.length > 0) {
+    const count = account.selectedTeams.length;
+    parts.push(count === 1 ? "1 team selected" : `${count} teams selected`);
+  }
+  return parts.join(" · ");
+}
+
+/** The connect dialog's body copy: what picking bundles here means, phrased
+ * for a first connect ("this account"/"this workspace") or for adding scope
+ * to an already-connected one. The sign-in surface and the kind of content
+ * named swap per provider so the promise reads correctly for either. */
+function connectDescription(provider: ConnectorProvider, target: ConnectorAccount | null): string {
+  const isGoogle = provider === "google";
+  const lead = target
+    ? `Add to what June may do with ${accountDisplayName(target)}.`
+    : `Pick what June may do with this ${isGoogle ? "account" : "workspace"}.`;
+  const contentPhrase = isGoogle
+    ? "selected mail or calendar content"
+    : "selected project and issue content";
+  return `${lead} You approve everything in ${PROVIDER_NAMES[provider]}'s own sign-in, and you can disconnect any time. When a feature uses AI, ${contentPhrase} goes to your chosen model provider. Choose a local model to keep inference on this device.`;
 }
 
 /**
  * The Connectors settings page: a provider directory (one row per provider,
- * always listed) with Google's feature-bundle picker, reconnect for lapsed
- * grants, and disconnect with optional provider-side revoke. Local mode only:
- * tokens live in the Mac's Keychain and provider calls originate on this
- * device.
+ * always listed) with a feature-bundle picker per provider, reconnect for
+ * lapsed grants, and disconnect with optional provider-side revoke. A
+ * connected Linear workspace also needs a team selection before June can
+ * read or write anything in it. Local mode only: tokens live in the Mac's
+ * Keychain and provider calls originate on this device.
  */
 export function ConnectorsSection() {
   const [accounts, setAccounts] = useState<ConnectorAccount[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [notConfigured, setNotConfigured] = useState<"google" | null>(null);
+  const [notConfigured, setNotConfigured] = useState<ConnectorProvider | null>(null);
+
+  const [connectProvider, setConnectProvider] = useState<ConnectorProvider>("google");
   const [connectOpen, setConnectOpen] = useState(false);
-  const [bundles, setBundles] = useState<ConnectorScopeBundle[]>([...DEFAULT_CONNECT_BUNDLES]);
-  // Email of the account we are adding scope to (single-account incremental
-  // auth), or null for a first-time connect. Sent as the login hint so Google
-  // preselects that account and the backend's single-account guard passes.
-  const [connectHint, setConnectHint] = useState<string | null>(null);
+  const [bundles, setBundles] = useState<ConnectorScopeBundle[]>([
+    ...DEFAULT_CONNECT_BUNDLES.google,
+  ]);
+  // The account we are adding scope to (single-account-per-provider
+  // incremental auth), or null for a first-time connect. Its login hint
+  // preselects that account/workspace so the backend's single-account guard
+  // passes.
+  const [connectTarget, setConnectTarget] = useState<ConnectorAccount | null>(null);
   const [connecting, setConnecting] = useState(false);
   const [reconnectingId, setReconnectingId] = useState<string | null>(null);
   const [disconnectTarget, setDisconnectTarget] = useState<ConnectorAccount | null>(null);
   const [revoke, setRevoke] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
+
+  // Linear team-selection dialog: the account id it's open for (null =
+  // closed). Kept separate from the fetched team list/selection so a fetch
+  // failure can be retried without losing the open state.
+  const [teamsAccountId, setTeamsAccountId] = useState<string | null>(null);
+  const [teamsLoading, setTeamsLoading] = useState(false);
+  const [teamsError, setTeamsError] = useState<string | null>(null);
+  const [availableTeams, setAvailableTeams] = useState<LinearTeam[]>([]);
+  const [selectedTeamIds, setSelectedTeamIds] = useState<ReadonlySet<string>>(new Set());
+  const [savingTeams, setSavingTeams] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -103,27 +194,61 @@ export function ConnectorsSection() {
     };
   }, [refresh]);
 
-  async function runConnect(input: { scopes: ConnectorScopeBundle[]; loginHint?: string }) {
-    await connectorsConnect({ scopes: input.scopes, loginHint: input.loginHint });
-    // A fresh grant only takes effect once the rendered MCP config picks it
-    // up; apply immediately so the user's next routine or chat sees it.
-    await connectorsApplyRuntime();
+  const loadTeams = useCallback(async (accountId: string) => {
+    setTeamsLoading(true);
+    setTeamsError(null);
+    try {
+      const teams = await connectorsLinearTeams({ accountId });
+      setAvailableTeams(teams);
+    } catch (err) {
+      setTeamsError(messageFromError(err));
+    } finally {
+      setTeamsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!teamsAccountId) return;
+    void loadTeams(teamsAccountId);
+  }, [teamsAccountId, loadTeams]);
+
+  async function runConnect(input: {
+    provider: ConnectorProvider;
+    scopes: ConnectorScopeBundle[];
+    loginHint?: string;
+  }) {
+    const account = await connectorsConnect({
+      provider: input.provider,
+      scopes: input.scopes,
+      loginHint: input.loginHint,
+    });
+    // A fresh Google grant only takes effect once the rendered MCP config
+    // picks it up, so apply immediately. Linear ships no MCP server in this
+    // slice — there is no runtime surface for a Linear grant to apply, and
+    // restarting Hermes anyway would drop live sessions for nothing.
+    if (input.provider === "google") {
+      await connectorsApplyRuntime();
+    }
     await refresh();
+    return account;
   }
 
-  // Open the connect dialog for a brand-new account (only offered when none is
-  // connected), or to add scope to the one existing account.
-  function openConnectNew() {
-    setBundles([...DEFAULT_CONNECT_BUNDLES]);
-    setConnectHint(null);
+  // Open the connect dialog for a brand-new account of the given provider
+  // (only offered when none is connected), or to add scope to the one
+  // existing account.
+  function openConnectNew(provider: ConnectorProvider) {
+    setConnectProvider(provider);
+    setBundles([...DEFAULT_CONNECT_BUNDLES[provider]]);
+    setConnectTarget(null);
     setConnectOpen(true);
   }
 
   function openAddAccess(account: ConnectorAccount) {
     // Preselect what the account already holds so the dialog reads as "add to
     // these"; the checkboxes the user adds are the new scopes.
-    setBundles(bundlesFromScopes(account.scopes));
-    setConnectHint(account.email);
+    setConnectProvider(account.provider);
+    setBundles(bundlesFromScopes(account.scopes, account.provider));
+    setConnectTarget(account);
     setConnectOpen(true);
   }
 
@@ -132,15 +257,23 @@ export function ConnectorsSection() {
     setNotConfigured(null);
     setConnecting(true);
     try {
-      await runConnect({
+      const account = await runConnect({
+        provider: connectProvider,
         scopes: bundles,
-        loginHint: connectHint ?? undefined,
+        loginHint: connectTarget ? loginHintFor(connectTarget) : undefined,
       });
       setConnectOpen(false);
-      toast.success(connectHint ? "Google access updated" : "Google account connected");
+      const toasts = CONNECT_TOASTS[connectProvider];
+      toast.success(connectTarget ? toasts.add : toasts.connect);
+      // A Linear connect that comes back with no teams yet — always true on a
+      // first connect — needs one more step before June can read or write
+      // anything in the workspace, so walk straight into team selection.
+      if (connectProvider === "linear" && account.selectedTeams.length === 0) {
+        openTeamsDialog(account);
+      }
     } catch (err) {
       if (isConnectorNotConfiguredError(err)) {
-        setNotConfigured("google");
+        setNotConfigured(connectProvider);
         setConnectOpen(false);
       } else {
         toast.error(messageFromError(err));
@@ -154,13 +287,17 @@ export function ConnectorsSection() {
     setNotConfigured(null);
     setReconnectingId(account.accountId);
     try {
-      await runConnect({
-        scopes: bundlesFromScopes(account.scopes),
-        loginHint: account.email,
+      const updated = await runConnect({
+        provider: account.provider,
+        scopes: bundlesFromScopes(account.scopes, account.provider),
+        loginHint: loginHintFor(account),
       });
-      toast.success("Google reconnected");
+      toast.success(CONNECT_TOASTS[account.provider].reconnect);
+      if (account.provider === "linear" && updated.selectedTeams.length === 0) {
+        openTeamsDialog(updated);
+      }
     } catch (err) {
-      if (isConnectorNotConfiguredError(err)) setNotConfigured("google");
+      if (isConnectorNotConfiguredError(err)) setNotConfigured(account.provider);
       else toast.error(messageFromError(err));
     } finally {
       setReconnectingId(null);
@@ -173,10 +310,14 @@ export function ConnectorsSection() {
     setDisconnecting(true);
     try {
       await connectorsDisconnect({ accountId: account.accountId, revoke });
-      await connectorsApplyRuntime();
+      // Same runtime-surface reasoning as runConnect: only Google's MCP
+      // config needs a refresh after the change.
+      if (account.provider === "google") {
+        await connectorsApplyRuntime();
+      }
       await refresh();
       setDisconnectTarget(null);
-      toast.success(`Disconnected ${account.email}`);
+      toast.success(`Disconnected ${accountDisplayName(account)}`);
     } catch (err) {
       toast.error(messageFromError(err));
     } finally {
@@ -189,8 +330,49 @@ export function ConnectorsSection() {
       const next = new Set(current);
       if (checked) next.add(bundle);
       else next.delete(bundle);
-      return ALL_SCOPE_BUNDLES.filter((entry) => next.has(entry));
+      return bundlesForProvider(connectProvider).filter((entry) => next.has(entry));
     });
+  }
+
+  function openTeamsDialog(account: ConnectorAccount) {
+    // None preselected on a first connect; a "manage teams" open preselects
+    // what is already saved.
+    setSelectedTeamIds(new Set(account.selectedTeams.map((team) => team.id)));
+    setAvailableTeams([]);
+    setTeamsError(null);
+    setTeamsAccountId(account.accountId);
+  }
+
+  function closeTeamsDialog() {
+    // Cancelling on a first connect is allowed: the row falls back to its
+    // "select teams to finish setup" state until the user opens it again.
+    if (savingTeams) return;
+    setTeamsAccountId(null);
+  }
+
+  function toggleTeam(id: string, checked: boolean) {
+    setSelectedTeamIds((current) => {
+      const next = new Set(current);
+      if (checked) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }
+
+  async function saveTeams() {
+    if (!teamsAccountId || selectedTeamIds.size === 0 || savingTeams) return;
+    setSavingTeams(true);
+    try {
+      const teams = availableTeams.filter((team) => selectedTeamIds.has(team.id));
+      await connectorsSetSelectedTeams({ accountId: teamsAccountId, teams });
+      await refresh();
+      setTeamsAccountId(null);
+      toast.success("Linear teams updated");
+    } catch (err) {
+      toast.error(messageFromError(err));
+    } finally {
+      setSavingTeams(false);
+    }
   }
 
   return (
@@ -198,7 +380,7 @@ export function ConnectorsSection() {
       <SettingsPageHeader
         id="connectors-heading"
         title="Connectors"
-        blurb="Connect Google in local mode. Tokens stay in your Mac's Keychain, provider calls go straight from this device, and OpenSoftware's servers cannot read your mail or calendar."
+        blurb="Connect Google and Linear in local mode. Tokens stay in your Mac's Keychain, provider calls go straight from this device, and OpenSoftware's servers cannot read your data."
       />
 
       {notConfigured ? (
@@ -215,11 +397,22 @@ export function ConnectorsSection() {
       <div className="settings-card connectors-card">
         <ul className="connectors-list">
           {PROVIDER_ORDER.map((provider) => {
-            const account = accounts?.[0] ?? null;
+            const account = accounts?.find((entry) => entry.provider === provider) ?? null;
             const name = PROVIDER_NAMES[provider];
-            const status = account ? accountStatusMeta(account.status) : null;
+            const status = account ? accountStatusMeta(account.status, provider) : null;
             const subtitle = account ? accountSubtitle(account) : PROVIDER_BLURBS[provider];
             const reconnecting = account !== null && reconnectingId === account.accountId;
+            // Linear only: a connected workspace with no teams picked yet
+            // still needs one more step before June can read or write
+            // anything in it.
+            const needsTeams =
+              account !== null && provider === "linear" && account.selectedTeams.length === 0;
+            const showTeamsHint = needsTeams && account !== null && account.status === "connected";
+            // Google's "Add access" stays unconditional (preserves existing
+            // Google behavior); Linear hides it once both bundles are
+            // granted, since there is nothing left to add.
+            const showAddAccess =
+              account !== null && (provider === "google" || !allBundlesGranted(account));
             return (
               <li key={provider} className="connector-row">
                 <span className="connector-logo" aria-hidden>
@@ -230,6 +423,11 @@ export function ConnectorsSection() {
                   <p className="connector-subtitle" title={subtitle}>
                     {subtitle}
                   </p>
+                  {showTeamsHint ? (
+                    <span className="status-pill" data-tone="warning">
+                      Select teams to finish setup
+                    </span>
+                  ) : null}
                 </div>
                 <div className="connector-actions">
                   {account && status ? (
@@ -247,7 +445,7 @@ export function ConnectorsSection() {
                       className="btn btn-secondary"
                       aria-label={`Connect ${name}`}
                       disabled={accounts === null}
-                      onClick={openConnectNew}
+                      onClick={() => openConnectNew(provider)}
                     >
                       Connect
                     </button>
@@ -265,13 +463,26 @@ export function ConnectorsSection() {
                           {reconnecting ? "Waiting for browser…" : "Reconnect"}
                         </button>
                       ) : (
-                        <button
-                          type="button"
-                          className="btn btn-secondary"
-                          onClick={() => openAddAccess(account)}
-                        >
-                          Add access
-                        </button>
+                        <>
+                          {provider === "linear" ? (
+                            <button
+                              type="button"
+                              className="btn btn-secondary"
+                              onClick={() => openTeamsDialog(account)}
+                            >
+                              {needsTeams ? "Select teams" : "Manage teams"}
+                            </button>
+                          ) : null}
+                          {showAddAccess ? (
+                            <button
+                              type="button"
+                              className="btn btn-secondary"
+                              onClick={() => openAddAccess(account)}
+                            >
+                              Add access
+                            </button>
+                          ) : null}
+                        </>
                       )}
                       <button
                         type="button"
@@ -298,12 +509,12 @@ export function ConnectorsSection() {
         onClose={() => {
           if (!connecting) setConnectOpen(false);
         }}
-        title={connectHint ? "Add Google access" : "Connect Google account"}
-        description={
-          connectHint
-            ? `Add to what June may do with ${connectHint}. You approve everything in Google's own sign-in, and you can disconnect any time. When a feature uses AI, selected mail or calendar content goes to your chosen model provider. Choose a local model to keep inference on this device.`
-            : "Pick what June may do with this account. You approve everything in Google's own sign-in, and you can disconnect any time. When a feature uses AI, selected mail or calendar content goes to your chosen model provider. Choose a local model to keep inference on this device."
+        title={
+          connectTarget
+            ? CONNECT_TITLES[connectProvider].add
+            : CONNECT_TITLES[connectProvider].connect
         }
+        description={connectDescription(connectProvider, connectTarget)}
         footer={
           <>
             <button
@@ -327,7 +538,7 @@ export function ConnectorsSection() {
         }
       >
         <div className="connectors-bundle-list">
-          {ALL_SCOPE_BUNDLES.map((bundle) => {
+          {bundlesForProvider(connectProvider).map((bundle) => {
             const meta = BUNDLE_META[bundle];
             return (
               <label
@@ -356,7 +567,7 @@ export function ConnectorsSection() {
         onClose={() => {
           if (!disconnecting) setDisconnectTarget(null);
         }}
-        title={`Disconnect ${disconnectTarget?.email ?? ""}?`}
+        title={`Disconnect ${disconnectTarget ? accountDisplayName(disconnectTarget) : ""}?`}
         description="June stops using this account and removes its tokens from your Keychain. Routines that rely on it will fail until you reconnect."
         footer={
           <>
@@ -387,8 +598,80 @@ export function ConnectorsSection() {
             disabled={disconnecting}
             onChange={(event) => setRevoke(event.currentTarget.checked)}
           />
-          Also revoke June's access with {disconnectTarget ? "Google" : "the provider"}
+          Also revoke June's access with{" "}
+          {disconnectTarget ? PROVIDER_NAMES[disconnectTarget.provider] : "the provider"}
         </label>
+      </Dialog>
+
+      <Dialog
+        open={teamsAccountId !== null}
+        onClose={closeTeamsDialog}
+        title="Select Linear teams"
+        description="June only reads and changes Linear data in the teams you select. You can change this any time."
+        footer={
+          <>
+            <button
+              type="button"
+              className="primary-action"
+              onClick={closeTeamsDialog}
+              disabled={savingTeams}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="primary-action primary-solid"
+              disabled={
+                selectedTeamIds.size === 0 || savingTeams || teamsLoading || teamsError !== null
+              }
+              aria-busy={savingTeams || undefined}
+              onClick={() => void saveTeams()}
+            >
+              {savingTeams ? "Saving…" : "Save teams"}
+            </button>
+          </>
+        }
+      >
+        {teamsLoading ? (
+          <p className="routines-tool-summary">Loading teams…</p>
+        ) : teamsError ? (
+          <InlineNotice
+            tone="warning"
+            body={teamsError}
+            actions={
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => {
+                  if (teamsAccountId) void loadTeams(teamsAccountId);
+                }}
+              >
+                Retry
+              </button>
+            }
+          />
+        ) : (
+          <div className="connectors-bundle-list">
+            {availableTeams.map((team) => (
+              <label
+                key={team.id}
+                className="connectors-bundle-option"
+                htmlFor={`connectors-team-${team.id}`}
+              >
+                <Checkbox
+                  id={`connectors-team-${team.id}`}
+                  checked={selectedTeamIds.has(team.id)}
+                  disabled={savingTeams}
+                  onChange={(event) => toggleTeam(team.id, event.currentTarget.checked)}
+                />
+                <span className="connectors-bundle-copy">
+                  <span className="connectors-bundle-label">{team.name}</span>
+                  <span className="connectors-bundle-description">{team.key}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+        )}
       </Dialog>
     </section>
   );

--- a/src/components/settings/ConnectorsSection.tsx
+++ b/src/components/settings/ConnectorsSection.tsx
@@ -164,8 +164,28 @@ export function ConnectorsSection() {
   const [teamsLoading, setTeamsLoading] = useState(false);
   const [teamsError, setTeamsError] = useState<string | null>(null);
   const [availableTeams, setAvailableTeams] = useState<LinearTeam[]>([]);
+  const [teamsTruncated, setTeamsTruncated] = useState(false);
   const [selectedTeamIds, setSelectedTeamIds] = useState<ReadonlySet<string>>(new Set());
   const [savingTeams, setSavingTeams] = useState(false);
+
+  // Previously selected teams the live listing no longer returns (archived,
+  // visibility lost, or beyond the truncation cap). They must stay visible
+  // and count toward the save payload, or an unrelated "Manage teams" save
+  // would silently narrow the stored selection - the selection is June's
+  // authorization boundary once Linear reads land.
+  const teamsAccount = teamsAccountId
+    ? ((accounts ?? []).find((account) => account.accountId === teamsAccountId) ?? null)
+    : null;
+  const missingSelectedTeams = (teamsAccount?.selectedTeams ?? []).filter(
+    (team) => !availableTeams.some((live) => live.id === team.id),
+  );
+  // The exact set a save would persist: checked teams, with metadata from
+  // the live listing when present and from the persisted selection
+  // otherwise. The save button gates on THIS length, not on
+  // selectedTeamIds.size, so the two can never disagree.
+  const teamsPayload = [...availableTeams, ...missingSelectedTeams].filter((team) =>
+    selectedTeamIds.has(team.id),
+  );
 
   const refresh = useCallback(async () => {
     try {
@@ -198,8 +218,9 @@ export function ConnectorsSection() {
     setTeamsLoading(true);
     setTeamsError(null);
     try {
-      const teams = await connectorsLinearTeams({ accountId });
-      setAvailableTeams(teams);
+      const listing = await connectorsLinearTeams({ accountId });
+      setAvailableTeams(listing.teams);
+      setTeamsTruncated(listing.truncated);
     } catch (err) {
       setTeamsError(messageFromError(err));
     } finally {
@@ -360,11 +381,10 @@ export function ConnectorsSection() {
   }
 
   async function saveTeams() {
-    if (!teamsAccountId || selectedTeamIds.size === 0 || savingTeams) return;
+    if (!teamsAccountId || teamsPayload.length === 0 || savingTeams) return;
     setSavingTeams(true);
     try {
-      const teams = availableTeams.filter((team) => selectedTeamIds.has(team.id));
-      await connectorsSetSelectedTeams({ accountId: teamsAccountId, teams });
+      await connectorsSetSelectedTeams({ accountId: teamsAccountId, teams: teamsPayload });
       await refresh();
       setTeamsAccountId(null);
       toast.success("Linear teams updated");
@@ -622,7 +642,7 @@ export function ConnectorsSection() {
               type="button"
               className="primary-action primary-solid"
               disabled={
-                selectedTeamIds.size === 0 || savingTeams || teamsLoading || teamsError !== null
+                teamsPayload.length === 0 || savingTeams || teamsLoading || teamsError !== null
               }
               aria-busy={savingTeams || undefined}
               onClick={() => void saveTeams()}
@@ -651,26 +671,55 @@ export function ConnectorsSection() {
             }
           />
         ) : (
-          <div className="connectors-bundle-list">
-            {availableTeams.map((team) => (
-              <label
-                key={team.id}
-                className="connectors-bundle-option"
-                htmlFor={`connectors-team-${team.id}`}
-              >
-                <Checkbox
-                  id={`connectors-team-${team.id}`}
-                  checked={selectedTeamIds.has(team.id)}
-                  disabled={savingTeams}
-                  onChange={(event) => toggleTeam(team.id, event.currentTarget.checked)}
-                />
-                <span className="connectors-bundle-copy">
-                  <span className="connectors-bundle-label">{team.name}</span>
-                  <span className="connectors-bundle-description">{team.key}</span>
-                </span>
-              </label>
-            ))}
-          </div>
+          <>
+            {teamsTruncated ? (
+              <InlineNotice
+                tone="info"
+                body="Linear returned only the first 500 teams, so this list is incomplete."
+                aria-label="Team list truncated"
+              />
+            ) : null}
+            <div className="connectors-bundle-list">
+              {availableTeams.map((team) => (
+                <label
+                  key={team.id}
+                  className="connectors-bundle-option"
+                  htmlFor={`connectors-team-${team.id}`}
+                >
+                  <Checkbox
+                    id={`connectors-team-${team.id}`}
+                    checked={selectedTeamIds.has(team.id)}
+                    disabled={savingTeams}
+                    onChange={(event) => toggleTeam(team.id, event.currentTarget.checked)}
+                  />
+                  <span className="connectors-bundle-copy">
+                    <span className="connectors-bundle-label">{team.name}</span>
+                    <span className="connectors-bundle-description">{team.key}</span>
+                  </span>
+                </label>
+              ))}
+              {missingSelectedTeams.map((team) => (
+                <label
+                  key={team.id}
+                  className="connectors-bundle-option"
+                  htmlFor={`connectors-team-${team.id}`}
+                >
+                  <Checkbox
+                    id={`connectors-team-${team.id}`}
+                    checked={selectedTeamIds.has(team.id)}
+                    disabled={savingTeams}
+                    onChange={(event) => toggleTeam(team.id, event.currentTarget.checked)}
+                  />
+                  <span className="connectors-bundle-copy">
+                    <span className="connectors-bundle-label">{team.name}</span>
+                    <span className="connectors-bundle-description">
+                      {team.key} · not visible in Linear right now
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </>
         )}
       </Dialog>
     </section>

--- a/src/lib/connectors.ts
+++ b/src/lib/connectors.ts
@@ -1,8 +1,8 @@
 /**
- * Pure, render-free view logic for the private Google connectors (local
- * mode): scope-bundle metadata, account status labels, trust-mode metadata
- * and earned-autonomy gating, the trust-mode to Hermes toolset composition,
- * and event-trigger metadata.
+ * Pure, render-free view logic for the private connectors (Google, Linear)
+ * in local mode: scope-bundle metadata, account status labels, trust-mode
+ * metadata and earned-autonomy gating, the trust-mode to Hermes toolset
+ * composition, and event-trigger metadata.
  *
  * Kept separate from the React components and the Tauri bindings (mirroring
  * the hermes-admin/*-view.ts split) so all of it is unit-testable without a
@@ -16,6 +16,7 @@ import { errorCode } from "./errors";
 import { UNRESTRICTED_ROUTINE_TOOLSETS } from "./hermes-routines";
 import type {
   ConnectorAccountStatus,
+  ConnectorProvider,
   ConnectorScopeBundle,
   ConnectorTriggerKind,
   RoutineTrustMode,
@@ -30,8 +31,9 @@ export type ConnectorBundleMeta = {
   label: string;
   /** One-line supporting copy under the label. */
   description: string;
-  /** The Google scope URLs the bundle grants. Mirrors ScopeBundle::scopes()
-   * in src-tauri/src/connectors/scopes.rs; keep in sync. */
+  /** The provider scope identifiers the bundle grants: Google's full auth
+   * URLs, Linear's short scope names. Mirrors ScopeBundle::scopes() in
+   * src-tauri/src/connectors/scopes.rs; keep in sync. */
   scopeUrls: string[];
   /** Short feature phrase for "This routine can: ..." summaries. */
   feature: string;
@@ -75,9 +77,24 @@ export const BUNDLE_META: Readonly<Record<ConnectorScopeBundle, ConnectorBundleM
       scopeUrls: ["https://www.googleapis.com/auth/calendar.events"],
       feature: "manage your calendar",
     },
+    linear_read: {
+      label: "Read workspace",
+      description: "Read teams, projects, cycles, and issues for planning and status briefs.",
+      scopeUrls: ["read"],
+      feature: "read your Linear workspace",
+    },
+    linear_write: {
+      label: "Create and update issues",
+      description:
+        "Draft issues, comments, and project updates. Nothing is written without your approval.",
+      scopeUrls: ["write"],
+      feature: "create and update issues",
+    },
   });
 
-export const ALL_SCOPE_BUNDLES: readonly ConnectorScopeBundle[] = Object.freeze([
+/** The six Google feature bundles, in the order the connect dialog lists
+ * them. */
+export const GOOGLE_SCOPE_BUNDLES: readonly ConnectorScopeBundle[] = Object.freeze([
   "gmail_read",
   "gmail_draft",
   "gmail_modify",
@@ -85,6 +102,19 @@ export const ALL_SCOPE_BUNDLES: readonly ConnectorScopeBundle[] = Object.freeze(
   "calendar_read",
   "calendar_events",
 ]);
+
+/** The two Linear feature bundles, in the order the connect dialog lists
+ * them. */
+export const LINEAR_SCOPE_BUNDLES: readonly ConnectorScopeBundle[] = Object.freeze([
+  "linear_read",
+  "linear_write",
+]);
+
+/** The feature bundles a provider's connect dialog offers, in display
+ * order. */
+export function bundlesForProvider(provider: ConnectorProvider): readonly ConnectorScopeBundle[] {
+  return provider === "linear" ? LINEAR_SCOPE_BUNDLES : GOOGLE_SCOPE_BUNDLES;
+}
 
 /** A granted Google scope implies these narrower scope needs: a write scope
  * already grants the matching read, so an account with `calendar.events` need
@@ -110,22 +140,27 @@ function grantsScope(granted: Set<string>, needed: string): boolean {
   return false;
 }
 
-/** Maps an account's granted Google scope URLs back to the feature bundles it
- * explicitly holds, in registry order. Exact match (not superset): this drives
- * display and reconnect, which should reflect what was actually granted, not
- * what a broader scope could stand in for. Unknown URLs (identity scopes,
- * future grants) are ignored: the UI shows features, not raw scopes. */
-export function bundlesFromScopes(scopeUrls: string[]): ConnectorScopeBundle[] {
+/** Maps an account's granted scope identifiers back to the feature bundles it
+ * explicitly holds, in registry order, scoped to that account's provider so a
+ * hypothetical scope-string collision across providers can never cross-match.
+ * Exact match (not superset): this drives display and reconnect, which should
+ * reflect what was actually granted, not what a broader scope could stand in
+ * for. Unknown identifiers (identity scopes, future grants) are ignored: the
+ * UI shows features, not raw scopes. */
+export function bundlesFromScopes(
+  scopeUrls: string[],
+  provider: ConnectorProvider,
+): ConnectorScopeBundle[] {
   const granted = new Set(scopeUrls);
-  return ALL_SCOPE_BUNDLES.filter((bundle) =>
+  return bundlesForProvider(provider).filter((bundle) =>
     BUNDLE_META[bundle].scopeUrls.every((url) => granted.has(url)),
   );
 }
 
 /** "Read mail, draft replies and calendar" — the human feature list an
  * account's grants render as. */
-export function grantedFeatureLabels(scopeUrls: string[]): string[] {
-  return bundlesFromScopes(scopeUrls).map((bundle) => BUNDLE_META[bundle].label);
+export function grantedFeatureLabels(scopeUrls: string[], provider: ConnectorProvider): string[] {
+  return bundlesFromScopes(scopeUrls, provider).map((bundle) => BUNDLE_META[bundle].label);
 }
 
 /** True when the account's granted scopes already cover every bundle a routine
@@ -151,21 +186,30 @@ export type ConnectorStatusMeta = {
   blurb: string;
 };
 
-const STATUS_META: Readonly<Record<ConnectorAccountStatus, ConnectorStatusMeta>> = Object.freeze({
-  connected: {
-    label: "Connected",
-    tone: "ok",
-    blurb: "This account is ready. Tokens stay in your Mac's Keychain.",
-  },
-  reconnect_required: {
-    label: "Reconnect needed",
-    tone: "attention",
-    blurb: "Google needs you to sign in again before June can use this account.",
-  },
+const STATUS_LABELS: Readonly<
+  Record<ConnectorAccountStatus, { label: string; tone: "ok" | "attention" }>
+> = Object.freeze({
+  connected: { label: "Connected", tone: "ok" },
+  reconnect_required: { label: "Reconnect needed", tone: "attention" },
 });
 
-export function accountStatusMeta(status: ConnectorAccountStatus): ConnectorStatusMeta {
-  return STATUS_META[status];
+/** Connected blurb is shared across providers; reconnect names the provider
+ * and what it gates ("this account" for Google, "this workspace" for
+ * Linear) so the prompt reads correctly for either. */
+const CONNECTED_BLURB = "This account is ready. Tokens stay in your Mac's Keychain.";
+
+const RECONNECT_BLURB: Readonly<Record<ConnectorProvider, string>> = Object.freeze({
+  google: "Google needs you to sign in again before June can use this account.",
+  linear: "Linear needs you to sign in again before June can use this workspace.",
+});
+
+export function accountStatusMeta(
+  status: ConnectorAccountStatus,
+  provider: ConnectorProvider,
+): ConnectorStatusMeta {
+  const { label, tone } = STATUS_LABELS[status];
+  const blurb = status === "reconnect_required" ? RECONNECT_BLURB[provider] : CONNECTED_BLURB;
+  return { label, tone, blurb };
 }
 
 /** True for the Rust "connector_not_configured" error: this build ships no

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1980,7 +1980,7 @@ export async function latestDictationEvent() {
 }
 
 // ---------------------------------------------------------------------------
-// Private Google connectors (local mode)
+// Private connectors (local mode): Google and Linear
 // ---------------------------------------------------------------------------
 
 /** Feature bundle wire names the connect flow requests. Mirrors the Rust
@@ -1991,19 +1991,46 @@ export type ConnectorScopeBundle =
   | "gmail_modify"
   | "gmail_send"
   | "calendar_read"
-  | "calendar_events";
+  | "calendar_events"
+  | "linear_read"
+  | "linear_write";
 
 export type ConnectorAccountStatus = "connected" | "reconnect_required";
 
-/** One connected Google account, as the connectors module reports it. Carries
- * only metadata (email, granted scope URLs, health) — never a token. */
+export type ConnectorProvider = "google" | "linear";
+
+/** One Linear team: the granularity June's Linear read/write access is
+ * scoped to. Returned both by the live team list and on the account once
+ * selected. */
+export type LinearTeam = {
+  id: string;
+  key: string;
+  name: string;
+};
+
+/** One connected connector account, as the connectors module reports it.
+ * Carries only metadata (identity, granted scopes, health) — never a token.
+ * Google rows leave `workspaceName`/`workspaceUrlKey` null and
+ * `selectedTeams` empty. A Linear row's `accountId` is the Linear workspace
+ * id (an opaque UUID, not an email); `email` is the signed-in Linear user's
+ * email and may be empty. */
 export type ConnectorAccount = {
   accountId: string;
-  provider: "google";
+  provider: ConnectorProvider;
   email: string;
-  /** Granted Google scope URLs (not bundle names). */
+  /** Granted scope identifiers: Google's full auth URLs, Linear's short
+   * scope names ("read", "write") — not bundle names. */
   scopes: string[];
   status: ConnectorAccountStatus;
+  /** Linear workspace display name; null for Google rows. */
+  workspaceName: string | null;
+  /** Linear workspace URL key (the org's linear.app subdomain segment);
+   * null for Google rows. */
+  workspaceUrlKey: string | null;
+  /** Linear teams June may read/write on this workspace. Empty for Google
+   * rows, and for a fresh Linear connect before the user finishes team
+   * selection. */
+  selectedTeams: LinearTeam[];
 };
 
 /** Per-routine trust mode for connector action tools. Distinct from the
@@ -2060,15 +2087,19 @@ export async function connectorsList() {
   return invoke<ConnectorAccount[]>("connectors_list");
 }
 
-/** Runs the Google OAuth connect flow for the given feature bundles. Blocks
- * until the browser flow completes (the Rust side enforces a 300s timeout).
- * `loginHint` pre-selects the Google account, for reconnects. */
+/** Runs the OAuth connect flow for the given provider and feature bundles.
+ * Blocks until the browser flow completes (the Rust side enforces a 300s
+ * timeout). `provider` defaults to Google on the Rust side when omitted.
+ * `loginHint` pre-selects the account to reconnect or add scope to: a Google
+ * email for Google, the workspace's `accountId` for Linear (Linear
+ * escalates by workspace, not by user email). */
 export async function connectorsConnect(input: {
   scopes: ConnectorScopeBundle[];
   loginHint?: string;
+  provider?: ConnectorProvider;
 }) {
   return invoke<ConnectorAccount>("connectors_connect", {
-    request: { scopes: input.scopes, loginHint: input.loginHint },
+    request: { scopes: input.scopes, loginHint: input.loginHint, provider: input.provider },
   });
 }
 
@@ -2077,15 +2108,39 @@ export async function connectorsCancelConnect() {
 }
 
 /** Removes a connected account. With `revoke`, also revokes June's grant with
- * Google before clearing the Keychain item. */
+ * the provider before clearing the Keychain item. */
 export async function connectorsDisconnect(input: { accountId: string; revoke: boolean }) {
   return invoke<void>("connectors_disconnect", {
     request: { accountId: input.accountId, revoke: input.revoke },
   });
 }
 
+/** Lists the Linear teams the connected workspace's user can see, for the
+ * team-selection dialog. A live call, not cached client-side: a workspace's
+ * teams can change between visits. */
+export async function connectorsLinearTeams(input: { accountId: string }) {
+  return invoke<LinearTeam[]>("connectors_linear_teams", {
+    request: { accountId: input.accountId },
+  });
+}
+
+/** Persists which Linear teams June may read/write on this workspace.
+ * Returns the updated account with `selectedTeams` set. The Rust side
+ * rejects an empty team list, so a workspace mid-setup stays in the
+ * "unfinished" state rather than recording zero teams on purpose. */
+export async function connectorsSetSelectedTeams(input: {
+  accountId: string;
+  teams: LinearTeam[];
+}) {
+  return invoke<ConnectorAccount>("connectors_selected_teams_set", {
+    request: { accountId: input.accountId, teams: input.teams },
+  });
+}
+
 /** Restarts the Hermes runtimes so a connect/disconnect/grant change lands in
- * the rendered MCP config. Call after connectorsConnect resolves. */
+ * the rendered MCP config. Call after connectorsConnect resolves. Google
+ * only today — Linear ships no MCP server in this slice, so there is no
+ * runtime surface for a Linear grant to apply. */
 export async function connectorsApplyRuntime() {
   return invoke<void>("connectors_apply_runtime");
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -2115,11 +2115,19 @@ export async function connectorsDisconnect(input: { accountId: string; revoke: b
   });
 }
 
+/** The live team listing for the selection dialog. `truncated` means the
+ * Rust side's pagination cap cut the listing short, so the UI must not
+ * present it as the complete team inventory. */
+export type LinearTeamsResult = {
+  teams: LinearTeam[];
+  truncated: boolean;
+};
+
 /** Lists the Linear teams the connected workspace's user can see, for the
  * team-selection dialog. A live call, not cached client-side: a workspace's
  * teams can change between visits. */
 export async function connectorsLinearTeams(input: { accountId: string }) {
-  return invoke<LinearTeam[]>("connectors_linear_teams", {
+  return invoke<LinearTeamsResult>("connectors_linear_teams", {
     request: { accountId: input.accountId },
   });
 }

--- a/src/test/connectors-section.test.tsx
+++ b/src/test/connectors-section.test.tsx
@@ -69,7 +69,10 @@ beforeEach(() => {
   mocks.connectorsConnect.mockResolvedValue(account());
   mocks.connectorsDisconnect.mockResolvedValue(undefined);
   mocks.connectorsApplyRuntime.mockResolvedValue(undefined);
-  mocks.connectorsLinearTeams.mockResolvedValue([TEAM_ENG, TEAM_DESIGN]);
+  mocks.connectorsLinearTeams.mockResolvedValue({
+    teams: [TEAM_ENG, TEAM_DESIGN],
+    truncated: false,
+  });
   mocks.connectorsSetSelectedTeams.mockResolvedValue(linearAccount({ selectedTeams: [TEAM_ENG] }));
   mocks.listen.mockResolvedValue(() => {});
 });
@@ -316,10 +319,55 @@ describe("ConnectorsSection — Linear", () => {
     const dialog = await screen.findByRole("dialog", { name: "Select Linear teams" });
 
     expect(await within(dialog).findByText("Linear is unreachable")).toBeInTheDocument();
-    mocks.connectorsLinearTeams.mockResolvedValueOnce([TEAM_ENG, TEAM_DESIGN]);
+    mocks.connectorsLinearTeams.mockResolvedValueOnce({
+      teams: [TEAM_ENG, TEAM_DESIGN],
+      truncated: false,
+    });
     await userEvent.click(within(dialog).getByRole("button", { name: "Retry" }));
 
     expect(await within(dialog).findByRole("checkbox", { name: /engineering/i })).toBeChecked();
+  });
+
+  it("keeps a selected team the live listing no longer returns", async () => {
+    // TEAM_ENG is persisted as selected but absent from the live fetch
+    // (archived, hidden, or beyond the pagination cap). It must stay
+    // visible, stay checked, and survive an unrelated save untouched.
+    mocks.connectorsList.mockResolvedValue([linearAccount({ selectedTeams: [TEAM_ENG] })]);
+    mocks.connectorsLinearTeams.mockResolvedValue({ teams: [TEAM_DESIGN], truncated: false });
+    render(<ConnectorsSection />);
+    await screen.findByText(/1 team selected/i);
+
+    await userEvent.click(screen.getByRole("button", { name: "Manage teams" }));
+    const dialog = await screen.findByRole("dialog", { name: "Select Linear teams" });
+
+    const stale = await within(dialog).findByRole("checkbox", { name: /engineering/i });
+    expect(stale).toBeChecked();
+    expect(within(dialog).getByText(/not visible in Linear right now/i)).toBeInTheDocument();
+
+    await userEvent.click(within(dialog).getByRole("checkbox", { name: /design/i }));
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save teams" }));
+
+    await waitFor(() =>
+      expect(mocks.connectorsSetSelectedTeams).toHaveBeenCalledWith({
+        accountId: "linear-acc-1",
+        teams: [TEAM_DESIGN, TEAM_ENG],
+      }),
+    );
+  });
+
+  it("flags a truncated team listing instead of presenting it as complete", async () => {
+    mocks.connectorsList.mockResolvedValue([linearAccount({ selectedTeams: [TEAM_ENG] })]);
+    mocks.connectorsLinearTeams.mockResolvedValue({
+      teams: [TEAM_ENG, TEAM_DESIGN],
+      truncated: true,
+    });
+    render(<ConnectorsSection />);
+    await screen.findByText(/1 team selected/i);
+
+    await userEvent.click(screen.getByRole("button", { name: "Manage teams" }));
+    const dialog = await screen.findByRole("dialog", { name: "Select Linear teams" });
+
+    expect(await within(dialog).findByText(/only the first 500 teams/i)).toBeInTheDocument();
   });
 
   it("reconnects a workspace using the account id as the login hint", async () => {

--- a/src/test/connectors-section.test.tsx
+++ b/src/test/connectors-section.test.tsx
@@ -2,13 +2,15 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectorsSection } from "../components/settings/ConnectorsSection";
-import type { ConnectorAccount } from "../lib/tauri";
+import type { ConnectorAccount, LinearTeam } from "../lib/tauri";
 
 const mocks = vi.hoisted(() => ({
   connectorsList: vi.fn<() => Promise<ConnectorAccount[]>>(),
   connectorsConnect: vi.fn(),
   connectorsDisconnect: vi.fn(),
   connectorsApplyRuntime: vi.fn(),
+  connectorsLinearTeams: vi.fn(),
+  connectorsSetSelectedTeams: vi.fn(),
   listen: vi.fn(),
 }));
 
@@ -18,6 +20,8 @@ vi.mock("../lib/tauri", async (importOriginal) => ({
   connectorsConnect: mocks.connectorsConnect,
   connectorsDisconnect: mocks.connectorsDisconnect,
   connectorsApplyRuntime: mocks.connectorsApplyRuntime,
+  connectorsLinearTeams: mocks.connectorsLinearTeams,
+  connectorsSetSelectedTeams: mocks.connectorsSetSelectedTeams,
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -27,6 +31,9 @@ vi.mock("@tauri-apps/api/event", () => ({
 const GMAIL_READONLY = "https://www.googleapis.com/auth/gmail.readonly";
 const CALENDAR_EVENTS = "https://www.googleapis.com/auth/calendar.events";
 
+const TEAM_ENG: LinearTeam = { id: "team-eng", key: "ENG", name: "Engineering" };
+const TEAM_DESIGN: LinearTeam = { id: "team-design", key: "DES", name: "Design" };
+
 function account(overrides: Partial<ConnectorAccount> = {}): ConnectorAccount {
   const email = overrides.email ?? "alex@example.com";
   return {
@@ -35,6 +42,23 @@ function account(overrides: Partial<ConnectorAccount> = {}): ConnectorAccount {
     email,
     scopes: [GMAIL_READONLY, CALENDAR_EVENTS],
     status: "connected",
+    workspaceName: null,
+    workspaceUrlKey: null,
+    selectedTeams: [],
+    ...overrides,
+  };
+}
+
+function linearAccount(overrides: Partial<ConnectorAccount> = {}): ConnectorAccount {
+  return {
+    accountId: "linear-acc-1",
+    provider: "linear",
+    email: "alex@example.com",
+    scopes: ["read"],
+    status: "connected",
+    workspaceName: "Acme",
+    workspaceUrlKey: "acme",
+    selectedTeams: [],
     ...overrides,
   };
 }
@@ -45,6 +69,8 @@ beforeEach(() => {
   mocks.connectorsConnect.mockResolvedValue(account());
   mocks.connectorsDisconnect.mockResolvedValue(undefined);
   mocks.connectorsApplyRuntime.mockResolvedValue(undefined);
+  mocks.connectorsLinearTeams.mockResolvedValue([TEAM_ENG, TEAM_DESIGN]);
+  mocks.connectorsSetSelectedTeams.mockResolvedValue(linearAccount({ selectedTeams: [TEAM_ENG] }));
   mocks.listen.mockResolvedValue(() => {});
 });
 
@@ -62,6 +88,16 @@ describe("ConnectorsSection", () => {
 
     expect(screen.getByText("Google")).toBeInTheDocument();
     expect(screen.getByText(/mail and calendar for briefings/i)).toBeInTheDocument();
+  });
+
+  it("renders both provider rows", async () => {
+    render(<ConnectorsSection />);
+    await findEnabledConnect("Connect Google");
+
+    expect(screen.getByText("Google")).toBeInTheDocument();
+    expect(screen.getByText("Linear")).toBeInTheDocument();
+    expect(await findEnabledConnect("Connect Linear")).toBeInTheDocument();
+    expect(screen.getByText(/projects, cycles, and issues/i)).toBeInTheDocument();
   });
 
   it("lists connected accounts with feature labels and status", async () => {
@@ -84,7 +120,7 @@ describe("ConnectorsSection", () => {
     // connector servers, triggers, and grants all bind to that single account.
     expect(screen.queryByRole("button", { name: "Connect Google" })).toBeNull();
     expect(screen.getByRole("button", { name: "Add access" })).toBeInTheDocument();
-    expect(screen.getByText(/Connect Google in local mode/i)).toBeInTheDocument();
+    expect(screen.getByText(/Connect Google and Linear in local mode/i)).toBeInTheDocument();
   });
 
   it("connects an account from the feature-bundle dialog and applies the runtime", async () => {
@@ -105,6 +141,7 @@ describe("ConnectorsSection", () => {
       expect(mocks.connectorsConnect).toHaveBeenCalledWith({
         scopes: ["gmail_read", "gmail_draft", "calendar_read"],
         loginHint: undefined,
+        provider: "google",
       }),
     );
     await waitFor(() => expect(mocks.connectorsApplyRuntime).toHaveBeenCalled());
@@ -139,6 +176,7 @@ describe("ConnectorsSection", () => {
       expect(mocks.connectorsConnect).toHaveBeenCalledWith({
         scopes: ["gmail_read", "calendar_events"],
         loginHint: "alex@example.com",
+        provider: "google",
       }),
     );
     await waitFor(() => expect(mocks.connectorsApplyRuntime).toHaveBeenCalled());
@@ -181,5 +219,126 @@ describe("ConnectorsSection", () => {
         revoke: false,
       }),
     );
+  });
+});
+
+describe("ConnectorsSection — Linear", () => {
+  it("connects a workspace, skips applying the runtime, and auto-opens team selection", async () => {
+    mocks.connectorsConnect.mockResolvedValue(linearAccount({ selectedTeams: [] }));
+    render(<ConnectorsSection />);
+
+    await userEvent.click(await findEnabledConnect("Connect Linear"));
+    const dialog = screen.getByRole("dialog", { name: "Connect Linear workspace" });
+    expect(within(dialog).getByRole("checkbox", { name: /read workspace/i })).toBeChecked();
+    expect(
+      within(dialog).getByRole("checkbox", { name: /create and update issues/i }),
+    ).not.toBeChecked();
+
+    mocks.connectorsList.mockResolvedValue([linearAccount({ selectedTeams: [] })]);
+    await userEvent.click(within(dialog).getByRole("button", { name: "Connect" }));
+
+    await waitFor(() =>
+      expect(mocks.connectorsConnect).toHaveBeenCalledWith({
+        scopes: ["linear_read"],
+        loginHint: undefined,
+        provider: "linear",
+      }),
+    );
+    // Slice 1 ships no Linear runtime surface (no MCP servers), so applying
+    // the runtime must never fire for a Linear connect — it would restart
+    // Hermes for nothing.
+    expect(mocks.connectorsApplyRuntime).not.toHaveBeenCalled();
+
+    const teamsDialog = await screen.findByRole("dialog", { name: "Select Linear teams" });
+    await waitFor(() =>
+      expect(mocks.connectorsLinearTeams).toHaveBeenCalledWith({ accountId: "linear-acc-1" }),
+    );
+    // Nothing preselected on a first connect.
+    expect(within(teamsDialog).getByRole("checkbox", { name: /engineering/i })).not.toBeChecked();
+  });
+
+  it("shows the unfinished-setup hint and a Select teams action when no teams are chosen yet", async () => {
+    mocks.connectorsList.mockResolvedValue([linearAccount({ selectedTeams: [] })]);
+    render(<ConnectorsSection />);
+
+    expect(await screen.findByText("Select teams to finish setup")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Select teams" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Manage teams" })).toBeNull();
+  });
+
+  it("disables Save teams until a team is checked, then saves the chosen teams", async () => {
+    mocks.connectorsList.mockResolvedValue([linearAccount({ selectedTeams: [] })]);
+    render(<ConnectorsSection />);
+    await screen.findByText("Select teams to finish setup");
+
+    await userEvent.click(screen.getByRole("button", { name: "Select teams" }));
+    const dialog = await screen.findByRole("dialog", { name: "Select Linear teams" });
+    await waitFor(() => expect(mocks.connectorsLinearTeams).toHaveBeenCalled());
+
+    const saveButton = within(dialog).getByRole("button", { name: "Save teams" });
+    expect(saveButton).toBeDisabled();
+
+    await userEvent.click(within(dialog).getByRole("checkbox", { name: /engineering/i }));
+    expect(saveButton).toBeEnabled();
+
+    mocks.connectorsList.mockResolvedValue([linearAccount({ selectedTeams: [TEAM_ENG] })]);
+    await userEvent.click(saveButton);
+
+    await waitFor(() =>
+      expect(mocks.connectorsSetSelectedTeams).toHaveBeenCalledWith({
+        accountId: "linear-acc-1",
+        teams: [TEAM_ENG],
+      }),
+    );
+    expect(await screen.findByText(/1 team selected/i)).toBeInTheDocument();
+  });
+
+  it("preselects the account's current teams when managing teams", async () => {
+    mocks.connectorsList.mockResolvedValue([linearAccount({ selectedTeams: [TEAM_ENG] })]);
+    render(<ConnectorsSection />);
+    await screen.findByText(/1 team selected/i);
+
+    await userEvent.click(screen.getByRole("button", { name: "Manage teams" }));
+    const dialog = await screen.findByRole("dialog", { name: "Select Linear teams" });
+    await waitFor(() => expect(mocks.connectorsLinearTeams).toHaveBeenCalled());
+
+    expect(within(dialog).getByRole("checkbox", { name: /engineering/i })).toBeChecked();
+    expect(within(dialog).getByRole("checkbox", { name: /design/i })).not.toBeChecked();
+  });
+
+  it("shows an error with a retry when the team list fails to load", async () => {
+    mocks.connectorsList.mockResolvedValue([linearAccount({ selectedTeams: [TEAM_ENG] })]);
+    mocks.connectorsLinearTeams.mockRejectedValueOnce({ message: "Linear is unreachable" });
+    render(<ConnectorsSection />);
+    await screen.findByText(/1 team selected/i);
+
+    await userEvent.click(screen.getByRole("button", { name: "Manage teams" }));
+    const dialog = await screen.findByRole("dialog", { name: "Select Linear teams" });
+
+    expect(await within(dialog).findByText("Linear is unreachable")).toBeInTheDocument();
+    mocks.connectorsLinearTeams.mockResolvedValueOnce([TEAM_ENG, TEAM_DESIGN]);
+    await userEvent.click(within(dialog).getByRole("button", { name: "Retry" }));
+
+    expect(await within(dialog).findByRole("checkbox", { name: /engineering/i })).toBeChecked();
+  });
+
+  it("reconnects a workspace using the account id as the login hint", async () => {
+    mocks.connectorsList.mockResolvedValue([
+      linearAccount({ status: "reconnect_required", selectedTeams: [TEAM_ENG] }),
+    ]);
+    mocks.connectorsConnect.mockResolvedValue(linearAccount({ selectedTeams: [TEAM_ENG] }));
+    render(<ConnectorsSection />);
+    await screen.findByText(/Acme/);
+
+    await userEvent.click(screen.getByRole("button", { name: "Reconnect Linear" }));
+
+    await waitFor(() =>
+      expect(mocks.connectorsConnect).toHaveBeenCalledWith({
+        scopes: ["linear_read"],
+        loginHint: "linear-acc-1",
+        provider: "linear",
+      }),
+    );
+    expect(mocks.connectorsApplyRuntime).not.toHaveBeenCalled();
   });
 });

--- a/src/test/connectors.test.ts
+++ b/src/test/connectors.test.ts
@@ -1,17 +1,19 @@
 import { describe, expect, it } from "vitest";
 import {
-  ALL_SCOPE_BUNDLES,
   AUTONOMY_RUN_THRESHOLD,
   BUNDLE_META,
   autonomyRuntimeNeedsRestart,
   CONNECTOR_ACTION_TOOLSETS,
   CONNECTOR_READ_TOOLSETS,
+  GOOGLE_SCOPE_BUNDLES,
+  LINEAR_SCOPE_BUNDLES,
   SANDBOXED_ROUTINE_BASE_TOOLSETS,
   TRIGGER_META,
   TRUST_MODE_META,
   accountStatusMeta,
   autonomyProgressLabel,
   autonomyUnlockHint,
+  bundlesForProvider,
   bundlesFromScopes,
   canSelectAutonomous,
   eventTriggerScheduleDraft,
@@ -41,18 +43,54 @@ describe("scope bundles", () => {
     expect(BUNDLE_META.calendar_events.scopeUrls).toEqual([CALENDAR_EVENTS]);
   });
 
+  it("maps every Linear bundle to its short scope name", () => {
+    expect(BUNDLE_META.linear_read.scopeUrls).toEqual(["read"]);
+    expect(BUNDLE_META.linear_write.scopeUrls).toEqual(["write"]);
+    expect(BUNDLE_META.linear_read.label).toBe("Read workspace");
+    expect(BUNDLE_META.linear_write.label).toBe("Create and update issues");
+  });
+
+  it("lists bundles per provider with no cross-provider bundles", () => {
+    expect(bundlesForProvider("google")).toEqual(GOOGLE_SCOPE_BUNDLES);
+    expect(bundlesForProvider("linear")).toEqual(LINEAR_SCOPE_BUNDLES);
+    expect(GOOGLE_SCOPE_BUNDLES).not.toEqual(
+      expect.arrayContaining(["linear_read", "linear_write"]),
+    );
+    expect(LINEAR_SCOPE_BUNDLES).not.toEqual(
+      expect.arrayContaining([
+        "gmail_read",
+        "gmail_draft",
+        "gmail_modify",
+        "gmail_send",
+        "calendar_read",
+        "calendar_events",
+      ]),
+    );
+  });
+
   it("recovers bundles from granted scope URLs, ignoring identity scopes", () => {
-    expect(bundlesFromScopes(["openid", "email", GMAIL_READONLY, CALENDAR_EVENTS])).toEqual([
-      "gmail_read",
-      "calendar_events",
-    ]);
-    expect(bundlesFromScopes([])).toEqual([]);
+    expect(
+      bundlesFromScopes(["openid", "email", GMAIL_READONLY, CALENDAR_EVENTS], "google"),
+    ).toEqual(["gmail_read", "calendar_events"]);
+    expect(bundlesFromScopes([], "google")).toEqual([]);
+  });
+
+  it("scopes bundlesFromScopes to the given provider, never cross-matching", () => {
+    // Linear's "read" scope name never collides with a Google bundle, even
+    // though both providers are checked against the same account.scopes
+    // shape.
+    expect(bundlesFromScopes(["read"], "linear")).toEqual(["linear_read"]);
+    expect(bundlesFromScopes(["read"], "google")).toEqual([]);
   });
 
   it("renders granted scopes as human feature labels", () => {
-    expect(grantedFeatureLabels([GMAIL_READONLY, GMAIL_COMPOSE])).toEqual([
+    expect(grantedFeatureLabels([GMAIL_READONLY, GMAIL_COMPOSE], "google")).toEqual([
       "Read mail",
       "Draft replies",
+    ]);
+    expect(grantedFeatureLabels(["read", "write"], "linear")).toEqual([
+      "Read workspace",
+      "Create and update issues",
     ]);
   });
 
@@ -84,7 +122,7 @@ describe("scope bundles", () => {
   });
 
   it("keeps bundle copy sentence case with no typographic dashes", () => {
-    for (const bundle of ALL_SCOPE_BUNDLES) {
+    for (const bundle of [...GOOGLE_SCOPE_BUNDLES, ...LINEAR_SCOPE_BUNDLES]) {
       const meta = BUNDLE_META[bundle];
       for (const text of [meta.label, meta.description, meta.feature]) {
         expect(text).not.toMatch(/[–—]/);
@@ -136,11 +174,26 @@ describe("autonomyRuntimeNeedsRestart", () => {
 
 describe("account status", () => {
   it("labels connected and reconnect_required accounts", () => {
-    expect(accountStatusMeta("connected")).toMatchObject({ label: "Connected", tone: "ok" });
-    expect(accountStatusMeta("reconnect_required")).toMatchObject({
+    expect(accountStatusMeta("connected", "google")).toMatchObject({
+      label: "Connected",
+      tone: "ok",
+    });
+    expect(accountStatusMeta("reconnect_required", "google")).toMatchObject({
       label: "Reconnect needed",
       tone: "attention",
     });
+  });
+
+  it("names the provider in the reconnect blurb, sharing the connected blurb", () => {
+    expect(accountStatusMeta("reconnect_required", "google").blurb).toBe(
+      "Google needs you to sign in again before June can use this account.",
+    );
+    expect(accountStatusMeta("reconnect_required", "linear").blurb).toBe(
+      "Linear needs you to sign in again before June can use this workspace.",
+    );
+    expect(accountStatusMeta("connected", "google").blurb).toBe(
+      accountStatusMeta("connected", "linear").blurb,
+    );
   });
 
   it("recognizes the connector_not_configured error code", () => {


### PR DESCRIPTION
## Summary

Delivery slice 1 of the Linear plugin (part of JUN-284; deliberately no
`Closes` - the issue tracks all five slices and stays in progress): a user
can connect one Linear workspace
in local mode with tokens in the Keychain, pick the teams June is allowed
to touch, see connection health, and disconnect with optional provider-side
revoke.

- Phase 0 OAuth spike findings recorded in
  `docs/plugins/linear-oauth-spike.md`: Linear supports a PKCE public
  client (no client secret ships in the binary), rotating refresh tokens
  with a 30-minute grace window, and client-supplied UUIDs on create
  mutations. No new ADR needed: the plan's ADR triggers (confidential
  exchange, app credential, webhook relay) are all avoided, so this extends
  ADR-0016's local-mode pattern to a second provider.
- Connector kit generalized for multiple providers: per-provider keychain
  services (`co.opensoftware.june.linear`) and dev token files,
  per-provider single-account guard, a provider-neutral loopback OAuth
  primitive, `connector_accounts.metadata`, and a `connector_selected_teams`
  table (migration 014).
- Linear flow: authorize with comma-joined scopes + S256 + `actor=user`,
  secretless exchange/refresh/revoke, viewer/organization identity keyed by
  workspace id, teams listing with bounded pagination. The loopback
  listener binds fixed candidate ports (44741-44743, or
  `LINEAR_OAUTH_LOOPBACK_PORT`) because Linear matches registered callback
  URLs exactly - it does not ignore loopback ports the way Google does.
- Settings UI: Linear provider row, read/write consent bundles, post-connect
  team selection (none preselected; at least one to save; cancel leaves a
  visible "Select teams to finish setup" fail-closed state), manage teams,
  reconnect, disconnect.
- Security-sensitive hardening called out: Gmail/Calendar base MCP servers,
  routine trigger pickers, `connector_trigger_set`, and autonomy grant
  account resolution now all filter to Google accounts, so a connected
  Linear workspace can never be bound to a mail/calendar surface. Linear
  GraphQL authentication failures classify as unauthorized from the error
  code/type as well as HTTP 401, so revoked grants still flip the account
  to reconnect-required. `dev-linear-connector-tokens.json` joined the
  hermes sandbox deny-read set and secret-filename denylist.
- CONTEXT.md gains the "Selected teams (Linear)" term.

## Validation

- `make verify` green (Biome, typecheck, vitest, cargo fmt/clippy/test for
  both Rust crates); 89 connector-scoped Rust tests and 104 targeted vitest
  tests pass.
- Pre-publish review battery (5 adversarial rounds to convergence, final
  Standards + Spec passes both clean): round 1 found the unfiltered MCP
  account binding (fixed + family swept - every `list_accounts` consumer
  is now provider-filtered or provider-agnostic); round 2 found the
  manage-teams payload drop and invisible truncation (fixed); round 4
  found two low resilience gaps (fixed: best-effort per-row team reads,
  distinct rotation-persist logging); rounds 3 and 5 approved with no
  material findings, round 5 specifically verifying the fix commits.
- Cross-harness (Codex) review was blocked: the installed Codex CLI cannot
  run the account's configured model. All axes ran on Claude models
  instead.

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end.

No June API deploy needed: the connector is fully on-device, per
ADR-0016's local mode.

Live manual QA was completed by the maintainer against a real Linear
workspace (dev OAuth app registered with the three fixed callback URLs),
walking an eight-item charter: provider directory, connect dialog shape,
consent + auto-opening team picker (none preselected, save gated),
manage teams (live GraphQL), cancel-into-"Select teams to finish setup",
Google row unaffected, grant visible under Linear's authorized
applications with matching scopes, and revoke-on-disconnect verified
against that same Linear page. Token custody was verified on disk
(owner-only dev token file; Keychain path covered by unit tests).

The live run caught one real defect the automated layers had not: a
revoking disconnect left the app authorized at Linear. Root cause: the
revoke call sent only the refresh token with no type hint and treated
Linear's 400 as success, and Linear documents no cross-token cascade, so
the 24-hour access token could stay alive. Fixed in ce02e8c5 (revoke
both tokens with type hints; 400 now logged with the OAuth error word),
then re-verified live: the authorization disappears from Linear's
authorized-applications page on disconnect.

## Out of scope

Later delivery slices of the same plan: the `june_linear` /
`june_linear_actions` MCP servers, provider-proxy routes and selected-team
enforcement on reads/writes, planning reads (projects, cycles, issues),
approved writes with the idempotency journal, skills, and any
trigger/webhook support. Slice 1 only establishes and stores the
selected-team grant.

## Followups

- Slice 2 (planning reads over the provider proxy with selected-team
  enforcement in Rust) per `docs/plugins/linear-implementation-plan.md`.
- Live verification of Linear OAuth behavior (rotation grace, revoke,
  strict redirect matching) against a real workspace once the OAuth app
  exists; recorded as a residual item in the spike doc.
- ADR-0016 status is still "proposed" while its implementation has shipped;
  moving it to accepted deserves its own docs change.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs. <!-- no workflow changes -->
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. <!-- none -->
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. <!-- June API untouched -->
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
