### PR TITLE
Announce RC builds in Slack

### DIFF
--- a/.agents/skills/repo-review/CALIBRATION.md
+++ b/.agents/skills/repo-review/CALIBRATION.md
@@ -103,3 +103,7 @@ data-driven: discount reviewer patterns with a bad true/findings ratio
 | JUN-324 (pre-PR) | Standards (codex, r1+final) | 1 | 1 | caught the ambiguous bare “transcription” term in the new regression test; renamed it to canonical note transcription wording, final clean |
 | JUN-324 (pre-PR) | Spec (codex, r1+final) | 0 | — | clean against the chevron visibility, enabled-state, open/close interaction, and regression-coverage acceptance criteria |
 | JUN-324 (pre-PR) | Adversarial (codex, r1+convergence) | 0 | — | approved after tracing the persisted recording source mode and confirming the newly reachable options affect only the next recording |
+| #798 | Standards (codex, r1+final) | 3 | 3 | all three findings qualified the overloaded “channel” term with the canonical RC release channel vocabulary; final clean |
+| #798 | Spec (codex, r1+final) | 0 | — | clean against the RC Slack announcement contract and documented amendments |
+| #798 | Adversarial (codex, r1-r5) | 5 | 3.5 | found mutable historical download links, fail-open provenance guards, and duplicate non-idempotent webhook retries; the notification-only recovery request was partly deliberate, and fixed-alias atomicity was verified as origin/main parity; final approve |
+| #798 | Cross-harness convergence (claude + codex CLI) | — | — | both runner attempts produced no usable verdict; the cycle continued with fresh read-only reviewers rather than treating missing output as approval |

--- a/.github/workflows/rc-desktop-dmg.yml
+++ b/.github/workflows/rc-desktop-dmg.yml
@@ -377,10 +377,12 @@ jobs:
           rm -rf "$release_dir"
           mkdir -p "$release_dir"
           stable_dmg="$release_dir/June_universal.dmg"
+          versioned_dmg="$release_dir/June_v${VERSION}_universal.dmg"
           app_archive="$release_dir/June_universal.app.tar.gz"
           app_signature="$release_dir/June_universal.app.tar.gz.sig"
           latest_rc_json="$release_dir/latest-rc.json"
           cp "$dmg" "$stable_dmg"
+          cp "$dmg" "$versioned_dmg"
           cp "${app_archives[0]}" "$app_archive"
           cp "${app_signatures[0]}" "$app_signature"
 
@@ -438,6 +440,7 @@ jobs:
 
           gh release upload rc \
             "$stable_dmg" \
+            "$versioned_dmg" \
             "$app_archive" \
             "$app_signature" \
             "$latest_rc_json" \
@@ -454,6 +457,7 @@ jobs:
           set -euo pipefail
           if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
             echo "::warning::SLACK_WEBHOOK_URL secret is not configured; skipping Slack notification."
+            echo "- Slack notification: skipped (SLACK_WEBHOOK_URL is not configured)" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
@@ -467,7 +471,7 @@ jobs:
           const releaseUrl =
             "https://github.com/open-software-network/os-june-releases/releases/tag/rc";
           const downloadUrl =
-            "https://github.com/open-software-network/os-june-releases/releases/download/rc/June_universal.dmg";
+            `https://github.com/open-software-network/os-june-releases/releases/download/rc/June_v${version}_universal.dmg`;
           const commitUrl = `https://github.com/open-software-network/os-june/commit/${commit}`;
 
           const payload = {
@@ -523,13 +527,21 @@ jobs:
           NODE
 
           response=$(curl -sS -f -X POST \
+            --connect-timeout 5 \
+            --max-time 20 \
+            --retry 3 \
+            --retry-all-errors \
+            --retry-delay 2 \
+            --retry-max-time 60 \
             -H "Content-Type: application/json" \
             --data-binary "@$payload_file" \
             "$SLACK_WEBHOOK_URL" 2>&1) || {
             echo "::warning::Slack notification failed: $response"
+            echo "- Slack notification: failed after bounded retries (see step warning)" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           }
           echo "Slack notification sent successfully."
+          echo "- Slack notification: sent for v$VERSION" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Summary
         run: |

--- a/.github/workflows/rc-desktop-dmg.yml
+++ b/.github/workflows/rc-desktop-dmg.yml
@@ -451,7 +451,7 @@ jobs:
           gh release upload rc "$versioned_dmg" \
             --repo open-software-network/os-june-releases
 
-          # Fixed channel assets intentionally follow the newest candidate.
+          # Fixed RC release channel assets intentionally follow the newest candidate.
           gh release upload rc \
             "$stable_dmg" \
             "$app_archive" \

--- a/.github/workflows/rc-desktop-dmg.yml
+++ b/.github/workflows/rc-desktop-dmg.yml
@@ -201,10 +201,18 @@ jobs:
           dir="$RUNNER_TEMP/rc-guard"
           rm -rf "$dir"
           mkdir -p "$dir"
-          if gh release view rc --repo open-software-network/os-june-releases >/dev/null 2>&1; then
+          lookup_error=""
+          if lookup_error=$(gh api --silent \
+            repos/open-software-network/os-june-releases/releases/tags/rc 2>&1); then
             gh release download rc \
               --repo open-software-network/os-june-releases \
               --pattern "rc-build.json" --dir "$dir"
+          elif grep -q 'HTTP 404' <<< "$lookup_error"; then
+            echo "No existing rc release was found."
+          else
+            echo "::error::Could not determine the current rc release; refusing to publish without the forward-only guard."
+            printf '%s\n' "$lookup_error" >&2
+            exit 1
           fi
           RC_GUARD_DIR="$dir" node --input-type=module <<'NODE'
           import { existsSync, readFileSync } from "node:fs";
@@ -438,9 +446,14 @@ jobs:
               --target main
           fi
 
+          # The candidate-specific DMG is append-only: an existing name means
+          # this version was already attempted and must never be replaced.
+          gh release upload rc "$versioned_dmg" \
+            --repo open-software-network/os-june-releases
+
+          # Fixed channel assets intentionally follow the newest candidate.
           gh release upload rc \
             "$stable_dmg" \
-            "$versioned_dmg" \
             "$app_archive" \
             "$app_signature" \
             "$latest_rc_json" \

--- a/.github/workflows/rc-desktop-dmg.yml
+++ b/.github/workflows/rc-desktop-dmg.yml
@@ -445,6 +445,92 @@ jobs:
             --repo open-software-network/os-june-releases \
             --clobber
 
+      - name: Notify Slack about rc build
+        if: ${{ success() }}
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "::warning::SLACK_WEBHOOK_URL secret is not configured; skipping Slack notification."
+            exit 0
+          fi
+
+          payload_file="$RUNNER_TEMP/rc-slack-payload.json"
+          SLACK_PAYLOAD_PATH="$payload_file" node <<'NODE'
+          const fs = require("node:fs");
+
+          const version = process.env.VERSION;
+          const commit = process.env.BUILD_COMMIT;
+          const shortCommit = commit.slice(0, 7);
+          const releaseUrl =
+            "https://github.com/open-software-network/os-june-releases/releases/tag/rc";
+          const downloadUrl =
+            "https://github.com/open-software-network/os-june-releases/releases/download/rc/June_universal.dmg";
+          const commitUrl = `https://github.com/open-software-network/os-june/commit/${commit}`;
+
+          const payload = {
+            text: `June v${version} release candidate is ready for testing`,
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: `:test_tube: *June v${version} release candidate is ready for testing*`,
+                },
+              },
+              {
+                type: "section",
+                fields: [
+                  {
+                    type: "mrkdwn",
+                    text: `*Version:*\nv${version}`,
+                  },
+                  {
+                    type: "mrkdwn",
+                    text: `*Source:*\n<${commitUrl}|${shortCommit}>`,
+                  },
+                ],
+              },
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: `*Download:*\n<${downloadUrl}|macOS DMG (Apple Silicon and Intel)>`,
+                },
+              },
+              {
+                type: "actions",
+                elements: [
+                  {
+                    type: "button",
+                    text: {
+                      type: "plain_text",
+                      text: "View release candidate",
+                    },
+                    url: releaseUrl,
+                  },
+                ],
+              },
+            ],
+          };
+
+          fs.writeFileSync(
+            process.env.SLACK_PAYLOAD_PATH,
+            `${JSON.stringify(payload)}\n`,
+          );
+          NODE
+
+          response=$(curl -sS -f -X POST \
+            -H "Content-Type: application/json" \
+            --data-binary "@$payload_file" \
+            "$SLACK_WEBHOOK_URL" 2>&1) || {
+            echo "::warning::Slack notification failed: $response"
+            exit 0
+          }
+          echo "Slack notification sent successfully."
+
       - name: Summary
         run: |
           {

--- a/.github/workflows/rc-desktop-dmg.yml
+++ b/.github/workflows/rc-desktop-dmg.yml
@@ -542,15 +542,11 @@ jobs:
           response=$(curl -sS -f -X POST \
             --connect-timeout 5 \
             --max-time 20 \
-            --retry 3 \
-            --retry-all-errors \
-            --retry-delay 2 \
-            --retry-max-time 60 \
             -H "Content-Type: application/json" \
             --data-binary "@$payload_file" \
             "$SLACK_WEBHOOK_URL" 2>&1) || {
-            echo "::warning::Slack notification failed: $response"
-            echo "- Slack notification: failed after bounded retries (see step warning)" >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Slack notification failed or delivery could not be confirmed: $response"
+            echo "- Slack notification: delivery unconfirmed (check Slack before posting manually)" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           }
           echo "Slack notification sent successfully."

--- a/docs/adr/0003-release-candidate-channel-and-promotion.md
+++ b/docs/adr/0003-release-candidate-channel-and-promotion.md
@@ -164,4 +164,8 @@ the fixed `rc` prerelease in place, so `rc-desktop-dmg.yml` now posts a
 best-effort incoming-webhook message after the candidate assets are published.
 The separate path is intentional: it announces every RC iteration without
 changing the fixed-tag update-channel contract. A missing or failing webhook
-warns but does not fail the release after signed artifacts have published.
+warns but does not fail the release after signed artifacts have published. The
+fixed DMG asset continues to follow the update channel, while Slack links an
+additional versioned DMG that remains immutable for the candidate named in the
+announcement. Delivery uses bounded retries; manual posting is the recovery path
+for a notification that still fails.

--- a/docs/adr/0003-release-candidate-channel-and-promotion.md
+++ b/docs/adr/0003-release-candidate-channel-and-promotion.md
@@ -167,5 +167,7 @@ changing the fixed-tag update-channel contract. A missing or failing webhook
 warns but does not fail the release after signed artifacts have published. The
 fixed DMG asset continues to follow the update channel, while Slack links an
 additional versioned DMG that remains immutable for the candidate named in the
-announcement. Delivery uses bounded retries; manual posting is the recovery path
-for a notification that still fails.
+announcement. The versioned asset is uploaded without replacement, and the RC
+version guard fails closed unless GitHub explicitly reports that the fixed
+release does not exist. Delivery uses bounded retries; manual posting is the
+recovery path for a notification that still fails.

--- a/docs/adr/0003-release-candidate-channel-and-promotion.md
+++ b/docs/adr/0003-release-candidate-channel-and-promotion.md
@@ -155,3 +155,13 @@ version-bump PR being merged first.
 - **The escape rule must stay a tested pure function.** Its correctness is not
   observable from the updater builder, so `should_update` is unit-tested for the
   stable-escape, rc-forward-only, and clean-stable-forward-only cases.
+
+## 2026-07-16 addendum: RC Slack announcements
+
+Stable announcements remain delegated to the GitHub Slack app because every
+stable version is a newly published `vX.Y.Z` release. RC iterations still edit
+the fixed `rc` prerelease in place, so `rc-desktop-dmg.yml` now posts a
+best-effort incoming-webhook message after the candidate assets are published.
+The separate path is intentional: it announces every RC iteration without
+changing the fixed-tag update-channel contract. A missing or failing webhook
+warns but does not fail the release after signed artifacts have published.

--- a/docs/adr/0003-release-candidate-channel-and-promotion.md
+++ b/docs/adr/0003-release-candidate-channel-and-promotion.md
@@ -163,9 +163,9 @@ stable version is a newly published `vX.Y.Z` release. RC iterations still edit
 the fixed `rc` prerelease in place, so `rc-desktop-dmg.yml` now posts a
 best-effort incoming-webhook message after the candidate assets are published.
 The separate path is intentional: it announces every RC iteration without
-changing the fixed-tag update-channel contract. A missing or failing webhook
+changing the fixed-tag RC release channel contract. A missing or failing webhook
 warns but does not fail the release after signed artifacts have published. The
-fixed DMG asset continues to follow the update channel, while Slack links an
+fixed DMG asset continues to follow the RC release channel, while Slack links an
 additional versioned DMG that remains immutable for the candidate named in the
 announcement. The versioned asset is uploaded without replacement, and the RC
 version guard fails closed unless GitHub explicitly reports that the fixed

--- a/docs/adr/0003-release-candidate-channel-and-promotion.md
+++ b/docs/adr/0003-release-candidate-channel-and-promotion.md
@@ -169,5 +169,6 @@ fixed DMG asset continues to follow the RC release channel, while Slack links an
 additional versioned DMG that remains immutable for the candidate named in the
 announcement. The versioned asset is uploaded without replacement, and the RC
 version guard fails closed unless GitHub explicitly reports that the fixed
-release does not exist. Delivery uses bounded retries; manual posting is the
-recovery path for a notification that still fails.
+release does not exist. Webhook delivery gets one bounded attempt because the
+incoming webhook is not idempotent; on an unconfirmed result, the operator checks
+Slack before manually posting a recovery announcement.

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -137,10 +137,12 @@ It posts when a `vX.Y.Z` stable release is published. RC builds reuse the fixed
 `rc-desktop-release` workflow posts each successful candidate through
 `SLACK_WEBHOOK_URL` after its release assets are available. The webhook message
 links the source commit, that candidate's immutable versioned macOS DMG, and the
-fixed `rc` release page. Delivery uses bounded retries and reports its result in
-the Actions summary. It remains best effort and never turns a successfully
-published candidate into a failed release run; a missed announcement is handled
-manually rather than rerunning or replacing the signed release.
+fixed `rc` release page. Delivery uses one bounded attempt and reports its result
+in the Actions summary. It remains best effort and never turns a successfully
+published candidate into a failed release run. If delivery is unconfirmed, check
+Slack before posting manually; automatically retrying an incoming webhook could
+duplicate an announcement when Slack accepted the request but its response was
+lost.
 
 The app polls:
 

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -78,8 +78,11 @@ version `X.Y.Z-rc.N` (bundling the Hermes runtime), and publishes it to a fixed
 `rc` prerelease in `open-software-network/os-june-releases` with `latest-rc.json`.
 The fixed `June_universal.dmg` asset follows the current RC for the updater, while
 an immutable versioned DMG remains available for each Slack announcement. The
-workflow records the source commit in `rc-build.json` (so promote can rebuild the
-same tree) and does NOT touch `main`.
+versioned asset is uploaded without replacement before the fixed channel aliases;
+reuse a higher RC number if that append-only upload already exists. The workflow
+records the source commit in `rc-build.json` (so promote can rebuild the same
+tree) and does NOT touch `main`. It also fails closed if it cannot read the
+current RC metadata, preserving the channel's forward-only ordering.
 
 ### 2. Test the candidate
 

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -76,8 +76,10 @@ GitHub Actions -> rc-desktop-release -> Run workflow
 `rc-desktop-release` builds a signed + notarized `universal-apple-darwin` app at
 version `X.Y.Z-rc.N` (bundling the Hermes runtime), and publishes it to a fixed
 `rc` prerelease in `open-software-network/os-june-releases` with `latest-rc.json`.
-It records the source commit in `rc-build.json` (so promote can rebuild the same
-tree) and does NOT touch `main`.
+The fixed `June_universal.dmg` asset follows the current RC for the updater, while
+an immutable versioned DMG remains available for each Slack announcement. The
+workflow records the source commit in `rc-build.json` (so promote can rebuild the
+same tree) and does NOT touch `main`.
 
 ### 2. Test the candidate
 
@@ -130,9 +132,11 @@ It posts when a `vX.Y.Z` stable release is published. RC builds reuse the fixed
 `rc` release tag and are edited in place rather than re-published, so the
 `rc-desktop-release` workflow posts each successful candidate through
 `SLACK_WEBHOOK_URL` after its release assets are available. The webhook message
-links the source commit, macOS DMG, and fixed `rc` release page. Notification
-delivery is best effort and never turns a successfully published candidate into
-a failed release run.
+links the source commit, that candidate's immutable versioned macOS DMG, and the
+fixed `rc` release page. Delivery uses bounded retries and reports its result in
+the Actions summary. It remains best effort and never turns a successfully
+published candidate into a failed release run; a missed announcement is handled
+manually rather than rerunning or replacing the signed release.
 
 The app polls:
 

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -36,6 +36,9 @@ Create or confirm these before cutting the first updater release:
 - Production runtime secrets: `PRODUCTION_OS_ACCOUNTS_URL`,
   `PRODUCTION_OS_ACCOUNTS_API_URL`, `PRODUCTION_OS_ACCOUNTS_CLIENT_ID`, and
   `PRODUCTION_JUNE_API_URL`.
+- Slack incoming-webhook secret: `SLACK_WEBHOOK_URL`, configured for the release
+  announcements channel. An absent or failing webhook warns but does not fail an
+  otherwise successful RC build.
 - Optional fast release runner: a dedicated self-hosted Mac Studio runner with
   the `desktop-release` label. See
   [desktop-release-runner.md](desktop-release-runner.md).
@@ -116,16 +119,20 @@ it does not depend on the bump and can run as soon as promote finishes (see
 
 ## Release notifications
 
-Stable releases are announced in Slack by the org's GitHub Slack app. Subscribe a
-channel once with:
+Stable releases are announced in Slack by the org's GitHub Slack app. Subscribe
+the release announcements channel once with:
 
 ```text
 /github subscribe open-software-network/os-june-releases releases
 ```
 
 It posts when a `vX.Y.Z` stable release is published. RC builds reuse the fixed
-`rc` release tag and are edited in place rather than re-published, so they do not
-reliably trigger a Slack post; watch the `rc` release page for candidates.
+`rc` release tag and are edited in place rather than re-published, so the
+`rc-desktop-release` workflow posts each successful candidate through
+`SLACK_WEBHOOK_URL` after its release assets are available. The webhook message
+links the source commit, macOS DMG, and fixed `rc` release page. Notification
+delivery is best effort and never turns a successfully published candidate into
+a failed release run.
 
 The app polls:
 

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -78,11 +78,12 @@ version `X.Y.Z-rc.N` (bundling the Hermes runtime), and publishes it to a fixed
 `rc` prerelease in `open-software-network/os-june-releases` with `latest-rc.json`.
 The fixed `June_universal.dmg` asset follows the current RC for the updater, while
 an immutable versioned DMG remains available for each Slack announcement. The
-versioned asset is uploaded without replacement before the fixed channel aliases;
-reuse a higher RC number if that append-only upload already exists. The workflow
-records the source commit in `rc-build.json` (so promote can rebuild the same
-tree) and does NOT touch `main`. It also fails closed if it cannot read the
-current RC metadata, preserving the channel's forward-only ordering.
+versioned asset is uploaded without replacement before the fixed RC release
+channel aliases; reuse a higher RC number if that append-only upload already
+exists. The workflow records the source commit in `rc-build.json` (so promote can
+rebuild the same tree) and does NOT touch `main`. It also fails closed if it
+cannot read the current RC metadata, preserving the RC release channel's
+forward-only ordering.
 
 ### 2. Test the candidate
 


### PR DESCRIPTION
## Summary

- send a best-effort Slack webhook after each successful macOS RC publication
- include the RC version, source commit, immutable versioned DMG, and fixed RC release page
- keep fixed updater aliases while making RC provenance lookups fail closed
- document the webhook prerequisite and append the release-channel ADR clarification

## Why

The GitHub Slack subscription announces stable releases because each stable version is newly published. RC builds edit the fixed `rc` prerelease in place, so later candidates do not reliably create Slack updates.

## Validation

- `actionlint .github/workflows/rc-desktop-dmg.yml`
- `git diff --check`
- generated and asserted a sample Slack payload with Node
- verified the GitHub API lookup distinguishes an existing RC release from an explicit 404
- `make local-ci` after every pushed review fix and rebase (frontend and Rust/macOS signoffs correctly reported not applicable)
- standard repo review battery, five adversarial convergence rounds, and final Standards/Spec/Adversarial passes: clean/clean/approve

## Review fixes

- publish and link an append-only versioned DMG so old Slack messages never download a newer RC
- fail closed when the current RC cannot be read, except for an explicit GitHub 404
- upload immutable candidate artifacts without `--clobber`
- bound webhook delivery to one attempt so a lost response cannot create duplicate announcements
- qualify release-channel terminology per `CONTEXT.md`

## Visual testing

Not run. This change only affects release automation and documentation; it has no app UI surface.

## June API deploy

Not required.

## Out of scope

- stable release notifications remain on the existing GitHub Slack app subscription
- the existing multi-asset replacement behavior for fixed RC release channel aliases is unchanged; the Slack step runs only after that publication command succeeds

## Operational note

The production environment must provide `SLACK_WEBHOOK_URL`. Missing or unconfirmed webhook delivery warns without failing an RC whose signed assets already published. Check Slack before manually recovering an unconfirmed delivery.
