### PR TITLE
Keep chat content visible above the composer

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -9650,7 +9650,7 @@ export function AgentWorkspace({
     // persisted, never retried.
     w.__imageGenDemo = (
       show: boolean | "complete" = true,
-      prompt = "a calm mountain lake at dawn",
+      prompt = "Generate an image of a wide, zoomed-out view of people sunbathing along the Rio Grande in New Mexico, painted in the style of Claude Monet. The riverbank is as crowded and lively as a New Jersey beach, creating a striking contrast with the high-desert landscape.",
     ) => {
       if (!selectedHermesSessionId || selectedHermesSessionIsProvisional) {
         return "Open a real session first, then run __imageGenDemo().";
@@ -9695,6 +9695,32 @@ export function AgentWorkspace({
           [selectedHermesSessionId]: show
             ? [
                 ...others,
+                {
+                  id: `${turnId}:seed-user`,
+                  role: "user" as const,
+                  createdAt: new Date(startedAt - 120_000).toISOString(),
+                  status: "complete" as const,
+                  parts: [
+                    {
+                      type: "text" as const,
+                      text: "I'm putting together a visual concept for a summer scene in New Mexico.",
+                      status: "complete" as const,
+                    },
+                  ],
+                },
+                {
+                  id: `${turnId}:seed-assistant`,
+                  role: "assistant" as const,
+                  createdAt: new Date(startedAt - 60_000).toISOString(),
+                  status: "complete" as const,
+                  parts: [
+                    {
+                      type: "text" as const,
+                      text: "What kind of setting and atmosphere would you like the image to have?",
+                      status: "complete" as const,
+                    },
+                  ],
+                },
                 ...runningImageSlashTurns({
                   id: turnId,
                   prompt,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -534,10 +534,10 @@ input:focus-visible,
   overflow-y: auto;
   overscroll-behavior: contain;
   margin: calc(-1 * var(--detail-bar-h)) calc(-1 * var(--sp-8)) 0;
-  /* The fixed composer is outside layout. Its measured overlap grows with the
-   * Up next queue and shrinks as rows drain; the final gap keeps the last chat
-   * item visibly separated from the top of that floating surface. */
-  padding: var(--detail-bar-h) var(--sp-8) calc(var(--agent-composer-clearance, 0px) + var(--sp-5));
+  /* The fixed composer is outside layout. Keep the resting gap here; its live
+   * overlap is reserved on the in-flow .agent-main child below so WebKit
+   * cannot absorb it into a non-scrolling flex viewport. */
+  padding: var(--detail-bar-h) var(--sp-8) var(--sp-5);
   /* Center the thread column from the LEFT GUTTER, not margin:auto inside the
    * scroller: the classic scrollbar steals an engine-specific slice of the
    * content box (8px custom in Chrome, wider native in WKWebView), and auto
@@ -584,7 +584,11 @@ input:focus-visible,
  * Auto margins here would re-split the scrollbar's bite into the centering.
  * The hero's .agent-main has no scrollbar and keeps margin:auto. */
 .agent-scroll .agent-main {
-  margin: 0;
+  /* The measured composer overlap grows with the Up next queue and shrinks as
+   * rows drain. It must live on this in-flow child, not as outer scroller
+   * padding: WKWebView can otherwise report no scroll range when a short thread
+   * fits the full viewport but not the unobscured space above the composer. */
+  margin: 0 0 var(--agent-composer-clearance, 0px);
 }
 
 .agent-detail-title {
@@ -3109,12 +3113,12 @@ input:focus-visible,
   overflow: hidden;
   /* Concentric with the card: inner radius = outer - the card's 4px inset. */
   border-radius: calc(var(--r-lg) - var(--sp-1));
-  /* The gray canvas itself gradates into the card surface at the bottom (and
+  /* The quiet canvas tint gradates into the card surface at the bottom (and
    * the dot field thins out over the same run), so the footer transition is
    * owned by the background rather than an overlay fading in on top. */
   background: linear-gradient(
     to bottom,
-    color-mix(in oklch, var(--secondary) 97%, var(--foreground)) 62%,
+    color-mix(in oklch, var(--secondary) 60%, var(--card)) 62%,
     var(--card)
   );
   color: var(--muted-foreground);
@@ -3128,7 +3132,7 @@ input:focus-visible,
 [data-theme="dark"] .agent-generated-video-placeholder,
 [data-theme="dark"] .agent-generated-media-reveal {
   --agent-generated-dot-alpha: 0.05;
-  --agent-generated-sheen-glow: 0.27;
+  --agent-generated-sheen-glow: 0.15;
   --agent-generated-mark-alpha: 0.3;
   color: var(--foreground);
 }

--- a/src/test/agent-scroll-to-latest-css.test.ts
+++ b/src/test/agent-scroll-to-latest-css.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import appCss from "../styles/app.css?raw";
 
-function cssRuleFor(selector: string) {
+function cssRuleFor(selector: string, topLevel = false) {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = new RegExp(`${escaped}\\s*\\{`).exec(appCss);
-  if (!match) throw new Error(`Missing CSS rule for ${selector}`);
+  const match = new RegExp(`${topLevel ? "(?:^|\\n)" : ""}${escaped}\\s*\\{`).exec(appCss);
+  if (!match) throw new Error(`Missing ${topLevel ? "top-level " : ""}CSS rule for ${selector}`);
   const openIndex = match.index + match[0].length - 1;
   let depth = 0;
   for (let index = openIndex; index < appCss.length; index += 1) {
@@ -14,12 +14,18 @@ function cssRuleFor(selector: string) {
       if (depth === 0) return appCss.slice(openIndex + 1, index);
     }
   }
-  throw new Error(`Unclosed CSS rule for ${selector}`);
+  throw new Error(`Unclosed ${topLevel ? "top-level " : ""}CSS rule for ${selector}`);
 }
 
 describe("agent scroll-to-latest styles", () => {
   it("reserves the measured fixed-composer overlap below the conversation", () => {
-    expect(appCss).toContain("calc(var(--agent-composer-clearance, 0px) + var(--sp-5))");
+    expect(cssRuleFor(".agent-scroll", true)).toContain(
+      "padding: var(--detail-bar-h) var(--sp-8) var(--sp-5)",
+    );
+    expect(cssRuleFor(".agent-scroll", true)).not.toContain("--agent-composer-clearance");
+    expect(cssRuleFor(".agent-scroll .agent-main", true)).toContain(
+      "margin: 0 0 var(--agent-composer-clearance, 0px)",
+    );
     expect(cssRuleFor(".agent-timeline")).not.toContain("148px");
     expect(cssRuleFor(".agent-timeline")).toContain(
       "calc(var(--agent-turn-actions-h) + var(--sp-2))",


### PR DESCRIPTION
## Summary

- keep short and medium chat threads scrollable above the fixed composer in WKWebView
- seed the image-generation demo with a natural conversation and a Rio Grande prompt for recording
- soften the generated-media canvas and dark-mode sheen while preserving the loading motion

## Root cause

The measured composer overlap was applied as bottom padding on the flex scroller. In WKWebView, a thread that fit the full viewport but not the unobscured area above the composer could absorb that padding without increasing `scrollHeight`. The final turn then had no scroll range and could remain beneath the composer.

## Validation

- `pnpm check` (passes with the repository's existing warnings)
- `pnpm typecheck`
- `pnpm test`
- `pnpm exec vitest run src/test/agent-scroll-to-latest-css.test.ts src/test/agent-scroll-to-latest.test.tsx`
- Playwright WebKit at the failing middle-height band: the old layout had no scroll range and overlapped the composer; the fixed layout creates scroll range and rests the final card 44px above it
- Playwright Chromium visual comparison of the image-generation field in light and dark themes

- [x] Tested visually where it matters. Screenshots were captured for WebKit clearance and both generated-media themes during local QA.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- changing composer geometry or queue behavior
- changing image-generation requests, models, metering, or backend contracts
- changing the generated-media wave speed, width, displacement, or light-mode sheen

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. No security-sensitive behavior changed.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such changes are included.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend changes are included.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786736470&installation_id=144203540&pr_number=782&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F782&signature=1ca4a05acb3c6790b8e0ab5094dd543dbb41ac87fb65afb78e6d80c9ca1f583d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->