### PR TITLE
Center single-line inline notices against actions

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12133,9 +12133,10 @@ input:focus-visible,
  * consumer class passed through via the InlineNotice `className` prop. */
 .inline-notice {
   display: flex;
-  /* Top-align so the leading icon lines up with the first line of the content,
-   * not the vertical middle of a multi-line body. */
-  align-items: flex-start;
+  /* Match the first text line across the message and any actions. This reads
+   * centered for a one-line notice while wrapped copy grows downward from the
+   * same top line, without measuring line count in JavaScript. */
+  align-items: first baseline;
   gap: var(--sp-3);
   padding: var(--sp-3) var(--sp-4);
   border: 1px solid var(--border-subtle);
@@ -12150,6 +12151,9 @@ input:focus-visible,
 .inline-notice-icon {
   display: inline-flex;
   flex-shrink: 0;
+  /* Icons have no useful text baseline, so keep the glyph centered against
+   * the message's first line while the text and actions baseline-align. */
+  align-self: flex-start;
   align-items: center;
   height: calc(var(--fs-md) * 1.5);
   color: var(--muted-foreground);

--- a/src/test/approval-card-css.test.ts
+++ b/src/test/approval-card-css.test.ts
@@ -225,12 +225,14 @@ describe("pending action card styles", () => {
 });
 
 describe("credits notice centering", () => {
-  it("centers the single-line credits notice via an override that outranks the base rule", () => {
-    // The base rule top-aligns every inline notice.
-    expect(cssRuleFor(".inline-notice")).toContain("align-items: flex-start;");
-    // The credits override centers it — and because the base rule sits LATER in
-    // this flat stylesheet, the override must carry higher specificity (a
-    // two-class compound, 0,2,0) to beat the single-class base (0,1,0).
+  it("centers the tier-card credits notice via an override that outranks the base rule", () => {
+    // The base rule aligns notice copy with action-label baselines while
+    // wrapped copy grows downward from the first line.
+    expect(cssRuleFor(".inline-notice")).toContain("align-items: first baseline;");
+    // The credits override centers its taller tier card — and because the base
+    // rule sits LATER in this flat stylesheet, the override must carry higher
+    // specificity (a two-class compound, 0,2,0) to beat the single-class base
+    // (0,1,0).
     expect(cssRuleFor(".inline-notice.agent-credits-notice")).toContain("align-items: center;");
     const baseIndex = appCss.indexOf(".inline-notice {");
     const overrideIndex = appCss.indexOf(".inline-notice.agent-credits-notice {");


### PR DESCRIPTION
## Summary

- Align shared inline notice copy with action-label baselines.
- Keep one-line notices visually centered while wrapped copy grows downward from the first line.
- Keep icons aligned with the message's first line without runtime line measurement.

## Root cause

The shared inline notice used `align-items: flex-start`, which aligned the message box with the top of taller buttons. Because button labels are centered inside their controls, one-line notice copy appeared several pixels above the action labels.

## Validation

- `pnpm exec vitest run src/test/note-editor.test.tsx` (38 tests passed)
- `pnpm check` (passes with the existing warning baseline)
- `git diff --check`
- Visually checked one-line and three-line notice fixtures at 2x scale. The one-line message and action centers differ by less than 1 px; wrapped copy stays aligned from its first line and grows downward.

- [x] Tested visually where it matters.
- [ ] Needs a June API (backend) deploy before it works end to end. No, this is a desktop CSS-only change.

## Out of scope

- No changes to notice copy, spacing, control sizes, or component APIs.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. Not applicable.
- [x] Workflow action references are pinned to full-length commit SHAs. Not applicable.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786806404&installation_id=144203540&pr_number=793&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F793&signature=88345930f5ad36680c1cb9cf0184d83214dfd2bdc91b65da217cd2cfcedd100a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->