### PR TITLE
Restore agent messages after relaunch

### DIFF
--- a/.agents/skills/repo-review/CALIBRATION.md
+++ b/.agents/skills/repo-review/CALIBRATION.md
@@ -90,3 +90,6 @@ data-driven: discount reviewer patterns with a bad true/findings ratio
 | os-api private routing (pre-PR) | Standards (codex, r1+final) | 3 | 3 | caught `/v1` provider-semantic drift, missing canonical glossary coverage, and stale response-shape wording; final clean |
 | os-api private routing (pre-PR) | Spec (codex, r1+final) | 0 | — | clean twice; verified deliberate Venice-private-first policy, BYOK isolation, additive metadata, compatibility, and pricing |
 | os-api private routing (pre-PR) | Adversarial (codex, r1-r3) | 2 | 2 | caught underpriced canonical Kimi first, then expanded the same billing invariant to all five multi-route preferred models; final approve |
+| JUN-349 (pre-PR) | Standards (codex) | 0 | — | clean on the runtime startup guard and focused relaunch regression coverage |
+| JUN-349 (pre-PR) | Spec (codex) | 0 | — | clean against the immediate relaunch-history restoration contract and explicit non-goals |
+| JUN-349 (pre-PR) | Adversarial (claude) | 0 | — | approved after tracing double-start locking, shared session storage across runtime modes, and the canonical message read path |

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -4417,7 +4417,11 @@ export function AgentWorkspace({
     sessionContinuity = null;
     void (async () => {
       try {
-        const status = await hermesBridgeStatus();
+        let status = await hermesBridgeStatus();
+        if (cancelled) return;
+        if (!status.running) {
+          status = await startHermesBridge(undefined, false);
+        }
         if (cancelled) return;
         setBridge(status);
       } catch (err) {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -4443,6 +4443,36 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByText("Newer session")).toBeNull();
   });
 
+  it("starts the runtime and restores messages after a full app relaunch", async () => {
+    window.localStorage.setItem("june:agent:last-open-session", "session-1");
+    mocks.hermesBridgeStatus.mockResolvedValue({ running: false });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "user",
+        content: "Keep this conversation visible after relaunch",
+        timestamp: "2026-06-05T12:00:00Z",
+      },
+      {
+        id: "message-2",
+        role: "assistant",
+        content: "The conversation will be ready when June reopens.",
+        timestamp: "2026-06-05T12:00:01Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(
+      await screen.findByText("Keep this conversation visible after relaunch"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("The conversation will be ready when June reopens."),
+    ).toBeInTheDocument();
+    expect(mocks.startHermesBridge).toHaveBeenCalledWith(undefined, false);
+    expect(mocks.listHermesSessionMessages).toHaveBeenCalledWith("session-1");
+  });
+
   it("honors an initial session id before session metadata is available", async () => {
     mocks.listHermesSessions.mockResolvedValue([
       {


### PR DESCRIPTION
## Summary

- Start June's sandboxed agent runtime when the agent workspace mounts after a full app relaunch, so stored conversations and messages load immediately.
- Add regression coverage for a stopped runtime restoring the last open conversation before the user sends another message.
- Closes JUN-349.

## Root cause

Quitting June stops the embedded agent runtime. On the next launch, the agent workspace only read the stopped runtime status, while both session listing and message restoration were gated on a running runtime. Sending a message happened to start the runtime through a separate path, which then allowed the stored history to appear.

## Validation

- `make verify`
- `make local-ci`
- Focused regression test and the complete `agent-workspace.test.tsx` suite
- Live relaunch simulation in Chromium with a stopped Tauri bridge, stored conversation data, command-order assertions, screenshot inspection, and recorded video
- Recording: [stored conversation restored after relaunch](https://app.opensoftware.co/api/v1/files/fil_ua2xpSRF5Slx/download)

- [x] Tested visually where it matters (recording attached to this PR).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Changing conversation persistence, June API contracts, or runtime sandbox policy.
- Redesigning the existing first-run runtime installation or transient startup-error experience.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. This change does not alter security boundaries.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. None changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. None changed.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.
