### PR TITLE
Preserve literal dictation beginning with here

### DIFF
--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3941,11 +3941,20 @@ fn looks_like_instruction_response(value: &str) -> bool {
 fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
     let normalized = normalized.replace('’', "'");
     let normalized = normalized.as_str();
-    let strong_preamble_end = [":", ". ", "! ", "? ", "\n", " - ", " — ", " – ", "—", "–"]
+    let structural_preamble_end = [":", "\n", " - ", " — ", " – ", "—", "–"]
         .iter()
         .filter_map(|separator| normalized.find(separator))
         .min();
-    if strong_preamble_end.is_some_and(|end| is_here_instruction_preamble(&normalized[..end])) {
+    if structural_preamble_end.is_some_and(|end| is_here_instruction_preamble(&normalized[..end])) {
+        return true;
+    }
+    let punctuation_preamble_end = [". ", "! ", "? "]
+        .iter()
+        .filter_map(|separator| normalized.find(separator))
+        .min();
+    if punctuation_preamble_end
+        .is_some_and(|end| is_terminal_here_instruction_preamble(&normalized[..end]))
+    {
         return true;
     }
     if normalized
@@ -7057,6 +7066,9 @@ mod tests {
         assert!(looks_like_instruction_response("Here is the email: Hello."));
         assert!(!looks_like_instruction_response(
             "Here's your text message from John."
+        ));
+        assert!(!looks_like_instruction_response(
+            "Here's your text message from John. Call him back."
         ));
         assert!(!looks_like_instruction_response(
             "Here's the result of the game."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4052,6 +4052,10 @@ fn is_generic_here_instruction_preamble(preamble: &str) -> bool {
             | "here's what i got"
             | "here is what you said"
             | "here's what you said"
+            | "here is what you asked for"
+            | "here's what you asked for"
+            | "here is what you requested"
+            | "here's what you requested"
     ) {
         return true;
     }
@@ -7106,6 +7110,9 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here is what you said: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here's what you asked for: Send it today."
         ));
         assert!(looks_like_instruction_response(
             "Here's your corrected transcript. Send it today."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4006,7 +4006,7 @@ fn is_terminal_here_instruction_preamble(normalized: &str) -> bool {
             || is_here_instruction_cleanup_modifier(word)
             || matches!(
                 *word,
-                "a" | "an" | "as" | "requested" | "the" | "up" | "your"
+                "a" | "an" | "as" | "for" | "per" | "request" | "requested" | "the" | "up" | "your"
             )
     })
 }
@@ -7144,6 +7144,9 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here is the corrected transcript as requested."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is the corrected transcript for your request. Send it today."
         ));
         assert!(looks_like_instruction_response(
             "Here is the transcription: Send it today."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4025,7 +4025,7 @@ fn is_here_instruction_subject_marker(word: &str) -> bool {
 }
 
 fn is_generic_here_instruction_preamble(preamble: &str) -> bool {
-    matches!(
+    if matches!(
         preamble,
         "here you go"
             | "here it is"
@@ -4034,7 +4034,18 @@ fn is_generic_here_instruction_preamble(preamble: &str) -> bool {
             | "here's what i heard"
             | "here is what i got"
             | "here's what i got"
-    )
+    ) {
+        return true;
+    }
+    preamble.starts_with("here, i")
+        && preamble
+            .split(|character: char| !character.is_ascii_alphanumeric())
+            .any(|word| {
+                matches!(
+                    word,
+                    "cleaned" | "corrected" | "normalized" | "punctuated" | "rewritten"
+                )
+            })
 }
 
 fn looks_like_report_summary_response(normalized: &str) -> bool {
@@ -7054,6 +7065,12 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here's what I got: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here, I've cleaned it up: Send it today."
+        ));
+        assert!(!looks_like_instruction_response(
+            "Here, I think we should send it today."
         ));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3970,6 +3970,7 @@ fn is_here_instruction_preamble(preamble: &str) -> bool {
         "version",
         "result",
         "content",
+        "output",
     ]
     .iter()
     .any(|marker| subject.contains(marker))
@@ -6968,6 +6969,9 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here is the cleaned content: Hello."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is the cleaned output: Hello."
         ));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4025,6 +4025,8 @@ fn is_here_instruction_subject_marker(word: &str) -> bool {
         word,
         "transcript"
             | "transcription"
+            | "correction"
+            | "corrections"
             | "dictation"
             | "text"
             | "notes"
@@ -7161,6 +7163,9 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here are the improvements: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here are the corrections: Send it today."
         ));
         assert!(looks_like_instruction_response(
             "Here is what you said: Send it today."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3993,6 +3993,7 @@ fn is_terminal_here_instruction_preamble(normalized: &str) -> bool {
                 "a" | "an"
                     | "and"
                     | "as"
+                    | "below"
                     | "for"
                     | "per"
                     | "request"
@@ -4054,6 +4055,8 @@ fn is_generic_here_instruction_preamble(preamble: &str) -> bool {
             | "here's what i heard"
             | "here is what i got"
             | "here's what i got"
+            | "here is what i have"
+            | "here's what i have"
             | "here is what you said"
             | "here's what you said"
             | "here is what you asked for"
@@ -7139,6 +7142,12 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here is what I heard: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is the cleaned transcript below:\nSend it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is what I have:\nSend it today."
         ));
         assert!(looks_like_instruction_response(
             "Here's what I got: Send it today."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3962,9 +3962,17 @@ fn is_here_instruction_preamble(preamble: &str) -> bool {
     else {
         return false;
     };
-    ["transcript", "dictation", "text", "notes", "version"]
-        .iter()
-        .any(|marker| subject.contains(marker))
+    [
+        "transcript",
+        "dictation",
+        "text",
+        "notes",
+        "version",
+        "result",
+        "content",
+    ]
+    .iter()
+    .any(|marker| subject.contains(marker))
 }
 
 fn looks_like_report_summary_response(normalized: &str) -> bool {
@@ -6954,6 +6962,12 @@ mod tests {
         assert!(looks_like_instruction_response("Here you are: Hello."));
         assert!(looks_like_instruction_response(
             "Here is the cleaned dictation: Hello."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is the result: Hello."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is the cleaned content: Hello."
         ));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3947,7 +3947,7 @@ fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
         return false;
     };
     let preamble = normalized[..preamble_end].trim_end_matches('.').trim_end();
-    if preamble == "here you go" {
+    if ["here you go", "here it is", "here you are"].contains(&preamble) {
         return true;
     }
     let Some(subject) = ["here is ", "here's ", "here are "]
@@ -6938,6 +6938,8 @@ mod tests {
         assert!(looks_like_instruction_response(
             "Here's the cleaned-up version—Hello."
         ));
+        assert!(looks_like_instruction_response("Here it is: Hello."));
+        assert!(looks_like_instruction_response("Here you are: Hello."));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."
         ));

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3959,7 +3959,7 @@ fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
     }
     if normalized
         .find(", ")
-        .is_some_and(|end| is_here_instruction_preamble(&normalized[..end]))
+        .is_some_and(|end| is_terminal_here_instruction_preamble(&normalized[..end]))
     {
         return true;
     }
@@ -7093,6 +7093,9 @@ mod tests {
         ));
         assert!(!looks_like_instruction_response(
             "Here's your text message from John. Call him back."
+        ));
+        assert!(!looks_like_instruction_response(
+            "Here's your text message from John, call him back."
         ));
         assert!(!looks_like_instruction_response(
             "Here's the result of the game."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3951,7 +3951,7 @@ fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
     else {
         return false;
     };
-    ["transcript", "text", "notes"]
+    ["transcript", "text", "notes", "version"]
         .iter()
         .any(|marker| subject.contains(marker))
 }
@@ -6914,6 +6914,9 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here are the cleaned notes: Hello."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here's the cleaned-up version: Hello."
         ));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3939,15 +3939,20 @@ fn looks_like_instruction_response(value: &str) -> bool {
 }
 
 fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
-    let Some(preamble_end) = [":", ". ", "\n", " - ", " — ", " – ", "—", "–"]
+    let strong_preamble_end = [":", ". ", "\n", " - ", " — ", " – ", "—", "–"]
         .iter()
         .filter_map(|separator| normalized.find(separator))
-        .min()
-        .or_else(|| normalized.find(", "))
-    else {
-        return false;
-    };
-    let preamble = normalized[..preamble_end].trim_end_matches('.').trim_end();
+        .min();
+    if strong_preamble_end.is_some_and(|end| is_here_instruction_preamble(&normalized[..end])) {
+        return true;
+    }
+    normalized
+        .find(", ")
+        .is_some_and(|end| is_here_instruction_preamble(&normalized[..end]))
+}
+
+fn is_here_instruction_preamble(preamble: &str) -> bool {
+    let preamble = preamble.trim_end_matches('.').trim_end();
     if ["here you go", "here it is", "here you are"].contains(&preamble) {
         return true;
     }
@@ -6938,6 +6943,9 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here is the corrected, punctuated transcript: Hello."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here you go, Hello. World."
         ));
         assert!(looks_like_instruction_response(
             "Here's the cleaned-up version—Hello."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3967,7 +3967,7 @@ fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
 }
 
 fn is_here_instruction_preamble(preamble: &str) -> bool {
-    let preamble = preamble.trim_end_matches('.').trim_end();
+    let preamble = preamble.trim_end_matches(['.', '!', '?']).trim_end();
     if is_generic_here_instruction_preamble(preamble) {
         return true;
     }
@@ -3985,7 +3985,7 @@ fn is_here_instruction_preamble(preamble: &str) -> bool {
 }
 
 fn is_terminal_here_instruction_preamble(normalized: &str) -> bool {
-    let preamble = normalized.trim_end_matches('.').trim_end();
+    let preamble = normalized.trim_end_matches(['.', '!', '?']).trim_end();
     if is_generic_here_instruction_preamble(preamble) {
         return true;
     }
@@ -7062,6 +7062,8 @@ mod tests {
         ));
         assert!(looks_like_instruction_response("Here is the transcript."));
         assert!(looks_like_instruction_response("Here you go."));
+        assert!(looks_like_instruction_response("Here you go!"));
+        assert!(looks_like_instruction_response("Here is the transcript?"));
         assert!(looks_like_instruction_response(
             "Here's the cleaned-up message: Hello."
         ));

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3914,7 +3914,6 @@ fn looks_like_instruction_response(value: &str) -> bool {
     let normalized = value.trim().to_ascii_lowercase();
     looks_like_report_summary_response(&normalized)
         || normalized.starts_with("sure")
-        || normalized.starts_with("here")
         || normalized.starts_with("summary:")
         || normalized.starts_with("the transcript ")
         || normalized.starts_with("the user expresses")
@@ -6293,6 +6292,32 @@ mod tests {
     }
 
     #[test]
+    fn literal_dictation_starting_with_heres_maps_to_paste_command() {
+        let outcome = outcome_from_transcription_result(
+            Ok(TranscriptionProviderResult {
+                text: "Here's the API key to Poncho.".to_string(),
+                language: Some("en".to_string()),
+                provider: crate::providers::VENICE_PROVIDER.to_string(),
+            }),
+            None,
+            DictationStyle::Standard,
+        );
+
+        assert_eq!(
+            outcome.helper_command,
+            serde_json::json!({
+                "type": "paste_text",
+                "text": "Here's the API key to Poncho.",
+            })
+        );
+        assert!(outcome.event.is_none());
+        assert_eq!(
+            outcome.transcript.as_ref().map(|item| item.text.as_str()),
+            Some("Here's the API key to Poncho.")
+        );
+    }
+
+    #[test]
     fn summary_like_transcription_discards_with_visible_error() {
         let outcome = outcome_from_transcription_result(
             Ok(TranscriptionProviderResult {
@@ -6873,6 +6898,9 @@ mod tests {
         ));
         assert!(!looks_like_instruction_response(
             "User reported the bug to support."
+        ));
+        assert!(!looks_like_instruction_response(
+            "Here's the API key to Poncho."
         ));
     }
 

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3941,7 +3941,7 @@ fn looks_like_instruction_response(value: &str) -> bool {
 fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
     let normalized = normalized.replace('’', "'");
     let normalized = normalized.as_str();
-    let strong_preamble_end = [":", ". ", "\n", " - ", " — ", " – ", "—", "–"]
+    let strong_preamble_end = [":", ". ", "! ", "? ", "\n", " - ", " — ", " – ", "—", "–"]
         .iter()
         .filter_map(|separator| normalized.find(separator))
         .min();
@@ -7087,6 +7087,12 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here is the transcription: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here you go! Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is the transcript? Send it today."
         ));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -7149,6 +7149,9 @@ mod tests {
             "Here it is with punctuation: Send it today."
         ));
         assert!(looks_like_instruction_response(
+            "Here it is, punctuated: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
             "Here's your corrected transcript. Send it today."
         ));
         assert!(looks_like_instruction_response(

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4004,7 +4004,10 @@ fn is_terminal_here_instruction_preamble(normalized: &str) -> bool {
     }) && words.iter().all(|word| {
         is_here_instruction_subject_marker(word)
             || is_here_instruction_cleanup_modifier(word)
-            || matches!(*word, "a" | "an" | "the" | "up")
+            || matches!(
+                *word,
+                "a" | "an" | "as" | "requested" | "the" | "up" | "your"
+            )
     })
 }
 
@@ -7103,6 +7106,12 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here is what you said: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here's your corrected transcript. Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is the corrected transcript as requested."
         ));
         assert!(looks_like_instruction_response(
             "Here is the transcription: Send it today."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3968,7 +3968,9 @@ fn is_here_instruction_preamble(preamble: &str) -> bool {
     };
     subject
         .split(|character: char| !character.is_ascii_alphanumeric())
-        .any(is_here_instruction_subject_marker)
+        .any(|word| {
+            is_here_instruction_subject_marker(word) || is_here_instruction_cleanup_modifier(word)
+        })
 }
 
 fn is_terminal_here_instruction_preamble(normalized: &str) -> bool {
@@ -3986,25 +3988,13 @@ fn is_terminal_here_instruction_preamble(normalized: &str) -> bool {
         .split(|character: char| !character.is_ascii_alphanumeric())
         .filter(|word| !word.is_empty())
         .collect();
-    words
-        .iter()
-        .copied()
-        .any(is_here_instruction_subject_marker)
-        && words.iter().all(|word| {
-            is_here_instruction_subject_marker(word)
-                || matches!(
-                    *word,
-                    "a" | "an"
-                        | "the"
-                        | "clean"
-                        | "cleaned"
-                        | "corrected"
-                        | "normalized"
-                        | "punctuated"
-                        | "rewritten"
-                        | "up"
-                )
-        })
+    words.iter().copied().any(|word| {
+        is_here_instruction_subject_marker(word) || is_here_instruction_cleanup_modifier(word)
+    }) && words.iter().all(|word| {
+        is_here_instruction_subject_marker(word)
+            || is_here_instruction_cleanup_modifier(word)
+            || matches!(*word, "a" | "an" | "the" | "up")
+    })
 }
 
 fn is_here_instruction_subject_marker(word: &str) -> bool {
@@ -4021,6 +4011,17 @@ fn is_here_instruction_subject_marker(word: &str) -> bool {
             | "message"
             | "email"
             | "response"
+            | "copy"
+            | "draft"
+            | "improvements"
+            | "rewrite"
+    )
+}
+
+fn is_here_instruction_cleanup_modifier(word: &str) -> bool {
+    matches!(
+        word,
+        "clean" | "cleaned" | "corrected" | "normalized" | "punctuated" | "rewritten"
     )
 }
 
@@ -7071,6 +7072,15 @@ mod tests {
         ));
         assert!(!looks_like_instruction_response(
             "Here, I think we should send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here's a cleaned-up copy: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here's the rewritten draft: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here are the improvements: Send it today."
         ));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3914,6 +3914,17 @@ fn looks_like_instruction_response(value: &str) -> bool {
     let normalized = value.trim().to_ascii_lowercase();
     looks_like_report_summary_response(&normalized)
         || normalized.starts_with("sure")
+        || [
+            "here is the corrected transcript:",
+            "here's the corrected transcript:",
+            "here is the cleaned-up text:",
+            "here's the cleaned-up text:",
+            "here is the cleaned up text:",
+            "here's the cleaned up text:",
+            "here you go:",
+        ]
+        .iter()
+        .any(|prefix| normalized.starts_with(prefix))
         || normalized.starts_with("summary:")
         || normalized.starts_with("the transcript ")
         || normalized.starts_with("the user expresses")
@@ -6883,6 +6894,10 @@ mod tests {
         assert!(looks_like_instruction_response(
             "Here is the normalized transcript: Hello."
         ));
+        assert!(looks_like_instruction_response(
+            "Here is the corrected transcript: Hello."
+        ));
+        assert!(looks_like_instruction_response("Here you go: Hello."));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."
         ));

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4056,6 +4056,8 @@ fn is_generic_here_instruction_preamble(preamble: &str) -> bool {
             | "here's what you asked for"
             | "here is what you requested"
             | "here's what you requested"
+            | "here is what you dictated"
+            | "here's what you dictated"
     ) {
         return true;
     }
@@ -7113,6 +7115,9 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here's what you asked for: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here's what you dictated: Send it today."
         ));
         assert!(looks_like_instruction_response(
             "Here's your corrected transcript. Send it today."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3945,7 +3945,9 @@ fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
         .iter()
         .filter_map(|separator| normalized.find(separator))
         .min();
-    if structural_preamble_end.is_some_and(|end| is_here_instruction_preamble(&normalized[..end])) {
+    if structural_preamble_end
+        .is_some_and(|end| is_terminal_here_instruction_preamble(&normalized[..end]))
+    {
         return true;
     }
     let punctuation_preamble_end = [". ", "! ", "? "]
@@ -3964,24 +3966,6 @@ fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
         return true;
     }
     is_terminal_here_instruction_preamble(normalized)
-}
-
-fn is_here_instruction_preamble(preamble: &str) -> bool {
-    let preamble = preamble.trim_end_matches(['.', '!', '?']).trim_end();
-    if is_generic_here_instruction_preamble(preamble) {
-        return true;
-    }
-    let Some(subject) = ["here is ", "here's ", "here are "]
-        .iter()
-        .find_map(|prefix| preamble.strip_prefix(prefix))
-    else {
-        return false;
-    };
-    subject
-        .split(|character: char| !character.is_ascii_alphanumeric())
-        .any(|word| {
-            is_here_instruction_subject_marker(word) || is_here_instruction_cleanup_modifier(word)
-        })
 }
 
 fn is_terminal_here_instruction_preamble(normalized: &str) -> bool {
@@ -4007,6 +3991,7 @@ fn is_terminal_here_instruction_preamble(normalized: &str) -> bool {
             || matches!(
                 *word,
                 "a" | "an"
+                    | "and"
                     | "as"
                     | "for"
                     | "per"
@@ -7101,6 +7086,9 @@ mod tests {
             "Here is the corrected, punctuated transcript: Hello."
         ));
         assert!(looks_like_instruction_response(
+            "Here is the cleaned and punctuated transcript. Send it today."
+        ));
+        assert!(looks_like_instruction_response(
             "Here you go, Hello. World."
         ));
         assert!(looks_like_instruction_response(
@@ -7136,6 +7124,12 @@ mod tests {
         ));
         assert!(!looks_like_instruction_response(
             "Here's your text message from John, call him back."
+        ));
+        assert!(!looks_like_instruction_response(
+            "Here's my email: jane@example.com"
+        ));
+        assert!(!looks_like_instruction_response(
+            "Here's the text message from John: call him back"
         ));
         assert!(!looks_like_instruction_response(
             "Here's the result of the game."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3975,6 +3975,9 @@ fn is_here_instruction_preamble(preamble: &str) -> bool {
         "result",
         "content",
         "output",
+        "message",
+        "email",
+        "response",
     ]
     .iter()
     .any(|marker| subject.contains(marker))
@@ -6979,6 +6982,10 @@ mod tests {
         ));
         assert!(looks_like_instruction_response("Here is the transcript."));
         assert!(looks_like_instruction_response("Here you go."));
+        assert!(looks_like_instruction_response(
+            "Here's the cleaned-up message: Hello."
+        ));
+        assert!(looks_like_instruction_response("Here is the email: Hello."));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."
         ));

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3911,7 +3911,7 @@ fn emit_dictation_cleanup_skipped(
 }
 
 fn looks_like_instruction_response(value: &str) -> bool {
-    let normalized = value.trim().to_ascii_lowercase();
+    let normalized = value.trim().to_ascii_lowercase().replace('’', "'");
     looks_like_report_summary_response(&normalized)
         || normalized.starts_with("sure")
         || [
@@ -6897,6 +6897,9 @@ mod tests {
         assert!(looks_like_instruction_response(
             "Here is the corrected transcript: Hello."
         ));
+        assert!(looks_like_instruction_response(
+            "Here’s the corrected transcript: Hello."
+        ));
         assert!(looks_like_instruction_response("Here you go: Hello."));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."
@@ -6916,6 +6919,9 @@ mod tests {
         ));
         assert!(!looks_like_instruction_response(
             "Here's the API key to Poncho."
+        ));
+        assert!(!looks_like_instruction_response(
+            "Here’s the API key to Poncho."
         ));
     }
 

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3914,17 +3914,7 @@ fn looks_like_instruction_response(value: &str) -> bool {
     let normalized = value.trim().to_ascii_lowercase().replace('’', "'");
     looks_like_report_summary_response(&normalized)
         || normalized.starts_with("sure")
-        || [
-            "here is the corrected transcript:",
-            "here's the corrected transcript:",
-            "here is the cleaned-up text:",
-            "here's the cleaned-up text:",
-            "here is the cleaned up text:",
-            "here's the cleaned up text:",
-            "here you go:",
-        ]
-        .iter()
-        .any(|prefix| normalized.starts_with(prefix))
+        || looks_like_here_prefaced_instruction_response(&normalized)
         || normalized.starts_with("summary:")
         || normalized.starts_with("the transcript ")
         || normalized.starts_with("the user expresses")
@@ -3946,6 +3936,24 @@ fn looks_like_instruction_response(value: &str) -> bool {
         || normalized.contains(" spelled correctly ")
         || normalized.contains("rewritten text")
         || normalized.contains("normalized transcript")
+}
+
+fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
+    let Some((preamble, _)) = normalized.split_once(':') else {
+        return false;
+    };
+    if preamble == "here you go" {
+        return true;
+    }
+    let Some(subject) = ["here is ", "here's ", "here are "]
+        .iter()
+        .find_map(|prefix| preamble.strip_prefix(prefix))
+    else {
+        return false;
+    };
+    ["transcript", "text", "notes"]
+        .iter()
+        .any(|marker| subject.contains(marker))
 }
 
 fn looks_like_report_summary_response(normalized: &str) -> bool {
@@ -6901,6 +6909,12 @@ mod tests {
             "Here’s the corrected transcript: Hello."
         ));
         assert!(looks_like_instruction_response("Here you go: Hello."));
+        assert!(looks_like_instruction_response(
+            "Here is the transcript: Hello."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here are the cleaned notes: Hello."
+        ));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."
         ));

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4030,6 +4030,7 @@ fn is_here_instruction_subject_marker(word: &str) -> bool {
             | "draft"
             | "improvements"
             | "rewrite"
+            | "summary"
     )
 }
 
@@ -7118,6 +7119,9 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here's what you dictated: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is a summary: Send it today."
         ));
         assert!(looks_like_instruction_response(
             "Here's your corrected transcript. Send it today."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4088,6 +4088,23 @@ fn is_generic_here_instruction_preamble(preamble: &str) -> bool {
     {
         return true;
     }
+    if let Some(subject) = preamble.strip_prefix("here it is ") {
+        let words: Vec<&str> = subject
+            .split(|character: char| !character.is_ascii_alphanumeric())
+            .filter(|word| !word.is_empty())
+            .collect();
+        if words
+            .iter()
+            .copied()
+            .any(is_here_instruction_cleanup_modifier)
+            && words.iter().all(|word| {
+                is_here_instruction_cleanup_modifier(word)
+                    || matches!(*word, "as" | "for" | "requested" | "up" | "you")
+            })
+        {
+            return true;
+        }
+    }
     (preamble.starts_with("here, i") || preamble.starts_with("here i"))
         && preamble
             .split(|character: char| !character.is_ascii_alphanumeric())
@@ -7162,6 +7179,12 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here it is, punctuated: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here it is cleaned up: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here it is punctuated. Send it today."
         ));
         assert!(looks_like_instruction_response(
             "Here is the final transcript. Send it today."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3952,7 +3952,7 @@ fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
     {
         return true;
     }
-    is_here_instruction_preamble(normalized)
+    is_terminal_here_instruction_preamble(normalized)
 }
 
 fn is_here_instruction_preamble(preamble: &str) -> bool {
@@ -3966,21 +3966,62 @@ fn is_here_instruction_preamble(preamble: &str) -> bool {
     else {
         return false;
     };
-    [
-        "transcript",
-        "dictation",
-        "text",
-        "notes",
-        "version",
-        "result",
-        "content",
-        "output",
-        "message",
-        "email",
-        "response",
-    ]
-    .iter()
-    .any(|marker| subject.contains(marker))
+    subject
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .any(is_here_instruction_subject_marker)
+}
+
+fn is_terminal_here_instruction_preamble(normalized: &str) -> bool {
+    let preamble = normalized.trim_end_matches('.').trim_end();
+    if ["here you go", "here it is", "here you are"].contains(&preamble) {
+        return true;
+    }
+    let Some(subject) = ["here is ", "here's ", "here are "]
+        .iter()
+        .find_map(|prefix| preamble.strip_prefix(prefix))
+    else {
+        return false;
+    };
+    let words: Vec<&str> = subject
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|word| !word.is_empty())
+        .collect();
+    words
+        .iter()
+        .copied()
+        .any(is_here_instruction_subject_marker)
+        && words.iter().all(|word| {
+            is_here_instruction_subject_marker(word)
+                || matches!(
+                    *word,
+                    "a" | "an"
+                        | "the"
+                        | "clean"
+                        | "cleaned"
+                        | "corrected"
+                        | "normalized"
+                        | "punctuated"
+                        | "rewritten"
+                        | "up"
+                )
+        })
+}
+
+fn is_here_instruction_subject_marker(word: &str) -> bool {
+    matches!(
+        word,
+        "transcript"
+            | "dictation"
+            | "text"
+            | "notes"
+            | "version"
+            | "result"
+            | "content"
+            | "output"
+            | "message"
+            | "email"
+            | "response"
+    )
 }
 
 fn looks_like_report_summary_response(normalized: &str) -> bool {
@@ -6986,6 +7027,15 @@ mod tests {
             "Here's the cleaned-up message: Hello."
         ));
         assert!(looks_like_instruction_response("Here is the email: Hello."));
+        assert!(!looks_like_instruction_response(
+            "Here's your text message from John."
+        ));
+        assert!(!looks_like_instruction_response(
+            "Here's the result of the game."
+        ));
+        assert!(!looks_like_instruction_response(
+            "Here's my notes on the trip."
+        ));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."
         ));

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4062,6 +4062,16 @@ fn is_generic_here_instruction_preamble(preamble: &str) -> bool {
     ) {
         return true;
     }
+    if [
+        "here it is with ",
+        "here you go with ",
+        "here you are with ",
+    ]
+    .iter()
+    .any(|prefix| preamble.starts_with(prefix))
+    {
+        return true;
+    }
     preamble.starts_with("here, i")
         && preamble
             .split(|character: char| !character.is_ascii_alphanumeric())
@@ -7122,6 +7132,9 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here is a summary: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here it is with punctuation: Send it today."
         ));
         assert!(looks_like_instruction_response(
             "Here's your corrected transcript. Send it today."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4006,7 +4006,16 @@ fn is_terminal_here_instruction_preamble(normalized: &str) -> bool {
             || is_here_instruction_cleanup_modifier(word)
             || matches!(
                 *word,
-                "a" | "an" | "as" | "for" | "per" | "request" | "requested" | "the" | "up" | "your"
+                "a" | "an"
+                    | "as"
+                    | "for"
+                    | "per"
+                    | "request"
+                    | "requested"
+                    | "the"
+                    | "up"
+                    | "you"
+                    | "your"
             )
     })
 }
@@ -7147,6 +7156,12 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here is the corrected transcript for your request. Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here's the cleaned-up transcript for you. Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is the corrected transcript as you requested. Send it today."
         ));
         assert!(looks_like_instruction_response(
             "Here is the transcription: Send it today."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3939,7 +3939,7 @@ fn looks_like_instruction_response(value: &str) -> bool {
 }
 
 fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
-    let Some(preamble_end) = [":", ". ", "\n", " - ", " — ", " – "]
+    let Some(preamble_end) = [":", ". ", ", ", "\n", " - ", " — ", " – ", "—", "–"]
         .iter()
         .filter_map(|separator| normalized.find(separator))
         .min()
@@ -6931,6 +6931,12 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here is the corrected text\nHello."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is the corrected transcript, Hello."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here's the cleaned-up version—Hello."
         ));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3956,7 +3956,7 @@ fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
     else {
         return false;
     };
-    ["transcript", "text", "notes", "version"]
+    ["transcript", "dictation", "text", "notes", "version"]
         .iter()
         .any(|marker| subject.contains(marker))
 }
@@ -6940,6 +6940,9 @@ mod tests {
         ));
         assert!(looks_like_instruction_response("Here it is: Hello."));
         assert!(looks_like_instruction_response("Here you are: Hello."));
+        assert!(looks_like_instruction_response(
+            "Here is the cleaned dictation: Hello."
+        ));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."
         ));

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4047,6 +4047,8 @@ fn is_generic_here_instruction_preamble(preamble: &str) -> bool {
             | "here's what i heard"
             | "here is what i got"
             | "here's what i got"
+            | "here is what you said"
+            | "here's what you said"
     ) {
         return true;
     }
@@ -7096,6 +7098,9 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here are the improvements: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is what you said: Send it today."
         ));
         assert!(looks_like_instruction_response(
             "Here is the transcription: Send it today."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4046,7 +4046,14 @@ fn is_here_instruction_subject_marker(word: &str) -> bool {
 fn is_here_instruction_cleanup_modifier(word: &str) -> bool {
     matches!(
         word,
-        "clean" | "cleaned" | "corrected" | "normalized" | "punctuated" | "rewritten"
+        "clean"
+            | "cleaned"
+            | "corrected"
+            | "final"
+            | "normalized"
+            | "polished"
+            | "punctuated"
+            | "rewritten"
     )
 }
 
@@ -4081,13 +4088,18 @@ fn is_generic_here_instruction_preamble(preamble: &str) -> bool {
     {
         return true;
     }
-    preamble.starts_with("here, i")
+    (preamble.starts_with("here, i") || preamble.starts_with("here i"))
         && preamble
             .split(|character: char| !character.is_ascii_alphanumeric())
             .any(|word| {
                 matches!(
                     word,
-                    "cleaned" | "corrected" | "normalized" | "punctuated" | "rewritten"
+                    "cleaned"
+                        | "corrected"
+                        | "normalized"
+                        | "polished"
+                        | "punctuated"
+                        | "rewritten"
                 )
             })
 }
@@ -7150,6 +7162,15 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here it is, punctuated: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is the final transcript. Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here's the polished version. Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here I've cleaned it up: Send it today."
         ));
         assert!(looks_like_instruction_response(
             "Here's your corrected transcript. Send it today."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3946,9 +3946,13 @@ fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
     if strong_preamble_end.is_some_and(|end| is_here_instruction_preamble(&normalized[..end])) {
         return true;
     }
-    normalized
+    if normalized
         .find(", ")
         .is_some_and(|end| is_here_instruction_preamble(&normalized[..end]))
+    {
+        return true;
+    }
+    is_here_instruction_preamble(normalized)
 }
 
 fn is_here_instruction_preamble(preamble: &str) -> bool {
@@ -6973,6 +6977,8 @@ mod tests {
         assert!(looks_like_instruction_response(
             "Here is the cleaned output: Hello."
         ));
+        assert!(looks_like_instruction_response("Here is the transcript."));
+        assert!(looks_like_instruction_response("Here you go."));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."
         ));

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3939,9 +3939,14 @@ fn looks_like_instruction_response(value: &str) -> bool {
 }
 
 fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
-    let Some((preamble, _)) = normalized.split_once(':') else {
+    let Some(preamble_end) = [":", ". ", "\n", " - ", " — ", " – "]
+        .iter()
+        .filter_map(|separator| normalized.find(separator))
+        .min()
+    else {
         return false;
     };
+    let preamble = normalized[..preamble_end].trim_end_matches('.').trim_end();
     if preamble == "here you go" {
         return true;
     }
@@ -6917,6 +6922,15 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here's the cleaned-up version: Hello."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is the corrected transcript. Hello."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here are the cleaned notes - Hello."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is the corrected text\nHello."
         ));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3939,10 +3939,11 @@ fn looks_like_instruction_response(value: &str) -> bool {
 }
 
 fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
-    let Some(preamble_end) = [":", ". ", ", ", "\n", " - ", " — ", " – ", "—", "–"]
+    let Some(preamble_end) = [":", ". ", "\n", " - ", " — ", " – ", "—", "–"]
         .iter()
         .filter_map(|separator| normalized.find(separator))
         .min()
+        .or_else(|| normalized.find(", "))
     else {
         return false;
     };
@@ -6934,6 +6935,9 @@ mod tests {
         ));
         assert!(looks_like_instruction_response(
             "Here is the corrected transcript, Hello."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is the corrected, punctuated transcript: Hello."
         ));
         assert!(looks_like_instruction_response(
             "Here's the cleaned-up version—Hello."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3957,7 +3957,7 @@ fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
 
 fn is_here_instruction_preamble(preamble: &str) -> bool {
     let preamble = preamble.trim_end_matches('.').trim_end();
-    if ["here you go", "here it is", "here you are"].contains(&preamble) {
+    if is_generic_here_instruction_preamble(preamble) {
         return true;
     }
     let Some(subject) = ["here is ", "here's ", "here are "]
@@ -3973,7 +3973,7 @@ fn is_here_instruction_preamble(preamble: &str) -> bool {
 
 fn is_terminal_here_instruction_preamble(normalized: &str) -> bool {
     let preamble = normalized.trim_end_matches('.').trim_end();
-    if ["here you go", "here it is", "here you are"].contains(&preamble) {
+    if is_generic_here_instruction_preamble(preamble) {
         return true;
     }
     let Some(subject) = ["here is ", "here's ", "here are "]
@@ -4021,6 +4021,19 @@ fn is_here_instruction_subject_marker(word: &str) -> bool {
             | "message"
             | "email"
             | "response"
+    )
+}
+
+fn is_generic_here_instruction_preamble(preamble: &str) -> bool {
+    matches!(
+        preamble,
+        "here you go"
+            | "here it is"
+            | "here you are"
+            | "here is what i heard"
+            | "here's what i heard"
+            | "here is what i got"
+            | "here's what i got"
     )
 }
 
@@ -7035,6 +7048,12 @@ mod tests {
         ));
         assert!(!looks_like_instruction_response(
             "Here's my notes on the trip."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here is what I heard: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
+            "Here's what I got: Send it today."
         ));
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3911,7 +3911,7 @@ fn emit_dictation_cleanup_skipped(
 }
 
 fn looks_like_instruction_response(value: &str) -> bool {
-    let normalized = value.trim().to_ascii_lowercase().replace('’', "'");
+    let normalized = value.trim().to_ascii_lowercase();
     looks_like_report_summary_response(&normalized)
         || normalized.starts_with("sure")
         || looks_like_here_prefaced_instruction_response(&normalized)
@@ -3939,6 +3939,8 @@ fn looks_like_instruction_response(value: &str) -> bool {
 }
 
 fn looks_like_here_prefaced_instruction_response(normalized: &str) -> bool {
+    let normalized = normalized.replace('’', "'");
+    let normalized = normalized.as_str();
     let strong_preamble_end = [":", ". ", "\n", " - ", " — ", " – ", "—", "–"]
         .iter()
         .filter_map(|separator| normalized.find(separator))
@@ -4001,6 +4003,7 @@ fn is_here_instruction_subject_marker(word: &str) -> bool {
     matches!(
         word,
         "transcript"
+            | "transcription"
             | "dictation"
             | "text"
             | "notes"
@@ -7083,6 +7086,9 @@ mod tests {
             "Here are the improvements: Send it today."
         ));
         assert!(looks_like_instruction_response(
+            "Here is the transcription: Send it today."
+        ));
+        assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."
         ));
         assert!(looks_like_instruction_response(
@@ -7104,6 +7110,7 @@ mod tests {
         assert!(!looks_like_instruction_response(
             "Here’s the API key to Poncho."
         ));
+        assert!(!looks_like_instruction_response("I’ll send the agenda."));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Removed the overbroad `starts_with("here")` instruction-response check.
- Added a regression test proving `Here's the API key to Poncho.` is pasted and retained.
- Kept targeted model-summary and normalized-transcript rejection coverage.

## Why

Literal dictation beginning with `Here's` was classified as a model-generated summary and discarded, even when the cleanup output exactly represented the speaker's words.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- Focused Rust regression tests for literal dictation and instruction-response detection
- `cargo test --manifest-path src-tauri/Cargo.toml --locked` (710 passed, 4 ignored)

## Live QA

BLOCKED: reproducing the complete native flow requires microphone capture plus a live transcription/cleanup request. The QA policy requires explicit authorization before recording microphone audio or entering credentials. The deterministic test exercises the affected paste-versus-discard decision directly.

## Known gaps

- No live microphone walkthrough or QA video for the reason above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786738818&installation_id=144203540&pr_number=784&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F784&signature=58cfc3aff59bd4688293e9ac1895831887493f2798554326a83b39e0f6cfc404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->