### PR TITLE
Add Linear OAuth client ID to production builds

### DIFF
--- a/.github/workflows/production-desktop-windows.yml
+++ b/.github/workflows/production-desktop-windows.yml
@@ -125,6 +125,7 @@ jobs:
           PRODUCTION_GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_ID }}
           PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET }}
           PRODUCTION_JUNE_API_URL: ${{ secrets.PRODUCTION_JUNE_API_URL }}
+          PRODUCTION_LINEAR_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_LINEAR_OAUTH_CLIENT_ID }}
         run: |
           $missing = 0
           $required = @(
@@ -138,7 +139,8 @@ jobs:
             "PRODUCTION_OS_ACCOUNTS_CLIENT_ID",
             "PRODUCTION_GOOGLE_OAUTH_CLIENT_ID",
             "PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET",
-            "PRODUCTION_JUNE_API_URL"
+            "PRODUCTION_JUNE_API_URL",
+            "PRODUCTION_LINEAR_OAUTH_CLIENT_ID"
           )
 
           foreach ($name in $required) {
@@ -228,6 +230,7 @@ jobs:
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_ID }}
           GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET }}
           JUNE_API_URL: ${{ secrets.PRODUCTION_JUNE_API_URL }}
+          LINEAR_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_LINEAR_OAUTH_CLIENT_ID }}
           # Match macOS: new installs start in Auto at Higher Quality.
           OS_JUNE_AUTO_MODE_DEFAULT: "true"
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}

--- a/.github/workflows/promote-desktop.yml
+++ b/.github/workflows/promote-desktop.yml
@@ -156,6 +156,7 @@ jobs:
           PRODUCTION_GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_ID }}
           PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET }}
           PRODUCTION_JUNE_API_URL: ${{ secrets.PRODUCTION_JUNE_API_URL }}
+          PRODUCTION_LINEAR_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_LINEAR_OAUTH_CLIENT_ID }}
         run: |
           set -euo pipefail
           missing=0
@@ -172,7 +173,8 @@ jobs:
             PRODUCTION_OS_ACCOUNTS_CLIENT_ID \
             PRODUCTION_GOOGLE_OAUTH_CLIENT_ID \
             PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET \
-            PRODUCTION_JUNE_API_URL
+            PRODUCTION_JUNE_API_URL \
+            PRODUCTION_LINEAR_OAUTH_CLIENT_ID
           do
             if [ -z "${!name:-}" ]; then
               echo "::error::${name} is required to promote a stable release."
@@ -257,6 +259,7 @@ jobs:
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_ID }}
           GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET }}
           JUNE_API_URL: ${{ secrets.PRODUCTION_JUNE_API_URL }}
+          LINEAR_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_LINEAR_OAUTH_CLIENT_ID }}
           # Preserve the RC's first-run Auto behavior when it is promoted.
           OS_JUNE_AUTO_MODE_DEFAULT: "true"
         with:

--- a/.github/workflows/rc-desktop-dmg.yml
+++ b/.github/workflows/rc-desktop-dmg.yml
@@ -113,6 +113,7 @@ jobs:
           PRODUCTION_GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_ID }}
           PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET }}
           PRODUCTION_JUNE_API_URL: ${{ secrets.PRODUCTION_JUNE_API_URL }}
+          PRODUCTION_LINEAR_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_LINEAR_OAUTH_CLIENT_ID }}
         run: |
           set -euo pipefail
           missing=0
@@ -131,7 +132,8 @@ jobs:
             PRODUCTION_OS_ACCOUNTS_CLIENT_ID \
             PRODUCTION_GOOGLE_OAUTH_CLIENT_ID \
             PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET \
-            PRODUCTION_JUNE_API_URL
+            PRODUCTION_JUNE_API_URL \
+            PRODUCTION_LINEAR_OAUTH_CLIENT_ID
           do
             if [ -z "${!name:-}" ]; then
               echo "::error::${name} is required for an rc auto-update release."
@@ -311,6 +313,7 @@ jobs:
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_ID }}
           GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET }}
           JUNE_API_URL: ${{ secrets.PRODUCTION_JUNE_API_URL }}
+          LINEAR_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_LINEAR_OAUTH_CLIENT_ID }}
           # New installs start in Auto at its default Higher Quality preference.
           OS_JUNE_AUTO_MODE_DEFAULT: "true"
         with:


### PR DESCRIPTION
## What changed

- Pass `LINEAR_OAUTH_CLIENT_ID` from the `PRODUCTION_LINEAR_OAUTH_CLIENT_ID` GitHub environment secret into RC macOS, stable macOS, and production Windows builds.
- Require the secret in each production release workflow's validation step.

## Why

June's Linear OAuth client ID needs to be embedded at build time. The production environment secret already exists, but the current release workflows did not expose it to the build.

## Impact

Future production desktop artifacts receive the Linear OAuth client ID without hardcoding it in source control. A missing secret now fails release validation explicitly.

## Validation

- Parsed all three workflow files as YAML.
- `git diff --check` passes.
- `actionlint` reports only the existing custom `blacksmith-4vcpu-windows-2025` runner label.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786802925&installation_id=144203540&pr_number=790&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F790&signature=159f74463bad132a87dfb48d17b4caa88346c6bc48f40e81133100bf6b4aa376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->