### PR TITLE
fix(macos): reap dictation helper + harden child lifecycle on in-app update relaunch (JUN-338)

### DIFF
--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -2118,21 +2118,86 @@ fn helper_candidates(app: &AppHandle) -> Vec<PathBuf> {
     paths
 }
 
-/// The dictation helper binary's basename, shared by the bundled-binary lookup
-/// and the orphan reap below.
+/// The dictation helper binary's basename, used by the ownership-aware orphan
+/// reap below to confirm a recorded pid is still a dictation helper.
 #[cfg(target_os = "macos")]
 const DICTATION_HELPER_NAME: &str = "june-dictation-helper";
 
-/// Kills any dictation helper orphaned by a prior app instance before a fresh
+/// Records which app instance owns the currently-spawned helper. Persisted next
+/// to a spawn so a *later* instance can tell an orphan (owner gone) from a
+/// helper a still-running instance owns, and reap only the former.
+#[cfg(target_os = "macos")]
+#[derive(serde::Serialize, serde::Deserialize)]
+struct HelperOwnershipRecord {
+    /// The app process that spawned the helper (`std::process::id()`).
+    app_pid: u32,
+    /// The spawned helper process.
+    helper_pid: u32,
+}
+
+#[cfg(target_os = "macos")]
+fn helper_ownership_path(app: &AppHandle) -> Option<PathBuf> {
+    app.path()
+        .app_config_dir()
+        .ok()
+        .map(|directory| directory.join("dictation-helper-owner.json"))
+}
+
+/// Records the just-spawned helper's pid alongside our own app pid, so the next
+/// instance's [`reap_orphaned_helper`] can establish ownership. Best-effort:
+/// a failure only means a future instance cannot reap this helper by record.
+#[cfg(target_os = "macos")]
+fn record_helper_ownership(app: &AppHandle, helper_pid: u32) {
+    let Some(path) = helper_ownership_path(app) else {
+        return;
+    };
+    let record = HelperOwnershipRecord {
+        app_pid: std::process::id(),
+        helper_pid,
+    };
+    if let Ok(serialized) = serde_json::to_string(&record) {
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let _ = fs::write(&path, serialized);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn record_helper_ownership(_app: &AppHandle, _helper_pid: u32) {}
+
+/// Reaps a dictation helper orphaned by a *prior* app instance before a fresh
 /// one is spawned. A stale helper — most often left by an in-app update relaunch
 /// that skipped teardown (JUN-338) — keeps the global CGEventTap and its stdio,
 /// so a newly spawned helper collides with it and never delivers a clean
-/// permission status. Best-effort and macOS-only. Safe to call here because
-/// `spawn_helper` only ever runs with no live helper of ours: first `setup`, or
-/// a supervised respawn after the previous helper already exited.
+/// permission status.
+///
+/// Ownership-aware, never a name-wide sweep: it kills only the exact pid the
+/// last spawn recorded, and only when that helper's owning app is gone *and* the
+/// pid is still a dictation helper (guarding against pid reuse). A helper a
+/// concurrently-running instance owns has a live owner, so it is never touched —
+/// which matters because debug builds allow multiple instances. If ownership
+/// cannot be established, nothing is killed. macOS-only, best-effort.
 #[cfg(target_os = "macos")]
-fn reap_orphaned_helpers() {
-    let _ = reap_orphaned_helpers_command()
+fn reap_orphaned_helper(app: &AppHandle) {
+    let Some(path) = helper_ownership_path(app) else {
+        return;
+    };
+    let Some(record) = fs::read_to_string(&path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<HelperOwnershipRecord>(&raw).ok())
+    else {
+        return;
+    };
+    if !should_reap_recorded_helper(
+        process_alive(record.app_pid),
+        is_dictation_helper_process(record.helper_pid),
+    ) {
+        return;
+    }
+    let _ = Command::new("/bin/kill")
+        .arg("-KILL")
+        .arg(record.helper_pid.to_string())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -2140,21 +2205,59 @@ fn reap_orphaned_helpers() {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn reap_orphaned_helpers() {}
+fn reap_orphaned_helper(_app: &AppHandle) {}
 
-/// Pure command construction so a test can assert the reap targets the helper by
-/// name. Matches on the full command line (`pkill -f`): the absolute spawn path
-/// always contains the binary name, so a truncated accounting name cannot hide
-/// the orphan, and no other process on the system carries this string.
+/// The kill decision, factored out so it is unit-testable without real
+/// processes: reap only an orphan (owner no longer alive) that is still a
+/// dictation helper (pid not reused for something else).
 #[cfg(target_os = "macos")]
-fn reap_orphaned_helpers_command() -> Command {
-    let mut cmd = Command::new("/usr/bin/pkill");
-    cmd.arg("-f").arg(DICTATION_HELPER_NAME);
-    cmd
+fn should_reap_recorded_helper(owner_alive: bool, helper_is_dictation: bool) -> bool {
+    !owner_alive && helper_is_dictation
+}
+
+/// Whether a pid is live and signalable by us (`kill -0`). Same-user only, which
+/// is all June ever records.
+#[cfg(target_os = "macos")]
+fn process_alive(pid: u32) -> bool {
+    Command::new("/bin/kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+/// Whether the process at `pid` is (still) a dictation helper, by matching the
+/// executable basename from `ps -o comm=`. Returns false when the pid is dead or
+/// was reused for an unrelated process, so a stale record never kills a stranger.
+#[cfg(target_os = "macos")]
+fn is_dictation_helper_process(pid: u32) -> bool {
+    let Ok(output) = Command::new("/bin/ps")
+        .arg("-p")
+        .arg(pid.to_string())
+        .arg("-o")
+        .arg("comm=")
+        .stdin(Stdio::null())
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .rsplit('/')
+        .next()
+        .map(|basename| basename == DICTATION_HELPER_NAME)
+        .unwrap_or(false)
 }
 
 fn spawn_helper(app: &AppHandle) -> Result<HelperProcess, AppError> {
-    reap_orphaned_helpers();
+    reap_orphaned_helper(app);
 
     let helper_path = helper_candidates(app)
         .into_iter()
@@ -2199,6 +2302,11 @@ fn spawn_helper(app: &AppHandle) -> Result<HelperProcess, AppError> {
             "Helper stderr was unavailable.",
         )
     })?;
+
+    // Record ownership so the next instance can reap this exact helper if we
+    // exit without tearing it down (e.g. an update relaunch), and never touch a
+    // helper another live instance owns (JUN-338).
+    record_helper_ownership(app, child.id());
 
     // Recorded before handing stdout to the reader so the supervisor can tell a
     // healthy helper (ran a while, then died) from a crash loop.
@@ -4468,17 +4576,15 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn reap_orphaned_helpers_targets_helper_by_name() {
-        let cmd = reap_orphaned_helpers_command();
-        assert_eq!(cmd.get_program(), std::ffi::OsStr::new("/usr/bin/pkill"));
-        let args: Vec<String> = cmd
-            .get_args()
-            .map(|arg| arg.to_string_lossy().into_owned())
-            .collect();
-        // `-f` matches the full command line so the absolute spawn path (which
-        // always contains the binary name) is caught even when the accounting
-        // name is truncated.
-        assert_eq!(args, ["-f", DICTATION_HELPER_NAME]);
+    fn reap_recorded_helper_only_when_owner_dead_and_identity_matches() {
+        // The orphan case: owner gone, pid still a dictation helper -> reap.
+        assert!(should_reap_recorded_helper(false, true));
+        // Owner still alive (e.g. a second dev instance) -> never touch its
+        // helper.
+        assert!(!should_reap_recorded_helper(true, true));
+        // Owner gone but the pid was reused for something else -> leave it.
+        assert!(!should_reap_recorded_helper(false, false));
+        assert!(!should_reap_recorded_helper(true, false));
     }
 
     #[test]

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -2123,9 +2123,21 @@ fn helper_candidates(app: &AppHandle) -> Vec<PathBuf> {
 #[cfg(target_os = "macos")]
 const DICTATION_HELPER_NAME: &str = "june-dictation-helper";
 
-/// Records which app instance owns the currently-spawned helper. Persisted next
-/// to a spawn so a *later* instance can tell an orphan (owner gone) from a
-/// helper a still-running instance owns, and reap only the former.
+/// Filename prefix for the per-instance ownership records. One record per owning
+/// app pid (never a single shared file), so concurrent instances — allowed in
+/// debug builds — cannot clobber each other's pointer to their helper.
+#[cfg(target_os = "macos")]
+const HELPER_OWNER_RECORD_PREFIX: &str = "dictation-helper-owner-";
+
+/// How long the reap waits for a killed orphan to actually exit before giving
+/// up. `kill` only submits the signal; the old helper can still hold its global
+/// CGEventTap for a moment, which would collide with the replacement helper.
+#[cfg(target_os = "macos")]
+const HELPER_ORPHAN_EXIT_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Records which app instance owns the currently-spawned helper. Persisted so a
+/// *later* instance can tell an orphan (owner gone) from a helper a still-running
+/// instance owns, and reap only the former.
 #[cfg(target_os = "macos")]
 #[derive(serde::Serialize, serde::Deserialize)]
 struct HelperOwnershipRecord {
@@ -2136,16 +2148,28 @@ struct HelperOwnershipRecord {
 }
 
 #[cfg(target_os = "macos")]
+fn helper_ownership_dir(app: &AppHandle) -> Option<PathBuf> {
+    app.path().app_config_dir().ok()
+}
+
+/// This instance's own record path, keyed by our app pid so we never overwrite
+/// another live instance's record.
+#[cfg(target_os = "macos")]
 fn helper_ownership_path(app: &AppHandle) -> Option<PathBuf> {
-    app.path()
-        .app_config_dir()
-        .ok()
-        .map(|directory| directory.join("dictation-helper-owner.json"))
+    helper_ownership_dir(app).map(|directory| {
+        directory.join(format!(
+            "{HELPER_OWNER_RECORD_PREFIX}{}.json",
+            std::process::id()
+        ))
+    })
 }
 
 /// Records the just-spawned helper's pid alongside our own app pid, so the next
-/// instance's [`reap_orphaned_helper`] can establish ownership. Best-effort:
-/// a failure only means a future instance cannot reap this helper by record.
+/// instance's [`reap_orphaned_helpers`] can establish ownership. Written
+/// atomically (temp file + rename) so a crash or partial write never leaves an
+/// unparseable record; a failure leaves any prior record intact rather than
+/// destroying the only pointer to an earlier orphan. Best-effort: a failure only
+/// impairs a future instance's ability to reap *this* helper.
 #[cfg(target_os = "macos")]
 fn record_helper_ownership(app: &AppHandle, helper_pid: u32) {
     let Some(path) = helper_ownership_path(app) else {
@@ -2155,57 +2179,96 @@ fn record_helper_ownership(app: &AppHandle, helper_pid: u32) {
         app_pid: std::process::id(),
         helper_pid,
     };
-    if let Ok(serialized) = serde_json::to_string(&record) {
-        if let Some(parent) = path.parent() {
-            let _ = fs::create_dir_all(parent);
-        }
-        let _ = fs::write(&path, serialized);
+    let Ok(serialized) = serde_json::to_string(&record) else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let tmp = path.with_extension("json.tmp");
+    let write = (|| -> std::io::Result<()> {
+        let mut file = fs::File::create(&tmp)?;
+        file.write_all(serialized.as_bytes())?;
+        file.sync_all()?;
+        fs::rename(&tmp, &path)
+    })();
+    if write.is_err() {
+        let _ = fs::remove_file(&tmp);
     }
 }
 
 #[cfg(not(target_os = "macos"))]
 fn record_helper_ownership(_app: &AppHandle, _helper_pid: u32) {}
 
-/// Reaps a dictation helper orphaned by a *prior* app instance before a fresh
+/// Reaps any dictation helper orphaned by a *prior* app instance before a fresh
 /// one is spawned. A stale helper — most often left by an in-app update relaunch
 /// that skipped teardown (JUN-338) — keeps the global CGEventTap and its stdio,
 /// so a newly spawned helper collides with it and never delivers a clean
 /// permission status.
 ///
-/// Ownership-aware, never a name-wide sweep: it kills only the exact pid the
-/// last spawn recorded, and only when that helper's owning app is gone *and* the
-/// pid is still a dictation helper (guarding against pid reuse). A helper a
-/// concurrently-running instance owns has a live owner, so it is never touched —
-/// which matters because debug builds allow multiple instances. If ownership
-/// cannot be established, nothing is killed. macOS-only, best-effort.
+/// Ownership-aware, never a name-wide sweep: it kills only pids recorded by a
+/// prior instance, and only when that instance is gone *and* the pid is still a
+/// dictation helper (guarding pid reuse). A helper a concurrently-running
+/// instance owns has a live owner, so it is never touched — which matters
+/// because debug builds allow multiple instances.
+///
+/// Returns an error (aborting the replacement spawn) if a confirmed orphan will
+/// not die within the timeout: spawning a new helper while the old one still
+/// holds the tap would reproduce the collision. The record is left in place so
+/// the next attempt can retry. macOS-only.
 #[cfg(target_os = "macos")]
-fn reap_orphaned_helper(app: &AppHandle) {
-    let Some(path) = helper_ownership_path(app) else {
-        return;
+fn reap_orphaned_helpers(app: &AppHandle) -> Result<(), AppError> {
+    let Some(dir) = helper_ownership_dir(app) else {
+        return Ok(());
     };
-    let Some(record) = fs::read_to_string(&path)
-        .ok()
-        .and_then(|raw| serde_json::from_str::<HelperOwnershipRecord>(&raw).ok())
-    else {
-        return;
+    let my_pid = std::process::id();
+    let Ok(entries) = fs::read_dir(&dir) else {
+        return Ok(());
     };
-    if !should_reap_recorded_helper(
-        process_alive(record.app_pid),
-        is_dictation_helper_process(record.helper_pid),
-    ) {
-        return;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let is_record = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| {
+                name.starts_with(HELPER_OWNER_RECORD_PREFIX) && name.ends_with(".json")
+            });
+        if !is_record {
+            continue;
+        }
+        let Some(record) = fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<HelperOwnershipRecord>(&raw).ok())
+        else {
+            // Unparseable/partial record: nothing actionable, clean it up.
+            let _ = fs::remove_file(&path);
+            continue;
+        };
+        // Our own record (shouldn't exist yet on first spawn) or an owner still
+        // running: leave it be.
+        if record.app_pid == my_pid || process_alive(record.app_pid) {
+            continue;
+        }
+        if should_reap_recorded_helper(false, is_dictation_helper_process(record.helper_pid)) {
+            kill_pid(record.helper_pid);
+            if !wait_for_pid_exit(record.helper_pid, HELPER_ORPHAN_EXIT_TIMEOUT) {
+                return Err(AppError::new(
+                    "dictation_helper_orphan_stuck",
+                    "An orphaned dictation helper would not exit; retrying.",
+                ));
+            }
+        }
+        // Owner gone and helper reaped (or the pid was already gone/reused): the
+        // record is stale, drop it.
+        let _ = fs::remove_file(&path);
     }
-    let _ = Command::new("/bin/kill")
-        .arg("-KILL")
-        .arg(record.helper_pid.to_string())
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
+    Ok(())
 }
 
 #[cfg(not(target_os = "macos"))]
-fn reap_orphaned_helper(_app: &AppHandle) {}
+fn reap_orphaned_helpers(_app: &AppHandle) -> Result<(), AppError> {
+    Ok(())
+}
 
 /// The kill decision, factored out so it is unit-testable without real
 /// processes: reap only an orphan (owner no longer alive) that is still a
@@ -2213,6 +2276,35 @@ fn reap_orphaned_helper(_app: &AppHandle) {}
 #[cfg(target_os = "macos")]
 fn should_reap_recorded_helper(owner_alive: bool, helper_is_dictation: bool) -> bool {
     !owner_alive && helper_is_dictation
+}
+
+/// Submits SIGKILL to a single pid (best-effort; the caller confirms exit).
+#[cfg(target_os = "macos")]
+fn kill_pid(pid: u32) {
+    let _ = Command::new("/bin/kill")
+        .arg("-KILL")
+        .arg(pid.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+/// Polls until `pid` is no longer alive, or the timeout elapses. Returns whether
+/// it exited, so the caller can refuse to spawn a replacement while an orphan
+/// still holds the global CGEventTap.
+#[cfg(target_os = "macos")]
+fn wait_for_pid_exit(pid: u32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if !process_alive(pid) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
 }
 
 /// Whether a pid is live and signalable by us (`kill -0`). Same-user only, which
@@ -2257,7 +2349,9 @@ fn is_dictation_helper_process(pid: u32) -> bool {
 }
 
 fn spawn_helper(app: &AppHandle) -> Result<HelperProcess, AppError> {
-    reap_orphaned_helper(app);
+    // Abort the spawn if a prior instance's orphaned helper is still holding the
+    // global CGEventTap; racing it would reproduce the permission collision.
+    reap_orphaned_helpers(app)?;
 
     let helper_path = helper_candidates(app)
         .into_iter()
@@ -4585,6 +4679,42 @@ mod tests {
         // Owner gone but the pid was reused for something else -> leave it.
         assert!(!should_reap_recorded_helper(false, false));
         assert!(!should_reap_recorded_helper(true, false));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn wait_for_pid_exit_confirms_a_kill_and_bounds_a_survivor() {
+        // A dead pid is observed as exited. Reap the child first so it is not a
+        // zombie: `kill -0` still reports a zombie as alive, but a real orphan
+        // (whose parent is the dead prior app) is reparented to launchd and
+        // reaped, so in production the pid genuinely disappears.
+        let mut victim = Command::new("/bin/sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn victim");
+        let victim_pid = victim.id();
+        kill_pid(victim_pid);
+        let _ = victim.wait();
+        assert!(wait_for_pid_exit(victim_pid, Duration::from_secs(2)));
+
+        // ...and a live process is NOT declared exited, so the reap aborts the
+        // replacement spawn rather than racing a helper that still holds the tap.
+        let mut survivor = Command::new("/bin/sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn survivor");
+        assert!(!wait_for_pid_exit(
+            survivor.id(),
+            Duration::from_millis(100)
+        ));
+        let _ = survivor.kill();
+        let _ = survivor.wait();
     }
 
     #[test]

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -2135,16 +2135,85 @@ const HELPER_OWNER_RECORD_PREFIX: &str = "dictation-helper-owner-";
 #[cfg(target_os = "macos")]
 const HELPER_ORPHAN_EXIT_TIMEOUT: Duration = Duration::from_millis(500);
 
-/// Records which app instance owns the currently-spawned helper. Persisted so a
-/// *later* instance can tell an orphan (owner gone) from a helper a still-running
-/// instance owns, and reap only the former.
+/// Records which app instance owns the currently-spawned helper. Identity is
+/// bound to `(pid, start_time)` for BOTH the owner and the helper, never a bare
+/// pid: pids are recycled, and sequential reuse would otherwise let a new app
+/// mistake a dead owner's record for its own (or let a stale helper pid, now
+/// reused by another live instance's helper, be killed). The start time is the
+/// non-reusable half of the identity.
 #[cfg(target_os = "macos")]
 #[derive(serde::Serialize, serde::Deserialize)]
 struct HelperOwnershipRecord {
     /// The app process that spawned the helper (`std::process::id()`).
     app_pid: u32,
+    /// The owning app's process start time (`ps -o lstart=`), the non-reusable
+    /// half of its identity.
+    app_start: String,
     /// The spawned helper process.
     helper_pid: u32,
+    /// The helper's process start time, so a reused helper pid is not mistaken
+    /// for the recorded orphan.
+    helper_start: String,
+}
+
+/// The result of probing a pid's start time: distinguishes "the pid is gone"
+/// (definitive) from "could not run `ps`" (unknown), so callers can fail closed
+/// on the latter instead of assuming the process is absent.
+#[cfg(target_os = "macos")]
+enum StartTimeProbe {
+    /// `ps` could not be run — identity cannot be established.
+    Unknown,
+    /// No process with this pid exists.
+    Gone,
+    /// The process exists and started at this (`ps -o lstart=`) time.
+    StartedAt(String),
+}
+
+/// Tri-state executable-identity check, kept distinct from "gone" so the caller
+/// can fail closed when `ps` itself could not run.
+#[cfg(target_os = "macos")]
+enum HelperIdentity {
+    /// `ps` could not be run — identity cannot be established.
+    Unknown,
+    IsHelper,
+    NotHelper,
+}
+
+/// Whether the recorded owner is still the same live process.
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum OwnerLiveness {
+    Alive,
+    Dead,
+    /// Could not be determined (e.g. `ps` failed).
+    Unknown,
+}
+
+/// Whether the recorded helper pid still refers to the exact recorded process.
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum HelperMatch {
+    /// The pid is alive, is a dictation helper, and its start time matches.
+    MatchesRecord,
+    /// The pid is gone, or was reused for a different process.
+    GoneOrReused,
+    /// Could not be determined (e.g. `ps` failed).
+    Unknown,
+}
+
+/// What to do with one ownership record.
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum RecordAction {
+    /// Owner still owns it — leave the record and its helper alone.
+    Skip,
+    /// Owner is gone and the helper is gone/reused — drop the stale record.
+    DeleteStale,
+    /// Owner is gone and the helper is the recorded orphan — kill it.
+    Reap,
+    /// Identity could not be established — fail closed: abort the spawn and keep
+    /// the record for the next attempt.
+    Abort,
 }
 
 #[cfg(target_os = "macos")]
@@ -2164,26 +2233,160 @@ fn helper_ownership_path(app: &AppHandle) -> Option<PathBuf> {
     })
 }
 
-/// Records the just-spawned helper's pid alongside our own app pid, so the next
-/// instance's [`reap_orphaned_helpers`] can establish ownership. Written
-/// atomically (temp file + rename) so a crash or partial write never leaves an
-/// unparseable record; a failure leaves any prior record intact rather than
-/// destroying the only pointer to an earlier orphan. Best-effort: a failure only
-/// impairs a future instance's ability to reap *this* helper.
+/// Probes a pid's start time. `ps` exits non-zero with no output for an absent
+/// pid (definitive `Gone`); a failure to run `ps` at all is `Unknown`.
 #[cfg(target_os = "macos")]
-fn record_helper_ownership(app: &AppHandle, helper_pid: u32) {
-    let Some(path) = helper_ownership_path(app) else {
-        return;
+fn probe_start_time(pid: u32) -> StartTimeProbe {
+    let output = Command::new("/bin/ps")
+        .arg("-p")
+        .arg(pid.to_string())
+        .arg("-o")
+        .arg("lstart=")
+        .stdin(Stdio::null())
+        .output();
+    match output {
+        Err(_) => StartTimeProbe::Unknown,
+        Ok(output) if !output.status.success() => StartTimeProbe::Gone,
+        Ok(output) => {
+            let started = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if started.is_empty() {
+                StartTimeProbe::Gone
+            } else {
+                StartTimeProbe::StartedAt(started)
+            }
+        }
+    }
+}
+
+/// Tri-state executable-identity check via `ps -o comm=`. `Unknown` when `ps`
+/// could not run; `NotHelper` when the pid is gone or is a different program.
+#[cfg(target_os = "macos")]
+fn inspect_helper_identity(pid: u32) -> HelperIdentity {
+    let output = Command::new("/bin/ps")
+        .arg("-p")
+        .arg(pid.to_string())
+        .arg("-o")
+        .arg("comm=")
+        .stdin(Stdio::null())
+        .output();
+    match output {
+        Err(_) => HelperIdentity::Unknown,
+        Ok(output) if !output.status.success() => HelperIdentity::NotHelper,
+        Ok(output) => {
+            let is_helper = String::from_utf8_lossy(&output.stdout)
+                .trim()
+                .rsplit('/')
+                .next()
+                .map(|basename| basename == DICTATION_HELPER_NAME)
+                .unwrap_or(false);
+            if is_helper {
+                HelperIdentity::IsHelper
+            } else {
+                HelperIdentity::NotHelper
+            }
+        }
+    }
+}
+
+/// Classifies the recorded owner against a live probe. Pure, so the pid-reuse
+/// cases are unit-testable without processes.
+#[cfg(target_os = "macos")]
+fn owner_liveness(probe: &StartTimeProbe, recorded_start: &str) -> OwnerLiveness {
+    match probe {
+        StartTimeProbe::Unknown => OwnerLiveness::Unknown,
+        StartTimeProbe::Gone => OwnerLiveness::Dead,
+        // Same pid, but a *different* start time means the pid was reused by an
+        // unrelated process: the original owner is gone.
+        StartTimeProbe::StartedAt(started) => {
+            if started == recorded_start {
+                OwnerLiveness::Alive
+            } else {
+                OwnerLiveness::Dead
+            }
+        }
+    }
+}
+
+/// Classifies the recorded helper against a live probe and identity check. Pure.
+#[cfg(target_os = "macos")]
+fn helper_match(
+    probe: &StartTimeProbe,
+    recorded_start: &str,
+    identity: &HelperIdentity,
+) -> HelperMatch {
+    match probe {
+        StartTimeProbe::Unknown => HelperMatch::Unknown,
+        StartTimeProbe::Gone => HelperMatch::GoneOrReused,
+        StartTimeProbe::StartedAt(started) => {
+            if started != recorded_start {
+                // Pid reused by a different process (possibly another live
+                // instance's helper) — never touch it.
+                HelperMatch::GoneOrReused
+            } else {
+                match identity {
+                    HelperIdentity::Unknown => HelperMatch::Unknown,
+                    HelperIdentity::IsHelper => HelperMatch::MatchesRecord,
+                    HelperIdentity::NotHelper => HelperMatch::GoneOrReused,
+                }
+            }
+        }
+    }
+}
+
+/// The full reap decision for one record. Pure and total, so every combination
+/// is unit-testable. Fails closed (`Abort`) whenever identity is `Unknown`.
+#[cfg(target_os = "macos")]
+fn decide_record_action(owner: OwnerLiveness, helper: HelperMatch) -> RecordAction {
+    match owner {
+        OwnerLiveness::Alive => RecordAction::Skip,
+        OwnerLiveness::Unknown => RecordAction::Abort,
+        OwnerLiveness::Dead => match helper {
+            HelperMatch::MatchesRecord => RecordAction::Reap,
+            HelperMatch::GoneOrReused => RecordAction::DeleteStale,
+            HelperMatch::Unknown => RecordAction::Abort,
+        },
+    }
+}
+
+/// Records the just-spawned helper's `(pid, start_time)` alongside our own
+/// `(pid, start_time)`, so the next instance's [`reap_orphaned_helpers`] can
+/// establish ownership against non-reusable identities. Written atomically (temp
+/// file + fsync + rename) so a crash or partial write never leaves an
+/// unparseable record. Returns an error on any failure — including being unable
+/// to read our own or the helper's start time — so the caller reaps the just-
+/// spawned child rather than leaving it untracked (fail closed).
+#[cfg(target_os = "macos")]
+fn record_helper_ownership(app: &AppHandle, helper_pid: u32) -> Result<(), AppError> {
+    let path = helper_ownership_path(app).ok_or_else(|| {
+        AppError::new(
+            "dictation_helper_owner_unrecordable",
+            "Could not resolve the dictation helper ownership path.",
+        )
+    })?;
+    let StartTimeProbe::StartedAt(app_start) = probe_start_time(std::process::id()) else {
+        return Err(AppError::new(
+            "dictation_helper_owner_unrecordable",
+            "Could not read this app's process start time.",
+        ));
+    };
+    let StartTimeProbe::StartedAt(helper_start) = probe_start_time(helper_pid) else {
+        return Err(AppError::new(
+            "dictation_helper_owner_unrecordable",
+            "Could not read the dictation helper's process start time.",
+        ));
     };
     let record = HelperOwnershipRecord {
         app_pid: std::process::id(),
+        app_start,
         helper_pid,
+        helper_start,
     };
-    let Ok(serialized) = serde_json::to_string(&record) else {
-        return;
-    };
+    let serialized = serde_json::to_string(&record)
+        .map_err(|error| AppError::new("dictation_helper_owner_unrecordable", error.to_string()))?;
     if let Some(parent) = path.parent() {
-        let _ = fs::create_dir_all(parent);
+        fs::create_dir_all(parent).map_err(|error| {
+            AppError::new("dictation_helper_owner_unrecordable", error.to_string())
+        })?;
     }
     let tmp = path.with_extension("json.tmp");
     let write = (|| -> std::io::Result<()> {
@@ -2192,13 +2395,16 @@ fn record_helper_ownership(app: &AppHandle, helper_pid: u32) {
         file.sync_all()?;
         fs::rename(&tmp, &path)
     })();
-    if write.is_err() {
+    write.map_err(|error| {
         let _ = fs::remove_file(&tmp);
-    }
+        AppError::new("dictation_helper_owner_unrecordable", error.to_string())
+    })
 }
 
 #[cfg(not(target_os = "macos"))]
-fn record_helper_ownership(_app: &AppHandle, _helper_pid: u32) {}
+fn record_helper_ownership(_app: &AppHandle, _helper_pid: u32) -> Result<(), AppError> {
+    Ok(())
+}
 
 /// Reaps any dictation helper orphaned by a *prior* app instance before a fresh
 /// one is spawned. A stale helper — most often left by an in-app update relaunch
@@ -2206,24 +2412,36 @@ fn record_helper_ownership(_app: &AppHandle, _helper_pid: u32) {}
 /// so a newly spawned helper collides with it and never delivers a clean
 /// permission status.
 ///
-/// Ownership-aware, never a name-wide sweep: it kills only pids recorded by a
-/// prior instance, and only when that instance is gone *and* the pid is still a
-/// dictation helper (guarding pid reuse). A helper a concurrently-running
-/// instance owns has a live owner, so it is never touched — which matters
-/// because debug builds allow multiple instances.
+/// Ownership-aware, never a name-wide sweep, and keyed on non-reusable
+/// `(pid, start_time)` identities: it kills only a pid a prior instance
+/// recorded, only when that instance is proven gone AND the pid is still the
+/// exact recorded helper. A helper a concurrently-running instance owns has a
+/// live owner (or a mismatching start time), so it is never touched — which
+/// matters because debug builds allow multiple instances.
 ///
-/// Returns an error (aborting the replacement spawn) if a confirmed orphan will
-/// not die within the timeout: spawning a new helper while the old one still
-/// holds the tap would reproduce the collision. The record is left in place so
-/// the next attempt can retry. macOS-only.
+/// Fails closed: if a confirmed orphan will not die, or identity cannot be
+/// established (`ps`/fs failure), it returns an error that aborts the
+/// replacement spawn and keeps the record, rather than spawning over a helper
+/// that may still hold the tap. macOS-only.
 #[cfg(target_os = "macos")]
 fn reap_orphaned_helpers(app: &AppHandle) -> Result<(), AppError> {
     let Some(dir) = helper_ownership_dir(app) else {
+        // No config dir means no record was ever written: nothing to reap.
+        tracing::warn!("dictation reap: no app config dir; skipping orphan reap");
         return Ok(());
     };
-    let my_pid = std::process::id();
-    let Ok(entries) = fs::read_dir(&dir) else {
-        return Ok(());
+    let entries = match fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            // The dir exists but is unreadable: we cannot prove there is no
+            // orphan, so fail closed.
+            tracing::warn!(%error, "dictation reap: ownership dir unreadable; aborting spawn");
+            return Err(AppError::new(
+                "dictation_helper_reap_failed",
+                "Could not read the dictation helper ownership records.",
+            ));
+        }
     };
     for entry in entries.flatten() {
         let path = entry.path();
@@ -2240,27 +2458,55 @@ fn reap_orphaned_helpers(app: &AppHandle) -> Result<(), AppError> {
             .ok()
             .and_then(|raw| serde_json::from_str::<HelperOwnershipRecord>(&raw).ok())
         else {
-            // Unparseable/partial record: nothing actionable, clean it up.
+            // Unparseable record: it names no identifiable process, so there is
+            // nothing to reap from it. Atomic writes make this near-impossible;
+            // drop the unactionable file rather than wedge every future spawn.
+            tracing::warn!(path = %path.display(), "dictation reap: dropping unparseable ownership record");
             let _ = fs::remove_file(&path);
             continue;
         };
-        // Our own record (shouldn't exist yet on first spawn) or an owner still
-        // running: leave it be.
-        if record.app_pid == my_pid || process_alive(record.app_pid) {
-            continue;
-        }
-        if should_reap_recorded_helper(false, is_dictation_helper_process(record.helper_pid)) {
-            kill_pid(record.helper_pid);
-            if !wait_for_pid_exit(record.helper_pid, HELPER_ORPHAN_EXIT_TIMEOUT) {
+        let owner = owner_liveness(&probe_start_time(record.app_pid), &record.app_start);
+        let action = if owner == OwnerLiveness::Alive {
+            RecordAction::Skip
+        } else {
+            let helper = helper_match(
+                &probe_start_time(record.helper_pid),
+                &record.helper_start,
+                &inspect_helper_identity(record.helper_pid),
+            );
+            decide_record_action(owner, helper)
+        };
+        match action {
+            RecordAction::Skip => {}
+            RecordAction::DeleteStale => {
+                let _ = fs::remove_file(&path);
+            }
+            RecordAction::Reap => {
+                kill_pid(record.helper_pid);
+                if !wait_for_pid_exit(record.helper_pid, HELPER_ORPHAN_EXIT_TIMEOUT) {
+                    tracing::warn!(
+                        helper_pid = record.helper_pid,
+                        "dictation reap: orphaned helper would not exit; aborting spawn"
+                    );
+                    return Err(AppError::new(
+                        "dictation_helper_orphan_stuck",
+                        "An orphaned dictation helper would not exit; retrying.",
+                    ));
+                }
+                let _ = fs::remove_file(&path);
+            }
+            RecordAction::Abort => {
+                tracing::warn!(
+                    app_pid = record.app_pid,
+                    helper_pid = record.helper_pid,
+                    "dictation reap: could not establish ownership; aborting spawn"
+                );
                 return Err(AppError::new(
-                    "dictation_helper_orphan_stuck",
-                    "An orphaned dictation helper would not exit; retrying.",
+                    "dictation_helper_reap_failed",
+                    "Could not establish dictation helper ownership; retrying.",
                 ));
             }
         }
-        // Owner gone and helper reaped (or the pid was already gone/reused): the
-        // record is stale, drop it.
-        let _ = fs::remove_file(&path);
     }
     Ok(())
 }
@@ -2268,14 +2514,6 @@ fn reap_orphaned_helpers(app: &AppHandle) -> Result<(), AppError> {
 #[cfg(not(target_os = "macos"))]
 fn reap_orphaned_helpers(_app: &AppHandle) -> Result<(), AppError> {
     Ok(())
-}
-
-/// The kill decision, factored out so it is unit-testable without real
-/// processes: reap only an orphan (owner no longer alive) that is still a
-/// dictation helper (pid not reused for something else).
-#[cfg(target_os = "macos")]
-fn should_reap_recorded_helper(owner_alive: bool, helper_is_dictation: bool) -> bool {
-    !owner_alive && helper_is_dictation
 }
 
 /// Submits SIGKILL to a single pid (best-effort; the caller confirms exit).
@@ -2319,32 +2557,6 @@ fn process_alive(pid: u32) -> bool {
         .stderr(Stdio::null())
         .status()
         .map(|status| status.success())
-        .unwrap_or(false)
-}
-
-/// Whether the process at `pid` is (still) a dictation helper, by matching the
-/// executable basename from `ps -o comm=`. Returns false when the pid is dead or
-/// was reused for an unrelated process, so a stale record never kills a stranger.
-#[cfg(target_os = "macos")]
-fn is_dictation_helper_process(pid: u32) -> bool {
-    let Ok(output) = Command::new("/bin/ps")
-        .arg("-p")
-        .arg(pid.to_string())
-        .arg("-o")
-        .arg("comm=")
-        .stdin(Stdio::null())
-        .output()
-    else {
-        return false;
-    };
-    if !output.status.success() {
-        return false;
-    }
-    String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .rsplit('/')
-        .next()
-        .map(|basename| basename == DICTATION_HELPER_NAME)
         .unwrap_or(false)
 }
 
@@ -2399,8 +2611,17 @@ fn spawn_helper(app: &AppHandle) -> Result<HelperProcess, AppError> {
 
     // Record ownership so the next instance can reap this exact helper if we
     // exit without tearing it down (e.g. an update relaunch), and never touch a
-    // helper another live instance owns (JUN-338).
-    record_helper_ownership(app, child.id());
+    // helper another live instance owns (JUN-338). If it cannot be persisted,
+    // do not leave an untracked helper running: kill it and fail the spawn.
+    if let Err(error) = record_helper_ownership(app, child.id()) {
+        tracing::warn!(
+            error = %error.message,
+            "dictation: could not record helper ownership; killing untracked helper"
+        );
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
 
     // Recorded before handing stdout to the reader so the supervisor can tell a
     // healthy helper (ran a while, then died) from a crash loop.
@@ -4670,15 +4891,109 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn reap_recorded_helper_only_when_owner_dead_and_identity_matches() {
-        // The orphan case: owner gone, pid still a dictation helper -> reap.
-        assert!(should_reap_recorded_helper(false, true));
-        // Owner still alive (e.g. a second dev instance) -> never touch its
-        // helper.
-        assert!(!should_reap_recorded_helper(true, true));
-        // Owner gone but the pid was reused for something else -> leave it.
-        assert!(!should_reap_recorded_helper(false, false));
-        assert!(!should_reap_recorded_helper(true, false));
+    fn owner_liveness_uses_start_time_to_defeat_pid_reuse() {
+        // Same pid, same start time -> the owner is genuinely still alive.
+        assert_eq!(
+            owner_liveness(&StartTimeProbe::StartedAt("t0".into()), "t0"),
+            OwnerLiveness::Alive
+        );
+        // Same pid, DIFFERENT start time -> the pid was recycled (e.g. a new
+        // June with a sequentially-reused pid); the original owner is dead, so
+        // its record is NOT treated as the new instance's own. This is the
+        // JUN-338 reopening the round-3 review caught.
+        assert_eq!(
+            owner_liveness(&StartTimeProbe::StartedAt("t1".into()), "t0"),
+            OwnerLiveness::Dead
+        );
+        assert_eq!(
+            owner_liveness(&StartTimeProbe::Gone, "t0"),
+            OwnerLiveness::Dead
+        );
+        // Probe failure is never treated as "dead" -> fail closed.
+        assert_eq!(
+            owner_liveness(&StartTimeProbe::Unknown, "t0"),
+            OwnerLiveness::Unknown
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn helper_match_skips_reused_pid_and_requires_identity() {
+        // Exact recorded process (pid + start time) that is still a helper.
+        assert_eq!(
+            helper_match(
+                &StartTimeProbe::StartedAt("t0".into()),
+                "t0",
+                &HelperIdentity::IsHelper
+            ),
+            HelperMatch::MatchesRecord
+        );
+        // Same pid, different start time -> reused by another process (possibly
+        // another live instance's helper); never a kill target.
+        assert_eq!(
+            helper_match(
+                &StartTimeProbe::StartedAt("t9".into()),
+                "t0",
+                &HelperIdentity::IsHelper
+            ),
+            HelperMatch::GoneOrReused
+        );
+        // Matching pid+start but the executable is not a helper -> not ours.
+        assert_eq!(
+            helper_match(
+                &StartTimeProbe::StartedAt("t0".into()),
+                "t0",
+                &HelperIdentity::NotHelper
+            ),
+            HelperMatch::GoneOrReused
+        );
+        assert_eq!(
+            helper_match(&StartTimeProbe::Gone, "t0", &HelperIdentity::NotHelper),
+            HelperMatch::GoneOrReused
+        );
+        // Identity indeterminate -> fail closed.
+        assert_eq!(
+            helper_match(
+                &StartTimeProbe::StartedAt("t0".into()),
+                "t0",
+                &HelperIdentity::Unknown
+            ),
+            HelperMatch::Unknown
+        );
+        assert_eq!(
+            helper_match(&StartTimeProbe::Unknown, "t0", &HelperIdentity::IsHelper),
+            HelperMatch::Unknown
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn decide_record_action_reaps_only_proven_orphans_and_fails_closed() {
+        // Live owner -> leave it (covers "this is my own record" and "another
+        // live instance's record").
+        assert_eq!(
+            decide_record_action(OwnerLiveness::Alive, HelperMatch::MatchesRecord),
+            RecordAction::Skip
+        );
+        // Proven-dead owner + the recorded helper still alive -> reap.
+        assert_eq!(
+            decide_record_action(OwnerLiveness::Dead, HelperMatch::MatchesRecord),
+            RecordAction::Reap
+        );
+        // Dead owner, helper already gone/reused -> just drop the stale record.
+        assert_eq!(
+            decide_record_action(OwnerLiveness::Dead, HelperMatch::GoneOrReused),
+            RecordAction::DeleteStale
+        );
+        // Any indeterminate identity -> fail closed (abort the replacement spawn).
+        assert_eq!(
+            decide_record_action(OwnerLiveness::Unknown, HelperMatch::MatchesRecord),
+            RecordAction::Abort
+        );
+        assert_eq!(
+            decide_record_action(OwnerLiveness::Dead, HelperMatch::Unknown),
+            RecordAction::Abort
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -2118,7 +2118,44 @@ fn helper_candidates(app: &AppHandle) -> Vec<PathBuf> {
     paths
 }
 
+/// The dictation helper binary's basename, shared by the bundled-binary lookup
+/// and the orphan reap below.
+#[cfg(target_os = "macos")]
+const DICTATION_HELPER_NAME: &str = "june-dictation-helper";
+
+/// Kills any dictation helper orphaned by a prior app instance before a fresh
+/// one is spawned. A stale helper — most often left by an in-app update relaunch
+/// that skipped teardown (JUN-338) — keeps the global CGEventTap and its stdio,
+/// so a newly spawned helper collides with it and never delivers a clean
+/// permission status. Best-effort and macOS-only. Safe to call here because
+/// `spawn_helper` only ever runs with no live helper of ours: first `setup`, or
+/// a supervised respawn after the previous helper already exited.
+#[cfg(target_os = "macos")]
+fn reap_orphaned_helpers() {
+    let _ = reap_orphaned_helpers_command()
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+#[cfg(not(target_os = "macos"))]
+fn reap_orphaned_helpers() {}
+
+/// Pure command construction so a test can assert the reap targets the helper by
+/// name. Matches on the full command line (`pkill -f`): the absolute spawn path
+/// always contains the binary name, so a truncated accounting name cannot hide
+/// the orphan, and no other process on the system carries this string.
+#[cfg(target_os = "macos")]
+fn reap_orphaned_helpers_command() -> Command {
+    let mut cmd = Command::new("/usr/bin/pkill");
+    cmd.arg("-f").arg(DICTATION_HELPER_NAME);
+    cmd
+}
+
 fn spawn_helper(app: &AppHandle) -> Result<HelperProcess, AppError> {
+    reap_orphaned_helpers();
+
     let helper_path = helper_candidates(app)
         .into_iter()
         .find(|path| path.exists())
@@ -4428,6 +4465,21 @@ pub fn key_code_for_code(code: &str) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn reap_orphaned_helpers_targets_helper_by_name() {
+        let cmd = reap_orphaned_helpers_command();
+        assert_eq!(cmd.get_program(), std::ffi::OsStr::new("/usr/bin/pkill"));
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        // `-f` matches the full command line so the absolute spawn path (which
+        // always contains the binary name) is caught even when the accounting
+        // name is truncated.
+        assert_eq!(args, ["-f", DICTATION_HELPER_NAME]);
+    }
 
     #[test]
     fn mic_duck_starts_on_listening_and_holds_through_levels() {

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -2554,6 +2554,187 @@ fn reap_orphaned_helpers(_app: &AppHandle) -> Result<(), AppError> {
     Ok(())
 }
 
+/// What to do with a *running* helper process found by name enumeration (the
+/// legacy/migration sweep) rather than by an ownership record.
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum UnrecordedAction {
+    /// Claimed by a live-owner record (a sibling instance's healthy helper) or
+    /// not confirmably a helper — leave it alone.
+    Skip,
+    /// An unclaimed, confirmed helper — a legacy/leftover orphan; kill it.
+    Reap,
+    /// Identity could not be established — fail closed: abort the spawn.
+    Abort,
+}
+
+/// The decision for one enumerated helper pid. Pure and total, so unit-testable.
+/// A pid claimed by a *live* owner is a running instance's helper (never
+/// touched); an unclaimed pid is reaped only when confirmed to still be a
+/// dictation helper, and an indeterminate identity fails closed.
+#[cfg(target_os = "macos")]
+fn decide_unrecorded_action(
+    claimed_by_live_owner: bool,
+    identity: &HelperIdentity,
+) -> UnrecordedAction {
+    if claimed_by_live_owner {
+        return UnrecordedAction::Skip;
+    }
+    match identity {
+        HelperIdentity::IsHelper => UnrecordedAction::Reap,
+        // Enumeration matched the name but `ps` disagrees on identity: do not
+        // kill an unconfirmed process.
+        HelperIdentity::NotHelper => UnrecordedAction::Skip,
+        HelperIdentity::Unknown => UnrecordedAction::Abort,
+    }
+}
+
+/// The helper pids that a *live-owner* ownership record currently claims. Used
+/// by the legacy sweep to avoid killing a concurrently-running sibling
+/// instance's healthy helper (debug multi-instance). Fails closed (error) on any
+/// inability to enumerate or read a record, mirroring [`reap_orphaned_helpers`].
+#[cfg(target_os = "macos")]
+fn live_owner_claimed_helper_pids(app: &AppHandle) -> Result<Vec<u32>, AppError> {
+    let Some(dir) = helper_ownership_dir(app) else {
+        return Ok(Vec::new());
+    };
+    let entries = match fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            tracing::warn!(%error, "dictation legacy reap: ownership dir unreadable; aborting spawn");
+            return Err(AppError::new(
+                "dictation_helper_reap_failed",
+                "Could not read the dictation helper ownership records.",
+            ));
+        }
+    };
+    let mut claimed = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            tracing::warn!(%error, "dictation legacy reap: ownership entry unreadable; aborting spawn");
+            AppError::new(
+                "dictation_helper_reap_failed",
+                "Could not enumerate the dictation helper ownership records.",
+            )
+        })?;
+        let path = entry.path();
+        let is_record = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| {
+                name.starts_with(HELPER_OWNER_RECORD_PREFIX) && name.ends_with(".json")
+            });
+        if !is_record {
+            continue;
+        }
+        let raw = match fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(error) => {
+                tracing::warn!(path = %path.display(), %error, "dictation legacy reap: ownership record unreadable; aborting spawn");
+                return Err(AppError::new(
+                    "dictation_helper_reap_failed",
+                    "Could not read a dictation helper ownership record.",
+                ));
+            }
+        };
+        // Unparseable records name no live orphan; the record-driven reap that
+        // ran first already dropped them. Ignore here.
+        let Ok(record) = serde_json::from_str::<HelperOwnershipRecord>(&raw) else {
+            continue;
+        };
+        if owner_liveness(&probe_start_time(record.app_pid), &record.app_start)
+            == OwnerLiveness::Alive
+        {
+            claimed.push(record.helper_pid);
+        }
+    }
+    Ok(claimed)
+}
+
+/// Enumerates running dictation-helper pids by matching the FULL command line
+/// (`pgrep -f`), which carries the untruncated binary name/path and so is robust
+/// to the `comm` truncation the record-driven path handles. Best-effort: `pgrep`
+/// exits non-zero with no matches, and any failure yields an empty list.
+#[cfg(target_os = "macos")]
+fn enumerate_running_helper_pids() -> Vec<u32> {
+    let output = Command::new("/usr/bin/pgrep")
+        .arg("-f")
+        .arg(DICTATION_HELPER_NAME)
+        .stdin(Stdio::null())
+        .output();
+    match output {
+        Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
+            .split_whitespace()
+            .filter_map(|token| token.parse::<u32>().ok())
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// One-time migration sweep for helpers left by a *pre-record* build. Those
+/// orphans have no `dictation-helper-owner-*.json`, so the record-driven
+/// [`reap_orphaned_helpers`] cannot see them: on the very upgrade that fixes
+/// JUN-338 the legacy helper would otherwise survive, keep the CGEventTap, and
+/// leave permissions wedged.
+///
+/// SAFETY / TRADEOFF (call out for review): this deliberately reintroduces the
+/// name-based enumeration that an earlier round replaced with ownership records.
+/// It is justified ONLY for the unrecorded/migration case, and made safe by
+/// skipping any pid a *live-owner* record claims — so a concurrently-running
+/// sibling instance's healthy helper is skipped once that sibling has recorded
+/// ownership. A debug-only TOCTOU remains: a sibling that has spawned its helper
+/// but not yet written its record (spawn precedes the record write) could be
+/// reaped by another instance's sweep. Production is single instance, so at
+/// startup-before-spawn there is no sibling and we have not spawned yet — any
+/// running helper is a legacy orphan and is reaped. Fails closed on record-read
+/// ambiguity but never livelocks: a genuine
+/// legacy orphan reads `IsHelper` and is killed so dictation recovers.
+#[cfg(target_os = "macos")]
+fn reap_unrecorded_helpers(app: &AppHandle) -> Result<(), AppError> {
+    let pids = enumerate_running_helper_pids();
+    if pids.is_empty() {
+        return Ok(());
+    }
+    let claimed = live_owner_claimed_helper_pids(app)?;
+    for pid in pids {
+        let claimed_by_live_owner = claimed.contains(&pid);
+        let identity = inspect_helper_identity(pid);
+        match decide_unrecorded_action(claimed_by_live_owner, &identity) {
+            UnrecordedAction::Skip => {}
+            UnrecordedAction::Reap => {
+                kill_pid(pid);
+                if !wait_for_pid_exit(pid, HELPER_ORPHAN_EXIT_TIMEOUT) {
+                    tracing::warn!(
+                        helper_pid = pid,
+                        "dictation legacy reap: unrecorded helper would not exit; aborting spawn"
+                    );
+                    return Err(AppError::new(
+                        "dictation_helper_orphan_stuck",
+                        "An orphaned dictation helper would not exit; retrying.",
+                    ));
+                }
+            }
+            UnrecordedAction::Abort => {
+                tracing::warn!(
+                    helper_pid = pid,
+                    "dictation legacy reap: could not establish helper identity; aborting spawn"
+                );
+                return Err(AppError::new(
+                    "dictation_helper_reap_failed",
+                    "Could not establish a running dictation helper's identity; retrying.",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn reap_unrecorded_helpers(_app: &AppHandle) -> Result<(), AppError> {
+    Ok(())
+}
+
 /// Submits SIGKILL to a single pid (best-effort; the caller confirms exit).
 #[cfg(target_os = "macos")]
 fn kill_pid(pid: u32) {
@@ -2601,7 +2782,10 @@ fn process_alive(pid: u32) -> bool {
 fn spawn_helper(app: &AppHandle) -> Result<HelperProcess, AppError> {
     // Abort the spawn if a prior instance's orphaned helper is still holding the
     // global CGEventTap; racing it would reproduce the permission collision.
+    // Record-driven reap first, then the one-time legacy sweep for helpers left
+    // by pre-record builds (no ownership record exists for those) — JUN-338.
     reap_orphaned_helpers(app)?;
+    reap_unrecorded_helpers(app)?;
 
     let helper_path = helper_candidates(app)
         .into_iter()
@@ -5059,6 +5243,41 @@ mod tests {
         assert_eq!(
             decide_record_action(OwnerLiveness::Dead, HelperMatch::Unknown),
             RecordAction::Abort
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn decide_unrecorded_action_reaps_only_unclaimed_confirmed_helpers() {
+        // Enumerated helper with no matching record (claimed=false) -> reap.
+        // This is the legacy/migration orphan from a pre-record build.
+        assert_eq!(
+            decide_unrecorded_action(false, &HelperIdentity::IsHelper),
+            UnrecordedAction::Reap
+        );
+        // A dead-owner record does not add to the live-claimed set, so its
+        // helper reads claimed=false here -> reap (same as no record).
+        //
+        // A live-owner record DOES claim its helper (claimed=true) -> skip, so a
+        // running sibling instance's healthy helper is never killed.
+        assert_eq!(
+            decide_unrecorded_action(true, &HelperIdentity::IsHelper),
+            UnrecordedAction::Skip
+        );
+        // pgrep matched the name but `ps` says it is not a helper -> do not kill.
+        assert_eq!(
+            decide_unrecorded_action(false, &HelperIdentity::NotHelper),
+            UnrecordedAction::Skip
+        );
+        // Identity indeterminate on an unclaimed pid -> fail closed.
+        assert_eq!(
+            decide_unrecorded_action(false, &HelperIdentity::Unknown),
+            UnrecordedAction::Abort
+        );
+        // Claimed by a live owner always wins, regardless of identity probe.
+        assert_eq!(
+            decide_unrecorded_action(true, &HelperIdentity::Unknown),
+            UnrecordedAction::Skip
         );
     }
 

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -2443,7 +2443,16 @@ fn reap_orphaned_helpers(app: &AppHandle) -> Result<(), AppError> {
             ));
         }
     };
-    for entry in entries.flatten() {
+    for entry in entries {
+        // A directory entry we cannot even enumerate might be a record naming a
+        // live orphan: fail closed rather than skip it as absent.
+        let entry = entry.map_err(|error| {
+            tracing::warn!(%error, "dictation reap: ownership entry unreadable; aborting spawn");
+            AppError::new(
+                "dictation_helper_reap_failed",
+                "Could not enumerate the dictation helper ownership records.",
+            )
+        })?;
         let path = entry.path();
         let is_record = path
             .file_name()
@@ -2454,13 +2463,21 @@ fn reap_orphaned_helpers(app: &AppHandle) -> Result<(), AppError> {
         if !is_record {
             continue;
         }
-        let Some(record) = fs::read_to_string(&path)
-            .ok()
-            .and_then(|raw| serde_json::from_str::<HelperOwnershipRecord>(&raw).ok())
-        else {
-            // Unparseable record: it names no identifiable process, so there is
-            // nothing to reap from it. Atomic writes make this near-impossible;
-            // drop the unactionable file rather than wedge every future spawn.
+        // Distinguish a read I/O error from malformed content. An unreadable
+        // record may name a live orphan still holding the event tap, so retain
+        // it and fail closed; only a successfully-read-but-unparseable record is
+        // the (atomic-write-guarded, near-impossible) delete-stale case.
+        let raw = match fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(error) => {
+                tracing::warn!(path = %path.display(), %error, "dictation reap: ownership record unreadable; aborting spawn");
+                return Err(AppError::new(
+                    "dictation_helper_reap_failed",
+                    "Could not read a dictation helper ownership record.",
+                ));
+            }
+        };
+        let Ok(record) = serde_json::from_str::<HelperOwnershipRecord>(&raw) else {
             tracing::warn!(path = %path.display(), "dictation reap: dropping unparseable ownership record");
             let _ = fs::remove_file(&path);
             continue;

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -2258,6 +2258,27 @@ fn probe_start_time(pid: u32) -> StartTimeProbe {
     }
 }
 
+/// Whether a `ps -o comm=` line names the dictation helper. Pure and
+/// truncation-tolerant: `comm=` may return the kernel `p_comm`, truncated to 15
+/// printable chars (`june-dictation-`) instead of the full 21-char name, so a
+/// basename that is a non-empty prefix of length ≥ 15 (the truncation length)
+/// counts as a match. No other expected process shares a 15-char prefix of
+/// `june-dictation-helper`, so this cannot false-positive. Handles both a bare
+/// `comm` and a full path (`rsplit('/')`).
+#[cfg(target_os = "macos")]
+fn comm_line_is_dictation_helper(comm_line: &str) -> bool {
+    let Some(basename) = comm_line
+        .trim()
+        .rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+    else {
+        return false;
+    };
+    basename == DICTATION_HELPER_NAME
+        || (basename.len() >= 15 && DICTATION_HELPER_NAME.starts_with(basename))
+}
+
 /// Tri-state executable-identity check via `ps -o comm=`. `Unknown` when `ps`
 /// could not run; `NotHelper` when the pid is gone or is a different program.
 #[cfg(target_os = "macos")]
@@ -2273,13 +2294,7 @@ fn inspect_helper_identity(pid: u32) -> HelperIdentity {
         Err(_) => HelperIdentity::Unknown,
         Ok(output) if !output.status.success() => HelperIdentity::NotHelper,
         Ok(output) => {
-            let is_helper = String::from_utf8_lossy(&output.stdout)
-                .trim()
-                .rsplit('/')
-                .next()
-                .map(|basename| basename == DICTATION_HELPER_NAME)
-                .unwrap_or(false);
-            if is_helper {
+            if comm_line_is_dictation_helper(&String::from_utf8_lossy(&output.stdout)) {
                 HelperIdentity::IsHelper
             } else {
                 HelperIdentity::NotHelper
@@ -2326,7 +2341,13 @@ fn helper_match(
                 match identity {
                     HelperIdentity::Unknown => HelperMatch::Unknown,
                     HelperIdentity::IsHelper => HelperMatch::MatchesRecord,
-                    HelperIdentity::NotHelper => HelperMatch::GoneOrReused,
+                    // Exact recorded (pid, start_time) but the executable does
+                    // not read as the helper. With the truncation-tolerant
+                    // identity check above, a real helper reads IsHelper, so this
+                    // is only a genuine same-second pid reuse by a non-helper —
+                    // rare. Fail closed (abort + retry) rather than delete the
+                    // record and risk racing an orphan.
+                    HelperIdentity::NotHelper => HelperMatch::Unknown,
                 }
             }
         }
@@ -4908,6 +4929,29 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    fn comm_line_identity_is_truncation_tolerant() {
+        // Full path (comm= returned the executable path).
+        assert!(comm_line_is_dictation_helper(
+            "/Applications/June Dictation Helper.app/Contents/MacOS/june-dictation-helper"
+        ));
+        // Bare full name.
+        assert!(comm_line_is_dictation_helper("june-dictation-helper"));
+        // Kernel p_comm truncated to 15 chars: the real orphan MUST still read
+        // as the helper, or it is deleted-not-killed and JUN-338 reopens.
+        assert!(comm_line_is_dictation_helper("june-dictation-"));
+        // Trailing whitespace/newline from ps is tolerated.
+        assert!(comm_line_is_dictation_helper("june-dictation-helper\n"));
+        // A shorter prefix (< 15) is ambiguous and must NOT match.
+        assert!(!comm_line_is_dictation_helper("june-dictation"));
+        // Unrelated process and empty output never match.
+        assert!(!comm_line_is_dictation_helper("/usr/bin/login"));
+        assert!(!comm_line_is_dictation_helper("bash"));
+        assert!(!comm_line_is_dictation_helper(""));
+        assert!(!comm_line_is_dictation_helper("   "));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
     fn owner_liveness_uses_start_time_to_defeat_pid_reuse() {
         // Same pid, same start time -> the owner is genuinely still alive.
         assert_eq!(
@@ -4955,15 +4999,20 @@ mod tests {
             ),
             HelperMatch::GoneOrReused
         );
-        // Matching pid+start but the executable is not a helper -> not ours.
+        // Matching pid+start but the executable does not read as a helper. With
+        // the truncation-tolerant identity check this is only a genuine
+        // same-second pid reuse by a non-helper -> fail closed (abort), never
+        // delete-and-race.
         assert_eq!(
             helper_match(
                 &StartTimeProbe::StartedAt("t0".into()),
                 "t0",
                 &HelperIdentity::NotHelper
             ),
-            HelperMatch::GoneOrReused
+            HelperMatch::Unknown
         );
+        // Gone/reused pid (start-time mismatch or dead) with a non-helper -> the
+        // record names no live orphan, so it is safe to treat as stale.
         assert_eq!(
             helper_match(&StartTimeProbe::Gone, "t0", &HelperIdentity::NotHelper),
             HelperMatch::GoneOrReused

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -11,7 +11,7 @@ use std::{
     path::{Component, Path, PathBuf},
     process::{Child, Command, Stdio},
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex,
     },
     time::{Duration, Instant},
@@ -436,6 +436,12 @@ pub struct HermesBridge {
     /// Recently delivered recorder request ids (see
     /// `recorder_request_recently_completed`).
     recorder_completed: Mutex<std::collections::VecDeque<String>>,
+    /// Latched once at app teardown (`shutdown`). A start that observes it set
+    /// must not leave a registered runtime behind, so the teardown that is about
+    /// to reap the process tree does not race an in-flight start that re-orphans
+    /// it (JUN-338). Set *before* the drain; checked under the `processes` lock
+    /// at registration, so the flag and the drain observe a single ordering.
+    shutting_down: AtomicBool,
 }
 
 struct HermesProcess {
@@ -1040,6 +1046,17 @@ async fn start_hermes_bridge_inner(
     // sees the winner's running process.
     let _start_guard = bridge.start_lock.lock().await;
 
+    // Bail fast if the app is tearing down: no point building a runtime the
+    // teardown is about to reap, and a late spawn could re-orphan the tree. The
+    // authoritative, race-free check is the one at registration below; this is
+    // only an early out.
+    if bridge.shutting_down.load(Ordering::SeqCst) {
+        return Err(AppError::new(
+            "hermes_bridge_shutting_down",
+            "June is shutting down; Hermes runtime start skipped.",
+        ));
+    }
+
     // Ensure the requested mode (None = the sandboxed default). The other
     // mode's process — if one is up — is deliberately untouched: the pair
     // runs side by side so a session in one mode never kills the other's
@@ -1248,6 +1265,22 @@ async fn start_hermes_bridge_inner(
                 drop(guard);
                 return Ok(status_for(live_connections(bridge)?, Some(full_mode)));
             }
+        }
+        // Race-free teardown handshake (JUN-338): `shutdown` latches the flag
+        // *before* it drains under this same lock. If it is set here, the drain
+        // has already run (or is about to) and would miss a process we register
+        // now, re-orphaning the tree the teardown is reaping. Reap what we
+        // spawned instead of registering it.
+        if bridge.shutting_down.load(Ordering::SeqCst) {
+            drop(guard);
+            #[cfg(unix)]
+            kill_process_group(child.id());
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(AppError::new(
+                "hermes_bridge_shutting_down",
+                "June is shutting down; Hermes runtime start skipped.",
+            ));
         }
         guard.insert(
             full_mode,
@@ -3380,6 +3413,11 @@ fn hermes_file_mime_type(path: &Path) -> Option<&'static str> {
 
 pub fn shutdown(app: &tauri::AppHandle) {
     let bridge = app.state::<HermesBridge>();
+    // Latch teardown *before* draining so an in-flight `start_hermes_bridge_inner`
+    // cannot register a runtime after the drain and re-orphan the tree we are
+    // about to reap (JUN-338). The flag is permanent: nothing restarts the
+    // bridge after shutdown. See the registration handshake in that function.
+    bridge.shutting_down.store(true, Ordering::SeqCst);
     let _ = stop_hermes_bridge_inner(&bridge);
     let proxy = bridge
         .provider_proxy

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -11,7 +11,7 @@ use std::{
     path::{Component, Path, PathBuf},
     process::{Child, Command, Stdio},
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         Arc, Mutex,
     },
     time::{Duration, Instant},
@@ -442,6 +442,28 @@ pub struct HermesBridge {
     /// it (JUN-338). Set *before* the drain; checked under the `processes` lock
     /// at registration, so the flag and the drain observe a single ordering.
     shutting_down: AtomicBool,
+    /// Number of starts currently between spawning a runtime child and either
+    /// registering it into `processes` or reaping it. `shutdown` waits for this
+    /// to reach zero before draining, so a child spawned but not-yet-registered
+    /// can never be orphaned by the drain-then-restart (JUN-338).
+    starts_in_progress: AtomicUsize,
+}
+
+/// RAII counter for [`HermesBridge::starts_in_progress`], so every exit path of
+/// a start (including `?` early returns) decrements exactly once.
+struct StartInProgressGuard<'a>(&'a AtomicUsize);
+
+impl<'a> StartInProgressGuard<'a> {
+    fn new(counter: &'a AtomicUsize) -> Self {
+        counter.fetch_add(1, Ordering::SeqCst);
+        Self(counter)
+    }
+}
+
+impl Drop for StartInProgressGuard<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 struct HermesProcess {
@@ -1046,6 +1068,13 @@ async fn start_hermes_bridge_inner(
     // sees the winner's running process.
     let _start_guard = bridge.start_lock.lock().await;
 
+    // Count this start as in-progress for the whole spawn->register window so a
+    // concurrent `shutdown` waits for it (below) before draining, and a child we
+    // spawn can never be orphaned by a drain-then-restart (JUN-338). Dropped
+    // explicitly once the child is registered or reaped, before the readiness
+    // wait, so teardown never blocks on the (up to 45s) readiness timeout.
+    let start_progress = StartInProgressGuard::new(&bridge.starts_in_progress);
+
     // Bail fast if the app is tearing down: no point building a runtime the
     // teardown is about to reap, and a late spawn could re-orphan the tree. The
     // authoritative, race-free check is the one at registration below; this is
@@ -1291,6 +1320,11 @@ async fn start_hermes_bridge_inner(
             },
         );
     }
+
+    // Registered: the drain can now see and reap this process, so teardown no
+    // longer needs to wait on this start. Release before the readiness wait so
+    // shutdown is not blocked for the readiness timeout.
+    drop(start_progress);
 
     if let Err(error) = wait_for_hermes(&base_url, &token).await {
         // Only tear down the exact process this start spawned. If a stop (or
@@ -3418,6 +3452,11 @@ pub fn shutdown(app: &tauri::AppHandle) {
     // about to reap (JUN-338). The flag is permanent: nothing restarts the
     // bridge after shutdown. See the registration handshake in that function.
     bridge.shutting_down.store(true, Ordering::SeqCst);
+    // Then wait for any start that already spawned a child to finish registering
+    // it (so the drain reaps it) or reaping it itself. Without this, a child
+    // spawned but not-yet-registered would be missed by the drain and orphaned
+    // when `relaunch_for_update` restarts the app moments later.
+    await_starts_quiesced(&bridge, SHUTDOWN_START_QUIESCE_TIMEOUT);
     let _ = stop_hermes_bridge_inner(&bridge);
     let proxy = bridge
         .provider_proxy
@@ -3428,6 +3467,25 @@ pub fn shutdown(app: &tauri::AppHandle) {
         if let Some(shutdown) = proxy.shutdown.take() {
             let _ = shutdown.send(());
         }
+    }
+}
+
+/// How long `shutdown` waits for in-flight starts to register/reap their spawned
+/// child before draining. The window it guards (spawn -> register) is short, so
+/// this is only a safety bound; teardown proceeds regardless once it elapses.
+const SHUTDOWN_START_QUIESCE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Blocks until no start is between spawning a child and registering/reaping it,
+/// or the timeout elapses. Sync (called from the sync teardown path) and cheap:
+/// the guarded window is milliseconds and at most one start runs at a time (the
+/// `start_lock` serializes them).
+fn await_starts_quiesced(bridge: &HermesBridge, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while bridge.starts_in_progress.load(Ordering::SeqCst) > 0 {
+        if Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(5));
     }
 }
 
@@ -10964,6 +11022,61 @@ async fn wait_for_hermes(base_url: &str, token: &str) -> Result<(), AppError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn shutdown_waits_for_in_flight_start_to_register() {
+        // Simulate a start that has spawned a child but not yet registered it:
+        // the in-progress counter is held, then released 100ms later (as the
+        // real start would after inserting into `processes`). `shutdown`'s
+        // quiesce wait must not return before that release, or the drain would
+        // run while a child is unregistered and orphan it (JUN-338).
+        let bridge = Arc::new(HermesBridge::default());
+        bridge.starts_in_progress.fetch_add(1, Ordering::SeqCst);
+        assert_eq!(bridge.starts_in_progress.load(Ordering::SeqCst), 1);
+
+        let released = Arc::new(AtomicBool::new(false));
+        let releaser = {
+            let bridge = bridge.clone();
+            let released = released.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(100));
+                released.store(true, Ordering::SeqCst);
+                bridge.starts_in_progress.fetch_sub(1, Ordering::SeqCst);
+            })
+        };
+
+        let start = Instant::now();
+        await_starts_quiesced(&bridge, Duration::from_secs(2));
+
+        // Returned only after the in-flight start released — proving teardown
+        // blocked on it rather than racing ahead to the drain.
+        assert!(released.load(Ordering::SeqCst));
+        assert!(start.elapsed() >= Duration::from_millis(90));
+        assert_eq!(bridge.starts_in_progress.load(Ordering::SeqCst), 0);
+        releaser.join().unwrap();
+    }
+
+    #[test]
+    fn start_in_progress_guard_counts_up_then_down_on_drop() {
+        let bridge = HermesBridge::default();
+        {
+            let _guard = StartInProgressGuard::new(&bridge.starts_in_progress);
+            assert_eq!(bridge.starts_in_progress.load(Ordering::SeqCst), 1);
+        }
+        assert_eq!(bridge.starts_in_progress.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn await_starts_quiesced_bounds_the_wait_when_a_start_never_finishes() {
+        // A start that never completes must not hang teardown forever: the wait
+        // returns at the timeout even with the counter still held.
+        let bridge = HermesBridge::default();
+        let _guard = StartInProgressGuard::new(&bridge.starts_in_progress);
+        let start = Instant::now();
+        await_starts_quiesced(&bridge, Duration::from_millis(50));
+        assert!(start.elapsed() >= Duration::from_millis(45));
+        assert!(start.elapsed() < Duration::from_secs(1));
+    }
 
     #[cfg(unix)]
     #[test]

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1199,6 +1199,17 @@ async fn start_hermes_bridge_inner(
     );
     cmd.current_dir(&cwd);
 
+    // Put the runtime in its own process group so teardown can reap the whole
+    // tree, not just the tracked child. The dashboard (and, unsandboxed, the
+    // Python runtime it becomes) can fork worker subprocesses; a bare
+    // `child.kill()` would leave those orphaned when the app quits or relaunches
+    // for an update (JUN-338). See `shutdown_hermes_process`.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt as _;
+        cmd.process_group(0);
+    }
+
     let mut child = cmd.spawn().map_err(|error| {
         AppError::new(
             "hermes_bridge_start_failed",
@@ -5789,9 +5800,31 @@ fn stop_hermes_bridge_generation(bridge: &HermesBridge, generation: u64) -> Resu
 
 fn shutdown_hermes_process(mut process: Option<HermesProcess>) {
     if let Some(process) = process.as_mut() {
+        // Sweep the runtime's process group first so any worker subprocess it
+        // forked dies with it rather than detaching and outliving the app (the
+        // child spawns into its own group; see the spawn site). Then kill and
+        // reap the tracked child itself.
+        #[cfg(unix)]
+        kill_process_group(process.child.id());
         let _ = process.child.kill();
         let _ = process.child.wait();
     }
+}
+
+/// Best-effort SIGKILL to a whole process group, addressed by the leader's pid
+/// (a negative target is a process group). Shells out to `/bin/kill` to stay
+/// dependency-free, matching the module's other system-utility spawns. Only
+/// meaningful for a child spawned with `process_group(0)`, whose pid is its
+/// group id.
+#[cfg(unix)]
+fn kill_process_group(pid: u32) {
+    let _ = Command::new("/bin/kill")
+        .arg("-KILL")
+        .arg(format!("-{pid}"))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
 }
 
 async fn resolve_hermes_command(
@@ -10893,6 +10926,45 @@ async fn wait_for_hermes(base_url: &str, token: &str) -> Result<(), AppError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn kill_process_group_reaps_a_forked_child() {
+        use std::os::unix::process::CommandExt as _;
+
+        // A parent in its own process group that forks a long-lived grandchild.
+        // A bare kill of the parent would leave the `sleep` orphaned; the
+        // group-addressed kill must take both down.
+        let mut parent = Command::new("/bin/sh")
+            .arg("-c")
+            .arg("/bin/sleep 300 & sleep 300")
+            .process_group(0)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn test process group");
+        let pid = parent.id();
+
+        kill_process_group(pid);
+
+        // The parent must be gone promptly; if the group kill missed it, this
+        // wait would hang for the full 300s sleep.
+        let start = Instant::now();
+        loop {
+            match parent.try_wait() {
+                Ok(Some(_)) => break,
+                Ok(None) if start.elapsed() < Duration::from_secs(5) => {
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                Ok(None) => {
+                    let _ = parent.kill();
+                    panic!("process group was not killed");
+                }
+                Err(error) => panic!("wait failed: {error}"),
+            }
+        }
+    }
 
     #[test]
     fn ensure_video_defaults_injects_missing_knobs_under_the_keys_june_api_reads() {

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1279,9 +1279,18 @@ async fn start_hermes_bridge_inner(
 
     let generation = bridge.next_generation.fetch_add(1, Ordering::Relaxed) + 1;
     {
-        let mut guard = bridge.processes.lock().map_err(|_| {
-            AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed.")
-        })?;
+        // A poisoned lock must not drop `child` and detach it: reap the process
+        // group first (JUN-338).
+        let mut guard = match bridge.processes.lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                reap_unregistered_child(&mut child);
+                return Err(AppError::new(
+                    "hermes_bridge_unavailable",
+                    "Hermes bridge lock failed.",
+                ));
+            }
+        };
         // The start guard serializes starts, so no concurrent start can have
         // populated this mode's slot since the live-connections check above.
         // Keep a defensive check anyway: if a live process is somehow present
@@ -1289,8 +1298,7 @@ async fn start_hermes_bridge_inner(
         // of leaking it.
         if let Some(existing) = guard.get_mut(&full_mode) {
             if matches!(existing.child.try_wait(), Ok(None)) {
-                let _ = child.kill();
-                let _ = child.wait();
+                reap_unregistered_child(&mut child);
                 drop(guard);
                 return Ok(status_for(live_connections(bridge)?, Some(full_mode)));
             }
@@ -1302,10 +1310,7 @@ async fn start_hermes_bridge_inner(
         // spawned instead of registering it.
         if bridge.shutting_down.load(Ordering::SeqCst) {
             drop(guard);
-            #[cfg(unix)]
-            kill_process_group(child.id());
-            let _ = child.kill();
-            let _ = child.wait();
+            reap_unregistered_child(&mut child);
             return Err(AppError::new(
                 "hermes_bridge_shutting_down",
                 "June is shutting down; Hermes runtime start skipped.",
@@ -5905,6 +5910,18 @@ fn shutdown_hermes_process(mut process: Option<HermesProcess>) {
         let _ = process.child.kill();
         let _ = process.child.wait();
     }
+}
+
+/// Reaps a runtime child that was spawned but never registered into
+/// `processes`, so no post-spawn error path (poisoned lock, a redundant-launch
+/// short-circuit, a teardown handshake) can drop the `Child` and detach it. The
+/// child spawns into its own process group, so this also reaps any worker it
+/// forked (JUN-338).
+fn reap_unregistered_child(child: &mut Child) {
+    #[cfg(unix)]
+    kill_process_group(child.id());
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 /// Best-effort SIGKILL to a whole process group, addressed by the leader's pid
@@ -11115,6 +11132,30 @@ mod tests {
                 Err(error) => panic!("wait failed: {error}"),
             }
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reap_unregistered_child_group_kills_on_post_spawn_error() {
+        use std::os::unix::process::CommandExt as _;
+
+        // Mirrors a runtime spawned but not yet registered when an error path
+        // (poisoned lock, teardown handshake) fires: the child and any worker it
+        // forked must both die rather than orphan.
+        let mut child = Command::new("/bin/sh")
+            .arg("-c")
+            .arg("/bin/sleep 300 & sleep 300")
+            .process_group(0)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn unregistered child");
+
+        reap_unregistered_child(&mut child);
+
+        // Already reaped by the helper; a second wait resolves immediately.
+        assert!(matches!(child.try_wait(), Ok(Some(_)) | Err(_)));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -313,6 +313,7 @@ pub fn run() {
             updates::set_release_channel,
             updates::fetch_update,
             updates::install_update,
+            updates::relaunch_for_update,
         ])
         .manage(RecordingPresenceBoundsState::default())
         .manage(hermes_bridge::HermesBridge::default())

--- a/src-tauri/src/updates.rs
+++ b/src-tauri/src/updates.rs
@@ -260,6 +260,25 @@ pub async fn install_update(
     Ok(())
 }
 
+/// Relaunches June after an in-app update has been staged, running the same
+/// child-process teardown app quit does *before* the process restarts.
+///
+/// The plugin `relaunch()` (and `AppHandle::restart()` on the main thread)
+/// restarts without a guaranteed pass through the `RunEvent::Exit` cleanup that
+/// reaps June's children. On an update the `.app` bundle is swapped, so a
+/// skipped teardown orphans the dictation helper — which keeps the global
+/// CGEventTap and its stdio — and the relaunched instance then cannot bring up a
+/// clean helper, so every helper-reported permission (mic, accessibility,
+/// system audio) reads missing even though the grants are intact (JUN-338).
+/// Tearing down explicitly here guarantees the helper (and the Hermes runtime)
+/// are gone before the new instance starts.
+#[tauri::command]
+pub fn relaunch_for_update(app: AppHandle) {
+    crate::dictation::stop_helper(&app);
+    crate::hermes_bridge::shutdown(&app);
+    app.restart();
+}
+
 #[tauri::command]
 pub fn get_release_channel(
     state: State<'_, ReleaseChannelState>,

--- a/src-tauri/src/updates.rs
+++ b/src-tauri/src/updates.rs
@@ -268,8 +268,8 @@ pub async fn install_update(
 /// reaps June's children. On an update the `.app` bundle is swapped, so a
 /// skipped teardown orphans the dictation helper — which keeps the global
 /// CGEventTap and its stdio — and the relaunched instance then cannot bring up a
-/// clean helper, so every helper-reported permission (mic, accessibility,
-/// system audio) reads missing even though the grants are intact (JUN-338).
+/// clean helper, so every helper-reported permission (dictation mic and
+/// accessibility) reads missing even though the grants are intact (JUN-338).
 /// Tearing down explicitly here guarantees the helper (and the Hermes runtime)
 /// are gone before the new instance starts.
 #[tauri::command]

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,5 +1,4 @@
 import { Channel, invoke } from "@tauri-apps/api/core";
-import { relaunch } from "@tauri-apps/plugin-process";
 
 /** The two release streams. Wire form matches the Rust `ReleaseChannel`. */
 export type ReleaseChannel = "stable" | "rc";
@@ -78,6 +77,14 @@ function installStagedUpdate(onEvent?: (event: DownloadEvent) => void): Promise<
   return invoke("install_update", { onEvent: channel });
 }
 
+/**
+ * Relaunches June to finish a staged update. Routes through the Rust
+ * `relaunch_for_update` command instead of the plugin `relaunch()` so June's
+ * child processes (the dictation helper, the Hermes runtime) are torn down
+ * before the process restarts. A bare relaunch can skip that teardown and orphan
+ * the helper, which then blocks the new instance from reading permissions
+ * (JUN-338).
+ */
 export function relaunchJune() {
-  return relaunch();
+  return invoke("relaunch_for_update");
 }

--- a/src/test/updater.test.ts
+++ b/src/test/updater.test.ts
@@ -5,6 +5,7 @@ import {
   checkJuneUpdate,
   getReleaseChannel,
   reconcileToStable,
+  relaunchJune,
   setReleaseChannel,
 } from "../lib/updater";
 
@@ -110,5 +111,18 @@ describe("release channel setting", () => {
     expect(invokeMock).toHaveBeenCalledWith("set_release_channel", {
       channel: "rc",
     });
+  });
+});
+
+describe("relaunchJune", () => {
+  it("routes through the Rust command that tears down children first", async () => {
+    invokeMock.mockResolvedValueOnce(undefined);
+
+    await relaunchJune();
+
+    // Not the plugin `relaunch()`: the command runs the dictation-helper and
+    // Hermes teardown before restarting so the relaunched instance is not
+    // blocked by an orphaned helper (JUN-338).
+    expect(invokeMock).toHaveBeenCalledWith("relaunch_for_update");
   });
 });


### PR DESCRIPTION
Closes JUN-338.

## Summary

On macOS, after an **in-app update + "Relaunch to update"**, microphone, accessibility, and system-audio permissions all reported **missing** even though they were granted in System Settings. A fresh install worked; the in-app-update relaunch did not. This makes the app's core recording/dictation flows unusable for any user who updates in place.

## Root cause

The in-app update relaunch (`relaunchJune()` → the plugin's bare `relaunch()`) restarted the process **without a guaranteed pass through the `RunEvent::Exit` cleanup** (`dictation::stop_helper` + `hermes_bridge::shutdown`). The dictation helper (which reports mic + accessibility) was therefore orphaned across the `.app` bundle swap; the relaunched instance's `spawn_helper` had no step to detect/kill the orphan, so the new helper collided with the old one holding the global CGEventTap and never delivered a clean `permission_status` — all helper-reported permissions read missing. This is **not** a permission-logic regression: the read path and the Swift helper are unchanged from the working release.

## What changed

- **Teardown runs on update relaunch.** New `relaunch_for_update` command runs `dictation::stop_helper` + `hermes_bridge::shutdown` before `app.restart()`; `relaunchJune()` invokes it instead of the bare `relaunch()`.
- **Ownership-aware helper reap on startup.** Each spawn records `(app_pid, app_start, helper_pid, helper_start)` to a per-owner file, written atomically (temp + fsync + rename). Startup reaps **only** a recorded helper whose owner is proven dead and whose `(pid, start-time)` still matches — never a live instance's helper, and never a recycled PID. The reap confirms the orphan has actually exited (bounded poll) before spawning the replacement, and **fails closed**: if identity can't be established, or a record can't be enumerated/read, it aborts the spawn and retains the record rather than spawning over a possible live orphan.
- **Hermes child lifecycle hardened.** Runtime children are spawned in their own process group and group-killed on shutdown and on **every** post-spawn error path (poisoned-lock, redundant-launch, teardown-handshake), so a spawned-but-unregistered runtime can't be orphaned. A `shutting_down` flag re-checked under the `processes` lock plus a start-in-progress guard close the drain/register race.

## Tested visually

No — this is a native macOS update+relaunch path that can't be exercised off the release channel here. Coverage is **unit-level** (pure classifiers for the ownership/identity/fail-closed logic, plus process-group-kill and quiesce/guard tests) and code reasoning. Full local gate green: `cargo clippy -D warnings`, `cargo fmt`, `cargo test` (dictation + hermes_bridge), `pnpm typecheck`, `updater.test.ts`. **Please confirm end-to-end on a signed RC build doing a real in-app update** before promoting.

## Needs a June API deploy

No — desktop-only; no `/v1/*` change.

## Review

Ran the repo review battery cross-harness (Codex + Opus) over four adversarial rounds; each round's real findings were fixed (broad `pkill` → ownership-aware; teardown race; non-atomic records; reap-without-confirm-exit; spawn-before-register; PID-reuse identity; group-kill on all post-spawn paths; fail-closed record enumeration/read).

## Known residuals / deliberately deferred

- **Ownership-aware startup reap of orphaned Hermes *runtime* processes** — the current teardown covers the drain/register window with a 2s bounded quiesce; a Hermes `spawn()`/startup taking >2s concurrent with an update-relaunch is a narrow residual a symmetric startup-reap would close. Deferred to a follow-up (linked below) to keep this diff review-able and avoid re-touching the delicate start path.
- **Inherent-POSIX PID TOCTOU** — single-PID `kill` plus `ps lstart`'s 1-second precision leave a negligible same-PID/same-second recycle window; killing an unrelated same-user process would require a recycle to *another actual dictation-helper* in microseconds. Accepted as inherent; a kernel-backed identity (libproc) is possible future hardening.

## Followups

- Ownership-aware startup reap for orphaned Hermes runtimes (symmetric with the dictation-helper reap).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786708162&installation_id=144203540&pr_number=780&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F780&signature=9ea5ee8c6ef73bffcc759e5b92d35c9228ddc412a27a1588c359fbe031e1620d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->