### PR TITLE
Fix MCP approval storm after reconnect

### DIFF
--- a/docs/adr/0025-targeted-hermes-approval-protocol.md
+++ b/docs/adr/0025-targeted-hermes-approval-protocol.md
@@ -1,0 +1,96 @@
+# ADR 0025: Targeted Hermes approval protocol
+
+Date: 2026-07-16
+Status: accepted
+
+## Context
+
+Hermes routes MCP elicitation consent through the same approval surface as
+dangerous commands. In the pinned `v2026.6.19` runtime, that path discarded the
+MCP SDK request id, appended every request to a per-session FIFO queue, emitted
+`approval.request` without a stable identity, and resolved `approval.respond`
+against the queue head. MCP reconnect retries could therefore create several
+indistinguishable unresolved approvals for one logical elicitation.
+
+June amplified the symptom when an idless frame was delivered more than once:
+its compatibility fallback included the receive timestamp, so each delivery
+became a new permission card. Filtering duplicate cards in React would not drain
+the upstream queue and could let a click resolve a different request from the
+one shown.
+
+The protocol is a load-bearing integration boundary. It must distinguish
+legitimate concurrent approvals, target the exact request the user answered,
+and retire unverifiable requests without granting permission.
+
+## Decision
+
+June applies the sealed `june-approval-v1` compatibility patch to the exact
+pinned Hermes source before building or installing the runtime.
+
+- MCP elicitation preserves the SDK `RequestContext.request_id` as upstream identity.
+  Missing, blank, boolean, or otherwise malformed identities decline without
+  showing an actionable request.
+- Hermes derives an opaque request id from the MCP surface, current tool call,
+  and upstream request id. While a request is unanswered, a retry with the same
+  tool-call/prompt identity after an MCP transport reconnect joins the existing
+  queue entry. Separate requests delivered on the same transport remain
+  distinct, including concurrent requests with matching prompt text. Retry
+  aliases are bounded and receive the one targeted decision without emitting
+  more cards.
+- Existing command and code approvals derive their opaque identity from the
+  gateway's turn/tool-call context, preserving those non-MCP flows while making
+  their resolution targeted too. Missing context fails closed.
+- `approval.respond` accepts `request_id` and resolves only that queue entry.
+  June never sends `all: true`.
+- The per-session queue is bounded at 32 unresolved entries and each logical
+  entry accepts at most 16 reconnect aliases. Completed request tombstones are
+  bounded at 128 per session and 256 sessions so a late exact replay reuses the
+  prior decision without growing memory forever.
+- Timeout, notification failure, queue overflow, malformed input, and gateway
+  disconnect fail closed. Timeout and disconnect emit a targeted
+  `approval.expire`; June retires the matching card and does not send a response.
+- June treats approval resolution and expiration as sticky. A delayed duplicate
+  cannot reopen a request. On an unexpected gateway close, the pre-drop card is
+  retired locally before the stored session is resumed.
+- The patcher verifies exact upstream and post-patch SHA-256 values for
+  `tools/approval.py`, `tools/mcp_tool.py`, and `tui_gateway/server.py`. Source
+  drift fails the build or managed install. Both macOS and Windows bundlers run
+  the same patch and protocol smoke, stamp `PATCHSET`, and the bridge verifies
+  managed runtime checksums before launch.
+- Production runtime resolution accepts only the sealed bundled runtime or a
+  verified June-managed install. Installation or checksum failure stops launch;
+  June does not fall back to an unpatched user-local or `PATH` runtime. The
+  explicit `JUNE_HERMES_COMMAND` development override remains available.
+- The Hermes pin remains `v2026.6.19` at commit
+  `2bd1977d8fad185c9b4be47884f7e87f1add0ce3`. The patch set is a separate
+  provenance dimension and does not masquerade as an upstream pin.
+
+## Consequences
+
+- One logical MCP elicitation has one actionable card and one targeted decision,
+  even when delivery or connection retries occur.
+- A disconnected or timed-out card becomes a visible expired receipt. Retrying
+  the tool requires a new upstream request; June never silently approves stale
+  work.
+- Non-MCP command/code approvals keep working with derived stable identities;
+  clarify, sudo, and secret protocols keep their existing identities and
+  response methods. Legacy external callers that omit `request_id` retain FIFO
+  behavior inside Hermes, but June always sends a targeted id.
+- Every Hermes pin bump must re-evaluate whether upstream now provides the same
+  stable identity and targeted response contract. The local patch must be
+  removed, rebased with new sealed hashes, or replaced by a verified upstream
+  implementation before release.
+- This is desktop runtime behavior only. No June API deployment is required.
+
+## Alternatives considered
+
+- **Deduplicate only in React.** Rejected because hidden upstream queue entries
+  would remain unresolved and a visible card could answer the wrong FIFO entry.
+- **Resolve every queued approval together.** Rejected because distinct
+  legitimate requests can coexist and must receive independent decisions.
+- **Keep FIFO resolution and add only a display id.** Rejected because the id
+  would not control which blocked request resumes.
+- **Upgrade Hermes immediately.** Rejected because a pin bump is broader than
+  this fix and no verified upstream release was shown to provide the required
+  protocol. The sealed patch keeps the current audited pin and is removed when
+  an upstream implementation passes the full upgrade checklist.

--- a/docs/hermes-gateway-gotchas.md
+++ b/docs/hermes-gateway-gotchas.md
@@ -106,6 +106,23 @@ falls back to the config's `oauth` marker and OAuth-shaped probe errors.
 
 ## Events
 
+**MCP approvals are identity-addressed, not FIFO.** The pinned runtime carries
+June's checksum-gated `june-approval-v1` patch. MCP elicitation preserves the
+SDK request id and emits an opaque stable `request_id` on `approval.request`.
+While unanswered, the same logical request retried after an MCP transport
+reconnect joins the existing entry; separate requests on one transport remain
+separate even when their prompt text matches.
+Send that exact id back with `approval.respond`; never use `all: true` and never
+assume the first visible card is the queue head. Timeout and disconnect emit
+`approval.expire` and must render as a retired, non-actionable request. A
+missing or malformed id fails closed. See ADR 0025.
+
+**A gateway drop retires pre-drop approvals.** The patched runtime drains them
+fail closed as soon as the WebSocket transport detaches. AgentWorkspace mirrors that boundary locally
+before `session.resume`, then replaces the session event listener with the new
+runtime id. A delayed replay is diagnostic noise, not a reason to reopen the
+card.
+
 **The control plane fails loudly on unknown event types — by design.** A new
 raw type renders as the red "event June does not support yet" banner until it
 gets a branch in `classifyHermesEvent` (`hermes-control-plane/event-classifier.ts`)

--- a/docs/hermes-upgrade-checklist.md
+++ b/docs/hermes-upgrade-checklist.md
@@ -38,6 +38,31 @@ On a bump, set the new version here, in the matrix constant, and in a new pin
 note (copy `docs/hermes-upstream-template.md` to
 `docs/hermes-upstream-v<version>.md`), then re-run `pnpm hermes:upgrade-check`.
 
+## June compatibility patch set
+
+The current pin also carries the checksum-gated `june-approval-v1` patch set
+documented in `docs/hermes-upstream-v2026.6.19.md` and ADR 0025. On every pin
+bump:
+
+1. Check whether upstream now preserves MCP request identity, deduplicates one
+   still-pending logical elicitation across transport reconnects without
+   merging distinct same-transport requests, bounds unresolved approvals, targets
+   `approval.respond`, and retires timeout and disconnect fail closed.
+2. If upstream supplies the complete contract, remove the local patch and its
+   `PATCHSET` plumbing only after the protocol smoke passes against the new pin.
+3. Otherwise rebase `apply_june_patches.py` onto the exact new sources and seal
+   both upstream and patched SHA-256 values. Source drift must remain a hard
+   failure.
+4. Build both macOS and Windows bundles. Confirm both packaging paths apply the
+   same patch, stamp the patch set, verify it after relocation, and run
+   `scripts/hermes-approval-patch-smoke.py`.
+5. Confirm managed installs record the new commit and patch set independently
+   and verify patched source hashes before launch. Confirm production cannot
+   fall back to an unpatched user-local or `PATH` runtime.
+
+Never carry the old post-patch hashes onto a new pin, patch only one platform,
+or treat a UI deduplication filter as a replacement for the runtime protocol.
+
 ## Runtime start command
 
 Confirm June still launches the new build the same way (the smoke test asserts
@@ -71,6 +96,13 @@ url, status url, request/response framing, binary discovery) are pinned as pure
 helpers in `src/lib/hermes-smoke/helpers.ts` and unit-tested in
 `src/test/hermes-smoke.test.ts`. Run `pnpm test` to catch a framing change, and
 `pnpm test:hermes-smoke` to catch a behavior change against the live runtime.
+
+Recheck the targeted approval extension at the same time: `approval.request`
+must carry a stable `request_id`; `approval.respond` with that id must resolve
+exactly one request; `approval.response` and `approval.expire` must reference
+the same id. A missing or malformed id must not fall back to an actionable
+approval. Re-run the reconnect-retry, same-transport concurrency, disconnect
+drain, non-MCP command approval, alias-bound, and tombstone-bound smoke cases.
 
 ## New methods/events (gateway method + event catalog diff)
 

--- a/docs/hermes-upstream-v2026.6.19.md
+++ b/docs/hermes-upstream-v2026.6.19.md
@@ -7,6 +7,38 @@
 - Archive checksum: `7a9bd367066183898831c2760f269368ab54b458a1d1b51d14ef1f484dd490cc`
 - Upstream changelog: `https://github.com/NousResearch/hermes-agent/compare/v2026.6.5...v2026.6.19`
 
+## June compatibility patch
+
+The upstream pin remains unchanged. June applies the deterministic
+`june-approval-v1` patch set before building the bundled runtime and before
+finishing a managed runtime install. See
+[ADR 0025](adr/0025-targeted-hermes-approval-protocol.md).
+
+The patch preserves MCP `RequestContext.request_id`, derives an opaque stable
+approval id, and coalesces a still-pending logical request retried after an MCP
+transport reconnect without merging separate requests on one live transport.
+It bounds queue entries, reconnect aliases, completed requests, and completed
+sessions; adds targeted `approval.respond`; and emits targeted
+`approval.expire` events on timeout and disconnect. Missing identity, malformed
+responses, notification failure, queue overflow, timeout, and disconnect fail
+closed. Existing command/code approvals derive targeted identity from their
+turn/tool-call context, so non-MCP approval behavior is preserved.
+
+The patcher in `src-tauri/src/hermes/apply_june_patches.py` accepts only these
+exact source states:
+
+| File | Upstream SHA-256 | Patched SHA-256 |
+| --- | --- | --- |
+| `tools/approval.py` | `e31abc88357afa28c05f3a4753ea9908b540b0dfef8dab2fa62960ae19a63c85` | `56e88034ebcac8cff8c579c56345e4cb3fe2fe597360687d40b68daefd402e3d` |
+| `tools/mcp_tool.py` | `3f0aca90d076a1b0aa5daffd7bb39b0d1a4fee83265f855e68d556e5c8a29d01` | `48a2fddfee5d5a8c33723e27639907e9f2cf062c82e7beeb844f457e6a372cfa` |
+| `tui_gateway/server.py` | `1743cec5c6684651d2b7cb18b7b73a37ea99538a4f56bcd8476700ce23d4f01a` | `41197c75c3aee760a05a8ecdce4daa3d0ca7f62b34486f29a21f097086a4ef4e` |
+
+Both macOS and Windows bundlers apply the same patch, write `PATCHSET`, verify
+the patched hashes after relocation, and run
+`scripts/hermes-approval-patch-smoke.py`. Managed installs record the upstream
+commit and patch set separately in `runtime.json`; the bridge verifies the
+patched source hashes before launch.
+
 ## Compatibility checked
 
 June still starts Hermes through:
@@ -101,15 +133,20 @@ Two phases, gated independently:
   (4009 busy is retried, but only acceptance passes), `session.interrupt`. A local
   `/v1/models` stub validates a switch from the configured model to an alternate
   listed model; no model tokens are spent.
+- Approval patch smoke (during macOS and Windows bundle self-test): duplicate
+  delivery, distinct concurrent requests, targeted approval and denial,
+  replay, timeout, malformed identity, bounded overflow, and disconnect drain.
 - Model smoke (opt-in): set `HERMES_SMOKE_MODEL=1` and ensure the runtime config
   has a real provider key. This adds a minimal no-tool `prompt.submit` and waits
   for a completion. It costs provider tokens, so it is off by default.
 
 Environment variables:
 
-- `JUNE_HERMES_COMMAND`: absolute path to a `hermes` binary. Highest priority
-  (mirrors the Rust override). When unset, the script probes the same
-  user-local venv locations the bridge falls back to.
+- `JUNE_HERMES_COMMAND`: explicit development override for an absolute path to
+  a `hermes` binary. Production resolution otherwise accepts only a verified
+  June-bundled or June-managed runtime and fails closed instead of using an
+  unpatched user-local or `PATH` fallback. The standalone smoke still probes
+  common developer-local installs when the override is unset.
 - `HERMES_SMOKE_MODEL=1`: also run the model-costing `prompt.submit` phase.
 - `HERMES_SMOKE_TIMEOUT_MS`: per-step RPC timeout (default 120000).
 - `HERMES_SMOKE_READY_MS`: readiness-wait budget (default 45000, matches the

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ decision. See "When to add an ADR" in [AGENTS.md](../AGENTS.md).
 - [adr/0022](adr/0022-venice-private-first-model-routing.md) — service-managed text uses Venice private zero-retention first with Phala TEE fallback; existing `/v1` provider semantics stay compatible and pricing is fallback-safe
 - [adr/0023](adr/0023-attested-os-api-service-chain.md) - superseded by ADR-0024
 - [adr/0024](adr/0024-independent-product-verification.md) - June, Open Software API, and Chat publish independent verification evidence without cross-product release pinning
+- [adr/0025](adr/0025-targeted-hermes-approval-protocol.md) - MCP approvals use stable request identity, targeted resolution, bounded queues, and fail-closed retirement
 
 ## Enforceable rules (spec/)
 
@@ -112,7 +113,7 @@ Per-repo config the engineering skills read before acting (see the
 
 - [hermes-upgrade-checklist.md](hermes-upgrade-checklist.md) — the gate for bumping the pinned runtime
 - [hermes-upstream-template.md](hermes-upstream-template.md) — per-bump pin-note template
-- [hermes-upstream-v2026.6.19.md](hermes-upstream-v2026.6.19.md) — current pin note (v2026.6.19)
+- [hermes-upstream-v2026.6.19.md](hermes-upstream-v2026.6.19.md) — current pin and local compatibility patch note (v2026.6.19, `june-approval-v1`)
 - [hermes-tui-debug.md](hermes-tui-debug.md) — dev-only raw-TUI debug fallback
 
 ## Release & ops runbooks

--- a/scripts/bundle-hermes-runtime-windows.ps1
+++ b/scripts/bundle-hermes-runtime-windows.ps1
@@ -159,9 +159,11 @@ $work = Join-Path $outParent "work-windows"
 $bridgeRs = Join-Path $root "src-tauri\src\hermes_bridge.rs"
 
 $commit = Read-Pin $bridgeRs "HERMES_AGENT_INSTALL_COMMIT"
+$patchSet = Read-Pin $bridgeRs "HERMES_RUNTIME_PATCH_SET"
 $tarballUrl = Read-Pin $bridgeRs "HERMES_SOURCE_TARBALL_URL"
 $tarballSha256 = (Read-Pin $bridgeRs "HERMES_SOURCE_TARBALL_SHA256").ToLowerInvariant()
 Log "pin: $commit"
+Log "patch set: $patchSet"
 
 Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $out, $work
 New-Item -ItemType Directory -Force -Path $out, $work | Out-Null
@@ -267,6 +269,11 @@ if (!(Test-Path -LiteralPath $py -PathType Leaf)) {
   Fail "bundled python missing at $py."
 }
 
+Invoke-Native $py @(
+  (Join-Path $root "src-tauri\src\hermes\apply_june_patches.py"),
+  $agentDir
+)
+
 Log "installing python deps"
 $venvDir = Join-Path $agentDir "venv"
 $syncSucceeded = $true
@@ -371,6 +378,7 @@ fn main() {
 Invoke-Native "rustc" @($launcherSource, "-O", "-o", (Join-Path $binDir "hermes.exe"))
 
 [IO.File]::WriteAllText((Join-Path $out "PIN"), "$commit`n", [Text.UTF8Encoding]::new($false))
+[IO.File]::WriteAllText((Join-Path $out "PATCHSET"), "$patchSet`n", [Text.UTF8Encoding]::new($false))
 
 if (!$SkipSelfTest) {
   Log "self-test: running the launcher from a relocated copy"
@@ -386,6 +394,15 @@ if (!$SkipSelfTest) {
       $env:HERMES_HOME = $testHome
       Invoke-Native (Join-Path $selftest "hermes\bin\hermes.exe") @("--version")
       Invoke-Native (Join-Path $selftest "hermes\python\current\python.exe") @("-c", "import hermes_cli.main")
+      Invoke-Native (Join-Path $selftest "hermes\python\current\python.exe") @(
+        (Join-Path $root "src-tauri\src\hermes\apply_june_patches.py"),
+        (Join-Path $selftest "hermes\hermes-agent"),
+        "--verify"
+      )
+      Invoke-Native (Join-Path $selftest "hermes\python\current\python.exe") @(
+        (Join-Path $root "scripts\hermes-approval-patch-smoke.py"),
+        (Join-Path $selftest "hermes\hermes-agent")
+      )
       $pluginRoot = Join-Path $selftest "hermes\hermes-agent\plugins"
       $previousPluginRoot = $env:HERMES_PLUGIN_ROOT
       try {

--- a/scripts/bundle-hermes-runtime.sh
+++ b/scripts/bundle-hermes-runtime.sh
@@ -83,6 +83,13 @@ run_self_test() {
   esac
   "$selftest/hermes/python/current/bin/python3.11" -c "import hermes_cli.main" \
     || die "self-test failed: bare interpreter cannot import hermes_cli (pth broken)"
+  /usr/bin/python3 "$root/src-tauri/src/hermes/apply_june_patches.py" \
+    "$selftest/hermes/hermes-agent" --verify \
+    || die "self-test failed: June Hermes patch checksums do not match"
+  "$selftest/hermes/python/current/bin/python3.11" \
+    "$root/scripts/hermes-approval-patch-smoke.py" \
+    "$selftest/hermes/hermes-agent" \
+    || die "self-test failed: June Hermes approval protocol"
   HERMES_PLUGIN_ROOT="$selftest/hermes/hermes-agent/plugins" \
     "$selftest/hermes/python/current/bin/python3.11" \
     -c "import os, sys; sys.path.insert(0, os.environ['HERMES_PLUGIN_ROOT']); from cron import jobs; assert '/hermes-agent/cron/jobs.py' in jobs.__file__.replace('\\\\', '/'), jobs.__file__" \
@@ -98,6 +105,8 @@ print_bundle_size() {
 bundle_is_reusable() {
   [ -f "$out/PIN" ] || return 1
   [ "$(cat "$out/PIN")" = "$commit" ] || return 1
+  [ -f "$out/PATCHSET" ] || return 1
+  [ "$(cat "$out/PATCHSET")" = "$patch_set" ] || return 1
   [ -x "$out/bin/hermes" ] || return 1
   [ -x "$out/python/current/bin/python3.11" ] || return 1
   [ -d "$out/hermes-agent" ] || return 1
@@ -121,12 +130,15 @@ pin() {
   ' "$bridge_rs"
 }
 commit="$(pin HERMES_AGENT_INSTALL_COMMIT)"
+patch_set="$(pin HERMES_RUNTIME_PATCH_SET)"
 tarball_sha256="$(pin HERMES_SOURCE_TARBALL_SHA256)"
 tarball_url="$(pin HERMES_SOURCE_TARBALL_URL)"
 [ -n "$commit" ] || die "could not read HERMES_AGENT_INSTALL_COMMIT from $bridge_rs"
+[ -n "$patch_set" ] || die "could not read HERMES_RUNTIME_PATCH_SET from $bridge_rs"
 [ -n "$tarball_sha256" ] || die "could not read HERMES_SOURCE_TARBALL_SHA256 from $bridge_rs"
 [ -n "$tarball_url" ] || die "could not read HERMES_SOURCE_TARBALL_URL from $bridge_rs"
 log "pin: $commit"
+log "patch set: $patch_set"
 
 work="$out_parent/work"
 if bundle_is_reusable; then
@@ -169,6 +181,10 @@ unpacked="$(find "$work" -maxdepth 1 -type d -name 'hermes-agent-*' | head -1)"
 [ -n "$unpacked" ] || die "tarball did not contain a hermes-agent directory"
 mkdir -p "$out"
 mv "$unpacked" "$out/hermes-agent"
+
+# Apply June's sealed compatibility patch to the exact pinned sources. The
+# patcher verifies each upstream and post-patch file hash and fails on drift.
+/usr/bin/python3 "$root/src-tauri/src/hermes/apply_june_patches.py" "$out/hermes-agent"
 
 # Dev-only weight the runtime never imports. Conservative on purpose: web/ and
 # ui-tui/ stay (hermes resolves them relative to its project root), and they
@@ -312,6 +328,7 @@ sign_macho_files
 # pins in hermes_bridge.rs and evicts a stale bundle (built before a pin
 # bump) instead of letting it ship silently from a developer machine.
 printf '%s\n' "$commit" > "$out/PIN"
+printf '%s\n' "$patch_set" > "$out/PATCHSET"
 
 # ---- self-test: prove relocatability from a moved path with a space -----------
 run_self_test

--- a/scripts/hermes-approval-patch-smoke.py
+++ b/scripts/hermes-approval-patch-smoke.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Exercise June's patched Hermes approval protocol without provider credentials."""
+
+import argparse
+import hashlib
+import importlib.util
+from pathlib import Path
+import sys
+import threading
+import time
+import types
+
+
+def load_approval(root: Path):
+    hermes_cli = types.ModuleType("hermes_cli")
+    config = types.ModuleType("hermes_cli.config")
+    config.cfg_get = lambda data, *path, default=None: default
+    config.load_config = lambda: {}
+    config.save_config = lambda _data: None
+    hermes_cli.config = config
+    sys.modules["hermes_cli"] = hermes_cli
+    sys.modules["hermes_cli.config"] = config
+
+    utils = types.ModuleType("utils")
+    utils.env_var_enabled = lambda _name: False
+    utils.is_truthy_value = lambda value: str(value).lower() in {"1", "true", "yes"}
+    sys.modules["utils"] = utils
+
+    path = root / "tools" / "approval.py"
+    if not path.is_file():
+        raise RuntimeError("patched Hermes approval module is missing: %s" % path)
+    spec = importlib.util.spec_from_file_location("june_patched_hermes_approval", str(path))
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load patched Hermes approval module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module._get_approval_config = lambda: {"gateway_timeout": 5}
+    module._fire_approval_hook = lambda *_args, **_kwargs: None
+    return module
+
+
+def wait_until(predicate, message: str) -> None:
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError(message)
+
+
+def exercise(approval) -> None:
+    session = "synthetic-session"
+    notifications = []
+    expirations = []
+    results = []
+    approval.register_gateway_notify(
+        session,
+        lambda data: notifications.append(data["request_id"]),
+        lambda data: expirations.append((data["request_id"], data["reason"])),
+    )
+
+    def wait(label: str, request_id: str) -> None:
+        result = approval._await_gateway_decision(
+            session,
+            lambda data: notifications.append(data["request_id"]),
+            {"description": "Synthetic MCP approval", "request_id": request_id},
+            surface="mcp-elicitation/synthetic",
+            request_id=request_id,
+        )
+        results.append((label, result["choice"], result["resolved"]))
+
+    threads = [
+        threading.Thread(target=wait, args=("same-a", "mcp-stable-1")),
+        threading.Thread(target=wait, args=("same-b", "mcp-stable-1")),
+        threading.Thread(target=wait, args=("distinct", "mcp-stable-2")),
+    ]
+    for thread in threads:
+        thread.start()
+
+    def two_queued() -> bool:
+        with approval._lock:
+            return len(approval._gateway_queues.get(session, [])) == 2
+
+    wait_until(two_queued, "duplicate requests did not converge to two logical queue entries")
+    assert notifications == ["mcp-stable-1", "mcp-stable-2"], notifications
+    assert approval.resolve_gateway_approval(
+        session, "deny", request_id="mcp-stable-2"
+    ) == 1
+    assert approval.resolve_gateway_approval(
+        session, "once", request_id="mcp-stable-1"
+    ) == 1
+    for thread in threads:
+        thread.join(timeout=2)
+        assert not thread.is_alive(), "targeted approval thread did not resolve"
+    assert sorted(results) == [
+        ("distinct", "deny", True),
+        ("same-a", "once", True),
+        ("same-b", "once", True),
+    ], results
+
+    replayed = approval._await_gateway_decision(
+        session,
+        lambda data: notifications.append(data["request_id"]),
+        {"request_id": "mcp-stable-1"},
+        request_id="mcp-stable-1",
+    )
+    assert replayed == {"resolved": True, "choice": "once", "replayed": True}, replayed
+    assert notifications == ["mcp-stable-1", "mcp-stable-2"], notifications
+
+    # Non-MCP command/code approvals do not have an upstream request id. The
+    # gateway's existing observability context supplies stable per-tool-call
+    # identity so duplicate delivery converges without merging distinct calls.
+    command_session = "synthetic-command-session"
+    command_notifications = []
+    command_results = []
+    approval.register_gateway_notify(
+        command_session,
+        lambda data: command_notifications.append(data["request_id"]),
+    )
+
+    def command_approval(label: str, tool_call_id: str) -> None:
+        tokens = approval.set_current_observability_context(
+            turn_id="synthetic-turn",
+            tool_call_id=tool_call_id,
+        )
+        try:
+            result = approval._await_gateway_decision(
+                command_session,
+                lambda data: command_notifications.append(data["request_id"]),
+                {
+                    "command": "synthetic-command",
+                    "description": "Synthetic command approval",
+                    "pattern_key": "synthetic_pattern",
+                },
+                surface="gateway",
+            )
+            command_results.append((label, result["choice"], result["resolved"]))
+        finally:
+            approval.reset_current_observability_context(tokens)
+
+    command_threads = [
+        threading.Thread(target=command_approval, args=("same-a", "tool-call-1")),
+        threading.Thread(target=command_approval, args=("same-b", "tool-call-1")),
+        threading.Thread(target=command_approval, args=("distinct", "tool-call-2")),
+    ]
+    for thread in command_threads:
+        thread.start()
+
+    def two_commands_queued() -> bool:
+        with approval._lock:
+            return len(approval._gateway_queues.get(command_session, [])) == 2
+
+    wait_until(two_commands_queued, "non-MCP approvals lost stable tool-call identity")
+    assert len(command_notifications) == 2, command_notifications
+    assert len(set(command_notifications)) == 2, command_notifications
+
+    def command_request_id(tool_call_id: str) -> str:
+        identity = "\0".join(
+            (
+                "gateway",
+                command_session,
+                "synthetic-turn",
+                tool_call_id,
+                "synthetic-command",
+                "Synthetic command approval",
+                "synthetic_pattern",
+                "synthetic_pattern",
+            )
+        )
+        return "gateway-" + hashlib.sha256(identity.encode("utf-8")).hexdigest()[:32]
+
+    command_same = command_request_id("tool-call-1")
+    command_distinct = command_request_id("tool-call-2")
+    assert set(command_notifications) == {command_same, command_distinct}, command_notifications
+    assert approval.resolve_gateway_approval(
+        command_session, "once", request_id=command_same
+    ) == 1
+    assert approval.resolve_gateway_approval(
+        command_session, "deny", request_id=command_distinct
+    ) == 1
+    for thread in command_threads:
+        thread.join(timeout=2)
+        assert not thread.is_alive(), "non-MCP approval thread did not resolve"
+    assert sorted(choice for _, choice, _ in command_results) == ["deny", "once", "once"], (
+        command_results
+    )
+    assert all(resolved for _, _, resolved in command_results), command_results
+
+    # Exercise the MCP-facing entry point too. Exact duplicate delivery and a
+    # reconnect retry converge, while separate requests on one live transport
+    # remain independently addressable even when their prompt text matches.
+    mcp_session = "synthetic-mcp-session"
+    mcp_notifications = []
+    mcp_results = []
+    approval._is_gateway_approval_context = lambda: True
+    approval.register_gateway_notify(
+        mcp_session,
+        lambda data: mcp_notifications.append(data["request_id"]),
+    )
+
+    def consent(label: str, upstream_request_id: int, upstream_transport_id: int) -> None:
+        session_token = approval.set_current_session_key(mcp_session)
+        tool_token = approval._approval_tool_call_id.set("synthetic-tool-call")
+        try:
+            result = approval.request_elicitation_consent(
+                "Distinct permission" if label == "distinct" else "Synthetic permission",
+                "Synthetic MCP approval",
+                surface="mcp-elicitation/synthetic",
+                upstream_request_id=upstream_request_id,
+                upstream_transport_id=upstream_transport_id,
+            )
+            mcp_results.append((label, result))
+        finally:
+            approval._approval_tool_call_id.reset(tool_token)
+            approval.reset_current_session_key(session_token)
+
+    consent_threads = [
+        threading.Thread(target=consent, args=("same-a", 41, 101)),
+        threading.Thread(target=consent, args=("same-b", 41, 101)),
+        threading.Thread(target=consent, args=("concurrent", 44, 101)),
+        threading.Thread(target=consent, args=("distinct", 42, 101)),
+    ]
+    for thread in consent_threads:
+        thread.start()
+
+    def three_mcp_queued() -> bool:
+        with approval._lock:
+            return len(approval._gateway_queues.get(mcp_session, [])) == 3
+
+    wait_until(three_mcp_queued, "MCP identities did not preserve three logical approvals")
+    assert len(mcp_notifications) == 3, mcp_notifications
+    assert len(set(mcp_notifications)) == 3, mcp_notifications
+    request_41 = "mcp-" + hashlib.sha256(
+        "\0".join(("mcp-elicitation/synthetic", "synthetic-tool-call", "41")).encode("utf-8")
+    ).hexdigest()[:32]
+    request_42 = "mcp-" + hashlib.sha256(
+        "\0".join(("mcp-elicitation/synthetic", "synthetic-tool-call", "42")).encode("utf-8")
+    ).hexdigest()[:32]
+    request_43 = "mcp-" + hashlib.sha256(
+        "\0".join(("mcp-elicitation/synthetic", "synthetic-tool-call", "43")).encode("utf-8")
+    ).hexdigest()[:32]
+    request_44 = "mcp-" + hashlib.sha256(
+        "\0".join(("mcp-elicitation/synthetic", "synthetic-tool-call", "44")).encode("utf-8")
+    ).hexdigest()[:32]
+    assert set(mcp_notifications) == {request_41, request_42, request_44}, mcp_notifications
+
+    retry_thread = threading.Thread(target=consent, args=("retry", 43, 202))
+    consent_threads.append(retry_thread)
+    retry_thread.start()
+
+    def retry_joined_pending_request() -> bool:
+        with approval._lock:
+            return any(
+                request_43 in entry.request_ids
+                for entry in approval._gateway_queues.get(mcp_session, [])
+            )
+
+    wait_until(retry_joined_pending_request, "reconnect retry created no pending alias")
+    assert three_mcp_queued(), "reconnect retry multiplied the MCP queue"
+    assert set(mcp_notifications) == {request_41, request_42, request_44}, mcp_notifications
+    approval._MAX_GATEWAY_APPROVAL_ALIASES = 2
+    logical_identity = "\0".join(
+        (
+            "mcp-elicitation/synthetic",
+            "synthetic-tool-call",
+            "Synthetic permission",
+            "Synthetic MCP approval",
+        )
+    )
+    dedup_key = "mcp-logical-" + hashlib.sha256(logical_identity.encode("utf-8")).hexdigest()[:32]
+    alias_overflow = approval._await_gateway_decision(
+        mcp_session,
+        lambda data: mcp_notifications.append(data["request_id"]),
+        {"request_id": "mcp-alias-overflow"},
+        request_id="mcp-alias-overflow",
+        dedup_key=dedup_key,
+        upstream_transport_id=303,
+    )
+    assert alias_overflow == {"resolved": False, "choice": None, "overflow": True}, (
+        alias_overflow
+    )
+    approval._MAX_GATEWAY_APPROVAL_ALIASES = 16
+    assert approval.resolve_gateway_approval(
+        mcp_session, "once", request_id=request_41
+    ) == 1
+    assert approval.resolve_gateway_approval(
+        mcp_session, "once", request_id=request_42
+    ) == 1
+    assert approval.resolve_gateway_approval(
+        mcp_session, "deny", request_id=request_44
+    ) == 1
+    for thread in consent_threads:
+        thread.join(timeout=2)
+        assert not thread.is_alive(), "MCP approval thread did not resolve"
+    assert sorted(result for _, result in mcp_results) == [
+        "accept",
+        "accept",
+        "accept",
+        "accept",
+        "decline",
+    ], mcp_results
+    with approval._lock:
+        assert approval._gateway_completed[mcp_session][request_43] == {"choice": "once"}
+
+    approval._get_approval_config = lambda: {"gateway_timeout": 0}
+    timed_out = approval._await_gateway_decision(
+        session,
+        lambda data: notifications.append(data["request_id"]),
+        {"request_id": "mcp-timeout"},
+        request_id="mcp-timeout",
+    )
+    assert timed_out["resolved"] is False, timed_out
+    assert expirations == [("mcp-timeout", "timeout")], expirations
+
+    malformed = approval._await_gateway_decision(session, lambda _data: None, {})
+    assert malformed["malformed"] is True and malformed["resolved"] is False, malformed
+
+    approval._get_approval_config = lambda: {"gateway_timeout": 5}
+    approval._MAX_GATEWAY_APPROVALS_PER_SESSION = 2
+    disconnect_results = []
+
+    def wait_for_disconnect(request_id: str) -> None:
+        result = approval._await_gateway_decision(
+            session,
+            lambda data: notifications.append(data["request_id"]),
+            {"request_id": request_id},
+            request_id=request_id,
+        )
+        disconnect_results.append(result)
+
+    blocked = [
+        threading.Thread(target=wait_for_disconnect, args=("mcp-blocked-1",)),
+        threading.Thread(target=wait_for_disconnect, args=("mcp-blocked-2",)),
+    ]
+    for thread in blocked:
+        thread.start()
+    wait_until(two_queued, "bounded approval queue did not reach its expected size")
+    overflow = approval._await_gateway_decision(
+        session,
+        lambda data: notifications.append(data["request_id"]),
+        {"request_id": "mcp-overflow"},
+        request_id="mcp-overflow",
+    )
+    assert overflow == {"resolved": False, "choice": None, "overflow": True}, overflow
+    approval.unregister_gateway_notify(session)
+    for thread in blocked:
+        thread.join(timeout=2)
+        assert not thread.is_alive(), "disconnect did not drain a blocked approval"
+    assert all(
+        result["resolved"] is False and result["reason"] == "disconnect"
+        for result in disconnect_results
+    ), disconnect_results
+    with approval._lock:
+        assert not approval._gateway_queues.get(session), "disconnect left queued approvals"
+    replay_notifications = []
+    approval.register_gateway_notify(
+        session,
+        lambda data: replay_notifications.append(data["request_id"]),
+    )
+    disconnected_replay = approval._await_gateway_decision(
+        session,
+        lambda data: replay_notifications.append(data["request_id"]),
+        {"request_id": "mcp-blocked-1"},
+        request_id="mcp-blocked-1",
+    )
+    assert disconnected_replay == {
+        "resolved": False,
+        "choice": None,
+        "replayed": True,
+    }, disconnected_replay
+    assert replay_notifications == [], replay_notifications
+
+    # Repeated reconnect/session ids cannot grow tombstone bookkeeping without
+    # bound even when each session leaves a completed request behind.
+    approval._MAX_COMPLETED_GATEWAY_SESSIONS = 2
+    with approval._lock:
+        approval._gateway_completed.clear()
+        approval._remember_gateway_completion_locked("old-session", "request-1", None)
+        approval._remember_gateway_completion_locked("new-session", "request-2", None)
+        approval._remember_gateway_completion_locked("newest-session", "request-3", None)
+        assert set(approval._gateway_completed) == {"new-session", "newest-session"}, (
+            approval._gateway_completed
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root", type=Path, help="Patched hermes-agent source root")
+    args = parser.parse_args()
+    try:
+        exercise(load_approval(args.root.resolve()))
+    except Exception as exc:
+        print("patched Hermes approval protocol: FAIL: %s" % exc, file=sys.stderr)
+        return 1
+    print("patched Hermes approval protocol: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hermes-smoke.ts
+++ b/scripts/hermes-smoke.ts
@@ -232,9 +232,9 @@ async function main(): Promise<void> {
 
 /**
  * The ordered binary locations the bridge probes, minus the env override (the
- * helper applies that). Mirrors `resolve_hermes_command` /
- * `bundled_hermes_command_candidates` / `user_local_hermes_command` closely
- * enough that a developer with any working June runtime can run the smoke test.
+ * helper applies that). The production bridge accepts only June-bundled or
+ * June-managed patched runtimes; this standalone developer smoke also probes
+ * common local install paths so it can be run before packaging.
  */
 function hermesCandidatePaths(): string[] {
   const windows = process.platform === "win32";
@@ -242,7 +242,7 @@ function hermesCandidatePaths(): string[] {
     windows ? join(root, "Scripts", "hermes.exe") : join(root, "bin", "hermes");
   const candidates: string[] = [];
   // Managed runtime under the worktree-local app data is not knowable here, so
-  // probe the user-local install locations the bridge falls back to.
+  // probe common developer-local install locations for this standalone smoke.
   const home = homedir();
   if (home) {
     candidates.push(venvBin(join(home, ".hermes", "hermes-agent", "venv")));

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -35,13 +35,14 @@ fn main() {
 /// placeholder keeps the build green and the app falls back to the managed
 /// on-device install (`bundled_hermes_command` finds no launcher in it).
 ///
-/// A populated bundle carries a PIN stamp (the hermes-agent commit it was
-/// built from). When that stamp no longer matches the pin in
-/// src/hermes_bridge.rs — a developer bumped the pin after bundling — the
-/// stale bundle is evicted and replaced with the placeholder rather than
-/// silently shipping outdated runtime code.
+/// A populated bundle carries PIN and PATCHSET stamps (the hermes-agent commit
+/// and June compatibility patch it was built from). When either stamp no
+/// longer matches src/hermes_bridge.rs, the stale bundle is evicted and
+/// replaced with the placeholder rather than silently shipping outdated
+/// runtime code.
 fn ensure_bundled_hermes_dir() {
     println!("cargo:rerun-if-changed=../.tauri-hermes/hermes/PIN");
+    println!("cargo:rerun-if-changed=../.tauri-hermes/hermes/PATCHSET");
     let manifest_dir = std::path::PathBuf::from(
         std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR should be set"),
     );
@@ -62,12 +63,21 @@ fn ensure_bundled_hermes_dir() {
             .map(|raw| raw.trim().to_string())
             .unwrap_or_default();
         let pinned = hermes_agent_pinned_commit(&manifest_dir);
-        if !stamped.is_empty() && stamped == pinned {
+        let stamped_patch_set = std::fs::read_to_string(hermes_dir.join("PATCHSET"))
+            .map(|raw| raw.trim().to_string())
+            .unwrap_or_default();
+        let pinned_patch_set = hermes_runtime_patch_set(&manifest_dir);
+        if !stamped.is_empty()
+            && stamped == pinned
+            && !stamped_patch_set.is_empty()
+            && stamped_patch_set == pinned_patch_set
+        {
             return;
         }
         println!(
-            "cargo:warning=bundled Hermes runtime is stale (built from {stamped:?}, pin is \
-             {pinned:?}); evicting it — rerun scripts/bundle-hermes-runtime.sh to bundle again"
+            "cargo:warning=bundled Hermes runtime is stale (built from {stamped:?} with patch \
+             {stamped_patch_set:?}, expected {pinned:?} with patch {pinned_patch_set:?}); evicting \
+             it — rerun scripts/bundle-hermes-runtime.sh to bundle again"
         );
         if let Err(error) = std::fs::remove_dir_all(&hermes_dir) {
             println!(
@@ -96,11 +106,19 @@ ship the runtime inside the app.\n";
 /// script cannot import crate constants, so this parses the declaration the
 /// same way scripts/bundle-hermes-runtime.sh does — one source of truth.
 fn hermes_agent_pinned_commit(manifest_dir: &std::path::Path) -> String {
+    hermes_bridge_constant(manifest_dir, "HERMES_AGENT_INSTALL_COMMIT")
+}
+
+fn hermes_runtime_patch_set(manifest_dir: &std::path::Path) -> String {
+    hermes_bridge_constant(manifest_dir, "HERMES_RUNTIME_PATCH_SET")
+}
+
+fn hermes_bridge_constant(manifest_dir: &std::path::Path, name: &str) -> String {
     let source = std::fs::read_to_string(manifest_dir.join("src").join("hermes_bridge.rs"))
         .unwrap_or_default();
     source
         .lines()
-        .find(|line| line.contains("const HERMES_AGENT_INSTALL_COMMIT"))
+        .find(|line| line.contains(&format!("const {name}")))
         .and_then(|line| {
             let start = line.find('"')? + 1;
             let end = line[start..].find('"')? + start;

--- a/src-tauri/src/hermes/apply_june_patches.py
+++ b/src-tauri/src/hermes/apply_june_patches.py
@@ -1,0 +1,704 @@
+#!/usr/bin/env python3
+"""Apply June's deterministic compatibility patches to the pinned Hermes tree.
+
+The source archive is still verified against the upstream SHA-256 before this
+script runs. Each touched file must then match either its exact upstream hash or
+its exact patched hash. Any other input fails closed.
+"""
+
+import argparse
+import hashlib
+from pathlib import Path
+import sys
+from typing import Callable, Dict
+
+
+PATCH_SET = "june-approval-v1"
+
+UPSTREAM_SHA256: Dict[str, str] = {
+    "tools/approval.py": "e31abc88357afa28c05f3a4753ea9908b540b0dfef8dab2fa62960ae19a63c85",
+    "tools/mcp_tool.py": "3f0aca90d076a1b0aa5daffd7bb39b0d1a4fee83265f855e68d556e5c8a29d01",
+    "tui_gateway/server.py": "1743cec5c6684651d2b7cb18b7b73a37ea99538a4f56bcd8476700ce23d4f01a",
+}
+
+# Filled after applying the transformations to the exact upstream files. These
+# hashes are part of the runtime provenance contract, not best-effort checks.
+PATCHED_SHA256: Dict[str, str] = {
+    "tools/approval.py": "56e88034ebcac8cff8c579c56345e4cb3fe2fe597360687d40b68daefd402e3d",
+    "tools/mcp_tool.py": "48a2fddfee5d5a8c33723e27639907e9f2cf062c82e7beeb844f457e6a372cfa",
+    "tui_gateway/server.py": "41197c75c3aee760a05a8ecdce4daa3d0ca7f62b34486f29a21f097086a4ef4e",
+}
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def replace_once(source: str, old: str, new: str, label: str) -> str:
+    count = source.count(old)
+    if count != 1:
+        raise RuntimeError("%s: expected one match, found %d" % (label, count))
+    return source.replace(old, new, 1)
+
+
+def replace_region(source: str, start: str, end: str, replacement: str, label: str) -> str:
+    start_index = source.find(start)
+    if start_index < 0:
+        raise RuntimeError("%s: start marker not found" % label)
+    end_index = source.find(end, start_index)
+    if end_index < 0:
+        raise RuntimeError("%s: end marker not found" % label)
+    if source.find(start, start_index + 1) >= 0:
+        raise RuntimeError("%s: start marker is not unique" % label)
+    return source[:start_index] + replacement + source[end_index:]
+
+
+def patch_approval(source: str) -> str:
+    source = replace_once(
+        source,
+        "import contextvars\nimport fnmatch\n",
+        "import contextvars\nimport fnmatch\nimport hashlib\n",
+        "approval imports",
+    )
+
+    queue_region = r'''class _ApprovalEntry:
+    """One pending dangerous-command approval inside a gateway session."""
+    __slots__ = (
+        "event", "data", "request_id", "request_ids", "dedup_key",
+        "upstream_transport_id", "result", "notify_failed", "retired_reason",
+    )
+
+    def __init__(
+        self,
+        data: dict,
+        request_id: str,
+        dedup_key: Optional[str] = None,
+        upstream_transport_id: Optional[str] = None,
+    ):
+        self.event = threading.Event()
+        self.data = data          # command, description, pattern_keys, …
+        self.request_id = request_id
+        self.request_ids = {request_id}
+        self.dedup_key = dedup_key
+        self.upstream_transport_id = upstream_transport_id
+        self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
+        self.notify_failed = False
+        self.retired_reason: Optional[str] = None
+
+
+_MAX_GATEWAY_APPROVALS_PER_SESSION = 32
+_MAX_GATEWAY_APPROVAL_ALIASES = 16
+_MAX_COMPLETED_GATEWAY_APPROVALS_PER_SESSION = 128
+_MAX_COMPLETED_GATEWAY_SESSIONS = 256
+_gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
+_gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
+_gateway_expire_cbs: dict[str, object] = {}  # session_key → callable(expiration_data)
+_gateway_completed: dict[str, dict] = {}     # session_key → request_id → choice|None
+
+
+def register_gateway_notify(session_key: str, cb, expire_cb=None) -> None:
+    """Register callbacks for approval requests and fail-closed retirement."""
+    with _lock:
+        _gateway_notify_cbs[session_key] = cb
+        if expire_cb is None:
+            _gateway_expire_cbs.pop(session_key, None)
+        else:
+            _gateway_expire_cbs[session_key] = expire_cb
+
+
+def _emit_gateway_expiration(session_key: str, entry: _ApprovalEntry, reason: str) -> None:
+    with _lock:
+        expire_cb = _gateway_expire_cbs.get(session_key)
+    if expire_cb is None:
+        return
+    try:
+        expire_cb({"request_id": entry.request_id, "reason": reason})
+    except Exception as exc:
+        logger.warning("Gateway approval expiration notify failed: %s", exc)
+
+
+def _remember_gateway_completion_locked(
+    session_key: str,
+    request_id: str,
+    choice: Optional[str],
+) -> None:
+    completed = _gateway_completed.get(session_key)
+    if completed is None:
+        while len(_gateway_completed) >= _MAX_COMPLETED_GATEWAY_SESSIONS:
+            _gateway_completed.pop(next(iter(_gateway_completed)))
+        completed = {}
+        _gateway_completed[session_key] = completed
+    completed[request_id] = {"choice": choice}
+    while len(completed) > _MAX_COMPLETED_GATEWAY_APPROVALS_PER_SESSION:
+        completed.pop(next(iter(completed)))
+
+
+def _remember_gateway_entry_completion_locked(
+    session_key: str,
+    entry: _ApprovalEntry,
+    choice: Optional[str],
+) -> None:
+    for request_id in entry.request_ids:
+        _remember_gateway_completion_locked(session_key, request_id, choice)
+
+
+def unregister_gateway_notify(session_key: str) -> None:
+    """Unregister callbacks and fail closed every blocked approval."""
+    with _lock:
+        _gateway_notify_cbs.pop(session_key, None)
+        expire_cb = _gateway_expire_cbs.pop(session_key, None)
+        entries = _gateway_queues.pop(session_key, [])
+        for entry in entries:
+            entry.retired_reason = "disconnect"
+            _remember_gateway_entry_completion_locked(session_key, entry, None)
+    for entry in entries:
+        entry.event.set()
+        if expire_cb is not None:
+            try:
+                expire_cb({"request_id": entry.request_id, "reason": "disconnect"})
+            except Exception as exc:
+                logger.warning("Gateway approval expiration notify failed: %s", exc)
+
+
+def resolve_gateway_approval(
+    session_key: str,
+    choice: str,
+    resolve_all: bool = False,
+    request_id: Optional[str] = None,
+) -> int:
+    """Resolve a targeted request, retaining FIFO only for legacy callers."""
+    with _lock:
+        queue = _gateway_queues.get(session_key)
+        if not queue:
+            return 0
+        if request_id:
+            target = next((entry for entry in queue if entry.request_id == request_id), None)
+            if target is None:
+                return 0
+            targets = [target]
+            queue.remove(target)
+        elif resolve_all:
+            targets = list(queue)
+            queue.clear()
+        else:
+            targets = [queue.pop(0)]
+        if not queue:
+            _gateway_queues.pop(session_key, None)
+        for entry in targets:
+            entry.result = choice
+            _remember_gateway_entry_completion_locked(session_key, entry, choice)
+
+    for entry in targets:
+        entry.event.set()
+    return len(targets)
+
+
+def has_blocking_approval(session_key: str) -> bool:
+    """Check if a session has one or more blocking gateway approvals waiting."""
+    with _lock:
+        return bool(_gateway_queues.get(session_key))
+
+
+'''
+    source = replace_region(
+        source,
+        "class _ApprovalEntry:\n",
+        "def submit_pending(session_key: str, approval: dict):\n",
+        queue_region,
+        "approval queue protocol",
+    )
+
+    await_region = r'''def _await_gateway_decision(
+    session_key: str,
+    notify_cb,
+    approval_data: dict,
+    *,
+    surface: str = "gateway",
+    request_id: Optional[str] = None,
+    dedup_key: Optional[str] = None,
+    upstream_transport_id: Optional[str] = None,
+) -> dict:
+    """Wait for one bounded, identity-addressable gateway approval."""
+    command = approval_data.get("command", "")
+    description = approval_data.get("description", "")
+    primary_key = approval_data.get("pattern_key", "")
+    all_keys = approval_data.get("pattern_keys", [primary_key])
+
+    if not isinstance(all_keys, (list, tuple)):
+        all_keys = [primary_key]
+
+    request_id = str(request_id or approval_data.get("request_id") or "").strip()
+    if not request_id:
+        turn_id = str(_approval_turn_id.get() or "").strip()
+        tool_call_id = str(_approval_tool_call_id.get() or "").strip()
+        if not tool_call_id:
+            logger.warning("Gateway approval has no stable request context; failing closed")
+            return {"resolved": False, "choice": None, "malformed": True}
+        identity = "\0".join(
+            (
+                surface,
+                session_key,
+                turn_id,
+                tool_call_id,
+                str(command),
+                str(description),
+                str(primary_key),
+                "\x1f".join(str(key) for key in all_keys),
+            )
+        )
+        request_id = "gateway-" + hashlib.sha256(identity.encode("utf-8")).hexdigest()[:32]
+    approval_data = dict(approval_data)
+    approval_data["request_id"] = request_id
+    dedup_key = str(dedup_key or "").strip()
+    upstream_transport_id = str(upstream_transport_id or "").strip()
+
+    owner = False
+    with _lock:
+        completed = _gateway_completed.get(session_key, {}).get(request_id)
+        if completed is not None:
+            choice = completed.get("choice")
+            return {"resolved": choice is not None, "choice": choice, "replayed": True}
+
+        queue = _gateway_queues.setdefault(session_key, [])
+        entry = next((candidate for candidate in queue if candidate.request_id == request_id), None)
+        if entry is None and dedup_key and upstream_transport_id:
+            entry = next(
+                (
+                    candidate
+                    for candidate in queue
+                    if candidate.dedup_key == dedup_key
+                    and candidate.upstream_transport_id
+                    and candidate.upstream_transport_id != upstream_transport_id
+                ),
+                None,
+            )
+        if entry is not None:
+            if (
+                request_id not in entry.request_ids
+                and len(entry.request_ids) >= _MAX_GATEWAY_APPROVAL_ALIASES
+            ):
+                logger.warning(
+                    "Gateway approval retry aliases full for %s; failing request %s closed",
+                    session_key,
+                    request_id,
+                )
+                return {"resolved": False, "choice": None, "overflow": True}
+            entry.request_ids.add(request_id)
+        if entry is None:
+            if len(queue) >= _MAX_GATEWAY_APPROVALS_PER_SESSION:
+                logger.warning(
+                    "Gateway approval queue full for %s; failing request %s closed",
+                    session_key,
+                    request_id,
+                )
+                return {
+                    "resolved": False,
+                    "choice": None,
+                    "overflow": True,
+                }
+            entry = _ApprovalEntry(
+                approval_data,
+                request_id,
+                dedup_key or None,
+                upstream_transport_id or None,
+            )
+            queue.append(entry)
+            owner = True
+
+    if owner:
+        _fire_approval_hook(
+            "pre_approval_request",
+            command=command,
+            description=description,
+            pattern_key=primary_key,
+            pattern_keys=list(all_keys),
+            session_key=session_key,
+            surface=surface,
+        )
+        try:
+            notify_cb(approval_data)
+        except Exception as exc:
+            logger.warning("Gateway approval notify failed: %s", exc)
+            with _lock:
+                queue = _gateway_queues.get(session_key, [])
+                if entry in queue:
+                    queue.remove(entry)
+                if not queue:
+                    _gateway_queues.pop(session_key, None)
+                entry.notify_failed = True
+                entry.retired_reason = "notify_failed"
+                _remember_gateway_entry_completion_locked(session_key, entry, None)
+            entry.event.set()
+
+    timeout = _get_approval_config().get("gateway_timeout", 300)
+    try:
+        timeout = int(timeout)
+    except (ValueError, TypeError):
+        timeout = 300
+
+    try:
+        from tools.environments.base import touch_activity_if_due
+    except Exception:  # pragma: no cover
+        touch_activity_if_due = None
+
+    now = time.monotonic()
+    deadline = now + max(timeout, 0)
+    activity_state = {"last_touch": now, "start": now}
+    while not entry.event.is_set():
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            retired = False
+            with _lock:
+                queue = _gateway_queues.get(session_key, [])
+                if entry in queue:
+                    queue.remove(entry)
+                    if not queue:
+                        _gateway_queues.pop(session_key, None)
+                    entry.retired_reason = "timeout"
+                    _remember_gateway_entry_completion_locked(session_key, entry, None)
+                    retired = True
+            if retired:
+                entry.event.set()
+                _emit_gateway_expiration(session_key, entry, "timeout")
+            break
+        entry.event.wait(timeout=min(1.0, remaining))
+        if not entry.event.is_set() and touch_activity_if_due is not None:
+            touch_activity_if_due(activity_state, "waiting for user approval")
+
+    choice = entry.result
+    resolved = choice is not None
+    if owner:
+        outcome = choice if resolved else (entry.retired_reason or "timeout")
+        _fire_approval_hook(
+            "post_approval_response",
+            command=command,
+            description=description,
+            pattern_key=primary_key,
+            pattern_keys=list(all_keys),
+            session_key=session_key,
+            surface=surface,
+            choice=outcome,
+        )
+    return {
+        "resolved": resolved,
+        "choice": choice,
+        "notify_failed": entry.notify_failed,
+        "reason": entry.retired_reason,
+    }
+
+
+'''
+    source = replace_region(
+        source,
+        "def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,\n",
+        "def check_all_command_guards(command: str, env_type: str,\n",
+        await_region,
+        "approval wait protocol",
+    )
+
+    source = replace_once(
+        source,
+        '''def request_elicitation_consent(
+    message: str,
+    description: str,
+    *,
+    timeout_seconds: int | None = None,
+    surface: str = "mcp-elicitation",
+) -> str:
+''',
+        '''def request_elicitation_consent(
+    message: str,
+    description: str,
+    *,
+    timeout_seconds: int | None = None,
+    surface: str = "mcp-elicitation",
+    upstream_request_id=None,
+    upstream_transport_id=None,
+) -> str:
+''',
+        "elicitation signature",
+    )
+    source = replace_once(
+        source,
+        '''        approval_data = {
+            "command": message,
+            "description": description,
+            "pattern_key": "mcp_elicitation",
+            "pattern_keys": ["mcp_elicitation"],
+        }
+        try:
+            decision = _await_gateway_decision(
+                session_key, notify_cb, approval_data, surface=surface,
+            )
+''',
+        '''        if isinstance(upstream_request_id, bool) or not isinstance(
+            upstream_request_id, (str, int)
+        ) or not str(upstream_request_id).strip():
+            logger.warning("MCP elicitation has no valid upstream request id; failing closed")
+            return "decline"
+        if isinstance(upstream_transport_id, bool) or not isinstance(
+            upstream_transport_id, (str, int)
+        ) or not str(upstream_transport_id).strip():
+            logger.warning("MCP elicitation has no valid transport identity; failing closed")
+            return "decline"
+        identity = "\\0".join(
+            (surface, _approval_tool_call_id.get(), str(upstream_request_id))
+        )
+        request_id = "mcp-" + hashlib.sha256(identity.encode("utf-8")).hexdigest()[:32]
+        logical_identity = "\\0".join(
+            (surface, _approval_tool_call_id.get(), message, description)
+        )
+        dedup_key = "mcp-logical-" + hashlib.sha256(
+            logical_identity.encode("utf-8")
+        ).hexdigest()[:32]
+        approval_data = {
+            "command": message,
+            "description": description,
+            "pattern_key": "mcp_elicitation",
+            "pattern_keys": ["mcp_elicitation"],
+            "request_id": request_id,
+            "allow_permanent": False,
+        }
+        try:
+            decision = _await_gateway_decision(
+                session_key,
+                notify_cb,
+                approval_data,
+                surface=surface,
+                request_id=request_id,
+                dedup_key=dedup_key,
+                upstream_transport_id=upstream_transport_id,
+            )
+''',
+        "elicitation stable identity",
+    )
+    return source
+
+
+def patch_mcp_tool(source: str) -> str:
+    source = replace_once(
+        source,
+        '''        schema = getattr(params, "requested_schema", {}) or {}
+        description = _format_elicitation_schema_summary(schema, self.server_name)
+
+        logger.info(
+''',
+        '''        schema = getattr(params, "requested_schema", {}) or {}
+        description = _format_elicitation_schema_summary(schema, self.server_name)
+        upstream_request_id = getattr(context, "request_id", None)
+        if isinstance(upstream_request_id, bool) or not isinstance(
+            upstream_request_id, (str, int)
+        ) or not str(upstream_request_id).strip():
+            logger.warning(
+                "MCP server '%s' elicitation has no valid request id; declining",
+                self.server_name,
+            )
+            self.metrics["declined"] += 1
+            return ElicitResult(action="decline")
+        upstream_transport_id = id(getattr(context, "session", context))
+
+        logger.info(
+''',
+        "MCP context request id",
+    )
+    source = source.replace(
+        '''                    surface=f"mcp-elicitation/{self.server_name}",
+                )
+''',
+        '''                    surface=f"mcp-elicitation/{self.server_name}",
+                    upstream_request_id=upstream_request_id,
+                    upstream_transport_id=upstream_transport_id,
+                )
+''',
+    )
+    source = replace_once(
+        source,
+        '''                timeout_seconds=int(self.timeout),
+                surface=f"mcp-elicitation/{self.server_name}",
+            )
+''',
+        '''                timeout_seconds=int(self.timeout),
+                surface=f"mcp-elicitation/{self.server_name}",
+                upstream_request_id=upstream_request_id,
+                upstream_transport_id=upstream_transport_id,
+            )
+''',
+        "captured MCP request id",
+    )
+    if source.count("upstream_request_id=upstream_request_id") != 2:
+        raise RuntimeError("MCP request id: expected two consent call sites")
+    if source.count("upstream_transport_id=upstream_transport_id") != 2:
+        raise RuntimeError("MCP transport id: expected two consent call sites")
+    return source
+
+
+def patch_server(source: str) -> str:
+    source = replace_once(
+        source,
+        '''            session["transport"] = _detached_ws_transport
+            detached += 1
+            try:
+                _schedule_ws_orphan_reap(sid)
+''',
+        '''            session["transport"] = _detached_ws_transport
+            detached += 1
+            # A parked session can be resumed, but an approval tied to the
+            # disconnected client cannot. Drain it immediately fail closed;
+            # session.resume registers a fresh callback for future requests.
+            try:
+                from tools.approval import unregister_gateway_notify
+
+                if key := session.get("session_key"):
+                    unregister_gateway_notify(key)
+            except Exception:
+                pass
+            try:
+                _schedule_ws_orphan_reap(sid)
+''',
+        "server disconnect approval drain",
+    )
+    source = replace_once(
+        source,
+        '''                register_gateway_notify(
+                    key, lambda data: _emit("approval.request", sid, data)
+                )
+''',
+        '''                register_gateway_notify(
+                    key,
+                    lambda data: _emit("approval.request", sid, data),
+                    lambda data: _emit("approval.expire", sid, data),
+                )
+''',
+        "server create approval callbacks",
+    )
+    source = replace_once(
+        source,
+        '''            register_gateway_notify(
+                new_session_id,
+                lambda data: _emit("approval.request", sid, data),
+            )
+''',
+        '''            register_gateway_notify(
+                new_session_id,
+                lambda data: _emit("approval.request", sid, data),
+                lambda data: _emit("approval.expire", sid, data),
+            )
+''',
+        "server continuation approval callbacks",
+    )
+    source = replace_once(
+        source,
+        '''        register_gateway_notify(key, lambda data: _emit("approval.request", sid, data))
+''',
+        '''        register_gateway_notify(
+            key,
+            lambda data: _emit("approval.request", sid, data),
+            lambda data: _emit("approval.expire", sid, data),
+        )
+''',
+        "server exec approval callbacks",
+    )
+
+    handler = r'''@method("approval.respond")
+def _(rid, params: dict) -> dict:
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    request_id = params.get("request_id")
+    if request_id is not None and (
+        not isinstance(request_id, str) or not request_id.strip()
+    ):
+        return _err(rid, 4002, "approval.respond request_id must be a non-empty string")
+    choice = params.get("choice", "deny")
+    if choice not in ("once", "session", "always", "deny"):
+        return _err(rid, 4002, "approval.respond choice is invalid")
+    try:
+        from tools.approval import resolve_gateway_approval
+
+        resolved = resolve_gateway_approval(
+            session["session_key"],
+            choice,
+            resolve_all=params.get("all", False) if request_id is None else False,
+            request_id=request_id,
+        )
+        if resolved == 1 and request_id:
+            _emit(
+                "approval.response",
+                params.get("session_id", ""),
+                {"request_id": request_id, "choice": choice},
+            )
+        return _ok(rid, {"resolved": resolved})
+    except Exception as e:
+        return _err(rid, 5004, str(e))
+
+
+'''
+    source = replace_region(
+        source,
+        '@method("approval.respond")\n',
+        '@method("config.set")\n',
+        handler,
+        "targeted approval response",
+    )
+    return source
+
+
+PATCHERS: Dict[str, Callable[[str], str]] = {
+    "tools/approval.py": patch_approval,
+    "tools/mcp_tool.py": patch_mcp_tool,
+    "tui_gateway/server.py": patch_server,
+}
+
+
+def apply(root: Path, verify_only: bool) -> Dict[str, str]:
+    observed: Dict[str, str] = {}
+    for relative, patcher in PATCHERS.items():
+        path = root / relative
+        if not path.is_file():
+            raise RuntimeError("missing pinned Hermes file: %s" % path)
+        current = sha256(path)
+        patched = PATCHED_SHA256[relative]
+        if patched and current == patched:
+            observed[relative] = current
+            continue
+        if current != UPSTREAM_SHA256[relative]:
+            raise RuntimeError(
+                "%s hash mismatch: expected upstream %s or patched %s, got %s"
+                % (relative, UPSTREAM_SHA256[relative], patched or "<unsealed>", current)
+            )
+        if verify_only:
+            raise RuntimeError("%s is still unpatched" % relative)
+        transformed = patcher(path.read_text(encoding="utf-8"))
+        # Write bytes so Python 3.9 (the macOS system interpreter) works and
+        # Windows cannot translate LF into CRLF before the sealed hash check.
+        path.write_bytes(transformed.encode("utf-8"))
+        observed[relative] = sha256(path)
+        if patched and observed[relative] != patched:
+            raise RuntimeError(
+                "%s patched hash mismatch: expected %s, got %s"
+                % (relative, patched, observed[relative])
+            )
+    return observed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root", type=Path)
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--print-hashes", action="store_true")
+    args = parser.parse_args()
+    try:
+        hashes = apply(args.root.resolve(), args.verify)
+    except Exception as exc:
+        print("Hermes patch set %s failed: %s" % (PATCH_SET, exc), file=sys.stderr)
+        return 1
+    if args.print_hashes:
+        for relative in sorted(hashes):
+            print('%s = "%s"' % (relative, hashes[relative]))
+    else:
+        print("Hermes patch set %s verified" % PATCH_SET)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -34,6 +34,7 @@ const JUNE_HERMES_DISABLE_SANDBOX_ENV: &str = "JUNE_HERMES_DISABLE_SANDBOX";
 const SANDBOX_EXEC_PATH: &str = "/usr/bin/sandbox-exec";
 // v2026.6.19 - see the bump PR for the audited pin-to-tag compatibility delta.
 const HERMES_AGENT_INSTALL_COMMIT: &str = "2bd1977d8fad185c9b4be47884f7e87f1add0ce3";
+const HERMES_RUNTIME_PATCH_SET: &str = "june-approval-v1";
 const HERMES_SOURCE_TARBALL_URL: &str =
     "https://github.com/NousResearch/hermes-agent/archive/2bd1977d8fad185c9b4be47884f7e87f1add0ce3.tar.gz";
 const HERMES_SOURCE_TARBALL_SHA256: &str =
@@ -548,8 +549,6 @@ enum HermesCommandSource {
     EnvOverride,
     BundledRuntime,
     ManagedRuntime,
-    UserLocalFallback,
-    PathFallback,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -5975,6 +5974,7 @@ async fn resolve_hermes_command(
     let managed_install_dir = managed_hermes_runtime_dir(app)?.join("hermes-agent");
     let managed_command = hermes_venv_command(&managed_install_dir.join("venv"));
     if managed_command.exists() && managed_hermes_runtime_current(app)? {
+        verify_managed_hermes_runtime_patch(app, &managed_install_dir)?;
         ensure_managed_hermes_sitecustomize(&managed_install_dir)?;
         return Ok(HermesCommandResolution {
             command: managed_command.to_string_lossy().into_owned(),
@@ -5982,21 +5982,10 @@ async fn resolve_hermes_command(
         });
     }
 
-    if let Err(error) = install_managed_hermes_runtime(app, hermes_home).await {
-        if let Some(command) = user_local_hermes_command() {
-            eprintln!(
-                "failed to install June-managed Hermes runtime; using existing user-local Hermes fallback: {}",
-                error.message
-            );
-            return Ok(HermesCommandResolution {
-                command: command.to_string_lossy().into_owned(),
-                source: HermesCommandSource::UserLocalFallback,
-            });
-        }
-        return Err(error);
-    }
+    install_managed_hermes_runtime(app, hermes_home).await?;
 
     if managed_command.exists() {
+        verify_managed_hermes_runtime_patch(app, &managed_install_dir)?;
         ensure_managed_hermes_sitecustomize(&managed_install_dir)?;
         return Ok(HermesCommandResolution {
             command: managed_command.to_string_lossy().into_owned(),
@@ -6004,17 +5993,10 @@ async fn resolve_hermes_command(
         });
     }
 
-    if let Some(command) = user_local_hermes_command() {
-        return Ok(HermesCommandResolution {
-            command: command.to_string_lossy().into_owned(),
-            source: HermesCommandSource::UserLocalFallback,
-        });
-    }
-
-    Ok(HermesCommandResolution {
-        command: "hermes".to_string(),
-        source: HermesCommandSource::PathFallback,
-    })
+    Err(AppError::new(
+        "hermes_runtime_install_failed",
+        "June-managed Hermes install completed without a Hermes executable",
+    ))
 }
 
 fn bundled_hermes_command(app: &AppHandle) -> Option<PathBuf> {
@@ -6058,22 +6040,10 @@ fn managed_hermes_runtime_current(app: &AppHandle) -> Result<bool, AppError> {
     let Ok(metadata) = fs::read_to_string(metadata_path) else {
         return Ok(false);
     };
-    Ok(metadata.contains(&format!(r#""commit":"{HERMES_AGENT_INSTALL_COMMIT}""#)))
-}
-
-fn user_local_hermes_command() -> Option<PathBuf> {
-    let mut candidates = Vec::new();
-    for home in home_dir_candidates() {
-        candidates.push(hermes_venv_command(
-            &home.join(".hermes").join("hermes-agent").join("venv"),
-        ));
-        candidates.push(if cfg!(target_os = "windows") {
-            home.join(".local").join("bin").join("hermes.exe")
-        } else {
-            home.join(".local").join("bin").join("hermes")
-        });
-    }
-    candidates.into_iter().find(|path| path.exists())
+    Ok(
+        metadata.contains(&format!(r#""commit":"{HERMES_AGENT_INSTALL_COMMIT}""#))
+            && metadata.contains(&format!(r#""patchSet":"{HERMES_RUNTIME_PATCH_SET}""#)),
+    )
 }
 
 fn hermes_venv_command(venv_dir: &Path) -> PathBuf {
@@ -6085,6 +6055,45 @@ fn hermes_venv_command(venv_dir: &Path) -> PathBuf {
 }
 
 const HERMES_SITE_CUSTOMIZE: &str = include_str!("hermes/sitecustomize.py");
+const HERMES_RUNTIME_PATCH_SCRIPT: &str = include_str!("hermes/apply_june_patches.py");
+
+fn write_managed_hermes_patch_script(runtime_dir: &Path) -> Result<PathBuf, AppError> {
+    let path = runtime_dir.join("apply-june-hermes-patches.py");
+    if fs::read_to_string(&path).ok().as_deref() != Some(HERMES_RUNTIME_PATCH_SCRIPT) {
+        fs::write(&path, HERMES_RUNTIME_PATCH_SCRIPT)
+            .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
+    }
+    Ok(path)
+}
+
+fn verify_managed_hermes_runtime_patch(
+    app: &AppHandle,
+    install_dir: &Path,
+) -> Result<(), AppError> {
+    let runtime_dir = managed_hermes_runtime_dir(app)?;
+    let script = write_managed_hermes_patch_script(&runtime_dir)?;
+    let python = if cfg!(target_os = "windows") {
+        install_dir.join("venv").join("Scripts").join("python.exe")
+    } else {
+        install_dir.join("venv").join("bin").join("python")
+    };
+    let status = Command::new(&python)
+        .arg(&script)
+        .arg(install_dir)
+        .arg("--verify")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|error| AppError::new("hermes_runtime_patch_failed", error.to_string()))?;
+    if !status.success() {
+        return Err(AppError::new(
+            "hermes_runtime_patch_failed",
+            "The managed Hermes runtime failed its June patch checksum verification.",
+        ));
+    }
+    Ok(())
+}
 
 fn ensure_managed_hermes_sitecustomize(install_dir: &Path) -> Result<(), AppError> {
     for site_packages in managed_hermes_site_packages_dirs(install_dir)? {
@@ -6202,6 +6211,7 @@ async fn install_managed_hermes_runtime_unix(
     let install_dir = runtime_dir.join("hermes-agent");
     fs::create_dir_all(&runtime_dir)
         .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
+    let patch_script = write_managed_hermes_patch_script(&runtime_dir)?;
     if install_dir.exists() && !managed_hermes_runtime_current(app)? {
         fs::remove_dir_all(&install_dir)
             .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
@@ -6233,6 +6243,8 @@ async fn install_managed_hermes_runtime_unix(
                 .env("JUNE_HERMES_INSTALL_DIR", &install_dir)
                 .env("JUNE_HERMES_HOME", &hermes_home)
                 .env("JUNE_HERMES_INSTALL_COMMIT", HERMES_AGENT_INSTALL_COMMIT)
+                .env("JUNE_HERMES_PATCH_SET", HERMES_RUNTIME_PATCH_SET)
+                .env("JUNE_HERMES_PATCH_SCRIPT", &patch_script)
                 .env("JUNE_HERMES_SOURCE_TARBALL_URL", HERMES_SOURCE_TARBALL_URL)
                 .env(
                     "JUNE_HERMES_SOURCE_TARBALL_SHA256",
@@ -6291,6 +6303,7 @@ async fn install_managed_hermes_runtime_windows(
     let install_dir = runtime_dir.join("hermes-agent");
     fs::create_dir_all(&runtime_dir)
         .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
+    let patch_script = write_managed_hermes_patch_script(&runtime_dir)?;
     if install_dir.exists() && !managed_hermes_runtime_current(app)? {
         fs::remove_dir_all(&install_dir)
             .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
@@ -6326,6 +6339,8 @@ async fn install_managed_hermes_runtime_windows(
                 .env("JUNE_HERMES_INSTALL_DIR", &install_dir)
                 .env("JUNE_HERMES_HOME", &hermes_home)
                 .env("JUNE_HERMES_INSTALL_COMMIT", HERMES_AGENT_INSTALL_COMMIT)
+                .env("JUNE_HERMES_PATCH_SET", HERMES_RUNTIME_PATCH_SET)
+                .env("JUNE_HERMES_PATCH_SCRIPT", &patch_script)
                 .env("JUNE_HERMES_SOURCE_TARBALL_URL", HERMES_SOURCE_TARBALL_URL)
                 .env(
                     "JUNE_HERMES_SOURCE_TARBALL_SHA256",
@@ -6380,6 +6395,8 @@ runtime_dir="${JUNE_HERMES_RUNTIME_DIR:?}"
 install_dir="${JUNE_HERMES_INSTALL_DIR:?}"
 hermes_home="${JUNE_HERMES_HOME:?}"
 install_commit="${JUNE_HERMES_INSTALL_COMMIT:?}"
+patch_set="${JUNE_HERMES_PATCH_SET:?}"
+patch_script="${JUNE_HERMES_PATCH_SCRIPT:?}"
 source_tarball_url="${JUNE_HERMES_SOURCE_TARBALL_URL:?}"
 source_tarball_sha256="${JUNE_HERMES_SOURCE_TARBALL_SHA256:?}"
 
@@ -6421,6 +6438,8 @@ sed -e 's/^\$UV_CMD/"$UV_CMD"/g' \
   > "$install_dir/scripts/install.sh.quoted"
 mv "$install_dir/scripts/install.sh.quoted" "$install_dir/scripts/install.sh"
 
+/usr/bin/python3 "$patch_script" "$install_dir"
+
 run_stage() {
   local stage="$1"
   HERMES_HOME="$hermes_home" HERMES_INSTALL_DIR="$install_dir" \
@@ -6439,7 +6458,7 @@ run_stage config
 run_stage complete
 
 cat > "$runtime_dir/runtime.json" <<EOF
-{"source":"NousResearch/hermes-agent","commit":"$install_commit","installDir":"$install_dir"}
+{"source":"NousResearch/hermes-agent","commit":"$install_commit","patchSet":"$patch_set","installDir":"$install_dir"}
 EOF
 "#;
 
@@ -6452,6 +6471,8 @@ $runtimeDir = $env:JUNE_HERMES_RUNTIME_DIR
 $installDir = $env:JUNE_HERMES_INSTALL_DIR
 $hermesHome = $env:JUNE_HERMES_HOME
 $installCommit = $env:JUNE_HERMES_INSTALL_COMMIT
+$patchSet = $env:JUNE_HERMES_PATCH_SET
+$patchScript = $env:JUNE_HERMES_PATCH_SCRIPT
 $sourceTarballUrl = $env:JUNE_HERMES_SOURCE_TARBALL_URL
 $sourceTarballSha256 = ($env:JUNE_HERMES_SOURCE_TARBALL_SHA256).ToLowerInvariant()
 
@@ -6534,6 +6555,8 @@ if (!(Test-Path (Join-Path $installDir "pyproject.toml"))) {
 }
 
 $python = Resolve-Python
+$patchArgs = @($python.Args + @($patchScript, $installDir))
+Invoke-Native $python.Exe $patchArgs
 $venvDir = Join-Path $installDir "venv"
 if (Test-Path $venvDir) {
   Remove-Item -Recurse -Force -Path $venvDir
@@ -6597,6 +6620,7 @@ if (!(Test-Path $hermesExe)) {
 $metadata = [ordered]@{
   source = "NousResearch/hermes-agent"
   commit = $installCommit
+  patchSet = $patchSet
   installDir = $installDir
 } | ConvertTo-Json -Compress
 [System.IO.File]::WriteAllText((Join-Path $runtimeDir "runtime.json"), $metadata, (New-Object System.Text.UTF8Encoding $false))

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -35,6 +35,20 @@ const SANDBOX_EXEC_PATH: &str = "/usr/bin/sandbox-exec";
 // v2026.6.19 - see the bump PR for the audited pin-to-tag compatibility delta.
 const HERMES_AGENT_INSTALL_COMMIT: &str = "2bd1977d8fad185c9b4be47884f7e87f1add0ce3";
 const HERMES_RUNTIME_PATCH_SET: &str = "june-approval-v1";
+const HERMES_RUNTIME_PATCHED_SOURCE_HASHES: &[(&str, &str)] = &[
+    (
+        "tools/approval.py",
+        "56e88034ebcac8cff8c579c56345e4cb3fe2fe597360687d40b68daefd402e3d",
+    ),
+    (
+        "tools/mcp_tool.py",
+        "48a2fddfee5d5a8c33723e27639907e9f2cf062c82e7beeb844f457e6a372cfa",
+    ),
+    (
+        "tui_gateway/server.py",
+        "41197c75c3aee760a05a8ecdce4daa3d0ca7f62b34486f29a21f097086a4ef4e",
+    ),
+];
 const HERMES_SOURCE_TARBALL_URL: &str =
     "https://github.com/NousResearch/hermes-agent/archive/2bd1977d8fad185c9b4be47884f7e87f1add0ce3.tar.gz";
 const HERMES_SOURCE_TARBALL_SHA256: &str =
@@ -5974,7 +5988,7 @@ async fn resolve_hermes_command(
     let managed_install_dir = managed_hermes_runtime_dir(app)?.join("hermes-agent");
     let managed_command = hermes_venv_command(&managed_install_dir.join("venv"));
     if managed_command.exists() && managed_hermes_runtime_current(app)? {
-        verify_managed_hermes_runtime_patch(app, &managed_install_dir)?;
+        verify_managed_hermes_runtime_patch(&managed_install_dir)?;
         ensure_managed_hermes_sitecustomize(&managed_install_dir)?;
         return Ok(HermesCommandResolution {
             command: managed_command.to_string_lossy().into_owned(),
@@ -5985,7 +5999,7 @@ async fn resolve_hermes_command(
     install_managed_hermes_runtime(app, hermes_home).await?;
 
     if managed_command.exists() {
-        verify_managed_hermes_runtime_patch(app, &managed_install_dir)?;
+        verify_managed_hermes_runtime_patch(&managed_install_dir)?;
         ensure_managed_hermes_sitecustomize(&managed_install_dir)?;
         return Ok(HermesCommandResolution {
             command: managed_command.to_string_lossy().into_owned(),
@@ -6066,31 +6080,35 @@ fn write_managed_hermes_patch_script(runtime_dir: &Path) -> Result<PathBuf, AppE
     Ok(path)
 }
 
-fn verify_managed_hermes_runtime_patch(
-    app: &AppHandle,
+fn verify_managed_hermes_runtime_patch(install_dir: &Path) -> Result<(), AppError> {
+    verify_hermes_runtime_source_hashes(install_dir, HERMES_RUNTIME_PATCHED_SOURCE_HASHES)
+}
+
+fn verify_hermes_runtime_source_hashes(
     install_dir: &Path,
+    expected_sources: &[(&str, &str)],
 ) -> Result<(), AppError> {
-    let runtime_dir = managed_hermes_runtime_dir(app)?;
-    let script = write_managed_hermes_patch_script(&runtime_dir)?;
-    let python = if cfg!(target_os = "windows") {
-        install_dir.join("venv").join("Scripts").join("python.exe")
-    } else {
-        install_dir.join("venv").join("bin").join("python")
-    };
-    let status = Command::new(&python)
-        .arg(&script)
-        .arg(install_dir)
-        .arg("--verify")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map_err(|error| AppError::new("hermes_runtime_patch_failed", error.to_string()))?;
-    if !status.success() {
-        return Err(AppError::new(
-            "hermes_runtime_patch_failed",
-            "The managed Hermes runtime failed its June patch checksum verification.",
-        ));
+    for (relative_path, expected_hash) in expected_sources {
+        let path = install_dir.join(relative_path);
+        let bytes = fs::read(&path).map_err(|error| {
+            AppError::new(
+                "hermes_runtime_patch_failed",
+                format!(
+                    "Could not verify managed Hermes source {}: {error}",
+                    path.display()
+                ),
+            )
+        })?;
+        let actual_hash = hex_encode(&sha256_bytes(&bytes));
+        if actual_hash != *expected_hash {
+            return Err(AppError::new(
+                "hermes_runtime_patch_failed",
+                format!(
+                    "Managed Hermes source {} failed checksum verification: expected {expected_hash}, got {actual_hash}",
+                    path.display()
+                ),
+            ));
+        }
     }
     Ok(())
 }
@@ -13499,6 +13517,32 @@ mcp_servers:
                     .join("hermes")
             ));
         }
+    }
+
+    #[test]
+    fn managed_runtime_source_verification_is_native_and_fail_closed() {
+        let install_dir = tempfile::tempdir().expect("tempdir");
+        let source_path = install_dir.path().join("tools").join("approval.py");
+        std::fs::create_dir_all(source_path.parent().expect("parent")).expect("source dir");
+        std::fs::write(&source_path, b"patched source").expect("source");
+        let expected_hash = hex_encode(&sha256_bytes(b"patched source"));
+
+        verify_hermes_runtime_source_hashes(
+            install_dir.path(),
+            &[("tools/approval.py", expected_hash.as_str())],
+        )
+        .expect("matching source hash");
+
+        std::fs::write(&source_path, b"tampered source").expect("tampered source");
+        let error = verify_hermes_runtime_source_hashes(
+            install_dir.path(),
+            &[("tools/approval.py", expected_hash.as_str())],
+        )
+        .expect_err("tampered source must fail closed");
+        assert_eq!(error.code, "hermes_runtime_patch_failed");
+        assert!(error.message.contains("tools/approval.py"));
+        assert!(error.message.contains("expected"));
+        assert!(error.message.contains("got"));
     }
 
     #[test]

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -404,6 +404,10 @@ const SESSION_GONE_MESSAGE = "This session has ended, so the request can no long
 const SESSION_NOT_AVAILABLE_MESSAGE =
   "This session is no longer available. Open another conversation or start a new one.";
 
+function approvalResponseKey(sessionId: string, requestId: string): string {
+  return `${sessionId}\u0000${requestId}`;
+}
+
 // A stable id for the "June is still working" nudge (fired when a send is
 // rejected mid-turn), so repeated send attempts refresh one toast instead of
 // stacking.
@@ -2740,6 +2744,10 @@ export function AgentWorkspace({
   const [approvalSubmitting, setApprovalSubmitting] = useState<
     Partial<Record<string, AgentApprovalChoice>>
   >({});
+  // Synchronous transport state for disconnect reconciliation. React state can
+  // lag behind the socket close callback by one render, so it cannot tell us
+  // reliably whether Hermes may already have accepted a response.
+  const approvalResponsesInFlightRef = useRef(new Map<string, AgentApprovalChoice>());
   const [clarifySubmitting, setClarifySubmitting] = useState<Record<string, string>>({});
   // Sudo records which choice (approve/deny) is in flight per request id;
   // secret records only that a submit is in flight (NEVER the value).
@@ -7525,14 +7533,23 @@ export function AgentWorkspace({
     const retiredAt = new Date().toISOString();
     for (const record of pendingActionStore.openRecords()) {
       if (!activeSessionIds.has(record.sessionId) || record.action.kind !== "approval") continue;
-      pendingActionStore.expireRequest(record.sessionId, record.requestId, "disconnect");
+      // The socket rejects pending RPCs immediately before this close handler
+      // runs. A response that was already processed upstream may therefore be
+      // unacknowledged locally. Retire it so it cannot be sent twice, but do not
+      // claim that nothing was approved when the outcome is unknowable.
+      const reason = approvalResponsesInFlightRef.current.has(
+        approvalResponseKey(record.sessionId, record.requestId),
+      )
+        ? "unconfirmed"
+        : "disconnect";
+      pendingActionStore.expireRequest(record.sessionId, record.requestId, reason);
       const expiration: JuneHermesEvent = {
         kind: "pending_action_expiration",
         sessionId: record.sessionId,
         action: {
           kind: "approval",
           requestId: record.requestId,
-          reason: "disconnect",
+          reason,
         },
         receivedAt: retiredAt,
       };
@@ -7818,6 +7835,11 @@ export function AgentWorkspace({
     choice: AgentApprovalChoice,
     unrestricted = false,
   ) {
+    const responseKey = approvalResponseKey(liveEventKey, requestId);
+    // The card disables on the next render; guard synchronously too so a rapid
+    // second activation cannot target the same logical approval twice.
+    if (approvalResponsesInFlightRef.current.has(responseKey)) return;
+    approvalResponsesInFlightRef.current.set(responseKey, choice);
     setApprovalSubmitting((current) => ({ ...current, [requestId]: choice }));
     try {
       // The approval lives in the runtime process that asked, so the
@@ -7898,6 +7920,7 @@ export function AgentWorkspace({
         setError(message, { sessionId });
       }
     } finally {
+      approvalResponsesInFlightRef.current.delete(responseKey);
       setApprovalSubmitting((current) => {
         const next = { ...current };
         delete next[requestId];
@@ -14154,19 +14177,23 @@ function videoProgressLabel(part: Extract<AgentChatPart, { type: "video" }>) {
 
 /** A resolved action card renders as a quiet, expandable one-line row instead
  * of a full card — a receipt in the transcript rather than a prompt. The row
- * mirrors {@link ContextCompactionPart}: an outcome glyph (checkmark / cross)
+ * mirrors {@link ContextCompactionPart}: an outcome glyph (checkmark / cross /
+ * warning)
  * that cross-fades to a plain-text "+"/"−" on hover (pure opacity — no layout
  * shift, a WKWebView compositing constraint), a short outcome label, and a
  * truncated one-line detail. Expanding reveals the full detail body (the
  * `children`) minus the action buttons. */
 function ResolvedActionRow({
   denied = false,
+  unknown = false,
   label,
   detail,
   children,
 }: {
   /** Renders the cross glyph and destructive tint instead of the checkmark. */
   denied?: boolean;
+  /** Renders a neutral warning glyph when the transport lost the outcome. */
+  unknown?: boolean;
   /** Short outcome word(s), e.g. "Approved once" / "Answered" / "Denied". */
   label: string;
   /** One-line truncated detail shown inline on the collapsed row. */
@@ -14177,11 +14204,16 @@ function ResolvedActionRow({
   return (
     <details
       className="agent-tool-disclosure agent-resolved-row"
-      data-choice={denied ? "deny" : "done"}
+      data-choice={unknown ? "unknown" : denied ? "deny" : "done"}
     >
       <summary>
         <span className="agent-tool-icon">
-          {denied ? (
+          {unknown ? (
+            <IconExclamationTriangle
+              size={15}
+              className="agent-tool-icon-glyph agent-resolved-icon-glyph"
+            />
+          ) : denied ? (
             <IconCrossSmall size={15} className="agent-tool-icon-glyph agent-resolved-icon-glyph" />
           ) : (
             <IconCheckmark2Small
@@ -14646,10 +14678,12 @@ export function ApprovalPart({
   // description and command — no action buttons.
   if (resolved) {
     if (part.status === "expired") {
+      const outcomeUnconfirmed = part.retiredReason === "unconfirmed";
       return (
         <ResolvedActionRow
-          denied
-          label="Approval expired"
+          denied={!outcomeUnconfirmed}
+          unknown={outcomeUnconfirmed}
+          label={outcomeUnconfirmed ? "Approval outcome unknown" : "Approval expired"}
           detail={
             part.command ? (
               <span className="agent-resolved-mono">{part.command}</span>
@@ -14658,7 +14692,15 @@ export function ApprovalPart({
             )
           }
         >
-          <p>This approval is no longer pending. June did not approve anything.</p>
+          {outcomeUnconfirmed ? (
+            <p>
+              The connection closed before June could confirm the response. This approval is no
+              longer actionable, but it may have already been applied. Check the agent activity
+              before retrying.
+            </p>
+          ) : (
+            <p>This approval is no longer pending. June did not approve anything.</p>
+          )}
           {part.command ? <pre>{part.command}</pre> : null}
         </ResolvedActionRow>
       );

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -3057,6 +3057,23 @@ export function AgentWorkspace({
     return agentStatusFromHermesEvent(event, hasOpenPendingAction);
   }
 
+  function recordOptimisticHermesActivityAndDispatchStatus(
+    event: JuneHermesEvent,
+    storedSessionId: string,
+  ) {
+    const storedEvent = withStoredHermesSessionId(event, storedSessionId);
+    const status = recordHermesActivityAndDeriveStatus(storedEvent, storedSessionId);
+    if (!status) return;
+    dispatchAgentSessionStatus({
+      sessionId: storedSessionId,
+      title:
+        hermesSessionItemsRef.current.find((session) => session.id === storedSessionId)?.title ??
+        "Agent session",
+      status,
+      summary: agentStatusSummaryFromHermesEvent(storedEvent, status),
+    });
+  }
+
   function recordSessionErrorActivity(sessionId: string, message: string) {
     cancelAgentRunSettlement(sessionId);
     hermesActivityStore.record(
@@ -7899,29 +7916,27 @@ export function AgentWorkspace({
         return;
       }
       if (response.resolved === 0) {
-        pushLiveEvent(
-          liveEventKey,
-          classifyOptimisticLiveEvent({
-            type: "approval.expire",
-            session_id: sessionId,
-            payload: { request_id: requestId, reason: "stale" },
-          }),
-        );
+        const expiration = classifyOptimisticLiveEvent({
+          type: "approval.expire",
+          session_id: sessionId,
+          payload: { request_id: requestId, reason: "stale" },
+        });
+        pushLiveEvent(liveEventKey, expiration);
         pendingActionStore.expireRequest(liveEventKey, requestId, "stale");
+        recordOptimisticHermesActivityAndDispatchStatus(expiration, liveEventKey);
         setError("This approval is no longer pending. Nothing was approved.", { sessionId });
         return;
       }
-      pushLiveEvent(
-        liveEventKey,
-        classifyOptimisticLiveEvent({
-          type: "approval.response",
-          session_id: sessionId,
-          payload: { request_id: requestId, choice },
-        }),
-      );
+      const resolution = classifyOptimisticLiveEvent({
+        type: "approval.response",
+        session_id: sessionId,
+        payload: { request_id: requestId, choice },
+      });
+      pushLiveEvent(liveEventKey, resolution);
       // Feature 04: the user just answered this approval — clear its global
       // "Needs you" row immediately (the response itself is the resolution).
       pendingActionStore.resolveRequest(liveEventKey, requestId);
+      recordOptimisticHermesActivityAndDispatchStatus(resolution, liveEventKey);
       setError(null);
     } catch (err) {
       const message = messageFromError(err);
@@ -7973,15 +7988,14 @@ export function AgentWorkspace({
         request_id: requestId,
         answer,
       });
-      pushLiveEvent(
-        liveEventKey,
-        classifyOptimisticLiveEvent({
-          type: "clarify.response",
-          payload: { request_id: requestId, answer },
-        }),
-      );
+      const resolution = classifyOptimisticLiveEvent({
+        type: "clarify.response",
+        payload: { request_id: requestId, answer },
+      });
+      pushLiveEvent(liveEventKey, resolution);
       // Feature 04: the user answered the clarification — clear its pending record.
       pendingActionStore.resolveRequest(liveEventKey, requestId);
+      recordOptimisticHermesActivityAndDispatchStatus(resolution, liveEventKey);
       setError(null);
     } catch (err) {
       const message = messageFromError(err);
@@ -8026,16 +8040,15 @@ export function AgentWorkspace({
         approved,
         mode,
       });
-      pushLiveEvent(
-        liveEventKey,
-        classifyOptimisticLiveEvent({
-          type: "sudo.response",
-          session_id: sessionId,
-          payload: { request_id: requestId, granted: approved, mode },
-        }),
-      );
+      const resolution = classifyOptimisticLiveEvent({
+        type: "sudo.response",
+        session_id: sessionId,
+        payload: { request_id: requestId, granted: approved, mode },
+      });
+      pushLiveEvent(liveEventKey, resolution);
       // Feature 04: the user resolved the sudo prompt — clear its pending record.
       pendingActionStore.resolveRequest(liveEventKey, requestId);
+      recordOptimisticHermesActivityAndDispatchStatus(resolution, liveEventKey);
       setError(null);
     } catch (err) {
       const message = messageFromError(err);
@@ -8074,16 +8087,15 @@ export function AgentWorkspace({
         requestId,
         value,
       });
-      pushLiveEvent(
-        liveEventKey,
-        classifyOptimisticLiveEvent({
-          type: "secret.response",
-          session_id: sessionId,
-          payload: { request_id: requestId, provided: true },
-        }),
-      );
+      const resolution = classifyOptimisticLiveEvent({
+        type: "secret.response",
+        session_id: sessionId,
+        payload: { request_id: requestId, provided: true },
+      });
+      pushLiveEvent(liveEventKey, resolution);
       // Feature 04: the user provided the secret — clear its pending record.
       pendingActionStore.resolveRequest(liveEventKey, requestId);
+      recordOptimisticHermesActivityAndDispatchStatus(resolution, liveEventKey);
       setError(null);
     } catch (err) {
       const message = messageFromError(err);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7828,12 +7828,24 @@ export function AgentWorkspace({
         method: "approval.respond",
         params: { session_id: sessionId, request_id: requestId, choice },
       });
-      const response = await gateway.request<{ resolved?: number }>("approval.respond", {
+      const response = await gateway.request<unknown>("approval.respond", {
         session_id: sessionId,
         request_id: requestId,
         choice,
       });
-      if (response?.resolved !== 1) {
+      if (
+        response === null ||
+        typeof response !== "object" ||
+        Array.isArray(response) ||
+        !("resolved" in response) ||
+        (response.resolved !== 0 && response.resolved !== 1)
+      ) {
+        setError("June could not confirm the approval outcome. Reconnect, then try again.", {
+          sessionId: liveEventKey,
+        });
+        return;
+      }
+      if (response.resolved === 0) {
         pushLiveEvent(
           liveEventKey,
           classifyOptimisticLiveEvent({

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -3049,6 +3049,14 @@ export function AgentWorkspace({
     );
   }
 
+  function recordHermesActivityAndDeriveStatus(event: JuneHermesEvent, storedSessionId: string) {
+    hermesActivityStore.record(event, hermesModeFor(storedSessionId));
+    const hasOpenPendingAction = pendingActionStore
+      .openRecords()
+      .some((record) => record.sessionId === storedSessionId);
+    return agentStatusFromHermesEvent(event, hasOpenPendingAction);
+  }
+
   function recordSessionErrorActivity(sessionId: string, message: string) {
     cancelAgentRunSettlement(sessionId);
     hermesActivityStore.record(
@@ -6726,6 +6734,12 @@ export function AgentWorkspace({
         // fresh event for a known request also re-confirms a row that went
         // stale across a reconnect (see the store's reconcile logic).
         pendingActionStore.record(storedClassified, hermesModeFor(storedSessionId));
+      } else if (storedClassified.kind === "pending_action_resolution") {
+        // Resolution events can arrive independently of this surface's local
+        // response promise (for example after reconnect). Reconcile the exact
+        // logical request before deriving the session status so another
+        // distinct pending action keeps the session in "Needs you".
+        pendingActionStore.resolveRequest(storedSessionId, storedClassified.action.requestId);
       } else if (storedClassified.kind === "pending_action_expiration") {
         pendingActionStore.expireRequest(
           storedSessionId,
@@ -6739,7 +6753,7 @@ export function AgentWorkspace({
       // derives the session's phase (running/waiting/background/error/complete),
       // current tool, and subagent count from the normalized event — never from
       // the raw frame (raw JSON belongs to feature 15's trace panel).
-      hermesActivityStore.record(storedClassified, hermesModeFor(storedSessionId));
+      const status = recordHermesActivityAndDeriveStatus(storedClassified, storedSessionId);
       // Feature 14: extract any file/artifact reference this event carries into
       // the per-session artifact timeline behind the drawer's "Artifacts"
       // section. The store is total and only acts on `tool` completions that
@@ -6773,7 +6787,6 @@ export function AgentWorkspace({
           for (const entry of list) entry.toolDrained = true;
         }
       }
-      const status = agentStatusFromHermesEvent(classified);
       const activityCounts =
         status === "completed" || status === "failed" || status === "cancelled"
           ? agentActivityCountsFromStore()
@@ -7530,6 +7543,10 @@ export function AgentWorkspace({
     // keep their existing stale/reannounce reconciliation contract.
     let retiredApprovalEvents = liveEventsRef.current;
     let retiredApprovalChanged = false;
+    const retiredApprovalStatuses = new Map<
+      string,
+      { event: JuneHermesEvent; status: AgentSessionStatusKind }
+    >();
     const retiredAt = new Date().toISOString();
     for (const record of pendingActionStore.openRecords()) {
       if (!activeSessionIds.has(record.sessionId) || record.action.kind !== "approval") continue;
@@ -7553,6 +7570,10 @@ export function AgentWorkspace({
         },
         receivedAt: retiredAt,
       };
+      const status = recordHermesActivityAndDeriveStatus(expiration, record.sessionId);
+      if (status) {
+        retiredApprovalStatuses.set(record.sessionId, { event: expiration, status });
+      }
       retiredApprovalEvents = {
         ...retiredApprovalEvents,
         [record.sessionId]: [...(retiredApprovalEvents[record.sessionId] ?? []), expiration].slice(
@@ -7564,6 +7585,16 @@ export function AgentWorkspace({
     if (retiredApprovalChanged) {
       liveEventsRef.current = retiredApprovalEvents;
       setLiveEvents(retiredApprovalEvents);
+    }
+    for (const [sessionId, { event, status }] of retiredApprovalStatuses) {
+      dispatchAgentSessionStatus({
+        sessionId,
+        title:
+          hermesSessionItemsRef.current.find((session) => session.id === sessionId)?.title ??
+          "Agent session",
+        status,
+        summary: agentStatusSummaryFromHermesEvent(event, status),
+      });
     }
     try {
       const gateway = await ensureHermesGateway(fullMode);
@@ -16354,10 +16385,10 @@ export function projectAgentActivityLevels(
   const waitingSessionIds = new Set<string>();
   const toolCallSessionIds = new Set<string>();
   for (const record of records) {
-    if (record.phase === "running" || record.phase === "background") {
-      workingSessionIds.add(record.sessionId);
-    } else if (record.phase === "waiting") {
+    if (record.pendingActionCount > 0 || record.phase === "waiting") {
       waitingSessionIds.add(record.sessionId);
+    } else if (record.phase === "running" || record.phase === "background") {
+      workingSessionIds.add(record.sessionId);
     }
     if (record.currentTool) {
       toolCallSessionIds.add(record.sessionId);
@@ -16390,11 +16421,14 @@ function lifecycleStatusLooksRunning(event: Extract<JuneHermesEvent, { kind: "li
   return event.flavor === "running";
 }
 
-function agentStatusFromHermesEvent(event: JuneHermesEvent): AgentSessionStatusKind | undefined {
+function agentStatusFromHermesEvent(
+  event: JuneHermesEvent,
+  hasOpenPendingAction = false,
+): AgentSessionStatusKind | undefined {
   if (event.kind === "error") return "failed";
   if (event.kind === "pending_action") return "waitingForUser";
   if (event.kind === "pending_action_resolution" || event.kind === "pending_action_expiration") {
-    return "running";
+    return hasOpenPendingAction ? "waitingForUser" : "running";
   }
   if (event.kind === "transcript" && event.complete) {
     return event.failed ? "failed" : "completed";

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -4243,10 +4243,9 @@ export function AgentWorkspace({
       removeHermesSessionLocally,
     };
     gatewayCloseHandlerRef.current = (fullMode: boolean) => {
-      // Feature 04: a disconnect is NOT a resolution — pending actions must
-      // survive it. markDisconnected is intentionally a no-op on state; the
-      // reconcile after a successful reconnect (below) is what marks anything
-      // unconfirmed as stale rather than dropping it.
+      // Feature 04: mark the transport drop, then let recovery retire approvals
+      // fail closed while preserving the existing stale/reannounce contract for
+      // clarify, sudo, and secret actions.
       pendingActionStore.markDisconnected();
       void recoverFromGatewayClose(fullMode);
     };
@@ -6719,6 +6718,12 @@ export function AgentWorkspace({
         // fresh event for a known request also re-confirms a row that went
         // stale across a reconnect (see the store's reconcile logic).
         pendingActionStore.record(storedClassified, hermesModeFor(storedSessionId));
+      } else if (storedClassified.kind === "pending_action_expiration") {
+        pendingActionStore.expireRequest(
+          storedSessionId,
+          storedClassified.action.requestId,
+          storedClassified.action.reason,
+        );
       }
       // Feature 11: roll EVERY classified event into the global activity store
       // that backs the Agent activity drawer. The store is total and ignores
@@ -7510,6 +7515,39 @@ export function AgentWorkspace({
     );
     if (!activeSessionIds.size) return;
     gatewayRecoveringRef.current.add(fullMode);
+    // The patched Hermes gateway denies and drains unresolved MCP approvals
+    // when its notification socket disconnects. Mirror that fail-closed
+    // boundary locally before reconnecting: an old card must never remain
+    // actionable against a newly resumed runtime. Other pending-action kinds
+    // keep their existing stale/reannounce reconciliation contract.
+    let retiredApprovalEvents = liveEventsRef.current;
+    let retiredApprovalChanged = false;
+    const retiredAt = new Date().toISOString();
+    for (const record of pendingActionStore.openRecords()) {
+      if (!activeSessionIds.has(record.sessionId) || record.action.kind !== "approval") continue;
+      pendingActionStore.expireRequest(record.sessionId, record.requestId, "disconnect");
+      const expiration: JuneHermesEvent = {
+        kind: "pending_action_expiration",
+        sessionId: record.sessionId,
+        action: {
+          kind: "approval",
+          requestId: record.requestId,
+          reason: "disconnect",
+        },
+        receivedAt: retiredAt,
+      };
+      retiredApprovalEvents = {
+        ...retiredApprovalEvents,
+        [record.sessionId]: [...(retiredApprovalEvents[record.sessionId] ?? []), expiration].slice(
+          -200,
+        ),
+      };
+      retiredApprovalChanged = true;
+    }
+    if (retiredApprovalChanged) {
+      liveEventsRef.current = retiredApprovalEvents;
+      setLiveEvents(retiredApprovalEvents);
+    }
     try {
       const gateway = await ensureHermesGateway(fullMode);
       await Promise.all(
@@ -7525,6 +7563,14 @@ export function AgentWorkspace({
                 ...current,
                 [sessionId]: runtimeSessionId,
               }));
+              attachHermesSessionEventListener({
+                gateway,
+                runtimeSessionId,
+                sessionDisplayTitle:
+                  hermesSessionItemsRef.current.find((session) => session.id === sessionId)
+                    ?.title ?? "Agent session",
+                storedSessionId: sessionId,
+              });
             }
           } catch {
             // The runtime session may be gone; the poll reconciles it.
@@ -7536,10 +7582,10 @@ export function AgentWorkspace({
     } finally {
       gatewayRecoveringRef.current.delete(fullMode);
     }
-    // Feature 04: the gateway is back. Any pending action not re-announced by a
-    // fresh event is now unverifiable across the drop, so mark it stale —
-    // visible but visually distinct — rather than silently dropping a possible
-    // blocker. A re-announced request flips its row back to open in the feed.
+    // Feature 04: the gateway is back. Any non-approval pending action not
+    // re-announced by a fresh event is unverifiable across the drop, so mark it
+    // stale rather than silently dropping a possible blocker. Approvals were
+    // already retired above because the gateway drains them fail closed.
     pendingActionStore.reconcileAfterReconnect();
     for (const sessionId of activeSessionIds) {
       void refreshHermesSession(sessionId);
@@ -7777,10 +7823,29 @@ export function AgentWorkspace({
       // The approval lives in the runtime process that asked, so the
       // response must go out on that mode's gateway.
       const gateway = await ensureHermesGateway(unrestricted);
-      await gateway.request("approval.respond", {
+      hermesTraceBuffer.recordOutbound({
+        sessionId: liveEventKey,
+        method: "approval.respond",
+        params: { session_id: sessionId, request_id: requestId, choice },
+      });
+      const response = await gateway.request<{ resolved?: number }>("approval.respond", {
         session_id: sessionId,
+        request_id: requestId,
         choice,
       });
+      if (response?.resolved !== 1) {
+        pushLiveEvent(
+          liveEventKey,
+          classifyOptimisticLiveEvent({
+            type: "approval.expire",
+            session_id: sessionId,
+            payload: { request_id: requestId, reason: "stale" },
+          }),
+        );
+        pendingActionStore.expireRequest(liveEventKey, requestId, "stale");
+        setError("This approval is no longer pending. Nothing was approved.", { sessionId });
+        return;
+      }
       pushLiveEvent(
         liveEventKey,
         classifyOptimisticLiveEvent({
@@ -7814,7 +7879,7 @@ export function AgentWorkspace({
         setLiveEvents(liveEventsRef.current);
         // The request can never be answered now — retire its card so neither the
         // sidebar count nor the inline prompt offers a dead-end "Respond".
-        pendingActionStore.resolveRequest(liveEventKey, requestId);
+        pendingActionStore.expireRequest(liveEventKey, requestId, "disconnect");
         void loadHermesSessions();
         setError(SESSION_GONE_MESSAGE, { sessionId });
       } else {
@@ -14568,6 +14633,24 @@ export function ApprovalPart({
   // command (or description) truncated to one line, expandable to the full
   // description and command — no action buttons.
   if (resolved) {
+    if (part.status === "expired") {
+      return (
+        <ResolvedActionRow
+          denied
+          label="Approval expired"
+          detail={
+            part.command ? (
+              <span className="agent-resolved-mono">{part.command}</span>
+            ) : (
+              part.description
+            )
+          }
+        >
+          <p>This approval is no longer pending. June did not approve anything.</p>
+          {part.command ? <pre>{part.command}</pre> : null}
+        </ResolvedActionRow>
+      );
+    }
     return (
       <ResolvedActionRow
         denied={activeChoice === "deny"}
@@ -16256,7 +16339,9 @@ function lifecycleStatusLooksRunning(event: Extract<JuneHermesEvent, { kind: "li
 function agentStatusFromHermesEvent(event: JuneHermesEvent): AgentSessionStatusKind | undefined {
   if (event.kind === "error") return "failed";
   if (event.kind === "pending_action") return "waitingForUser";
-  if (event.kind === "pending_action_resolution") return "running";
+  if (event.kind === "pending_action_resolution" || event.kind === "pending_action_expiration") {
+    return "running";
+  }
   if (event.kind === "transcript" && event.complete) {
     return event.failed ? "failed" : "completed";
   }

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -56,7 +56,8 @@ export type AgentChatApprovalPart = {
   description: string;
   allowPermanent: boolean;
   choice?: AgentApprovalChoice;
-  status: "pending" | "resolved";
+  status: "pending" | "resolved" | "expired";
+  retiredReason?: string;
 };
 
 export type AgentChatClarifyPart = {
@@ -843,6 +844,20 @@ function appendLiveHermesEvents(
         break;
       }
 
+      case "pending_action_expiration": {
+        const targetParts = (currentAssistant ?? lastAssistantTurn(turns))?.parts ?? [];
+        upsertApprovalPart(targetParts, {
+          id: event.action.requestId,
+          command: "",
+          description: "",
+          sessionId: optionalSessionId(event.sessionId),
+          allowPermanent: false,
+          status: "expired",
+          retiredReason: event.action.reason,
+        });
+        break;
+      }
+
       case "error": {
         currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
         const notice = event.message ? turnNotice(event.message) : undefined;
@@ -1112,7 +1127,10 @@ function completeRunningParts(parts: AgentChatPart[]) {
       part.status = "complete";
     }
     if (part.type === "tool" && part.status === "running") part.status = "complete";
-    if (part.type === "approval" && part.status === "pending") part.status = "resolved";
+    if (part.type === "approval" && part.status === "pending") {
+      part.status = "expired";
+      part.retiredReason = "session-complete";
+    }
     if (part.type === "clarify" && part.status === "pending") part.status = "resolved";
     if (part.type === "sudo" && part.status === "pending") part.status = "resolved";
     if (part.type === "secret" && part.status === "pending") part.status = "resolved";
@@ -1215,17 +1233,21 @@ function upsertApprovalPart(
     AgentChatApprovalPart,
     "id" | "command" | "description" | "allowPermanent" | "status"
   > &
-    Partial<Pick<AgentChatApprovalPart, "choice" | "sessionId">>,
+    Partial<Pick<AgentChatApprovalPart, "choice" | "sessionId" | "retiredReason">>,
 ) {
   const existing = parts.find(
     (part): part is AgentChatApprovalPart => part.type === "approval" && part.id === next.id,
   );
   if (existing) {
+    // Resolution and expiration are sticky. A delayed replay must not reopen a
+    // card the user already answered or Hermes already retired.
+    if (next.status === "pending" && existing.status !== "pending") return;
     existing.command = next.command || existing.command;
     existing.description = next.description || existing.description;
     existing.sessionId = next.sessionId || existing.sessionId;
     existing.allowPermanent = next.allowPermanent;
     existing.choice = next.choice ?? existing.choice;
+    existing.retiredReason = next.retiredReason ?? existing.retiredReason;
     existing.status = next.status;
     return;
   }
@@ -1238,6 +1260,7 @@ function upsertApprovalPart(
     allowPermanent: next.allowPermanent,
     choice: next.choice,
     status: next.status,
+    retiredReason: next.retiredReason,
   });
 }
 

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -1242,6 +1242,8 @@ function upsertApprovalPart(
     // Resolution and expiration are sticky. A delayed replay must not reopen a
     // card the user already answered or Hermes already retired.
     if (next.status === "pending" && existing.status !== "pending") return;
+    // A late expiration must not hide the decision the user already made.
+    if (next.status === "expired" && existing.status === "resolved") return;
     existing.command = next.command || existing.command;
     existing.description = next.description || existing.description;
     existing.sessionId = next.sessionId || existing.sessionId;

--- a/src/lib/hermes-activity-store.ts
+++ b/src/lib/hermes-activity-store.ts
@@ -186,6 +186,14 @@ export function createHermesActivityStore(
     if (mode === "unrestricted") row.mode = mode;
     row.lastEventAt = eventTimestamp(event);
     applyEvent(row, event);
+    if (
+      (event.kind === "pending_action_resolution" || event.kind === "pending_action_expiration") &&
+      pendingCountFor(sessionId) > 0 &&
+      row.phase !== "complete" &&
+      row.phase !== "error"
+    ) {
+      row.phase = "waiting";
+    }
 
     // Re-key so this becomes the most-recently-touched entry for eviction.
     bySession.delete(sessionId);
@@ -304,8 +312,8 @@ type InternalRecord = {
  * derived from event kind:
  * - `tool` (any phase)        -> running, and remember the tool name.
  * - `pending_action`          -> waiting (the agent is blocked on the user).
- * - `pending_action_resolution`-> running (the user answered; the agent resumes).
- * - `pending_action_expiration`-> running (the request failed closed; the agent resumes).
+ * - `pending_action_resolution`-> running when no other pending action remains.
+ * - `pending_action_expiration`-> running when no other pending action remains.
  * - `background_activity`     -> background, and track the subagent's id/count.
  * - `error`                   -> error.
  * - `lifecycle`               -> complete when the flavor is terminal, running when

--- a/src/lib/hermes-activity-store.ts
+++ b/src/lib/hermes-activity-store.ts
@@ -305,6 +305,7 @@ type InternalRecord = {
  * - `tool` (any phase)        -> running, and remember the tool name.
  * - `pending_action`          -> waiting (the agent is blocked on the user).
  * - `pending_action_resolution`-> running (the user answered; the agent resumes).
+ * - `pending_action_expiration`-> running (the request failed closed; the agent resumes).
  * - `background_activity`     -> background, and track the subagent's id/count.
  * - `error`                   -> error.
  * - `lifecycle`               -> complete when the flavor is terminal, running when
@@ -328,6 +329,11 @@ function applyEvent(row: InternalRecord, event: JuneHermesEvent): void {
       return;
     case "pending_action_resolution":
       // The user answered, so the run resumes unless a terminal event already won.
+      if (row.phase !== "complete" && row.phase !== "error") row.phase = "running";
+      return;
+    case "pending_action_expiration":
+      // Timeout/disconnect retires the request without approving it. Hermes
+      // resumes the tool with a deny result, so this session is no longer waiting.
       if (row.phase !== "complete" && row.phase !== "error") row.phase = "running";
       return;
     case "background_activity":

--- a/src/lib/hermes-control-plane/compatibility/matrix.ts
+++ b/src/lib/hermes-control-plane/compatibility/matrix.ts
@@ -107,6 +107,12 @@ const methods: HermesCompatibilitySection = {
       "AgentWorkspace polls session.active_list as ground truth for what is actually running.",
     since: PIN,
   },
+  "approval.respond": {
+    status: "supported",
+    rationale:
+      "AgentWorkspace sends the stable request id with approval.respond so June's sealed Hermes patch resolves exactly the approval represented by the clicked card.",
+    since: PIN,
+  },
 
   // --- Feature 01 stubs: typed wrappers exist, no UI wiring yet. ---
   "session.steer": {
@@ -208,7 +214,7 @@ const events: HermesCompatibilitySection = {
   approval: {
     status: "supported",
     rationale:
-      "approval.request classifies to a pending_action and renders an approval card resolved via approval.respond.",
+      "approval.request classifies to a pending_action with stable identity, approval.response resolves the targeted card, and approval.expire retires it without granting permission.",
     since: PIN,
   },
   clarify: {
@@ -256,6 +262,12 @@ const events: HermesCompatibilitySection = {
  * June's UI, not Hermes' capability.
  */
 const features: HermesCompatibilitySection = {
+  targetedMcpApprovals: {
+    status: "supported",
+    rationale:
+      "The checksum-gated june-approval-v1 patch preserves MCP request identity, deduplicates retries, bounds the per-session queue, resolves a targeted approval or denial exactly once, and drains timeout or disconnect fail closed on macOS and Windows.",
+    since: PIN,
+  },
   backgroundSubagentWatch: {
     status: "supported",
     rationale:
@@ -300,6 +312,7 @@ export const hermesCompatibilityMatrix: HermesCompatibilityMatrix = Object.freez
  * greppable and testable. Feature numbers match the pack plan.
  */
 export const OWNERSHIP: Readonly<Record<string, readonly string[]>> = Object.freeze({
+  "JUN-350": ["methods.approval.respond", "events.approval", "features.targetedMcpApprovals"],
   "03": ["events.sudo", "events.secret", "methods.sudo.respond", "methods.secret.respond"],
   "06": ["methods.session.steer"],
   "07": ["methods.session.branch"],

--- a/src/lib/hermes-control-plane/event-classifier.ts
+++ b/src/lib/hermes-control-plane/event-classifier.ts
@@ -4,6 +4,7 @@ import type {
   BackgroundHermesPhase,
   JuneHermesEvent,
   PendingHermesAction,
+  PendingHermesActionExpiration,
   PendingHermesActionResolution,
 } from "./events";
 import { parseHermesMode } from "./events";
@@ -78,6 +79,25 @@ export function classifyHermesEvent(raw: HermesGatewayEvent): JuneHermesEvent {
         action: classifyPendingActionResolution(type, payload, receivedAt),
         receivedAt,
       };
+
+    case "approval.expire": {
+      const requestId = explicitRequestIdOf(payload);
+      if (!requestId) {
+        return {
+          kind: "unsupported",
+          sessionId,
+          rawType: type,
+          sanitizedPayload: payload === undefined ? undefined : sanitizePayload(payload),
+          receivedAt,
+        };
+      }
+      return {
+        kind: "pending_action_expiration",
+        sessionId: sessionId ?? "",
+        action: classifyPendingActionExpiration(requestId, payload),
+        receivedAt,
+      };
+    }
 
     case "error":
       return classifyError(sessionId, payload, receivedAt);
@@ -400,6 +420,21 @@ function classifyPendingActionResolution(
   }
 }
 
+function classifyPendingActionExpiration(
+  requestId: string,
+  payload: RawHermesPayload | undefined,
+): PendingHermesActionExpiration {
+  const rawReason = stringValue(payload?.reason)?.toLowerCase();
+  const reason =
+    rawReason === "timeout" ||
+    rawReason === "disconnect" ||
+    rawReason === "overflow" ||
+    rawReason === "stale"
+      ? rawReason
+      : "unknown";
+  return { kind: "approval", requestId, reason };
+}
+
 function classifyBackgroundActivity(
   type: string,
   sessionId: string | undefined,
@@ -531,11 +566,53 @@ function requestIdOf(
   receivedAt: string,
 ): string {
   return (
-    stringValue(payload?.request_id) ??
-    stringValue(payload?.requestId) ??
-    stringValue(payload?.id) ??
-    `${type}:${receivedAt}`
+    explicitRequestIdOf(payload) ??
+    (type === "approval.request" ? stableLegacyRequestId(type, payload) : `${type}:${receivedAt}`)
   );
+}
+
+function explicitRequestIdOf(payload: RawHermesPayload | undefined): string | undefined {
+  return (
+    stringValue(payload?.request_id) ?? stringValue(payload?.requestId) ?? stringValue(payload?.id)
+  );
+}
+
+/**
+ * Legacy Hermes builds omitted approval request ids. A timestamp made each
+ * replay look unique, so derive an opaque, deterministic fingerprint from the
+ * already-sanitized payload instead. The pinned runtime now supplies a real id;
+ * this approval-only fallback prevents old or partially-upgraded runtimes from
+ * causing a card storm without changing non-MCP action compatibility. No raw
+ * payload text is retained in the id.
+ */
+function stableLegacyRequestId(type: string, payload: RawHermesPayload | undefined): string {
+  const canonical = stableJson(sanitizePayload(payload ?? {}));
+  return `legacy:${type}:${fingerprint(canonical)}`;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function fingerprint(value: string): string {
+  let left = 0x811c9dc5;
+  let right = 0x9e3779b9;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    left = Math.imul(left ^ code, 0x01000193);
+    right = Math.imul(right ^ code, 0x85ebca6b);
+  }
+  return `${(left >>> 0).toString(16).padStart(8, "0")}${(right >>> 0)
+    .toString(16)
+    .padStart(8, "0")}`;
 }
 
 function messageRole(

--- a/src/lib/hermes-control-plane/event-classifier.ts
+++ b/src/lib/hermes-control-plane/event-classifier.ts
@@ -429,7 +429,8 @@ function classifyPendingActionExpiration(
     rawReason === "timeout" ||
     rawReason === "disconnect" ||
     rawReason === "overflow" ||
-    rawReason === "stale"
+    rawReason === "stale" ||
+    rawReason === "unconfirmed"
       ? rawReason
       : "unknown";
   return { kind: "approval", requestId, reason };

--- a/src/lib/hermes-control-plane/events.ts
+++ b/src/lib/hermes-control-plane/events.ts
@@ -113,7 +113,7 @@ export type PendingHermesActionResolution =
 export type PendingHermesActionExpiration = {
   kind: "approval";
   requestId: string;
-  reason: "timeout" | "disconnect" | "overflow" | "stale" | "unknown";
+  reason: "timeout" | "disconnect" | "overflow" | "stale" | "unconfirmed" | "unknown";
 };
 
 /** The lifecycle phase a background subagent is reporting. */

--- a/src/lib/hermes-control-plane/events.ts
+++ b/src/lib/hermes-control-plane/events.ts
@@ -107,6 +107,15 @@ export type PendingHermesActionResolution =
       redacted: true;
     };
 
+/** A pending approval that Hermes retired without a user decision. Expiration
+ * is deliberately distinct from denial: neither outcome approves anything,
+ * but only denial is an explicit user response. */
+export type PendingHermesActionExpiration = {
+  kind: "approval";
+  requestId: string;
+  reason: "timeout" | "disconnect" | "overflow" | "stale" | "unknown";
+};
+
 /** The lifecycle phase a background subagent is reporting. */
 export type BackgroundHermesPhase =
   | "start"
@@ -202,6 +211,11 @@ export type JuneHermesEvent =
       kind: "pending_action_resolution";
       sessionId: string;
       action: PendingHermesActionResolution;
+    })
+  | (JuneHermesEventBase & {
+      kind: "pending_action_expiration";
+      sessionId: string;
+      action: PendingHermesActionExpiration;
     })
   | (JuneHermesEventBase & {
       kind: "background_activity";

--- a/src/lib/hermes-control-plane/raw-types.ts
+++ b/src/lib/hermes-control-plane/raw-types.ts
@@ -58,6 +58,7 @@ export type RawHermesEventName =
   | "clarify.response"
   | "approval.request"
   | "approval.response"
+  | "approval.expire"
   | "sudo.request"
   | "sudo.response"
   | "secret.request"

--- a/src/lib/hermes-gateway.ts
+++ b/src/lib/hermes-gateway.ts
@@ -14,6 +14,7 @@ export type HermesGatewayEventName =
   | "clarify.response"
   | "approval.request"
   | "approval.response"
+  | "approval.expire"
   | "subagent.start"
   | "subagent.tool"
   | "subagent.progress"

--- a/src/lib/hermes-pending-actions.ts
+++ b/src/lib/hermes-pending-actions.ts
@@ -21,8 +21,8 @@
  *   `stale`: they remain visible (a stale-but-dismissable row beats a hidden
  *   blocker) but the tray renders them visually distinct. A fresh event for the
  *   same request after reconnect re-confirms it back to `open`.
- * - Resolution is sticky: once `resolved`, a straggler duplicate of the same
- *   request can't resurrect the row.
+ * - Resolution and expiration are sticky: once `resolved` or `expired`, a
+ *   straggler duplicate of the same request can't resurrect the row.
  *
  * Framework-agnostic (no React) so tests drive it directly; AgentWorkspace
  * adapts it with a `useSyncExternalStore` wrapper, mirroring features 02/15.
@@ -43,7 +43,7 @@ type PendingActionEvent = Extract<JuneHermesEvent, { kind: "pending_action" }>;
 export const PENDING_ACTIONS_CAP = 200;
 
 /** A record's lifecycle phase. `stale` = unreconciled after a reconnect. */
-export type PendingActionStatus = "open" | "submitting" | "resolved" | "stale";
+export type PendingActionStatus = "open" | "submitting" | "resolved" | "stale" | "expired";
 
 /** Stable identity across the pack: mode, session, and the request id. */
 export type PendingActionKey = `${HermesMode}:${string}:${string}`;
@@ -62,6 +62,7 @@ export type PendingActionRecord = {
   firstSeenAt: number;
   lastSeenAt: number;
   status: PendingActionStatus;
+  retiredReason?: string;
 };
 
 /** Statuses that still demand the user's attention (and so show in the tray). */
@@ -81,6 +82,8 @@ export type PendingActionStore = {
    * or a matching response arrived. No-op (and no version bump) if unknown.
    */
   resolveRequest(sessionId: string, requestId: string): void;
+  /** Retire an approval that timed out, disconnected, or was no longer pending. */
+  expireRequest(sessionId: string, requestId: string, reason?: string): void;
   /**
    * Resolve every still-open action for a session. Call when the session
    * completes, is interrupted, or reports a terminal (non-recoverable) error —
@@ -144,7 +147,7 @@ export function createPendingActionStore(): PendingActionStore {
 
     if (existing) {
       // A duplicate of an already-resolved request must NOT reopen it.
-      if (existing.status === "resolved") return;
+      if (existing.status === "resolved" || existing.status === "expired") return;
       existing.lastSeenAt = now;
       // A fresh event proves the action is still pending → clear any staleness.
       existing.status = "open";
@@ -177,8 +180,34 @@ export function createPendingActionStore(): PendingActionStore {
     if (!sid || !rid) return;
     let changed = false;
     for (const record of byKey.values()) {
-      if (record.sessionId === sid && record.requestId === rid && record.status !== "resolved") {
+      if (
+        record.sessionId === sid &&
+        record.requestId === rid &&
+        record.status !== "resolved" &&
+        record.status !== "expired"
+      ) {
         record.status = "resolved";
+        record.lastSeenAt = Date.now();
+        changed = true;
+      }
+    }
+    if (changed) emit();
+  }
+
+  function expireRequest(sessionId: string, requestId: string, reason?: string): void {
+    const sid = nonEmpty(sessionId);
+    const rid = nonEmpty(requestId);
+    if (!sid || !rid) return;
+    let changed = false;
+    for (const record of byKey.values()) {
+      if (
+        record.sessionId === sid &&
+        record.requestId === rid &&
+        record.status !== "resolved" &&
+        record.status !== "expired"
+      ) {
+        record.status = "expired";
+        record.retiredReason = nonEmpty(reason);
         record.lastSeenAt = Date.now();
         changed = true;
       }
@@ -191,7 +220,7 @@ export function createPendingActionStore(): PendingActionStore {
     if (!sid) return;
     let changed = false;
     for (const record of byKey.values()) {
-      if (record.sessionId === sid && record.status !== "resolved") {
+      if (record.sessionId === sid && record.status !== "resolved" && record.status !== "expired") {
         record.status = "resolved";
         record.lastSeenAt = Date.now();
         changed = true;
@@ -267,6 +296,7 @@ export function createPendingActionStore(): PendingActionStore {
   return {
     record,
     resolveRequest,
+    expireRequest,
     resolveSession,
     markDisconnected,
     reconcileAfterReconnect,

--- a/src/lib/hermes-pending-actions.ts
+++ b/src/lib/hermes-pending-actions.ts
@@ -274,17 +274,17 @@ export function createPendingActionStore(): PendingActionStore {
   }
 
   /**
-   * Keep the map within the cap. Evict already-resolved history first (oldest by
-   * insertion order), and only touch still-open rows if resolved history alone
+   * Keep the map within the cap. Evict terminal history first (oldest by
+   * insertion order), and only touch still-open rows if terminal history alone
    * can't get us under the cap — a blocker the user hasn't answered is the last
    * thing we want to silently drop.
    */
   function evict(): void {
     if (byKey.size <= PENDING_ACTIONS_CAP) return;
-    // First pass: drop oldest resolved.
+    // First pass: drop oldest terminal history.
     for (const [key, record] of byKey) {
       if (byKey.size <= PENDING_ACTIONS_CAP) break;
-      if (record.status === "resolved") byKey.delete(key);
+      if (record.status === "resolved" || record.status === "expired") byKey.delete(key);
     }
     // Second pass (rare): still over cap with only open rows — drop oldest.
     for (const key of byKey.keys()) {

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -1188,6 +1188,48 @@ describe("Agent chat runtime", () => {
     );
   });
 
+  it("does not let a replayed expiration overwrite a resolved approval", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        pendingActionEvent({
+          action: {
+            kind: "approval",
+            requestId: "approval-resolved-before-expire",
+            description: "Connect Todoist?",
+            allowPermanent: false,
+          },
+        }),
+        pendingActionResolutionEvent({
+          action: {
+            kind: "approval",
+            requestId: "approval-resolved-before-expire",
+            command: "",
+            description: "",
+            allowPermanent: false,
+            choice: "once",
+          },
+        }),
+        pendingActionExpirationEvent({
+          action: {
+            kind: "approval",
+            requestId: "approval-resolved-before-expire",
+            reason: "disconnect",
+          },
+        }),
+      ],
+    );
+    expect(turns[0]?.parts).toContainEqual(
+      expect.objectContaining({
+        type: "approval",
+        id: "approval-resolved-before-expire",
+        status: "resolved",
+        choice: "once",
+      }),
+    );
+  });
+
   it("preserves whitespace-only message deltas", () => {
     const turns = buildAgentChatTurns(
       [],

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -23,6 +23,7 @@ type ReasoningEvent = Extract<JuneHermesEvent, { kind: "reasoning" }>;
 type ToolEvent = Extract<JuneHermesEvent, { kind: "tool" }>;
 type PendingActionEvent = Extract<JuneHermesEvent, { kind: "pending_action" }>;
 type PendingActionResolutionEvent = Extract<JuneHermesEvent, { kind: "pending_action_resolution" }>;
+type PendingActionExpirationEvent = Extract<JuneHermesEvent, { kind: "pending_action_expiration" }>;
 type BackgroundActivityEvent = Extract<JuneHermesEvent, { kind: "background_activity" }>;
 type ErrorEvent = Extract<JuneHermesEvent, { kind: "error" }>;
 type LifecycleEvent = Extract<JuneHermesEvent, { kind: "lifecycle" }>;
@@ -66,6 +67,17 @@ function pendingActionEvent(
 ): PendingActionEvent {
   return {
     kind: "pending_action",
+    sessionId: "",
+    receivedAt: DEFAULT_RECEIVED_AT,
+    ...event,
+  };
+}
+
+function pendingActionExpirationEvent(
+  event: Pick<PendingActionExpirationEvent, "action"> & Partial<PendingActionExpirationEvent>,
+): PendingActionExpirationEvent {
+  return {
+    kind: "pending_action_expiration",
     sessionId: "",
     receivedAt: DEFAULT_RECEIVED_AT,
     ...event,
@@ -1104,6 +1116,76 @@ describe("Agent chat runtime", () => {
         status: "resolved",
       },
     ]);
+  });
+
+  it("deduplicates one approval before and after reconnect while keeping distinct requests", () => {
+    const approval = pendingActionEvent({
+      sessionId: "runtime-session",
+      action: {
+        kind: "approval",
+        requestId: "approval-1",
+        description: "Connect Todoist?",
+        allowPermanent: false,
+      },
+    });
+    const distinct = pendingActionEvent({
+      sessionId: "runtime-session",
+      action: {
+        kind: "approval",
+        requestId: "approval-2",
+        description: "Share another resource?",
+        allowPermanent: false,
+      },
+    });
+    const response = pendingActionResolutionEvent({
+      sessionId: "runtime-session",
+      action: {
+        kind: "approval",
+        requestId: "approval-1",
+        command: "",
+        description: "",
+        allowPermanent: false,
+        choice: "once",
+      },
+    });
+
+    const turns = buildAgentChatTurns([], [], [approval, approval, distinct, response, approval]);
+    const approvals = turns[0]?.parts.filter((part) => part.type === "approval") ?? [];
+    expect(approvals).toHaveLength(2);
+    expect(approvals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "approval-1", status: "resolved", choice: "once" }),
+        expect.objectContaining({ id: "approval-2", status: "pending" }),
+      ]),
+    );
+  });
+
+  it("shows a fail-closed expiration instead of a resolved approval", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        pendingActionEvent({
+          action: {
+            kind: "approval",
+            requestId: "approval-expired",
+            description: "Connect Todoist?",
+            allowPermanent: false,
+          },
+        }),
+        pendingActionExpirationEvent({
+          action: { kind: "approval", requestId: "approval-expired", reason: "timeout" },
+        }),
+      ],
+    );
+    expect(turns[0]?.parts).toContainEqual(
+      expect.objectContaining({
+        type: "approval",
+        id: "approval-expired",
+        status: "expired",
+        retiredReason: "timeout",
+      }),
+    );
   });
 
   it("preserves whitespace-only message deltas", () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -8226,6 +8226,7 @@ describe("AgentWorkspace", () => {
         pendingActionStore.openRecords().some((record) => record.requestId === "approval-runtime"),
       ).toBe(false),
     );
+    expect(hermesActivityStore.getRecord("session-2")?.phase).toBe("running");
   });
 
   it("keeps the session waiting until every distinct inbound approval resolves", async () => {
@@ -8350,9 +8351,15 @@ describe("AgentWorkspace", () => {
     expect(pendingActionStore.openRecords().some((row) => row.requestId === "mcp-deny")).toBe(
       false,
     );
+    expect(hermesActivityStore.getRecord("session-2")?.phase).toBe("running");
   });
 
   it("fails closed when a targeted approval is no longer pending", async () => {
+    const statusDetails: AgentSessionStatusDetail[] = [];
+    const handleStatus = (event: Event) => {
+      statusDetails.push((event as CustomEvent<AgentSessionStatusDetail>).detail);
+    };
+    window.addEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
     const user = userEvent.setup();
     mocks.gatewayRequest.mockImplementation((method: string) => {
       if (method === "session.create") {
@@ -8390,6 +8397,7 @@ describe("AgentWorkspace", () => {
       }
     });
     expect(await screen.findByText("Approval required")).toBeInTheDocument();
+    expect(hermesActivityStore.getRecord("session-2")?.phase).toBe("waiting");
     await user.click(screen.getByRole("button", { name: "Approve" }));
 
     expect(await screen.findByText("Approval expired")).toBeInTheDocument();
@@ -8399,6 +8407,15 @@ describe("AgentWorkspace", () => {
     expect(pendingActionStore.openRecords().some((row) => row.requestId === "mcp-stale")).toBe(
       false,
     );
+    expect(hermesActivityStore.getRecord("session-2")?.phase).toBe("running");
+    expect(statusDetails.at(-1)).toEqual(
+      expect.objectContaining({
+        sessionId: "session-2",
+        status: "running",
+        summary: "June is working.",
+      }),
+    );
+    window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
   });
 
   it.each([

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -653,6 +653,24 @@ describe("AgentWorkspace", () => {
     expect(second.toolCallSessionIds).toBe(first.toolCallSessionIds);
   });
 
+  it("keeps a session waiting while any distinct pending action remains", () => {
+    const projection = projectAgentActivityLevels([
+      {
+        id: "session-1",
+        mode: "sandboxed",
+        sessionId: "session-1",
+        phase: "running",
+        pendingActionCount: 1,
+        subagentCount: 0,
+        subagents: [],
+        lastEventAt: 1,
+      },
+    ]);
+
+    expect(projection.waitingSessionIds).toEqual(new Set(["session-1"]));
+    expect(projection.workingSessionIds).toEqual(new Set());
+  });
+
   it("scopes an in-flight submit's steer state to its owning session", () => {
     const base = {
       provisional: false,
@@ -8210,6 +8228,87 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("keeps the session waiting until every distinct inbound approval resolves", async () => {
+    const statusDetails: AgentSessionStatusDetail[] = [];
+    const handleStatus = (event: Event) => {
+      statusDetails.push((event as CustomEvent<AgentSessionStatusDetail>).detail);
+    };
+    window.addEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "connect Todoist" }),
+    );
+    render(<AgentWorkspace />);
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "connect Todoist",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        for (const requestId of ["approval-a", "approval-b"]) {
+          handler({
+            type: "approval.request",
+            session_id: "runtime-session-2",
+            payload: {
+              request_id: requestId,
+              description: `Approve ${requestId}?`,
+              allow_permanent: false,
+            },
+          });
+        }
+      }
+    });
+
+    expect(
+      pendingActionStore
+        .openRecords()
+        .filter((record) => record.sessionId === "session-2" && record.action.kind === "approval"),
+    ).toHaveLength(2);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.response",
+          session_id: "runtime-session-2",
+          payload: { request_id: "approval-a", choice: "once" },
+        });
+      }
+    });
+
+    expect(pendingActionStore.openRecords().map((record) => record.requestId)).toContain(
+      "approval-b",
+    );
+    expect(pendingActionStore.openRecords().map((record) => record.requestId)).not.toContain(
+      "approval-a",
+    );
+    expect(hermesActivityStore.getRecord("session-2")?.phase).toBe("waiting");
+    expect(statusDetails.at(-1)).toEqual(
+      expect.objectContaining({ sessionId: "session-2", status: "waitingForUser" }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.response",
+          session_id: "runtime-session-2",
+          payload: { request_id: "approval-b", choice: "deny" },
+        });
+      }
+    });
+
+    expect(
+      pendingActionStore.openRecords().some((record) => record.sessionId === "session-2"),
+    ).toBe(false);
+    expect(hermesActivityStore.getRecord("session-2")?.phase).toBe("running");
+    expect(statusDetails.at(-1)).toEqual(
+      expect.objectContaining({ sessionId: "session-2", status: "running" }),
+    );
+    window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
+  });
+
   it("denies only the targeted approval and records the outcome", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
@@ -8405,6 +8504,11 @@ describe("AgentWorkspace", () => {
   });
 
   it("retires an approval across an unexpected close and does not reopen its replay", async () => {
+    const statusDetails: AgentSessionStatusDetail[] = [];
+    const handleStatus = (event: Event) => {
+      statusDetails.push((event as CustomEvent<AgentSessionStatusDetail>).detail);
+    };
+    window.addEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,
       JSON.stringify({ createdAt: Date.now(), prompt: "connect Todoist" }),
@@ -8431,6 +8535,7 @@ describe("AgentWorkspace", () => {
       }
     });
     expect(await screen.findByText("Approval required")).toBeInTheDocument();
+    expect(hermesActivityStore.getRecord("session-2")?.phase).toBe("waiting");
 
     act(() => {
       for (const handler of [...mocks.gatewayCloseHandlers]) handler();
@@ -8442,6 +8547,17 @@ describe("AgentWorkspace", () => {
       }),
     );
     expect(await screen.findByText("Approval expired")).toBeInTheDocument();
+    expect(hermesActivityStore.getRecord("session-2")?.phase).toBe("running");
+    expect(statusDetails).toContainEqual(
+      expect.objectContaining({
+        sessionId: "session-2",
+        status: "running",
+        summary: "June is working.",
+      }),
+    );
+    const activityProjection = projectAgentActivityLevels(hermesActivityStore.getRecords());
+    expect(activityProjection.waitingSessionIds.has("session-2")).toBe(false);
+    expect(activityProjection.workingSessionIds.has("session-2")).toBe(true);
 
     act(() => {
       for (const handler of mocks.gatewayEventHandlers) {
@@ -8464,6 +8580,7 @@ describe("AgentWorkspace", () => {
       false,
     );
     expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("approval.respond", expect.anything());
+    window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
   });
 
   it("retires an in-flight approval response without claiming its outcome after disconnect", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -8466,6 +8466,82 @@ describe("AgentWorkspace", () => {
     expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("approval.respond", expect.anything());
   });
 
+  it("retires an in-flight approval response without claiming its outcome after disconnect", async () => {
+    const user = userEvent.setup();
+    let rejectApproval: ((error: Error) => void) | undefined;
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        return Promise.resolve({
+          session_id: "runtime-session-2",
+          stored_session_id: "session-2",
+        });
+      }
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      if (method === "approval.respond") {
+        return new Promise((_resolve, reject) => {
+          rejectApproval = reject;
+        });
+      }
+      return Promise.resolve({});
+    });
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "connect Todoist" }),
+    );
+    render(<AgentWorkspace />);
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "connect Todoist",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.request",
+          session_id: "runtime-session-2",
+          payload: {
+            request_id: "mcp-in-flight",
+            description: "Connect Todoist?",
+            allow_permanent: false,
+          },
+        });
+      }
+    });
+    expect(await screen.findByText("Approval required")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("approval.respond", {
+        session_id: "runtime-session-2",
+        request_id: "mcp-in-flight",
+        choice: "once",
+      }),
+    );
+
+    // The real gateway rejects pending RPCs immediately before invoking its
+    // close handlers. The response may nevertheless have reached Hermes.
+    act(() => {
+      rejectApproval?.(new Error("Hermes gateway connection closed."));
+      for (const handler of [...mocks.gatewayCloseHandlers]) handler();
+    });
+
+    expect(await screen.findByText("Approval outcome unknown")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /This approval is no longer actionable, but it may have already been applied/,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Approval expired")).not.toBeInTheDocument();
+    expect(screen.queryByText(/June did not approve anything/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+    expect(pendingActionStore.openRecords().some((row) => row.requestId === "mcp-in-flight")).toBe(
+      false,
+    );
+  });
+
   it("keys inbound diagnostics by the stored session id", async () => {
     mocks.gatewayRequest.mockImplementation((method: string) => {
       if (method === "session.create") {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -8302,6 +8302,61 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it.each([
+    ["null", null],
+    ["empty", {}],
+    ["invalid", { resolved: 2 }],
+  ])("keeps an approval pending when the gateway response is malformed: %s", async (responseKind, gatewayResponse) => {
+    const requestId = `mcp-indeterminate-${responseKind}`;
+    const user = userEvent.setup();
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        return Promise.resolve({
+          session_id: "runtime-session-2",
+          stored_session_id: "session-2",
+        });
+      }
+      if (method === "approval.respond") return Promise.resolve(gatewayResponse);
+      return Promise.resolve({});
+    });
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "connect Todoist" }),
+    );
+    render(<AgentWorkspace />);
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "connect Todoist",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.request",
+          session_id: "runtime-session-2",
+          payload: {
+            request_id: requestId,
+            description: "Connect Todoist?",
+            allow_permanent: false,
+          },
+        });
+      }
+    });
+    expect(await screen.findByText("Approval required")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+
+    expect(
+      await screen.findByText(
+        "June could not confirm the approval outcome. Reconnect, then try again.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Approval expired")).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole("button", { name: "Approve" })).toBeEnabled());
+    expect(pendingActionStore.openRecords().some((row) => row.requestId === requestId)).toBe(true);
+  });
+
   it("retires a timed-out approval without approving it", async () => {
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -102,6 +102,7 @@ const mocks = vi.hoisted(() => ({
   releaseAgentRunSettlement: vi.fn(),
   startAgentRunMonitoring: vi.fn(),
   gatewayEventHandlers: new Set<(event: Record<string, unknown>) => void>(),
+  gatewayCloseHandlers: new Set<() => void>(),
   gatewayInstances: [] as Array<{
     connect: ReturnType<typeof vi.fn>;
     close: ReturnType<typeof vi.fn>;
@@ -224,7 +225,10 @@ vi.mock("../lib/hermes-gateway", async (importOriginal) => ({
       mocks.gatewayEventHandlers.add(handler);
       return () => mocks.gatewayEventHandlers.delete(handler);
     });
-    onClose = vi.fn(() => vi.fn());
+    onClose = vi.fn((handler: () => void) => {
+      mocks.gatewayCloseHandlers.add(handler);
+      return () => mocks.gatewayCloseHandlers.delete(handler);
+    });
     request = mocks.gatewayRequest;
   },
 }));
@@ -462,6 +466,7 @@ describe("AgentWorkspace", () => {
     vi.clearAllMocks();
     mocks.suggestAgentSessionTitle.mockReset();
     mocks.gatewayEventHandlers.clear();
+    mocks.gatewayCloseHandlers.clear();
     mocks.gatewayInstances.length = 0;
     // Auto-cleanup unmounts the workspace after each test, which snapshots
     // any still-working session for the next mount — across tests that would
@@ -620,6 +625,9 @@ describe("AgentWorkspace", () => {
       }
       if (method === "session.resume") {
         return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      if (method === "approval.respond") {
+        return Promise.resolve({ resolved: 1 });
       }
       return Promise.resolve({});
     });
@@ -8191,6 +8199,7 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("approval.respond", {
         session_id: "runtime-session-2",
+        request_id: "approval-runtime",
         choice: "once",
       }),
     );
@@ -8199,6 +8208,207 @@ describe("AgentWorkspace", () => {
         pendingActionStore.openRecords().some((record) => record.requestId === "approval-runtime"),
       ).toBe(false),
     );
+  });
+
+  it("denies only the targeted approval and records the outcome", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "connect Todoist" }),
+    );
+    render(<AgentWorkspace />);
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "connect Todoist",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.request",
+          session_id: "runtime-session-2",
+          payload: {
+            request_id: "mcp-deny",
+            description: "Connect Todoist?",
+            allow_permanent: false,
+          },
+        });
+      }
+    });
+    expect(await screen.findByText("Approval required")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Deny" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("approval.respond", {
+        session_id: "runtime-session-2",
+        request_id: "mcp-deny",
+        choice: "deny",
+      }),
+    );
+    expect(await screen.findByText("Denied")).toBeInTheDocument();
+    expect(pendingActionStore.openRecords().some((row) => row.requestId === "mcp-deny")).toBe(
+      false,
+    );
+  });
+
+  it("fails closed when a targeted approval is no longer pending", async () => {
+    const user = userEvent.setup();
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        return Promise.resolve({
+          session_id: "runtime-session-2",
+          stored_session_id: "session-2",
+        });
+      }
+      if (method === "approval.respond") return Promise.resolve({ resolved: 0 });
+      return Promise.resolve({});
+    });
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "connect Todoist" }),
+    );
+    render(<AgentWorkspace />);
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "connect Todoist",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.request",
+          session_id: "runtime-session-2",
+          payload: {
+            request_id: "mcp-stale",
+            description: "Connect Todoist?",
+            allow_permanent: false,
+          },
+        });
+      }
+    });
+    expect(await screen.findByText("Approval required")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+
+    expect(await screen.findByText("Approval expired")).toBeInTheDocument();
+    expect(
+      await screen.findByText("This approval is no longer pending. June did not approve anything."),
+    ).toBeInTheDocument();
+    expect(pendingActionStore.openRecords().some((row) => row.requestId === "mcp-stale")).toBe(
+      false,
+    );
+  });
+
+  it("retires a timed-out approval without approving it", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "connect Todoist" }),
+    );
+    render(<AgentWorkspace />);
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "connect Todoist",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.request",
+          session_id: "runtime-session-2",
+          payload: {
+            request_id: "mcp-expired",
+            description: "Connect Todoist?",
+            allow_permanent: false,
+          },
+        });
+      }
+    });
+    expect(await screen.findByText("Approval required")).toBeInTheDocument();
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.expire",
+          session_id: "runtime-session-2",
+          payload: { request_id: "mcp-expired", reason: "timeout" },
+        });
+      }
+    });
+
+    expect(await screen.findByText("Approval expired")).toBeInTheDocument();
+    expect(screen.getByText(/June did not approve anything/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+    expect(pendingActionStore.openRecords().some((row) => row.requestId === "mcp-expired")).toBe(
+      false,
+    );
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("approval.respond", expect.anything());
+  });
+
+  it("retires an approval across an unexpected close and does not reopen its replay", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "connect Todoist" }),
+    );
+    render(<AgentWorkspace />);
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "connect Todoist",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.request",
+          session_id: "runtime-session-2",
+          payload: {
+            request_id: "mcp-reconnect",
+            description: "Connect Todoist?",
+            allow_permanent: false,
+          },
+        });
+      }
+    });
+    expect(await screen.findByText("Approval required")).toBeInTheDocument();
+
+    act(() => {
+      for (const handler of [...mocks.gatewayCloseHandlers]) handler();
+    });
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.resume", {
+        session_id: "session-2",
+        cols: 96,
+      }),
+    );
+    expect(await screen.findByText("Approval expired")).toBeInTheDocument();
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.request",
+          session_id: "runtime-session-1",
+          payload: {
+            request_id: "mcp-reconnect",
+            description: "Connect Todoist?",
+            allow_permanent: false,
+          },
+        });
+      }
+    });
+
+    expect(screen.getAllByText("Approval expired")).toHaveLength(1);
+    expect(screen.queryByText("Approval required")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+    expect(pendingActionStore.openRecords().some((row) => row.requestId === "mcp-reconnect")).toBe(
+      false,
+    );
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("approval.respond", expect.anything());
   });
 
   it("keys inbound diagnostics by the stored session id", async () => {

--- a/src/test/hermes-activity-store.test.ts
+++ b/src/test/hermes-activity-store.test.ts
@@ -91,6 +91,40 @@ describe("createHermesActivityStore", () => {
     expect(store.getRecord("s1")?.phase).toBe("running");
   });
 
+  it("keeps the session waiting when a different pending action remains", () => {
+    let pendingCount = 2;
+    const store = createHermesActivityStore({ pendingCountFor: () => pendingCount });
+    store.record(
+      classified("approval.request", "s1", {
+        request_id: "r1",
+        tool_name: "write_file",
+      }),
+      "sandboxed",
+    );
+
+    pendingCount = 1;
+    store.record(
+      classified("approval.response", "s1", {
+        request_id: "r1",
+        choice: "once",
+      }),
+      "sandboxed",
+    );
+
+    expect(store.getRecord("s1")?.phase).toBe("waiting");
+
+    pendingCount = 0;
+    store.record(
+      classified("approval.expire", "s1", {
+        request_id: "r2",
+        reason: "disconnect",
+      }),
+      "sandboxed",
+    );
+
+    expect(store.getRecord("s1")?.phase).toBe("running");
+  });
+
   it("a failed tool event clears the in-flight tool", () => {
     const store = createHermesActivityStore();
     store.record(classified("tool.start", "s1", { tool_name: "bash" }), "sandboxed");

--- a/src/test/hermes-approval-patch.test.ts
+++ b/src/test/hermes-approval-patch.test.ts
@@ -32,7 +32,17 @@ describe("June Hermes approval patch", () => {
   it("pins managed installs to the patch set and verifies them before launch", () => {
     expect(bridge).toContain('const HERMES_RUNTIME_PATCH_SET: &str = "june-approval-v1"');
     expect(bridge).toContain('include_str!("hermes/apply_june_patches.py")');
-    expect(bridge).toContain("verify_managed_hermes_runtime_patch(app, &managed_install_dir)?");
+    expect(bridge).toContain("verify_managed_hermes_runtime_patch(&managed_install_dir)?");
+    const patchedHashes = patcher
+      .match(/PATCHED_SHA256: Dict\[str, str\] = \{([\s\S]*?)\n\}/)?.[1]
+      ?.matchAll(/"([^"]+)": "([a-f0-9]{64})"/g);
+    expect(patchedHashes).toBeDefined();
+    for (const [, path, hash] of patchedHashes ?? []) {
+      expect(bridge).toContain(`"${path}",`);
+      expect(bridge).toContain(`"${hash}"`);
+    }
+    expect(bridge).toContain("verify_hermes_runtime_source_hashes");
+    expect(bridge).not.toContain('.arg("--verify")\n        .stdin(Stdio::null())');
     expect(bridge).toContain('.env("JUNE_HERMES_PATCH_SET", HERMES_RUNTIME_PATCH_SET)');
     expect(bridge).toContain('r#""patchSet":"{HERMES_RUNTIME_PATCH_SET}""#');
     expect(bridge).not.toContain("UserLocalFallback");

--- a/src/test/hermes-approval-patch.test.ts
+++ b/src/test/hermes-approval-patch.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import macBundler from "../../scripts/bundle-hermes-runtime.sh?raw";
+import windowsBundler from "../../scripts/bundle-hermes-runtime-windows.ps1?raw";
+import patcher from "../../src-tauri/src/hermes/apply_june_patches.py?raw";
+import bridge from "../../src-tauri/src/hermes_bridge.rs?raw";
+
+describe("June Hermes approval patch", () => {
+  it("seals upstream and patched hashes for every protocol file", () => {
+    for (const path of ["tools/approval.py", "tools/mcp_tool.py", "tui_gateway/server.py"]) {
+      const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      expect(patcher.match(new RegExp(`"${escaped}": "[a-f0-9]{64}"`, "g"))).toHaveLength(2);
+    }
+    expect(patcher).toContain('PATCH_SET = "june-approval-v1"');
+    expect(patcher).toContain('upstream_request_id = getattr(context, "request_id", None)');
+    expect(patcher).toContain("request_id=request_id");
+    expect(patcher).toContain("_MAX_GATEWAY_APPROVALS_PER_SESSION = 32");
+    expect(patcher).toContain("_MAX_GATEWAY_APPROVAL_ALIASES = 16");
+    expect(patcher).toContain("_MAX_COMPLETED_GATEWAY_SESSIONS = 256");
+    expect(patcher).toContain("tool_call_id = str(_approval_tool_call_id.get()");
+    expect(patcher).toContain('if key := session.get("session_key")');
+    expect(patcher).toContain('lambda data: _emit("approval.expire", sid, data)');
+  });
+
+  it("applies the same patch and protocol smoke to macOS and Windows bundles", () => {
+    for (const bundler of [macBundler, windowsBundler]) {
+      expect(bundler).toContain("apply_june_patches.py");
+      expect(bundler).toContain("hermes-approval-patch-smoke.py");
+      expect(bundler).toContain("PATCHSET");
+    }
+  });
+
+  it("pins managed installs to the patch set and verifies them before launch", () => {
+    expect(bridge).toContain('const HERMES_RUNTIME_PATCH_SET: &str = "june-approval-v1"');
+    expect(bridge).toContain('include_str!("hermes/apply_june_patches.py")');
+    expect(bridge).toContain("verify_managed_hermes_runtime_patch(app, &managed_install_dir)?");
+    expect(bridge).toContain('.env("JUNE_HERMES_PATCH_SET", HERMES_RUNTIME_PATCH_SET)');
+    expect(bridge).toContain('r#""patchSet":"{HERMES_RUNTIME_PATCH_SET}""#');
+    expect(bridge).not.toContain("UserLocalFallback");
+    expect(bridge).not.toContain("PathFallback");
+    expect(bridge).not.toContain("user_local_hermes_command");
+  });
+});

--- a/src/test/hermes-compatibility-matrix.test.ts
+++ b/src/test/hermes-compatibility-matrix.test.ts
@@ -65,6 +65,7 @@ describe("hermes compatibility matrix — required keys", () => {
       "prompt.submit",
       "session.interrupt",
       "session.active_list",
+      "approval.respond",
     ]) {
       expect(methodKeys, `methods.${required}`).toContain(required);
     }
@@ -95,6 +96,7 @@ describe("hermes compatibility matrix — required keys", () => {
       "imageEditing",
       "automationBlueprints",
       "messagingIntegrations",
+      "targetedMcpApprovals",
     ]) {
       expect(featureKeys, `features.${required}`).toContain(required);
     }
@@ -176,6 +178,13 @@ describe("isHermesFeatureSupported — honest support gate", () => {
     expect(isHermesFeatureSupported("sudo.respond")).toBe(true);
     expect(getFeatureStatus("secret.respond")).toBe("supported");
     expect(isHermesFeatureSupported("secret.respond")).toBe(true);
+  });
+
+  it("reports targeted MCP approvals as supported by the sealed runtime patch", () => {
+    expect(getFeatureStatus("approval.respond")).toBe("supported");
+    expect(isHermesFeatureSupported("approval.respond")).toBe(true);
+    expect(getFeatureStatus("targetedMcpApprovals")).toBe("supported");
+    expect(isHermesFeatureSupported("targetedMcpApprovals")).toBe(true);
   });
 
   it("reports feature 10's config.set model seam as supported once shipped", () => {

--- a/src/test/hermes-control-plane-classifier.test.ts
+++ b/src/test/hermes-control-plane-classifier.test.ts
@@ -35,6 +35,7 @@ const CURRENT_GATEWAY_EVENT_NAMES = [
   "clarify.response",
   "approval.request",
   "approval.response",
+  "approval.expire",
   "sudo.request",
   "sudo.response",
   "secret.request",
@@ -47,8 +48,15 @@ const CURRENT_GATEWAY_EVENT_NAMES = [
   "error",
 ] as const;
 
-function event<P>(type: string, payload?: P, sessionId = "sess-1") {
-  return { type, session_id: sessionId, payload, receivedAt: RECEIVED_AT } as HermesGatewayEvent<P>;
+function event<P>(
+  type: string,
+  payload?: P,
+  sessionId = "sess-1",
+  receivedAt = RECEIVED_AT,
+): HermesGatewayEvent<P> & { receivedAt: string } {
+  return { type, session_id: sessionId, payload, receivedAt } as HermesGatewayEvent<P> & {
+    receivedAt: string;
+  };
 }
 
 describe("classifyHermesEvent — totality", () => {
@@ -382,6 +390,50 @@ describe("classifyHermesEvent — pending actions", () => {
       expect(result.action.description).toBe("Run the build");
       expect(result.action.allowPermanent).toBe(true);
     }
+  });
+
+  it("keeps an idless approval stable across duplicate delivery timestamps", () => {
+    const first = classifyHermesEvent(
+      event(
+        "approval.request",
+        {
+          description: "An MCP server requests permission",
+          pattern_key: "mcp_elicitation",
+        },
+        "sess-1",
+        "2026-06-24T12:00:00.000Z",
+      ),
+    );
+    const replay = classifyHermesEvent(
+      event(
+        "approval.request",
+        {
+          pattern_key: "mcp_elicitation",
+          description: "An MCP server requests permission",
+        },
+        "sess-1",
+        "2026-06-24T12:00:05.000Z",
+      ),
+    );
+    expect(first.kind).toBe("pending_action");
+    expect(replay.kind).toBe("pending_action");
+    if (first.kind === "pending_action" && replay.kind === "pending_action") {
+      expect(first.action.requestId).toBe(replay.action.requestId);
+      expect(first.action.requestId).toMatch(/^legacy:approval\.request:/);
+    }
+  });
+
+  it("maps approval expiration only when it can target a stable request", () => {
+    const expired = classifyHermesEvent(
+      event("approval.expire", { request_id: "a-expired", reason: "timeout" }),
+    );
+    expect(expired).toMatchObject({
+      kind: "pending_action_expiration",
+      action: { kind: "approval", requestId: "a-expired", reason: "timeout" },
+    });
+
+    const malformed = classifyHermesEvent(event("approval.expire", { reason: "timeout" }));
+    expect(malformed.kind).toBe("unsupported");
   });
 
   it("maps sudo.request to a sudo pending action carrying mode", () => {
@@ -788,6 +840,8 @@ describe("exhaustive switch ergonomics", () => {
           return "pending";
         case "pending_action_resolution":
           return "resolved";
+        case "pending_action_expiration":
+          return "expired";
         case "background_activity":
           return "background";
         case "steering":

--- a/src/test/hermes-control-plane-classifier.test.ts
+++ b/src/test/hermes-control-plane-classifier.test.ts
@@ -432,6 +432,14 @@ describe("classifyHermesEvent — pending actions", () => {
       action: { kind: "approval", requestId: "a-expired", reason: "timeout" },
     });
 
+    const unconfirmed = classifyHermesEvent(
+      event("approval.expire", { request_id: "a-unconfirmed", reason: "unconfirmed" }),
+    );
+    expect(unconfirmed).toMatchObject({
+      kind: "pending_action_expiration",
+      action: { kind: "approval", requestId: "a-unconfirmed", reason: "unconfirmed" },
+    });
+
     const malformed = classifyHermesEvent(event("approval.expire", { reason: "timeout" }));
     expect(malformed.kind).toBe("unsupported");
   });

--- a/src/test/hermes-pending-action-store.test.ts
+++ b/src/test/hermes-pending-action-store.test.ts
@@ -259,4 +259,31 @@ describe("createPendingActionStore", () => {
     expect(store.getRecords().length).toBeLessThanOrEqual(PENDING_ACTIONS_CAP);
     expect(store.openRecords().map((r) => r.sessionId)).toContain("live");
   });
+
+  it("evicts expired history before an older unanswered action", () => {
+    const store = createPendingActionStore();
+    store.record(
+      pendingClassified("approval.request", "old-live", { request_id: "old-live" }),
+      "unrestricted",
+    );
+    for (let i = 0; i < PENDING_ACTIONS_CAP - 1; i += 1) {
+      const sessionId = `expired-${i}`;
+      const requestId = `expired-request-${i}`;
+      store.record(
+        pendingClassified("approval.request", sessionId, { request_id: requestId }),
+        "unrestricted",
+      );
+      store.expireRequest(sessionId, requestId, "timeout");
+    }
+
+    store.record(
+      pendingClassified("approval.request", "new-live", { request_id: "new-live" }),
+      "unrestricted",
+    );
+
+    expect(store.getRecords()).toHaveLength(PENDING_ACTIONS_CAP);
+    expect(store.openRecords().map((record) => record.sessionId)).toEqual(
+      expect.arrayContaining(["old-live", "new-live"]),
+    );
+  });
 });

--- a/src/test/hermes-pending-action-store.test.ts
+++ b/src/test/hermes-pending-action-store.test.ts
@@ -161,6 +161,28 @@ describe("createPendingActionStore", () => {
     expect(store.openRecords()).toHaveLength(0);
   });
 
+  it("retires an expired approval without letting a replay reopen it", () => {
+    const store = createPendingActionStore();
+    const request = pendingClassified("approval.request", "s1", { request_id: "r-expired" });
+    store.record(request, "sandboxed");
+
+    store.expireRequest("s1", "r-expired", "timeout");
+    expect(store.openCount()).toBe(0);
+    expect(store.getRecords()[0]).toMatchObject({
+      requestId: "r-expired",
+      status: "expired",
+      retiredReason: "timeout",
+    });
+
+    store.record(request, "sandboxed");
+    expect(store.openCount()).toBe(0);
+    expect(store.getRecords()[0]?.status).toBe("expired");
+
+    store.resolveRequest("s1", "r-expired");
+    store.resolveSession("s1");
+    expect(store.getRecords()[0]?.status).toBe("expired");
+  });
+
   it("secret actions never carry a value, only the request", () => {
     const store = createPendingActionStore();
     store.record(


### PR DESCRIPTION
## Summary

- Patch the pinned Hermes runtime at build/install time so every approval has a stable opaque request ID, reconnect retries for one still-pending MCP elicitation coalesce across transport generations, and `approval.respond` resolves one targeted request instead of the FIFO head.
- Bound pending approvals, retry aliases, and completed tombstones; expire unanswered work on timeout or gateway disconnect; and fail closed for malformed or missing identity.
- Make June retain terminal approval state, retire stale cards on unexpected gateway close, classify legacy ID-less approvals deterministically, and render an explicit expired receipt without an active approval control.
- Apply and verify the same `june-approval-v1` patch set in macOS and Windows bundles and managed installs, and refuse unpatched implicit local/PATH Hermes fallbacks in production.
- Update the Hermes compatibility matrix, pin/provenance documentation, upgrade checklist, gateway gotchas, ADR, and protocol/bundle smoke coverage.

This changes the security-sensitive approval wire contract and bundled runtime verification.

## Root cause

The issue hypothesis was only part of the cause. The pinned Hermes MCP elicitation handler discarded the MCP SDK `RequestContext.request_id`, queued anonymous approvals per session, and `approval.respond` always resolved the FIFO head. MCP retry/reconnect could therefore append multiple unresolved queue entries for one logical elicitation. Hermes then emitted approvals without stable IDs, so June's `${type}:${receivedAt}` fallback classified every replay as new. Unexpected session resumption could replay those notifications, amplifying the visible card count, but the React subscription/render path was not an independent duplicate source.

The fix is at the earliest owning boundary: Hermes now preserves upstream identity, assigns a targeted opaque request ID, coalesces only a still-pending logical retry arriving on a different MCP transport generation, and resolves or expires exactly that request. June's legacy classifier fallback remains only as deterministic, sanitized compatibility behavior.

## Validation

- `pnpm check` (passes with the repository's existing warnings)
- `pnpm typecheck`
- Focused Vitest suites for classifier, pending state, runtime, workspace reconnect/resume, compatibility matrix, and patch contract: 578 passed, 2 skipped
- Fresh exact-pin patch apply and `--verify`, plus Python bytecode compilation of the patched Hermes files
- `scripts/hermes-approval-patch-smoke.py` against a freshly patched pinned runtime: duplicate delivery; non-MCP identity; distinct concurrent approvals; cross-transport retry coalescing; alias/queue/tombstone bounds; targeted approval and denial; replay; timeout; malformed payload; and disconnect drain
- `pnpm test:hermes-smoke` (protocol smoke passed; model phase skipped because no provider key was available)
- `pnpm hermes:upgrade-check`
- `pnpm test:rust` (710 passed, 4 ignored, plus integration suites)
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `env NODE_OPTIONS=--no-experimental-webstorage make verify` (169 frontend files / 2,751 passed / 2 skipped; desktop Rust gate; June API Rust gate with 144 passed)
- `git diff --check`

### macOS and Todoist regression status

- Real Todoist connection: exercised with the patched runtime using an authenticated, validation-only `find_tasks` request with an empty query. Todoist returned a validation error, no task data, and no MCP elicitation. No write tool was invoked.
- Wake/unlock with a pending Todoist approval: not exercised live because the current Todoist path did not create a pending elicitation. Covered synthetically by unexpected gateway-close retirement and session-resume replay tests.
- App restart with a pending Todoist approval: not exercised live for the same reason. Covered by stale pending-action reconciliation and resume/replay tests.
- Network drop/reconnect: not exercised against live Todoist without a pending elicitation. Covered against the freshly patched pinned runtime, including cross-transport logical retry coalescing and immediate fail-closed disconnect drain.
- Duplicate delivery before and after reconnect: covered by focused classifier, runtime, workspace, and patched-protocol regression tests.
- No access tokens, OAuth codes, tool payload secrets, or personal Todoist data were captured in traces or screenshots.

- [x] Tested visually where it matters. Sanitized evidence:
  - [One pending approval card](https://app.opensoftware.co/api/v1/files/fil_AwsaOsYNTVEo/download)
  - [Expired approval receipt with no active control](https://app.opensoftware.co/api/v1/files/fil_4LiXcCsBLSwc/download)
- [ ] Needs a June API (backend) deploy before it works end to end. No June API deploy is required; this is a desktop and bundled-Hermes change.

## Out of scope

- Changing Todoist's MCP server or forcing it to emit an elicitation for validation/read-only requests.
- Broad approval-card visual redesign or approving multiple requests with `all: true`.
- Upgrading the Hermes pin; this keeps the pinned upstream revision and applies a hash-verified June patch set.
- June API changes.

## Followups

- Repeat the live wake, unlock, restart, and network-drop matrix when a Todoist operation exposes a safe pending MCP elicitation.
- Upstream the stable identity and targeted-resolution protocol to Hermes so the June patch can eventually be retired through the normal pin upgrade checklist.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs (no workflow references changed).
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. Bundled Hermes behavior needs normal owner review before merge.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable; no backend changes).
- [x] User-facing copy follows the repo UI conventions.

Closes JUN-350

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786795669&installation_id=144203540&pr_number=788&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F788&signature=8508d9aa34e7db717bc9a66fcfd4a55b11025b9e096ff7cfa38e6d2faa9dd1bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->