### PR TITLE
Fix explicit anonymized model routing

### DIFF
--- a/june-api/crates/domain/src/lib.rs
+++ b/june-api/crates/domain/src/lib.rs
@@ -159,6 +159,15 @@ impl ProviderCredentials {
     }
 }
 
+/// Privacy class advertised by the selected upstream model. This controls
+/// which model-routing-service policy is requested for service-managed calls.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum InferencePrivacy {
+    #[default]
+    Private,
+    Anonymized,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Authorization {
@@ -239,6 +248,7 @@ pub struct GenerationRequest {
     pub system_prompt: String,
     pub cost_quality: Option<f64>,
     pub provider_credentials: ProviderCredentials,
+    pub inference_privacy: InferencePrivacy,
     /// See `AgentChatRequest::unmetered`.
     pub unmetered: bool,
 }
@@ -253,6 +263,7 @@ pub struct CleanupRequest {
     pub model: ModelId,
     pub system_prompt: String,
     pub provider_credentials: ProviderCredentials,
+    pub inference_privacy: InferencePrivacy,
 }
 
 #[derive(Clone, Debug)]
@@ -260,6 +271,7 @@ pub struct AgentChatRequest {
     pub body: serde_json::Value,
     pub model: ModelId,
     pub provider_credentials: ProviderCredentials,
+    pub inference_privacy: InferencePrivacy,
     /// True when the caller settles no OS Accounts charge for this request
     /// (user-supplied upstream key). Providers may then use their full-route
     /// client: the shortened metered window exists only to keep settlement

--- a/june-api/crates/providers/src/venice.rs
+++ b/june-api/crates/providers/src/venice.rs
@@ -5,8 +5,8 @@ use june_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit, Upstrea
 use june_domain::{
     AgentChatCompleter, AgentChatCompletion, AgentChatRequest, AgentChatStream,
     AgentChatStreamOutcome, CleanedText, Cleaner, CleanupRequest, DomainError, GeneratedNote,
-    GenerationRequest, Generator, ProviderCredentials, TokenUsage, Transcriber, Transcript,
-    TranscriptionRequest, UpstreamRouteMetadata,
+    GenerationRequest, Generator, InferencePrivacy, ProviderCredentials, TokenUsage, Transcriber,
+    Transcript, TranscriptionRequest, UpstreamRouteMetadata,
 };
 use reqwest::{
     RequestBuilder, StatusCode,
@@ -19,6 +19,7 @@ use tokio::sync::{mpsc, oneshot};
 pub const PROVIDER_NAME: &str = "venice";
 const CONFIDENTIAL_COMPUTE_HEADER: &str = "X-Confidential-Compute";
 const PREFERRED_PRIVATE_ROUTING: &str = "preferred";
+const STANDARD_ANONYMIZED_ROUTING: &str = "disabled";
 const OS_PROVIDER_HEADER: &str = "X-OS-Provider";
 const OS_PRIVACY_LEVEL_HEADER: &str = "X-OS-Privacy-Level";
 const OS_ENDPOINT_HEADER: &str = "X-OS-Endpoint";
@@ -338,6 +339,7 @@ impl Generator for VeniceGenerator {
                 },
                 ChatCallAuth {
                     provider_credentials: &request.provider_credentials,
+                    inference_privacy: request.inference_privacy,
                     unmetered: request.unmetered,
                 },
             )
@@ -400,6 +402,7 @@ impl AgentChatCompleter for VeniceAgentChat {
                 request.model,
                 ChatCallAuth {
                     provider_credentials: &request.provider_credentials,
+                    inference_privacy: request.inference_privacy,
                     unmetered: request.unmetered,
                 },
             )
@@ -416,6 +419,7 @@ impl AgentChatCompleter for VeniceAgentChat {
                 request.model,
                 ChatCallAuth {
                     provider_credentials: &request.provider_credentials,
+                    inference_privacy: request.inference_privacy,
                     unmetered: request.unmetered,
                 },
             )
@@ -464,6 +468,7 @@ impl Cleaner for VeniceCleaner {
                 // it never gets the unmetered client.
                 ChatCallAuth {
                     provider_credentials: &request.provider_credentials,
+                    inference_privacy: request.inference_privacy,
                     unmetered: false,
                 },
             )
@@ -489,6 +494,7 @@ impl Cleaner for VeniceCleaner {
 #[derive(Clone, Copy)]
 struct ChatCallAuth<'a> {
     provider_credentials: &'a ProviderCredentials,
+    inference_privacy: InferencePrivacy,
     unmetered: bool,
 }
 
@@ -757,7 +763,11 @@ fn apply_private_routing(request: RequestBuilder, auth: ChatCallAuth<'_>) -> Req
     if auth.provider_credentials.has_venice_api_key() {
         request
     } else {
-        request.header(CONFIDENTIAL_COMPUTE_HEADER, PREFERRED_PRIVATE_ROUTING)
+        let routing = match auth.inference_privacy {
+            InferencePrivacy::Private => PREFERRED_PRIVATE_ROUTING,
+            InferencePrivacy::Anonymized => STANDARD_ANONYMIZED_ROUTING,
+        };
+        request.header(CONFIDENTIAL_COMPUTE_HEADER, routing)
     }
 }
 
@@ -1595,7 +1605,7 @@ mod tests {
     use june_config::UpstreamConfig;
     use june_domain::{
         AgentChatCompleter, AgentChatRequest, AgentChatStreamOutcome, DomainError,
-        GenerationRequest, Generator, ModelId, ProviderCredentials,
+        GenerationRequest, Generator, InferencePrivacy, ModelId, ProviderCredentials,
     };
     use pretty_assertions::assert_eq;
     use serde_json::json;
@@ -1655,6 +1665,7 @@ mod tests {
                 system_prompt: "system".to_string(),
                 cost_quality: None,
                 provider_credentials: ProviderCredentials::default(),
+                inference_privacy: InferencePrivacy::Private,
                 unmetered: false,
             })
             .await;
@@ -1724,6 +1735,7 @@ mod tests {
                 provider_credentials: ProviderCredentials {
                     venice_api_key: Some("user_venice_key".to_string()),
                 },
+                inference_privacy: InferencePrivacy::Private,
                 unmetered: true,
             })
             .await;
@@ -1774,6 +1786,7 @@ mod tests {
                 system_prompt: "system".to_string(),
                 cost_quality: None,
                 provider_credentials: ProviderCredentials::default(),
+                inference_privacy: InferencePrivacy::Private,
                 unmetered: false,
             })
             .await
@@ -1823,6 +1836,7 @@ mod tests {
                 system_prompt: "system".to_string(),
                 cost_quality: None,
                 provider_credentials: ProviderCredentials::default(),
+                inference_privacy: InferencePrivacy::Private,
                 unmetered: false,
             })
             .await
@@ -1899,6 +1913,7 @@ mod tests {
                 system_prompt: "system".to_string(),
                 cost_quality: None,
                 provider_credentials: ProviderCredentials::default(),
+                inference_privacy: InferencePrivacy::Private,
                 unmetered: false,
             })
             .await;
@@ -1940,6 +1955,7 @@ mod tests {
                 system_prompt: "system".to_string(),
                 cost_quality: None,
                 provider_credentials: ProviderCredentials::default(),
+                inference_privacy: InferencePrivacy::Private,
                 unmetered: false,
             })
             .await;
@@ -2128,6 +2144,7 @@ mod tests {
                 }),
                 model: ModelId("text-model".to_string()),
                 provider_credentials: ProviderCredentials::default(),
+                inference_privacy: InferencePrivacy::Private,
                 unmetered: false,
             })
             .await
@@ -2139,6 +2156,46 @@ mod tests {
         assert_eq!(completion.route.provider.as_deref(), Some("phala"));
         assert_eq!(completion.route.privacy_level.as_deref(), Some("tee"));
         assert_eq!(completion.route.endpoint.as_deref(), Some("phala-glm-5.2"));
+    }
+
+    #[tokio::test]
+    async fn agent_chat_uses_standard_route_for_anonymized_model() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("x-confidential-compute", "disabled"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{ "message": { "content": "hi" } }],
+                "usage": { "prompt_tokens": 1, "completion_tokens": 2 }
+            })))
+            .mount(&server)
+            .await;
+        let agent = VeniceAgentChat::from_config(
+            http::default_client(),
+            http::default_client(),
+            &UpstreamConfig {
+                api_key: "venice_key".to_string(),
+                base_url: server.uri(),
+                byok_base_url: None,
+            },
+        );
+
+        let completion = agent
+            .complete(AgentChatRequest {
+                body: json!({
+                    "model": "kimi-k3",
+                    "messages": [{ "role": "user", "content": "hi" }],
+                }),
+                model: ModelId("kimi-k3".to_string()),
+                provider_credentials: ProviderCredentials::default(),
+                inference_privacy: InferencePrivacy::Anonymized,
+                unmetered: false,
+            })
+            .await
+            .expect("completion succeeds");
+
+        assert_eq!(completion.usage.prompt_tokens, 1);
+        assert_eq!(completion.usage.completion_tokens, 2);
     }
 
     #[tokio::test]
@@ -2173,6 +2230,7 @@ mod tests {
                 provider_credentials: ProviderCredentials {
                     venice_api_key: Some("VENICE_INFERENCE_KEY_bad".to_string()),
                 },
+                inference_privacy: InferencePrivacy::Private,
                 unmetered: true,
             })
             .await
@@ -2359,6 +2417,7 @@ mod tests {
                 system_prompt: "caller system prompt".to_string(),
                 cost_quality: None,
                 provider_credentials: ProviderCredentials::default(),
+                inference_privacy: InferencePrivacy::Private,
                 unmetered: false,
             })
             .await
@@ -2406,6 +2465,7 @@ mod tests {
                 }),
                 model: ModelId("text-model".to_string()),
                 provider_credentials: ProviderCredentials::default(),
+                inference_privacy: InferencePrivacy::Private,
                 unmetered: false,
             })
             .await
@@ -2591,6 +2651,7 @@ mod tests {
             }),
             model: ModelId("text-model".to_string()),
             provider_credentials: ProviderCredentials::default(),
+            inference_privacy: InferencePrivacy::Private,
             unmetered: false,
         }
     }

--- a/june-api/crates/services/src/agent_chat.rs
+++ b/june-api/crates/services/src/agent_chat.rs
@@ -45,6 +45,7 @@ impl AgentChatService {
     pub async fn complete(&self, params: AgentChatParams) -> Result<AgentChatOutput, ServiceError> {
         self.pricing
             .ensure_model_kind(&params.model_id.0, ModelKind::Text)?;
+        let inference_privacy = self.pricing.inference_privacy(&params.model_id.0);
         if uses_user_venice_key_for_model(
             &self.pricing,
             &params.model_id.0,
@@ -56,6 +57,7 @@ impl AgentChatService {
                     body: params.body,
                     model: params.model_id.clone(),
                     provider_credentials: params.provider_credentials.clone(),
+                    inference_privacy,
                     unmetered: true,
                 })
                 .await?;
@@ -81,6 +83,7 @@ impl AgentChatService {
                 body: params.body,
                 model: params.model_id.clone(),
                 provider_credentials: params.provider_credentials.clone(),
+                inference_privacy,
                 unmetered: false,
             })
             .await
@@ -125,6 +128,7 @@ impl AgentChatService {
     ) -> Result<AgentChatStreamOutput, ServiceError> {
         self.pricing
             .ensure_model_kind(&params.model_id.0, ModelKind::Text)?;
+        let inference_privacy = self.pricing.inference_privacy(&params.model_id.0);
         if uses_user_venice_key_for_model(
             &self.pricing,
             &params.model_id.0,
@@ -136,6 +140,7 @@ impl AgentChatService {
                     body: params.body,
                     model: params.model_id.clone(),
                     provider_credentials: params.provider_credentials.clone(),
+                    inference_privacy,
                     unmetered: true,
                 })
                 .await?;
@@ -167,6 +172,7 @@ impl AgentChatService {
                 body: params.body,
                 model: params.model_id.clone(),
                 provider_credentials: params.provider_credentials.clone(),
+                inference_privacy,
                 unmetered: false,
             })
             .await

--- a/june-api/crates/services/src/dictate.rs
+++ b/june-api/crates/services/src/dictate.rs
@@ -157,6 +157,7 @@ impl DictateService {
     ) -> Result<DictateCleanupOutput, ServiceError> {
         self.pricing
             .ensure_model_kind(&params.model_id.0, ModelKind::Text)?;
+        let inference_privacy = self.pricing.inference_privacy(&params.model_id.0);
         if uses_user_venice_key_for_model(
             &self.pricing,
             &params.model_id.0,
@@ -172,6 +173,7 @@ impl DictateService {
                     model: params.model_id.clone(),
                     system_prompt: prompts::DICTATE_CLEANUP.to_string(),
                     provider_credentials: params.provider_credentials.clone(),
+                    inference_privacy,
                 })
                 .await?;
             log_skipped_user_venice_key(
@@ -202,6 +204,7 @@ impl DictateService {
                 model: params.model_id.clone(),
                 system_prompt: prompts::DICTATE_CLEANUP.to_string(),
                 provider_credentials: params.provider_credentials.clone(),
+                inference_privacy,
             })
             .await
         {

--- a/june-api/crates/services/src/issue_reports.rs
+++ b/june-api/crates/services/src/issue_reports.rs
@@ -115,6 +115,7 @@ impl IssueReportService {
             body: issue_report_diagnosis_body(report),
             model: model.clone(),
             provider_credentials: ProviderCredentials::default(),
+            inference_privacy: june_domain::InferencePrivacy::Private,
             unmetered: false,
         };
         match timeout(

--- a/june-api/crates/services/src/note_generate.rs
+++ b/june-api/crates/services/src/note_generate.rs
@@ -49,6 +49,7 @@ impl NoteGenerateService {
     ) -> Result<NoteGenerateOutput, ServiceError> {
         self.pricing
             .ensure_model_kind(&params.model_id.0, ModelKind::Text)?;
+        let inference_privacy = self.pricing.inference_privacy(&params.model_id.0);
         if uses_user_venice_key_for_model(
             &self.pricing,
             &params.model_id.0,
@@ -67,6 +68,7 @@ impl NoteGenerateService {
                     system_prompt: prompts::NOTE_GENERATE.to_string(),
                     cost_quality: params.cost_quality,
                     provider_credentials: params.provider_credentials.clone(),
+                    inference_privacy,
                     unmetered: true,
                 })
                 .await?;
@@ -75,14 +77,8 @@ impl NoteGenerateService {
                 &params.user_id,
                 &params.model_id.0,
             );
-            return Ok(NoteGenerateOutput {
-                generated,
-                receipt: zero_receipt(),
-                prompt_version: NOTE_GENERATE_PROMPT_VERSION.to_string(),
-            });
+            return Ok(note_generate_output(generated, zero_receipt()));
         }
-        // Flat-estimate mode — see note_transcribe.rs. The actual charge below
-        // is still computed from real token usage; only the Hold size changes.
         let estimate = Credits(self.flat_estimate_credits);
         let authorization = authorize_or_deny(AuthorizeParams {
             os_accounts: self.os_accounts.as_ref(),
@@ -105,6 +101,7 @@ impl NoteGenerateService {
                 system_prompt: prompts::NOTE_GENERATE.to_string(),
                 cost_quality: params.cost_quality,
                 provider_credentials: params.provider_credentials.clone(),
+                inference_privacy,
                 unmetered: false,
             })
             .await
@@ -141,11 +138,15 @@ impl NoteGenerateService {
             &params.model_id.0,
             &receipt,
         );
-        Ok(NoteGenerateOutput {
-            generated,
-            receipt,
-            prompt_version: NOTE_GENERATE_PROMPT_VERSION.to_string(),
-        })
+        Ok(note_generate_output(generated, receipt))
+    }
+}
+
+fn note_generate_output(generated: GeneratedNote, receipt: Receipt) -> NoteGenerateOutput {
+    NoteGenerateOutput {
+        generated,
+        receipt,
+        prompt_version: NOTE_GENERATE_PROMPT_VERSION.to_string(),
     }
 }
 

--- a/june-api/crates/services/src/pricing.rs
+++ b/june-api/crates/services/src/pricing.rs
@@ -1,5 +1,5 @@
 use june_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
-use june_domain::{Credits, ModelKind, TokenUsage};
+use june_domain::{Credits, InferencePrivacy, ModelKind, TokenUsage};
 use std::collections::BTreeMap;
 use thiserror::Error;
 
@@ -59,6 +59,14 @@ impl PricingTable {
         self.models
             .get(model_id)
             .is_some_and(|model| model.provider == ModelProvider::Venice)
+    }
+
+    pub fn inference_privacy(&self, model_id: &str) -> InferencePrivacy {
+        self.models
+            .get(model_id)
+            .and_then(|model| model.privacy.as_deref())
+            .filter(|privacy| privacy.eq_ignore_ascii_case("anonymized"))
+            .map_or(InferencePrivacy::Private, |_| InferencePrivacy::Anonymized)
     }
 
     pub fn ensure_model_kind(&self, model_id: &str, kind: ModelKind) -> Result<(), PricingError> {
@@ -145,7 +153,7 @@ pub enum PricingError {
 mod tests {
     use super::{PricingError, PricingTable};
     use june_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
-    use june_domain::{ModelKind, TokenUsage};
+    use june_domain::{InferencePrivacy, ModelKind, TokenUsage};
     use pretty_assertions::assert_eq;
     use std::collections::BTreeMap;
 
@@ -204,6 +212,31 @@ mod tests {
                 )
                 .map(|credits| credits.0),
             Ok(1)
+        );
+    }
+
+    #[test]
+    fn derives_inference_privacy_and_fails_closed() {
+        let mut configured = models([(
+            "anonymized-text",
+            PriceUnit::Tokens,
+            70,
+            300,
+            ModelType::Text,
+        )]);
+        configured
+            .get_mut("anonymized-text")
+            .expect("model exists")
+            .privacy = Some("Anonymized".to_string());
+        let table = PricingTable::new(configured);
+
+        assert_eq!(
+            table.inference_privacy("anonymized-text"),
+            InferencePrivacy::Anonymized
+        );
+        assert_eq!(
+            table.inference_privacy("missing-model"),
+            InferencePrivacy::Private
         );
     }
 


### PR DESCRIPTION
## Summary

- carry catalog privacy metadata through June API text-inference requests
- keep Auto and private models on zero-retention-first routing
- route explicitly selected anonymized models, including `kimi-k3`, through the standard route
- leave BYOK routing direct and unchanged

## Root cause

June imported Kimi K3 from the live catalog as an anonymized model, but every service-managed text request still sent `X-Confidential-Compute: preferred`. The model routing service interprets that as a no-retention privacy floor, so K3 had no eligible endpoint and June surfaced the rejection as `upstream_provider_failed`.

## User impact

Auto remains private-only and cannot select Kimi K3. A user who explicitly selects Kimi K3 now receives Kimi K3 through its advertised anonymized route.

## Validation

- `pnpm test:june-api`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all --check`
- focused K3 anonymized-routing regression test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786817499&installation_id=144203540&pr_number=799&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F799&signature=49735a6c8f7c49023f0048654cfe3b2ed5d58896fa1058279007d6a0533717b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->