### PR TITLE
Prevent phantom text from low-signal dictation

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -446,6 +446,7 @@ fn build_dictation_helper() {
                 "Carbon",
                 "CoreMedia",
                 "CoreGraphics",
+                "SoundAnalysis",
             ],
         );
         if !built {

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -1599,8 +1599,9 @@ enum RecordingPurpose {
 
 let micTestCapturePaddingSeconds: Double = 0.35
 // Keep in sync with DICTATION_AUDIO_ACTIVITY_THRESHOLD in dictation.rs. The
-// trained classifier only affects captures below this independent meter gate,
-// so louder dictation should not pay for file analysis during finalization.
+// trained classifier only affects complete-window captures below this
+// independent meter gate, so louder dictation should not pay for file analysis
+// during finalization. Sub-window captures are quarantined before this gate.
 let dictationAudioActivityThreshold: Float = 0.04
 
 final class DictationController {
@@ -1935,15 +1936,15 @@ final class DictationController {
             "observedAudioLevel": String(format: "%.4f", observedAudioLevel),
             "targetBundleIdentifier": targetBundleIdentifier,
         ]
-        guard observedAudioLevel < dictationAudioActivityThreshold else {
-            emit("recording_ready", basePayload)
-            return
-        }
         if let duration = audioDurationSeconds(at: recordingURL),
            duration < speechAnalysisWindowDurationSeconds {
             var payload = basePayload
             payload["speechAnalysisStatus"] = "no_complete_window"
             emit("recording_ready", payload)
+            return
+        }
+        guard observedAudioLevel < dictationAudioActivityThreshold else {
+            emit("recording_ready", basePayload)
             return
         }
         analyzeSpeechConfidence(at: recordingURL) { [weak self] speechConfidence in

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -1767,14 +1767,14 @@ final class DictationController {
         resetRecordingState()
     }
 
-    func copyForReview(text: String, keepRecordingFile: Bool, historySaved: Bool) {
+    func copyForRecovery(text: String, keepRecordingFile: Bool) {
         let text = dictationPasteText(text)
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             fail(DictationError.missingTranscript)
             return
         }
 
-        PasteboardInserter.copyForReview(text, historySaved: historySaved)
+        PasteboardInserter.copyForRecovery(text)
         resetRecordingState(keepRecordingFile: keepRecordingFile)
     }
 
@@ -2275,29 +2275,26 @@ enum PasteboardInserter {
         }
     }
 
-    /// Keeps an uncertain transcript recoverable without typing it into the
-    /// user's active app. Unlike a normal paste, the clipboard is deliberately
-    /// not restored after a successful write.
-    static func copyForReview(_ text: String, historySaved: Bool) {
+    /// Last-resort recovery when Dictation history could not save a transcript.
+    /// Unlike a normal paste, the clipboard is deliberately not restored after
+    /// a successful write.
+    static func copyForRecovery(_ text: String) {
         let pasteboard = NSPasteboard.general
         let snapshot = capture(pasteboard)
 
         pasteboard.clearContents()
         guard pasteboard.setString(text, forType: .string) else {
             restore(snapshot, to: pasteboard)
-            let message = historySaved
-                ? "Could not write transcript to the clipboard. Find it in Dictation history."
-                : "Could not save or copy this dictation. The recording was kept for recovery."
-            emit("error", ["code": "pasteboard_write_failed", "message": message])
+            emit("error", [
+                "code": "pasteboard_write_failed",
+                "message": "Could not save or copy this dictation. The recording was kept for recovery.",
+            ])
             return
         }
 
-        let message = historySaved
-            ? "Speech was unclear. Use Cmd+V to paste the transcript."
-            : "Could not save this dictation. Use Cmd+V to keep the transcript."
         emit("error", [
-            "code": "dictation_low_speech_evidence",
-            "message": message,
+            "code": "dictation_recovery_clipboard",
+            "message": "Could not save this dictation. Use Cmd+V to keep the transcript.",
         ])
     }
 
@@ -2458,15 +2455,13 @@ func handleCommandLine(_ line: String) {
         runOnMain {
             dictation.paste(text: text)
         }
-    case "copy_text_for_review":
+    case "copy_text_for_recovery":
         let text = command?["text"] as? String ?? ""
         let keepRecordingFile = command?["keepRecordingFile"] as? Bool ?? false
-        let historySaved = command?["historySaved"] as? Bool ?? true
         runOnMain {
-            dictation.copyForReview(
+            dictation.copyForRecovery(
                 text: text,
-                keepRecordingFile: keepRecordingFile,
-                historySaved: historySaved
+                keepRecordingFile: keepRecordingFile
             )
         }
     case "discard_recording":

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -260,7 +260,7 @@ enum RecordingCuePlayer {
 }
 
 private final class SpeechActivityObserver: NSObject, SNResultsObserving {
-    private(set) var speechResultCount = 0
+    private(set) var resultCount = 0
     private(set) var maxSpeechConfidence = 0.0
     private(set) var failed = false
 
@@ -268,11 +268,11 @@ private final class SpeechActivityObserver: NSObject, SNResultsObserving {
         guard let classification = result as? SNClassificationResult else {
             return
         }
-        guard let speech = classification.classification(forIdentifier: "speech") else {
-            return
-        }
-        speechResultCount += 1
-        let confidence = speech.confidence
+        resultCount += 1
+        // The request's knownClassifications is validated during setup, so a
+        // valid window that omits speech from its candidates is zero evidence
+        // for speech, not an analyzer failure.
+        let confidence = classification.classification(forIdentifier: "speech")?.confidence ?? 0
         maxSpeechConfidence = max(maxSpeechConfidence, confidence)
     }
 
@@ -285,6 +285,10 @@ private final class SpeechActivityObserver: NSObject, SNResultsObserving {
 
 let speechAnalysisWindowDurationSeconds: Double = 0.5
 
+private enum SpeechConfidenceAnalysisError: Error {
+    case missingSpeechClassification
+}
+
 private final class SpeechConfidenceAnalysis {
     private static let timeout: TimeInterval = 5
 
@@ -295,6 +299,9 @@ private final class SpeechConfidenceAnalysis {
     init(url: URL, completion: @escaping (Double?) -> Void) throws {
         self.completion = completion
         let request = try SNClassifySoundRequest(classifierIdentifier: .version1)
+        guard request.knownClassifications.contains("speech") else {
+            throw SpeechConfidenceAnalysisError.missingSpeechClassification
+        }
         request.windowDuration = CMTime(
             seconds: speechAnalysisWindowDurationSeconds,
             preferredTimescale: 16_000
@@ -306,7 +313,7 @@ private final class SpeechConfidenceAnalysis {
 
     func start() {
         analyzer.analyze { success in
-            let confidence = success && !self.observer.failed && self.observer.speechResultCount > 0
+            let confidence = success && !self.observer.failed && self.observer.resultCount > 0
                 ? self.observer.maxSpeechConfidence
                 : nil
             runOnMain {
@@ -1774,8 +1781,8 @@ final class DictationController {
             return
         }
 
-        PasteboardInserter.copyForRecovery(text)
-        resetRecordingState(keepRecordingFile: keepRecordingFile)
+        let copied = PasteboardInserter.copyForRecovery(text)
+        resetRecordingState(keepRecordingFile: keepRecordingFile && !copied)
     }
 
     func discard() {
@@ -2278,7 +2285,7 @@ enum PasteboardInserter {
     /// Last-resort recovery when Dictation history could not save a transcript.
     /// Unlike a normal paste, the clipboard is deliberately not restored after
     /// a successful write.
-    static func copyForRecovery(_ text: String) {
+    static func copyForRecovery(_ text: String) -> Bool {
         let pasteboard = NSPasteboard.general
         let snapshot = capture(pasteboard)
 
@@ -2289,13 +2296,14 @@ enum PasteboardInserter {
                 "code": "pasteboard_write_failed",
                 "message": "Could not save or copy this dictation. The recording was kept for recovery.",
             ])
-            return
+            return false
         }
 
         emit("error", [
             "code": "dictation_recovery_clipboard",
             "message": "Could not save this dictation. Use Cmd+V to keep the transcript.",
         ])
+        return true
     }
 
     /// Calls `completion(true)` only when `target` is alive and frontmost at

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -4,6 +4,7 @@ import AppKit
 import Carbon
 import CoreMedia
 import CoreGraphics
+import SoundAnalysis
 
 struct HelperEvent: Encodable {
     let type: String
@@ -167,8 +168,31 @@ enum RecordingCueSound: String {
     case stop = "record-end"
 }
 
+private final class RecordingCueCompletion: NSObject, NSSoundDelegate {
+    private var completion: (() -> Void)?
+
+    init(completion: @escaping () -> Void) {
+        self.completion = completion
+    }
+
+    func sound(_ sound: NSSound, didFinishPlaying flag: Bool) {
+        finish()
+    }
+
+    func finish() {
+        let completion = completion
+        self.completion = nil
+        completion?()
+    }
+
+    func cancel() {
+        completion = nil
+    }
+}
+
 enum RecordingCuePlayer {
     private static var sounds: [RecordingCueSound: NSSound] = [:]
+    private static var completions: [RecordingCueSound: RecordingCueCompletion] = [:]
 
     static func play(_ cue: RecordingCueSound) {
         let sound = sounds[cue] ?? load(cue)
@@ -178,6 +202,49 @@ enum RecordingCuePlayer {
         sound.stop()
         sound.currentTime = 0
         sound.play()
+    }
+
+    static func play(_ cue: RecordingCueSound, completion: @escaping () -> Void) {
+        let sound = sounds[cue] ?? load(cue)
+        guard let sound else {
+            completion()
+            return
+        }
+
+        cancel(cue)
+        let delegate = RecordingCueCompletion {
+            sound.delegate = nil
+            completions.removeValue(forKey: cue)
+            completion()
+        }
+        completions[cue] = delegate
+        sound.delegate = delegate
+        sound.currentTime = 0
+        guard sound.play() else {
+            delegate.finish()
+            return
+        }
+
+        // NSSound normally calls its delegate when playback finishes. Keep a
+        // bounded fallback so a broken output route cannot wedge dictation in
+        // the pending state forever.
+        DispatchQueue.main.asyncAfter(deadline: .now() + max(1, sound.duration + 0.5)) {
+            guard completions[cue] === delegate else {
+                return
+            }
+            sound.delegate = nil
+            sound.stop()
+            delegate.finish()
+        }
+    }
+
+    static func cancel(_ cue: RecordingCueSound) {
+        completions.removeValue(forKey: cue)?.cancel()
+        guard let sound = sounds[cue] else {
+            return
+        }
+        sound.delegate = nil
+        sound.stop()
     }
 
     private static func load(_ cue: RecordingCueSound) -> NSSound? {
@@ -190,6 +257,94 @@ enum RecordingCuePlayer {
         sounds[cue] = sound
         return sound
     }
+}
+
+private final class SpeechActivityObserver: NSObject, SNResultsObserving {
+    private(set) var speechResultCount = 0
+    private(set) var maxSpeechConfidence = 0.0
+    private(set) var failed = false
+
+    func request(_ request: SNRequest, didProduce result: SNResult) {
+        guard let classification = result as? SNClassificationResult else {
+            return
+        }
+        guard let speech = classification.classification(forIdentifier: "speech") else {
+            return
+        }
+        speechResultCount += 1
+        let confidence = speech.confidence
+        maxSpeechConfidence = max(maxSpeechConfidence, confidence)
+    }
+
+    func request(_ request: SNRequest, didFailWithError error: Error) {
+        failed = true
+    }
+
+    func requestDidComplete(_ request: SNRequest) {}
+}
+
+let speechAnalysisWindowDurationSeconds: Double = 0.5
+
+private final class SpeechConfidenceAnalysis {
+    private static let timeout: TimeInterval = 5
+
+    private let analyzer: SNAudioFileAnalyzer
+    private let observer = SpeechActivityObserver()
+    private var completion: ((Double?) -> Void)?
+
+    init(url: URL, completion: @escaping (Double?) -> Void) throws {
+        self.completion = completion
+        let request = try SNClassifySoundRequest(classifierIdentifier: .version1)
+        request.windowDuration = CMTime(
+            seconds: speechAnalysisWindowDurationSeconds,
+            preferredTimescale: 16_000
+        )
+        request.overlapFactor = 0.5
+        analyzer = try SNAudioFileAnalyzer(url: url)
+        try analyzer.add(request, withObserver: observer)
+    }
+
+    func start() {
+        analyzer.analyze { success in
+            let confidence = success && !self.observer.failed && self.observer.speechResultCount > 0
+                ? self.observer.maxSpeechConfidence
+                : nil
+            runOnMain {
+                self.finish(confidence)
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.timeout) {
+            self.finish(nil)
+        }
+    }
+
+    private func finish(_ confidence: Double?) {
+        guard let completion else {
+            return
+        }
+        self.completion = nil
+        analyzer.cancelAnalysis()
+        completion(confidence)
+    }
+}
+
+func analyzeSpeechConfidence(at url: URL, completion: @escaping (Double?) -> Void) {
+    do {
+        let analysis = try SpeechConfidenceAnalysis(url: url, completion: completion)
+        analysis.start()
+    } catch {
+        completion(nil)
+    }
+}
+
+func audioDurationSeconds(at url: URL) -> Double? {
+    guard
+        let file = try? AVAudioFile(forReading: url),
+        file.fileFormat.sampleRate > 0
+    else {
+        return nil
+    }
+    return Double(file.length) / file.fileFormat.sampleRate
 }
 
 func microphoneDevices() -> [[String: String]] {
@@ -1436,6 +1591,10 @@ enum RecordingPurpose {
 }
 
 let micTestCapturePaddingSeconds: Double = 0.35
+// Keep in sync with DICTATION_AUDIO_ACTIVITY_THRESHOLD in dictation.rs. The
+// trained classifier only affects captures below this independent meter gate,
+// so louder dictation should not pay for file analysis during finalization.
+let dictationAudioActivityThreshold: Float = 0.04
 
 final class DictationController {
     private var audioRecorder: AVAudioRecorder?
@@ -1489,7 +1648,7 @@ final class DictationController {
     /// sees the mismatch and does nothing.
     private var dictationStartGeneration = 0
 
-    func start() {
+    func start(playCue: Bool) {
         if startPending {
             return
         }
@@ -1509,13 +1668,33 @@ final class DictationController {
                 guard let self, self.dictationStartGeneration == generation else {
                     return
                 }
-                self.startPending = false
                 guard microphoneAllowed else {
+                    self.startPending = false
                     emit("error", ["code": "microphone_permission_missing", "message": "Microphone permission is required."])
                     emit("permission_status", permissionPayload())
                     return
                 }
-                self.startRecording(purpose: .dictation, durationSeconds: nil)
+                let beginRecording = { [weak self] in
+                    guard
+                        let self,
+                        self.startPending,
+                        self.dictationStartGeneration == generation
+                    else {
+                        return
+                    }
+                    self.startPending = false
+                    self.startRecording(purpose: .dictation, durationSeconds: nil)
+                }
+                if playCue {
+                    // Toggle dictation has no key-up timing contract, so its
+                    // cue can finish before capture starts without entering
+                    // the recording. Push-to-talk skips this cue and calls
+                    // beginRecording immediately so the down edge remains
+                    // the start of capture.
+                    RecordingCuePlayer.play(.start, completion: beginRecording)
+                } else {
+                    beginRecording()
+                }
             }
         }
     }
@@ -1527,7 +1706,8 @@ final class DictationController {
         // pending flag until a helper restart.
         if startPending && !isListening {
             dictationStartGeneration += 1
-            startPending = false
+            RecordingCuePlayer.cancel(.start)
+            resetRecordingState()
             emit("recording_discarded", ["reason": "start_cancelled"])
             return
         }
@@ -1540,12 +1720,12 @@ final class DictationController {
     }
 
     func toggle(shortcut: String) {
-        if isListening {
+        if isListening || startPending {
             emit("hotkey_trigger", ["action": "stop", "shortcut": shortcut])
             stop()
-        } else if !isFinalizing && !startPending {
+        } else if !isFinalizing {
             emit("hotkey_trigger", ["action": "start", "shortcut": shortcut])
-            start()
+            start(playCue: true)
         }
     }
 
@@ -1585,6 +1765,17 @@ final class DictationController {
         emit("final_transcript", ["text": text])
         PasteboardInserter.paste(text)
         resetRecordingState()
+    }
+
+    func copyForReview(text: String, keepRecordingFile: Bool, historySaved: Bool) {
+        let text = dictationPasteText(text)
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            fail(DictationError.missingTranscript)
+            return
+        }
+
+        PasteboardInserter.copyForReview(text, historySaved: historySaved)
+        resetRecordingState(keepRecordingFile: keepRecordingFile)
     }
 
     func discard() {
@@ -1730,11 +1921,37 @@ final class DictationController {
             return
         }
 
-        emit("recording_ready", [
+        let observedAudioLevel = maxObservedAudioLevel
+        let targetBundleIdentifier = FocusTargetController.shared.targetBundleIdentifier() ?? ""
+        let basePayload = [
             "path": recordingURL.path,
-            "observedAudioLevel": String(format: "%.4f", maxObservedAudioLevel),
-            "targetBundleIdentifier": FocusTargetController.shared.targetBundleIdentifier() ?? "",
-        ])
+            "observedAudioLevel": String(format: "%.4f", observedAudioLevel),
+            "targetBundleIdentifier": targetBundleIdentifier,
+        ]
+        guard observedAudioLevel < dictationAudioActivityThreshold else {
+            emit("recording_ready", basePayload)
+            return
+        }
+        if let duration = audioDurationSeconds(at: recordingURL),
+           duration < speechAnalysisWindowDurationSeconds {
+            var payload = basePayload
+            payload["speechAnalysisStatus"] = "no_complete_window"
+            emit("recording_ready", payload)
+            return
+        }
+        analyzeSpeechConfidence(at: recordingURL) { [weak self] speechConfidence in
+            guard let self, self.isFinalizing, self.recordingURL == recordingURL else {
+                return
+            }
+            var payload = basePayload
+            if let speechConfidence {
+                payload["speechConfidence"] = String(format: "%.4f", speechConfidence)
+                payload["speechAnalysisStatus"] = "ok"
+            } else {
+                payload["speechAnalysisStatus"] = "unavailable"
+            }
+            emit("recording_ready", payload)
+        }
     }
 
     private func emitMicTestReady(url: URL) {
@@ -1755,8 +1972,8 @@ final class DictationController {
         durationSeconds: Double?
     ) {
         isListening = true
-        RecordingCuePlayer.play(.start)
         if purpose == .micTest {
+            RecordingCuePlayer.play(.start)
             scheduleMicTestStop(after: durationSeconds ?? 5)
             emitJSON("mic_test_started", [
                 "durationMs": Int((durationSeconds ?? 5) * 1000),
@@ -1782,7 +1999,6 @@ final class DictationController {
         micTestStopWorkItem?.cancel()
         micTestStopWorkItem = nil
         stopMetering()
-        RecordingCuePlayer.play(.stop)
         if purpose == .dictation {
             emit("finalizing_transcript")
         }
@@ -1791,6 +2007,7 @@ final class DictationController {
             selectedDeviceRecorder.stop { [weak self] error in
                 runOnMain {
                     self?.selectedDeviceRecorder = nil
+                    RecordingCuePlayer.play(.stop)
                     if let error {
                         self?.fail(error)
                         return
@@ -1802,6 +2019,7 @@ final class DictationController {
         }
 
         audioRecorder?.stop()
+        RecordingCuePlayer.play(.stop)
         emitRecordingReady()
     }
 
@@ -1936,6 +2154,7 @@ final class DictationController {
     }
 
     private func resetRecordingState(keepRecordingFile: Bool = false) {
+        RecordingCuePlayer.cancel(.start)
         FocusTargetController.shared.clearPinnedTarget()
         isListening = false
         isFinalizing = false
@@ -2056,6 +2275,32 @@ enum PasteboardInserter {
         }
     }
 
+    /// Keeps an uncertain transcript recoverable without typing it into the
+    /// user's active app. Unlike a normal paste, the clipboard is deliberately
+    /// not restored after a successful write.
+    static func copyForReview(_ text: String, historySaved: Bool) {
+        let pasteboard = NSPasteboard.general
+        let snapshot = capture(pasteboard)
+
+        pasteboard.clearContents()
+        guard pasteboard.setString(text, forType: .string) else {
+            restore(snapshot, to: pasteboard)
+            let message = historySaved
+                ? "Could not write transcript to the clipboard. Find it in Dictation history."
+                : "Could not save or copy this dictation. The recording was kept for recovery."
+            emit("error", ["code": "pasteboard_write_failed", "message": message])
+            return
+        }
+
+        let message = historySaved
+            ? "Speech was unclear. Use Cmd+V to paste the transcript."
+            : "Could not save this dictation. Use Cmd+V to keep the transcript."
+        emit("error", [
+            "code": "dictation_low_speech_evidence",
+            "message": message,
+        ])
+    }
+
     /// Calls `completion(true)` only when `target` is alive and frontmost at
     /// that moment. `NSRunningApplication.isActive` means "currently
     /// frontmost", so a read taken right before the keystroke is the strongest
@@ -2158,7 +2403,7 @@ func handleCommandLine(_ line: String) {
         }
     case "start_listening":
         runOnMain {
-            dictation.start()
+            dictation.start(playCue: false)
         }
     case "stop_and_paste":
         runOnMain {
@@ -2212,6 +2457,17 @@ func handleCommandLine(_ line: String) {
         let text = command?["text"] as? String ?? ""
         runOnMain {
             dictation.paste(text: text)
+        }
+    case "copy_text_for_review":
+        let text = command?["text"] as? String ?? ""
+        let keepRecordingFile = command?["keepRecordingFile"] as? Bool ?? false
+        let historySaved = command?["historySaved"] as? Bool ?? true
+        runOnMain {
+            dictation.copyForReview(
+                text: text,
+                keepRecordingFile: keepRecordingFile,
+                historySaved: historySaved
+            )
         }
     case "discard_recording":
         runOnMain {

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3346,7 +3346,7 @@ async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInf
             observed_audio_level = recording.observed_audio_level,
             speech_confidence = recording.speech_confidence,
             speech_analysis_status = ?recording.speech_analysis_status,
-            "dictation capture had low speech evidence; automatic paste will require manual review"
+            "dictation capture had low speech evidence; automatic paste will be suppressed"
         );
     }
     // Backstop for the toggle-start path (where the start-time gate in
@@ -3498,10 +3498,9 @@ fn retain_low_speech_evidence_recording(
     );
     let state = app.state::<HelperState>();
     let command = serde_json::json!({
-        "type": "copy_text_for_review",
+        "type": "copy_text_for_recovery",
         "text": transcript.text,
         "keepRecordingFile": true,
-        "historySaved": false,
     });
     if let Err(error) = send_helper_command(&state, command) {
         update_shortcut_helper_finalizing(app, false);
@@ -4420,15 +4419,10 @@ fn quarantine_low_speech_evidence_outcome(
     };
 
     // A generic speech classifier cannot prove that a quiet capture contains
-    // no real words. Keep the ASR result in history and on the clipboard, but
-    // never let a low-evidence hallucination type itself into another app or
-    // launch an agent action without the user's review.
-    outcome.helper_command = serde_json::json!({
-        "type": "copy_text_for_review",
-        "text": transcript.text,
-        "historySaved": true,
-    });
-    outcome.event = None;
+    // no real words. Keep the ASR result in history, but leave the clipboard
+    // and active app untouched and dismiss the no-audio path silently.
+    outcome.helper_command = serde_json::json!({ "type": "discard_recording" });
+    outcome.event = Some(silent_no_speech_event());
     outcome.transcript = Some(transcript);
     outcome.quarantine_transcript = None;
     outcome
@@ -7278,7 +7272,7 @@ mod tests {
     }
 
     #[test]
-    fn low_speech_evidence_copies_transcript_for_review_and_keeps_history_item() {
+    fn low_speech_evidence_dismisses_silently_and_keeps_history_item() {
         let outcome = outcome_from_transcription_result(
             Ok(TranscriptionProviderResult {
                 text: "Oh, yeah.".to_string(),
@@ -7293,13 +7287,12 @@ mod tests {
 
         assert_eq!(
             outcome.helper_command,
-            serde_json::json!({
-                "type": "copy_text_for_review",
-                "text": "Oh, yeah.",
-                "historySaved": true,
-            })
+            serde_json::json!({ "type": "discard_recording" })
         );
-        assert!(outcome.event.is_none());
+        assert!(outcome
+            .event
+            .as_ref()
+            .is_some_and(is_silent_transcription_error));
         assert_eq!(
             outcome.transcript.as_ref().map(|item| item.text.as_str()),
             Some("Oh, yeah.")
@@ -7326,18 +7319,17 @@ mod tests {
 
         assert_eq!(
             outcome.helper_command,
-            serde_json::json!({
-                "type": "copy_text_for_review",
-                "text": "Hey June delete this note.",
-                "historySaved": true,
-            })
+            serde_json::json!({ "type": "discard_recording" })
         );
-        assert!(outcome.event.is_none());
+        assert!(outcome
+            .event
+            .as_ref()
+            .is_some_and(is_silent_transcription_error));
         assert!(outcome.transcript.is_some());
     }
 
     #[test]
-    fn low_speech_evidence_preserves_summary_like_transcription_for_review() {
+    fn low_speech_evidence_preserves_summary_like_transcription_in_history() {
         let outcome = outcome_from_transcription_result(
             Ok(TranscriptionProviderResult {
                 text: "User report summary: the user said hello.".to_string(),
@@ -7354,13 +7346,12 @@ mod tests {
 
         assert_eq!(
             outcome.helper_command,
-            serde_json::json!({
-                "type": "copy_text_for_review",
-                "text": "User report summary: the user said hello.",
-                "historySaved": true,
-            })
+            serde_json::json!({ "type": "discard_recording" })
         );
-        assert!(outcome.event.is_none());
+        assert!(outcome
+            .event
+            .as_ref()
+            .is_some_and(is_silent_transcription_error));
         assert_eq!(
             outcome.transcript.as_ref().map(|item| item.text.as_str()),
             Some("User report summary: the user said hello.")
@@ -7418,12 +7409,12 @@ mod tests {
     }
 
     #[test]
-    fn low_speech_evidence_error_is_visible() {
+    fn recovery_clipboard_error_is_visible() {
         let mut event = serde_json::json!({
             "type": "error",
             "payload": {
-                "code": "dictation_low_speech_evidence",
-                "message": "Speech was unclear. Use Cmd+V to paste the transcript.",
+                "code": "dictation_recovery_clipboard",
+                "message": "Could not save this dictation. Use Cmd+V to keep the transcript.",
             }
         });
         assert!(!is_silent_transcription_error(&event));

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -7300,7 +7300,7 @@ mod tests {
     }
 
     #[test]
-    fn low_speech_evidence_cannot_launch_an_agent_action() {
+    fn low_speech_evidence_cannot_emit_an_agent_session_prompt() {
         let outcome = outcome_from_transcription_result(
             Ok(TranscriptionProviderResult {
                 text: "Hey June delete this note.".to_string(),

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -70,6 +70,11 @@ const EMAIL_APP_BUNDLE_IDS: &[&str] = &[
     "com.superhuman.electron",
 ];
 const DICTATION_AUDIO_ACTIVITY_THRESHOLD: f32 = 0.04;
+/// Sound Analysis reports a confidence for its trained `speech` class. When
+/// both this score and the helper's independent peak/RMS meter stay low, June
+/// withholds automatic paste but keeps the transcript recoverable. This is not
+/// a destructive silence test: quiet speech can also fall below both cutoffs.
+const DICTATION_SPEECH_CONFIDENCE_THRESHOLD: f32 = 0.4;
 const DICTATION_EVENT_LOG: &str = "dictation-events.log";
 
 static SETTINGS_CACHE: OnceLock<Mutex<DictationSettings>> = OnceLock::new();
@@ -3335,6 +3340,15 @@ async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInf
         .as_deref()
         .map(|bundle_id| is_email_app_bundle(bundle_id).then(|| APP_CONTEXT_EMAIL.to_string()))
         .unwrap_or_else(frontmost_app_context);
+    let low_speech_evidence = recording_has_low_speech_evidence(&recording);
+    if low_speech_evidence {
+        tracing::info!(
+            observed_audio_level = recording.observed_audio_level,
+            speech_confidence = recording.speech_confidence,
+            speech_analysis_status = ?recording.speech_analysis_status,
+            "dictation capture had low speech evidence; automatic paste will require manual review"
+        );
+    }
     // Backstop for the toggle-start path (where the start-time gate in
     // send_dictation_command can't tell start from stop) and for tokens that
     // expired between start and finish.
@@ -3417,24 +3431,93 @@ async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInf
     )
     .await;
     let outcome = outcome_from_transcription_result(result, recording.observed_audio_level, style);
-    let state = app.state::<HelperState>();
-    if let Err(error) = send_helper_command(&state, outcome.helper_command) {
-        update_shortcut_helper_finalizing(&app, false);
-        emit_dictation_event_value(&app, app_error_event(error));
-        let _ = std::fs::remove_file(&audio_path);
-        return;
-    }
+    let history_already_persisted = if low_speech_evidence {
+        let recovery_transcript = outcome
+            .transcript
+            .as_ref()
+            .or(outcome.quarantine_transcript.as_ref());
+        if let Some(transcript) = recovery_transcript {
+            match persist_dictation_history_item(&app, transcript).await {
+                Ok(()) => true,
+                Err(error) => {
+                    retain_low_speech_evidence_recording(&app, &audio_path, transcript, &error);
+                    return;
+                }
+            }
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+    let outcome = quarantine_low_speech_evidence_outcome(outcome, low_speech_evidence);
+    deliver_dictation_outcome(&app, &audio_path, outcome, history_already_persisted);
+}
+
+fn deliver_dictation_outcome(
+    app: &AppHandle,
+    audio_path: &std::path::Path,
+    outcome: DictationTranscriptionOutcome,
+    history_already_persisted: bool,
+) {
+    // Low-evidence transcripts reach this point only after a successful,
+    // awaited history write. Normal transcripts keep the existing best-effort
+    // background write so their paste path does not gain database latency.
     if let Some(transcript) = outcome.transcript.as_ref() {
         crate::p3a::record_question_best_effort(
             app.clone(),
             crate::p3a::questions::Question::DictationSessions,
         );
-        spawn_dictation_history_write(app.clone(), transcript.clone());
+        if !history_already_persisted {
+            spawn_dictation_history_write(app.clone(), transcript.clone());
+        }
+    }
+    let state = app.state::<HelperState>();
+    if let Err(error) = send_helper_command(&state, outcome.helper_command) {
+        update_shortcut_helper_finalizing(app, false);
+        emit_dictation_event_value(app, app_error_event(error));
+        let _ = std::fs::remove_file(audio_path);
+        return;
     }
     if let Some(event) = outcome.event {
-        emit_dictation_event_value(&app, event);
+        emit_dictation_event_value(app, event);
     }
-    let _ = std::fs::remove_file(&audio_path);
+    let _ = std::fs::remove_file(audio_path);
+}
+
+fn retain_low_speech_evidence_recording(
+    app: &AppHandle,
+    audio_path: &std::path::Path,
+    transcript: &TranscriptionProviderResult,
+    history_error: &AppError,
+) {
+    tracing::error!(
+        code = %history_error.code,
+        audio_path = %audio_path.display(),
+        "dictation history save failed; retaining low-evidence recording"
+    );
+    let state = app.state::<HelperState>();
+    let command = serde_json::json!({
+        "type": "copy_text_for_review",
+        "text": transcript.text,
+        "keepRecordingFile": true,
+        "historySaved": false,
+    });
+    if let Err(error) = send_helper_command(&state, command) {
+        update_shortcut_helper_finalizing(app, false);
+        emit_dictation_event_value(
+            app,
+            app_error_event(AppError::new(
+                "dictation_recovery_unavailable",
+                "June couldn't save this dictation. The recording was kept for recovery.",
+            )),
+        );
+        tracing::error!(
+            code = %error.code,
+            audio_path = %audio_path.display(),
+            "could not hand retained dictation to helper"
+        );
+    }
 }
 
 fn prepare_dictation_audio(
@@ -4229,6 +4312,8 @@ fn recording_ready_info_from_event(
     Ok(RecordingReadyInfo {
         audio_path: PathBuf::from(path),
         observed_audio_level: observed_audio_level_from_event(event),
+        speech_confidence: speech_confidence_from_event(event),
+        speech_analysis_status: speech_analysis_status_from_event(event),
         target_bundle_id: event
             .get("payload")
             .and_then(|payload| payload.get("targetBundleIdentifier"))
@@ -4240,9 +4325,30 @@ fn recording_ready_info_from_event(
 }
 
 fn observed_audio_level_from_event(event: &serde_json::Value) -> Option<f32> {
-    let value = event
+    let level = finite_f32_from_event_payload(event, "observedAudioLevel")?;
+    (0.0..=1.0).contains(&level).then_some(level)
+}
+
+fn speech_confidence_from_event(event: &serde_json::Value) -> Option<f32> {
+    let confidence = finite_f32_from_event_payload(event, "speechConfidence")?;
+    (0.0..=1.0).contains(&confidence).then_some(confidence)
+}
+
+fn speech_analysis_status_from_event(event: &serde_json::Value) -> Option<SpeechAnalysisStatus> {
+    let status = event
         .get("payload")
-        .and_then(|payload| payload.get("observedAudioLevel"))?;
+        .and_then(|payload| payload.get("speechAnalysisStatus"))
+        .and_then(serde_json::Value::as_str)?;
+    match status {
+        "ok" => Some(SpeechAnalysisStatus::Ok),
+        "no_complete_window" => Some(SpeechAnalysisStatus::NoCompleteWindow),
+        "unavailable" => Some(SpeechAnalysisStatus::Unavailable),
+        _ => None,
+    }
+}
+
+fn finite_f32_from_event_payload(event: &serde_json::Value, key: &str) -> Option<f32> {
+    let value = event.get("payload").and_then(|payload| payload.get(key))?;
     let level = value
         .as_f64()
         .map(|level| level as f32)
@@ -4259,16 +4365,73 @@ struct DictationTranscriptionOutcome {
     helper_command: serde_json::Value,
     event: Option<serde_json::Value>,
     transcript: Option<TranscriptionProviderResult>,
+    quarantine_transcript: Option<TranscriptionProviderResult>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SpeechAnalysisStatus {
+    Ok,
+    NoCompleteWindow,
+    Unavailable,
 }
 
 #[derive(Debug)]
 struct RecordingReadyInfo {
     audio_path: PathBuf,
     observed_audio_level: Option<f32>,
+    /// Maximum confidence for the macOS built-in `speech` class over the
+    /// finalized capture. Missing when analysis failed, produced no complete
+    /// window, or came from a helper version/platform without Sound Analysis.
+    speech_confidence: Option<f32>,
+    speech_analysis_status: Option<SpeechAnalysisStatus>,
     /// Bundle id of the paste target the helper pinned when the recording
     /// stopped: the same app it will paste into once we hand back a
     /// transcript. None with older helper builds that predate the field.
     target_bundle_id: Option<String>,
+}
+
+fn recording_has_low_speech_evidence(recording: &RecordingReadyInfo) -> bool {
+    let classifier_is_low = match recording.speech_analysis_status {
+        Some(SpeechAnalysisStatus::NoCompleteWindow) => true,
+        Some(SpeechAnalysisStatus::Unavailable) => false,
+        Some(SpeechAnalysisStatus::Ok) | None => recording
+            .speech_confidence
+            .is_some_and(|confidence| confidence < DICTATION_SPEECH_CONFIDENCE_THRESHOLD),
+    };
+    classifier_is_low
+        && recording
+            .observed_audio_level
+            .is_some_and(|level| level < DICTATION_AUDIO_ACTIVITY_THRESHOLD)
+}
+
+fn quarantine_low_speech_evidence_outcome(
+    mut outcome: DictationTranscriptionOutcome,
+    low_speech_evidence: bool,
+) -> DictationTranscriptionOutcome {
+    if !low_speech_evidence {
+        return outcome;
+    }
+    let Some(transcript) = outcome
+        .transcript
+        .clone()
+        .or_else(|| outcome.quarantine_transcript.clone())
+    else {
+        return outcome;
+    };
+
+    // A generic speech classifier cannot prove that a quiet capture contains
+    // no real words. Keep the ASR result in history and on the clipboard, but
+    // never let a low-evidence hallucination type itself into another app or
+    // launch an agent action without the user's review.
+    outcome.helper_command = serde_json::json!({
+        "type": "copy_text_for_review",
+        "text": transcript.text,
+        "historySaved": true,
+    });
+    outcome.event = None;
+    outcome.transcript = Some(transcript);
+    outcome.quarantine_transcript = None;
+    outcome
 }
 
 fn outcome_from_transcription_result(
@@ -4286,11 +4449,7 @@ fn outcome_from_transcription_result(
                 // silent no_speech event, regardless of the observed audio
                 // level — the audio-detected-but-no-text error is meant for
                 // genuine silence misheard as loud audio, not for fillers.
-                return DictationTranscriptionOutcome {
-                    helper_command: serde_json::json!({ "type": "discard_recording" }),
-                    event: Some(silent_no_speech_event()),
-                    transcript: None,
-                };
+                return silent_no_speech_outcome();
             }
             outcome_from_clean_transcript(transcript, observed_audio_level)
         }
@@ -4303,8 +4462,18 @@ fn outcome_from_transcription_result(
                 helper_command: serde_json::json!({ "type": "discard_recording" }),
                 event: Some(event),
                 transcript: None,
+                quarantine_transcript: None,
             }
         }
+    }
+}
+
+fn silent_no_speech_outcome() -> DictationTranscriptionOutcome {
+    DictationTranscriptionOutcome {
+        helper_command: serde_json::json!({ "type": "discard_recording" }),
+        event: Some(silent_no_speech_event()),
+        transcript: None,
+        quarantine_transcript: None,
     }
 }
 
@@ -4320,6 +4489,7 @@ fn outcome_from_clean_transcript(
             helper_command: serde_json::json!({ "type": "discard_recording" }),
             event: Some(no_text_event_for_observed_audio(observed_audio_level)),
             transcript: None,
+            quarantine_transcript: None,
         },
         transcript if looks_like_instruction_response(&transcript.text) => {
             DictationTranscriptionOutcome {
@@ -4332,6 +4502,7 @@ fn outcome_from_clean_transcript(
                     },
                 })),
                 transcript: None,
+                quarantine_transcript: Some(transcript),
             }
         }
         transcript => {
@@ -4343,6 +4514,7 @@ fn outcome_from_clean_transcript(
                         "payload": { "prompt": prompt },
                     })),
                     transcript: Some(transcript),
+                    quarantine_transcript: None,
                 }
             } else {
                 DictationTranscriptionOutcome {
@@ -4352,6 +4524,7 @@ fn outcome_from_clean_transcript(
                     }),
                     event: None,
                     transcript: Some(transcript),
+                    quarantine_transcript: None,
                 }
             }
         }
@@ -4712,26 +4885,40 @@ fn skip_word_separators(value: &str) -> &str {
 }
 
 async fn store_dictation_history_item(app: &AppHandle, transcript: &TranscriptionProviderResult) {
-    match crate::commands::repositories(app).await {
-        Ok(repos) => {
-            if let Err(error) = repos
-                .create_dictation_history_item(
-                    &transcript.text,
-                    transcript.language.clone(),
-                    &transcript.provider,
-                )
-                .await
-            {
-                eprintln!("[dictation] history save failed: {error}");
-            }
-        }
-        Err(error) => {
-            eprintln!(
-                "[dictation] history unavailable code={} message={}",
-                error.code, error.message
-            );
-        }
+    if let Err(error) = persist_dictation_history_item(app, transcript).await {
+        tracing::error!(
+            code = %error.code,
+            "dictation history save failed after transcript delivery"
+        );
     }
+}
+
+async fn persist_dictation_history_item(
+    app: &AppHandle,
+    transcript: &TranscriptionProviderResult,
+) -> Result<(), AppError> {
+    let repos = crate::commands::repositories(app).await.map_err(|error| {
+        tracing::error!(code = %error.code, "dictation history repository unavailable");
+        AppError::new(
+            "dictation_history_save_failed",
+            "Dictation history could not save this transcript.",
+        )
+    })?;
+    repos
+        .create_dictation_history_item(
+            &transcript.text,
+            transcript.language.clone(),
+            &transcript.provider,
+        )
+        .await
+        .map_err(|error| {
+            tracing::error!(%error, "dictation history insert failed");
+            AppError::new(
+                "dictation_history_save_failed",
+                "Dictation history could not save this transcript.",
+            )
+        })?;
+    Ok(())
 }
 
 fn app_error_event(error: AppError) -> serde_json::Value {
@@ -4853,6 +5040,12 @@ fn dictation_event_log_entry(event_type: &str, event: &serde_json::Value) -> ser
             .and_then(serde_json::Value::as_str),
         "observedAudioLevel": payload
             .and_then(|payload| payload.get("observedAudioLevel"))
+            .cloned(),
+        "speechConfidence": payload
+            .and_then(|payload| payload.get("speechConfidence"))
+            .cloned(),
+        "speechAnalysisStatus": payload
+            .and_then(|payload| payload.get("speechAnalysisStatus"))
             .cloned(),
         "pasteTarget": payload
             .and_then(|payload| payload.get("app"))
@@ -6974,6 +7167,233 @@ mod tests {
     }
 
     #[test]
+    fn recording_ready_info_includes_valid_speech_confidence() {
+        let event = serde_json::json!({
+            "type": "recording_ready",
+            "payload": {
+                "path": "/tmp/os-june-dictation-test.m4a",
+                "speechConfidence": "0.2630",
+                "speechAnalysisStatus": "ok",
+            }
+        });
+        let info = recording_ready_info_from_event(&event).expect("recording info");
+        assert_eq!(info.speech_confidence, Some(0.263));
+        assert_eq!(info.speech_analysis_status, Some(SpeechAnalysisStatus::Ok));
+        let log_entry = dictation_event_log_entry("recording_ready", &event);
+        assert_eq!(log_entry["speechConfidence"], "0.2630");
+        assert_eq!(log_entry["speechAnalysisStatus"], "ok");
+
+        let invalid = serde_json::json!({
+            "type": "recording_ready",
+            "payload": {
+                "path": "/tmp/os-june-dictation-test.m4a",
+                "speechConfidence": "1.2",
+            }
+        });
+        let info = recording_ready_info_from_event(&invalid).expect("recording info");
+        assert_eq!(info.speech_confidence, None);
+    }
+
+    #[test]
+    fn observed_audio_level_rejects_values_outside_the_normalized_range() {
+        for value in ["-0.1", "1.1", "NaN", "inf"] {
+            let event = serde_json::json!({
+                "type": "recording_ready",
+                "payload": {
+                    "path": "/tmp/os-june-dictation-test.m4a",
+                    "observedAudioLevel": value,
+                }
+            });
+            let info = recording_ready_info_from_event(&event).expect("recording info");
+            assert_eq!(info.observed_audio_level, None, "accepted {value}");
+        }
+
+        let event = serde_json::json!({
+            "type": "recording_ready",
+            "payload": {
+                "path": "/tmp/os-june-dictation-test.m4a",
+                "observedAudioLevel": "0",
+            }
+        });
+        let info = recording_ready_info_from_event(&event).expect("recording info");
+        assert_eq!(info.observed_audio_level, Some(0.0));
+    }
+
+    #[test]
+    fn low_speech_evidence_requires_both_low_audio_signals() {
+        let info =
+            |speech_confidence, speech_analysis_status, observed_audio_level| RecordingReadyInfo {
+                audio_path: PathBuf::from("/tmp/os-june-dictation-test.m4a"),
+                observed_audio_level,
+                speech_confidence,
+                speech_analysis_status,
+                target_bundle_id: None,
+            };
+
+        assert!(recording_has_low_speech_evidence(&info(
+            Some(0.263),
+            Some(SpeechAnalysisStatus::Ok),
+            Some(0.0305)
+        )));
+        assert!(!recording_has_low_speech_evidence(&info(
+            Some(DICTATION_SPEECH_CONFIDENCE_THRESHOLD),
+            Some(SpeechAnalysisStatus::Ok),
+            Some(0.0305)
+        )));
+        assert!(!recording_has_low_speech_evidence(&info(
+            Some(0.263),
+            Some(SpeechAnalysisStatus::Ok),
+            Some(DICTATION_AUDIO_ACTIVITY_THRESHOLD)
+        )));
+        assert!(!recording_has_low_speech_evidence(&info(
+            None,
+            None,
+            Some(0.0305)
+        )));
+        assert!(!recording_has_low_speech_evidence(&info(
+            Some(0.263),
+            Some(SpeechAnalysisStatus::Ok),
+            None
+        )));
+    }
+
+    #[test]
+    fn short_low_level_capture_is_quarantined_but_analysis_failure_fails_open() {
+        let info = |status, speech_confidence| RecordingReadyInfo {
+            audio_path: PathBuf::from("/tmp/os-june-dictation-test.m4a"),
+            observed_audio_level: Some(0.0305),
+            speech_confidence,
+            speech_analysis_status: Some(status),
+            target_bundle_id: None,
+        };
+
+        assert!(recording_has_low_speech_evidence(&info(
+            SpeechAnalysisStatus::NoCompleteWindow,
+            None,
+        )));
+        assert!(!recording_has_low_speech_evidence(&info(
+            SpeechAnalysisStatus::Unavailable,
+            Some(0.0),
+        )));
+    }
+
+    #[test]
+    fn low_speech_evidence_copies_transcript_for_review_and_keeps_history_item() {
+        let outcome = outcome_from_transcription_result(
+            Ok(TranscriptionProviderResult {
+                text: "Oh, yeah.".to_string(),
+                language: Some("en".to_string()),
+                provider: crate::providers::VENICE_PROVIDER.to_string(),
+            }),
+            Some(0.0305),
+            DictationStyle::Standard,
+        );
+
+        let outcome = quarantine_low_speech_evidence_outcome(outcome, true);
+
+        assert_eq!(
+            outcome.helper_command,
+            serde_json::json!({
+                "type": "copy_text_for_review",
+                "text": "Oh, yeah.",
+                "historySaved": true,
+            })
+        );
+        assert!(outcome.event.is_none());
+        assert_eq!(
+            outcome.transcript.as_ref().map(|item| item.text.as_str()),
+            Some("Oh, yeah.")
+        );
+    }
+
+    #[test]
+    fn low_speech_evidence_cannot_launch_an_agent_action() {
+        let outcome = outcome_from_transcription_result(
+            Ok(TranscriptionProviderResult {
+                text: "Hey June delete this note.".to_string(),
+                language: Some("en".to_string()),
+                provider: crate::providers::VENICE_PROVIDER.to_string(),
+            }),
+            Some(0.0305),
+            DictationStyle::Standard,
+        );
+        assert_eq!(
+            outcome.event.as_ref().and_then(|event| event.get("type")),
+            Some(&serde_json::json!("agent_session_prompt"))
+        );
+
+        let outcome = quarantine_low_speech_evidence_outcome(outcome, true);
+
+        assert_eq!(
+            outcome.helper_command,
+            serde_json::json!({
+                "type": "copy_text_for_review",
+                "text": "Hey June delete this note.",
+                "historySaved": true,
+            })
+        );
+        assert!(outcome.event.is_none());
+        assert!(outcome.transcript.is_some());
+    }
+
+    #[test]
+    fn low_speech_evidence_preserves_summary_like_transcription_for_review() {
+        let outcome = outcome_from_transcription_result(
+            Ok(TranscriptionProviderResult {
+                text: "User report summary: the user said hello.".to_string(),
+                language: Some("en".to_string()),
+                provider: crate::providers::VENICE_PROVIDER.to_string(),
+            }),
+            Some(0.0305),
+            DictationStyle::Standard,
+        );
+        assert!(outcome.transcript.is_none());
+        assert!(outcome.quarantine_transcript.is_some());
+
+        let outcome = quarantine_low_speech_evidence_outcome(outcome, true);
+
+        assert_eq!(
+            outcome.helper_command,
+            serde_json::json!({
+                "type": "copy_text_for_review",
+                "text": "User report summary: the user said hello.",
+                "historySaved": true,
+            })
+        );
+        assert!(outcome.event.is_none());
+        assert_eq!(
+            outcome.transcript.as_ref().map(|item| item.text.as_str()),
+            Some("User report summary: the user said hello.")
+        );
+        assert!(outcome.quarantine_transcript.is_none());
+    }
+
+    #[test]
+    fn low_speech_evidence_keeps_empty_transcription_silent() {
+        let outcome = outcome_from_transcription_result(
+            Ok(TranscriptionProviderResult {
+                text: "   ".to_string(),
+                language: None,
+                provider: crate::providers::VENICE_PROVIDER.to_string(),
+            }),
+            Some(0.0305),
+            DictationStyle::Standard,
+        );
+
+        let outcome = quarantine_low_speech_evidence_outcome(outcome, true);
+
+        assert_eq!(
+            outcome.helper_command,
+            serde_json::json!({ "type": "discard_recording" })
+        );
+        assert!(outcome.transcript.is_none());
+        assert!(outcome
+            .event
+            .as_ref()
+            .is_some_and(is_silent_transcription_error));
+    }
+
+    #[test]
     fn dictation_text_empty_error_is_silent() {
         let event = app_error_event(AppError::new("june_request_failed", "dictation_text_empty"));
         assert!(is_silent_transcription_error(&event));
@@ -6990,6 +7410,20 @@ mod tests {
             "payload": {
                 "code": "accessibility_permission_missing",
                 "message": "June couldn't paste automatically. Your transcript is on the clipboard, so you can paste it with Cmd+V.",
+            }
+        });
+        assert!(!is_silent_transcription_error(&event));
+        annotate_silent_error(&mut event);
+        assert_eq!(event["payload"]["silent"], false);
+    }
+
+    #[test]
+    fn low_speech_evidence_error_is_visible() {
+        let mut event = serde_json::json!({
+            "type": "error",
+            "payload": {
+                "code": "dictation_low_speech_evidence",
+                "message": "Speech was unclear. Use Cmd+V to paste the transcript.",
             }
         });
         assert!(!is_silent_transcription_error(&event));

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4390,17 +4390,21 @@ struct RecordingReadyInfo {
 }
 
 fn recording_has_low_speech_evidence(recording: &RecordingReadyInfo) -> bool {
-    let classifier_is_low = match recording.speech_analysis_status {
+    match recording.speech_analysis_status {
+        // A sub-window capture has no classifier evidence in either direction.
+        // Quarantine it regardless of meter level rather than allowing a loud
+        // transient to bypass the incomplete analysis.
         Some(SpeechAnalysisStatus::NoCompleteWindow) => true,
         Some(SpeechAnalysisStatus::Unavailable) => false,
-        Some(SpeechAnalysisStatus::Ok) | None => recording
-            .speech_confidence
-            .is_some_and(|confidence| confidence < DICTATION_SPEECH_CONFIDENCE_THRESHOLD),
-    };
-    classifier_is_low
-        && recording
-            .observed_audio_level
-            .is_some_and(|level| level < DICTATION_AUDIO_ACTIVITY_THRESHOLD)
+        Some(SpeechAnalysisStatus::Ok) | None => {
+            recording
+                .speech_confidence
+                .is_some_and(|confidence| confidence < DICTATION_SPEECH_CONFIDENCE_THRESHOLD)
+                && recording
+                    .observed_audio_level
+                    .is_some_and(|level| level < DICTATION_AUDIO_ACTIVITY_THRESHOLD)
+        }
+    }
 }
 
 fn quarantine_low_speech_evidence_outcome(
@@ -7252,7 +7256,7 @@ mod tests {
     }
 
     #[test]
-    fn short_low_level_capture_is_quarantined_but_analysis_failure_fails_open() {
+    fn short_capture_is_quarantined_regardless_of_level_but_analysis_failure_fails_open() {
         let info = |status, speech_confidence| RecordingReadyInfo {
             audio_path: PathBuf::from("/tmp/os-june-dictation-test.m4a"),
             observed_audio_level: Some(0.0305),
@@ -7265,6 +7269,19 @@ mod tests {
             SpeechAnalysisStatus::NoCompleteWindow,
             None,
         )));
+        let loud_short_capture = RecordingReadyInfo {
+            audio_path: PathBuf::from("/tmp/os-june-dictation-test.m4a"),
+            observed_audio_level: Some(DICTATION_AUDIO_ACTIVITY_THRESHOLD),
+            speech_confidence: None,
+            speech_analysis_status: Some(SpeechAnalysisStatus::NoCompleteWindow),
+            target_bundle_id: None,
+        };
+        assert!(recording_has_low_speech_evidence(&loud_short_capture));
+        let unmetered_short_capture = RecordingReadyInfo {
+            observed_audio_level: None,
+            ..loud_short_capture
+        };
+        assert!(recording_has_low_speech_evidence(&unmetered_short_capture));
         assert!(!recording_has_low_speech_evidence(&info(
             SpeechAnalysisStatus::Unavailable,
             Some(0.0),


### PR DESCRIPTION
## Summary

- Keep June's start and stop cues out of captured dictation audio. Push-to-talk now captures immediately without a start cue; toggle dictation finishes its start cue before recording.
- Add local macOS Sound Analysis for low-level captures and combine its trained speech confidence with the helper's independent audio level.
- Treat dual-low evidence as uncertainty, not proof of silence: ASR still runs, the HUD dismisses silently, and non-empty results are saved only to Dictation history without touching the active app or clipboard.
- Quarantine sub-window captures as uncertain. If history persistence fails, attempt explicit clipboard recovery and keep the source recording only when that also fails.

Closes JUN-346

## Root cause

The helper recorded June's own cues, and every non-empty ASR result was trusted. Ambient noise or a captured cue could therefore reach ASR and occasionally produce plausible text such as “Oh, yeah.”, which June then pasted even though nobody spoke.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml dictation --lib` (113 passed)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`
- `make local-ci` on the rebased final commit (full Tauri Rust suite passed; `signoff/frontend` and `signoff/rust-macos` posted green)
- Swift helper compiled through the Tauri build; generated silence, fan, speech, quiet-speech, and whisper fixtures calibrated against the macOS classifier.
- Unit coverage verifies that low-evidence text takes the existing silent `no_speech` HUD path while remaining in history.

- [x] Tested visually where it matters. The final path adds no UI; it deliberately reuses the existing silent dismissal.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is required.

## Out of scope

- Changing Windows dictation, upstream transcription providers, or the June API.
- Adding a new confirmation surface. The normal low-evidence path is silent and leaves the clipboard untouched.
- Live-microphone QA. Validation used generated audio fixtures so no user audio left the machine.

## Followups

- Monitor low-evidence diagnostics and tune conservative thresholds only if production evidence supports it.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. Audio analysis stays local and finalized captures retain existing deletion behavior except when recovery requires keeping one.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. None changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend change is included.
- [x] User-facing copy follows the repo UI conventions.
