### PR TITLE
Redraw the dot spinner as June's mark with a diagonal brightness sweep

### DIFF
--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -96,6 +96,19 @@ warnings use `InlineNotice` (`src/components/ui/InlineNotice.tsx`) with
 `data-tone="warning"` or `"destructive"`; full-width banners are a separate
 treatment.
 
+The spinner defaults to the theme-aware `--spinner-neutral`, which is darker in
+the light theme and lighter in the dark theme. In-flow spinners (chat tool rows,
+inline loading) stay on that monotone neutral rather than a brand or semantic
+accent. A context that needs a solid-control foreground (a brand-filled button)
+or a status color (the Agent HUD) sets `--spinner-color` on the spinner or an
+ancestor; do not add another React tone variant for a one-off color.
+
+In a development build, run `__spinnerDemo()` in the main-window console to
+show representative production contexts together: the sidebar working row,
+Agent response gallery, expanded Agent HUD, and a loading toast. Run
+`__spinnerDemo(false)` to clear them. The demo never starts a real request or
+changes the saved Agent HUD preference.
+
 First-load skeleton bars are quiet and static: flat `var(--surface-subtle)`
 blocks with `var(--r-sm)` radius, sized to the line they stand in for, on an
 `aria-hidden` (or `aria-busy`) container — no sweep, no pulse (the settings

--- a/src/agent-hud.ts
+++ b/src/agent-hud.ts
@@ -22,7 +22,7 @@ import {
   type AgentHudVisibilityChangedDetail,
 } from "./lib/agent-hud-settings";
 import { isAgentSessionTitleCandidate, sessionSettledTitleKind } from "./lib/agent-session-titles";
-import { JUNE_SPINNER_ORDER } from "./lib/june-spinner-grid";
+import { JUNE_SPINNER_COLS, juneSpinnerGrid } from "./lib/june-spinner-grid";
 import { titleFromPrompt } from "./lib/hermes-adapter";
 import { agentHudHide, agentHudOpenAgent, agentHudSetLayout, agentHudShow } from "./lib/tauri";
 import { installNativeContextMenuGuard } from "./lib/native-context-menu";
@@ -897,18 +897,19 @@ function appendStatusIcon(parent: HTMLElement, status: HudSessionStatus) {
 
 // The app-wide dot spinner that draws June's mark (see components/DotSpinner.tsx
 // and lib/june-spinner-grid); this page has no React tree, so the same markup is
-// built by hand against the shared dot-spinner.css. Uses the sm (5×5) variant,
+// built by hand against the shared dot-spinner.css. Uses the sm (3×3) variant,
 // matching every inline usage.
 function appendDotSpinner(parent: HTMLElement) {
   const spinner = document.createElement("span");
   spinner.className = "dot-spinner";
   spinner.dataset.size = "sm";
   spinner.setAttribute("aria-hidden", "true");
-  for (const step of JUNE_SPINNER_ORDER.sm) {
+  spinner.style.setProperty("--june-cols", String(JUNE_SPINNER_COLS.sm));
+  for (const cell of juneSpinnerGrid("sm")) {
     const dot = document.createElement("span");
-    if (step !== null) {
-      dot.dataset.lit = "";
-      dot.style.setProperty("--june-order", String(step));
+    dot.style.setProperty("--june-order", String(cell.order));
+    if (cell.mark) {
+      dot.dataset.mark = "";
     }
     spinner.appendChild(dot);
   }

--- a/src/agent-hud.ts
+++ b/src/agent-hud.ts
@@ -22,6 +22,7 @@ import {
   type AgentHudVisibilityChangedDetail,
 } from "./lib/agent-hud-settings";
 import { isAgentSessionTitleCandidate, sessionSettledTitleKind } from "./lib/agent-session-titles";
+import { JUNE_SPINNER_ORDER } from "./lib/june-spinner-grid";
 import { titleFromPrompt } from "./lib/hermes-adapter";
 import { agentHudHide, agentHudOpenAgent, agentHudSetLayout, agentHudShow } from "./lib/tauri";
 import { installNativeContextMenuGuard } from "./lib/native-context-menu";
@@ -894,15 +895,22 @@ function appendStatusIcon(parent: HTMLElement, status: HudSessionStatus) {
   }
 }
 
-// The app-wide rolling dot spinner (see components/DotSpinner.tsx); this
-// page has no React tree, so the same markup is built by hand against the
-// shared dot-spinner.css.
+// The app-wide dot spinner that draws June's mark (see components/DotSpinner.tsx
+// and lib/june-spinner-grid); this page has no React tree, so the same markup is
+// built by hand against the shared dot-spinner.css. Uses the sm (5×5) variant,
+// matching every inline usage.
 function appendDotSpinner(parent: HTMLElement) {
   const spinner = document.createElement("span");
   spinner.className = "dot-spinner";
+  spinner.dataset.size = "sm";
   spinner.setAttribute("aria-hidden", "true");
-  for (let i = 0; i < 4; i += 1) {
-    spinner.appendChild(document.createElement("span"));
+  for (const step of JUNE_SPINNER_ORDER.sm) {
+    const dot = document.createElement("span");
+    if (step !== null) {
+      dot.dataset.lit = "";
+      dot.style.setProperty("--june-order", String(step));
+    }
+    spinner.appendChild(dot);
   }
   parent.appendChild(spinner);
 }

--- a/src/components/DotSpinner.tsx
+++ b/src/components/DotSpinner.tsx
@@ -3,16 +3,15 @@ import { JUNE_SPINNER_COLS, type JuneSpinnerSize, juneSpinnerGrid } from "../lib
 
 // The dot spinner, drawn rather than typeset: a full square grid of perfect
 // circles with a smooth highlight that climbs diagonally from the bottom-left.
-// The dots on June's mark — a stepped stroke from the squircle logo — swell
-// bright and large as the wave traces up it; the rest of the grid ripples
-// faintly, so the matrix reads as June's ascending stroke. The grid and each cell's sweep order
-// live in lib/june-spinner-grid; the motion is pure CSS — see
-// styles/dot-spinner.css — and rests as the mark under prefers-reduced-motion.
-// The grid is a fixed-size square per variant — integer px, deliberately not
-// font-scaled — and wrappers color it via currentColor.
+// June's stepped mark swells bright as the crest traces it; field dots ripple
+// faintly. The grid and sweep order live in lib/june-spinner-grid, while the
+// bounded motion lives in styles/dot-spinner.css and rests as the mark under
+// prefers-reduced-motion. Each variant is a fixed-size, integer-px square rather
+// than a font-scaled glyph, with a neutral gray default that contextual classes
+// can override through currentColor.
 //
-// "sm" is the 3×3 grid for inline and small loaders; "lg" is the 5×5 grid for
-// larger standalone loading moments.
+// "sm" and "md" are compact 3×3 grids; "lg" is the 5×5 board for larger
+// standalone loading moments.
 type DotSpinnerProps = {
   className?: string;
   size?: JuneSpinnerSize;

--- a/src/components/DotSpinner.tsx
+++ b/src/components/DotSpinner.tsx
@@ -1,16 +1,17 @@
 import type { CSSProperties } from "react";
-import { JUNE_SPINNER_ORDER, type JuneSpinnerSize } from "../lib/june-spinner-grid";
+import { JUNE_SPINNER_COLS, type JuneSpinnerSize, juneSpinnerGrid } from "../lib/june-spinner-grid";
 
-// The dot spinner, drawn rather than typeset: a matrix of perfect circles that
-// draws June's sparkle mark stroke by stroke, holds it, and redraws — a
-// flip-dot board writing the brand mark. (The earlier version was a 2×2 square
-// with a spot rolling around it.) The lit dots and their draw order live in
-// lib/june-spinner-grid; the roll is pure CSS — see styles/dot-spinner.css — and
-// rests under prefers-reduced-motion. The mark is a fixed-size square per
-// variant — integer px, deliberately not font-scaled — and wrappers color it via
-// currentColor.
+// The dot spinner, drawn rather than typeset: a full square grid of perfect
+// circles with a smooth highlight that climbs diagonally from the bottom-left.
+// The dots on June's mark — a stepped stroke from the squircle logo — swell
+// bright and large as the wave traces up it; the rest of the grid ripples
+// faintly, so the matrix reads as June's ascending stroke. The grid and each cell's sweep order
+// live in lib/june-spinner-grid; the motion is pure CSS — see
+// styles/dot-spinner.css — and rests as the mark under prefers-reduced-motion.
+// The grid is a fixed-size square per variant — integer px, deliberately not
+// font-scaled — and wrappers color it via currentColor.
 //
-// "sm" is the 5×5 mark for inline and small loaders; "lg" is the 7×7 board for
+// "sm" is the 3×3 grid for inline and small loaders; "lg" is the 5×5 grid for
 // larger standalone loading moments.
 type DotSpinnerProps = {
   className?: string;
@@ -18,22 +19,23 @@ type DotSpinnerProps = {
 };
 
 export function DotSpinner({ className, size = "sm" }: DotSpinnerProps) {
-  const order = JUNE_SPINNER_ORDER[size];
+  const cells = juneSpinnerGrid(size);
   // The surrounding status text carries the meaning for assistive tech, so the
   // glyph is decorative.
   return (
     <span
       className={["dot-spinner", className].filter(Boolean).join(" ")}
       data-size={size}
+      style={{ "--june-cols": JUNE_SPINNER_COLS[size] } as CSSProperties}
       aria-hidden
     >
-      {order.map((step, i) => (
+      {cells.map((cell, i) => (
         <span
           // Fixed-length constant grid: index is a stable key.
           // biome-ignore lint/suspicious/noArrayIndexKey: the grid is a fixed-length constant.
           key={i}
-          data-lit={step === null ? undefined : ""}
-          style={step === null ? undefined : ({ "--june-order": step } as CSSProperties)}
+          data-mark={cell.mark ? "" : undefined}
+          style={{ "--june-order": cell.order } as CSSProperties}
         />
       ))}
     </span>

--- a/src/components/DotSpinner.tsx
+++ b/src/components/DotSpinner.tsx
@@ -3,12 +3,12 @@ import { JUNE_SPINNER_COLS, type JuneSpinnerSize, juneSpinnerGrid } from "../lib
 
 // The dot spinner, drawn rather than typeset: a full square grid of perfect
 // circles with a smooth highlight that climbs diagonally from the bottom-left.
-// June's stepped mark swells bright as the crest traces it; field dots ripple
+// June's stepped mark reveals bright as the crest traces it; field dots ripple
 // faintly. The grid and sweep order live in lib/june-spinner-grid, while the
 // bounded motion lives in styles/dot-spinner.css and rests as the mark under
 // prefers-reduced-motion. Each variant is a fixed-size, integer-px square rather
-// than a font-scaled glyph, with a neutral gray default that contextual classes
-// can override through currentColor.
+// than a font-scaled glyph. Its theme-aware neutral default is exposed through
+// --spinner-neutral; contextual wrappers can override --spinner-color.
 //
 // "sm" and "md" are compact 3×3 grids; "lg" is the 5×5 board for larger
 // standalone loading moments.

--- a/src/components/DotSpinner.tsx
+++ b/src/components/DotSpinner.tsx
@@ -1,23 +1,41 @@
-// The dot spinner, drawn rather than typeset: a 2×2 grid of perfect
-// circles with a dim spot rolling clockwise around it. (The earlier
-// braille-glyph version left dot shape/spacing to the font; real circles
-// stay crisp.) The mark is a fixed-size square — integer px, deliberately
-// not font-scaled — and wrappers color it via currentColor. The roll is
-// pure CSS — see styles/dot-spinner.css — and rests under
-// prefers-reduced-motion.
+import type { CSSProperties } from "react";
+import { JUNE_SPINNER_ORDER, type JuneSpinnerSize } from "../lib/june-spinner-grid";
+
+// The dot spinner, drawn rather than typeset: a matrix of perfect circles that
+// draws June's sparkle mark stroke by stroke, holds it, and redraws — a
+// flip-dot board writing the brand mark. (The earlier version was a 2×2 square
+// with a spot rolling around it.) The lit dots and their draw order live in
+// lib/june-spinner-grid; the roll is pure CSS — see styles/dot-spinner.css — and
+// rests under prefers-reduced-motion. The mark is a fixed-size square per
+// variant — integer px, deliberately not font-scaled — and wrappers color it via
+// currentColor.
+//
+// "sm" is the 5×5 mark for inline and small loaders; "lg" is the 7×7 board for
+// larger standalone loading moments.
 type DotSpinnerProps = {
   className?: string;
+  size?: JuneSpinnerSize;
 };
 
-export function DotSpinner({ className }: DotSpinnerProps) {
+export function DotSpinner({ className, size = "sm" }: DotSpinnerProps) {
+  const order = JUNE_SPINNER_ORDER[size];
   // The surrounding status text carries the meaning for assistive tech, so the
   // glyph is decorative.
   return (
-    <span className={["dot-spinner", className].filter(Boolean).join(" ")} aria-hidden>
-      <span />
-      <span />
-      <span />
-      <span />
+    <span
+      className={["dot-spinner", className].filter(Boolean).join(" ")}
+      data-size={size}
+      aria-hidden
+    >
+      {order.map((step, i) => (
+        <span
+          // Fixed-length constant grid: index is a stable key.
+          // biome-ignore lint/suspicious/noArrayIndexKey: the grid is a fixed-length constant.
+          key={i}
+          data-lit={step === null ? undefined : ""}
+          style={step === null ? undefined : ({ "--june-order": step } as CSSProperties)}
+        />
+      ))}
     </span>
   );
 }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -14741,11 +14741,7 @@ export function BranchFromHereAction({
       disabled={submitting}
       onClick={() => onBranch(messageId, sessionId)}
     >
-      {submitting ? (
-        <DotSpinner className="agent-turn-action-spinner" />
-      ) : (
-        <IconBranchSimple size={14} aria-hidden />
-      )}
+      {submitting ? <DotSpinner /> : <IconBranchSimple size={14} aria-hidden />}
     </button>
   );
 

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -1,17 +1,21 @@
 import { DotSpinner } from "../DotSpinner";
+import type { JuneSpinnerSize } from "../../lib/june-spinner-grid";
 
-// The app-wide loading indicator: the rolling dot spinner (see DotSpinner).
-// This wrapper owns the accessibility contract — the glyph itself is decorative.
-// The mark is a fixed-size 2×2 dot square by design (no size knob); wrappers
-// only set color via currentColor.
+// The app-wide loading indicator: the dot spinner that draws June's mark (see
+// DotSpinner). This wrapper owns the accessibility contract — the glyph itself
+// is decorative. "sm" (5×5) is the default for inline and small loaders; pass
+// size="lg" for the 7×7 board in larger standalone loading moments. Wrappers set
+// color via currentColor.
 type SpinnerProps = {
   className?: string;
+  size?: JuneSpinnerSize;
   "aria-hidden"?: boolean;
   "aria-label"?: string;
 };
 
 export function Spinner({
   className,
+  size,
   "aria-hidden": ariaHidden,
   "aria-label": ariaLabel,
 }: SpinnerProps) {
@@ -23,7 +27,7 @@ export function Spinner({
       aria-label={ariaHidden ? undefined : (ariaLabel ?? "Loading")}
       className={classes}
     >
-      <DotSpinner />
+      <DotSpinner size={size} />
     </span>
   );
 }

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -3,9 +3,8 @@ import type { JuneSpinnerSize } from "../../lib/june-spinner-grid";
 
 // The app-wide loading indicator: the dot spinner that draws June's mark (see
 // DotSpinner). This wrapper owns the accessibility contract — the glyph itself
-// is decorative. "sm" (5×5) is the default for inline and small loaders; pass
-// size="lg" for the 7×7 board in larger standalone loading moments. Wrappers set
-// color via currentColor.
+// is decorative. "sm" (3×3) is the compact default, "md" is a slightly larger
+// 3×3 option, and "lg" is the 5×5 board for standalone loading moments.
 type SpinnerProps = {
   className?: string;
   size?: JuneSpinnerSize;

--- a/src/lib/june-spinner-grid.ts
+++ b/src/lib/june-spinner-grid.ts
@@ -1,0 +1,57 @@
+// The shape the dot spinner draws: June's sparkle mark on a dot matrix (see
+// src/assets/june-mark.svg for the mark it echoes). One source of truth so the
+// React spinner (components/DotSpinner.tsx) and the plain-DOM agent HUD
+// (agent-hud.ts, which has no React tree) light the exact same dots.
+//
+// The mark is not lit all at once — it is *drawn*, one stroke at a time, the way
+// a flip-dot board fills in: bottom-left accent, then the top bar left to right,
+// the top-right accent, the lower-left accent, the bottom bar, and finally the
+// right accent. Each lit cell therefore carries a draw ORDER (0 first); the
+// timing in dot-spinner.css staggers each dot's fade-in by that order, so the
+// mark keeps drawing itself, holding, and redrawing. Off cells (null) stay as
+// dim resting dots so the whole matrix reads like a flip-dot board.
+//
+// Two variants share one mark: "lg" is the 7×7 board; "sm" is the same drawing
+// with the 1-dot border cropped to 5×5 (the mark already lives in the interior
+// 5×5, so the two are the same strokes at two scales). "sm" is for inline and
+// small loaders, "lg" for larger standalone loading moments.
+
+export type JuneSpinnerSize = "sm" | "lg";
+
+export const JUNE_SPINNER_COLS: Record<JuneSpinnerSize, number> = {
+  sm: 5,
+  lg: 7,
+};
+
+// Row-major grids. null = off (dim resting dot); 0..9 = the dot's draw order.
+// biome-ignore format: the grid layout is the documentation.
+const SM_ORDER: readonly (number | null)[] = [
+  // . . . . X          . . . . 4
+  // . X X X .          . 1 2 3 .
+  // X . . . X          0 . . . 9
+  // . X X X .          . 6 7 8 .
+  // X . . . .          5 . . . .
+  null, null, null, null,    4,
+  null,    1,    2,    3, null,
+     0, null, null, null,    9,
+  null,    6,    7,    8, null,
+     5, null, null, null, null,
+];
+
+// The 7×7 board: the SM mark inset by one dot on every side. Same strokes,
+// same order, decoded straight from the reference frames.
+// biome-ignore format: the grid layout is the documentation.
+const LG_ORDER: readonly (number | null)[] = [
+  null, null, null, null, null, null, null,
+  null, null, null, null, null,    4, null,
+  null, null,    1,    2,    3, null, null,
+  null,    0, null, null, null,    9, null,
+  null, null,    6,    7,    8, null, null,
+  null,    5, null, null, null, null, null,
+  null, null, null, null, null, null, null,
+];
+
+export const JUNE_SPINNER_ORDER: Record<JuneSpinnerSize, readonly (number | null)[]> = {
+  sm: SM_ORDER,
+  lg: LG_ORDER,
+};

--- a/src/lib/june-spinner-grid.ts
+++ b/src/lib/june-spinner-grid.ts
@@ -1,57 +1,70 @@
-// The shape the dot spinner draws: June's sparkle mark on a dot matrix (see
-// src/assets/june-mark.svg for the mark it echoes). One source of truth so the
-// React spinner (components/DotSpinner.tsx) and the plain-DOM agent HUD
-// (agent-hud.ts, which has no React tree) light the exact same dots.
+// The dot spinner is a full square grid of dots with a smooth highlight that
+// sweeps left to right across it. Every cell is a dot; the dots on June's mark
+// swell bright and large as the wave passes, while the rest of the grid ripples
+// faintly, so a plain dot matrix reads as June. One source of truth so the React
+// spinner (components/DotSpinner.tsx) and the plain-DOM agent HUD (agent-hud.ts,
+// which has no React tree) build the exact same grid.
 //
-// The mark is not lit all at once — it is *drawn*, one stroke at a time, the way
-// a flip-dot board fills in: bottom-left accent, then the top bar left to right,
-// the top-right accent, the lower-left accent, the bottom bar, and finally the
-// right accent. Each lit cell therefore carries a draw ORDER (0 first); the
-// timing in dot-spinner.css staggers each dot's fade-in by that order, so the
-// mark keeps drawing itself, holding, and redrawing. Off cells (null) stay as
-// dim resting dots so the whole matrix reads like a flip-dot board.
-//
-// Two variants share one mark: "lg" is the 7×7 board; "sm" is the same drawing
-// with the 1-dot border cropped to 5×5 (the mark already lives in the interior
-// 5×5, so the two are the same strokes at two scales). "sm" is for inline and
-// small loaders, "lg" for larger standalone loading moments.
+// June's mark is the two stepped strokes of the squircle logo (see
+// src/assets/june-agents-mark.svg), each ascending low-left → high-right. At 3×3
+// the mark abstracts to one stepped stroke: the bottom-left corner, across the
+// middle row, up to the top-right corner (a `_/‾` step); at 5×5 it separates
+// into the full two strokes. Each cell carries a sweep order — its diagonal
+// distance from the bottom-left corner — and dot-spinner.css rides a swell keyed
+// to that order, so the crest climbs from bottom-left to top-right, tracing the
+// stroke's path, and loops.
 
 export type JuneSpinnerSize = "sm" | "lg";
 
+// "sm" is the 3×3 grid for inline and small loaders; "lg" is the 5×5 grid for
+// larger standalone loading moments.
 export const JUNE_SPINNER_COLS: Record<JuneSpinnerSize, number> = {
-  sm: 5,
-  lg: 7,
+  sm: 3,
+  lg: 5,
 };
 
-// Row-major grids. null = off (dim resting dot); 0..9 = the dot's draw order.
+// Row-major masks marking June's stroke(s) within the full grid. 1 = a mark dot
+// (swells bright), 0 = a field dot (ripples faintly).
+// 3×3: one stepped stroke — bottom-left corner, across the middle row, up to the
+// top-right corner.
 // biome-ignore format: the grid layout is the documentation.
-const SM_ORDER: readonly (number | null)[] = [
-  // . . . . X          . . . . 4
-  // . X X X .          . 1 2 3 .
-  // X . . . X          0 . . . 9
-  // . X X X .          . 6 7 8 .
-  // X . . . .          5 . . . .
-  null, null, null, null,    4,
-  null,    1,    2,    3, null,
-     0, null, null, null,    9,
-  null,    6,    7,    8, null,
-     5, null, null, null, null,
+const SM_MARK: readonly number[] = [
+  0, 0, 1,
+  1, 1, 1,
+  1, 0, 0,
 ];
 
-// The 7×7 board: the SM mark inset by one dot on every side. Same strokes,
-// same order, decoded straight from the reference frames.
+// 5×5: the two ascending strokes, traced 1:1 from the rasterized logo.
 // biome-ignore format: the grid layout is the documentation.
-const LG_ORDER: readonly (number | null)[] = [
-  null, null, null, null, null, null, null,
-  null, null, null, null, null,    4, null,
-  null, null,    1,    2,    3, null, null,
-  null,    0, null, null, null,    9, null,
-  null, null,    6,    7,    8, null, null,
-  null,    5, null, null, null, null, null,
-  null, null, null, null, null, null, null,
+const LG_MARK: readonly number[] = [
+  0, 0, 0, 0, 1,
+  0, 1, 1, 1, 0,
+  1, 0, 0, 0, 1,
+  0, 1, 1, 1, 0,
+  1, 0, 0, 0, 0,
 ];
 
-export const JUNE_SPINNER_ORDER: Record<JuneSpinnerSize, readonly (number | null)[]> = {
-  sm: SM_ORDER,
-  lg: LG_ORDER,
+const JUNE_SPINNER_MARK: Record<JuneSpinnerSize, readonly number[]> = {
+  sm: SM_MARK,
+  lg: LG_MARK,
 };
+
+export type JuneSpinnerCell = {
+  // Sweep order: diagonal distance from the bottom-left corner, so the highlight
+  // climbs from bottom-left to top-right, tracing June's ascending stroke.
+  order: number;
+  // Whether the cell sits on June's mark and swells bright.
+  mark: boolean;
+};
+
+// The full grid for a variant: every cell, in row-major order, with its sweep
+// order and whether it lands on June's mark.
+export function juneSpinnerGrid(size: JuneSpinnerSize): JuneSpinnerCell[] {
+  const cols = JUNE_SPINNER_COLS[size];
+  return JUNE_SPINNER_MARK[size].map((lit, i) => {
+    const row = Math.floor(i / cols);
+    const col = i % cols;
+    // Diagonal distance from the bottom-left corner (row = cols - 1).
+    return { order: col + (cols - 1 - row), mark: lit === 1 };
+  });
+}

--- a/src/lib/june-spinner-grid.ts
+++ b/src/lib/june-spinner-grid.ts
@@ -1,9 +1,8 @@
-// The dot spinner is a full square grid of dots with a smooth highlight that
-// sweeps left to right across it. Every cell is a dot; the dots on June's mark
-// swell bright and large as the wave passes, while the rest of the grid ripples
-// faintly, so a plain dot matrix reads as June. One source of truth so the React
-// spinner (components/DotSpinner.tsx) and the plain-DOM agent HUD (agent-hud.ts,
-// which has no React tree) build the exact same grid.
+// The dot spinner is a full square grid with a smooth brightness highlight that
+// climbs diagonally from the bottom-left. Dots on June's mark brighten to full;
+// field dots ripple faintly, so a plain matrix reads as June. One source of
+// truth keeps the React spinner (components/DotSpinner.tsx) and the plain-DOM
+// agent HUD (agent-hud.ts, which has no React tree) on the exact same grid.
 //
 // June's mark is the two stepped strokes of the squircle logo (see
 // src/assets/june-agents-mark.svg), each ascending low-left → high-right. At 3×3
@@ -11,15 +10,16 @@
 // middle row, up to the top-right corner (a `_/‾` step); at 5×5 it separates
 // into the full two strokes. Each cell carries a sweep order — its diagonal
 // distance from the bottom-left corner — and dot-spinner.css rides a swell keyed
-// to that order, so the crest climbs from bottom-left to top-right, tracing the
-// stroke's path, and loops.
+// to that order, so the crest traces the stroke from bottom-left to top-right,
+// settles, and takes a short breath before the next pass.
 
-export type JuneSpinnerSize = "sm" | "lg";
+export type JuneSpinnerSize = "sm" | "md" | "lg";
 
-// "sm" is the 3×3 grid for inline and small loaders; "lg" is the 5×5 grid for
-// larger standalone loading moments.
+// "sm" and "md" share the compact 3×3 mark at different optical sizes; "lg"
+// uses the full 5×5 mark for larger standalone loading moments.
 export const JUNE_SPINNER_COLS: Record<JuneSpinnerSize, number> = {
   sm: 3,
+  md: 3,
   lg: 5,
 };
 
@@ -46,6 +46,7 @@ const LG_MARK: readonly number[] = [
 
 const JUNE_SPINNER_MARK: Record<JuneSpinnerSize, readonly number[]> = {
   sm: SM_MARK,
+  md: SM_MARK,
   lg: LG_MARK,
 };
 

--- a/src/lib/june-spinner-grid.ts
+++ b/src/lib/june-spinner-grid.ts
@@ -9,7 +9,7 @@
 // the mark abstracts to one stepped stroke: the bottom-left corner, across the
 // middle row, up to the top-right corner (a `_/‾` step); at 5×5 it separates
 // into the full two strokes. Each cell carries a sweep order — its diagonal
-// distance from the bottom-left corner — and dot-spinner.css rides a swell keyed
+// distance from the bottom-left corner — and dot-spinner.css rides a reveal keyed
 // to that order, so the crest traces the stroke from bottom-left to top-right,
 // settles, and takes a short breath before the next pass.
 
@@ -24,7 +24,7 @@ export const JUNE_SPINNER_COLS: Record<JuneSpinnerSize, number> = {
 };
 
 // Row-major masks marking June's stroke(s) within the full grid. 1 = a mark dot
-// (swells bright), 0 = a field dot (ripples faintly).
+// (reveals at full brightness), 0 = a field dot (ripples faintly).
 // 3×3: one stepped stroke — bottom-left corner, across the middle row, up to the
 // top-right corner.
 // biome-ignore format: the grid layout is the documentation.
@@ -54,7 +54,7 @@ export type JuneSpinnerCell = {
   // Sweep order: diagonal distance from the bottom-left corner, so the highlight
   // climbs from bottom-left to top-right, tracing June's ascending stroke.
   order: number;
-  // Whether the cell sits on June's mark and swells bright.
+  // Whether the cell sits on June's mark and reveals bright.
   mark: boolean;
 };
 

--- a/src/lib/spinner-demo.ts
+++ b/src/lib/spinner-demo.ts
@@ -1,0 +1,107 @@
+// Dev-only coordinator for inspecting June's shared spinner in representative
+// production contexts from one console command:
+//
+//   window.__spinnerDemo()       show sidebar, gallery, HUD, and toast samples
+//   window.__spinnerDemo(false)  clear every sample
+//
+// The individual surfaces keep owning their own preview state. This module
+// composes those existing drivers so it never starts a real request, mutates
+// user data, or creates a second presentation-only version of a spinner.
+
+import { toast } from "../components/ui/Toaster";
+import { AGENT_HUD_VISIBILITY_CHANGED_EVENT, getAgentHudEnabled } from "./agent-hud-settings";
+
+type SpinnerDemoWindow = Window & {
+  __agentGallery?: (show?: boolean) => unknown;
+  __agentHud?: (state?: string, count?: number) => unknown;
+  __sidebarStates?: (show?: boolean) => unknown;
+  __spinnerDemo?: (show?: boolean) => string;
+};
+
+export type SpinnerDemoApi = {
+  dispose: () => void;
+};
+
+const GALLERY_SPINNER_SELECTOR = ".agent-gallery .agent-tool-spinner";
+const GALLERY_SCROLL_ATTEMPTS = 12;
+
+function emitAgentHudVisibility(enabled: boolean) {
+  void import("@tauri-apps/api/event")
+    .then(({ emit }) => emit(AGENT_HUD_VISIBILITY_CHANGED_EVENT, { enabled }))
+    .catch(() => {});
+}
+
+export function registerSpinnerDemo(): SpinnerDemoApi {
+  const target = window as SpinnerDemoWindow;
+  let active = false;
+  let loadingToastId: string | number | undefined;
+  let scrollTimer: number | undefined;
+
+  function cancelGalleryScroll() {
+    if (scrollTimer === undefined) return;
+    window.clearTimeout(scrollTimer);
+    scrollTimer = undefined;
+  }
+
+  function focusGallerySpinner() {
+    cancelGalleryScroll();
+    let attempts = 0;
+    const focus = () => {
+      scrollTimer = undefined;
+      const spinner = document.querySelector<HTMLElement>(GALLERY_SPINNER_SELECTOR);
+      if (spinner) {
+        spinner.scrollIntoView?.({ block: "center" });
+        return;
+      }
+      attempts += 1;
+      if (attempts < GALLERY_SCROLL_ATTEMPTS) {
+        scrollTimer = window.setTimeout(focus, 16);
+      }
+    };
+    scrollTimer = window.setTimeout(focus, 0);
+  }
+
+  function clear() {
+    cancelGalleryScroll();
+    target.__agentHud?.("clear");
+    target.__agentGallery?.(false);
+    target.__sidebarStates?.(false);
+    if (loadingToastId !== undefined) {
+      toast.dismiss(loadingToastId);
+      loadingToastId = undefined;
+    }
+    // The demo may temporarily reveal a disabled HUD, but never changes the
+    // saved preference. Teardown returns the Agent HUD to the current setting.
+    emitAgentHudVisibility(getAgentHudEnabled());
+    active = false;
+  }
+
+  const run = (show: boolean = true) => {
+    if (!show) {
+      clear();
+      return "Spinner demo cleared.";
+    }
+
+    active = true;
+    target.__sidebarStates?.(true);
+    target.__agentGallery?.(true);
+    // "mixed" auto-expands the Agent HUD, exposing its running-row spinners.
+    // A transient visibility event also reveals it when the saved preference
+    // is off; clear() restores that preference without rewriting localStorage.
+    emitAgentHudVisibility(true);
+    target.__agentHud?.("mixed");
+    loadingToastId ??= toast.loading("Spinner showcase");
+    focusGallerySpinner();
+
+    return "Spinner demo shown: sidebar, Agent gallery, Agent HUD, and loading toast. Run __spinnerDemo(false) to clear.";
+  };
+
+  target.__spinnerDemo = run;
+
+  return {
+    dispose() {
+      if (active) clear();
+      if (target.__spinnerDemo === run) delete target.__spinnerDemo;
+    },
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -35,9 +35,12 @@ installNativeContextMenuGuard();
 // from this window's devtools. Emits on the Tauri bus only, so fake demo
 // sessions never leak into the sidebar or menu bar. See lib/agent-hud-demo.ts.
 if (import.meta.env.DEV) {
-  void import("./lib/agent-hud-demo").then(({ registerAgentHudDemo }) =>
-    registerAgentHudDemo({ local: false }),
-  );
+  void import("./lib/agent-hud-demo").then(({ registerAgentHudDemo }) => {
+    registerAgentHudDemo({ local: false });
+    // Composite visual check: __spinnerDemo() opens representative real
+    // spinner contexts, including this separately rendered HUD window.
+    void import("./lib/spinner-demo").then(({ registerSpinnerDemo }) => registerSpinnerDemo());
+  });
   // Same pattern for the meeting-detection prompt: __meetingHud("detected")
   // drives the real dictation HUD window over the Tauri bus.
   void import("./lib/meeting-hud-demo").then(({ registerMeetingHudDemo }) =>

--- a/src/styleguide/sections/Color.tsx
+++ b/src/styleguide/sections/Color.tsx
@@ -23,6 +23,7 @@ const COLOR_GROUPS: { label: string; names: string[] }[] = [
       "--card-foreground",
       "--muted-foreground",
       "--body-copy",
+      "--spinner-neutral",
       "--primary",
       "--primary-foreground",
     ],

--- a/src/styleguide/sections/FeedbackIndicators.tsx
+++ b/src/styleguide/sections/FeedbackIndicators.tsx
@@ -41,7 +41,7 @@ export function FeedbackIndicators() {
         A full dot grid with a smooth highlight that climbs June's mark from bottom-left to
         top-right, then settles briefly before the next pass. The sm and md variants use the compact
         3×3 mark at two inline sizes; size="lg" uses the full 5×5 mark for standalone loading
-        moments.
+        moments. Its neutral follows the active theme and contexts can override --spinner-color.
       </p>
       <div className="sg-row">
         <div className="sg-card">

--- a/src/styleguide/sections/FeedbackIndicators.tsx
+++ b/src/styleguide/sections/FeedbackIndicators.tsx
@@ -37,12 +37,23 @@ export function FeedbackIndicators() {
       </p>
 
       <h2 className="sg-subheading">Spinner</h2>
+      <p className="sg-section-intro">
+        A dot matrix that draws June's mark stroke by stroke and redraws. The default sm (5×5)
+        variant is for inline and small loaders; size="lg" (7×7) is for larger standalone loading
+        moments.
+      </p>
       <div className="sg-row">
         <div className="sg-card">
           <div className="sg-token-meta" style={{ marginBottom: "var(--sp-4)" }}>
-            <span className="sg-token-name">Spinner</span>
+            <span className="sg-token-name">Spinner (sm)</span>
           </div>
           <Spinner aria-label="Loading" />
+        </div>
+        <div className="sg-card">
+          <div className="sg-token-meta" style={{ marginBottom: "var(--sp-4)" }}>
+            <span className="sg-token-name">Spinner (lg)</span>
+          </div>
+          <Spinner size="lg" aria-label="Loading" />
         </div>
         <div className="sg-card">
           <div className="sg-token-meta" style={{ marginBottom: "var(--sp-4)" }}>

--- a/src/styleguide/sections/FeedbackIndicators.tsx
+++ b/src/styleguide/sections/FeedbackIndicators.tsx
@@ -38,10 +38,10 @@ export function FeedbackIndicators() {
 
       <h2 className="sg-subheading">Spinner</h2>
       <p className="sg-section-intro">
-        A full dot grid with a smooth highlight that sweeps left to right across it; the dots on
-        June's mark swell brighter as the wave passes, so the matrix reads as June. The default sm
-        (3×3) variant is for inline and small loaders; size="lg" (5×5) is for larger standalone
-        loading moments.
+        A full dot grid with a smooth highlight that climbs June's mark from bottom-left to
+        top-right, then settles briefly before the next pass. The sm and md variants use the compact
+        3×3 mark at two inline sizes; size="lg" uses the full 5×5 mark for standalone loading
+        moments.
       </p>
       <div className="sg-row">
         <div className="sg-card">
@@ -49,6 +49,12 @@ export function FeedbackIndicators() {
             <span className="sg-token-name">Spinner (sm)</span>
           </div>
           <Spinner aria-label="Loading" />
+        </div>
+        <div className="sg-card">
+          <div className="sg-token-meta" style={{ marginBottom: "var(--sp-4)" }}>
+            <span className="sg-token-name">Spinner (md)</span>
+          </div>
+          <Spinner size="md" aria-label="Loading" />
         </div>
         <div className="sg-card">
           <div className="sg-token-meta" style={{ marginBottom: "var(--sp-4)" }}>

--- a/src/styleguide/sections/FeedbackIndicators.tsx
+++ b/src/styleguide/sections/FeedbackIndicators.tsx
@@ -38,9 +38,10 @@ export function FeedbackIndicators() {
 
       <h2 className="sg-subheading">Spinner</h2>
       <p className="sg-section-intro">
-        A dot matrix that draws June's mark stroke by stroke and redraws. The default sm (5×5)
-        variant is for inline and small loaders; size="lg" (7×7) is for larger standalone loading
-        moments.
+        A full dot grid with a smooth highlight that sweeps left to right across it; the dots on
+        June's mark swell brighter as the wave passes, so the matrix reads as June. The default sm
+        (3×3) variant is for inline and small loaders; size="lg" (5×5) is for larger standalone
+        loading moments.
       </p>
       <div className="sg-row">
         <div className="sg-card">

--- a/src/styles/agent-hud.css
+++ b/src/styles/agent-hud.css
@@ -321,7 +321,7 @@ body {
 /* The standalone HUD does not load app.css, so opt its spinner back into the
  * status foreground here instead of leaving the dot grid at its neutral default. */
 .agent-hud-status .dot-spinner {
-  color: currentColor;
+  --spinner-color: currentColor;
 }
 
 .agent-hud-status[data-status="received"],

--- a/src/styles/agent-hud.css
+++ b/src/styles/agent-hud.css
@@ -318,6 +318,12 @@ body {
   height: 14px;
 }
 
+/* The standalone HUD does not load app.css, so opt its spinner back into the
+ * status foreground here instead of leaving the dot grid at its neutral default. */
+.agent-hud-status .dot-spinner {
+  color: currentColor;
+}
+
 .agent-hud-status[data-status="received"],
 .agent-hud-status[data-status="starting"],
 .agent-hud-status[data-status="running"] {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -17074,8 +17074,8 @@ input:focus-visible,
 }
 
 /* App-wide loading indicator: the dot spinner that draws June's mark. Its size
- * is fixed per variant (data-size sm/lg) in dot-spinner.css, not font-scaled;
- * color inherits via currentColor. */
+ * is fixed per variant (data-size sm/md/lg) in dot-spinner.css, not font-scaled;
+ * the default color is the theme's neutral muted foreground. */
 .spinner {
   display: inline-flex;
   flex-shrink: 0;
@@ -17086,6 +17086,13 @@ input:focus-visible,
 
 /* The dot spinner itself lives in dot-spinner.css (shared with the agent
  * HUD page entry). */
+
+/* Solid controls need their own contrast foreground instead of the spinner's
+ * default gray. */
+.agent-composer-send .dot-spinner,
+.primary-action.primary-solid .dot-spinner {
+  color: currentColor;
+}
 
 @media (prefers-reduced-motion: reduce) {
   .sign-in-prompt-spinner,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2899,8 +2899,7 @@ input:focus-visible,
   opacity: 0;
 }
 
-/* Running rows trade the status word for the rolling dot spinner (fixed-size
- * mark; wrappers only set color). */
+/* Running rows trade the status word for the fixed-size June mark spinner. */
 .agent-tool-spinner {
   display: inline-flex;
   flex: 0 0 auto;
@@ -5004,7 +5003,7 @@ input:focus-visible,
 /* Why a rejected send didn't go through — sits on the composer because that's
  * where the user just acted, and clears itself when the turn finishes. A
  * content-sized pill (not another full-width box, which read as a second
- * composer) with the rolling dot spinner tying it to the working state. Same
+ * composer) with the dot-grid spinner tying it to the working state. Same
  * surface recipe as the "Generating notes…" pill so the app's progress
  * statuses read as one family. (The recording-consent note left this family
  * for the funding-notice card chrome — it asks, it doesn't report progress.) */
@@ -10936,8 +10935,8 @@ input:focus-visible,
   font-size: var(--fs-sm);
 }
 
-/* The rolling dot spinner (drawn, colored via currentColor) — the same working
- * indicator as the agent chat, sidebar, and composer notice. */
+/* The dot-grid spinner — the same working indicator as the agent chat, sidebar,
+ * and composer notice. */
 .note-processing-progress-spinner {
   flex: none;
   color: color-mix(in oklch, var(--muted-foreground) 80%, transparent);
@@ -17087,10 +17086,11 @@ input:focus-visible,
 /* The dot spinner itself lives in dot-spinner.css (shared with the agent
  * HUD page entry). */
 
-/* Solid controls need their own contrast foreground instead of the spinner's
- * default gray. */
+/* Contrasting contexts opt back into their inherited foreground instead of the
+ * spinner's neutral-gray default. */
 .agent-composer-send .dot-spinner,
-.primary-action.primary-solid .dot-spinner {
+.primary-action.primary-solid .dot-spinner,
+.agent-tool-spinner .dot-spinner {
   color: currentColor;
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2899,13 +2899,14 @@ input:focus-visible,
   opacity: 0;
 }
 
-/* Running rows trade the status word for the fixed-size June mark spinner. */
+/* Running rows trade the status word for the fixed-size June mark spinner.
+ * It stays on the spinner's neutral default — a working row is ambient
+ * activity, not a semantic accent. */
 .agent-tool-spinner {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  color: var(--warm-strong);
 }
 
 /* Name inherits the row's muted color (the whole line darkens on hover). */
@@ -5211,12 +5212,6 @@ input:focus-visible,
   --tier-ink: oklch(10% 0.01 60);
   --tier-mark: oklch(82% 0.07 75);
   --tier-mark-relief: oklch(16% 0.012 60);
-}
-
-/* Waiting states swap the coin glyph for the dot spinner: neutral progress,
- * not a caution accent. */
-.funding-notice-spinner {
-  color: var(--muted-foreground);
 }
 
 .funding-notice-body {
@@ -7748,7 +7743,7 @@ input:focus-visible,
 }
 
 .report-dialog-submit-spinner {
-  color: currentColor;
+  --spinner-color: currentColor;
 }
 
 /* Mic is the resting affordance — a light ghost button (matches our other ghost
@@ -9470,10 +9465,6 @@ input:focus-visible,
   border-radius: var(--r-pill);
 }
 
-.agent-sidebar-spinner {
-  color: color-mix(in oklch, var(--muted-foreground) 80%, transparent);
-}
-
 .agent-sidebar-working[data-status="waitingForUser"],
 .agent-sidebar-working[data-status="unread"] {
   background: var(--warm-strong);
@@ -10650,7 +10641,6 @@ input:focus-visible,
 
 .transcript-processing-spinner {
   flex: none;
-  color: color-mix(in oklch, var(--muted-foreground) 80%, transparent);
 }
 
 /* Pairs with the shared .shimmer utility in markup. The label just sets its
@@ -10939,7 +10929,6 @@ input:focus-visible,
  * and composer notice. */
 .note-processing-progress-spinner {
   flex: none;
-  color: color-mix(in oklch, var(--muted-foreground) 80%, transparent);
 }
 
 /* The rolling stage label: a one-line window the stage names roll through.
@@ -12006,10 +11995,6 @@ input:focus-visible,
 
 /* Feature 07: the fork lifecycle (creating → branched) is now surfaced as a
  * toast, not an inline banner — see branchFromMessage in AgentWorkspace.tsx. */
-
-.agent-turn-action-spinner {
-  color: var(--warm-strong);
-}
 
 .agent-error-banner {
   display: flex;
@@ -17074,7 +17059,7 @@ input:focus-visible,
 
 /* App-wide loading indicator: the dot spinner that draws June's mark. Its size
  * is fixed per variant (data-size sm/md/lg) in dot-spinner.css, not font-scaled;
- * the default color is the theme's neutral muted foreground. */
+ * the default color is the theme-aware --spinner-neutral token. */
 .spinner {
   display: inline-flex;
   flex-shrink: 0;
@@ -17086,12 +17071,11 @@ input:focus-visible,
 /* The dot spinner itself lives in dot-spinner.css (shared with the agent
  * HUD page entry). */
 
-/* Contrasting contexts opt back into their inherited foreground instead of the
- * spinner's neutral-gray default. */
+/* Solid controls opt back into their inherited foreground instead of the
+ * spinner's neutral-gray default, so the dots stay legible on a brand fill. */
 .agent-composer-send .dot-spinner,
-.primary-action.primary-solid .dot-spinner,
-.agent-tool-spinner .dot-spinner {
-  color: currentColor;
+.primary-action.primary-solid .dot-spinner {
+  --spinner-color: currentColor;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -17073,8 +17073,9 @@ input:focus-visible,
   animation: sign-in-prompt-spin 0.9s linear infinite;
 }
 
-/* App-wide loading indicator: the rolling dot spinner. Size comes
- * from font-size (set inline by <Spinner size>); color inherits. */
+/* App-wide loading indicator: the dot spinner that draws June's mark. Its size
+ * is fixed per variant (data-size sm/lg) in dot-spinner.css, not font-scaled;
+ * color inherits via currentColor. */
 .spinner {
   display: inline-flex;
   flex-shrink: 0;

--- a/src/styles/dot-spinner.css
+++ b/src/styles/dot-spinner.css
@@ -32,6 +32,10 @@
   --june-frame: calc((var(--t-fast) + var(--t-med)) / 2);
   --june-pulse: calc(var(--t-fast) + var(--t-med) + var(--t-slow));
   --june-pause: var(--t-fast);
+  /* The highest sweep order juneSpinnerGrid() emits for this grid, which paces
+   * the full cycle. For the bottom-left diagonal traversal it is (cols - 1) × 2,
+   * so the 3×3 sm/md grid tops out at 4. Keep this in lockstep with
+   * JUNE_SPINNER_COLS in lib/june-spinner-grid.ts if the grid is ever resized. */
   --june-max-order: 4;
   --june-dur: calc(
     var(--june-frame) *
@@ -53,9 +57,8 @@
 }
 
 .dot-spinner[data-size="md"] {
-  --june-off: 0.44;
-  --june-field-off: 0.14;
-  --june-field-peak: 0.26;
+  /* Shares the base tonal hierarchy; only the dot size grows for a slightly
+   * larger inline mark. */
   --june-dot: 3px;
   --june-gap: 2px;
 }
@@ -65,6 +68,9 @@
   --june-field-off: 0.15;
   --june-field-peak: 0.24;
   --june-frame: calc(var(--t-med) / 2);
+  /* Same (cols - 1) × 2 derivation as the base block, for the 5×5 lg grid: it
+   * tops out at 8. Kept in lockstep with JUNE_SPINNER_COLS / juneSpinnerGrid in
+   * lib/june-spinner-grid.ts. */
   --june-max-order: 8;
   --june-dot: 3px;
   --june-gap: 3px;

--- a/src/styles/dot-spinner.css
+++ b/src/styles/dot-spinner.css
@@ -1,13 +1,13 @@
 /* The dot spinner: a full square grid of circles with a brightness highlight
  * that sweeps diagonally from the bottom-left. The grid rests stable at full
- * size; as the highlight passes, each dot brightens and gives a small swell —
- * the mark dots pop a touch more than the field — then settles back. Motion is
- * mostly tone (a big scale excursion shimmers at 2–3px), with only a light
- * synchronized swell for life. A bright band glides along June's stepped mark;
- * field dots ripple faintly. The grid and each cell's sweep order live in
+ * size; as the highlight passes, every dot brightens while mark dots also give
+ * a small synchronized swell, then settle back. Motion is mostly tone (a big
+ * scale excursion shimmers at 2–3px). A bright band glides along June's stepped
+ * mark; field dots ripple faintly without changing size. The grid and each
+ * cell's sweep order live in
  * lib/june-spinner-grid (shared with the agent HUD page entry, which has no
- * React tree). The default is a neutral gray; contextual wrappers can still
- * override it through currentColor.
+ * React tree). The default is a neutral gray. Contexts that require their own
+ * contrast color opt back into inherited currentColor in app.css.
  *
  * Three optical variants: "sm" (3×3) for compact inline use, "md" (3×3) for a
  * slightly larger inline mark, and "lg" (5×5) for standalone loading moments.
@@ -27,7 +27,6 @@
    * steady. Only the mark swells so the motion stays on June's strokes; keep the
    * excursion small — a big swell shimmers at this dot size. */
   --june-swell: 1.16;
-  --june-field-swell: 1;
   /* Every dot gets the same 500ms brightening and each completed pass gets a
    * 100ms reset. The compact grid takes a deliberate 130ms diagonal step; the
    * denser large grid overrides that with an 80ms step so its crest stays
@@ -73,14 +72,12 @@
   --june-gap: 3px;
 }
 
-/* Each cell rests at full size and full-rest tone; the opacity and a light
- * synchronized swell animate together, shifted by the cell's diagonal order, so
- * a bright band sweeps across the otherwise stable grid. Cell variables keep the
- * field and mark tones and swells on the same envelope. */
+/* Every cell runs the brightness envelope, shifted by its diagonal order. Mark
+ * cells add the synchronized swell; field cells stay at scale 1, so they do not
+ * pay for a no-op transform animation or compositor hint. */
 .dot-spinner > span {
   --june-cell-opacity: var(--june-field-off);
   --june-cell-peak-opacity: var(--june-field-peak);
-  --june-cell-swell: var(--june-field-swell);
 
   width: var(--june-dot);
   height: var(--june-dot);
@@ -88,21 +85,26 @@
   background: currentColor;
   opacity: var(--june-cell-opacity);
   transform: scale(1);
-  animation:
-    june-sweep-sm var(--june-dur) var(--ease-in-out) infinite,
-    june-scale-sm var(--june-dur) var(--ease-in-out) infinite;
+  animation: june-sweep-sm var(--june-dur) var(--ease-in-out) infinite;
   animation-delay: calc(var(--june-order) * var(--june-frame) - var(--june-dur));
-  /* GPU-composite the fade and swell so the sweep stays smooth. */
-  will-change: opacity, transform;
+  will-change: opacity;
 }
 
 .dot-spinner > span[data-mark] {
   --june-cell-opacity: var(--june-off);
   --june-cell-peak-opacity: 1;
   --june-cell-swell: var(--june-swell);
+
+  animation-name: june-sweep-sm, june-scale-sm;
+  /* GPU-composite the visible swell as well as the fade. */
+  will-change: opacity, transform;
 }
 
 .dot-spinner[data-size="lg"] > span {
+  animation-name: june-sweep-lg;
+}
+
+.dot-spinner[data-size="lg"] > span[data-mark] {
   animation-name: june-sweep-lg, june-scale-lg;
 }
 

--- a/src/styles/dot-spinner.css
+++ b/src/styles/dot-spinner.css
@@ -1,107 +1,179 @@
-/* The dot spinner: a full square grid of tiny real circles with a smooth
- * highlight that climbs diagonally from the bottom-left. Every cell is a dot;
- * the dots on June's mark — a stepped stroke from the squircle logo — swell
- * bright and large as the wave traces up it, while the rest of the grid ripples
- * faintly, so the matrix reads as June's ascending stroke travelling through it. Drawn,
- * not typeset, so the dots stay crisp. The grid and each cell's sweep order live
- * in lib/june-spinner-grid (shared with the agent HUD page entry, which has no
- * React tree). Wrappers set only color (currentColor).
+/* The dot spinner: a full square grid of circles with a brightness highlight
+ * that sweeps diagonally from the bottom-left. The grid rests stable at full
+ * size; as the highlight passes, each dot brightens and gives a small swell —
+ * the mark dots pop a touch more than the field — then settles back. Motion is
+ * mostly tone (a big scale excursion shimmers at 2–3px), with only a light
+ * synchronized swell for life. A bright band glides along June's stepped mark;
+ * field dots ripple faintly. The grid and each cell's sweep order live in
+ * lib/june-spinner-grid (shared with the agent HUD page entry, which has no
+ * React tree). The default is a neutral gray; contextual wrappers can still
+ * override it through currentColor.
  *
- * Two variants: "sm" (3×3) for inline and small loaders — the default — and
- * "lg" (5×5) for larger standalone loading moments. The column count comes from
- * --june-cols, set per instance. */
+ * Three optical variants: "sm" (3×3) for compact inline use, "md" (3×3) for a
+ * slightly larger inline mark, and "lg" (5×5) for standalone loading moments.
+ * The column count comes from --june-cols, set per instance. */
 .dot-spinner {
-  /* Mark dots swell from --june-rest / --june-off up to full size and opacity;
-   * field dots swell only faintly (--june-field-*). Tune these to trade off how
-   * strongly the mark reads against the background grid. */
-  --june-off: 0.35;
-  --june-rest: 0.5;
-  --june-field-off: 0.1;
-  --june-field-rest: 0.42;
-  --june-field-peak: 0.28;
-  --june-field-scale: 0.62;
-  /* One diagonal step of the wave is --june-frame; --june-frames sets the loop
-   * length (the grid's diagonals plus a little trailing breath). */
-  --june-frames: 6;
-  --june-frame: 0.13s;
-  --june-dur: calc(var(--june-frame) * var(--june-frames));
-  /* Integer px so every column shares one subpixel phase. */
+  /* Tonal hierarchy — the mark must always outrank the field so June's shape
+   * reads at every frame, not just at rest. Mark dots sit at --june-off and
+   * brighten to full (1) as the highlight passes; field dots sit dimmer at
+   * --june-field-off and ripple only up to --june-field-peak, which MUST stay
+   * below --june-off. If the field peak ever exceeds the mark's rest, the sweep
+   * paints a diagonal band that hides the logo. All tones are opacity on
+   * currentColor (var(--muted-foreground)), so they track light/dark themes. */
+  --june-off: 0.44;
+  --june-field-off: 0.14;
+  --june-field-peak: 0.26;
+  /* Peak scale as the highlight passes; rest is always 1 so the grid holds
+   * steady. Only the mark swells so the motion stays on June's strokes; keep the
+   * excursion small — a big swell shimmers at this dot size. */
+  --june-swell: 1.16;
+  --june-field-swell: 1;
+  /* Every dot gets the same 500ms brightening and each completed pass gets a
+   * 100ms reset. The compact grid takes a deliberate 130ms diagonal step; the
+   * denser large grid overrides that with an 80ms step so its crest stays
+   * continuous. */
+  --june-frame: calc((var(--t-fast) + var(--t-med)) / 2);
+  --june-pulse: calc(var(--t-fast) + var(--t-med) + var(--t-slow));
+  --june-pause: var(--t-fast);
+  --june-max-order: 4;
+  --june-dur: calc(
+    var(--june-frame) *
+    var(--june-max-order) +
+    var(--june-pulse) +
+    var(--june-pause)
+  );
+  /* Integer px so every column shares one subpixel phase. The gap is set roughly
+   * as wide as the dot so the circles read as discrete points, not a blur. */
   --june-dot: 2px;
-  --june-gap: 1px;
+  --june-gap: 2px;
   --june-cols: 3;
 
   display: inline-grid;
   grid-template-columns: repeat(var(--june-cols), var(--june-dot));
   gap: var(--june-gap);
+  color: var(--muted-foreground);
   line-height: 1;
 }
 
-.dot-spinner[data-size="lg"] {
-  --june-field-off: 0.08;
-  --june-frames: 10;
-  --june-frame: 0.1s;
+.dot-spinner[data-size="md"] {
+  --june-off: 0.44;
+  --june-field-off: 0.14;
+  --june-field-peak: 0.26;
   --june-dot: 3px;
   --june-gap: 2px;
 }
 
-/* Every cell is a dot and rides the swell, phase-shifted by its diagonal order
- * so the crest climbs from bottom-left to top-right. Field dots ripple faintly;
- * mark dots swell to full. ease-in-out keeps the grow and shrink soft. */
+.dot-spinner[data-size="lg"] {
+  --june-off: 0.4;
+  --june-field-off: 0.15;
+  --june-field-peak: 0.24;
+  --june-frame: calc(var(--t-med) / 2);
+  --june-max-order: 8;
+  --june-dot: 3px;
+  --june-gap: 3px;
+}
+
+/* Each cell rests at full size and full-rest tone; the opacity and a light
+ * synchronized swell animate together, shifted by the cell's diagonal order, so
+ * a bright band sweeps across the otherwise stable grid. Cell variables keep the
+ * field and mark tones and swells on the same envelope. */
 .dot-spinner > span {
+  --june-cell-opacity: var(--june-field-off);
+  --june-cell-peak-opacity: var(--june-field-peak);
+  --june-cell-swell: var(--june-field-swell);
+
   width: var(--june-dot);
   height: var(--june-dot);
   border-radius: 50%;
   background: currentColor;
-  opacity: var(--june-field-off);
-  transform: scale(var(--june-field-rest));
-  animation: june-field-sweep var(--june-dur) ease-in-out infinite;
+  opacity: var(--june-cell-opacity);
+  transform: scale(1);
+  animation:
+    june-sweep-sm var(--june-dur) var(--ease-in-out) infinite,
+    june-scale-sm var(--june-dur) var(--ease-in-out) infinite;
   animation-delay: calc(var(--june-order) * var(--june-frame) - var(--june-dur));
-  /* GPU-composite the swell so scaled circles stay smooth. */
-  will-change: transform, opacity;
+  /* GPU-composite the fade and swell so the sweep stays smooth. */
+  will-change: opacity, transform;
 }
 
 .dot-spinner > span[data-mark] {
-  opacity: var(--june-off);
-  transform: scale(var(--june-rest));
-  animation-name: june-mark-sweep;
+  --june-cell-opacity: var(--june-off);
+  --june-cell-peak-opacity: 1;
+  --june-cell-swell: var(--june-swell);
 }
 
-@keyframes june-field-sweep {
+.dot-spinner[data-size="lg"] > span {
+  animation-name: june-sweep-lg, june-scale-lg;
+}
+
+/* sm/md: 1.12s cycle. Each dot brightens from rest to its peak over 150ms, holds
+ * bright for 200ms, and fades back over 150ms, then rests until the next pass —
+ * the staggered delays turn that into a bright band gliding across the grid. The
+ * 100ms all-rest tail is the settle before the sweep begins again. */
+@keyframes june-sweep-sm {
   0%,
+  44.643%,
   100% {
-    opacity: var(--june-field-off);
-    transform: scale(var(--june-field-rest));
+    opacity: var(--june-cell-opacity);
   }
 
-  40% {
-    opacity: var(--june-field-peak);
-    transform: scale(var(--june-field-scale));
+  13.393%,
+  31.25% {
+    opacity: var(--june-cell-peak-opacity);
   }
 }
 
-@keyframes june-mark-sweep {
+/* lg: the same 500ms brightening inside a 1.24s cycle, with closer diagonals. */
+@keyframes june-sweep-lg {
   0%,
+  40.323%,
   100% {
-    opacity: var(--june-off);
-    transform: scale(var(--june-rest));
+    opacity: var(--june-cell-opacity);
   }
 
-  40% {
-    opacity: 1;
+  12.097%,
+  28.226% {
+    opacity: var(--june-cell-peak-opacity);
+  }
+}
+
+/* The light swell that rides with the brightness: rest at full size, pop to the
+ * cell's peak scale across the same window, then settle. The grid holds steady
+ * between passes because rest is always scale 1. */
+@keyframes june-scale-sm {
+  0%,
+  44.643%,
+  100% {
     transform: scale(1);
+  }
+
+  13.393%,
+  31.25% {
+    transform: scale(var(--june-cell-swell));
+  }
+}
+
+@keyframes june-scale-lg {
+  0%,
+  40.323%,
+  100% {
+    transform: scale(1);
+  }
+
+  12.097%,
+  28.226% {
+    transform: scale(var(--june-cell-swell));
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  /* The spinner rests as the mark: both strokes up and bright, the field dim. */
+  /* The spinner rests as the mark: the strokes bright, the field dim. */
   .dot-spinner > span {
     animation: none;
     opacity: var(--june-field-off);
-    transform: scale(var(--june-field-rest));
   }
 
   .dot-spinner > span[data-mark] {
     opacity: 1;
-    transform: scale(1);
   }
 }

--- a/src/styles/dot-spinner.css
+++ b/src/styles/dot-spinner.css
@@ -1,78 +1,107 @@
-/* The dot spinner: a matrix of tiny real circles that holds June's sparkle
- * mark while a soft highlight traces along it, over and over — a flip-dot board
- * lit with the brand mark, gently scanned. Drawn, not typeset, so the dots stay
- * crisp. Which dots light, and the order the highlight travels through them,
- * live in lib/june-spinner-grid (shared with the agent HUD page entry, which
- * has no React tree). Wrappers set only color (currentColor). Dot and gap MUST
- * stay integer px: fractional sizes put later columns on a different subpixel
- * phase and their circles rasterize ovular.
+/* The dot spinner: a full square grid of tiny real circles with a smooth
+ * highlight that climbs diagonally from the bottom-left. Every cell is a dot;
+ * the dots on June's mark — a stepped stroke from the squircle logo — swell
+ * bright and large as the wave traces up it, while the rest of the grid ripples
+ * faintly, so the matrix reads as June's ascending stroke travelling through it. Drawn,
+ * not typeset, so the dots stay crisp. The grid and each cell's sweep order live
+ * in lib/june-spinner-grid (shared with the agent HUD page entry, which has no
+ * React tree). Wrappers set only color (currentColor).
  *
- * Two variants: "sm" (5×5) for inline and small loaders — the default — and
- * "lg" (7×7) for larger standalone loading moments. */
+ * Two variants: "sm" (3×3) for inline and small loaders — the default — and
+ * "lg" (5×5) for larger standalone loading moments. The column count comes from
+ * --june-cols, set per instance. */
 .dot-spinner {
-  /* Dim of the resting matrix, the brightness the lit mark holds at between
-   * passes of the highlight, and the number of draw steps the highlight walks
-   * (0..9 — set per dot as --june-order in the markup). */
-  --june-off: 0.12;
-  --june-rest: 0.36;
-  --june-steps: 10;
-  /* One full pass of the highlight around the mark. Sine-eased, so it reads as
-   * a smooth glide rather than a march. */
-  --june-dur: 2200ms;
-  /* sm (5×5) is the default. Integer px so every column shares one subpixel
-   * phase. */
-  --june-dot: 1px;
+  /* Mark dots swell from --june-rest / --june-off up to full size and opacity;
+   * field dots swell only faintly (--june-field-*). Tune these to trade off how
+   * strongly the mark reads against the background grid. */
+  --june-off: 0.35;
+  --june-rest: 0.5;
+  --june-field-off: 0.1;
+  --june-field-rest: 0.42;
+  --june-field-peak: 0.28;
+  --june-field-scale: 0.62;
+  /* One diagonal step of the wave is --june-frame; --june-frames sets the loop
+   * length (the grid's diagonals plus a little trailing breath). */
+  --june-frames: 6;
+  --june-frame: 0.13s;
+  --june-dur: calc(var(--june-frame) * var(--june-frames));
+  /* Integer px so every column shares one subpixel phase. */
+  --june-dot: 2px;
   --june-gap: 1px;
+  --june-cols: 3;
 
   display: inline-grid;
-  grid-template-columns: repeat(5, var(--june-dot));
+  grid-template-columns: repeat(var(--june-cols), var(--june-dot));
   gap: var(--june-gap);
   line-height: 1;
 }
 
 .dot-spinner[data-size="lg"] {
+  --june-field-off: 0.08;
+  --june-frames: 10;
+  --june-frame: 0.1s;
   --june-dot: 3px;
   --june-gap: 2px;
-  grid-template-columns: repeat(7, var(--june-dot));
 }
 
+/* Every cell is a dot and rides the swell, phase-shifted by its diagonal order
+ * so the crest climbs from bottom-left to top-right. Field dots ripple faintly;
+ * mark dots swell to full. ease-in-out keeps the grow and shrink soft. */
 .dot-spinner > span {
   width: var(--june-dot);
   height: var(--june-dot);
   border-radius: 50%;
   background: currentColor;
+  opacity: var(--june-field-off);
+  transform: scale(var(--june-field-rest));
+  animation: june-field-sweep var(--june-dur) ease-in-out infinite;
+  animation-delay: calc(var(--june-order) * var(--june-frame) - var(--june-dur));
+  /* GPU-composite the swell so scaled circles stay smooth. */
+  will-change: transform, opacity;
+}
+
+.dot-spinner > span[data-mark] {
   opacity: var(--june-off);
+  transform: scale(var(--june-rest));
+  animation-name: june-mark-sweep;
 }
 
-/* A lit dot rests at --june-rest and swells to full brightness once per loop.
- * Each dot's swell is offset by its place in the draw order (--june-order), and
- * the offsets span the whole loop, so a single soft peak glides along the mark
- * in draw order and wraps back seamlessly. The negative delay starts every dot
- * already inside its cycle, so the highlight is mid-glide on first paint. */
-.dot-spinner > span[data-lit] {
-  opacity: var(--june-rest);
-  animation: june-dot-trace var(--june-dur) ease-in-out infinite;
-  animation-delay: calc(var(--june-order) / var(--june-steps) * var(--june-dur) * -1);
-}
-
-@keyframes june-dot-trace {
+@keyframes june-field-sweep {
   0%,
   100% {
-    opacity: var(--june-rest);
+    opacity: var(--june-field-off);
+    transform: scale(var(--june-field-rest));
   }
 
-  50% {
+  40% {
+    opacity: var(--june-field-peak);
+    transform: scale(var(--june-field-scale));
+  }
+}
+
+@keyframes june-mark-sweep {
+  0%,
+  100% {
+    opacity: var(--june-off);
+    transform: scale(var(--june-rest));
+  }
+
+  40% {
     opacity: 1;
+    transform: scale(1);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  /* The spinner rests as the finished mark: lit dots up, the matrix dim. */
+  /* The spinner rests as the mark: both strokes up and bright, the field dim. */
   .dot-spinner > span {
     animation: none;
+    opacity: var(--june-field-off);
+    transform: scale(var(--june-field-rest));
   }
 
-  .dot-spinner > span[data-lit] {
-    opacity: 0.85;
+  .dot-spinner > span[data-mark] {
+    opacity: 1;
+    transform: scale(1);
   }
 }

--- a/src/styles/dot-spinner.css
+++ b/src/styles/dot-spinner.css
@@ -1,61 +1,79 @@
-/* The dot spinner: a perfectly square 2×2 grid of tiny real
- * circles with a dim spot rolling clockwise. Drawn, not typeset, so the
- * dots are crisp (à la Conductor's timer dots). The mark is one fixed size
- * everywhere by design. Wrappers set only color (currentColor), there is
- * no size knob. Dot and gap MUST stay integer px: fractional sizes put the
- * second column on a different subpixel phase and its circles rasterize
- * ovular. Shared by every page entry that shows agent activity. */
+/* The dot spinner: a matrix of tiny real circles that draws June's sparkle
+ * mark stroke by stroke, holds it, and redraws — a flip-dot board writing the
+ * brand mark. Drawn, not typeset, so the dots stay crisp. Which dots light, and
+ * the order they are drawn in, live in lib/june-spinner-grid (shared with the
+ * agent HUD page entry, which has no React tree). Wrappers set only color
+ * (currentColor). Dot and gap MUST stay integer px: fractional sizes put later
+ * columns on a different subpixel phase and their circles rasterize ovular.
+ *
+ * Two variants: "sm" (5×5) for inline and small loaders — the default — and
+ * "lg" (7×7) for larger standalone loading moments. */
 .dot-spinner {
+  /* Resting dim of the matrix, and the brightness a dot falls back to between
+   * strokes. */
+  --june-off: 0.16;
+  /* One full draw-and-redraw loop, and the delay between consecutive strokes.
+   * 10 strokes at 120ms spread the draw across the first ~1.1s; the rest of the
+   * loop holds the finished mark before it unwinds. */
+  --june-dur: 2000ms;
+  --june-stagger: 120ms;
+  /* sm (5×5) is the default. Integer px so every column shares one subpixel
+   * phase. */
+  --june-dot: 1px;
+  --june-gap: 1px;
+
   display: inline-grid;
-  grid-template-columns: repeat(2, auto);
-  gap: 2px;
+  grid-template-columns: repeat(5, var(--june-dot));
+  gap: var(--june-gap);
   line-height: 1;
 }
 
+.dot-spinner[data-size="lg"] {
+  --june-dot: 3px;
+  --june-gap: 2px;
+  grid-template-columns: repeat(7, var(--june-dot));
+}
+
 .dot-spinner > span {
-  width: 2px;
-  height: 2px;
+  width: var(--june-dot);
+  height: var(--june-dot);
   border-radius: 50%;
   background: currentColor;
-  animation: dot-spinner-roll 800ms linear infinite;
+  opacity: var(--june-off);
 }
 
-/* Stagger the dim spot clockwise: TL → TR → BR → BL (grid DOM order is
- * TL TR / BL BR, hence 3 and 4 swapped). Negative delays so the loop is
- * already rolling on first paint. */
-.dot-spinner > span:nth-child(1) {
-  animation-delay: -800ms;
+/* A lit dot fades up at its scheduled stroke (--june-order set per dot in the
+ * markup), holds bright through most of the loop, then falls back to dim. The
+ * strokes are staggered by draw order, so the mark writes itself, rests, and
+ * redraws. The −var(--june-dur) offset starts every dot already inside its
+ * cycle, so the mark is mid-draw on first paint rather than blank. */
+.dot-spinner > span[data-lit] {
+  animation: june-dot-draw var(--june-dur) ease-in-out infinite;
+  animation-delay: calc(var(--june-order) * var(--june-stagger) - var(--june-dur));
 }
 
-.dot-spinner > span:nth-child(2) {
-  animation-delay: -600ms;
-}
-
-.dot-spinner > span:nth-child(4) {
-  animation-delay: -400ms;
-}
-
-.dot-spinner > span:nth-child(3) {
-  animation-delay: -200ms;
-}
-
-/* Each dot dips once per revolution; the 25% phase offsets above turn the
- * dips into one gap travelling around the square. */
-@keyframes dot-spinner-roll {
-  0%,
-  100% {
-    opacity: 0.25;
+@keyframes june-dot-draw {
+  0% {
+    opacity: var(--june-off);
   }
 
-  35%,
-  65% {
+  12%,
+  72% {
     opacity: 1;
+  }
+
+  100% {
+    opacity: var(--june-off);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  /* The spinner rests as a steady square of dots. */
+  /* The spinner rests as the finished mark: lit dots up, the matrix dim. */
   .dot-spinner > span {
     animation: none;
+  }
+
+  .dot-spinner > span[data-lit] {
+    opacity: 0.92;
   }
 }

--- a/src/styles/dot-spinner.css
+++ b/src/styles/dot-spinner.css
@@ -1,22 +1,24 @@
-/* The dot spinner: a matrix of tiny real circles that draws June's sparkle
- * mark stroke by stroke, holds it, and redraws — a flip-dot board writing the
- * brand mark. Drawn, not typeset, so the dots stay crisp. Which dots light, and
- * the order they are drawn in, live in lib/june-spinner-grid (shared with the
- * agent HUD page entry, which has no React tree). Wrappers set only color
- * (currentColor). Dot and gap MUST stay integer px: fractional sizes put later
- * columns on a different subpixel phase and their circles rasterize ovular.
+/* The dot spinner: a matrix of tiny real circles that holds June's sparkle
+ * mark while a soft highlight traces along it, over and over — a flip-dot board
+ * lit with the brand mark, gently scanned. Drawn, not typeset, so the dots stay
+ * crisp. Which dots light, and the order the highlight travels through them,
+ * live in lib/june-spinner-grid (shared with the agent HUD page entry, which
+ * has no React tree). Wrappers set only color (currentColor). Dot and gap MUST
+ * stay integer px: fractional sizes put later columns on a different subpixel
+ * phase and their circles rasterize ovular.
  *
  * Two variants: "sm" (5×5) for inline and small loaders — the default — and
  * "lg" (7×7) for larger standalone loading moments. */
 .dot-spinner {
-  /* Resting dim of the matrix, and the brightness a dot falls back to between
-   * strokes. */
-  --june-off: 0.16;
-  /* One full draw-and-redraw loop, and the delay between consecutive strokes.
-   * 10 strokes at 120ms spread the draw across the first ~1.1s; the rest of the
-   * loop holds the finished mark before it unwinds. */
-  --june-dur: 2000ms;
-  --june-stagger: 120ms;
+  /* Dim of the resting matrix, the brightness the lit mark holds at between
+   * passes of the highlight, and the number of draw steps the highlight walks
+   * (0..9 — set per dot as --june-order in the markup). */
+  --june-off: 0.12;
+  --june-rest: 0.36;
+  --june-steps: 10;
+  /* One full pass of the highlight around the mark. Sine-eased, so it reads as
+   * a smooth glide rather than a march. */
+  --june-dur: 2200ms;
   /* sm (5×5) is the default. Integer px so every column shares one subpixel
    * phase. */
   --june-dot: 1px;
@@ -42,28 +44,25 @@
   opacity: var(--june-off);
 }
 
-/* A lit dot fades up at its scheduled stroke (--june-order set per dot in the
- * markup), holds bright through most of the loop, then falls back to dim. The
- * strokes are staggered by draw order, so the mark writes itself, rests, and
- * redraws. The −var(--june-dur) offset starts every dot already inside its
- * cycle, so the mark is mid-draw on first paint rather than blank. */
+/* A lit dot rests at --june-rest and swells to full brightness once per loop.
+ * Each dot's swell is offset by its place in the draw order (--june-order), and
+ * the offsets span the whole loop, so a single soft peak glides along the mark
+ * in draw order and wraps back seamlessly. The negative delay starts every dot
+ * already inside its cycle, so the highlight is mid-glide on first paint. */
 .dot-spinner > span[data-lit] {
-  animation: june-dot-draw var(--june-dur) ease-in-out infinite;
-  animation-delay: calc(var(--june-order) * var(--june-stagger) - var(--june-dur));
+  opacity: var(--june-rest);
+  animation: june-dot-trace var(--june-dur) ease-in-out infinite;
+  animation-delay: calc(var(--june-order) / var(--june-steps) * var(--june-dur) * -1);
 }
 
-@keyframes june-dot-draw {
-  0% {
-    opacity: var(--june-off);
-  }
-
-  12%,
-  72% {
-    opacity: 1;
-  }
-
+@keyframes june-dot-trace {
+  0%,
   100% {
-    opacity: var(--june-off);
+    opacity: var(--june-rest);
+  }
+
+  50% {
+    opacity: 1;
   }
 }
 
@@ -74,6 +73,6 @@
   }
 
   .dot-spinner > span[data-lit] {
-    opacity: 0.92;
+    opacity: 0.85;
   }
 }

--- a/src/styles/dot-spinner.css
+++ b/src/styles/dot-spinner.css
@@ -106,10 +106,10 @@
   animation-name: june-sweep-lg, june-scale-lg;
 }
 
-/* sm/md: 1.12s cycle. Each dot brightens from rest to its peak over 150ms, holds
- * bright for 200ms, and fades back over 150ms, then rests until the next pass —
- * the staggered delays turn that into a bright band gliding across the grid. The
- * 100ms all-rest tail is the settle before the sweep begins again. */
+/* sm/md: 1.12s cycle. Each dot eases from rest up to its peak at the midpoint of
+ * the 500ms window and straight back — a single smooth bell, never a plateau, so
+ * the dot is always in motion and the staggered crest glides instead of stepping.
+ * The 100ms all-rest tail is the settle before the sweep begins again. */
 @keyframes june-sweep-sm {
   0%,
   44.643%,
@@ -117,13 +117,12 @@
     opacity: var(--june-cell-opacity);
   }
 
-  13.393%,
-  31.25% {
+  22.321% {
     opacity: var(--june-cell-peak-opacity);
   }
 }
 
-/* lg: the same 500ms brightening inside a 1.24s cycle, with closer diagonals. */
+/* lg: the same 500ms bell inside a 1.24s cycle, with closer diagonals. */
 @keyframes june-sweep-lg {
   0%,
   40.323%,
@@ -131,15 +130,14 @@
     opacity: var(--june-cell-opacity);
   }
 
-  12.097%,
-  28.226% {
+  20.161% {
     opacity: var(--june-cell-peak-opacity);
   }
 }
 
-/* The light swell that rides with the brightness: rest at full size, pop to the
- * cell's peak scale across the same window, then settle. The grid holds steady
- * between passes because rest is always scale 1. */
+/* The light swell rides the same bell: rest at full size, ease to the cell's
+ * peak scale at the midpoint, and ease back. The grid holds steady between
+ * passes because rest is always scale 1. */
 @keyframes june-scale-sm {
   0%,
   44.643%,
@@ -147,8 +145,7 @@
     transform: scale(1);
   }
 
-  13.393%,
-  31.25% {
+  22.321% {
     transform: scale(var(--june-cell-swell));
   }
 }
@@ -160,8 +157,7 @@
     transform: scale(1);
   }
 
-  12.097%,
-  28.226% {
+  20.161% {
     transform: scale(var(--june-cell-swell));
   }
 }

--- a/src/styles/dot-spinner.css
+++ b/src/styles/dot-spinner.css
@@ -1,13 +1,12 @@
 /* The dot spinner: a full square grid of circles with a brightness highlight
- * that sweeps diagonally from the bottom-left. The grid rests stable at full
- * size; as the highlight passes, every dot brightens while mark dots also give
- * a small synchronized swell, then settle back. Motion is mostly tone (a big
- * scale excursion shimmers at 2–3px). A bright band glides along June's stepped
- * mark; field dots ripple faintly without changing size. The grid and each
- * cell's sweep order live in
+ * that sweeps diagonally from the bottom-left. Field dots stay at full size;
+ * as the highlight passes, every dot brightens while mark dots quickly
+ * reveal up to their designed size, then recede. They never grow beyond scale
+ * 1. A bright band glides along June's stepped mark; field dots ripple faintly
+ * without changing size. The grid and each cell's sweep order live in
  * lib/june-spinner-grid (shared with the agent HUD page entry, which has no
- * React tree). The default is a neutral gray. Contexts that require their own
- * contrast color opt back into inherited currentColor in app.css.
+ * React tree). The default neutral becomes darker in the light theme and lighter
+ * in the dark theme; contexts can override --spinner-color for local contrast.
  *
  * Three optical variants: "sm" (3×3) for compact inline use, "md" (3×3) for a
  * slightly larger inline mark, and "lg" (5×5) for standalone loading moments.
@@ -19,14 +18,13 @@
    * --june-field-off and ripple only up to --june-field-peak, which MUST stay
    * below --june-off. If the field peak ever exceeds the mark's rest, the sweep
    * paints a diagonal band that hides the logo. All tones are opacity on
-   * currentColor (var(--muted-foreground)), so they track light/dark themes. */
+   * currentColor (var(--spinner-neutral) by default), so they track themes. */
   --june-off: 0.44;
   --june-field-off: 0.14;
   --june-field-peak: 0.26;
-  /* Peak scale as the highlight passes; rest is always 1 so the grid holds
-   * steady. Only the mark swells so the motion stays on June's strokes; keep the
-   * excursion small — a big swell shimmers at this dot size. */
-  --june-swell: 1.16;
+  /* Only mark dots scale. They start below their designed diameter and reveal
+   * to exactly 1, matching the reference's fast arrival without overshoot. */
+  --june-rest-scale: 0.8;
   /* Every dot gets the same 500ms brightening and each completed pass gets a
    * 100ms reset. The compact grid takes a deliberate 130ms diagonal step; the
    * denser large grid overrides that with an 80ms step so its crest stays
@@ -50,7 +48,7 @@
   display: inline-grid;
   grid-template-columns: repeat(var(--june-cols), var(--june-dot));
   gap: var(--june-gap);
-  color: var(--muted-foreground);
+  color: var(--spinner-color, var(--spinner-neutral));
   line-height: 1;
 }
 
@@ -73,14 +71,16 @@
 }
 
 /* Every cell runs the brightness envelope, shifted by its diagonal order. Mark
- * cells add the synchronized swell; field cells stay at scale 1, so they do not
+ * cells add the synchronized reveal; field cells stay at scale 1, so they do not
  * pay for a no-op transform animation or compositor hint. */
 .dot-spinner > span {
   --june-cell-opacity: var(--june-field-off);
   --june-cell-peak-opacity: var(--june-field-peak);
 
+  box-sizing: border-box;
   width: var(--june-dot);
   height: var(--june-dot);
+  aspect-ratio: 1 / 1;
   border-radius: 50%;
   background: currentColor;
   opacity: var(--june-cell-opacity);
@@ -93,10 +93,11 @@
 .dot-spinner > span[data-mark] {
   --june-cell-opacity: var(--june-off);
   --june-cell-peak-opacity: 1;
-  --june-cell-swell: var(--june-swell);
+  --june-cell-rest-scale: var(--june-rest-scale);
 
   animation-name: june-sweep-sm, june-scale-sm;
-  /* GPU-composite the visible swell as well as the fade. */
+  animation-timing-function: var(--ease-in-out), linear;
+  /* GPU-composite the visible reveal as well as the fade. */
   will-change: opacity, transform;
 }
 
@@ -137,30 +138,50 @@
   }
 }
 
-/* The light swell rides the same bell: rest at full size, ease to the cell's
- * peak scale at the midpoint, and ease back. The grid holds steady between
- * passes because rest is always scale 1. */
+/* Scale is a reveal capped at the base dot. The strong ease-out
+ * reaches scale 1 at 100ms, matching the reference's measured fast arrival,
+ * holds through the crest, then the in-out curve returns it to the smaller rest
+ * state by 500ms. Chromium and WebKit ignore var() timing functions inside
+ * keyframes, so the token curves are repeated verbatim here. */
 @keyframes june-scale-sm {
-  0%,
-  44.643%,
-  100% {
+  0% {
+    transform: scale(var(--june-cell-rest-scale));
+    animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  8.929% {
     transform: scale(1);
   }
 
-  22.321% {
-    transform: scale(var(--june-cell-swell));
+  33.929% {
+    transform: scale(1);
+    animation-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
+  }
+
+  44.643%,
+  100% {
+    transform: scale(var(--june-cell-rest-scale));
   }
 }
 
 @keyframes june-scale-lg {
-  0%,
-  40.323%,
-  100% {
+  0% {
+    transform: scale(var(--june-cell-rest-scale));
+    animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  8.065% {
     transform: scale(1);
   }
 
-  20.161% {
-    transform: scale(var(--june-cell-swell));
+  30.645% {
+    transform: scale(1);
+    animation-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
+  }
+
+  40.323%,
+  100% {
+    transform: scale(var(--june-cell-rest-scale));
   }
 }
 
@@ -173,5 +194,6 @@
 
   .dot-spinner > span[data-mark] {
     opacity: 1;
+    transform: scale(1);
   }
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -280,6 +280,11 @@
   --border-subtle: color-mix(in oklch, var(--border) 55%, transparent);
   --detail-bar-border: color-mix(in oklch, var(--border-subtle) 58%, transparent);
   --body-copy: color-mix(in oklch, var(--foreground) 86%, var(--muted-foreground));
+  /* Loading dots need more presence than muted supporting copy. Light mode
+   * leans well past muted toward the foreground because the dots render at low
+   * opacity on bright surfaces; the dark theme re-mixes a gentler value below.
+   * Individual contexts can override --spinner-color. */
+  --spinner-neutral: color-mix(in oklch, var(--muted-foreground) 45%, var(--foreground));
   --popover-border: color-mix(in oklch, var(--foreground) 10%, transparent);
 
   /* Default accent — the clay terracotta, the base every derived token mixes
@@ -439,6 +444,9 @@
   --border-subtle: color-mix(in oklch, var(--border) 80%, transparent);
   --detail-bar-border: color-mix(in oklch, var(--border-subtle) 66%, transparent);
   --body-copy: color-mix(in oklch, var(--foreground) 88%, var(--muted-foreground));
+  /* Dark surfaces don't wash the low-opacity dots out the way light ones do,
+   * so the spinner keeps the softer muted-leaning mix here. */
+  --spinner-neutral: color-mix(in oklch, var(--muted-foreground) 72%, var(--foreground));
   --popover-border: color-mix(in oklch, white 12%, transparent);
   /* Dark inverts the roles: a deep brand-tinted surface + a lifted brand
    * foreground. Both still derive from --brand so theming cascades. */

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -13065,6 +13065,16 @@ describe("AgentWorkspace", () => {
         );
       }
       expect(section?.querySelector('[role="status"], [aria-live]')).toBeNull();
+
+      const runningToolSection = screen
+        .getByRole("heading", { name: "Thinking: in progress" })
+        .closest("section");
+      expect(runningToolSection).not.toBeNull();
+      expect(
+        within(runningToolSection as HTMLElement)
+          .getByRole("status", { name: "Running" })
+          .querySelector(".dot-spinner"),
+      ).not.toBeNull();
     } finally {
       act(() => void agentGallery(false));
     }

--- a/src/test/june-spinner-grid.test.ts
+++ b/src/test/june-spinner-grid.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { JUNE_SPINNER_COLS, juneSpinnerGrid } from "../lib/june-spinner-grid";
+import agentHudCss from "../styles/agent-hud.css?raw";
 import appCss from "../styles/app.css?raw";
 import spinnerCss from "../styles/dot-spinner.css?raw";
 
@@ -124,5 +125,6 @@ describe("June spinner grid", () => {
     expect(spinnerCss).toContain("--june-dot: 3px;");
     expect(spinnerCss).toContain("color: var(--muted-foreground);");
     expect(appCss).toContain(".agent-tool-spinner .dot-spinner");
+    expect(agentHudCss).toMatch(/\.agent-hud-status \.dot-spinner\s*{[^}]*color: currentColor;/s);
   });
 });

--- a/src/test/june-spinner-grid.test.ts
+++ b/src/test/june-spinner-grid.test.ts
@@ -3,6 +3,7 @@ import { JUNE_SPINNER_COLS, juneSpinnerGrid } from "../lib/june-spinner-grid";
 import agentHudCss from "../styles/agent-hud.css?raw";
 import appCss from "../styles/app.css?raw";
 import spinnerCss from "../styles/dot-spinner.css?raw";
+import tokensCss from "../styles/tokens.css?raw";
 
 describe("June spinner grid", () => {
   it("uses full 3×3 grids for sm and md, and a full 5×5 grid for lg", () => {
@@ -35,7 +36,7 @@ describe("June spinner grid", () => {
     expect(lg.filter(Boolean)).toHaveLength(10);
   });
 
-  it("orders each cell by its diagonal from the bottom-left so the swell climbs", () => {
+  it("orders each cell by its diagonal from the bottom-left so the reveal climbs", () => {
     // Diagonal distance from the bottom-left corner (row 2): bottom-left is 0,
     // top-right is 4, tracing the stroke's path up the grid.
     expect(juneSpinnerGrid("sm").map((c) => c.order)).toEqual([2, 3, 4, 1, 2, 3, 0, 1, 2]);
@@ -44,7 +45,7 @@ describe("June spinner grid", () => {
     ]);
   });
 
-  it("sweeps brightness across fixed-size dots with a settled reset for each pass", () => {
+  it("sweeps brightness while revealing mark dots up to their base size", () => {
     const normalizedCss = spinnerCss.replace(/\s+/g, " ");
     const pulseMs = 100 + 160 + 240;
     const pauseMs = 100;
@@ -92,17 +93,25 @@ describe("June spinner grid", () => {
     );
     expect(spinnerCss).toContain("--june-frame: calc((var(--t-fast) + var(--t-med)) / 2);");
     expect(spinnerCss).toContain("--june-frame: calc(var(--t-med) / 2);");
-    // The grid rests at full size (scale 1) and only swells lightly with the
-    // sweep — a large scale excursion shimmers at this dot size.
+    // Field dots stay at their base size. Mark dots reveal quickly from a
+    // smaller rest state to exactly scale 1, never beyond their designed size.
+    expect(spanRule).toContain("box-sizing: border-box;");
+    expect(spanRule).toContain("width: var(--june-dot);");
+    expect(spanRule).toContain("height: var(--june-dot);");
+    expect(spanRule).toContain("aspect-ratio: 1 / 1;");
+    expect(spanRule).toContain("border-radius: 50%;");
     expect(spanRule).toContain("transform: scale(1);");
     expect(spanRule).toContain(
       "animation: june-sweep-sm var(--june-dur) var(--ease-in-out) infinite;",
     );
     expect(spanRule).not.toContain("june-scale-sm");
     expect(spanRule).toContain("will-change: opacity;");
+    expect(markRule).toContain("--june-cell-rest-scale: var(--june-rest-scale);");
     expect(markRule).toContain("animation-name: june-sweep-sm, june-scale-sm;");
+    expect(markRule).toContain("animation-timing-function: var(--ease-in-out), linear;");
     expect(markRule).toContain("will-change: opacity, transform;");
-    expect(spinnerCss).toContain("--june-swell: 1.16;");
+    expect(spinnerCss).toContain("--june-rest-scale: 0.8;");
+    expect(spinnerCss).not.toContain("--june-swell");
     expect(spinnerCss).not.toContain("--june-field-swell");
     // The mark must always outrank the field: field peak stays below mark rest.
     expect(spinnerCss).toContain("--june-off: 0.44;");
@@ -113,18 +122,37 @@ describe("June spinner grid", () => {
     expect(smSweep).toMatch(/22\.321%\s*{[^}]*opacity: var\(--june-cell-peak-opacity\)/s);
     expect(lgSweep).toMatch(/0%,\s*40\.323%,\s*100%\s*{[^}]*opacity: var\(--june-cell-opacity\)/s);
     expect(lgSweep).toMatch(/20\.161%\s*{[^}]*opacity: var\(--june-cell-peak-opacity\)/s);
-    // The swell rides the same bell and returns to a steady scale 1 at rest.
-    expect(smScale).toMatch(/0%,\s*44\.643%,\s*100%\s*{[^}]*transform: scale\(1\)/s);
-    expect(smScale).toMatch(/22\.321%\s*{[^}]*transform: scale\(var\(--june-cell-swell\)\)/s);
-    expect(lgScale).toMatch(/0%,\s*40\.323%,\s*100%\s*{[^}]*transform: scale\(1\)/s);
-    expect(lgScale).toMatch(/20\.161%\s*{[^}]*transform: scale\(var\(--june-cell-swell\)\)/s);
+    // Scale arrives at the base diameter in 100ms, holds through the crest,
+    // and returns to the smaller rest state by the end of the 500ms pulse.
+    expect(smScale).toMatch(
+      /0%\s*{[^}]*scale\(var\(--june-cell-rest-scale\)\)[^}]*cubic-bezier\(0\.22, 1, 0\.36, 1\)/s,
+    );
+    expect(smScale).toMatch(/8\.929%\s*{[^}]*transform: scale\(1\)/s);
+    expect(smScale).toMatch(/33\.929%\s*{[^}]*scale\(1\)[^}]*cubic-bezier\(0\.65, 0, 0\.35, 1\)/s);
+    expect(smScale).toMatch(/44\.643%,\s*100%\s*{[^}]*scale\(var\(--june-cell-rest-scale\)\)/s);
+    expect(lgScale).toMatch(/8\.065%\s*{[^}]*transform: scale\(1\)/s);
+    expect(lgScale).toMatch(/30\.645%\s*{[^}]*scale\(1\)[^}]*cubic-bezier\(0\.65, 0, 0\.35, 1\)/s);
+    expect(lgScale).toMatch(/40\.323%,\s*100%\s*{[^}]*scale\(var\(--june-cell-rest-scale\)\)/s);
+    expect(spinnerCss).not.toMatch(/scale\(1\.\d+\)/);
     expect(spinnerCss).toContain("animation-name: june-sweep-lg;");
     expect(spinnerCss).toContain("animation-name: june-sweep-lg, june-scale-lg;");
     expect(spinnerCss).toContain("var(--june-order) * var(--june-frame)");
     expect(spinnerCss).toContain('.dot-spinner[data-size="md"]');
     expect(spinnerCss).toContain("--june-dot: 3px;");
-    expect(spinnerCss).toContain("color: var(--muted-foreground);");
-    expect(appCss).toContain(".agent-tool-spinner .dot-spinner");
-    expect(agentHudCss).toMatch(/\.agent-hud-status \.dot-spinner\s*{[^}]*color: currentColor;/s);
+    expect(spinnerCss).toContain("color: var(--spinner-color, var(--spinner-neutral));");
+    // Light mode leans toward the foreground for contrast on bright surfaces;
+    // the dark theme re-mixes a softer muted-leaning neutral.
+    expect(tokensCss).toMatch(
+      /--spinner-neutral:\s*color-mix\([^;]*var\(--muted-foreground\) 45%,\s*var\(--foreground\)/s,
+    );
+    expect(tokensCss).toMatch(
+      /--spinner-neutral:\s*color-mix\([^;]*var\(--muted-foreground\) 72%,\s*var\(--foreground\)/s,
+    );
+    // In-flow chat spinners stay on the neutral default — no themed override.
+    expect(appCss).not.toMatch(/\.agent-tool-spinner[^{]*{[^}]*--spinner-color/s);
+    expect(appCss).not.toMatch(/\.agent-tool-spinner\s*{[^}]*color:/s);
+    expect(agentHudCss).toMatch(
+      /\.agent-hud-status \.dot-spinner\s*{[^}]*--spinner-color: currentColor;/s,
+    );
   });
 });

--- a/src/test/june-spinner-grid.test.ts
+++ b/src/test/june-spinner-grid.test.ts
@@ -83,24 +83,17 @@ describe("June spinner grid", () => {
     // The mark must always outrank the field: field peak stays below mark rest.
     expect(spinnerCss).toContain("--june-off: 0.44;");
     expect(spinnerCss).toContain("--june-field-peak: 0.26;");
-    // The brightness envelope rests at the loop boundary and holds a broad peak.
+    // The brightness envelope rests at the loop boundary and peaks once at the
+    // midpoint — a smooth bell, not a plateau, so the crest glides.
     expect(smSweep).toMatch(/0%,\s*44\.643%,\s*100%\s*{[^}]*opacity: var\(--june-cell-opacity\)/s);
-    expect(smSweep).toMatch(
-      /13\.393%,\s*31\.25%\s*{[^}]*opacity: var\(--june-cell-peak-opacity\)/s,
-    );
+    expect(smSweep).toMatch(/22\.321%\s*{[^}]*opacity: var\(--june-cell-peak-opacity\)/s);
     expect(lgSweep).toMatch(/0%,\s*40\.323%,\s*100%\s*{[^}]*opacity: var\(--june-cell-opacity\)/s);
-    expect(lgSweep).toMatch(
-      /12\.097%,\s*28\.226%\s*{[^}]*opacity: var\(--june-cell-peak-opacity\)/s,
-    );
-    // The swell rides the same window and returns to a steady scale 1 at rest.
+    expect(lgSweep).toMatch(/20\.161%\s*{[^}]*opacity: var\(--june-cell-peak-opacity\)/s);
+    // The swell rides the same bell and returns to a steady scale 1 at rest.
     expect(smScale).toMatch(/0%,\s*44\.643%,\s*100%\s*{[^}]*transform: scale\(1\)/s);
-    expect(smScale).toMatch(
-      /13\.393%,\s*31\.25%\s*{[^}]*transform: scale\(var\(--june-cell-swell\)\)/s,
-    );
+    expect(smScale).toMatch(/22\.321%\s*{[^}]*transform: scale\(var\(--june-cell-swell\)\)/s);
     expect(lgScale).toMatch(/0%,\s*40\.323%,\s*100%\s*{[^}]*transform: scale\(1\)/s);
-    expect(lgScale).toMatch(
-      /12\.097%,\s*28\.226%\s*{[^}]*transform: scale\(var\(--june-cell-swell\)\)/s,
-    );
+    expect(lgScale).toMatch(/20\.161%\s*{[^}]*transform: scale\(var\(--june-cell-swell\)\)/s);
     expect(spinnerCss).toContain("animation-name: june-sweep-lg, june-scale-lg;");
     expect(spinnerCss).toContain("var(--june-order) * var(--june-frame)");
     expect(spinnerCss).toContain('.dot-spinner[data-size="md"]');

--- a/src/test/june-spinner-grid.test.ts
+++ b/src/test/june-spinner-grid.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { JUNE_SPINNER_COLS, juneSpinnerGrid } from "../lib/june-spinner-grid";
+import appCss from "../styles/app.css?raw";
 import spinnerCss from "../styles/dot-spinner.css?raw";
 
 describe("June spinner grid", () => {
@@ -19,14 +20,27 @@ describe("June spinner grid", () => {
     // Top-right corner, the whole middle row, and the bottom-left corner.
     expect(sm).toEqual([false, false, true, true, true, true, true, false, false]);
     expect(juneSpinnerGrid("md").map((c) => c.mark)).toEqual(sm);
-    // The 5×5 keeps two ascending strokes.
-    expect(juneSpinnerGrid("lg").filter((c) => c.mark)).toHaveLength(10);
+    // The 5×5 keeps the exact two ascending strokes, not only the same dot
+    // count with a different silhouette.
+    const lg = juneSpinnerGrid("lg").map((c) => c.mark);
+    // biome-ignore format: the grid layout is the assertion.
+    expect(lg.map(Number)).toEqual([
+      0, 0, 0, 0, 1,
+      0, 1, 1, 1, 0,
+      1, 0, 0, 0, 1,
+      0, 1, 1, 1, 0,
+      1, 0, 0, 0, 0,
+    ]);
+    expect(lg.filter(Boolean)).toHaveLength(10);
   });
 
   it("orders each cell by its diagonal from the bottom-left so the swell climbs", () => {
     // Diagonal distance from the bottom-left corner (row 2): bottom-left is 0,
     // top-right is 4, tracing the stroke's path up the grid.
     expect(juneSpinnerGrid("sm").map((c) => c.order)).toEqual([2, 3, 4, 1, 2, 3, 0, 1, 2]);
+    expect(juneSpinnerGrid("lg").map((c) => c.order)).toEqual([
+      4, 5, 6, 7, 8, 3, 4, 5, 6, 7, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4,
+    ]);
   });
 
   it("sweeps brightness across fixed-size dots with a settled reset for each pass", () => {
@@ -39,6 +53,10 @@ describe("June spinner grid", () => {
     const spanRule = spinnerCss.slice(
       spinnerCss.indexOf(".dot-spinner > span {"),
       spinnerCss.indexOf(".dot-spinner > span[data-mark]"),
+    );
+    const markRule = spinnerCss.slice(
+      spinnerCss.indexOf(".dot-spinner > span[data-mark]"),
+      spinnerCss.indexOf('.dot-spinner[data-size="lg"] > span'),
     );
     const smSweep = spinnerCss.slice(
       spinnerCss.indexOf("@keyframes june-sweep-sm"),
@@ -76,10 +94,15 @@ describe("June spinner grid", () => {
     // The grid rests at full size (scale 1) and only swells lightly with the
     // sweep — a large scale excursion shimmers at this dot size.
     expect(spanRule).toContain("transform: scale(1);");
-    expect(spanRule).toContain("june-sweep-sm var(--june-dur) var(--ease-in-out) infinite,");
-    expect(spanRule).toContain("june-scale-sm var(--june-dur) var(--ease-in-out) infinite;");
+    expect(spanRule).toContain(
+      "animation: june-sweep-sm var(--june-dur) var(--ease-in-out) infinite;",
+    );
+    expect(spanRule).not.toContain("june-scale-sm");
+    expect(spanRule).toContain("will-change: opacity;");
+    expect(markRule).toContain("animation-name: june-sweep-sm, june-scale-sm;");
+    expect(markRule).toContain("will-change: opacity, transform;");
     expect(spinnerCss).toContain("--june-swell: 1.16;");
-    expect(spinnerCss).toContain("--june-field-swell: 1;");
+    expect(spinnerCss).not.toContain("--june-field-swell");
     // The mark must always outrank the field: field peak stays below mark rest.
     expect(spinnerCss).toContain("--june-off: 0.44;");
     expect(spinnerCss).toContain("--june-field-peak: 0.26;");
@@ -94,10 +117,12 @@ describe("June spinner grid", () => {
     expect(smScale).toMatch(/22\.321%\s*{[^}]*transform: scale\(var\(--june-cell-swell\)\)/s);
     expect(lgScale).toMatch(/0%,\s*40\.323%,\s*100%\s*{[^}]*transform: scale\(1\)/s);
     expect(lgScale).toMatch(/20\.161%\s*{[^}]*transform: scale\(var\(--june-cell-swell\)\)/s);
+    expect(spinnerCss).toContain("animation-name: june-sweep-lg;");
     expect(spinnerCss).toContain("animation-name: june-sweep-lg, june-scale-lg;");
     expect(spinnerCss).toContain("var(--june-order) * var(--june-frame)");
     expect(spinnerCss).toContain('.dot-spinner[data-size="md"]');
     expect(spinnerCss).toContain("--june-dot: 3px;");
     expect(spinnerCss).toContain("color: var(--muted-foreground);");
+    expect(appCss).toContain(".agent-tool-spinner .dot-spinner");
   });
 });

--- a/src/test/june-spinner-grid.test.ts
+++ b/src/test/june-spinner-grid.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { JUNE_SPINNER_COLS, juneSpinnerGrid } from "../lib/june-spinner-grid";
+import spinnerCss from "../styles/dot-spinner.css?raw";
+
+describe("June spinner grid", () => {
+  it("is a full 3×3 grid inline and a full 5×5 grid standalone", () => {
+    expect(JUNE_SPINNER_COLS.sm).toBe(3);
+    expect(JUNE_SPINNER_COLS.lg).toBe(5);
+    // Every cell is a dot — the grid is full, not sparse.
+    expect(juneSpinnerGrid("sm")).toHaveLength(9);
+    expect(juneSpinnerGrid("lg")).toHaveLength(25);
+    expect(juneSpinnerGrid("sm").every((c) => typeof c.order === "number")).toBe(true);
+  });
+
+  it("marks the stepped stroke in the 3×3 and two strokes in the 5×5", () => {
+    const sm = juneSpinnerGrid("sm").map((c) => c.mark);
+    // Top-right corner, the whole middle row, and the bottom-left corner.
+    expect(sm).toEqual([false, false, true, true, true, true, true, false, false]);
+    // The 5×5 keeps two ascending strokes.
+    expect(juneSpinnerGrid("lg").filter((c) => c.mark)).toHaveLength(10);
+  });
+
+  it("orders each cell by its diagonal from the bottom-left so the swell climbs", () => {
+    // Diagonal distance from the bottom-left corner (row 2): bottom-left is 0,
+    // top-right is 4, tracing the stroke's path up the grid.
+    expect(juneSpinnerGrid("sm").map((c) => c.order)).toEqual([2, 3, 4, 1, 2, 3, 0, 1, 2]);
+  });
+
+  it("sweeps a smooth swell across the grid, mark dots swelling brighter", () => {
+    expect(spinnerCss).toContain("@keyframes june-field-sweep");
+    expect(spinnerCss).toContain("@keyframes june-mark-sweep");
+    expect(spinnerCss).toContain("animation-name: june-mark-sweep;");
+    expect(spinnerCss).toContain("transform: scale(1);");
+    expect(spinnerCss).toContain("var(--june-order) * var(--june-frame)");
+  });
+});

--- a/src/test/june-spinner-grid.test.ts
+++ b/src/test/june-spinner-grid.test.ts
@@ -3,11 +3,13 @@ import { JUNE_SPINNER_COLS, juneSpinnerGrid } from "../lib/june-spinner-grid";
 import spinnerCss from "../styles/dot-spinner.css?raw";
 
 describe("June spinner grid", () => {
-  it("is a full 3×3 grid inline and a full 5×5 grid standalone", () => {
+  it("uses full 3×3 grids for sm and md, and a full 5×5 grid for lg", () => {
     expect(JUNE_SPINNER_COLS.sm).toBe(3);
+    expect(JUNE_SPINNER_COLS.md).toBe(3);
     expect(JUNE_SPINNER_COLS.lg).toBe(5);
     // Every cell is a dot — the grid is full, not sparse.
     expect(juneSpinnerGrid("sm")).toHaveLength(9);
+    expect(juneSpinnerGrid("md")).toHaveLength(9);
     expect(juneSpinnerGrid("lg")).toHaveLength(25);
     expect(juneSpinnerGrid("sm").every((c) => typeof c.order === "number")).toBe(true);
   });
@@ -16,6 +18,7 @@ describe("June spinner grid", () => {
     const sm = juneSpinnerGrid("sm").map((c) => c.mark);
     // Top-right corner, the whole middle row, and the bottom-left corner.
     expect(sm).toEqual([false, false, true, true, true, true, true, false, false]);
+    expect(juneSpinnerGrid("md").map((c) => c.mark)).toEqual(sm);
     // The 5×5 keeps two ascending strokes.
     expect(juneSpinnerGrid("lg").filter((c) => c.mark)).toHaveLength(10);
   });
@@ -26,11 +29,82 @@ describe("June spinner grid", () => {
     expect(juneSpinnerGrid("sm").map((c) => c.order)).toEqual([2, 3, 4, 1, 2, 3, 0, 1, 2]);
   });
 
-  it("sweeps a smooth swell across the grid, mark dots swelling brighter", () => {
-    expect(spinnerCss).toContain("@keyframes june-field-sweep");
-    expect(spinnerCss).toContain("@keyframes june-mark-sweep");
-    expect(spinnerCss).toContain("animation-name: june-mark-sweep;");
-    expect(spinnerCss).toContain("transform: scale(1);");
+  it("sweeps brightness across fixed-size dots with a settled reset for each pass", () => {
+    const normalizedCss = spinnerCss.replace(/\s+/g, " ");
+    const pulseMs = 100 + 160 + 240;
+    const pauseMs = 100;
+    const smMaxOrder = Math.max(...juneSpinnerGrid("sm").map((c) => c.order));
+    const mdMaxOrder = Math.max(...juneSpinnerGrid("md").map((c) => c.order));
+    const lgMaxOrder = Math.max(...juneSpinnerGrid("lg").map((c) => c.order));
+    const spanRule = spinnerCss.slice(
+      spinnerCss.indexOf(".dot-spinner > span {"),
+      spinnerCss.indexOf(".dot-spinner > span[data-mark]"),
+    );
+    const smSweep = spinnerCss.slice(
+      spinnerCss.indexOf("@keyframes june-sweep-sm"),
+      spinnerCss.indexOf("@keyframes june-sweep-lg"),
+    );
+    const lgSweep = spinnerCss.slice(
+      spinnerCss.indexOf("@keyframes june-sweep-lg"),
+      spinnerCss.indexOf("@keyframes june-scale-sm"),
+    );
+    const smScale = spinnerCss.slice(
+      spinnerCss.indexOf("@keyframes june-scale-sm"),
+      spinnerCss.indexOf("@keyframes june-scale-lg"),
+    );
+    const lgScale = spinnerCss.slice(
+      spinnerCss.indexOf("@keyframes june-scale-lg"),
+      spinnerCss.indexOf("@media (prefers-reduced-motion: reduce)"),
+    );
+
+    // Each cycle covers its full traversal, the shared 500ms brightening, and a
+    // 100ms all-rest pause before the next head begins.
+    expect(smMaxOrder * 130 + pulseMs + pauseMs).toBe(1120);
+    expect(mdMaxOrder * 130 + pulseMs + pauseMs).toBe(1120);
+    expect(lgMaxOrder * 80 + pulseMs + pauseMs).toBe(1240);
+    expect(spinnerCss).toContain(
+      "--june-pulse: calc(var(--t-fast) + var(--t-med) + var(--t-slow));",
+    );
+    expect(spinnerCss).toContain("--june-pause: var(--t-fast);");
+    expect(spinnerCss).toContain("--june-max-order: 4;");
+    expect(spinnerCss).toContain("--june-max-order: 8;");
+    expect(normalizedCss).toContain(
+      "--june-dur: calc( var(--june-frame) * var(--june-max-order) + var(--june-pulse) + var(--june-pause) );",
+    );
+    expect(spinnerCss).toContain("--june-frame: calc((var(--t-fast) + var(--t-med)) / 2);");
+    expect(spinnerCss).toContain("--june-frame: calc(var(--t-med) / 2);");
+    // The grid rests at full size (scale 1) and only swells lightly with the
+    // sweep — a large scale excursion shimmers at this dot size.
+    expect(spanRule).toContain("transform: scale(1);");
+    expect(spanRule).toContain("june-sweep-sm var(--june-dur) var(--ease-in-out) infinite,");
+    expect(spanRule).toContain("june-scale-sm var(--june-dur) var(--ease-in-out) infinite;");
+    expect(spinnerCss).toContain("--june-swell: 1.16;");
+    expect(spinnerCss).toContain("--june-field-swell: 1;");
+    // The mark must always outrank the field: field peak stays below mark rest.
+    expect(spinnerCss).toContain("--june-off: 0.44;");
+    expect(spinnerCss).toContain("--june-field-peak: 0.26;");
+    // The brightness envelope rests at the loop boundary and holds a broad peak.
+    expect(smSweep).toMatch(/0%,\s*44\.643%,\s*100%\s*{[^}]*opacity: var\(--june-cell-opacity\)/s);
+    expect(smSweep).toMatch(
+      /13\.393%,\s*31\.25%\s*{[^}]*opacity: var\(--june-cell-peak-opacity\)/s,
+    );
+    expect(lgSweep).toMatch(/0%,\s*40\.323%,\s*100%\s*{[^}]*opacity: var\(--june-cell-opacity\)/s);
+    expect(lgSweep).toMatch(
+      /12\.097%,\s*28\.226%\s*{[^}]*opacity: var\(--june-cell-peak-opacity\)/s,
+    );
+    // The swell rides the same window and returns to a steady scale 1 at rest.
+    expect(smScale).toMatch(/0%,\s*44\.643%,\s*100%\s*{[^}]*transform: scale\(1\)/s);
+    expect(smScale).toMatch(
+      /13\.393%,\s*31\.25%\s*{[^}]*transform: scale\(var\(--june-cell-swell\)\)/s,
+    );
+    expect(lgScale).toMatch(/0%,\s*40\.323%,\s*100%\s*{[^}]*transform: scale\(1\)/s);
+    expect(lgScale).toMatch(
+      /12\.097%,\s*28\.226%\s*{[^}]*transform: scale\(var\(--june-cell-swell\)\)/s,
+    );
+    expect(spinnerCss).toContain("animation-name: june-sweep-lg, june-scale-lg;");
     expect(spinnerCss).toContain("var(--june-order) * var(--june-frame)");
+    expect(spinnerCss).toContain('.dot-spinner[data-size="md"]');
+    expect(spinnerCss).toContain("--june-dot: 3px;");
+    expect(spinnerCss).toContain("color: var(--muted-foreground);");
   });
 });

--- a/src/test/spinner-demo.test.ts
+++ b/src/test/spinner-demo.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AGENT_HUD_VISIBILITY_CHANGED_EVENT } from "../lib/agent-hud-settings";
+import { registerSpinnerDemo } from "../lib/spinner-demo";
+
+const mocks = vi.hoisted(() => ({
+  dismissToast: vi.fn(),
+  emit: vi.fn().mockResolvedValue(undefined),
+  showLoadingToast: vi.fn(() => "spinner-demo-toast"),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  emit: mocks.emit,
+}));
+
+vi.mock("../components/ui/Toaster", () => ({
+  toast: {
+    dismiss: mocks.dismissToast,
+    loading: mocks.showLoadingToast,
+  },
+}));
+
+type SpinnerDemoWindow = Window & {
+  __agentGallery?: (show?: boolean) => string;
+  __agentHud?: (state?: string, count?: number) => string;
+  __sidebarStates?: (show?: boolean) => string;
+  __spinnerDemo?: (show?: boolean) => string;
+};
+
+describe("spinner demo", () => {
+  const win = window as SpinnerDemoWindow;
+  let dispose: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem("june:agent-hud:enabled", "false");
+    win.__agentGallery = vi.fn(() => "gallery");
+    win.__agentHud = vi.fn(() => "hud");
+    win.__sidebarStates = vi.fn(() => "sidebar");
+  });
+
+  afterEach(() => {
+    dispose?.();
+    dispose = undefined;
+    delete win.__agentGallery;
+    delete win.__agentHud;
+    delete win.__sidebarStates;
+    delete win.__spinnerDemo;
+  });
+
+  it("shows representative real spinner contexts and clears them together", async () => {
+    ({ dispose } = registerSpinnerDemo());
+
+    expect(win.__spinnerDemo).toBeTypeOf("function");
+    expect(win.__spinnerDemo?.()).toBe(
+      "Spinner demo shown: sidebar, Agent gallery, Agent HUD, and loading toast. Run __spinnerDemo(false) to clear.",
+    );
+    expect(win.__sidebarStates).toHaveBeenCalledWith(true);
+    expect(win.__agentGallery).toHaveBeenCalledWith(true);
+    expect(win.__agentHud).toHaveBeenCalledWith("mixed");
+    expect(mocks.showLoadingToast).toHaveBeenCalledWith("Spinner showcase");
+    await vi.waitFor(() =>
+      expect(mocks.emit).toHaveBeenCalledWith(AGENT_HUD_VISIBILITY_CHANGED_EVENT, {
+        enabled: true,
+      }),
+    );
+
+    expect(win.__spinnerDemo?.(false)).toBe("Spinner demo cleared.");
+    expect(win.__agentHud).toHaveBeenCalledWith("clear");
+    expect(win.__agentGallery).toHaveBeenCalledWith(false);
+    expect(win.__sidebarStates).toHaveBeenCalledWith(false);
+    expect(mocks.dismissToast).toHaveBeenCalledWith("spinner-demo-toast");
+    await vi.waitFor(() =>
+      expect(mocks.emit).toHaveBeenCalledWith(AGENT_HUD_VISIBILITY_CHANGED_EVENT, {
+        enabled: false,
+      }),
+    );
+  });
+
+  it("does not create duplicate loading toasts when shown twice", () => {
+    ({ dispose } = registerSpinnerDemo());
+
+    win.__spinnerDemo?.();
+    win.__spinnerDemo?.();
+
+    expect(mocks.showLoadingToast).toHaveBeenCalledOnce();
+  });
+
+  it("removes its console hook and clears active demo state on disposal", () => {
+    ({ dispose } = registerSpinnerDemo());
+    win.__spinnerDemo?.();
+
+    dispose();
+    dispose = undefined;
+
+    expect(win.__spinnerDemo).toBeUndefined();
+    expect(win.__agentHud).toHaveBeenCalledWith("clear");
+    expect(mocks.dismissToast).toHaveBeenCalledWith("spinner-demo-toast");
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the shared 2×2 dot spinner with a drawn June mark: a full 3×3 (sm/md) or 5×5 (lg) grid of perfect circles where a brightness highlight sweeps diagonally from the bottom-left, tracing the stepped stroke. Mark dots reveal from 0.8 up to exactly scale 1 (fast arrival, no overshoot); field dots ripple in brightness only. The grid and per-cell sweep order live in `src/lib/june-spinner-grid.ts`, shared with the standalone Agent HUD entry.
- Adds a theme-aware neutral: the spinner defaults to the new `--spinner-neutral` token, mixed darker in the light theme (45% muted-foreground / 55% foreground) and softer in the dark theme (72% muted-foreground) so the low-opacity dots hold contrast on both surfaces.
- Neutralizes in-flow spinners: the chat tool-run row and the branch action drop their `--warm-strong` accent and render the monotone neutral. Solid brand-filled controls (composer send, primary actions) keep their `currentColor` opt-in, and the Agent HUD spinner keeps tracking its status color.
- Adds `__spinnerDemo()` (dev builds only): one console command that parks the sidebar working row, Agent response gallery, expanded Agent HUD, and a loading toast in their real running states for visual review, and clears them with `__spinnerDemo(false)`.
- Respects `prefers-reduced-motion` (rests as the static mark) and hides the glyph from assistive tech; the surrounding status text carries the meaning.

## Validation

- Full frontend suite: 170 files, 2,743 passed / 2 skipped (`pnpm test`); `pnpm typecheck` and Biome error-level clean.
- New suites pin the grid geometry, sweep timing, opacity hierarchy, capped reveal, theme mixes, and the demo command lifecycle (`src/test/june-spinner-grid.test.ts`, `src/test/spinner-demo.test.ts`).
- Live browser QA in Chromium and WebKit against the Vite preview with a faked Tauri bridge: gallery tool spinner computed color equals `--spinner-neutral` (not the theme accent) in both themes, light neutral measured darker (oklch L 0.478 → 0.401) with dark byte-identical, HUD spinner still renders its status foreground, zero page errors.

- [x] Tested visually where it matters (iterated live against the style guide and `__spinnerDemo()` with the reporter in the loop).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Bespoke non-shared loaders (sign-in prompt ring, shimmer text, skeleton bars) keep their existing treatments.
- The dot opacity envelope (`--june-off` / `--june-field-*`) is unchanged; contrast tuning happens entirely through the neutral token.

## Followups

- None planned; `.context/verify-spinner-contrast.mjs` (untracked) remains available locally for re-checking computed spinner colors.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. <!-- none -->
- [x] Workflow action references are pinned to full-length commit SHAs. <!-- no workflow changes -->
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. <!-- none -->
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. <!-- none -->
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786806172&installation_id=144203540&pr_number=792&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F792&signature=92ca97cc2df7ec51e62d6690ebbea597789b88e6b725a01494b81e5514443687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>


https://github.com/user-attachments/assets/c6ff9d51-6309-4c77-ad43-ffcfce309cf5


https://github.com/user-attachments/assets/7984b8f2-3c66-404d-bf04-091adaa1157d




<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->