### PR TITLE
feat: dedicated /v1/chat/completions body limit sized for 1M-token context (JUN-336)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ Non-secret (usually left to `config.toml`): `JUNE__SERVER__HOST` / `PORT`,
 
 ## Backend knobs (`june-api/config.toml`)
 
-- **Server:** `request_timeout_secs` 600, `max_audio_bytes` 25 MiB, `max_json_bytes` 512 KiB, `max_issue_report_bytes` 301 MiB total (one 300 MiB os-platform attachment plus multipart overhead), `max_image_edit_bytes` sized for a 50 MiB source image after base64 expansion.
+- **Server:** `request_timeout_secs` 600, `max_audio_bytes` 25 MiB, `max_json_bytes` 512 KiB, `max_agent_chat_bytes` 12 MiB (dedicated `/v1/chat/completions` cap, aligned with the desktop proxy and sized for a 1M-token context window; must be ≥ the 12 MiB proxy cap), `max_issue_report_bytes` 301 MiB total (one 300 MiB os-platform attachment plus multipart overhead), `max_image_edit_bytes` sized for a 50 MiB source image after base64 expansion.
 - **Metering estimate:** `flat_estimate_credits` 250 — the flat credit Hold per metered action; skips per-request estimation.
 - **Hold TTLs (secs):** `note_transcribe` 60, `note_generate` 300, `dictate_transcribe` 30, `dictate_cleanup` 30, `web` 30, `image` defaults to `request_timeout_secs` + 30 (630) — validation rejects an image TTL that cannot outlive the request timeout, so a slow generation can still settle its charge.
 - **Web tools:** `web_search_credits` 20, `web_fetch_credits` 20 (flat).

--- a/june-api/config.toml
+++ b/june-api/config.toml
@@ -9,9 +9,10 @@ max_json_bytes = 524288
 max_issue_report_bytes = 315621376
 max_image_edit_bytes = 69921452
 # Dedicated body cap for /v1/chat/completions, aligned with the desktop
-# provider proxy's 3 MiB chat body cap (JUN-336). Kept above the semantic
+# provider proxy's 12 MiB chat body cap (JUN-336) — the byte-image of the 6M-char
+# semantic cap, sized for a 1M-token context window. Kept above the semantic
 # agent chat string caps so in-window requests reach validate_agent_chat_body.
-max_agent_chat_bytes = 3145728
+max_agent_chat_bytes = 12582912
 
 # Public facts shown on the /verify attestation page. source_commit is not
 # set here — the Docker build stamps it via JUNE__ATTESTATION__SOURCE_COMMIT.

--- a/june-api/config.toml
+++ b/june-api/config.toml
@@ -8,6 +8,10 @@ max_json_bytes = 524288
 # framing and report text while keeping a single total request budget.
 max_issue_report_bytes = 315621376
 max_image_edit_bytes = 69921452
+# Dedicated body cap for /v1/chat/completions, aligned with the desktop
+# provider proxy's 3 MiB chat body cap (JUN-336). Kept above the semantic
+# agent chat string caps so in-window requests reach validate_agent_chat_body.
+max_agent_chat_bytes = 3145728
 
 # Public facts shown on the /verify attestation page. source_commit is not
 # set here — the Docker build stamps it via JUNE__ATTESTATION__SOURCE_COMMIT.

--- a/june-api/config.toml
+++ b/june-api/config.toml
@@ -13,6 +13,10 @@ max_image_edit_bytes = 69921452
 # semantic cap, sized for a 1M-token context window. Kept above the semantic
 # agent chat string caps so in-window requests reach validate_agent_chat_body.
 max_agent_chat_bytes = 12582912
+# Global in-flight request-body budget for large-body agent routes.
+max_agent_inflight_body_bytes = 1073741824
+# Per-user concurrent request cap for large-body agent routes.
+max_agent_concurrent_requests_per_user = 8
 
 # Public facts shown on the /verify attestation page. source_commit is not
 # set here — the Docker build stamps it via JUNE__ATTESTATION__SOURCE_COMMIT.

--- a/june-api/crates/api/src/envelope.rs
+++ b/june-api/crates/api/src/envelope.rs
@@ -12,6 +12,7 @@ pub const ERR_AUTHORIZATION_DENIED: i32 = 4401;
 pub const ERR_INTERNAL: i32 = 5000;
 pub const ERR_UPSTREAM: i32 = 5001;
 pub const ERR_METERING: i32 = 5031;
+pub const ERR_SERVICE_OVERLOADED: i32 = 5032;
 pub const ERR_TIMEOUT: i32 = 5041;
 pub(crate) const TRANSIENT_RETRY_AFTER_SECS: u64 = 2;
 

--- a/june-api/crates/api/src/error.rs
+++ b/june-api/crates/api/src/error.rs
@@ -137,7 +137,9 @@ impl ApiError {
     /// (an SSE body cannot set response headers).
     pub(crate) fn retry_after_secs(&self) -> Option<u64> {
         match self {
-            Self::AuthorizationDenied => Some(TRANSIENT_RETRY_AFTER_SECS),
+            // Load-shedding (503) is transient by definition: tell clients when to
+            // come back so admission overload degrades gracefully (JUN-336).
+            Self::AuthorizationDenied | Self::ServiceOverloaded => Some(TRANSIENT_RETRY_AFTER_SECS),
             _ => None,
         }
     }
@@ -261,6 +263,8 @@ mod tests {
         let response = ApiError::ServiceOverloaded.into_response();
 
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        // Load-shedding is transient — clients get a Retry-After to back off.
+        assert!(response.headers().get(header::RETRY_AFTER).is_some());
         let body = body_json(response).await;
         assert_eq!(body["error_code"], 5032);
         assert_eq!(body["message"], "server_busy");

--- a/june-api/crates/api/src/error.rs
+++ b/june-api/crates/api/src/error.rs
@@ -1,7 +1,7 @@
 use crate::envelope::{
     ERR_AUTHORIZATION_DENIED, ERR_BAD_REQUEST, ERR_INSUFFICIENT_CREDITS, ERR_INTERNAL,
-    ERR_METERING, ERR_NOT_FOUND, ERR_PAYLOAD_TOO_LARGE, ERR_UNAUTHORIZED, ERR_UNPROCESSABLE,
-    ERR_UPSTREAM, TRANSIENT_RETRY_AFTER_SECS,
+    ERR_METERING, ERR_NOT_FOUND, ERR_PAYLOAD_TOO_LARGE, ERR_SERVICE_OVERLOADED, ERR_UNAUTHORIZED,
+    ERR_UNPROCESSABLE, ERR_UPSTREAM, TRANSIENT_RETRY_AFTER_SECS,
 };
 use axum::{
     Json,
@@ -33,6 +33,8 @@ pub enum ApiError {
     Upstream,
     #[error("metering_provider_failed")]
     Metering,
+    #[error("server_busy")]
+    ServiceOverloaded,
     #[error("internal_error")]
     Internal,
 }
@@ -64,6 +66,10 @@ impl ApiError {
             code: ERR_NOT_FOUND,
             message: message.into(),
         }
+    }
+
+    pub fn service_overloaded() -> Self {
+        Self::ServiceOverloaded
     }
 
     pub(crate) fn response_parts(&self) -> (StatusCode, serde_json::Value) {
@@ -110,6 +116,11 @@ impl ApiError {
                 StatusCode::SERVICE_UNAVAILABLE,
                 ERR_METERING,
                 "metering_provider_failed",
+            ),
+            Self::ServiceOverloaded => error_parts(
+                StatusCode::SERVICE_UNAVAILABLE,
+                ERR_SERVICE_OVERLOADED,
+                "server_busy",
             ),
             Self::Internal => error_parts(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -242,6 +253,17 @@ mod tests {
         let body = body_json(response).await;
         assert_eq!(body["error_code"], 5031);
         assert_eq!(body["message"], "metering_provider_failed");
+        assert_eq!(body["success"], false);
+    }
+
+    #[tokio::test]
+    async fn service_overloaded_maps_to_503_with_structured_code() {
+        let response = ApiError::ServiceOverloaded.into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = body_json(response).await;
+        assert_eq!(body["error_code"], 5032);
+        assert_eq!(body["message"], "server_busy");
         assert_eq!(body["success"], false);
     }
 }

--- a/june-api/crates/api/src/lib.rs
+++ b/june-api/crates/api/src/lib.rs
@@ -203,14 +203,39 @@ async fn authenticate_and_admit(
     // Byte-weighted global + per-user admission BEFORE body extraction, so
     // concurrent authenticated large bodies cannot exhaust the shared TEE
     // (JUN-336 review). Held through body extraction + handler, released after.
-    let content_length = request
+    //
+    // Weight by what Axum will ACTUALLY buffer — the route's body cap — not the
+    // client's `Content-Length`. That header is untrusted: a missing/chunked
+    // length would otherwise reserve only the 1 KiB minimum while the body still
+    // buffers up to the cap, and an exaggerated length would reserve the whole
+    // global budget. An honest length under the cap is charged as-is.
+    let limits = state.limits();
+    let route_cap = agent_route_body_cap(request.uri().path(), &limits);
+    let declared = request
         .headers()
         .get(axum::http::header::CONTENT_LENGTH)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(0);
-    let _admission = state.admit_agent_request(&user_id, content_length)?;
+    let charge_bytes = if declared == 0 || declared > route_cap {
+        route_cap
+    } else {
+        declared
+    };
+    let _admission = state.admit_agent_request(&user_id, charge_bytes)?;
     Ok(next.run(request).await)
+}
+
+/// The body cap Axum enforces for a large-body route — the true upper bound on
+/// bytes it will buffer, used to weight admission independently of the untrusted
+/// `Content-Length` (JUN-336). Unknown paths fall back to the largest cap so the
+/// charge is never an underestimate.
+fn agent_route_body_cap(path: &str, limits: &ApiLimits) -> usize {
+    match path {
+        "/v1/chat/completions" => limits.max_agent_chat_bytes,
+        "/v1/notes/transcribe" | "/v1/dictate" => limits.max_audio_bytes,
+        _ => limits.max_image_edit_bytes,
+    }
 }
 
 async fn issue_report_permit_middleware(
@@ -245,4 +270,35 @@ fn hold_issue_report_permit_through_body(
         chunk
     });
     Response::from_parts(parts, Body::from_stream(stream))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::agent_route_body_cap;
+    use crate::state::ApiLimits;
+
+    fn limits() -> ApiLimits {
+        ApiLimits {
+            max_audio_bytes: 25,
+            max_json_bytes: 1,
+            max_issue_report_bytes: 2,
+            max_image_edit_bytes: 66,
+            max_agent_chat_bytes: 12,
+            max_agent_inflight_body_bytes: 100,
+            max_agent_concurrent_requests_per_user: 8,
+            request_timeout_secs: 1,
+        }
+    }
+
+    #[test]
+    fn route_body_cap_maps_each_large_body_route_to_its_real_cap() {
+        let l = limits();
+        assert_eq!(agent_route_body_cap("/v1/chat/completions", &l), 12);
+        assert_eq!(agent_route_body_cap("/v1/notes/transcribe", &l), 25);
+        assert_eq!(agent_route_body_cap("/v1/dictate", &l), 25);
+        assert_eq!(agent_route_body_cap("/v1/image/edit", &l), 66);
+        assert_eq!(agent_route_body_cap("/v1/video/animate", &l), 66);
+        // Unknown path falls back to the largest cap (never an underestimate).
+        assert_eq!(agent_route_body_cap("/v1/other", &l), 66);
+    }
 }

--- a/june-api/crates/api/src/lib.rs
+++ b/june-api/crates/api/src/lib.rs
@@ -26,8 +26,8 @@ use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
 pub use envelope::{
     ApiResponse, ERR_AUTHORIZATION_DENIED, ERR_BAD_REQUEST, ERR_INSUFFICIENT_CREDITS, ERR_INTERNAL,
-    ERR_METERING, ERR_NOT_FOUND, ERR_PAYLOAD_TOO_LARGE, ERR_TIMEOUT, ERR_UNAUTHORIZED,
-    ERR_UNPROCESSABLE, ERR_UPSTREAM,
+    ERR_METERING, ERR_NOT_FOUND, ERR_PAYLOAD_TOO_LARGE, ERR_SERVICE_OVERLOADED, ERR_TIMEOUT,
+    ERR_UNAUTHORIZED, ERR_UNPROCESSABLE, ERR_UPSTREAM,
 };
 pub use error::ApiError;
 pub use handlers::dictate::{
@@ -138,10 +138,10 @@ pub fn router(state: ApiState) -> Router {
 }
 
 /// The large-body routes — those whose cap is well above the shared 512 KiB
-/// small-JSON cap — grouped so `require_authenticated_bearer` runs, as the
+/// small-JSON cap — grouped so authentication and admission control run, as the
 /// outermost layer, before any of their body-limit layers buffer a request.
-/// Grouping keeps the unauthenticated resource-exhaustion surface closed for
-/// every multi-MiB route at once instead of route by route (JUN-336 review).
+/// Grouping keeps both unauthenticated and authenticated resource-exhaustion
+/// surfaces closed for every multi-MiB route at once (JUN-336 review).
 fn authenticated_body_routes(state: &ApiState, limits: ApiLimits) -> Router<ApiState> {
     Router::new()
         .route(
@@ -173,7 +173,7 @@ fn authenticated_body_routes(state: &ApiState, limits: ApiLimits) -> Router<ApiS
         )
         .layer(middleware::from_fn_with_state(
             state.clone(),
-            require_authenticated_bearer,
+            authenticate_and_admit,
         ))
 }
 
@@ -184,7 +184,7 @@ async fn handle_timeout_error(error: BoxError) -> axum::response::Response {
     error::ApiError::Internal.into_response()
 }
 
-/// Header-only bearer authentication run BEFORE the body extractor on the
+/// Header-only bearer authentication and admission run BEFORE the body extractor on the
 /// large-body routes (those whose cap exceeds the shared 512 KiB small-JSON
 /// cap). Without it, an unauthenticated client could force June API to buffer
 /// and JSON-parse a multi-MiB body — up to `max_agent_chat_bytes` (12 MiB),
@@ -193,12 +193,23 @@ async fn handle_timeout_error(error: BoxError) -> axum::response::Response {
 /// resource-exhaustion path that widened with the JUN-336 cap increase. The
 /// verify is a cached-JWKS signature check, so re-checking in the handler is
 /// cheap; keeping the handler check makes each handler correct on its own.
-async fn require_authenticated_bearer(
+async fn authenticate_and_admit(
     State(state): State<ApiState>,
     request: Request,
     next: Next,
 ) -> Result<Response, ApiError> {
-    auth::authenticated_user(&state, request.headers()).await?;
+    // Auth on headers before the body is buffered (JUN-336).
+    let user_id = auth::authenticated_user(&state, request.headers()).await?;
+    // Byte-weighted global + per-user admission BEFORE body extraction, so
+    // concurrent authenticated large bodies cannot exhaust the shared TEE
+    // (JUN-336 review). Held through body extraction + handler, released after.
+    let content_length = request
+        .headers()
+        .get(axum::http::header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
+    let _admission = state.admit_agent_request(&user_id, content_length)?;
     Ok(next.run(request).await)
 }
 

--- a/june-api/crates/api/src/lib.rs
+++ b/june-api/crates/api/src/lib.rs
@@ -64,47 +64,20 @@ pub fn router(state: ApiState) -> Router {
         .route("/verify", get(handlers::verify::verify))
         .route("/v1/models", get(handlers::models::list_models))
         .route(
-            "/v1/notes/transcribe",
-            post(handlers::notes::transcribe).layer(DefaultBodyLimit::max(limits.max_audio_bytes)),
-        )
-        .route(
             "/v1/notes/generate",
             post(handlers::notes::generate).layer(DefaultBodyLimit::max(limits.max_json_bytes)),
-        )
-        .route(
-            "/v1/chat/completions",
-            post(handlers::agent::chat_completions)
-                .layer(DefaultBodyLimit::max(limits.max_agent_chat_bytes)),
         )
         .route(
             "/v1/image/generate",
             post(handlers::image::generate).layer(DefaultBodyLimit::max(limits.max_json_bytes)),
         )
         .route(
-            // Edits carry a base64 source image, so use the explicit image-edit
-            // budget rather than the small JSON budget or unrelated audio cap.
-            "/v1/image/edit",
-            post(handlers::image::edit).layer(DefaultBodyLimit::max(limits.max_image_edit_bytes)),
-        )
-        .route(
             "/v1/video/generate",
             post(handlers::video::generate).layer(DefaultBodyLimit::max(limits.max_json_bytes)),
         )
         .route(
-            // Animate carries a base64 source image, so it uses the image-edit
-            // body budget rather than the small JSON budget.
-            "/v1/video/animate",
-            post(handlers::video::animate)
-                .layer(DefaultBodyLimit::max(limits.max_image_edit_bytes)),
-        )
-        .route(
             "/v1/video/status/{job_id}",
             get(handlers::video::status).layer(DefaultBodyLimit::max(limits.max_json_bytes)),
-        )
-        .route(
-            "/v1/dictate",
-            post(handlers::dictate::transcribe)
-                .layer(DefaultBodyLimit::max(limits.max_audio_bytes)),
         )
         .route(
             "/v1/dictate/cleanup",
@@ -139,6 +112,7 @@ pub fn router(state: ApiState) -> Router {
             "/v1/p3a/reports",
             post(handlers::p3a::submit).layer(DefaultBodyLimit::max(limits.max_json_bytes)),
         )
+        .merge(authenticated_body_routes(&state, limits))
         .layer(timeout)
         .layer(
             // The request span carries the calling app version so a deploy
@@ -163,11 +137,69 @@ pub fn router(state: ApiState) -> Router {
         .with_state(state)
 }
 
+/// The large-body routes — those whose cap is well above the shared 512 KiB
+/// small-JSON cap — grouped so `require_authenticated_bearer` runs, as the
+/// outermost layer, before any of their body-limit layers buffer a request.
+/// Grouping keeps the unauthenticated resource-exhaustion surface closed for
+/// every multi-MiB route at once instead of route by route (JUN-336 review).
+fn authenticated_body_routes(state: &ApiState, limits: ApiLimits) -> Router<ApiState> {
+    Router::new()
+        .route(
+            "/v1/chat/completions",
+            post(handlers::agent::chat_completions)
+                .layer(DefaultBodyLimit::max(limits.max_agent_chat_bytes)),
+        )
+        .route(
+            // Edits carry a base64 source image, so use the explicit image-edit
+            // budget rather than the small JSON budget or unrelated audio cap.
+            "/v1/image/edit",
+            post(handlers::image::edit).layer(DefaultBodyLimit::max(limits.max_image_edit_bytes)),
+        )
+        .route(
+            // Animate carries a base64 source image, so it uses the image-edit
+            // body budget rather than the small JSON budget.
+            "/v1/video/animate",
+            post(handlers::video::animate)
+                .layer(DefaultBodyLimit::max(limits.max_image_edit_bytes)),
+        )
+        .route(
+            "/v1/notes/transcribe",
+            post(handlers::notes::transcribe).layer(DefaultBodyLimit::max(limits.max_audio_bytes)),
+        )
+        .route(
+            "/v1/dictate",
+            post(handlers::dictate::transcribe)
+                .layer(DefaultBodyLimit::max(limits.max_audio_bytes)),
+        )
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_authenticated_bearer,
+        ))
+}
+
 async fn handle_timeout_error(error: BoxError) -> axum::response::Response {
     if error.is::<tower::timeout::error::Elapsed>() {
         return envelope::timeout_response();
     }
     error::ApiError::Internal.into_response()
+}
+
+/// Header-only bearer authentication run BEFORE the body extractor on the
+/// large-body routes (those whose cap exceeds the shared 512 KiB small-JSON
+/// cap). Without it, an unauthenticated client could force June API to buffer
+/// and JSON-parse a multi-MiB body — up to `max_agent_chat_bytes` (12 MiB),
+/// `max_image_edit_bytes` (~66 MiB) or `max_audio_bytes` (25 MiB) — before the
+/// handler's own `authenticated_user` check ran, an unauthenticated
+/// resource-exhaustion path that widened with the JUN-336 cap increase. The
+/// verify is a cached-JWKS signature check, so re-checking in the handler is
+/// cheap; keeping the handler check makes each handler correct on its own.
+async fn require_authenticated_bearer(
+    State(state): State<ApiState>,
+    request: Request,
+    next: Next,
+) -> Result<Response, ApiError> {
+    auth::authenticated_user(&state, request.headers()).await?;
+    Ok(next.run(request).await)
 }
 
 async fn issue_report_permit_middleware(

--- a/june-api/crates/api/src/lib.rs
+++ b/june-api/crates/api/src/lib.rs
@@ -74,7 +74,7 @@ pub fn router(state: ApiState) -> Router {
         .route(
             "/v1/chat/completions",
             post(handlers::agent::chat_completions)
-                .layer(DefaultBodyLimit::max(limits.max_json_bytes)),
+                .layer(DefaultBodyLimit::max(limits.max_agent_chat_bytes)),
         )
         .route(
             "/v1/image/generate",

--- a/june-api/crates/api/src/state.rs
+++ b/june-api/crates/api/src/state.rs
@@ -39,9 +39,14 @@ impl AgentAdmissionControl {
     }
 
     fn admit(&self, user_id: &UserId, content_length: usize) -> Result<AgentAdmission, ApiError> {
-        let weight_kib = content_length
-            .div_ceil(1024)
-            .clamp(1, self.total_budget_kib);
+        let weight_kib = content_length.div_ceil(1024).max(1);
+        // A request that cannot fit the whole budget is REJECTED, not clamped and
+        // admitted — clamping would let it buffer beyond the budget and defeat the
+        // memory guarantee (JUN-336 review). Config validation keeps the budget at
+        // or above every route cap, so a real request never trips this.
+        if weight_kib > self.total_budget_kib {
+            return Err(ApiError::service_overloaded());
+        }
         let weight_kib = u32::try_from(weight_kib).map_err(|_| ApiError::service_overloaded())?;
         let body_permit = self
             .body_budget_kib
@@ -328,21 +333,20 @@ mod tests {
     }
 
     #[test]
-    fn oversized_request_is_clamped_to_the_whole_budget() {
+    fn request_weight_over_budget_is_rejected_not_admitted() {
+        // A request that cannot fit the whole budget is load-shed rather than
+        // clamped and admitted (which would buffer beyond the budget). Config
+        // validation keeps this unreachable in production; the guard is defensive.
         let control = AgentAdmissionControl::new(4 * 1024, 100);
         let user_a = user("usr_a");
-        let user_b = user("usr_b");
 
-        let oversized = control
-            .admit(&user_a, 100 * 1024 * 1024)
-            .expect("oversized admission");
         let err = control
-            .admit(&user_b, 1024)
+            .admit(&user_a, 100 * 1024 * 1024)
             .err()
-            .expect("concurrent request must shed");
+            .expect("oversized request must be rejected");
         assert!(matches!(err, ApiError::ServiceOverloaded));
 
-        drop(oversized);
-        assert!(control.admit(&user_b, 1024).is_ok());
+        // A request within the budget still admits (the whole budget here).
+        assert!(control.admit(&user_a, 4 * 1024).is_ok());
     }
 }

--- a/june-api/crates/api/src/state.rs
+++ b/june-api/crates/api/src/state.rs
@@ -70,6 +70,7 @@ pub struct ApiLimits {
     pub max_json_bytes: usize,
     pub max_issue_report_bytes: usize,
     pub max_image_edit_bytes: usize,
+    pub max_agent_chat_bytes: usize,
     pub request_timeout_secs: u64,
 }
 

--- a/june-api/crates/api/src/state.rs
+++ b/june-api/crates/api/src/state.rs
@@ -1,13 +1,87 @@
-use june_domain::TokenVerifier;
+use crate::error::ApiError;
+use june_domain::{TokenVerifier, UserId};
 use june_services::{
     AgentChatService, DictateService, ImageService, IssueReportService, NoteGenerateService,
     NoteTranscribeService, P3aReportService, PricingTable, VideoService, WebAugmentService,
 };
-use std::{sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit, Semaphore};
 use tokio::time::Instant;
 
 const ISSUE_REPORT_MAX_CONCURRENCY: usize = 1;
+
+pub(crate) struct AgentAdmissionControl {
+    body_budget_kib: Arc<Semaphore>,
+    total_budget_kib: usize,
+    per_user: Arc<Mutex<HashMap<UserId, usize>>>,
+    max_per_user: usize,
+}
+
+pub(crate) struct AgentAdmission {
+    _body_permit: OwnedSemaphorePermit,
+    per_user: Arc<Mutex<HashMap<UserId, usize>>>,
+    user_id: UserId,
+}
+
+impl AgentAdmissionControl {
+    fn new(max_inflight_body_bytes: usize, max_per_user: usize) -> Self {
+        let total_budget_kib = (max_inflight_body_bytes / 1024).max(1);
+        Self {
+            body_budget_kib: Arc::new(Semaphore::new(total_budget_kib)),
+            total_budget_kib,
+            per_user: Arc::new(Mutex::new(HashMap::new())),
+            max_per_user,
+        }
+    }
+
+    fn admit(&self, user_id: &UserId, content_length: usize) -> Result<AgentAdmission, ApiError> {
+        let weight_kib = content_length
+            .div_ceil(1024)
+            .clamp(1, self.total_budget_kib);
+        let weight_kib = u32::try_from(weight_kib).map_err(|_| ApiError::service_overloaded())?;
+        let body_permit = self
+            .body_budget_kib
+            .clone()
+            .try_acquire_many_owned(weight_kib)
+            .map_err(|_| ApiError::service_overloaded())?;
+        let Ok(mut per_user) = self.per_user.lock() else {
+            return Err(ApiError::Internal);
+        };
+        let count = per_user.entry(user_id.clone()).or_insert(0);
+        if *count >= self.max_per_user {
+            return Err(ApiError::service_overloaded());
+        }
+        *count += 1;
+        drop(per_user);
+
+        Ok(AgentAdmission {
+            _body_permit: body_permit,
+            per_user: self.per_user.clone(),
+            user_id: user_id.clone(),
+        })
+    }
+}
+
+impl Drop for AgentAdmission {
+    fn drop(&mut self) {
+        let Ok(mut per_user) = self.per_user.lock() else {
+            return;
+        };
+        let remove = if let Some(count) = per_user.get_mut(&self.user_id) {
+            *count = count.saturating_sub(1);
+            *count == 0
+        } else {
+            false
+        };
+        if remove {
+            per_user.remove(&self.user_id);
+        }
+    }
+}
 
 /// Shared ownership keeps the one issue-report permit alive until both the
 /// delivery task and the HTTP response body have finished (or been dropped).
@@ -59,6 +133,7 @@ struct ApiStateInner {
     video: Arc<VideoService>,
     issue_reports: Arc<IssueReportService>,
     issue_report_permits: Arc<Semaphore>,
+    agent_admission: AgentAdmissionControl,
     p3a_reports: Arc<P3aReportService>,
     limits: ApiLimits,
     attestation: AttestationInfo,
@@ -71,6 +146,8 @@ pub struct ApiLimits {
     pub max_issue_report_bytes: usize,
     pub max_image_edit_bytes: usize,
     pub max_agent_chat_bytes: usize,
+    pub max_agent_inflight_body_bytes: usize,
+    pub max_agent_concurrent_requests_per_user: usize,
     pub request_timeout_secs: u64,
 }
 
@@ -121,6 +198,10 @@ impl ApiState {
                 video: params.video,
                 issue_reports: params.issue_reports,
                 issue_report_permits: Arc::new(Semaphore::new(ISSUE_REPORT_MAX_CONCURRENCY)),
+                agent_admission: AgentAdmissionControl::new(
+                    params.limits.max_agent_inflight_body_bytes,
+                    params.limits.max_agent_concurrent_requests_per_user,
+                ),
                 p3a_reports: params.p3a_reports,
                 limits: params.limits,
                 attestation: params.attestation,
@@ -188,11 +269,80 @@ impl ApiState {
         &self.inner.p3a_reports
     }
 
+    pub(crate) fn admit_agent_request(
+        &self,
+        user_id: &UserId,
+        content_length: usize,
+    ) -> Result<AgentAdmission, ApiError> {
+        self.inner.agent_admission.admit(user_id, content_length)
+    }
+
     pub(crate) fn limits(&self) -> ApiLimits {
         self.inner.limits
     }
 
     pub(crate) fn attestation(&self) -> &AttestationInfo {
         &self.inner.attestation
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AgentAdmissionControl;
+    use crate::ApiError;
+    use june_domain::UserId;
+
+    fn user(id: &str) -> UserId {
+        UserId(id.to_string())
+    }
+
+    #[test]
+    fn per_user_cap_load_sheds_beyond_limit() {
+        let control = AgentAdmissionControl::new(1024 * 1024, 2);
+        let user = user("usr_test");
+
+        let first = control.admit(&user, 1024).expect("first admission");
+        let _second = control.admit(&user, 1024).expect("second admission");
+        let err = control.admit(&user, 1024).err().expect("third must shed");
+        assert!(matches!(err, ApiError::ServiceOverloaded));
+
+        drop(first);
+        assert!(control.admit(&user, 1024).is_ok());
+    }
+
+    #[test]
+    fn global_budget_load_sheds_when_exhausted() {
+        let control = AgentAdmissionControl::new(10 * 1024, 100);
+        let user_a = user("usr_a");
+        let user_b = user("usr_b");
+
+        let first = control.admit(&user_a, 8 * 1024).expect("first admission");
+        let err = control
+            .admit(&user_b, 8 * 1024)
+            .err()
+            .expect("second must shed");
+        assert!(matches!(err, ApiError::ServiceOverloaded));
+
+        drop(first);
+        assert!(control.admit(&user_b, 8 * 1024).is_ok());
+    }
+
+    #[test]
+    fn oversized_request_is_clamped_to_the_whole_budget() {
+        let control = AgentAdmissionControl::new(4 * 1024, 100);
+        let user_a = user("usr_a");
+        let user_b = user("usr_b");
+
+        let oversized = control
+            .admit(&user_a, 100 * 1024 * 1024)
+            .expect("oversized admission");
+        let err = control
+            .admit(&user_b, 1024)
+            .err()
+            .expect("concurrent request must shed");
+        assert!(matches!(err, ApiError::ServiceOverloaded));
+
+        drop(oversized);
+        assert!(control.admit(&user_b, 1024).is_ok());
     }
 }

--- a/june-api/crates/api/src/validation.rs
+++ b/june-api/crates/api/src/validation.rs
@@ -20,31 +20,35 @@ pub(crate) const MAX_ISSUE_ATTACHMENT_BYTES: usize = june_config::ISSUE_REPORT_A
 // request from reaching it. They must sit with real HEADROOM above the largest
 // advertised model window so a legitimate in-window input is never rejected here
 // before the model sees it, and stay CONSISTENT with the Tauri provider proxy's
-// body cap (`JUNE_PROVIDER_PROXY_MAX_BODY_BYTES`) — otherwise the stricter gate
-// wins and an in-window upload fails anyway (JUN-169 review). The largest text
-// model is 256k tokens (Kimi K2.6, config.toml) ≈ 1.15M chars at a conservative
-// ~4.5 chars/token, so the cap is 1.5M — ~30% headroom above it, leaving room
-// for the system prompt and tool schemas on top of a near-window user input.
-// Per-string equals the aggregate because a single pasted document or file-read
-// may legitimately fill the whole allowance. JUN-169: the old 240k aggregate
-// (~60-68k tokens) rejected a single ~67k-token upload that GLM 5.2's 200k
-// window holds easily, and the proxy rebranded that rejection as a "maximum
-// context length" overflow, dead-ending the session on turn one.
+// body cap (`JUNE_PROVIDER_PROXY_MAX_CHAT_BODY_BYTES`) — otherwise the stricter
+// gate wins and an in-window upload fails anyway (JUN-169 review). Sized to a
+// 1M-token context window (bullet-proof headroom for the biggest windows the
+// app is built to serve — today's largest is Kimi K2.6 at 256k, but the picker
+// already renders ≥1M-token models): 1M tokens ≈ 4.5M chars at a conservative
+// ~4.5 chars/token, so the cap is 6M — ~33% headroom above it, leaving room for
+// the system prompt and tool schemas on top of a near-window user input. Below
+// the current 256k-token ceiling the model rejects an over-window request
+// itself; this cap only guards the byte/abuse envelope. Per-string equals the
+// aggregate because a single pasted document or file-read may legitimately fill
+// the whole allowance. JUN-169: the old 240k aggregate (~60-68k tokens)
+// rejected a single ~67k-token upload that GLM 5.2's 200k window holds easily,
+// and the proxy rebranded that rejection as a "maximum context length"
+// overflow, dead-ending the session on turn one.
 // Tune with cost/abuse in mind — a larger cap allows larger (costlier) requests.
-pub(crate) const MAX_AGENT_STRING_CHARS: usize = 1_500_000;
-pub(crate) const MAX_AGENT_TOTAL_STRING_CHARS: usize = 1_500_000;
+pub(crate) const MAX_AGENT_STRING_CHARS: usize = 6_000_000;
+pub(crate) const MAX_AGENT_TOTAL_STRING_CHARS: usize = 6_000_000;
 // Compile-time drift guard (JUN-336): the dedicated `/v1/chat/completions`
-// extractor cap must be pinned to the desktop proxy's 3 MiB chat cap
+// extractor cap must be pinned to the desktop proxy's 12 MiB chat cap
 // (`JUNE_PROVIDER_PROXY_MAX_CHAT_BODY_BYTES` in src-tauri) and sit at/above the
 // semantic aggregate string allowance treated as a BYTE floor. If it drops
 // below, the outer Axum extractor rejects an in-window agent chat request with a
 // raw 413 before `validate_agent_chat_body` runs — the exact regression this
 // fixes. The char cap is a byte floor only for ≤2-byte UTF-8: a semantically
-// valid 1.5M-char body of 3–4-byte code points can exceed 3 MiB and is rejected
+// valid 6M-char body of 3–4-byte code points can exceed 12 MiB and is rejected
 // by the extractor first — but that is by design and consistent, because the
-// desktop proxy already caps the same request at the same 3 MiB before it ever
+// desktop proxy already caps the same request at the same 12 MiB before it ever
 // reaches june-api, degrading it to the context-overflow notice.
-const _: () = assert!(june_config::DEFAULT_MAX_AGENT_CHAT_BYTES == 3 * 1024 * 1024);
+const _: () = assert!(june_config::DEFAULT_MAX_AGENT_CHAT_BYTES == 12 * 1024 * 1024);
 const _: () = assert!(june_config::DEFAULT_MAX_AGENT_CHAT_BYTES >= MAX_AGENT_TOTAL_STRING_CHARS);
 pub(crate) const MAX_AGENT_JSON_DEPTH: usize = 16;
 pub(crate) const MAX_AGENT_OUTPUT_TOKENS: u64 = 32_768;

--- a/june-api/crates/api/src/validation.rs
+++ b/june-api/crates/api/src/validation.rs
@@ -33,6 +33,19 @@ pub(crate) const MAX_ISSUE_ATTACHMENT_BYTES: usize = june_config::ISSUE_REPORT_A
 // Tune with cost/abuse in mind — a larger cap allows larger (costlier) requests.
 pub(crate) const MAX_AGENT_STRING_CHARS: usize = 1_500_000;
 pub(crate) const MAX_AGENT_TOTAL_STRING_CHARS: usize = 1_500_000;
+// Compile-time drift guard (JUN-336): the dedicated `/v1/chat/completions`
+// extractor cap must be pinned to the desktop proxy's 3 MiB chat cap
+// (`JUNE_PROVIDER_PROXY_MAX_CHAT_BODY_BYTES` in src-tauri) and sit at/above the
+// semantic aggregate string allowance treated as a BYTE floor. If it drops
+// below, the outer Axum extractor rejects an in-window agent chat request with a
+// raw 413 before `validate_agent_chat_body` runs — the exact regression this
+// fixes. The char cap is a byte floor only for ≤2-byte UTF-8: a semantically
+// valid 1.5M-char body of 3–4-byte code points can exceed 3 MiB and is rejected
+// by the extractor first — but that is by design and consistent, because the
+// desktop proxy already caps the same request at the same 3 MiB before it ever
+// reaches june-api, degrading it to the context-overflow notice.
+const _: () = assert!(june_config::DEFAULT_MAX_AGENT_CHAT_BYTES == 3 * 1024 * 1024);
+const _: () = assert!(june_config::DEFAULT_MAX_AGENT_CHAT_BYTES >= MAX_AGENT_TOTAL_STRING_CHARS);
 pub(crate) const MAX_AGENT_JSON_DEPTH: usize = 16;
 pub(crate) const MAX_AGENT_OUTPUT_TOKENS: u64 = 32_768;
 pub(crate) const MAX_PROVIDER_API_KEY_CHARS: usize = 4_096;

--- a/june-api/crates/api/tests/client_contract.rs
+++ b/june-api/crates/api/tests/client_contract.rs
@@ -399,6 +399,7 @@ fn error_code_registry_is_stable() -> Result<(), Box<dyn Error>> {
             ("internal", june_api::ERR_INTERNAL),
             ("upstream", june_api::ERR_UPSTREAM),
             ("metering", june_api::ERR_METERING),
+            ("serviceOverloaded", june_api::ERR_SERVICE_OVERLOADED),
             ("timeout", june_api::ERR_TIMEOUT),
         ]
         .map(|(name, code)| (name.to_string(), code)),

--- a/june-api/crates/api/tests/fixtures/client-contract/error-codes.json
+++ b/june-api/crates/api/tests/fixtures/client-contract/error-codes.json
@@ -9,5 +9,6 @@
   "internal": 5000,
   "upstream": 5001,
   "metering": 5031,
+  "serviceOverloaded": 5032,
   "timeout": 5041
 }

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -363,6 +363,41 @@ async fn integration_agent_chat_rejects_body_over_agent_cap() -> Result<(), Box<
 }
 
 #[tokio::test]
+async fn integration_agent_chat_authenticates_before_buffering_the_body()
+-> Result<(), Box<dyn Error>> {
+    // Unauthenticated + malformed body → 401: auth runs on headers first, so the
+    // body is never buffered or parsed. If auth ran after extraction this would
+    // be the 400 a JSON parse failure gives. This closes the unauthenticated
+    // resource-exhaustion path that the JUN-336 cap increase widened (an
+    // unauthenticated client could otherwise force up to 12 MiB of buffering).
+    let unauthenticated = Request::builder()
+        .method(Method::POST)
+        .uri("/v1/chat/completions")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from("{ not valid json"))?;
+    let response = match router(test_state()).oneshot(unauthenticated).await {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    // Authenticated + malformed body → 400: auth passes, so parsing proceeds and
+    // fails normally. The gate adds auth without changing handler behaviour.
+    let authenticated = Request::builder()
+        .method(Method::POST)
+        .uri("/v1/chat/completions")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, AUTHORIZATION)
+        .body(Body::from("{ not valid json"))?;
+    let response = match router(test_state()).oneshot(authenticated).await {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    Ok(())
+}
+
+#[tokio::test]
 async fn integration_agent_chat_routes_stale_model_through_auto() -> Result<(), Box<dyn Error>> {
     let response = send(json_request(
         "/v1/chat/completions",

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -321,6 +321,30 @@ async fn integration_agent_chat_stream_returns_upstream_sse_body() -> Result<(),
 }
 
 #[tokio::test]
+async fn integration_agent_admission_preserves_authenticated_happy_path()
+-> Result<(), Box<dyn Error>> {
+    let body = serde_json::json!({
+        "model": "text-model",
+        "stream": true,
+        "messages": [{ "role": "user", "content": "hello" }]
+    })
+    .to_string();
+    let response = send(
+        Request::builder()
+            .method(Method::POST)
+            .uri("/v1/chat/completions")
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::CONTENT_LENGTH, body.len())
+            .header(header::AUTHORIZATION, AUTHORIZATION)
+            .body(Body::from(body))?,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    Ok(())
+}
+
+#[tokio::test]
 async fn integration_agent_chat_accepts_tool_heavy_body_over_small_json_cap()
 -> Result<(), Box<dyn Error>> {
     // 4 MiB: STRICTLY above `test_state`'s shared `max_json_bytes` (1 MiB in

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -4,7 +4,7 @@ use axum::{
     http::{Method, Request, StatusCode, header},
 };
 use june_api::{AttestationInfo, router};
-use june_config::DEFAULT_MAX_IMAGE_EDIT_BYTES;
+use june_config::{DEFAULT_MAX_AGENT_CHAT_BYTES, DEFAULT_MAX_IMAGE_EDIT_BYTES};
 use june_domain::{
     AgentChatCompleter, AgentChatCompletion, AgentChatRequest, AgentChatStream, DomainError,
     GeneratedNote, GenerationRequest, Generator, IssueReport, IssueReportDelivery, IssueReportSink,
@@ -317,6 +317,47 @@ async fn integration_agent_chat_stream_returns_upstream_sse_body() -> Result<(),
     );
     let body = response_text(response).await?;
     assert_eq!(body, "data: {\"choices\":[]}\n\n");
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_agent_chat_accepts_tool_heavy_body_over_small_json_cap()
+-> Result<(), Box<dyn Error>> {
+    // 1.25 MiB: STRICTLY above `test_state`'s shared `max_json_bytes` (1 MiB in
+    // tests/support), so it would 413 under the old shared-cap route — this is
+    // what makes the test distinguish the fix from the bug. It stays under both
+    // the 3 MiB agent chat body cap (so the extractor lets it through) and the
+    // 1.5M-char semantic cap (so `validate_agent_chat_body` accepts it), and
+    // must reach the handler and stream from the mocked upstream (200, not 413).
+    let body = tool_heavy_chat_body_with_len(1024 * 1024 + 256 * 1024)?;
+    let router = router(test_state());
+    let response = match router
+        .oneshot(raw_json_request_with_auth("/v1/chat/completions", body)?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+    assert_ne!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(response.status(), StatusCode::OK);
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_agent_chat_rejects_body_over_agent_cap() -> Result<(), Box<dyn Error>> {
+    // One byte over the 3 MiB agent chat body cap: still fails deterministically with a
+    // 413 at the route boundary (JUN-336 acceptance: over-cap requests fail
+    // without wedging).
+    let body = tool_heavy_chat_body_with_len(DEFAULT_MAX_AGENT_CHAT_BYTES + 1)?;
+    let router = router(test_state());
+    let response = match router
+        .oneshot(raw_json_request_with_auth("/v1/chat/completions", body)?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     Ok(())
 }
 
@@ -1875,6 +1916,87 @@ fn raw_json_request_with_venice_api_key(
         .header(header::AUTHORIZATION, AUTHORIZATION)
         .header("x-venice-api-key", venice_api_key)
         .body(Body::from(body))
+}
+
+/// Raw string body plus the standard bearer, with NO `x-venice-api-key` header.
+/// `text-model` is an OpenAI-provider model in test pricing, so a Venice BYOK
+/// header would trip `venice_api_key_model_unavailable` (422) before the body
+/// ever streams; the plain bearer routes to the mocked upstream so the only
+/// thing that can produce a 413 is the route body-limit layer (JUN-336).
+fn raw_json_request_with_auth(uri: &str, body: String) -> Result<Request<Body>, axum::http::Error> {
+    Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, AUTHORIZATION)
+        .body(Body::from(body))
+}
+
+/// A tool-heavy `/v1/chat/completions` body of exactly `total_len` bytes,
+/// shaped like the JUN-336 production failure: several tool schemas plus a
+/// multi-turn assistant/tool-call/tool-result history, with the bulk of the
+/// size in the latest tool result (production: ~340k of ~382k chars were tool
+/// results from the current turn). `model`/`stream` route it to the mocked
+/// upstream. When the body clears the route extractor, `validate_agent_chat_body`
+/// still runs, so callers that want the accept path must keep `total_len` below
+/// the 1.5M-char semantic cap.
+fn tool_heavy_chat_body_with_len(total_len: usize) -> Result<String, Box<dyn Error>> {
+    let schema = |name: &str, description: &str| {
+        serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string", "description": "Absolute path" },
+                        "query": { "type": "string", "description": "Search query" },
+                        "limit": { "type": "integer", "description": "Max results" }
+                    },
+                    "required": ["path"]
+                }
+            }
+        })
+    };
+    let tool_call = |id: &str, name: &str, arguments: &str| {
+        serde_json::json!({
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": id,
+                "type": "function",
+                "function": { "name": name, "arguments": arguments }
+            }]
+        })
+    };
+    let mut body = serde_json::json!({
+        "model": "text-model",
+        "stream": true,
+        "tools": [
+            schema("read_file", "Read a file from disk and return its contents."),
+            schema("search_notes", "Full-text search across the user's notes."),
+            schema("list_dir", "List the entries of a directory."),
+            schema("web_fetch", "Fetch a URL and return its readable text.")
+        ],
+        "messages": [
+            { "role": "user", "content": "summarize everything the tools returned" },
+            tool_call("call_1", "read_file", "{\"path\":\"/notes/launch.md\"}"),
+            { "role": "tool", "tool_call_id": "call_1", "content": "earlier tool result: launch is Friday" },
+            tool_call("call_2", "search_notes", "{\"query\":\"rate limits\"}"),
+            // The current turn's tool result — padded below to dominate the body.
+            { "role": "tool", "tool_call_id": "call_2", "content": "" }
+        ]
+    });
+    let last = body["messages"]
+        .as_array()
+        .map_or(0, |messages| messages.len().saturating_sub(1));
+    let overhead = serde_json::to_string(&body)?.len();
+    let pad = total_len.saturating_sub(overhead);
+    body["messages"][last]["content"] = serde_json::Value::String("a".repeat(pad));
+    let out = serde_json::to_string(&body)?;
+    assert_eq!(out.len(), total_len, "body length must be exact");
+    Ok(out)
 }
 
 fn image_edit_body_with_len(total_len: usize) -> Result<String, Box<dyn Error>> {

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -323,13 +323,14 @@ async fn integration_agent_chat_stream_returns_upstream_sse_body() -> Result<(),
 #[tokio::test]
 async fn integration_agent_chat_accepts_tool_heavy_body_over_small_json_cap()
 -> Result<(), Box<dyn Error>> {
-    // 1.25 MiB: STRICTLY above `test_state`'s shared `max_json_bytes` (1 MiB in
-    // tests/support), so it would 413 under the old shared-cap route — this is
-    // what makes the test distinguish the fix from the bug. It stays under both
-    // the 3 MiB agent chat body cap (so the extractor lets it through) and the
-    // 1.5M-char semantic cap (so `validate_agent_chat_body` accepts it), and
-    // must reach the handler and stream from the mocked upstream (200, not 413).
-    let body = tool_heavy_chat_body_with_len(1024 * 1024 + 256 * 1024)?;
+    // 4 MiB: STRICTLY above `test_state`'s shared `max_json_bytes` (1 MiB in
+    // tests/support) so it would 413 under the old shared-cap route, AND above
+    // the previous 3 MiB agent cap so it exercises the raised 1M-token capacity.
+    // It stays under both the 12 MiB agent chat body cap (so the extractor lets
+    // it through) and the 6M-char semantic cap (~4.19M chars here, so
+    // `validate_agent_chat_body` accepts it), and must reach the handler and
+    // stream from the mocked upstream (200, not 413).
+    let body = tool_heavy_chat_body_with_len(4 * 1024 * 1024)?;
     let router = router(test_state());
     let response = match router
         .oneshot(raw_json_request_with_auth("/v1/chat/completions", body)?)

--- a/june-api/crates/api/tests/support/mod.rs
+++ b/june-api/crates/api/tests/support/mod.rs
@@ -12,8 +12,8 @@ use axum::{
 };
 use june_api::{ApiLimits, ApiState, ApiStateParams, AttestationInfo, router};
 use june_config::{
-    DEFAULT_MAX_IMAGE_EDIT_BYTES, DEFAULT_MAX_ISSUE_REPORT_BYTES, ModelPriceConfig, ModelProvider,
-    ModelType, PriceUnit,
+    DEFAULT_MAX_AGENT_CHAT_BYTES, DEFAULT_MAX_IMAGE_EDIT_BYTES, DEFAULT_MAX_ISSUE_REPORT_BYTES,
+    ModelPriceConfig, ModelProvider, ModelType, PriceUnit,
 };
 use june_domain::{
     AgentChatCompleter, AgentChatCompletion, AgentChatRequest, AgentChatStream,
@@ -343,6 +343,7 @@ pub(crate) fn test_state_from_deps(deps: TestStateDeps) -> ApiState {
             max_json_bytes: 1024 * 1024,
             max_issue_report_bytes: DEFAULT_MAX_ISSUE_REPORT_BYTES,
             max_image_edit_bytes: DEFAULT_MAX_IMAGE_EDIT_BYTES,
+            max_agent_chat_bytes: DEFAULT_MAX_AGENT_CHAT_BYTES,
             request_timeout_secs: deps.request_timeout_secs,
         },
         attestation: deps.attestation,

--- a/june-api/crates/api/tests/support/mod.rs
+++ b/june-api/crates/api/tests/support/mod.rs
@@ -344,6 +344,8 @@ pub(crate) fn test_state_from_deps(deps: TestStateDeps) -> ApiState {
             max_issue_report_bytes: DEFAULT_MAX_ISSUE_REPORT_BYTES,
             max_image_edit_bytes: DEFAULT_MAX_IMAGE_EDIT_BYTES,
             max_agent_chat_bytes: DEFAULT_MAX_AGENT_CHAT_BYTES,
+            max_agent_inflight_body_bytes: 1024 * 1024 * 1024,
+            max_agent_concurrent_requests_per_user: 1024,
             request_timeout_secs: deps.request_timeout_secs,
         },
         attestation: deps.attestation,

--- a/june-api/crates/app/src/main.rs
+++ b/june-api/crates/app/src/main.rs
@@ -335,6 +335,10 @@ fn build_router(
             max_issue_report_bytes: config.server.max_issue_report_bytes,
             max_image_edit_bytes: config.server.max_image_edit_bytes,
             max_agent_chat_bytes: config.server.max_agent_chat_bytes,
+            max_agent_inflight_body_bytes: config.server.max_agent_inflight_body_bytes,
+            max_agent_concurrent_requests_per_user: config
+                .server
+                .max_agent_concurrent_requests_per_user,
             request_timeout_secs: config.server.request_timeout_secs,
         },
         attestation: AttestationInfo {

--- a/june-api/crates/app/src/main.rs
+++ b/june-api/crates/app/src/main.rs
@@ -334,6 +334,7 @@ fn build_router(
             max_json_bytes: config.server.max_json_bytes,
             max_issue_report_bytes: config.server.max_issue_report_bytes,
             max_image_edit_bytes: config.server.max_image_edit_bytes,
+            max_agent_chat_bytes: config.server.max_agent_chat_bytes,
             request_timeout_secs: config.server.request_timeout_secs,
         },
         attestation: AttestationInfo {

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -1278,6 +1278,18 @@ fn validate_request_limits(config: &AppConfig) -> Result<(), ConfigError> {
         "server.max_agent_concurrent_requests_per_user",
         config.server.max_agent_concurrent_requests_per_user,
     )?;
+    // The global in-flight body budget must be at least the largest single
+    // large-body route cap (image edit, ~66 MiB), or the admission control would
+    // load-shed EVERY request on that route — and, worse, an operator could tune
+    // the budget below a route cap and defeat the memory-safety guarantee it
+    // exists to provide (JUN-336 review). max_image_edit_bytes is the largest of
+    // the agent route caps (image/video 66 MiB > audio 25 MiB > chat 12 MiB).
+    if config.server.max_agent_inflight_body_bytes < config.server.max_image_edit_bytes {
+        return Err(ConfigError::InvalidRequired {
+            field: "server.max_agent_inflight_body_bytes",
+            reason: "must be >= the largest agent route body cap (server.max_image_edit_bytes)",
+        });
+    }
     // The extractor cap must never sit BELOW the desktop provider proxy's fixed
     // 12 MiB chat body cap (mirrored here as `DEFAULT_MAX_AGENT_CHAT_BYTES`), or a
     // configured override silently reintroduces the JUN-336 regression: the proxy
@@ -1920,6 +1932,24 @@ mod tests {
             server.max_agent_concurrent_requests_per_user,
             DEFAULT_MAX_AGENT_CONCURRENT_REQUESTS_PER_USER
         );
+        // The default budget must clear the largest route cap so admission never
+        // load-sheds every request on a route.
+        assert!(server.max_agent_inflight_body_bytes >= server.max_image_edit_bytes);
+    }
+
+    #[test]
+    fn agent_inflight_budget_below_largest_route_cap_is_rejected() {
+        // An operator override that drops the global budget below a single route
+        // cap must fail loudly at load, not silently defeat the memory guarantee.
+        let mut config = AppConfig::default();
+        config.server.max_agent_inflight_body_bytes = config.server.max_image_edit_bytes - 1;
+        assert!(matches!(
+            validate_request_limits(&config),
+            Err(ConfigError::InvalidRequired {
+                field: "server.max_agent_inflight_body_bytes",
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -86,6 +86,13 @@ pub const DEFAULT_MAX_IMAGE_EDIT_BYTES: usize =
 /// in `validate_agent_chat_body`. Keep this in sync with the proxy constant
 /// across the src-tauri / june-api workspace boundary.
 pub const DEFAULT_MAX_AGENT_CHAT_BYTES: usize = 12 * 1024 * 1024;
+/// Global cap on the total in-flight request-body bytes buffered across the
+/// large-body agent routes, so concurrent authenticated requests cannot exhaust
+/// the shared TEE (JUN-336). Conservative default; tune against real traffic.
+pub const DEFAULT_MAX_AGENT_INFLIGHT_BODY_BYTES: usize = 1024 * 1024 * 1024;
+/// Max concurrent large-body agent requests a single user may have in flight
+/// before June API load-sheds with 503 (JUN-336).
+pub const DEFAULT_MAX_AGENT_CONCURRENT_REQUESTS_PER_USER: usize = 8;
 
 // --- Video generation (ADR 0015) ---------------------------------------------
 //
@@ -414,6 +421,10 @@ pub struct ServerConfig {
     /// 12 MiB chat body cap so an in-window agent chat request is not rejected by
     /// a stricter outer gate before semantic validation (JUN-336).
     pub max_agent_chat_bytes: usize,
+    /// Global in-flight request-body budget for the large-body agent routes.
+    pub max_agent_inflight_body_bytes: usize,
+    /// Per-user concurrent request cap for the large-body agent routes.
+    pub max_agent_concurrent_requests_per_user: usize,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -956,6 +967,9 @@ impl Default for AppConfig {
                 max_issue_report_bytes: DEFAULT_MAX_ISSUE_REPORT_BYTES,
                 max_image_edit_bytes: DEFAULT_MAX_IMAGE_EDIT_BYTES,
                 max_agent_chat_bytes: DEFAULT_MAX_AGENT_CHAT_BYTES,
+                max_agent_inflight_body_bytes: DEFAULT_MAX_AGENT_INFLIGHT_BODY_BYTES,
+                max_agent_concurrent_requests_per_user:
+                    DEFAULT_MAX_AGENT_CONCURRENT_REQUESTS_PER_USER,
             },
             local_dev: LocalDevConfig::default(),
             os_accounts: OsAccountsConfig {
@@ -1256,6 +1270,14 @@ fn validate_request_limits(config: &AppConfig) -> Result<(), ConfigError> {
         "server.max_agent_chat_bytes",
         config.server.max_agent_chat_bytes,
     )?;
+    validate_positive_usize_config(
+        "server.max_agent_inflight_body_bytes",
+        config.server.max_agent_inflight_body_bytes,
+    )?;
+    validate_positive_usize_config(
+        "server.max_agent_concurrent_requests_per_user",
+        config.server.max_agent_concurrent_requests_per_user,
+    )?;
     // The extractor cap must never sit BELOW the desktop provider proxy's fixed
     // 12 MiB chat body cap (mirrored here as `DEFAULT_MAX_AGENT_CHAT_BYTES`), or a
     // configured override silently reintroduces the JUN-336 regression: the proxy
@@ -1520,9 +1542,10 @@ fn validate_positive_rate(
 mod tests {
     use super::{
         AppConfig, ConfigError, DEFAULT_IMAGE_CLIENT_TIMEOUT_SECS, DEFAULT_IMAGE_HOLD_TTL_SECS,
-        DEFAULT_MAX_AGENT_CHAT_BYTES, DEFAULT_MAX_IMAGE_EDIT_BYTES, DEFAULT_MAX_ISSUE_REPORT_BYTES,
-        DEFAULT_REQUEST_TIMEOUT_SECS, DEFAULT_VIDEO_HOLD_TTL_SECS, DEFAULT_VIDEO_JOB_MAX_SECS,
-        DEFAULT_VIDEO_MAX_RESPONSE_BYTES, IMAGE_EDIT_SOURCE_MAX_BYTES,
+        DEFAULT_MAX_AGENT_CHAT_BYTES, DEFAULT_MAX_AGENT_CONCURRENT_REQUESTS_PER_USER,
+        DEFAULT_MAX_AGENT_INFLIGHT_BODY_BYTES, DEFAULT_MAX_IMAGE_EDIT_BYTES,
+        DEFAULT_MAX_ISSUE_REPORT_BYTES, DEFAULT_REQUEST_TIMEOUT_SECS, DEFAULT_VIDEO_HOLD_TTL_SECS,
+        DEFAULT_VIDEO_JOB_MAX_SECS, DEFAULT_VIDEO_MAX_RESPONSE_BYTES, IMAGE_EDIT_SOURCE_MAX_BYTES,
         IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS, ISSUE_REPORT_ATTACHMENT_MAX_BYTES, ModelPriceConfig,
         ModelProvider, ModelType, OPENAI_API_KEY_PLACEHOLDERS,
         OS_ACCOUNTS_APP_API_KEY_PLACEHOLDERS, OS_ACCOUNTS_AUTHORIZE_TIMEOUT_BUDGET_SECS,
@@ -1882,6 +1905,20 @@ mod tests {
         assert!(
             AppConfig::default().server.max_agent_chat_bytes
                 >= AppConfig::default().server.max_json_bytes
+        );
+    }
+
+    #[test]
+    fn default_agent_admission_limits_match_their_constants() {
+        let server = AppConfig::default().server;
+
+        assert_eq!(
+            server.max_agent_inflight_body_bytes,
+            DEFAULT_MAX_AGENT_INFLIGHT_BODY_BYTES
+        );
+        assert_eq!(
+            server.max_agent_concurrent_requests_per_user,
+            DEFAULT_MAX_AGENT_CONCURRENT_REQUESTS_PER_USER
         );
     }
 

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -74,6 +74,16 @@ const _: () = assert!(DEFAULT_IMAGE_HOLD_TTL_SECS <= OS_ACCOUNTS_MAX_HOLD_TTL_SE
 const IMAGE_EDIT_JSON_OVERHEAD_BYTES: usize = 16 * 1024;
 pub const DEFAULT_MAX_IMAGE_EDIT_BYTES: usize =
     base64_encoded_len(IMAGE_EDIT_SOURCE_MAX_BYTES) + IMAGE_EDIT_JSON_OVERHEAD_BYTES;
+/// Dedicated request-body cap for `/v1/chat/completions`. Sized to the
+/// desktop provider proxy's chat body cap
+/// (`JUNE_PROVIDER_PROXY_MAX_CHAT_BODY_BYTES`, 3 MiB, in
+/// `src-tauri/src/hermes_bridge.rs`) so an in-window agent chat request the
+/// proxy forwards is never rejected here by a stricter outer gate before
+/// `validate_agent_chat_body` can size-check it (JUN-336). This is only an
+/// abuse ceiling above every valid agent chat request; semantic size rejection
+/// stays in `validate_agent_chat_body`. Keep this in sync with the proxy
+/// constant across the src-tauri / june-api workspace boundary.
+pub const DEFAULT_MAX_AGENT_CHAT_BYTES: usize = 3 * 1024 * 1024;
 
 // --- Video generation (ADR 0015) ---------------------------------------------
 //
@@ -398,6 +408,10 @@ pub struct ServerConfig {
     /// JSON body cap for `/v1/image/edit`. It is sized for a 50 MiB source
     /// image after base64 expansion plus fixed request overhead.
     pub max_image_edit_bytes: usize,
+    /// JSON body cap for `/v1/chat/completions`, sized to the desktop proxy's
+    /// 3 MiB chat body cap so an in-window agent chat request is not rejected by
+    /// a stricter outer gate before semantic validation (JUN-336).
+    pub max_agent_chat_bytes: usize,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -939,6 +953,7 @@ impl Default for AppConfig {
                 max_json_bytes: 524_288,
                 max_issue_report_bytes: DEFAULT_MAX_ISSUE_REPORT_BYTES,
                 max_image_edit_bytes: DEFAULT_MAX_IMAGE_EDIT_BYTES,
+                max_agent_chat_bytes: DEFAULT_MAX_AGENT_CHAT_BYTES,
             },
             local_dev: LocalDevConfig::default(),
             os_accounts: OsAccountsConfig {
@@ -1236,6 +1251,23 @@ fn validate_request_limits(config: &AppConfig) -> Result<(), ConfigError> {
         config.server.max_image_edit_bytes,
     )?;
     validate_positive_usize_config(
+        "server.max_agent_chat_bytes",
+        config.server.max_agent_chat_bytes,
+    )?;
+    // The extractor cap must never sit BELOW the desktop provider proxy's fixed
+    // 3 MiB chat body cap (mirrored here as `DEFAULT_MAX_AGENT_CHAT_BYTES`), or a
+    // configured override silently reintroduces the JUN-336 regression: the proxy
+    // still forwards a 1-3 MiB agent chat request, but this route 413s it before
+    // `validate_agent_chat_body` runs. `max_json_bytes` is NOT the right floor —
+    // an override of e.g. 1 MiB clears it yet is still stricter than the proxy.
+    // The compile-time asserts only pin the default; this guards overrides.
+    if config.server.max_agent_chat_bytes < DEFAULT_MAX_AGENT_CHAT_BYTES {
+        return Err(ConfigError::InvalidRequired {
+            field: "server.max_agent_chat_bytes",
+            reason: "must be >= the 3 MiB desktop proxy chat body cap",
+        });
+    }
+    validate_positive_usize_config(
         "server.max_issue_report_bytes",
         config.server.max_issue_report_bytes,
     )?;
@@ -1486,14 +1518,15 @@ fn validate_positive_rate(
 mod tests {
     use super::{
         AppConfig, ConfigError, DEFAULT_IMAGE_CLIENT_TIMEOUT_SECS, DEFAULT_IMAGE_HOLD_TTL_SECS,
-        DEFAULT_MAX_IMAGE_EDIT_BYTES, DEFAULT_MAX_ISSUE_REPORT_BYTES, DEFAULT_REQUEST_TIMEOUT_SECS,
-        DEFAULT_VIDEO_HOLD_TTL_SECS, DEFAULT_VIDEO_JOB_MAX_SECS, DEFAULT_VIDEO_MAX_RESPONSE_BYTES,
-        IMAGE_EDIT_SOURCE_MAX_BYTES, IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS,
-        ISSUE_REPORT_ATTACHMENT_MAX_BYTES, ModelPriceConfig, ModelProvider, ModelType,
-        OPENAI_API_KEY_PLACEHOLDERS, OS_ACCOUNTS_APP_API_KEY_PLACEHOLDERS,
-        OS_ACCOUNTS_AUTHORIZE_TIMEOUT_BUDGET_SECS, OS_ACCOUNTS_MAX_HOLD_TTL_SECS, PriceUnit,
-        VENICE_API_KEY_PLACEHOLDERS, VIDEO_CLIENT_POLL_WINDOW_SECS,
-        VIDEO_SETTLEMENT_TIMEOUT_MARGIN_SECS, image_client_timeout_secs, validate,
+        DEFAULT_MAX_AGENT_CHAT_BYTES, DEFAULT_MAX_IMAGE_EDIT_BYTES, DEFAULT_MAX_ISSUE_REPORT_BYTES,
+        DEFAULT_REQUEST_TIMEOUT_SECS, DEFAULT_VIDEO_HOLD_TTL_SECS, DEFAULT_VIDEO_JOB_MAX_SECS,
+        DEFAULT_VIDEO_MAX_RESPONSE_BYTES, IMAGE_EDIT_SOURCE_MAX_BYTES,
+        IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS, ISSUE_REPORT_ATTACHMENT_MAX_BYTES, ModelPriceConfig,
+        ModelProvider, ModelType, OPENAI_API_KEY_PLACEHOLDERS,
+        OS_ACCOUNTS_APP_API_KEY_PLACEHOLDERS, OS_ACCOUNTS_AUTHORIZE_TIMEOUT_BUDGET_SECS,
+        OS_ACCOUNTS_MAX_HOLD_TTL_SECS, PriceUnit, VENICE_API_KEY_PLACEHOLDERS,
+        VIDEO_CLIENT_POLL_WINDOW_SECS, VIDEO_SETTLEMENT_TIMEOUT_MARGIN_SECS,
+        image_client_timeout_secs, validate, validate_request_limits,
     };
     use pretty_assertions::assert_eq;
     use std::collections::BTreeMap;
@@ -1833,6 +1866,39 @@ mod tests {
             AppConfig::default().server.max_image_edit_bytes,
             DEFAULT_MAX_IMAGE_EDIT_BYTES
         );
+    }
+
+    #[test]
+    fn default_agent_chat_body_limit_is_the_dedicated_3_mib_cap() {
+        assert_eq!(DEFAULT_MAX_AGENT_CHAT_BYTES, 3 * 1024 * 1024);
+        assert_eq!(
+            AppConfig::default().server.max_agent_chat_bytes,
+            DEFAULT_MAX_AGENT_CHAT_BYTES
+        );
+        // The dedicated agent chat cap must never be stricter than the shared
+        // small-JSON cap, or JUN-336 reopens.
+        assert!(
+            AppConfig::default().server.max_agent_chat_bytes
+                >= AppConfig::default().server.max_json_bytes
+        );
+    }
+
+    #[test]
+    fn agent_chat_body_limit_below_proxy_cap_is_rejected() {
+        // An override BELOW the 3 MiB desktop proxy cap must fail loudly at load,
+        // even when it clears the shared small-JSON cap — otherwise the proxy
+        // forwards a 1-3 MiB agent chat request that this route then 413s,
+        // reopening JUN-336 (Codex review on PR #776).
+        let mut config = AppConfig::default();
+        config.server.max_agent_chat_bytes = DEFAULT_MAX_AGENT_CHAT_BYTES - 1;
+        assert!(config.server.max_agent_chat_bytes > config.server.max_json_bytes);
+        assert!(matches!(
+            validate_request_limits(&config),
+            Err(ConfigError::InvalidRequired {
+                field: "server.max_agent_chat_bytes",
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -76,14 +76,16 @@ pub const DEFAULT_MAX_IMAGE_EDIT_BYTES: usize =
     base64_encoded_len(IMAGE_EDIT_SOURCE_MAX_BYTES) + IMAGE_EDIT_JSON_OVERHEAD_BYTES;
 /// Dedicated request-body cap for `/v1/chat/completions`. Sized to the
 /// desktop provider proxy's chat body cap
-/// (`JUNE_PROVIDER_PROXY_MAX_CHAT_BODY_BYTES`, 3 MiB, in
+/// (`JUNE_PROVIDER_PROXY_MAX_CHAT_BODY_BYTES`, 12 MiB, in
 /// `src-tauri/src/hermes_bridge.rs`) so an in-window agent chat request the
 /// proxy forwards is never rejected here by a stricter outer gate before
-/// `validate_agent_chat_body` can size-check it (JUN-336). This is only an
-/// abuse ceiling above every valid agent chat request; semantic size rejection
-/// stays in `validate_agent_chat_body`. Keep this in sync with the proxy
-/// constant across the src-tauri / june-api workspace boundary.
-pub const DEFAULT_MAX_AGENT_CHAT_BYTES: usize = 3 * 1024 * 1024;
+/// `validate_agent_chat_body` can size-check it (JUN-336). 12 MiB is the
+/// byte-image of the 6M-char semantic cap (`MAX_AGENT_TOTAL_STRING_CHARS`) at
+/// ~2 bytes/char, sized for a 1M-token context window. This is only an abuse
+/// ceiling above every valid agent chat request; semantic size rejection stays
+/// in `validate_agent_chat_body`. Keep this in sync with the proxy constant
+/// across the src-tauri / june-api workspace boundary.
+pub const DEFAULT_MAX_AGENT_CHAT_BYTES: usize = 12 * 1024 * 1024;
 
 // --- Video generation (ADR 0015) ---------------------------------------------
 //
@@ -409,7 +411,7 @@ pub struct ServerConfig {
     /// image after base64 expansion plus fixed request overhead.
     pub max_image_edit_bytes: usize,
     /// JSON body cap for `/v1/chat/completions`, sized to the desktop proxy's
-    /// 3 MiB chat body cap so an in-window agent chat request is not rejected by
+    /// 12 MiB chat body cap so an in-window agent chat request is not rejected by
     /// a stricter outer gate before semantic validation (JUN-336).
     pub max_agent_chat_bytes: usize,
 }
@@ -1255,16 +1257,16 @@ fn validate_request_limits(config: &AppConfig) -> Result<(), ConfigError> {
         config.server.max_agent_chat_bytes,
     )?;
     // The extractor cap must never sit BELOW the desktop provider proxy's fixed
-    // 3 MiB chat body cap (mirrored here as `DEFAULT_MAX_AGENT_CHAT_BYTES`), or a
+    // 12 MiB chat body cap (mirrored here as `DEFAULT_MAX_AGENT_CHAT_BYTES`), or a
     // configured override silently reintroduces the JUN-336 regression: the proxy
-    // still forwards a 1-3 MiB agent chat request, but this route 413s it before
+    // still forwards a 1-12 MiB agent chat request, but this route 413s it before
     // `validate_agent_chat_body` runs. `max_json_bytes` is NOT the right floor —
     // an override of e.g. 1 MiB clears it yet is still stricter than the proxy.
     // The compile-time asserts only pin the default; this guards overrides.
     if config.server.max_agent_chat_bytes < DEFAULT_MAX_AGENT_CHAT_BYTES {
         return Err(ConfigError::InvalidRequired {
             field: "server.max_agent_chat_bytes",
-            reason: "must be >= the 3 MiB desktop proxy chat body cap",
+            reason: "must be >= the 12 MiB desktop proxy chat body cap",
         });
     }
     validate_positive_usize_config(
@@ -1869,8 +1871,8 @@ mod tests {
     }
 
     #[test]
-    fn default_agent_chat_body_limit_is_the_dedicated_3_mib_cap() {
-        assert_eq!(DEFAULT_MAX_AGENT_CHAT_BYTES, 3 * 1024 * 1024);
+    fn default_agent_chat_body_limit_is_the_dedicated_12_mib_cap() {
+        assert_eq!(DEFAULT_MAX_AGENT_CHAT_BYTES, 12 * 1024 * 1024);
         assert_eq!(
             AppConfig::default().server.max_agent_chat_bytes,
             DEFAULT_MAX_AGENT_CHAT_BYTES
@@ -1885,7 +1887,7 @@ mod tests {
 
     #[test]
     fn agent_chat_body_limit_below_proxy_cap_is_rejected() {
-        // An override BELOW the 3 MiB desktop proxy cap must fail loudly at load,
+        // An override BELOW the 12 MiB desktop proxy cap must fail loudly at load,
         // even when it clears the shared small-JSON cap — otherwise the proxy
         // forwards a 1-3 MiB agent chat request that this route then 413s,
         // reopening JUN-336 (Codex review on PR #776).

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -55,24 +55,24 @@ const HERMES_TEXT_PREVIEW_MAX_BYTES: u64 = 2 * 1024 * 1024;
 const HERMES_SKILL_MAX_BYTES: usize = 512 * 1024;
 const JUNE_PROVIDER_PROXY_MAX_HEADER_BYTES: usize = 32 * 1024;
 // Must sit ABOVE june-api's aggregate request-string cap
-// (`MAX_AGENT_TOTAL_STRING_CHARS`, 1.5M chars) counted in BYTES, or this proxy
+// (`MAX_AGENT_TOTAL_STRING_CHARS`, 6M chars) counted in BYTES, or this proxy
 // rejects an in-window upload before june-api's larger cap can allow it (JUN-169
-// review). Chars vs bytes: 1.5M chars is up to ~3M bytes for 2-byte UTF-8, so
-// 3 MiB keeps the proxy from becoming the stricter gate. This is a 127.0.0.1
-// loopback proxy for a single-user desktop, so the memory/DoS surface of the
-// larger buffer is minimal. A body over this cap is genuinely beyond any model
-// window and degrades to the context-overflow notice (recognizable wording in
-// `read_http_request`).
+// review). Chars vs bytes: 6M chars is up to ~12M bytes for 2-byte UTF-8, so
+// 12 MiB keeps the proxy from becoming the stricter gate. The cap is sized for a
+// 1M-token context window. This is a 127.0.0.1 loopback proxy for a single-user
+// desktop, so the memory/DoS surface of the larger buffer is minimal. A body
+// over this cap is genuinely beyond any model window and degrades to the
+// context-overflow notice (recognizable wording in `read_http_request`).
 // Cross-workspace invariant (JUN-336): this MUST equal june-api's dedicated
 // `/v1/chat/completions` extractor cap (`DEFAULT_MAX_AGENT_CHAT_BYTES` in
 // june-api/crates/config/src/lib.rs). june-api is a separate cargo workspace
-// and cannot be imported here, so the two 3 MiB values are kept in sync by a
+// and cannot be imported here, so the two 12 MiB values are kept in sync by a
 // pinned-value assert on each side; change BOTH or an in-window agent chat
 // request is rejected by the stricter gate again.
-const JUNE_PROVIDER_PROXY_MAX_CHAT_BODY_BYTES: usize = 3 * 1024 * 1024;
+const JUNE_PROVIDER_PROXY_MAX_CHAT_BODY_BYTES: usize = 12 * 1024 * 1024;
 // Compile-time half of that cross-workspace invariant: the june-api side mirrors
 // it against `DEFAULT_MAX_AGENT_CHAT_BYTES`.
-const _: () = assert!(JUNE_PROVIDER_PROXY_MAX_CHAT_BODY_BYTES == 3 * 1024 * 1024);
+const _: () = assert!(JUNE_PROVIDER_PROXY_MAX_CHAT_BODY_BYTES == 12 * 1024 * 1024);
 // Image edit forwarding expands a source ref into base64 JSON before June API
 // sees it. Keep the loopback image cap derived from the same 50 MiB source
 // maximum enforced by imports and the proxy validator.

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -63,7 +63,16 @@ const JUNE_PROVIDER_PROXY_MAX_HEADER_BYTES: usize = 32 * 1024;
 // larger buffer is minimal. A body over this cap is genuinely beyond any model
 // window and degrades to the context-overflow notice (recognizable wording in
 // `read_http_request`).
+// Cross-workspace invariant (JUN-336): this MUST equal june-api's dedicated
+// `/v1/chat/completions` extractor cap (`DEFAULT_MAX_AGENT_CHAT_BYTES` in
+// june-api/crates/config/src/lib.rs). june-api is a separate cargo workspace
+// and cannot be imported here, so the two 3 MiB values are kept in sync by a
+// pinned-value assert on each side; change BOTH or an in-window agent chat
+// request is rejected by the stricter gate again.
 const JUNE_PROVIDER_PROXY_MAX_CHAT_BODY_BYTES: usize = 3 * 1024 * 1024;
+// Compile-time half of that cross-workspace invariant: the june-api side mirrors
+// it against `DEFAULT_MAX_AGENT_CHAT_BYTES`.
+const _: () = assert!(JUNE_PROVIDER_PROXY_MAX_CHAT_BODY_BYTES == 3 * 1024 * 1024);
 // Image edit forwarding expands a source ref into base64 JSON before June API
 // sees it. Keep the loopback image cap derived from the same 50 MiB source
 // maximum enforced by imports and the proxy validator.

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -62,7 +62,9 @@ const JUNE_PROVIDER_PROXY_MAX_HEADER_BYTES: usize = 32 * 1024;
 // 1M-token context window. This is a 127.0.0.1 loopback proxy for a single-user
 // desktop, so the memory/DoS surface of the larger buffer is minimal. A body
 // over this cap is genuinely beyond any model window and degrades to the
-// context-overflow notice (recognizable wording in `read_http_request`).
+// context-overflow notice (recognizable wording in
+// `provider_proxy_body_too_large_message`, enforced after auth in
+// `handle_june_provider_connection`).
 // Cross-workspace invariant (JUN-336): this MUST equal june-api's dedicated
 // `/v1/chat/completions` extractor cap (`DEFAULT_MAX_AGENT_CHAT_BYTES` in
 // june-api/crates/config/src/lib.rs). june-api is a separate cargo workspace
@@ -8318,8 +8320,8 @@ async fn handle_june_provider_connection(
     mut stream: tokio::net::TcpStream,
     state: Arc<ProviderProxyState>,
 ) -> io::Result<()> {
-    let request = match read_http_request(&mut stream).await {
-        Ok(request) => request,
+    let (mut request, content_length, leftover) = match read_http_head(&mut stream).await {
+        Ok(head) => head,
         Err(error) => {
             let _ = write_json_response(
                 &mut stream,
@@ -8336,6 +8338,9 @@ async fn handle_june_provider_connection(
         &state.recorder_token,
         &state.connector_token,
     );
+    // Authenticate on the parsed headers BEFORE reading the body, so an
+    // unauthenticated local process cannot force the loopback proxy to buffer a
+    // declared (up to 12 MiB) body before the 401 (JUN-336 review).
     if !provider_proxy_authorized(&request, required_token) {
         write_json_response(
             &mut stream,
@@ -8345,6 +8350,24 @@ async fn handle_june_provider_connection(
         .await?;
         return Ok(());
     }
+    if content_length > provider_proxy_max_body_bytes(&request.path) {
+        // Enforced here (was inside the old read_http_request) so it runs after
+        // auth. Chat bodies keep the context-overflow wording the frontend
+        // classifier keys on ("maximum context length" / `prompt_too_long`), so
+        // an over-cap chat body degrades into the recoverable overflow notice;
+        // image bodies use an image-specific message. Only authenticated callers
+        // reach this — an unauthenticated over-cap request is already a 401.
+        write_json_response(
+            &mut stream,
+            400,
+            serde_json::json!({
+                "error": { "message": provider_proxy_body_too_large_message(&request.path) }
+            }),
+        )
+        .await?;
+        return Ok(());
+    }
+    request.body = read_http_body(&mut stream, leftover, content_length).await?;
     match (request.method.as_str(), request.path.as_str()) {
         ("GET", "/v1/models") => {
             let selected_model = crate::providers::generation_model();
@@ -9398,7 +9421,16 @@ struct HttpRequest {
     body: Vec<u8>,
 }
 
-async fn read_http_request(stream: &mut tokio::net::TcpStream) -> io::Result<HttpRequest> {
+/// Read and parse the request line + headers only, WITHOUT consuming the body.
+/// Returns the request (with an empty `body`), its declared `Content-Length`,
+/// and any bytes already read past the header terminator. The caller must
+/// authorize on the returned headers before calling `read_http_body`, so an
+/// unauthenticated caller never makes the loopback proxy buffer a large body
+/// (JUN-336 review). The body-size cap is likewise enforced by the caller,
+/// after authentication.
+async fn read_http_head(
+    stream: &mut tokio::net::TcpStream,
+) -> io::Result<(HttpRequest, usize, Vec<u8>)> {
     let mut buffer = Vec::new();
     let mut chunk = [0u8; 4096];
     loop {
@@ -9450,21 +9482,28 @@ async fn read_http_request(stream: &mut tokio::net::TcpStream) -> io::Result<Htt
             }
         })
         .unwrap_or(0);
-    if content_length > provider_proxy_max_body_bytes(&path) {
-        // The handler turns this into a 400 for the client. Chat bodies are
-        // phrased as a context overflow (JUN-169): the wording carries the
-        // tokens Hermes' overflow patterns match ("maximum context length") and
-        // the frontend classifier keys on (`prompt_too_long`), so an over-cap
-        // chat body degrades into the recoverable context-overflow notice
-        // instead of a raw transport error that re-wedges or dead-ends the
-        // session. Image bodies use an image-specific message because they are
-        // bounded by upload size, not model context.
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            provider_proxy_body_too_large_message(&path),
-        ));
-    }
-    let mut body = buffer[header_end..].to_vec();
+    let leftover = buffer[header_end..].to_vec();
+    Ok((
+        HttpRequest {
+            method,
+            path,
+            headers,
+            body: Vec::new(),
+        },
+        content_length,
+        leftover,
+    ))
+}
+
+/// Read the request body. Call ONLY after `read_http_head` and a successful
+/// authorization + body-size check on the head — never for an unauthenticated
+/// or over-cap request (JUN-336).
+async fn read_http_body(
+    stream: &mut tokio::net::TcpStream,
+    mut body: Vec<u8>,
+    content_length: usize,
+) -> io::Result<Vec<u8>> {
+    let mut chunk = [0u8; 4096];
     while body.len() < content_length {
         let read = stream.read(&mut chunk).await?;
         if read == 0 {
@@ -9473,12 +9512,7 @@ async fn read_http_request(stream: &mut tokio::net::TcpStream) -> io::Result<Htt
         body.extend_from_slice(&chunk[..read]);
     }
     body.truncate(content_length);
-    Ok(HttpRequest {
-        method,
-        path,
-        headers,
-        body,
-    })
+    Ok(body)
 }
 
 fn provider_proxy_max_body_bytes(path: &str) -> usize {
@@ -11005,6 +11039,69 @@ mod tests {
             .expect("read response");
         server.await.expect("server task");
         response
+    }
+
+    #[tokio::test]
+    async fn provider_proxy_rejects_unauthenticated_request_before_reading_body() {
+        // The proxy authenticates on the parsed headers BEFORE reading the body,
+        // so an unauthenticated local process cannot make it buffer a declared
+        // (up to 12 MiB) body (JUN-336 review). We declare a large Content-Length
+        // but send NO body: with auth-before-read the proxy answers 401 at once;
+        // a regression that read the body first would block waiting for bytes
+        // that never arrive, tripping the timeout below.
+        let home = tempfile::tempdir().expect("tempdir");
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind proxy listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let state = Arc::new(ProviderProxyState {
+            token: "proxy-token".to_string(),
+            recorder_token: "recorder-token".to_string(),
+            connector_token: "connector-token".to_string(),
+            image_sources: ImageSourceCapabilities {
+                images_dir: home.path().join("images"),
+                secret: [7; IMAGE_SOURCE_CAPABILITY_SECRET_BYTES],
+            },
+            videos_dir: home.path().join("videos"),
+            video_generation_enabled: false,
+            app: None,
+            image_safe_mode_pins: Arc::new(Mutex::new(VecDeque::new())),
+            model_catalog_cache: Arc::new(Mutex::new(Vec::new())),
+            recorder_requests: Arc::new(Mutex::new(HashMap::new())),
+        });
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept connection");
+            handle_june_provider_connection(stream, state)
+                .await
+                .expect("handle connection");
+        });
+
+        let exchange = async {
+            let mut stream = tokio::net::TcpStream::connect(addr)
+                .await
+                .expect("connect proxy");
+            // Wrong bearer + a large declared body we never send.
+            let request = "POST /v1/chat/completions HTTP/1.1\r\nHost: 127.0.0.1\r\nAuthorization: Bearer wrong-token\r\nContent-Length: 5000000\r\n\r\n";
+            stream
+                .write_all(request.as_bytes())
+                .await
+                .expect("write request");
+            let mut response = String::new();
+            stream
+                .read_to_string(&mut response)
+                .await
+                .expect("read response");
+            response
+        };
+
+        let response = tokio::time::timeout(Duration::from_secs(5), exchange)
+            .await
+            .expect("proxy must answer 401 without waiting for the declared body");
+        assert!(
+            response.starts_with("HTTP/1.1 401"),
+            "expected 401 Unauthorized, got: {response}"
+        );
+        server.await.expect("server task");
     }
 
     fn oauth_test_connection() -> HermesBridgeConnection {


### PR DESCRIPTION
Closes JUN-336

## What changed

`/v1/chat/completions` gets its own request-body cap instead of inheriting the shared 512 KiB `max_json_bytes` gate — and all three agent-chat size gates are now sized for a **1M-token context window**.

- **New config field** `server.max_agent_chat_bytes` (default `DEFAULT_MAX_AGENT_CHAT_BYTES` = **12 MiB**), threaded `ServerConfig` → `ApiLimits` → router, mirroring the existing dedicated `max_image_edit_bytes` cap. Additive and backward-compatible: Figment seeds `AppConfig::default()` first, so a deployed `config.toml` that omits the field still loads.
- **Route** `/v1/chat/completions` now uses `DefaultBodyLimit::max(limits.max_agent_chat_bytes)`. Every other route keeps the shared 512 KiB cap.
- **Sized for 1M tokens.** The semantic caps `MAX_AGENT_STRING_CHARS` / `MAX_AGENT_TOTAL_STRING_CHARS` go **1.5M → 6M chars** (1M tokens × ~4.5 chars/token ≈ 4.5M chars, +~33% headroom); the byte gates (desktop proxy + June API extractor) go **3 MiB → 12 MiB** (the ~2 bytes/char byte-image of the 6M-char cap). Every ratio the original design used is preserved.
- **Drift guards** so the three gates can't silently diverge again:
  - **Compile-time** `const _: () = assert!(...)` invariants (the codebase idiom, e.g. `config/lib.rs`), so a violation fails the build: june-api pins `DEFAULT_MAX_AGENT_CHAT_BYTES == 12 MiB` and `>= MAX_AGENT_TOTAL_STRING_CHARS`; src-tauri pins `JUNE_PROVIDER_PROXY_MAX_CHAT_BODY_BYTES == 12 MiB`, with cross-referencing comments (the two live in separate cargo workspaces and can't share a symbol).
  - **Runtime config guard** in `validate_request_limits`: an override of `server.max_agent_chat_bytes` below the 12 MiB proxy cap (`DEFAULT_MAX_AGENT_CHAT_BYTES`) fails loudly at startup. The floor is the fixed proxy cap, not `max_json_bytes` — an override in (512 KiB, 12 MiB) would otherwise still let the proxy forward a request this route then 413s (strengthened per Codex review).
- **HTTP boundary regression tests**: a tool-heavy **4 MiB** chat body (above the old 3 MiB cap, so it exercises the raised capacity; large tool-result history + tool schemas, shaped like the production failure) now reaches the handler and streams `200 OK`; a body one byte over 12 MiB still deterministically returns `413`.
- **Auth before buffering (security hardening), both hops.** Both request-handling layers previously read/extracted the body *before* checking the bearer, so an unauthenticated caller could force buffering of a multi-MiB body before the 401 — a pre-existing property the cap increase widened.
  - **June API** (internet-facing): a `require_authenticated_bearer` middleware (header-only, cached-JWKS verify) is now the **outermost** layer on the grouped large-body routes (`/v1/chat/completions`, `/v1/image/edit`, `/v1/video/animate`, `/v1/notes/transcribe`, `/v1/dictate`). Regression test: unauthenticated + malformed body → `401` (not the `400` a parse failure gives), proving auth runs before extraction.
  - **Desktop loopback proxy** (`hermes_bridge.rs`): `read_http_request` is split into `read_http_head` (headers only) + `read_http_body`; the connection handler authenticates on the parsed headers and enforces the body cap **before** the body-read loop. Regression test opens a connection with a wrong bearer and a large declared `Content-Length` but sends no body, and asserts a prompt `401` (a body-first regression would block on the read). Lower severity — loopback/local-only — but reordered for parity and correctness.
- **Admission control (June API).** Auth alone doesn't stop an *authenticated* user from opening many concurrent large requests and exhausting the shared TEE. The `authenticate_and_admit` middleware now also acquires, before body extraction: a **byte-weighted global budget** (a semaphore in KiB of in-flight body, so a 66 MiB image weighs more than a 12 MiB chat; default **1 GiB**, configurable) and a **per-user concurrency cap** (default **8**, configurable). Both are non-blocking `try_acquire` — over budget **load-sheds with `503 server_busy`** (new `ServiceOverloaded` error, code 5032, pinned in the client-contract registry) rather than queuing. An RAII guard releases both after the request. The budget is weighted by the **route's real body cap**, not the client's `Content-Length` — that header is untrusted (a missing/chunked length would otherwise reserve only the 1 KiB minimum while the body still buffers to the cap; an exaggerated length would reserve the whole budget). A startup guard rejects a budget configured below the largest route cap, and `admit` **rejects** (rather than clamps-and-admits) a weight exceeding the budget, so the memory guarantee holds even under misconfiguration. The 503 carries a `Retry-After` header. Unit tests prove per-user shedding, global-budget shedding, over-budget rejection, route-cap weighting, and the budget-floor config guard; the defaults are conservative and should be tuned against real traffic.

## Why

Two things. **(1) The original bug (JUN-336):** the three request-size gates were inconsistent — the desktop proxy allowed 3 MiB and the semantic validator 1.5M chars, but the Axum extractor on `/v1/chat/completions` was still the pre-existing 512 KiB `max_json_bytes`. Axum rejected any agent body between 512 KiB and 3 MiB with a raw 413 **before** the handler or `validate_agent_chat_body` ran, so a valid tool-heavy turn (a representative production request was ~534 KiB) dead-ended after context compaction with the generic "June stopped before replying" banner. **(2) Headroom:** rather than re-align to the old 3 MiB, we size the whole system for a 1M-token context window so a bigger-window model (the picker already renders ≥1M-token models; today's largest served is Kimi K2.6 at 256k) is supported without ever re-tripping this gate.

## Root cause

Regression gap from JUN-169 / PR #549: commits `447a06ad` and `385181ec` raised the semantic caps and the desktop proxy to 3 MiB but did not touch the Axum `max_json_bytes` extractor on the chat route. That 512 KiB route-level gate remained the real production limit and made the newer validation unreachable above it.

## Validation

- `make june-api-test` — **green** (141 passed, 0 failed). New body-limit tests (`..._accepts_tool_heavy_body_over_small_json_cap` 4 MiB → 200, `..._rejects_body_over_agent_cap` 12 MiB+1 → 413, `..._authenticates_before_buffering_the_body` unauth → 401 pre-parse, plus the config default/floor tests); admission tests (`per_user_cap_load_sheds_beyond_limit`, `global_budget_load_sheds_when_exhausted`, `oversized_request_is_clamped_to_the_whole_budget`, `service_overloaded_maps_to_503_with_structured_code`, `integration_agent_admission_preserves_authenticated_happy_path`).
- `make tauri-test` — **green**.
- `make june-api-lint` / `make tauri-lint` (clippy `-D warnings`) — **green** on both.
- Review battery (`with codex`, vs `origin/main`): Standards + Spec + Adversarial. All findings triaged and fixed — notably an adversarial catch (the accept test didn't distinguish the fix) and a Codex P2 (operator-override floor); see the PR thread.

No live app walkthrough: backend request-size boundary change with no user-visible UI surface; exercised deterministically by the HTTP boundary regression tests. The user-visible effect is the *absence* of the dead-end for tool-heavy turns.

## Deploy / rollout

- **Needs a June API deploy** for the extractor + semantic caps (the primary JUN-336 fix). These are additive/backward-compatible; old app installs keep working.
- **The full 1M-token capacity also needs a desktop release**, because the 12 MiB cap lives in the shipped desktop proxy (`hermes_bridge.rs`). Until an app build with the 12 MiB proxy ships, an older install still caps chat bodies at its bundled 3 MiB proxy first (and degrades cleanly to the context-overflow notice above that) — no regression, just the old ceiling. New installs get the full 12 MiB / 6M-char envelope end to end.

## Notes / scope

- No model with a >256k-token window is served today, so below that ceiling the model still rejects an over-window request itself; these caps only guard the byte/abuse envelope and future-proof for bigger-window models.
- Backend memory: the extractor buffers up to 12 MiB per in-flight chat request before semantic rejection (4× the old ceiling), now bounded in aggregate by the admission-control global byte budget and per-user cap above. The proxy is single-user loopback.
- Out of scope: repairing any affected local session DB; redesigning Hermes compaction / tool-result pruning; frontend terminal-overflow persistence (the proxy overflow path already covers it).

## Followups

- **JUN-341** — desktop transcription/dictation should retry `503 server_busy` (5032) with bounded backoff honoring `Retry-After` (the backend side, the header, is done here). Low frequency at the default budget, but user-visible under genuine overload.
- Tune the admission-control defaults (1 GiB global / 8 per-user) against real production traffic and TEE memory once observed.
- Inline-image budget: `validate_agent_chat_body` exempts `image_url` data URLs from the char caps, so the 12 MiB body cap is the de-facto inline-image limit for chat. This PR raises it from 512 KiB → 12 MiB (a large improvement), but a request combining a near-limit image with substantial text can still exceed it and be labeled as context overflow. A dedicated text+image budget with a distinct over-size error is a separate follow-up.
- Optional uniformity: extend auth-before-buffering + admission to the remaining small-JSON body routes (negligible buffering today, so lower priority).
