### PR TITLE
Keep recording options available during note transcription

### DIFF
--- a/.agents/skills/repo-review/CALIBRATION.md
+++ b/.agents/skills/repo-review/CALIBRATION.md
@@ -93,3 +93,6 @@ data-driven: discount reviewer patterns with a bad true/findings ratio
 | JUN-349 (pre-PR) | Standards (codex) | 0 | — | clean on the runtime startup guard and focused relaunch regression coverage |
 | JUN-349 (pre-PR) | Spec (codex) | 0 | — | clean against the immediate relaunch-history restoration contract and explicit non-goals |
 | JUN-349 (pre-PR) | Adversarial (claude) | 0 | — | approved after tracing double-start locking, shared session storage across runtime modes, and the canonical message read path |
+| JUN-324 (pre-PR) | Standards (codex, r1+final) | 1 | 1 | caught the ambiguous bare “transcription” term in the new regression test; renamed it to canonical note transcription wording, final clean |
+| JUN-324 (pre-PR) | Spec (codex, r1+final) | 0 | — | clean against the chevron visibility, enabled-state, open/close interaction, and regression-coverage acceptance criteria |
+| JUN-324 (pre-PR) | Adversarial (codex, r1+convergence) | 0 | — | approved after tracing the persisted recording source mode and confirming the newly reachable options affect only the next recording |

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -282,8 +282,9 @@ export function NoteEditor({
   const processingLock = processingStatus !== null;
   const recordButtonDisabled = recordingDisabled || Boolean(recordingBlockedReason);
   // A funding block disables the record button but not the options chevron:
-  // choosing sources is free, so that setting stays reachable while gated.
-  const recordOptionsDisabled = processingLock || recordingDisabled;
+  // choosing sources is free, and note processing can queue another recording,
+  // so that setting stays reachable unless another recording is active.
+  const recordOptionsDisabled = recordingDisabled;
   // When generation finishes for the note you're looking at, reveal the fresh
   // notes with a top-down wipe instead of letting the text snap in. Only fires
   // on the live processing -> ready edge for this same note — never when

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -732,7 +732,7 @@ describe("NoteEditor", () => {
     expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
   });
 
-  it("keeps recording options interactive after recording transitions to transcription", async () => {
+  it("keeps recording options interactive after recording transitions to note transcription", async () => {
     const user = userEvent.setup();
     const recordingStatus = {
       sessionId: "session-1",

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -732,6 +732,33 @@ describe("NoteEditor", () => {
     expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
   });
 
+  it("keeps recording options interactive after recording transitions to transcription", async () => {
+    const user = userEvent.setup();
+    const recordingStatus = {
+      sessionId: "session-1",
+      state: "recording" as const,
+      elapsedMs: 1000,
+      level: { peak: 0.5, rms: 0.2, recentPeaks: [0.1, 0.3] },
+      silenceWarning: false,
+      bytesWritten: 2048,
+    };
+    const { rerender } = render(
+      <NoteEditor {...props} note={note()} recordingStatus={recordingStatus} />,
+    );
+
+    rerender(<NoteEditor {...props} note={note({ processingStatus: "transcribing" })} />);
+
+    const options = screen.getByRole("button", { name: "Recording options" });
+    expect(options).toBeEnabled();
+
+    await user.click(options);
+    expect(options).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("switch", { name: "Capture system audio" })).toBeInTheDocument();
+
+    await user.click(options);
+    expect(options).toHaveAttribute("aria-expanded", "false");
+  });
+
   it("shows validating progress in the notes tab", () => {
     render(
       <NoteEditor


### PR DESCRIPTION
## Summary

- Keep the recording options chevron rendered and enabled while note transcription is in progress.
- Preserve the existing guard that hides recording options during an active recording.
- Add regression coverage for the recording to note-transcription transition, including opening and closing the options panel.

Issue: [JUN-324](https://app.opensoftware.co/june/issues/JUN-324)

## Root cause

The recording options visibility still inherited the note-processing lock that originally disabled the whole recorder. A later change made follow-up recordings queueable during note processing and re-enabled the record button, but left the options chevron coupled to the stale lock. As a result, the chevron disappeared whenever the note entered transcription even though starting another recording was allowed.

## Validation

- `make verify`: 168 frontend test files passed with 2,739 tests passing and 2 skipped; 710 desktop native tests passed; all June API workspace checks and tests passed.
- `make local-ci`: frontend and macOS Rust signoffs posted for commit `911cb4fe`.
- Repository review battery: Standards, Spec, and Adversarial axes converged cleanly. The cross-harness Claude pass was unavailable because its local OAuth token had expired, so an independent fresh Codex reviewer ran the convergence pass.
- Agent-driven browser E2E: parked a synthetic meeting note at the note-transcription stage, verified the chevron was visible and enabled, opened the options panel, verified the system-audio control, closed the panel, and observed no material browser errors. A focused recording is attached in the PR comments.

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is required.

## Out of scope

- Native audio capture and source-readiness behavior are unchanged.
- The selected source mode still applies to the next recording, not the note transcription already in progress.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. No security-sensitive behavior changed.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow files changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. None changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. None changed.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786801602&installation_id=144203540&pr_number=789&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F789&signature=f18838f7425990f66aafc5a2ab25753e49f065dd7084d704150182cf0b770fcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->