### PR TITLE
Polish private sharing and copy feedback

### DIFF
--- a/docs/private-sharing-design.md
+++ b/docs/private-sharing-design.md
@@ -7,10 +7,14 @@ Sharing is deliberately a bearer-link flow:
 1. The owner clicks **Share**.
 2. They may enable **Require a passcode** and choose a passcode of at least
    eight characters.
-3. **Copy link** creates one encrypted snapshot and copies its URL.
-4. Anyone with the link can view without an OS Accounts sign-in. A protected
+3. **Create link** creates one encrypted snapshot, reveals its URL, and copies
+   it to the clipboard.
+4. **Copy** copies the URL again.
+5. Once a link exists, a link action beside the current breadcrumb copies it
+   without reopening the Share dialog.
+6. Anyone with the link can view without an OS Accounts sign-in. A protected
    link also requires the separately shared passcode.
-5. **Stop sharing** revokes the link for everyone.
+7. **Stop sharing** revokes the link for everyone.
 
 The link and passcode are transferable. There is no recipient list,
 per-recipient audit, or per-recipient revocation. Stopping a share cannot erase

--- a/june-api/crates/api/src/handlers/share_viewer_page.css
+++ b/june-api/crates/api/src/handlers/share_viewer_page.css
@@ -10,6 +10,7 @@
   --border-strong: rgba(45, 43, 39, 0.2);
   --primary: #34332f;
   --primary-fg: #ffffff;
+  --danger: #b04a35;
   --focus: rgba(98, 91, 80, 0.2);
   --shadow: 0 1px 2px rgba(36, 34, 30, 0.04), 0 18px 48px rgba(36, 34, 30, 0.08);
 }
@@ -26,6 +27,7 @@
     --border-strong: rgba(255, 255, 255, 0.18);
     --primary: #dedbd3;
     --primary-fg: #272622;
+    --danger: #e0a696;
     --focus: rgba(211, 205, 194, 0.18);
     --shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 20px 56px rgba(0, 0, 0, 0.28);
   }
@@ -62,6 +64,7 @@ a:focus-visible {
   box-shadow: 0 0 0 3px var(--focus);
 }
 
+/* ── Topbar (quiet header; hidden until decryption succeeds) ──────────────── */
 #topbar {
   position: sticky;
   top: 0;
@@ -69,7 +72,7 @@ a:focus-visible {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: 46px;
+  min-height: 48px;
   padding: 0 20px;
   border-bottom: 1px solid var(--border);
   background: color-mix(in srgb, var(--page) 86%, transparent);
@@ -100,38 +103,64 @@ a:focus-visible {
   display: inline-flex;
   align-items: center;
   min-height: 30px;
-  padding: 0 11px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--card);
-  color: var(--fg);
+  padding: 0 12px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--body-copy);
   font-size: 12px;
+  font-weight: 500;
   text-decoration: none;
   transition:
     background-color 120ms ease,
-    border-color 120ms ease;
+    color 120ms ease;
 }
 
 #download-cta:hover {
-  border-color: var(--border-strong);
   background: var(--surface);
+  color: var(--fg);
 }
 
+/* ── Layout ──────────────────────────────────────────────────────────────── */
 #main {
-  width: min(100%, 808px);
+  width: min(100%, 720px);
   margin: 0 auto;
-  padding: 56px 24px 96px;
+  padding: 32px 24px 120px;
 }
 
+/* ── Loading state: quiet centered spinner + line ────────────────────────── */
 #status {
-  width: min(100%, 460px);
-  margin: 12vh auto 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  width: min(100%, 420px);
+  margin: min(20vh, 176px) auto 0;
   color: var(--muted);
   text-align: center;
+  line-height: 1.55;
 }
 
+#status::before {
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--border);
+  border-top-color: var(--fg);
+  border-radius: 50%;
+  animation: share-spin 720ms linear infinite;
+  content: "";
+}
+
+@keyframes share-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Error state: centered quiet card, supportive copy ───────────────────── */
 #status.error {
-  padding: 20px;
+  display: block;
+  gap: 0;
+  width: min(100%, 430px);
+  margin: min(18vh, 150px) auto 0;
+  padding: 22px 26px;
   border: 1px solid var(--border);
   border-radius: 14px;
   background: var(--card);
@@ -139,53 +168,68 @@ a:focus-visible {
   box-shadow: var(--shadow);
 }
 
+#status.error::before { display: none; }
+
+/* ── Passcode gate ───────────────────────────────────────────────────────── */
 #passcode {
-  width: min(100%, 460px);
-  margin: 10vh auto 0;
-  padding: 20px;
+  width: min(100%, 430px);
+  margin: min(16vh, 132px) auto 0;
+  padding: 26px 26px 24px;
   border: 1px solid var(--border);
-  border-radius: 14px;
+  border-radius: 16px;
   background: var(--card);
   box-shadow: var(--shadow);
 }
 
 .eyebrow {
-  margin: 0 0 8px;
+  margin: 0 0 10px;
   color: var(--muted);
   font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
 }
 
 #passcode h1 {
   margin: 0;
-  font-size: 16px;
+  font-size: 17px;
   font-weight: 500;
   letter-spacing: -0.01em;
   line-height: 1.3;
 }
 
 .passcode-copy {
-  margin: 6px 0 18px;
+  margin: 7px 0 20px;
   color: var(--muted);
+  line-height: 1.5;
 }
 
 #passcode-form {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 6px 8px;
+  gap: 14px;
+}
+
+.field {
+  display: grid;
+  gap: 7px;
 }
 
 #passcode-form label {
-  grid-column: 1 / -1;
   color: var(--fg);
+  font-size: 12px;
+}
+
+.input-wrap {
+  position: relative;
+  display: flex;
 }
 
 #passcode-input {
   width: 100%;
   min-width: 0;
-  min-height: 34px;
-  padding: 7px 9px;
+  min-height: 38px;
+  padding: 8px 42px 8px 11px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 9px;
   background: var(--card);
   color: var(--fg);
   transition:
@@ -201,37 +245,74 @@ a:focus-visible {
   box-shadow: 0 0 0 3px var(--focus);
 }
 
-#passcode-form button {
-  min-height: 34px;
-  padding: 0 13px;
+.passcode-toggle {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.passcode-toggle:hover {
+  background: var(--surface);
+  color: var(--fg);
+}
+
+.passcode-toggle .icon {
+  display: block;
+  width: 17px;
+  height: 17px;
+}
+
+.passcode-toggle .icon-hide { display: none; }
+.passcode-toggle[aria-pressed="true"] .icon-show { display: none; }
+.passcode-toggle[aria-pressed="true"] .icon-hide { display: block; }
+
+.continue {
+  width: 100%;
+  min-height: 38px;
+  padding: 0 14px;
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: 9px;
   background: var(--primary);
   color: var(--primary-fg);
+  font-weight: 500;
   cursor: pointer;
   transition:
     filter 120ms ease,
     transform 120ms ease;
 }
 
-#passcode-form button:hover { filter: brightness(0.94); }
-#passcode-form button:active { transform: translateY(1px); }
+.continue:hover { filter: brightness(0.94); }
+.continue:active { transform: translateY(1px); }
 
 #passcode-error {
-  margin: 10px 0 0;
-  color: var(--body-copy);
+  margin: 0;
+  color: var(--danger);
+  font-size: 12px;
+  line-height: 1.45;
 }
 
+/* ── Decrypted content: quiet reading column ─────────────────────────────── */
 #content {
-  padding: 44px 52px 56px;
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  background: var(--card);
-  box-shadow: var(--shadow);
+  padding: 12px 4px 0;
 }
 
 #content-title {
-  margin: 0 0 5px;
+  margin: 0 0 6px;
   color: var(--fg);
   font-size: 30px;
   font-weight: 500;
@@ -240,7 +321,7 @@ a:focus-visible {
 }
 
 #content-meta {
-  margin: 0 0 36px;
+  margin: 0 0 40px;
   color: var(--muted);
   font-size: 12px;
 }
@@ -271,7 +352,8 @@ a:focus-visible {
 
 #content-body p { margin: 0 0 14px; }
 
-#content-body ul {
+#content-body ul,
+#content-body ol {
   margin: 0 0 18px;
   padding-left: 20px;
 }
@@ -285,12 +367,16 @@ a:focus-visible {
   text-underline-offset: 3px;
 }
 
+#content-body a:hover { text-decoration-color: var(--fg); }
+
+#content-body strong { font-weight: 500; }
+
 #content-body pre {
   margin: 18px 0;
   padding: 12px 14px;
   overflow-x: auto;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 9px;
   background: var(--surface);
 }
 
@@ -307,6 +393,7 @@ a:focus-visible {
   background: none;
 }
 
+/* ── Transcript turns (session shares mirror June chat) ──────────────────── */
 .turn {
   display: flex;
   width: 100%;
@@ -325,8 +412,8 @@ a:focus-visible {
 
 .turn.user .turn-body {
   max-width: 82%;
-  padding: 9px 12px;
-  border-radius: 10px;
+  padding: 10px 13px;
+  border-radius: 12px;
   background: var(--surface);
   color: var(--fg);
   line-height: 1.55;
@@ -337,25 +424,25 @@ a:focus-visible {
   line-height: 1.65;
 }
 
+/* ── Responsive ──────────────────────────────────────────────────────────── */
 @media (max-width: 640px) {
   #topbar { padding: 0 14px; }
 
-  #main { padding: 28px 14px 64px; }
+  #main { padding: 24px 16px 72px; }
 
+  #status { margin-top: 16vh; }
+
+  #status.error,
   #passcode {
-    margin-top: 8vh;
-    padding: 18px;
+    margin-top: 10vh;
+    padding: 22px 20px;
   }
 
-  #passcode-form { grid-template-columns: 1fr; }
-
-  #passcode-form button { width: 100%; }
-
-  #content {
-    padding: 28px 22px 38px;
-  }
+  #content { padding-top: 8px; }
 
   #content-title { font-size: 25px; }
+
+  #content-meta { margin-bottom: 32px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -364,5 +451,10 @@ a:focus-visible {
   *::after {
     scroll-behavior: auto !important;
     transition: none !important;
+  }
+
+  #status::before {
+    animation: none;
+    border-top-color: var(--border);
   }
 }

--- a/june-api/crates/api/src/handlers/share_viewer_page.html
+++ b/june-api/crates/api/src/handlers/share_viewer_page.html
@@ -19,11 +19,27 @@
     <h1>Passcode required</h1>
     <p class="passcode-copy">Enter the passcode the sender shared with you.</p>
     <form id="passcode-form">
-      <label for="passcode-input">Passcode</label>
-      <input id="passcode-input" type="password" autocomplete="current-password" autofocus required>
-      <button type="submit">Continue</button>
+      <div class="field">
+        <label for="passcode-input">Passcode</label>
+        <div class="input-wrap">
+          <input id="passcode-input" type="password" autocomplete="current-password" autofocus required>
+          <button type="button" id="passcode-toggle" class="passcode-toggle" aria-label="Show passcode" aria-pressed="false">
+            <svg class="icon icon-show" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M2 12s3.6-7 10-7 10 7 10 7-3.6 7-10 7-10-7-10-7Z"></path>
+              <circle cx="12" cy="12" r="3"></circle>
+            </svg>
+            <svg class="icon icon-hide" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M3 3l18 18"></path>
+              <path d="M10.6 5.2A9.7 9.7 0 0 1 12 5c6.4 0 10 7 10 7a17 17 0 0 1-3.4 4.2"></path>
+              <path d="M6.7 6.7A16.8 16.8 0 0 0 2 12s3.6 7 10 7a9.6 9.6 0 0 0 4-.85"></path>
+              <path d="M9.9 9.9a3 3 0 0 0 4.2 4.2"></path>
+            </svg>
+          </button>
+        </div>
+      </div>
+      <p id="passcode-error" role="alert" hidden></p>
+      <button type="submit" class="continue">Continue</button>
     </form>
-    <p id="passcode-error" role="alert" hidden></p>
   </section>
   <article id="content" hidden>
     <h1 id="content-title"></h1>

--- a/june-api/crates/api/src/handlers/share_viewer_page.js
+++ b/june-api/crates/api/src/handlers/share_viewer_page.js
@@ -302,8 +302,21 @@
     var form = document.getElementById("passcode-form");
     var input = document.getElementById("passcode-input");
     var errorEl = document.getElementById("passcode-error");
+    var toggle = document.getElementById("passcode-toggle");
     panel.hidden = false;
     input.focus();
+    if (toggle) {
+      toggle.onclick = function () {
+        var reveal = input.type === "password";
+        input.type = reveal ? "text" : "password";
+        toggle.setAttribute("aria-pressed", reveal ? "true" : "false");
+        toggle.setAttribute(
+          "aria-label",
+          reveal ? "Hide passcode" : "Show passcode"
+        );
+        input.focus();
+      };
+    }
     form.onsubmit = async function (event) {
       event.preventDefault();
       errorEl.hidden = true;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@react-three/drei": "^9",
     "@react-three/fiber": "^8",
     "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-notification": "^2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.1
         version: 2.11.1
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-deep-link':
         specifier: ^2.4.9
         version: 2.4.9
@@ -266,24 +269,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.16':
     resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.16':
     resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.16':
     resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.16':
     resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
@@ -778,66 +785,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -895,30 +915,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.3':
     resolution: {integrity: sha512-qomqYS+yAkd0gXMRmhguWXc7RfVN+XKKXaEwbf5QmKURwydLFOTldd6F8/WoZDSsBMrV8dpNxz0YneGLmobiSA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.3':
     resolution: {integrity: sha512-jOCXbDqeDj5XcclsOBAaXjtTgwZCVg8zEZ+dbPUCoADOgljFgL0rOkYTc96vUYgOrYEfuHYihWMxIDGaD6GwJw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.3':
     resolution: {integrity: sha512-+u3HO/F3gHwL48t9gWN/urqZvpaEJzBFmTaq5eSIhvy8TOvnhb+LgJr3Q3BG+5JxuBrCUjqtOEz6gMttdJFSBA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.3':
     resolution: {integrity: sha512-spr5Jpr6KF/vehkLwJ0YmdGv8QwpWU+uw7J8bgijO0sox6ZCYsSNMbcsQjTqPi4xl+p0woIYpWXgChgHYpAc8g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.3':
     resolution: {integrity: sha512-abkoRQih5xBa3vz2spWaex0kP/MzVzVPQHom2f8jnCq46R/luOD6Uy85EMU9/bfzf6ZzdorWJsgO+OMX90Fx2w==}
@@ -942,6 +967,9 @@ packages:
     resolution: {integrity: sha512-EElQe8z8uD7Pi5++tJ/UfEwWuK08rd3oCDYdeIbJAb6pZRrxlqmoF5gh5H5YvzmUPhS4IRCaLSsQhvWkrfK+GQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@tauri-apps/plugin-deep-link@2.4.9':
     resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
@@ -2983,6 +3011,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.3
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.3
       '@tauri-apps/cli-win32-x64-msvc': 2.11.3
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-deep-link@2.4.9':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -85,6 +85,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,7 +525,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -563,6 +584,15 @@ dependencies = [
  "glob",
  "libc",
  "libloading 0.8.9",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
 ]
 
 [[package]]
@@ -1005,6 +1035,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1203,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1196,6 +1244,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1478,6 +1532,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +1727,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2007,6 +2082,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2542,6 +2618,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,6 +2726,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2917,6 +3003,7 @@ dependencies = [
  "sqlx-sqlite",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
@@ -2932,6 +3019,16 @@ dependencies = [
  "window-vibrancy",
  "windows 0.61.3",
  "zeroize",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3007,6 +3104,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -3253,6 +3361,12 @@ name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4572,6 +4686,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-deep-link"
 version = "2.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4885,6 +5014,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5239,6 +5382,17 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
 ]
 
 [[package]]
@@ -5599,6 +5753,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5727,6 +5951,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -6331,6 +6561,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6400,6 +6648,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"
@@ -6606,6 +6871,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,7 @@ sha2 = "0.10"
 sqlx = { package = "sqlx-core", version = "0.8", default-features = false, features = ["_rt-tokio", "chrono", "uuid"] }
 sqlx-sqlite = { version = "0.8", default-features = false, features = ["bundled", "chrono", "uuid"] }
 tauri = { version = "2.8.0", features = ["protocol-asset", "macos-private-api", "tray-icon", "image-png"] }
+tauri-plugin-clipboard-manager = "2.3.2"
 tauri-plugin-deep-link = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -9,6 +9,7 @@
     "deep-link:default",
     "notification:default",
     "dialog:allow-open",
+    "clipboard-manager:allow-write-text",
     "process:allow-restart"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -117,6 +117,7 @@ pub fn run() {
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .on_menu_event(|app, event| {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1014,11 +1014,11 @@ export function App() {
   const [confirmDeleteNote, setConfirmDeleteNote] = useState(false);
   const [shareNoteOpen, setShareNoteOpen] = useState(false);
   const [noteShareUrl, setNoteShareUrl] = useState<string | null>(null);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset note-scoped UI on selection change
   useEffect(() => {
     setNoteChatOpen(false);
     setConfirmDeleteNote(false);
     setShareNoteOpen(false);
-    setNoteShareUrl(null);
   }, [selectedNoteId]);
   // The note's Ask June chat is owned here, not inside the panel, so its
   // session and working state survive the panel closing: a fired-off question

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -35,6 +35,7 @@ import { exportNoteAsPdf } from "../lib/note-pdf";
 import { NoteChatPanel } from "../components/note-chat/NoteChatPanel";
 import { useNoteChat } from "../components/note-chat/useNoteChat";
 import { ShareDialog } from "../components/share/ShareDialog";
+import { ShareLinkCopyAction } from "../components/share/ShareLinkCopyAction";
 import { buildNotePayload, noteReadyToShare } from "../lib/share-payload";
 import { GlobalRecorderPill } from "../components/recorder/GlobalRecorderPill";
 import type { GlobalRecorderDemoApi } from "../lib/global-recorder-demo";
@@ -1012,10 +1013,12 @@ export function App() {
   noteChatOpenRef.current = noteChatOpen;
   const [confirmDeleteNote, setConfirmDeleteNote] = useState(false);
   const [shareNoteOpen, setShareNoteOpen] = useState(false);
+  const [noteShareUrl, setNoteShareUrl] = useState<string | null>(null);
   useEffect(() => {
     setNoteChatOpen(false);
     setConfirmDeleteNote(false);
     setShareNoteOpen(false);
+    setNoteShareUrl(null);
   }, [selectedNoteId]);
   // The note's Ask June chat is owned here, not inside the panel, so its
   // session and working state survive the panel closing: a fired-off question
@@ -4121,6 +4124,7 @@ export function App() {
                         },
                         {
                           label: selectedNote.title.trim() || "New note",
+                          action: noteShareUrl ? <ShareLinkCopyAction url={noteShareUrl} /> : null,
                         },
                       ]}
                       actions={noteToolbarActions}
@@ -4142,6 +4146,7 @@ export function App() {
                         },
                         {
                           label: selectedNote.title.trim() || "New note",
+                          action: noteShareUrl ? <ShareLinkCopyAction url={noteShareUrl} /> : null,
                         },
                       ]}
                       actions={noteToolbarActions}
@@ -4150,7 +4155,10 @@ export function App() {
                     <BreadcrumbBar
                       items={[
                         { label: "Notes", onClick: () => setActiveView("all-notes") },
-                        { label: selectedNote.title.trim() || "New note" },
+                        {
+                          label: selectedNote.title.trim() || "New note",
+                          action: noteShareUrl ? <ShareLinkCopyAction url={noteShareUrl} /> : null,
+                        },
                       ]}
                       actions={noteToolbarActions}
                     />
@@ -4344,8 +4352,10 @@ export function App() {
         />
         {selectedNote ? (
           <ShareDialog
+            key={selectedNote.id}
             open={shareNoteOpen}
             onClose={() => setShareNoteOpen(false)}
+            onLinkChange={setNoteShareUrl}
             item={{
               kind: "note",
               itemId: selectedNote.id,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -9,9 +9,7 @@ import { IconBolt } from "central-icons/IconBolt";
 import { IconBranchSimple } from "central-icons/IconBranchSimple";
 import { IconBubble3 } from "central-icons/IconBubble3";
 import { IconBubbleWide } from "central-icons/IconBubbleWide";
-import { IconCheckmark2Medium } from "central-icons/IconCheckmark2Medium";
 import { IconCheckmark2Small } from "central-icons/IconCheckmark2Small";
-import { IconClipboard } from "central-icons/IconClipboard";
 import { IconCrossMedium } from "central-icons/IconCrossMedium";
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconExclamationTriangle } from "central-icons/IconExclamationTriangle";
@@ -79,6 +77,7 @@ import { BackButton } from "../ui/BackButton";
 import { TierMiniCard } from "../account/FundingNotice";
 import type { FundingTier } from "../account/FundingNotice";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { CopyStateIcon } from "../ui/CopyStateIcon";
 import { Dialog } from "../ui/Dialog";
 import { EmptyState } from "../ui/EmptyState";
 import { HoverTip } from "../ui/HoverTip";
@@ -216,6 +215,7 @@ import {
 import { normalizeSteerText } from "../../lib/hermes-session-steer";
 import { buildSessionPayload } from "../../lib/share-payload";
 import { ShareDialog } from "../share/ShareDialog";
+import { ShareLinkCopyAction } from "../share/ShareLinkCopyAction";
 import { recordPositiveFeedbackSent } from "../../lib/referral-nudge";
 import { useScrollFade } from "../../lib/use-scroll-fade";
 import { unsupportedEventStore } from "../../lib/hermes-unsupported-events";
@@ -2777,10 +2777,12 @@ export function AgentWorkspace({
   // Session currently being shared through the private-sharing dialog
   // (JUN-308); only ever the selected session, set from the session bar menu.
   const [shareSessionId, setShareSessionId] = useState<string | null>(null);
+  const [sessionShareUrl, setSessionShareUrl] = useState<string | null>(null);
   // The share payload snapshots the selected session's visible transcript,
   // so the dialog must never outlive its selection.
   useEffect(() => {
     setShareSessionId(null);
+    setSessionShareUrl(null);
   }, [selectedHermesSessionId]);
   // Dev-only sample files seeded by window.__agentFiles — surfaced alongside
   // the conversation's own artifacts so the viewer can be exercised at will.
@@ -11315,6 +11317,11 @@ export function AgentWorkspace({
               ? (selectedHermesSession?.title ?? "")
               : undefined
           }
+          shareUrl={
+            !newSessionMode && selectedHermesSessionId && !selectedHermesSessionIsProvisional
+              ? (sessionShareUrl ?? undefined)
+              : undefined
+          }
           onRename={
             !newSessionMode && selectedHermesSessionId && !selectedHermesSessionIsProvisional
               ? (title) => renameHermesSession(selectedHermesSessionId, title)
@@ -11561,13 +11568,15 @@ export function AgentWorkspace({
               onClose={() => setCompactSessionId(null)}
             />
           ) : null}
-          {shareSessionId ? (
+          {!newSessionMode && selectedHermesSessionId && !selectedHermesSessionIsProvisional ? (
             <ShareDialog
-              open
+              key={selectedHermesSessionId}
+              open={shareSessionId === selectedHermesSessionId}
               onClose={() => setShareSessionId(null)}
+              onLinkChange={setSessionShareUrl}
               item={{
                 kind: "session",
-                itemId: shareSessionId,
+                itemId: selectedHermesSessionId,
                 title: selectedHermesSession?.title ?? "",
                 // Sessions share the visible user/assistant transcript only:
                 // tool events, reasoning, and hidden context never enter the
@@ -11626,6 +11635,7 @@ function AgentSessionBar({
   privacyBadge,
   fullMode,
   title,
+  shareUrl,
   artifactCount = 0,
   artifactsOpen = false,
   inProject = false,
@@ -11643,6 +11653,7 @@ function AgentSessionBar({
   privacyBadge?: ModelPrivacyBadge;
   fullMode?: boolean;
   title?: string;
+  shareUrl?: string;
   artifactCount?: number;
   artifactsOpen?: boolean;
   inProject?: boolean;
@@ -11752,7 +11763,10 @@ function AgentSessionBar({
                   }}
                 />
               ) : (
-                <span className="detail-breadcrumb-current">{title || "Untitled session"}</span>
+                <span className="detail-breadcrumb-current-group">
+                  <span className="detail-breadcrumb-current">{title || "Untitled session"}</span>
+                  {shareUrl ? <ShareLinkCopyAction url={shareUrl} /> : null}
+                </span>
               )}
             </li>
           ) : origin ? (
@@ -13221,7 +13235,7 @@ function AgentChatTurnRow({
       copyResetTimerRef.current = window.setTimeout(() => {
         setCopied(false);
         copyResetTimerRef.current = undefined;
-      }, 1400);
+      }, 1600);
     } catch {
       // Clipboard can fail in restricted contexts; leave the transcript alone.
     }
@@ -13248,6 +13262,7 @@ function AgentChatTurnRow({
       width={104}
       delay={TURN_ACTION_TIP_DELAY_MS}
       tip={copied ? "Copied" : "Copy message"}
+      forceOpen={copied}
       className="agent-turn-action-tip"
     >
       <button
@@ -13257,13 +13272,7 @@ function AgentChatTurnRow({
         data-copied={copied ? "true" : undefined}
         onClick={() => void copyTurn()}
       >
-        {copied ? (
-          // Medium checkmark: the small variant reads too slight as the only
-          // confirmation left now that the label is gone.
-          <IconCheckmark2Medium size={14} aria-hidden />
-        ) : (
-          <IconClipboard size={14} aria-hidden />
-        )}
+        <CopyStateIcon copied={copied} />
       </button>
     </HoverTip>
   ) : null;

--- a/src/components/agent/HermesTracePanel.tsx
+++ b/src/components/agent/HermesTracePanel.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState, useSyncExternalStore } from "react";
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { IconConsole } from "central-icons/IconConsole";
 import { IconCrossMedium } from "central-icons/IconCrossMedium";
-import { IconArrowInbox } from "central-icons/IconArrowInbox";
 import type { HermesTraceBuffer, HermesTraceEntry } from "../../lib/hermes-trace-buffer";
 import type { JuneHermesEventKind } from "../../lib/hermes-control-plane";
+import { CopyStateIcon } from "../ui/CopyStateIcon";
+import { HoverTip } from "../ui/HoverTip";
 
 /**
  * Dev/debug-only inspector for the raw Hermes wire (feature 15). Renders the
@@ -38,6 +39,17 @@ export function HermesTracePanel({
 
   const [sessionFilter, setSessionFilter] = useState<string | undefined>(sessionId);
   const [kindFilter, setKindFilter] = useState<TraceKindFilter>("all");
+  const [copied, setCopied] = useState(false);
+  const copyResetTimerRef = useRef<number | undefined>(undefined);
+
+  useEffect(
+    () => () => {
+      if (copyResetTimerRef.current !== undefined) {
+        window.clearTimeout(copyResetTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const sessionIds = useMemo(
     // `version` is the change signal; the buffer read returns live state.
@@ -64,6 +76,14 @@ export function HermesTracePanel({
     const bundle = buffer.exportSanitizedTrace(activeSession);
     try {
       await navigator.clipboard.writeText(JSON.stringify(bundle, null, 2));
+      setCopied(true);
+      if (copyResetTimerRef.current !== undefined) {
+        window.clearTimeout(copyResetTimerRef.current);
+      }
+      copyResetTimerRef.current = window.setTimeout(() => {
+        setCopied(false);
+        copyResetTimerRef.current = undefined;
+      }, 1600);
     } catch {
       // Clipboard can reject (permissions, headless); a dev tool swallows it.
     }
@@ -107,14 +127,24 @@ export function HermesTracePanel({
               ))}
             </select>
           </label>
-          <button
-            type="button"
-            className="hermes-trace-panel-button"
-            onClick={() => void copyTrace()}
+          <HoverTip
+            compact
+            width={112}
+            tip={copied ? "Copied" : "Copy trace"}
+            forceOpen={copied}
+            className="hermes-trace-copy-tip"
           >
-            <IconArrowInbox size={14} aria-hidden="true" />
-            Copy trace
-          </button>
+            <button
+              type="button"
+              className="hermes-trace-panel-button"
+              aria-label={copied ? "Trace copied" : "Copy trace"}
+              data-copied={copied ? "true" : undefined}
+              onClick={() => void copyTrace()}
+            >
+              <CopyStateIcon copied={copied} />
+              Copy trace
+            </button>
+          </HoverTip>
           <button
             type="button"
             className="hermes-trace-panel-button hermes-trace-panel-close"

--- a/src/components/dictation/DictationHistoryView.tsx
+++ b/src/components/dictation/DictationHistoryView.tsx
@@ -1,7 +1,5 @@
 import { listen } from "@tauri-apps/api/event";
-import { IconCheckmark2Small } from "central-icons/IconCheckmark2Small";
 import { IconChevronRightSmall } from "central-icons/IconChevronRightSmall";
-import { IconClipboard } from "central-icons/IconClipboard";
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconFontStyle } from "central-icons/IconFontStyle";
 import { IconInfinity } from "central-icons/IconInfinity";
@@ -20,8 +18,10 @@ import {
   useState,
 } from "react";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { CopyStateIcon } from "../ui/CopyStateIcon";
 import { Dialog } from "../ui/Dialog";
 import { EmptyState } from "../ui/EmptyState";
+import { HoverTip } from "../ui/HoverTip";
 import { KeycapShortcut } from "../shortcuts/KeycapShortcut";
 import {
   deleteDictationHistoryItem,
@@ -85,6 +85,7 @@ export function DictationHistoryView({ onNavigateToSettings }: DictationHistoryV
   const items = forcedEmpty ? NO_DICTATIONS : allItems;
   const loading = !forcedEmpty && loadingState;
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const copyResetTimerRef = useRef<number | undefined>(undefined);
   const [settings, setSettings] = useState<DictationSettingsDto>();
   const [dictionaryCount, setDictionaryCount] = useState<number | null>(null);
   const [hintDismissed, setHintDismissed] = useState(readHintDismissed);
@@ -141,6 +142,15 @@ export function DictationHistoryView({ onNavigateToSettings }: DictationHistoryV
     };
   }, [loadHistory]);
 
+  useEffect(
+    () => () => {
+      if (copyResetTimerRef.current !== undefined) {
+        window.clearTimeout(copyResetTimerRef.current);
+      }
+    },
+    [],
+  );
+
   const filtered = useMemo(() => {
     const normalized = query.trim().toLowerCase();
     if (!normalized) return items;
@@ -182,7 +192,13 @@ export function DictationHistoryView({ onNavigateToSettings }: DictationHistoryV
     if (!text) return;
     await navigator.clipboard.writeText(`${text} `);
     setCopiedId(item.id);
-    window.setTimeout(() => setCopiedId(null), 1200);
+    if (copyResetTimerRef.current !== undefined) {
+      window.clearTimeout(copyResetTimerRef.current);
+    }
+    copyResetTimerRef.current = window.setTimeout(() => {
+      setCopiedId(null);
+      copyResetTimerRef.current = undefined;
+    }, 1600);
   }
 
   async function confirmDelete() {
@@ -380,15 +396,17 @@ function DictationHistoryRow({
         {formatTime(item.createdAt)}
       </time>
       <span className="dictation-history-actions">
-        <button
-          type="button"
-          className="dictation-row-act"
-          data-copied={copied}
-          aria-label={copied ? "Copied" : "Copy"}
-          onClick={onCopy}
-        >
-          {copied ? <IconCheckmark2Small size={14} /> : <IconClipboard size={14} />}
-        </button>
+        <HoverTip compact width={104} tip={copied ? "Copied" : "Copy"} forceOpen={copied && !open}>
+          <button
+            type="button"
+            className="dictation-row-act"
+            data-copied={copied}
+            aria-label={copied ? "Copied" : "Copy"}
+            onClick={onCopy}
+          >
+            <CopyStateIcon copied={copied} />
+          </button>
+        </HoverTip>
         <button
           type="button"
           className="dictation-row-act dictation-row-act-danger"
@@ -407,10 +425,17 @@ function DictationHistoryRow({
         width={540}
         className="transcript-dialog"
         footer={
-          <button type="button" className="btn btn-secondary" onClick={onCopy}>
-            {copied ? <IconCheckmark2Small size={14} /> : <IconClipboard size={14} />}
-            {copied ? "Copied" : "Copy"}
-          </button>
+          <HoverTip compact width={104} tip={copied ? "Copied" : "Copy"} forceOpen={copied && open}>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              aria-label={copied ? "Copied" : "Copy"}
+              onClick={onCopy}
+            >
+              <CopyStateIcon copied={copied} />
+              Copy
+            </button>
+          </HoverTip>
         }
       >
         <div className="transcript-dialog-scroll scroll-fade-mask" ref={scrollRef} {...fade.props}>

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -1,4 +1,3 @@
-import { IconClipboard } from "central-icons/IconClipboard";
 import { IconChevronRightSmall } from "central-icons/IconChevronRightSmall";
 import { IconProjects } from "central-icons/IconProjects";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
@@ -6,7 +5,6 @@ import { IconMicrophoneOff } from "central-icons/IconMicrophoneOff";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconMicrophone as IconMicrophoneLine } from "central-icons/IconMicrophone";
 import { IconVolumeFull } from "central-icons/IconVolumeFull";
-import { IconCheckmark2 } from "central-icons-filled/IconCheckmark2";
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconChevronBottom } from "central-icons-filled/IconChevronBottom";
 import { IconMicrophone } from "central-icons-filled/IconMicrophone";
@@ -27,6 +25,7 @@ import type {
 } from "../../lib/tauri";
 import { DotSpinner } from "../DotSpinner";
 import { InlineNotice } from "../ui/InlineNotice";
+import { CopyStateIcon } from "../ui/CopyStateIcon";
 import { HoverTip } from "../ui/HoverTip";
 import { SegmentedControl } from "../ui/SegmentedControl";
 import { RecorderBar } from "../recorder/RecorderBar";
@@ -1053,6 +1052,33 @@ function compareOptionalNumber(left?: number, right?: number) {
   return left - right;
 }
 
+function useCopyFeedback() {
+  const [copied, setCopied] = useState(false);
+  const copyResetTimerRef = useRef<number | undefined>(undefined);
+
+  useEffect(
+    () => () => {
+      if (copyResetTimerRef.current !== undefined) {
+        window.clearTimeout(copyResetTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  function showCopiedFeedback() {
+    setCopied(true);
+    if (copyResetTimerRef.current !== undefined) {
+      window.clearTimeout(copyResetTimerRef.current);
+    }
+    copyResetTimerRef.current = window.setTimeout(() => {
+      setCopied(false);
+      copyResetTimerRef.current = undefined;
+    }, 1600);
+  }
+
+  return { copied, showCopiedFeedback };
+}
+
 /** A single conversation turn in the Transcription tab. Mirrors the dictation
  * history row language: a source glyph, a light meta line, and the transcript
  * text — copy reveals on hover, long turns clamp to a "Show more" toggle. */
@@ -1064,7 +1090,7 @@ function TranscriptTurn({
   preview?: boolean;
 }) {
   const textRef = useRef<HTMLParagraphElement>(null);
-  const [copied, setCopied] = useState(false);
+  const { copied, showCopiedFeedback } = useCopyFeedback();
   const [expanded, setExpanded] = useState(false);
   const [clamped, setClamped] = useState(false);
 
@@ -1078,12 +1104,6 @@ function TranscriptTurn({
   const errorMessage = sourceTurnFailureMessage(transcript.lastError);
   const copyValue = hasText ? transcript.text : errorMessage;
   const canCopy = copyValue.trim().length > 0;
-
-  useEffect(() => {
-    if (!copied) return;
-    const timer = window.setTimeout(() => setCopied(false), 1600);
-    return () => window.clearTimeout(timer);
-  }, [copied]);
 
   // Measure whether the collapsed text overflows its line clamp so the
   // "Show more" toggle only appears when there's hidden content.
@@ -1104,7 +1124,7 @@ function TranscriptTurn({
   async function handleCopy() {
     try {
       await navigator.clipboard.writeText(copyValue);
-      setCopied(true);
+      showCopiedFeedback();
     } catch {
       // Clipboard can fail in restricted contexts; stay silent.
     }
@@ -1138,16 +1158,17 @@ function TranscriptTurn({
         {errorMessage ? <p className="source-transcript-error">{errorMessage}</p> : null}
       </div>
       {canCopy ? (
-        <button
-          type="button"
-          className="transcript-turn-copy"
-          data-copied={copied || undefined}
-          aria-label={copied ? "Copied" : "Copy turn"}
-          title={copied ? "Copied" : "Copy"}
-          onClick={() => void handleCopy()}
-        >
-          {copied ? <IconCheckmark2 size={14} /> : <IconClipboard size={14} />}
-        </button>
+        <HoverTip compact width={104} tip={copied ? "Copied" : "Copy"} forceOpen={copied}>
+          <button
+            type="button"
+            className="transcript-turn-copy"
+            data-copied={copied || undefined}
+            aria-label={copied ? "Copied" : "Copy turn"}
+            onClick={() => void handleCopy()}
+          >
+            <CopyStateIcon copied={copied} />
+          </button>
+        </HoverTip>
       ) : null}
     </article>
   );
@@ -1161,18 +1182,12 @@ function sourceTurnFailureMessage(message?: string) {
 }
 
 function CopyTranscriptButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    if (!copied) return;
-    const timer = window.setTimeout(() => setCopied(false), 1600);
-    return () => window.clearTimeout(timer);
-  }, [copied]);
+  const { copied, showCopiedFeedback } = useCopyFeedback();
 
   async function handleCopy() {
     try {
       await navigator.clipboard.writeText(text);
-      setCopied(true);
+      showCopiedFeedback();
     } catch {
       // Clipboard API can fail in restricted contexts; stay silent
       // rather than nag — the user can retry.
@@ -1180,17 +1195,18 @@ function CopyTranscriptButton({ text }: { text: string }) {
   }
 
   return (
-    <button
-      type="button"
-      className="transcript-copy"
-      onClick={() => void handleCopy()}
-      data-copied={copied || undefined}
-      aria-label={copied ? "Transcript copied" : "Copy transcript"}
-      title={copied ? "Copied" : "Copy transcript"}
-    >
-      {copied ? <IconCheckmark2 size={14} /> : <IconClipboard size={14} />}
-      {copied ? "Copied" : "Copy"}
-    </button>
+    <HoverTip compact width={104} tip={copied ? "Copied" : "Copy"} forceOpen={copied}>
+      <button
+        type="button"
+        className="transcript-copy"
+        onClick={() => void handleCopy()}
+        data-copied={copied || undefined}
+        aria-label={copied ? "Transcript copied" : "Copy transcript"}
+      >
+        <CopyStateIcon copied={copied} />
+        Copy
+      </button>
+    </HoverTip>
   );
 }
 

--- a/src/components/note-editor/NoteHeaderActions.tsx
+++ b/src/components/note-editor/NoteHeaderActions.tsx
@@ -1,17 +1,18 @@
 import { IconBubble3 } from "central-icons/IconBubble3";
-import { IconChainLink1 } from "central-icons/IconChainLink1";
-import { IconCheckmark2Small } from "central-icons/IconCheckmark2Small";
+import { IconArrowShareRight } from "central-icons/IconArrowShareRight";
 import { IconDotGrid1x3Horizontal } from "central-icons/IconDotGrid1x3Horizontal";
-import { IconArrowInbox } from "central-icons/IconArrowInbox";
-import { IconShareOs } from "central-icons/IconShareOs";
+import { IconFilePdf } from "central-icons/IconFilePdf";
+import { IconReference } from "central-icons/IconReference";
 import { IconTrashCan } from "central-icons/IconTrashCan";
 import { useEffect, useRef, useState } from "react";
 
 import { noteReferenceToken } from "../agent/composer/noteReference";
+import { toast } from "../ui/Toaster";
 
 /** The note's top-bar actions: Ask June (toggles the contextual chat panel),
- * copy-reference, and an overflow menu (delete). Lives in the note toolbar's
- * actions slot so it sits in a consistent, predictable spot across every note. */
+ * share, and an overflow menu (copy reference, export, delete). Lives in the
+ * note toolbar's actions slot so it sits in a consistent, predictable spot
+ * across every note. */
 export function NoteHeaderActions({
   noteId,
   noteTitle,
@@ -34,7 +35,7 @@ export function NoteHeaderActions({
   onShare?: () => void;
   /** Opens the system print sheet with a PDF-ready version of the note. */
   onExportPdf?: () => void;
-  /** Opens the delete-note confirmation. Omitted → no overflow menu. */
+  /** Opens the delete-note confirmation. */
   onDelete?: () => void;
 }) {
   return (
@@ -59,21 +60,27 @@ export function NoteHeaderActions({
           title="Share"
           onClick={onShare}
         >
-          <IconShareOs size={16} />
+          <IconArrowShareRight size={16} />
         </button>
       ) : null}
-      <CopyNoteReferenceButton noteId={noteId} title={noteTitle} />
-      {onExportPdf || onDelete ? (
-        <NoteOverflowMenu onExportPdf={onExportPdf} onDelete={onDelete} />
-      ) : null}
+      <NoteOverflowMenu
+        noteId={noteId}
+        noteTitle={noteTitle}
+        onExportPdf={onExportPdf}
+        onDelete={onDelete}
+      />
     </div>
   );
 }
 
 function NoteOverflowMenu({
+  noteId,
+  noteTitle,
   onExportPdf,
   onDelete,
 }: {
+  noteId: string;
+  noteTitle: string;
   onExportPdf?: () => void;
   onDelete?: () => void;
 }) {
@@ -96,6 +103,16 @@ function NoteOverflowMenu({
     };
   }, [open]);
 
+  async function handleCopyReference() {
+    try {
+      await navigator.clipboard.writeText(noteReferenceToken({ id: noteId, title: noteTitle }));
+      toast("Reference for June copied");
+    } catch {
+      // Clipboard API can fail in restricted contexts; stay silent so retrying
+      // the same menu action remains the least disruptive recovery.
+    }
+  }
+
   return (
     <div className="note-actions-menu-wrap" ref={wrapRef}>
       <button
@@ -110,6 +127,17 @@ function NoteOverflowMenu({
       </button>
       {open ? (
         <div className="sidebar-identity-menu note-actions-menu" role="menu">
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              void handleCopyReference();
+            }}
+          >
+            <IconReference size={14} />
+            Copy reference for June
+          </button>
           {onExportPdf ? (
             <button
               type="button"
@@ -119,7 +147,7 @@ function NoteOverflowMenu({
                 onExportPdf();
               }}
             >
-              <IconArrowInbox size={14} />
+              <IconFilePdf size={14} />
               Export as PDF
             </button>
           ) : null}
@@ -140,38 +168,5 @@ function NoteOverflowMenu({
         </div>
       ) : null}
     </div>
-  );
-}
-
-function CopyNoteReferenceButton({ noteId, title }: { noteId: string; title: string }) {
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    if (!copied) return;
-    const timer = window.setTimeout(() => setCopied(false), 1600);
-    return () => window.clearTimeout(timer);
-  }, [copied]);
-
-  async function handleCopy() {
-    try {
-      await navigator.clipboard.writeText(noteReferenceToken({ id: noteId, title }));
-      setCopied(true);
-    } catch {
-      // Clipboard API can fail in restricted contexts; stay silent
-      // rather than nag, since the user can retry.
-    }
-  }
-
-  return (
-    <button
-      type="button"
-      className="note-reference-copy"
-      onClick={() => void handleCopy()}
-      data-copied={copied || undefined}
-      aria-label="Copy note reference"
-      title={copied ? "Copied" : "Copy note reference"}
-    >
-      {copied ? <IconCheckmark2Small size={14} /> : <IconChainLink1 size={14} />}
-    </button>
   );
 }

--- a/src/components/share/ShareDialog.tsx
+++ b/src/components/share/ShareDialog.tsx
@@ -72,14 +72,22 @@ export function ShareDialog({
   const [copying, setCopying] = useState(false);
   const [legacyShare, setLegacyShare] = useState(false);
   const [loadFailed, setLoadFailed] = useState(false);
+  const [loadVersion, setLoadVersion] = useState(0);
   const [confirmStop, setConfirmStop] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const busyRef = useRef(false);
   const copyingRef = useRef(false);
   const copyResetTimerRef = useRef<number>();
   const activeItemRef = useRef(`${item.kind}:${item.itemId}`);
+  const previousOpenRef = useRef(open);
   activeItemRef.current = `${item.kind}:${item.itemId}`;
   const shouldLoadShare = open || Boolean(onLinkChange);
+
+  useEffect(() => {
+    const wasOpen = previousOpenRef.current;
+    previousOpenRef.current = open;
+    if (open && !wasOpen) setLoadVersion((version) => version + 1);
+  }, [open]);
 
   const clearCopyFeedback = useCallback(() => {
     if (copyResetTimerRef.current !== undefined) {
@@ -179,7 +187,7 @@ export function ShareDialog({
     return () => {
       cancelled = true;
     };
-  }, [shouldLoadShare, item.kind, item.itemId, clearCopyFeedback]);
+  }, [shouldLoadShare, item.kind, item.itemId, clearCopyFeedback, loadVersion]);
 
   const copyExistingLink = useCallback(
     async (

--- a/src/components/share/ShareDialog.tsx
+++ b/src/components/share/ShareDialog.tsx
@@ -1,6 +1,11 @@
+import { IconCircleInfo } from "central-icons/IconCircleInfo";
+import { IconExclamationCircle } from "central-icons/IconExclamationCircle";
+import { IconEyeOpen } from "central-icons/IconEyeOpen";
+import { IconEyeSlash } from "central-icons/IconEyeSlash";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { writeText as writeClipboardText } from "@tauri-apps/plugin-clipboard-manager";
 
-import { isShareNotFoundError, messageFromError } from "../../lib/errors";
+import { describeShareError, isShareNotFoundError } from "../../lib/errors";
 import {
   buildLinkShareFragment,
   derivePasscodeKey,
@@ -24,7 +29,12 @@ import {
   type ShareKind,
 } from "../../lib/tauri";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { CopyLinkField } from "../ui/CopyLinkField";
+import { CopyStateIcon } from "../ui/CopyStateIcon";
 import { Dialog } from "../ui/Dialog";
+import { HoverTip } from "../ui/HoverTip";
+import { InlineNotice } from "../ui/InlineNotice";
+import { Switch } from "../ui/Switch";
 
 export type ShareDialogItem = {
   kind: ShareKind;
@@ -40,10 +50,12 @@ const MIN_PASSCODE_LENGTH = 8;
 export function ShareDialog({
   open,
   onClose,
+  onLinkChange,
   item,
 }: {
   open: boolean;
   onClose: () => void;
+  onLinkChange?: (url: string | null) => void;
   item: ShareDialogItem;
 }) {
   const [loading, setLoading] = useState(false);
@@ -54,18 +66,51 @@ export function ShareDialog({
   const [passwordProtected, setPasswordProtected] = useState(false);
   const [requirePasscode, setRequirePasscode] = useState(false);
   const [passcode, setPasscode] = useState("");
+  const [revealPasscode, setRevealPasscode] = useState(false);
   const [baseUrl, setBaseUrl] = useState<string | null>(null);
   const [copied, setCopied] = useState<"link" | "passcode" | null>(null);
+  const [copying, setCopying] = useState(false);
   const [legacyShare, setLegacyShare] = useState(false);
   const [loadFailed, setLoadFailed] = useState(false);
   const [confirmStop, setConfirmStop] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const busyRef = useRef(false);
+  const copyingRef = useRef(false);
+  const copyResetTimerRef = useRef<number>();
   const activeItemRef = useRef(`${item.kind}:${item.itemId}`);
   activeItemRef.current = `${item.kind}:${item.itemId}`;
+  const shouldLoadShare = open || Boolean(onLinkChange);
+
+  const clearCopyFeedback = useCallback(() => {
+    if (copyResetTimerRef.current !== undefined) {
+      window.clearTimeout(copyResetTimerRef.current);
+      copyResetTimerRef.current = undefined;
+    }
+    setCopied(null);
+  }, []);
+
+  const showCopyFeedback = useCallback((kind: "link" | "passcode") => {
+    if (copyResetTimerRef.current !== undefined) {
+      window.clearTimeout(copyResetTimerRef.current);
+    }
+    setCopied(kind);
+    copyResetTimerRef.current = window.setTimeout(() => {
+      setCopied(null);
+      copyResetTimerRef.current = undefined;
+    }, 1600);
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (copyResetTimerRef.current !== undefined) {
+        window.clearTimeout(copyResetTimerRef.current);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
-    if (!open) return;
+    if (!shouldLoadShare) return;
     const startedItem = `${item.kind}:${item.itemId}`;
     let cancelled = false;
     setLoading(true);
@@ -75,7 +120,8 @@ export function ShareDialog({
     setPasswordProtected(false);
     setRequirePasscode(false);
     setPasscode("");
-    setCopied(null);
+    setRevealPasscode(false);
+    clearCopyFeedback();
     setLegacyShare(false);
     setLoadFailed(false);
     setConfirmStop(false);
@@ -125,7 +171,7 @@ export function ShareDialog({
           setShareId(null);
         }
       } catch (loadError) {
-        if (!cancelled) setError(messageFromError(loadError));
+        if (!cancelled) setError(describeShareError(loadError));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -133,7 +179,7 @@ export function ShareDialog({
     return () => {
       cancelled = true;
     };
-  }, [open, item.kind, item.itemId]);
+  }, [shouldLoadShare, item.kind, item.itemId, clearCopyFeedback]);
 
   const copyExistingLink = useCallback(
     async (
@@ -141,6 +187,7 @@ export function ShareDialog({
       nextInviteId: string,
       materialB64: string,
       protectedLink: boolean,
+      showFeedback = true,
     ) => {
       const url = baseUrl ?? (await getShareBaseUrl());
       const fragment = buildLinkShareFragment(
@@ -148,20 +195,33 @@ export function ShareDialog({
         fromBase64Url(materialB64),
         protectedLink,
       );
-      await navigator.clipboard.writeText(`${url}/s/${nextShareId}#${fragment}`);
+      await writeClipboardText(`${url}/s/${nextShareId}#${fragment}`);
       setBaseUrl(url);
-      setCopied("link");
+      if (showFeedback) showCopyFeedback("link");
     },
-    [baseUrl],
+    [baseUrl, showCopyFeedback],
   );
 
+  const runClipboardCopy = useCallback(async (copy: () => Promise<void>) => {
+    copyingRef.current = true;
+    setCopying(true);
+    try {
+      await copy();
+    } finally {
+      copyingRef.current = false;
+      setCopying(false);
+    }
+  }, []);
+
   const handleCopyLink = useCallback(async () => {
-    if (busyRef.current || loading || legacyShare || loadFailed) return;
+    if (busyRef.current || copyingRef.current || loading || legacyShare || loadFailed) return;
     setError(null);
-    setCopied(null);
+    clearCopyFeedback();
     if (shareId && inviteId && linkMaterialB64) {
       try {
-        await copyExistingLink(shareId, inviteId, linkMaterialB64, passwordProtected);
+        await runClipboardCopy(() =>
+          copyExistingLink(shareId, inviteId, linkMaterialB64, passwordProtected),
+        );
       } catch {
         setError("Couldn't copy the link. Try again.");
       }
@@ -210,23 +270,36 @@ export function ShareDialog({
         shareId: created.shareId,
         inviteKeyB64: materialB64,
       });
+      createdShareId = null;
       if (activeItemRef.current === startedItem) {
         setShareId(created.shareId);
         setInviteId(createdInvite.inviteId);
         setLinkMaterialB64(materialB64);
         setPasswordProtected(Boolean(salt));
+        try {
+          await runClipboardCopy(() =>
+            copyExistingLink(
+              created.shareId,
+              createdInvite.inviteId,
+              materialB64,
+              Boolean(salt),
+              false,
+            ),
+          );
+        } catch {
+          setError("Link created, but couldn't copy it. Select Copy to try again.");
+        }
       }
-      createdShareId = null;
-      await copyExistingLink(created.shareId, createdInvite.inviteId, materialB64, Boolean(salt));
     } catch (createError) {
       if (createdShareId) await shareDelete(createdShareId).catch(() => {});
-      if (activeItemRef.current === startedItem) setError(messageFromError(createError));
+      if (activeItemRef.current === startedItem) setError(describeShareError(createError));
     } finally {
       busyRef.current = false;
       setBusy(false);
     }
   }, [
     copyExistingLink,
+    clearCopyFeedback,
     inviteId,
     item,
     legacyShare,
@@ -236,13 +309,26 @@ export function ShareDialog({
     passcode,
     passwordProtected,
     requirePasscode,
+    runClipboardCopy,
     shareId,
   ]);
+
+  const handleCopyPasscode = useCallback(async () => {
+    if (!passcode || busyRef.current || copyingRef.current) return;
+    setError(null);
+    clearCopyFeedback();
+    try {
+      await runClipboardCopy(() => writeClipboardText(passcode));
+      showCopyFeedback("passcode");
+    } catch {
+      setError("Couldn't copy the passcode. Try again.");
+    }
+  }, [clearCopyFeedback, passcode, runClipboardCopy, showCopyFeedback]);
 
   const handleStopSharing = useCallback(async () => {
     if (!shareId) return;
     await shareDelete(shareId).catch((stopError) => {
-      setError(messageFromError(stopError));
+      setError(describeShareError(stopError));
       throw stopError;
     });
     setShareId(null);
@@ -250,8 +336,8 @@ export function ShareDialog({
     setLinkMaterialB64(null);
     setPasswordProtected(false);
     setLegacyShare(false);
-    setCopied(null);
-  }, [shareId]);
+    clearCopyFeedback();
+  }, [clearCopyFeedback, shareId]);
 
   const handleClose = useCallback(() => {
     if (!busyRef.current) onClose();
@@ -259,6 +345,19 @@ export function ShareDialog({
 
   const itemNoun = item.kind === "note" ? "note" : "session";
   const hasLink = Boolean(shareId && inviteId && linkMaterialB64);
+  const requiresPasscode = requirePasscode || passwordProtected;
+  const shareUrl =
+    shareId && inviteId && linkMaterialB64 && baseUrl
+      ? `${baseUrl}/s/${shareId}#${buildLinkShareFragment(
+          inviteId,
+          fromBase64Url(linkMaterialB64),
+          passwordProtected,
+        )}`
+      : null;
+
+  useEffect(() => {
+    onLinkChange?.(shareUrl);
+  }, [onLinkChange, shareUrl]);
 
   return (
     <>
@@ -267,111 +366,134 @@ export function ShareDialog({
         onClose={handleClose}
         disableBackdropClose={busy}
         title={`Share ${itemNoun}`}
-        description={`Anyone with the link can view a snapshot of "${item.title || `Untitled ${itemNoun}`}".`}
+        description={`Anyone with the link${requiresPasscode ? " and passcode" : ""} can view an encrypted snapshot of "${item.title || `Untitled ${itemNoun}`}".${requiresPasscode ? " June never stores the passcode." : ""}`}
         width={480}
         className="share-dialog"
         footer={
-          <>
-            {shareId ? (
-              <button
-                type="button"
-                className="primary-action share-unshare"
-                disabled={busy}
-                onClick={() => setConfirmStop(true)}
-              >
-                Stop sharing
-              </button>
-            ) : null}
+          shareId ? (
             <button
               type="button"
-              className="primary-action primary-solid"
+              className="primary-action share-unshare"
               disabled={busy}
-              onClick={handleClose}
+              onClick={() => setConfirmStop(true)}
             >
-              Done
+              Stop sharing
             </button>
-          </>
-        }
-      >
-        <div className="dialog-body share-dialog-body">
-          {loading ? <p className="share-dialog-caption">Loading share...</p> : null}
-          {!loading && legacyShare ? (
-            <p className="share-dialog-caption">
-              This item uses the previous invite-only sharing model. Stop sharing it to create a
-              simpler link.
-            </p>
-          ) : null}
-          {!loading && !legacyShare && !hasLink ? (
-            <label className="share-dialog-caption">
-              <input
-                type="checkbox"
-                checked={requirePasscode}
-                disabled={busy || loadFailed}
-                onChange={(event) => {
-                  setRequirePasscode(event.currentTarget.checked);
-                  setError(null);
-                }}
-              />{" "}
-              Require a passcode
-            </label>
-          ) : null}
-          {!loading && !legacyShare && !hasLink && requirePasscode ? (
-            <div className="share-invite-row">
-              <label className="dialog-field-label" htmlFor="share-passcode">
-                Passcode
-              </label>
-              <input
-                id="share-passcode"
-                className="dialog-input"
-                type="password"
-                autoComplete="new-password"
-                disabled={loadFailed}
-                value={passcode}
-                placeholder="At least 8 characters"
-                onChange={(event) => setPasscode(event.currentTarget.value)}
-              />
-              <p className="share-dialog-caption">
-                June never stores this passcode. Send it separately from the link.
-              </p>
-            </div>
-          ) : null}
-          {!loading && !legacyShare ? (
+          ) : !loading && !legacyShare ? (
             <button
               type="button"
               className="primary-action primary-solid"
               disabled={busy || loadFailed}
               onClick={() => void handleCopyLink()}
             >
-              {busy ? "Creating link..." : copied === "link" ? "Link copied" : "Copy link"}
+              {busy ? "Creating link..." : "Create link"}
             </button>
+          ) : undefined
+        }
+      >
+        <div className="dialog-body share-dialog-body">
+          {loading ? <p className="share-dialog-caption">Loading share...</p> : null}
+          {!loading && legacyShare ? (
+            <InlineNotice
+              tone="info"
+              aria-label="Legacy share notice"
+              icon={<IconCircleInfo size={14} aria-hidden />}
+              body="This item uses the previous invite-only sharing model. Stop sharing it to create a simpler link."
+            />
           ) : null}
-          {hasLink ? (
-            <p className="share-dialog-caption">
-              {passwordProtected
-                ? "This link requires the passcode you chose. June does not store the passcode."
-                : "Anyone with this encrypted link can view the snapshot without signing in."}
-            </p>
+          {!loading && !legacyShare && !hasLink ? (
+            <div className="share-dialog-section">
+              <div className="share-option-row">
+                <div className="share-option-info">
+                  <span className="share-option-title" id="share-passcode-label">
+                    Require a passcode
+                  </span>
+                  <span className="share-option-description">
+                    June never stores the passcode. Send it separately.
+                  </span>
+                </div>
+                <Switch
+                  checked={requirePasscode}
+                  disabled={busy || loadFailed}
+                  aria-labelledby="share-passcode-label"
+                  onCheckedChange={(next) => {
+                    setRequirePasscode(next);
+                    setError(null);
+                  }}
+                />
+              </div>
+              {requirePasscode ? (
+                <div className="share-option-row">
+                  <label className="share-option-title" htmlFor="share-passcode">
+                    Passcode
+                  </label>
+                  <div className="share-passcode-control">
+                    <input
+                      id="share-passcode"
+                      className="dialog-input"
+                      type={revealPasscode ? "text" : "password"}
+                      autoComplete="new-password"
+                      disabled={loadFailed}
+                      value={passcode}
+                      placeholder="At least 8 characters"
+                      onChange={(event) => setPasscode(event.currentTarget.value)}
+                    />
+                    <button
+                      type="button"
+                      className="icon-button share-passcode-reveal"
+                      aria-label={revealPasscode ? "Hide passcode" : "Show passcode"}
+                      aria-pressed={revealPasscode}
+                      onClick={() => setRevealPasscode((value) => !value)}
+                    >
+                      {revealPasscode ? <IconEyeSlash size={16} /> : <IconEyeOpen size={16} />}
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+            </div>
           ) : null}
-          {hasLink && passwordProtected && passcode ? (
-            <button
-              type="button"
-              className="primary-action"
-              onClick={() => {
-                void navigator.clipboard.writeText(passcode).then(() => setCopied("passcode"));
-              }}
-            >
-              {copied === "passcode" ? "Passcode copied" : "Copy passcode"}
-            </button>
+          {hasLink && shareUrl ? (
+            <div className="share-link-block">
+              <CopyLinkField
+                value={shareUrl}
+                label={`Share link for ${item.title || `Untitled ${itemNoun}`}`}
+                copied={copied === "link"}
+                disabled={busy || copying}
+                onCopy={() => void handleCopyLink()}
+              />
+              {passwordProtected && passcode ? (
+                <HoverTip
+                  compact
+                  width={112}
+                  tip={copied === "passcode" ? "Copied" : "Copy passcode"}
+                  forceOpen={copied === "passcode"}
+                  suppressed={busy || copying}
+                  className="share-link-copy-passcode-tip"
+                >
+                  <button
+                    type="button"
+                    className="share-link-copy-passcode"
+                    aria-label={copied === "passcode" ? "Passcode copied" : "Copy passcode"}
+                    data-copied={copied === "passcode" ? "true" : undefined}
+                    disabled={busy || copying}
+                    onClick={() => void handleCopyPasscode()}
+                  >
+                    <CopyStateIcon copied={copied === "passcode"} />
+                    Copy passcode
+                  </button>
+                </HoverTip>
+              ) : null}
+            </div>
           ) : null}
           {error ? (
-            <p className="share-dialog-error" role="alert">
-              {error}
-            </p>
+            <InlineNotice
+              tone="destructive"
+              role="alert"
+              aria-label="Share error"
+              icon={<IconExclamationCircle size={14} aria-hidden />}
+              body={error}
+            />
           ) : null}
-          <p className="share-dialog-caption">
-            Shares are encrypted snapshots. Anyone can forward the link and passcode; stopping
-            sharing disables the link for everyone.
-          </p>
         </div>
       </Dialog>
       <ConfirmDialog

--- a/src/components/share/ShareLinkCopyAction.tsx
+++ b/src/components/share/ShareLinkCopyAction.tsx
@@ -1,0 +1,65 @@
+import { writeText as writeClipboardText } from "@tauri-apps/plugin-clipboard-manager";
+import { IconChainLink1 } from "central-icons/IconChainLink1";
+import { useEffect, useRef, useState } from "react";
+
+import { CopyStateIcon } from "../ui/CopyStateIcon";
+import { HoverTip } from "../ui/HoverTip";
+
+export function ShareLinkCopyAction({ url }: { url: string }) {
+  const [copied, setCopied] = useState(false);
+  const copyingRef = useRef(false);
+  const copyResetTimerRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    setCopied(false);
+    if (copyResetTimerRef.current !== undefined) {
+      window.clearTimeout(copyResetTimerRef.current);
+      copyResetTimerRef.current = undefined;
+    }
+    return () => {
+      if (copyResetTimerRef.current !== undefined) {
+        window.clearTimeout(copyResetTimerRef.current);
+      }
+    };
+  }, [url]);
+
+  async function copyShareLink() {
+    if (copyingRef.current) return;
+    copyingRef.current = true;
+    try {
+      await writeClipboardText(url);
+      setCopied(true);
+      if (copyResetTimerRef.current !== undefined) {
+        window.clearTimeout(copyResetTimerRef.current);
+      }
+      copyResetTimerRef.current = window.setTimeout(() => {
+        setCopied(false);
+        copyResetTimerRef.current = undefined;
+      }, 1600);
+    } catch {
+      // Keep the action retryable. The full Share dialog owns detailed errors.
+    } finally {
+      copyingRef.current = false;
+    }
+  }
+
+  return (
+    <HoverTip
+      compact
+      width={128}
+      tip={copied ? "Copied" : "Copy share link"}
+      forceOpen={copied}
+      className="detail-breadcrumb-share-tip"
+    >
+      <button
+        type="button"
+        className="detail-breadcrumb-share"
+        aria-label={copied ? "Share link copied" : "Copy share link"}
+        data-copied={copied ? "true" : undefined}
+        onClick={() => void copyShareLink()}
+      >
+        <CopyStateIcon copied={copied} idleIcon={<IconChainLink1 size={14} />} />
+      </button>
+    </HoverTip>
+  );
+}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,5 +1,3 @@
-import { IconCheckmark2Small } from "central-icons/IconCheckmark2Small";
-import { IconClipboard } from "central-icons/IconClipboard";
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconArrowBoxRight } from "central-icons/IconArrowBoxRight";
 import { IconZap } from "central-icons/IconZap";
@@ -95,6 +93,7 @@ import { JuneMark } from "../account/AccountGate";
 import { OPEN_REFERRAL_DIALOG_EVENT } from "../referral/ReferralNudge";
 import { SETTINGS_TABS, type SettingsTab } from "../settings/AppSettings";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { CopyLinkField } from "../ui/CopyLinkField";
 import { Dialog } from "../ui/Dialog";
 import { DotSpinner } from "../DotSpinner";
 import { combineSourceAudioLevels, Waveform } from "../recorder/Waveform";
@@ -413,6 +412,7 @@ export function Sidebar({
   const [referralLoading, setReferralLoading] = useState(false);
   // Guards against a stale closure double-firing the summary fetch.
   const referralLoadingRef = useRef(false);
+  const referralCopyResetTimerRef = useRef<number>();
   const [referralError, setReferralError] = useState<string | null>(null);
   // The deployment can simply not offer referrals (a 404 from /referrals/me).
   // That's not a transient failure, so it gets a calm message with no retry.
@@ -546,6 +546,10 @@ export function Sidebar({
   function openReferralDialog() {
     if (account.localDev) return;
     setReferralDialogOpen(true);
+    if (referralCopyResetTimerRef.current !== undefined) {
+      window.clearTimeout(referralCopyResetTimerRef.current);
+      referralCopyResetTimerRef.current = undefined;
+    }
     setReferralCopied(false);
     setReferralCopyError(null);
     if (!referralLoading) {
@@ -572,19 +576,26 @@ export function Sidebar({
       await navigator.clipboard.writeText(referralSummary.url);
       setReferralCopyError(null);
       setReferralCopied(true);
+      if (referralCopyResetTimerRef.current !== undefined) {
+        window.clearTimeout(referralCopyResetTimerRef.current);
+      }
+      referralCopyResetTimerRef.current = window.setTimeout(() => {
+        setReferralCopied(false);
+        referralCopyResetTimerRef.current = undefined;
+      }, 1600);
     } catch {
       setReferralCopyError("Could not copy the link. Select it and copy manually.");
     }
   }
 
-  // Reset the "Copied" affordance the way every other copy button does
-  // (NoteEditor, dictation rows): a single effect with cleanup, so closing
-  // the dialog mid-flight can't fire a stray setState.
-  useEffect(() => {
-    if (!referralCopied) return;
-    const timer = window.setTimeout(() => setReferralCopied(false), 1600);
-    return () => window.clearTimeout(timer);
-  }, [referralCopied]);
+  useEffect(
+    () => () => {
+      if (referralCopyResetTimerRef.current !== undefined) {
+        window.clearTimeout(referralCopyResetTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const commandPromptGroups = useMemo<CommandPromptGroup[]>(() => {
     const normalized = normalizeCommandQuery(commandQuery);
@@ -1928,19 +1939,12 @@ function ReferralDialog({
           ) : summary ? (
             <>
               <span className="referral-panel-title">Share your invite link</span>
-              <div className="referral-link-field">
-                <input
-                  className="referral-link-url"
-                  value={summary.url}
-                  readOnly
-                  aria-label="Invite link"
-                  onFocus={(event) => event.currentTarget.select()}
-                />
-                <button type="button" className="referral-copy-inset" onClick={onCopy}>
-                  {copied ? <IconCheckmark2Small size={14} /> : <IconClipboard size={14} />}
-                  {copied ? "Copied" : "Copy"}
-                </button>
-              </div>
+              <CopyLinkField
+                value={summary.url}
+                label="Invite link"
+                copied={copied}
+                onCopy={onCopy}
+              />
               {copyError ? <p className="referral-copy-error">{copyError}</p> : null}
               <div className="referral-stats">
                 <div>

--- a/src/components/ui/BreadcrumbBar.tsx
+++ b/src/components/ui/BreadcrumbBar.tsx
@@ -6,6 +6,8 @@ type BreadcrumbItem = {
   /** Optional leading glyph (e.g. the project icon) for recognition. */
   icon?: ReactNode;
   onClick?: () => void;
+  /** Optional action revealed beside the current crumb on hover or focus. */
+  action?: ReactNode;
 };
 
 type Props = {
@@ -41,6 +43,18 @@ export function BreadcrumbBar({ backLabel, onBack, items, actions }: Props) {
                     ) : null}
                     {item.label}
                   </button>
+                ) : current && item.action ? (
+                  <span className="detail-breadcrumb-current-group">
+                    <span className="detail-breadcrumb-current">
+                      {item.icon ? (
+                        <span className="detail-breadcrumb-icon" aria-hidden>
+                          {item.icon}
+                        </span>
+                      ) : null}
+                      {item.label}
+                    </span>
+                    {item.action}
+                  </span>
                 ) : (
                   <span
                     className={current ? "detail-breadcrumb-current" : "detail-breadcrumb-label"}

--- a/src/components/ui/CopyLinkField.tsx
+++ b/src/components/ui/CopyLinkField.tsx
@@ -1,0 +1,47 @@
+import { CopyStateIcon } from "./CopyStateIcon";
+import { HoverTip } from "./HoverTip";
+
+export function CopyLinkField({
+  value,
+  label,
+  copied,
+  disabled = false,
+  onCopy,
+}: {
+  value: string;
+  label: string;
+  copied: boolean;
+  disabled?: boolean;
+  onCopy: () => void;
+}) {
+  return (
+    <div className="copy-link-field">
+      <input
+        className="copy-link-url"
+        value={value}
+        readOnly
+        aria-label={label}
+        onFocus={(event) => event.currentTarget.select()}
+      />
+      <HoverTip
+        compact
+        width={104}
+        tip={copied ? "Copied" : "Copy link"}
+        forceOpen={copied}
+        suppressed={disabled}
+        className="copy-link-action-tip"
+      >
+        <button
+          type="button"
+          className="copy-link-action"
+          aria-label={copied ? "Link copied" : "Copy link"}
+          data-copied={copied ? "true" : undefined}
+          disabled={disabled}
+          onClick={onCopy}
+        >
+          <CopyStateIcon copied={copied} />
+        </button>
+      </HoverTip>
+    </div>
+  );
+}

--- a/src/components/ui/CopyStateIcon.tsx
+++ b/src/components/ui/CopyStateIcon.tsx
@@ -1,0 +1,16 @@
+import { IconCheckmark2Medium } from "central-icons/IconCheckmark2Medium";
+import { IconSquareBehindSquare1 } from "central-icons/IconSquareBehindSquare1";
+import type { ReactNode } from "react";
+
+export function CopyStateIcon({ copied, idleIcon }: { copied: boolean; idleIcon?: ReactNode }) {
+  return (
+    <span className="t-icon-swap" data-state={copied ? "b" : "a"} aria-hidden>
+      <span className="t-icon" data-icon="a">
+        {idleIcon ?? <IconSquareBehindSquare1 size={14} />}
+      </span>
+      <span className="t-icon" data-icon="b">
+        <IconCheckmark2Medium size={14} />
+      </span>
+    </span>
+  );
+}

--- a/src/components/ui/HoverTip.tsx
+++ b/src/components/ui/HoverTip.tsx
@@ -106,6 +106,8 @@ type HoverTipProps = HTMLAttributes<HTMLSpanElement> & {
    * trigger's own picker popover is open, so the hover callout never fights the
    * popover for the same anchor. */
   suppressed?: boolean;
+  /** Keeps transient feedback visible without requiring hover or focus. */
+  forceOpen?: boolean;
   /** Keeps the callout alive while the pointer moves onto it. Use only for
    * rich, card-like tips with controls inside. */
   interactive?: boolean;
@@ -129,6 +131,7 @@ export function HoverTip({
   compact = false,
   delay = HOVER_INTENT_MS,
   suppressed = false,
+  forceOpen = false,
   interactive = false,
   children,
   ...spanProps
@@ -147,6 +150,7 @@ export function HoverTip({
   const hoverTimerRef = useRef<number | null>(null);
   const closeTimerRef = useRef<number | null>(null);
   const resizeFrameRef = useRef<number | null>(null);
+  const forcedOpenRef = useRef(false);
   // The side committed by the first measure pass, held for the tip's whole
   // mounted lifetime: a re-hover or a content swap (e.g. "Copy message" →
   // "Copied") re-measures, and re-deciding the side then would visibly
@@ -353,6 +357,31 @@ export function HoverTip({
     [cancelHoverIntent, cancelClose, cancelResizeMeasure],
   );
 
+  useEffect(() => {
+    if (forceOpen && !suppressed) {
+      forcedOpenRef.current = true;
+      cancelClose();
+      const rect = anchorRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      setAnchor({
+        centerX: rect.left + rect.width / 2,
+        bottom: rect.bottom + TIP_GAP,
+        top: rect.top - TIP_GAP,
+        spaceBelow: window.innerHeight - rect.bottom,
+      });
+      setPhase("open");
+      return;
+    }
+    if (forcedOpenRef.current) {
+      forcedOpenRef.current = false;
+      const anchorNode = anchorRef.current;
+      if (anchorNode?.matches(":hover") || anchorNode?.contains(document.activeElement)) {
+        return;
+      }
+      unmount();
+    }
+  }, [forceOpen, suppressed, cancelClose, unmount]);
+
   // Force-close the moment suppression turns on (the picker popover opened over
   // this anchor). Cancel any pending hover-intent and tear a shown tip down at
   // once rather than fading, so the callout never overlaps the popover.
@@ -393,6 +422,7 @@ export function HoverTip({
       }}
       onMouseLeave={(event) => {
         onMouseLeave?.(event);
+        if (forceOpen) return;
         if (interactive) hideAfterInteractiveGrace();
         else hide();
       }}
@@ -402,6 +432,7 @@ export function HoverTip({
       }}
       onBlur={(event) => {
         onBlur?.(event);
+        if (forceOpen) return;
         if (
           interactive &&
           (elementInsideAnchor(event.relatedTarget) ||

--- a/src/components/ui/HoverTip.tsx
+++ b/src/components/ui/HoverTip.tsx
@@ -359,10 +359,10 @@ export function HoverTip({
 
   useEffect(() => {
     if (forceOpen && !suppressed) {
-      forcedOpenRef.current = true;
       cancelClose();
       const rect = anchorRef.current?.getBoundingClientRect();
       if (!rect) return;
+      forcedOpenRef.current = true;
       setAnchor({
         centerX: rect.left + rect.width / 2,
         bottom: rect.bottom + TIP_GAP,

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -50,6 +50,21 @@ export function isShareNotFoundError(err: unknown): boolean {
   return messageFromError(err) === "share_not_found";
 }
 
+/** Human-readable share command error. The June API's share endpoints answer
+ * with bare machine codes as messages (`sharing_unavailable` when the server
+ * has no share database configured, `share_not_found` for unknown or revoked
+ * shares); user-facing surfaces must not leak those raw codes. */
+export function describeShareError(err: unknown): string {
+  const message = messageFromError(err);
+  if (message === "sharing_unavailable") {
+    return "Sharing isn't available on this June server yet. Try again after the next update.";
+  }
+  if (message === "share_not_found") {
+    return "This share no longer exists. It may have been stopped.";
+  }
+  return message;
+}
+
 export function isHermesSessionsStartupRequestError(err: unknown) {
   return /error sending request for url \(http:\/\/127\.0\.0\.1:\d+\/api\/sessions(?:\?|[)/])/i.test(
     messageFromError(err),

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5762,6 +5762,10 @@ input:focus-visible,
   outline-offset: 1px;
 }
 
+.hermes-trace-copy-tip {
+  display: inline-flex;
+}
+
 .hermes-trace-panel-close {
   padding: var(--sp-1) var(--sp-2);
 }
@@ -10294,8 +10298,7 @@ input:focus-visible,
   color: var(--foreground);
 }
 
-.note-header-ask,
-.note-reference-copy {
+.note-header-ask {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -10316,11 +10319,6 @@ input:focus-visible,
   padding: 0 var(--sp-2);
   font-size: var(--fs-sm);
   font-weight: 400;
-}
-
-.note-reference-copy {
-  width: var(--control-sm);
-  padding: 0;
 }
 
 .note-header-ask:hover,
@@ -10357,12 +10355,6 @@ input:focus-visible,
   }
 }
 
-.note-reference-copy:hover,
-.note-reference-copy[data-copied="true"] {
-  background: color-mix(in oklch, var(--muted) 55%, transparent);
-  color: var(--foreground);
-}
-
 /* Note toolbar overflow menu — mirrors the agent session bar's menu (same
    base .sidebar-identity-menu popover) so both detail-bar menus read alike. */
 .note-actions-menu-wrap {
@@ -10370,6 +10362,9 @@ input:focus-visible,
   display: inline-flex;
 }
 
+/* Both icon buttons share the toolbar's compact control size so share and
+ * the overflow trigger read as one consistent row. */
+.note-header-share,
 .note-actions-menu-trigger {
   width: var(--control-sm);
   height: var(--control-sm);
@@ -18179,6 +18174,50 @@ button.memory-project:hover {
   font-weight: 400;
 }
 
+.detail-breadcrumb-current-group {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  min-width: 0;
+}
+
+.detail-breadcrumb-share-tip {
+  flex: 0 0 auto;
+  display: inline-flex;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--t-fast) var(--ease-out);
+}
+
+.detail-breadcrumb-current-group:hover .detail-breadcrumb-share-tip,
+.detail-breadcrumb-current-group:focus-within .detail-breadcrumb-share-tip {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.detail-breadcrumb-share {
+  display: inline-grid;
+  place-items: center;
+  inline-size: var(--control-xs);
+  block-size: var(--control-xs);
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.detail-breadcrumb-share:hover,
+.detail-breadcrumb-share[data-copied] {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
 .detail-breadcrumb-separator {
   flex: 0 0 auto;
   color: var(--muted-foreground);
@@ -21473,59 +21512,114 @@ button.memory-project:hover {
   font-weight: 400;
 }
 
-/* Borderless filled field with the Copy button inset on the right. */
-.referral-link-field {
+/* Shared borderless URL field with an inset Copy action. Referral and private
+ * sharing use the same component so typography and feedback cannot drift. */
+.copy-link-field {
   display: flex;
   align-items: center;
   gap: var(--sp-2);
+  min-height: var(--control-lg);
   padding: var(--sp-1) var(--sp-1) var(--sp-1) var(--sp-3);
   border-radius: var(--r-md);
   background: var(--surface-subtle);
 }
 
-.referral-link-url {
+.copy-link-url {
   flex: 1;
   min-width: 0;
+  overflow: hidden;
+  padding: 0;
   border: 0;
   background: transparent;
   color: var(--muted-foreground);
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
   font-size: var(--fs-sm);
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.referral-link-url:focus {
+.copy-link-url:focus {
   outline: none;
 }
 
 /* Keep a visible ring for keyboard focus (clipped inside the field's
  * rounding) — only the mouse-focus outline is suppressed above. */
-.referral-link-url:focus-visible {
+.copy-link-url:focus-visible {
   outline: 2px solid var(--ring-focus);
   outline-offset: -2px;
   border-radius: var(--r-sm);
 }
 
-.referral-copy-inset {
+.copy-link-action-tip {
   flex: 0 0 auto;
   display: inline-flex;
-  align-items: center;
-  gap: var(--sp-1);
-  min-height: var(--control-md);
-  padding: 0 var(--sp-3);
+}
+
+.copy-link-action {
+  display: inline-grid;
+  place-items: center;
+  inline-size: var(--control-md);
+  block-size: var(--control-md);
+  padding: 0;
   border: 0;
   border-radius: var(--r-sm);
   background: var(--primary);
   color: var(--primary-foreground);
-  font-size: var(--fs-sm);
-  font-weight: 400;
-  white-space: nowrap;
+  line-height: 1;
   cursor: pointer;
   transition: opacity var(--t-fast) var(--ease-out);
 }
 
-.referral-copy-inset:hover {
+.copy-link-action:hover:not(:disabled) {
   opacity: 0.9;
+}
+
+.copy-link-action:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* Transitions.dev — Icon swap */
+.t-icon-swap {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  line-height: 0;
+}
+
+.t-icon-swap .t-icon {
+  grid-area: 1 / 1;
+  display: inline-grid;
+  place-items: center;
+  transition:
+    opacity var(--icon-swap-dur) var(--icon-swap-ease),
+    filter var(--icon-swap-dur) var(--icon-swap-ease),
+    transform var(--icon-swap-dur) var(--icon-swap-ease);
+  will-change: opacity, filter, transform;
+}
+
+.t-icon-swap svg {
+  display: block;
+}
+
+.t-icon-swap[data-state="a"] .t-icon[data-icon="a"],
+.t-icon-swap[data-state="b"] .t-icon[data-icon="b"] {
+  opacity: 1;
+  filter: blur(0);
+  transform: scale(1);
+}
+
+.t-icon-swap[data-state="a"] .t-icon[data-icon="b"],
+.t-icon-swap[data-state="b"] .t-icon[data-icon="a"] {
+  opacity: 0;
+  filter: blur(var(--icon-swap-blur));
+  transform: scale(var(--icon-swap-start-scale));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-icon-swap .t-icon {
+    transition: none !important;
+  }
 }
 
 .referral-copy-error,
@@ -26774,9 +26868,8 @@ button.connector-approvals-info {
 }
 
 /* ---- Share dialog (JUN-308) -------------------------------------------- */
-/* Owner-side private sharing: invite-by-email row, per-invite rows with a
- * quiet state chip, copy link, and revoke. Reuses the shared dialog recipes
- * (dialog-input, primary-action) so it reads like every other dialog. */
+/* Owner-side private sharing: a settings-style passcode option before the link
+ * exists, then one quiet link field directly in the dialog once it does. */
 
 .share-dialog-body {
   display: flex;
@@ -26784,99 +26877,116 @@ button.connector-approvals-info {
   gap: var(--sp-5);
 }
 
-.share-invite-row {
+/* Boxed option group inside the dialog body — same surface-in-card recipe as
+ * the app's other in-card boxes, so the passcode choice reads as one elevated
+ * section instead of loose lines under the description. */
+.share-dialog-section {
   display: flex;
   flex-direction: column;
-  gap: var(--sp-2);
+  gap: var(--sp-4);
+  padding: var(--sp-4) var(--sp-5);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-lg);
+  background: var(--surface);
 }
 
-.share-invite-controls {
-  display: flex;
-  gap: var(--sp-3);
+/* Option rows follow the settings-row recipe scaled to the dialog: title +
+ * muted description on the left (same size, color carries the hierarchy),
+ * control on the right, a hairline between stacked rows. */
+.share-option-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
+  gap: var(--sp-5);
 }
 
-.share-invite-controls .dialog-input {
-  flex: 1;
+.share-option-row + .share-option-row {
+  padding-top: var(--sp-4);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.share-option-info {
+  display: grid;
+  gap: var(--sp-px);
   min-width: 0;
 }
 
-.share-invite-controls .primary-action {
-  flex-shrink: 0;
-}
-
-.share-invite-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-.share-invite-item {
-  display: flex;
-  align-items: center;
-  gap: var(--sp-3);
-  padding: var(--sp-3) 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.share-invite-item:last-child {
-  border-bottom: none;
-}
-
-.share-invite-email {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: var(--fs-md);
+.share-option-title {
   color: var(--foreground);
+  font-size: var(--fs-md);
+  font-weight: 400;
 }
 
-.share-invite-state {
-  flex-shrink: 0;
-  font-size: var(--fs-xs);
-  line-height: 1;
-  padding: var(--sp-1) var(--sp-3);
-  border-radius: var(--r-pill);
-  background: var(--muted);
+.share-option-description {
   color: var(--muted-foreground);
+  font-size: var(--fs-md);
 }
 
-.share-invite-state[data-state="accepted"] {
-  color: var(--success);
-  background: color-mix(in oklch, var(--success) 12%, transparent);
+/* Passcode input with the reveal toggle tucked into its right edge. */
+.share-passcode-control {
+  position: relative;
+  width: min(240px, 100%);
 }
 
-.share-invite-state[data-state="revoked"] {
-  color: var(--destructive);
-  background: var(--destructive-soft);
+.share-passcode-control .dialog-input {
+  width: 100%;
+  padding-right: calc(var(--control-sm) + var(--sp-2));
 }
 
-.share-invite-copy,
-.share-invite-revoke {
-  flex-shrink: 0;
+.share-passcode-reveal {
+  position: absolute;
+  top: 50%;
+  right: var(--sp-1);
+  width: var(--control-sm);
+  height: var(--control-sm);
+  transform: translateY(-50%);
 }
 
-.share-invite-revoke {
-  color: var(--destructive);
+.share-link-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.share-link-copy-passcode-tip {
+  align-self: flex-start;
+  display: inline-flex;
+}
+
+.share-link-copy-passcode {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  min-height: var(--control-xs);
+  padding: 0 var(--sp-2);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  font: inherit;
+  font-size: var(--fs-md);
+  cursor: pointer;
+}
+
+.share-link-copy-passcode:hover {
+  background: var(--muted);
 }
 
 .share-unshare {
-  color: var(--destructive);
   margin-right: auto;
+  padding: 0 var(--sp-2);
+  border-color: transparent;
+  background: transparent;
+  color: var(--destructive);
+}
+
+.primary-action.share-unshare:hover {
+  border-color: transparent;
+  background: var(--destructive-soft);
 }
 
 .share-dialog-caption {
   margin: 0;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-md);
   color: var(--muted-foreground);
-}
-
-.share-dialog-error {
-  margin: 0;
-  font-size: var(--fs-sm);
-  color: var(--destructive);
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -353,6 +353,10 @@
   --t-fast: 100ms;
   --t-med: 160ms;
   --t-slow: 240ms;
+  --icon-swap-dur: 250ms;
+  --icon-swap-blur: 2px;
+  --icon-swap-start-scale: 0.25;
+  --icon-swap-ease: ease-in-out;
   transition: --brand 220ms var(--ease-out);
 
   /* Shadows ---------------------------------------------------------- */

--- a/src/test/agent-note-entry-points.test.ts
+++ b/src/test/agent-note-entry-points.test.ts
@@ -154,18 +154,19 @@ describe("note header actions", () => {
     expect(container.querySelector(".note-header-ask-dot")).not.toBeNull();
   });
 
-  it("copies the exact note reference token", async () => {
+  it("copies a portable reference for June", async () => {
     const user = userEvent.setup();
     const writeText = installClipboard();
     render(createElement(NoteHeaderActions, { noteId: "note-1", noteTitle: "Launch plan" }));
 
-    const copyButton = screen.getByRole("button", { name: "Copy note reference" });
-    await user.click(copyButton);
+    await user.click(screen.getByRole("button", { name: "Note actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Copy reference for June" }));
 
-    expect(writeText).toHaveBeenCalledWith(
-      noteReferenceToken({ id: "note-1", title: "Launch plan" }),
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        noteReferenceToken({ id: "note-1", title: "Launch plan" }),
+      ),
     );
-    await waitFor(() => expect(copyButton).toHaveAttribute("data-copied", "true"));
   });
 
   it("exports the note from the actions menu", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6121,12 +6121,26 @@ describe("AgentWorkspace", () => {
       expect(userTurn).not.toBeNull();
       expect(assistantTurn).not.toBeNull();
 
-      await user.click(
-        within(assistantTurn as HTMLElement).getByRole("button", {
-          name: "Copy message",
-        }),
-      );
+      const assistantCopy = within(assistantTurn as HTMLElement).getByRole("button", {
+        name: "Copy message",
+      });
+      const iconSwap = assistantCopy.querySelector(".t-icon-swap");
+      const idleIcon = iconSwap?.querySelector('[data-icon="a"]');
+      const copiedIcon = iconSwap?.querySelector('[data-icon="b"]');
+
+      expect(iconSwap).toHaveAttribute("data-state", "a");
+      expect(idleIcon).toBeInTheDocument();
+      expect(copiedIcon).toBeInTheDocument();
+      fireEvent.focus(assistantCopy);
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Copy message");
+
+      await user.click(assistantCopy);
       expect(writeText).toHaveBeenLastCalledWith("Here is the launch plan.");
+      expect(assistantCopy).toHaveAccessibleName("Copied message");
+      expect(iconSwap).toHaveAttribute("data-state", "b");
+      expect(iconSwap?.querySelector('[data-icon="a"]')).toBe(idleIcon);
+      expect(iconSwap?.querySelector('[data-icon="b"]')).toBe(copiedIcon);
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Copied");
 
       await user.click(
         within(userTurn as HTMLElement).getByRole("button", {

--- a/src/test/dictation-history.test.tsx
+++ b/src/test/dictation-history.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DictationHistoryView } from "../components/dictation/DictationHistoryView";
@@ -118,7 +118,6 @@ describe("DictationHistoryView", () => {
   });
 
   it("renders recent dictations and copies with trailing space", async () => {
-    const user = userEvent.setup();
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText: mocks.writeText },
@@ -130,8 +129,89 @@ describe("DictationHistoryView", () => {
     expect(screen.getByText("Hands-free")).toBeInTheDocument();
     expect(screen.getByLabelText("Shortcut Ctrl+Opt+T")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Copy" }));
-    await waitFor(() => expect(mocks.writeText).toHaveBeenCalledWith("Send the follow up. "));
+    const copyButton = screen.getByRole("button", { name: "Copy" });
+    const iconSwap = copyButton.querySelector(".t-icon-swap");
+    expect(iconSwap).toHaveAttribute("data-state", "a");
+    expect(iconSwap?.querySelectorAll(".t-icon")).toHaveLength(2);
+    expect(iconSwap?.querySelector('[data-icon="a"]')).not.toBeNull();
+    expect(iconSwap?.querySelector('[data-icon="b"]')).not.toBeNull();
+
+    copyButton.focus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Copy");
+
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        fireEvent.click(copyButton);
+        await Promise.resolve();
+      });
+      expect(mocks.writeText).toHaveBeenCalledWith("Send the follow up. ");
+      expect(copyButton).toHaveAccessibleName("Copied");
+      expect(iconSwap).toHaveAttribute("data-state", "b");
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Copied");
+
+      act(() => vi.advanceTimersByTime(1200));
+      await act(async () => {
+        fireEvent.click(copyButton);
+        await Promise.resolve();
+      });
+      expect(mocks.writeText).toHaveBeenCalledTimes(2);
+
+      act(() => vi.advanceTimersByTime(401));
+      expect(copyButton).toHaveAccessibleName("Copied");
+      expect(iconSwap).toHaveAttribute("data-state", "b");
+
+      act(() => vi.advanceTimersByTime(1199));
+      expect(copyButton).toHaveAccessibleName("Copy");
+      expect(iconSwap).toHaveAttribute("data-state", "a");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps dialog copy feedback inside a fixed button footprint", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: mocks.writeText },
+    });
+    const scrollHeight = vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(48);
+    const clientHeight = vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(24);
+
+    try {
+      render(<DictationHistoryView />);
+
+      const transcript = await screen.findByRole("button", { name: "Show full transcript" });
+      const row = transcript.closest("li");
+      expect(row).not.toBeNull();
+      const rowCopyButton = within(row as HTMLElement).getByRole("button", { name: "Copy" });
+      const rowIconSwap = rowCopyButton.querySelector(".t-icon-swap");
+
+      await user.click(transcript);
+      const dialog = screen.getByRole("dialog");
+      const dialogCopyButton = within(dialog).getByRole("button", { name: "Copy" });
+      const dialogIconSwap = dialogCopyButton.querySelector(".t-icon-swap");
+
+      expect(dialogCopyButton).toHaveTextContent(/^Copy$/);
+      expect(dialogIconSwap).toHaveAttribute("data-state", "a");
+      expect(dialogIconSwap?.querySelectorAll(".t-icon")).toHaveLength(2);
+      expect(dialogIconSwap?.querySelector('[data-icon="a"]')).not.toBeNull();
+      expect(dialogIconSwap?.querySelector('[data-icon="b"]')).not.toBeNull();
+
+      dialogCopyButton.focus();
+      expect(await screen.findByRole("tooltip")).toHaveTextContent("Copy");
+
+      await user.click(dialogCopyButton);
+      await waitFor(() => expect(mocks.writeText).toHaveBeenCalledWith("Send the follow up. "));
+      expect(dialogCopyButton).toHaveAccessibleName("Copied");
+      expect(dialogCopyButton).toHaveTextContent(/^Copy$/);
+      expect(dialogIconSwap).toHaveAttribute("data-state", "b");
+      expect(rowIconSwap).toHaveAttribute("data-state", "b");
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Copied");
+    } finally {
+      scrollHeight.mockRestore();
+      clientHeight.mockRestore();
+    }
   });
 
   it("advertises shortcut dictation on Windows", async () => {

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -578,16 +578,24 @@ describe("Sidebar primary navigation", () => {
     expect(screen.getByLabelText("Invite link")).toHaveValue(
       "https://accounts.opensoftware.co/join?ref=JUNE-ALEX",
     );
+    expect(screen.getByLabelText("Invite link").closest(".copy-link-field")).not.toBeNull();
     expect(screen.getByText("Friends referred")).toBeInTheDocument();
     expect(screen.getByText("1 invited friend is waiting to subscribe.")).toBeInTheDocument();
 
-    fireEvent.click(within(dialog).getByRole("button", { name: "Copy" }));
+    const copyButton = within(dialog).getByRole("button", { name: "Copy link" });
+    const iconSwap = copyButton.querySelector(".t-icon-swap");
+    expect(iconSwap).toHaveAttribute("data-state", "a");
+    expect(iconSwap?.querySelectorAll(".t-icon")).toHaveLength(2);
+
+    await user.click(copyButton);
     await waitFor(() =>
       expect(clipboardWrite).toHaveBeenCalledWith(
         "https://accounts.opensoftware.co/join?ref=JUNE-ALEX",
       ),
     );
-    expect(await screen.findByRole("button", { name: "Copied" })).toBeEnabled();
+    expect(await screen.findByRole("button", { name: "Link copied" })).toBeEnabled();
+    expect(iconSwap).toHaveAttribute("data-state", "b");
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Copied");
   });
 
   it("handles unavailable referral links without retry noise", async () => {

--- a/src/test/hermes-trace-panel.test.tsx
+++ b/src/test/hermes-trace-panel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HermesTracePanel } from "../components/agent/HermesTracePanel";
@@ -25,6 +25,7 @@ function seedBuffer() {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
@@ -90,13 +91,21 @@ describe("HermesTracePanel", () => {
   });
 
   it("copies a sanitized export to the clipboard with NO secret values", async () => {
-    const user = userEvent.setup();
     const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
 
     const buffer = seedBuffer();
     render(<HermesTracePanel buffer={buffer} open sessionId="s1" onClose={vi.fn()} />);
-    await user.click(screen.getByRole("button", { name: "Copy trace" }));
+    const copyButton = screen.getByRole("button", { name: "Copy trace" });
+    fireEvent.focus(copyButton);
+    vi.useFakeTimers();
+    await act(async () => {
+      fireEvent.click(copyButton);
+      await Promise.resolve();
+    });
     expect(writeText).toHaveBeenCalledTimes(1);
+    expect(copyButton).toHaveAccessibleName("Trace copied");
+    expect(copyButton.querySelector(".t-icon-swap")).toHaveAttribute("data-state", "b");
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Copied");
     const copied = writeText.mock.calls[0][0] as string;
     // The export carries raw type + normalized kind ...
     expect(copied).toContain("future.unknown");
@@ -104,6 +113,21 @@ describe("HermesTracePanel", () => {
     // ... but never the secret value the inbound frame carried.
     expect(copied).not.toContain("sk-abcdef0123456789abcdef0123456789");
     expect(copied).toContain("[redacted]");
+
+    act(() => vi.advanceTimersByTime(1200));
+    await act(async () => {
+      fireEvent.click(copyButton);
+      await Promise.resolve();
+    });
+    expect(writeText).toHaveBeenCalledTimes(2);
+
+    act(() => vi.advanceTimersByTime(401));
+    expect(copyButton).toHaveAccessibleName("Trace copied");
+    expect(copyButton.querySelector(".t-icon-swap")).toHaveAttribute("data-state", "b");
+
+    act(() => vi.advanceTimersByTime(1199));
+    expect(copyButton).toHaveAccessibleName("Copy trace");
+    expect(copyButton.querySelector(".t-icon-swap")).toHaveAttribute("data-state", "a");
   });
 
   it("invokes onClose from the close button", async () => {

--- a/src/test/hover-tip.test.tsx
+++ b/src/test/hover-tip.test.tsx
@@ -56,6 +56,27 @@ describe("HoverTip", () => {
     expect(tooltip.style.left).not.toBe("");
   });
 
+  it("keeps forced feedback visible after the pointer leaves", () => {
+    const { rerender } = render(
+      <HoverTip tip="Copied" compact forceOpen>
+        Copy
+      </HoverTip>,
+    );
+
+    const anchor = screen.getByText("Copy");
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Copied");
+    fireEvent.mouseLeave(anchor);
+    fireEvent.blur(anchor);
+    expect(screen.getByRole("tooltip")).toHaveAttribute("data-state", "open");
+
+    rerender(
+      <HoverTip tip="Copy" compact forceOpen={false}>
+        Copy
+      </HoverTip>,
+    );
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
   it("fades out on blur, then unmounts once the exit timer elapses", () => {
     vi.useFakeTimers();
     try {

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -117,6 +117,110 @@ describe("NoteEditor", () => {
     expect(screen.getByText("Exact raw transcript")).toBeInTheDocument();
   });
 
+  it("copies a transcript turn with icon-swap feedback", async () => {
+    const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+
+    try {
+      render(
+        <NoteEditor
+          {...props}
+          note={note({
+            activeTab: "transcription",
+            sourceTranscripts: [
+              {
+                id: "turn-1",
+                text: "System playback text",
+                source: "system",
+                startMs: 1000,
+                endMs: 2500,
+                turnIndex: 0,
+                status: "succeeded",
+              },
+            ],
+          })}
+        />,
+      );
+
+      const copyButton = screen.getByRole("button", { name: "Copy turn" });
+      const iconSwap = copyButton.querySelector(".t-icon-swap");
+      expect(iconSwap).toHaveAttribute("data-state", "a");
+      expect(iconSwap?.querySelectorAll(".t-icon")).toHaveLength(2);
+      expect(copyButton).not.toHaveAttribute("title");
+
+      fireEvent.focus(copyButton);
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Copy");
+
+      vi.useFakeTimers();
+      await act(async () => {
+        fireEvent.click(copyButton);
+        await Promise.resolve();
+      });
+
+      expect(writeText).toHaveBeenCalledWith("System playback text");
+      expect(copyButton).toHaveAccessibleName("Copied");
+      expect(iconSwap).toHaveAttribute("data-state", "b");
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Copied");
+
+      act(() => vi.advanceTimersByTime(1200));
+      await act(async () => {
+        fireEvent.click(copyButton);
+        await Promise.resolve();
+      });
+      expect(writeText).toHaveBeenCalledTimes(2);
+
+      act(() => vi.advanceTimersByTime(401));
+      expect(copyButton).toHaveAccessibleName("Copied");
+      expect(iconSwap).toHaveAttribute("data-state", "b");
+
+      act(() => vi.advanceTimersByTime(1199));
+      expect(copyButton).toHaveAccessibleName("Copy turn");
+      expect(iconSwap).toHaveAttribute("data-state", "a");
+    } finally {
+      vi.useRealTimers();
+      writeText.mockRestore();
+    }
+  });
+
+  it("keeps the whole-transcript copy label stable while the icon swaps", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+
+    try {
+      render(
+        <NoteEditor
+          {...props}
+          note={note({
+            activeTab: "transcription",
+            transcript: {
+              id: "transcript-1",
+              text: "Exact raw transcript",
+              status: "succeeded",
+            },
+          })}
+        />,
+      );
+
+      const copyButton = screen.getByRole("button", { name: "Copy transcript" });
+      const iconSwap = copyButton.querySelector(".t-icon-swap");
+      expect(iconSwap).toHaveAttribute("data-state", "a");
+      expect(iconSwap?.querySelectorAll(".t-icon")).toHaveLength(2);
+      expect(copyButton).toHaveTextContent(/^Copy$/);
+      expect(copyButton).not.toHaveAttribute("title");
+
+      fireEvent.focus(copyButton);
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Copy");
+      await user.click(copyButton);
+
+      expect(writeText).toHaveBeenCalledWith("Exact raw transcript");
+      expect(copyButton).toHaveAccessibleName("Transcript copied");
+      expect(copyButton).toHaveTextContent(/^Copy$/);
+      expect(iconSwap).toHaveAttribute("data-state", "b");
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Copied");
+    } finally {
+      writeText.mockRestore();
+    }
+  });
+
   it("shows transcript coverage notice with whole-minute missing speech", () => {
     render(
       <NoteEditor

--- a/src/test/share-dialog.test.tsx
+++ b/src/test/share-dialog.test.tsx
@@ -261,7 +261,30 @@ describe("ShareDialog", () => {
     );
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    expect(mocks.shareKeyGet).toHaveBeenCalledOnce();
+    expect(mocks.shareKeyGet).toHaveBeenCalledTimes(2);
+    expect(onLinkChange).toHaveBeenLastCalledWith(expect.stringContaining("/s/shr_1#link."));
+  });
+
+  it("retries a failed background load when the dialog opens", async () => {
+    const keyB64 = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE";
+    mocks.shareKeyGet.mockResolvedValue({ shareId: "shr_1", contentKeyB64: keyB64 });
+    mocks.shareGet.mockRejectedValueOnce(new Error("temporary load failure")).mockResolvedValue({
+      shareId: "shr_1",
+      kind: "note",
+      invites: [{ inviteId: "shi_link", email: "link@share.invalid", state: "pending" }],
+    });
+    mocks.shareInviteKeysGet.mockResolvedValue([{ inviteId: "shi_link", inviteKeyB64: keyB64 }]);
+    const onLinkChange = vi.fn();
+
+    const { rerender } = render(
+      <ShareDialog open={false} onClose={vi.fn()} onLinkChange={onLinkChange} item={noteItem()} />,
+    );
+    await waitFor(() => expect(mocks.shareGet).toHaveBeenCalledOnce());
+
+    rerender(<ShareDialog open onClose={vi.fn()} onLinkChange={onLinkChange} item={noteItem()} />);
+
+    expect(await screen.findByRole("button", { name: "Copy link" })).toBeEnabled();
+    expect(mocks.shareGet).toHaveBeenCalledTimes(2);
     expect(onLinkChange).toHaveBeenLastCalledWith(expect.stringContaining("/s/shr_1#link."));
   });
 

--- a/src/test/share-dialog.test.tsx
+++ b/src/test/share-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   shareInviteKeySave: vi.fn(),
   shareInviteKeysGet: vi.fn(),
   getShareBaseUrl: vi.fn(),
+  writeClipboardText: vi.fn(),
 }));
 
 vi.mock("../lib/tauri", () => ({
@@ -26,6 +27,10 @@ vi.mock("../lib/tauri", () => ({
   shareInviteKeySave: mocks.shareInviteKeySave,
   shareInviteKeysGet: mocks.shareInviteKeysGet,
   getShareBaseUrl: mocks.getShareBaseUrl,
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: mocks.writeClipboardText,
 }));
 
 const BASE_URL = "https://june-api.opensoftware.co";
@@ -46,12 +51,19 @@ function noteItem(overrides: Partial<Parameters<typeof ShareDialog>[0]["item"]> 
 }
 
 function mockClipboard() {
-  const writeText = vi.fn().mockResolvedValue(undefined);
-  Object.defineProperty(navigator, "clipboard", {
-    configurable: true,
-    value: { writeText },
+  mocks.writeClipboardText.mockResolvedValue(undefined);
+  return mocks.writeClipboardText;
+}
+
+function mockStoredLink() {
+  const keyB64 = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE";
+  mocks.shareKeyGet.mockResolvedValue({ shareId: "shr_1", contentKeyB64: keyB64 });
+  mocks.shareGet.mockResolvedValue({
+    shareId: "shr_1",
+    kind: "note",
+    invites: [{ inviteId: "shi_link", email: "link@share.invalid", state: "pending" }],
   });
-  return writeText;
+  mocks.shareInviteKeysGet.mockResolvedValue([{ inviteId: "shi_link", inviteKeyB64: keyB64 }]);
 }
 
 beforeEach(() => {
@@ -62,35 +74,48 @@ beforeEach(() => {
   mocks.shareInviteKeySave.mockResolvedValue(undefined);
   mocks.shareInviteKeysGet.mockResolvedValue([]);
   mocks.shareDelete.mockResolvedValue(undefined);
+  mocks.writeClipboardText.mockResolvedValue(undefined);
 });
 
 describe("ShareDialog", () => {
-  it("offers one copy-link action with an optional passcode", async () => {
+  it("offers one create-link action with an optional passcode", async () => {
     render(<ShareDialog open onClose={vi.fn()} item={noteItem()} />);
-    expect(await screen.findByRole("button", { name: "Copy link" })).toBeEnabled();
-    expect(screen.getByRole("checkbox", { name: "Require a passcode" })).not.toBeChecked();
+    expect(await screen.findByRole("button", { name: "Create link" })).toBeEnabled();
+    expect(screen.getByRole("switch", { name: "Require a passcode" })).not.toBeChecked();
     expect(screen.queryByLabelText("Passcode")).not.toBeInTheDocument();
     expect(screen.queryByText(/Invite by email/i)).not.toBeInTheDocument();
   });
 
-  it("creates an anonymous encrypted link and copies a decryptable URL", async () => {
+  it("creates an anonymous encrypted link and copies it automatically", async () => {
     mocks.shareCreate.mockImplementation(async (input) => ({
       shareId: "shr_1",
       invites: [{ inviteId: "shi_link", email: input.invites[0].email }],
     }));
+    let finishInviteKeySave: () => void = () => {};
+    mocks.shareInviteKeySave.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishInviteKeySave = resolve;
+        }),
+    );
     const user = userEvent.setup();
     const clipboard = mockClipboard();
     render(<ShareDialog open onClose={vi.fn()} item={noteItem()} />);
 
-    await user.click(await screen.findByRole("button", { name: "Copy link" }));
+    await user.click(await screen.findByRole("button", { name: "Create link" }));
+    await waitFor(() => expect(mocks.shareInviteKeySave).toHaveBeenCalledTimes(1));
+    expect(clipboard).not.toHaveBeenCalled();
+    finishInviteKeySave();
 
-    await waitFor(() => expect(clipboard).toHaveBeenCalledTimes(1));
+    const linkField = (await screen.findByRole("textbox", {
+      name: /Share link for/i,
+    })) as HTMLInputElement;
     expect(mocks.shareCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         invites: [expect.objectContaining({ email: "link@share.invalid" })],
       }),
     );
-    const link = clipboard.mock.calls[0][0] as string;
+    const link = linkField.value;
     const fragment = link.split("#")[1].split(".");
     expect(fragment.slice(0, 3)).toEqual(["link", "shi_link", "key"]);
 
@@ -110,6 +135,8 @@ describe("ShareDialog", () => {
     expect(mocks.shareInviteKeySave).toHaveBeenCalledWith(
       expect.objectContaining({ inviteId: "shi_link" }),
     );
+    await waitFor(() => expect(clipboard).toHaveBeenCalledWith(link));
+    expect(screen.getByRole("button", { name: "Copy link" })).toBeEnabled();
   });
 
   it("creates a passcode link whose fragment carries only a salt", async () => {
@@ -121,34 +148,82 @@ describe("ShareDialog", () => {
     const clipboard = mockClipboard();
     render(<ShareDialog open onClose={vi.fn()} item={noteItem()} />);
 
-    await user.click(await screen.findByRole("checkbox", { name: "Require a passcode" }));
+    await user.click(await screen.findByRole("switch", { name: "Require a passcode" }));
     await user.type(screen.getByLabelText("Passcode"), "correct horse battery staple");
-    await user.click(screen.getByRole("button", { name: "Copy link" }));
+    await user.click(screen.getByRole("button", { name: "Create link" }));
 
-    await waitFor(() => expect(clipboard).toHaveBeenCalledTimes(1));
-    const fragment = (clipboard.mock.calls[0][0] as string).split("#")[1].split(".");
+    const linkField = (await screen.findByRole("textbox", {
+      name: /Share link for/i,
+    })) as HTMLInputElement;
+    const fragment = linkField.value.split("#")[1].split(".");
     expect(fragment.slice(0, 3)).toEqual(["link", "shi_link", "pass"]);
     expect(fromBase64Url(fragment[3])).toHaveLength(16);
     expect(mocks.shareInviteKeySave.mock.calls[0][0].inviteKeyB64).toBe(fragment[3]);
-    expect(screen.getByText(/June does not store the passcode/i)).toBeInTheDocument();
+    await waitFor(() => expect(clipboard).toHaveBeenCalledWith(linkField.value));
+    expect(screen.getByText(/June never stores the passcode/i)).toBeInTheDocument();
+
+    let finishPasscodeCopy: () => void = () => {};
+    clipboard.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishPasscodeCopy = resolve;
+        }),
+    );
+    await user.click(screen.getByRole("button", { name: "Copy passcode" }));
+    expect(screen.getByRole("button", { name: "Copy link" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Copy passcode" })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Copy link" }));
+    expect(clipboard).toHaveBeenCalledTimes(2);
+    finishPasscodeCopy();
+    await waitFor(() => expect(clipboard).toHaveBeenLastCalledWith("correct horse battery staple"));
+    const copiedPasscodeButton = screen.getByRole("button", { name: "Passcode copied" });
+    expect(copiedPasscodeButton).toBeEnabled();
+    expect(copiedPasscodeButton).toHaveTextContent("Copy passcode");
+    expect(copiedPasscodeButton.querySelector(".t-icon-swap")).toHaveAttribute("data-state", "b");
+    fireEvent.focus(copiedPasscodeButton);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Copied");
+  });
+
+  it("keeps a created link available when automatic copy fails", async () => {
+    mocks.shareCreate.mockResolvedValue({
+      shareId: "shr_1",
+      invites: [{ inviteId: "shi_link", email: "link@share.invalid" }],
+    });
+    mocks.writeClipboardText.mockRejectedValueOnce(new Error("clipboard unavailable"));
+    const user = userEvent.setup();
+    render(<ShareDialog open onClose={vi.fn()} item={noteItem()} />);
+
+    await user.click(await screen.findByRole("button", { name: "Create link" }));
+
+    const linkField = (await screen.findByRole("textbox", {
+      name: /Share link for/i,
+    })) as HTMLInputElement;
+    expect(await screen.findByText(/Link created, but couldn't copy it/i)).toBeInTheDocument();
+    expect(mocks.shareDelete).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Copy link" }));
+    await waitFor(() => expect(mocks.writeClipboardText).toHaveBeenLastCalledWith(linkField.value));
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
   });
 
   it("loads and copies an existing link without recreating the share", async () => {
-    const keyB64 = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE";
-    mocks.shareKeyGet.mockResolvedValue({ shareId: "shr_1", contentKeyB64: keyB64 });
-    mocks.shareGet.mockResolvedValue({
-      shareId: "shr_1",
-      kind: "note",
-      invites: [{ inviteId: "shi_link", email: "link@share.invalid", state: "pending" }],
-    });
-    mocks.shareInviteKeysGet.mockResolvedValue([{ inviteId: "shi_link", inviteKeyB64: keyB64 }]);
+    mockStoredLink();
     const user = userEvent.setup();
     const clipboard = mockClipboard();
     render(<ShareDialog open onClose={vi.fn()} item={noteItem()} />);
 
-    await user.click(await screen.findByRole("button", { name: "Copy link" }));
+    const linkField = (await screen.findByRole("textbox", {
+      name: /Share link for/i,
+    })) as HTMLInputElement;
+    expect(linkField).toHaveAttribute("readonly");
+    expect(linkField.value).toContain("/s/shr_1#link.");
+    expect(linkField.closest(".copy-link-field")).not.toBeNull();
+    expect(linkField.closest(".share-dialog-section")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Copy link" }));
     await waitFor(() => expect(clipboard).toHaveBeenCalledWith(expect.stringContaining("#link.")));
     expect(mocks.shareCreate).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Link copied" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Stop sharing" })).toBeEnabled();
   });
 
@@ -159,32 +234,82 @@ describe("ShareDialog", () => {
     render(<ShareDialog open onClose={vi.fn()} item={noteItem()} />);
 
     expect(await screen.findByRole("alert")).toHaveTextContent("temporary load failure");
-    const copyButton = screen.getByRole("button", { name: "Copy link" });
-    expect(copyButton).toBeDisabled();
-    fireEvent.click(copyButton);
+    const passcodeSwitch = screen.getByRole("switch", { name: "Require a passcode" });
+    expect(passcodeSwitch).toBeDisabled();
+    fireEvent.click(passcodeSwitch);
     expect(mocks.shareCreate).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "Stop sharing" })).toBeEnabled();
   });
 
-  it("keeps a created share attached when copying its link fails", async () => {
-    mocks.shareCreate.mockResolvedValue({
-      shareId: "shr_1",
-      invites: [{ inviteId: "shi_link", email: "link@share.invalid" }],
-    });
-    const user = userEvent.setup();
-    const clipboard = mockClipboard();
-    clipboard.mockRejectedValueOnce(new Error("clipboard unavailable"));
+  it("reports a stored link while closed for breadcrumb actions", async () => {
+    mockStoredLink();
+    const onLinkChange = vi.fn();
+
+    const { rerender } = render(
+      <ShareDialog open={false} onClose={vi.fn()} onLinkChange={onLinkChange} item={noteItem()} />,
+    );
+
+    await waitFor(() =>
+      expect(onLinkChange).toHaveBeenLastCalledWith(expect.stringContaining("/s/shr_1#link.")),
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    rerender(<ShareDialog open onClose={vi.fn()} onLinkChange={onLinkChange} item={noteItem()} />);
+    expect(await screen.findByRole("button", { name: "Copy link" })).toBeEnabled();
+    rerender(
+      <ShareDialog open={false} onClose={vi.fn()} onLinkChange={onLinkChange} item={noteItem()} />,
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(mocks.shareKeyGet).toHaveBeenCalledOnce();
+    expect(onLinkChange).toHaveBeenLastCalledWith(expect.stringContaining("/s/shr_1#link."));
+  });
+
+  it("resets explicit copy feedback after the platform delay", async () => {
+    mockStoredLink();
+    mockClipboard();
     render(<ShareDialog open onClose={vi.fn()} item={noteItem()} />);
 
-    await user.click(await screen.findByRole("button", { name: "Copy link" }));
+    const copyButton = await screen.findByRole("button", { name: "Copy link" });
+    const iconSwap = copyButton.querySelector(".t-icon-swap");
+    expect(iconSwap).toHaveAttribute("data-state", "a");
+    expect(iconSwap?.querySelectorAll(".t-icon")).toHaveLength(2);
+    expect(iconSwap?.querySelector('[data-icon="a"]')).not.toBeNull();
+    expect(iconSwap?.querySelector('[data-icon="b"]')).not.toBeNull();
+    expect(copyButton).toHaveTextContent("");
 
-    expect(await screen.findByRole("alert")).toHaveTextContent("clipboard unavailable");
-    expect(screen.getByRole("button", { name: "Stop sharing" })).toBeEnabled();
-    expect(mocks.shareDelete).not.toHaveBeenCalled();
+    vi.useFakeTimers();
+    try {
+      fireEvent.focus(copyButton);
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Copy link");
 
-    await user.click(screen.getByRole("button", { name: "Copy link" }));
-    await waitFor(() => expect(clipboard).toHaveBeenCalledTimes(2));
-    expect(mocks.shareCreate).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        fireEvent.click(copyButton);
+        await Promise.resolve();
+      });
+      expect(copyButton).toHaveAccessibleName("Link copied");
+      expect(iconSwap).toHaveAttribute("data-state", "b");
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Copied");
+
+      act(() => vi.advanceTimersByTime(1_599));
+      expect(copyButton).toHaveAccessibleName("Link copied");
+      expect(iconSwap).toHaveAttribute("data-state", "b");
+
+      await act(async () => {
+        fireEvent.click(copyButton);
+        await Promise.resolve();
+      });
+      act(() => vi.advanceTimersByTime(1));
+      expect(copyButton).toHaveAccessibleName("Link copied");
+      expect(iconSwap).toHaveAttribute("data-state", "b");
+
+      act(() => vi.advanceTimersByTime(1_599));
+      expect(copyButton).toHaveAccessibleName("Copy link");
+      expect(iconSwap).toHaveAttribute("data-state", "a");
+      expect(screen.queryByRole("tooltip")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("blocks every close path while link creation is in flight", async () => {
@@ -199,9 +324,9 @@ describe("ShareDialog", () => {
     const user = userEvent.setup();
     render(<ShareDialog open onClose={onClose} item={noteItem()} />);
 
-    await user.click(await screen.findByRole("button", { name: "Copy link" }));
+    await user.click(await screen.findByRole("button", { name: "Create link" }));
     await waitFor(() => expect(mocks.shareCreate).toHaveBeenCalledTimes(1));
-    expect(screen.getByRole("button", { name: "Done" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Creating link..." })).toBeDisabled();
     await user.click(screen.getByRole("button", { name: "Close" }));
     fireEvent.keyDown(window, { key: "Escape" });
     expect(onClose).not.toHaveBeenCalled();
@@ -209,7 +334,21 @@ describe("ShareDialog", () => {
       shareId: "shr_1",
       invites: [{ inviteId: "shi_link", email: "link@share.invalid" }],
     });
-    await waitFor(() => expect(screen.getByRole("button", { name: "Done" })).toBeEnabled());
+    await waitFor(() => expect(screen.getByRole("button", { name: "Stop sharing" })).toBeEnabled());
+  });
+
+  it("maps the sharing_unavailable machine code to a human message", async () => {
+    mocks.shareCreate.mockRejectedValue({ message: "sharing_unavailable" });
+    mockClipboard();
+    const user = userEvent.setup();
+    render(<ShareDialog open onClose={vi.fn()} item={noteItem()} />);
+
+    await user.click(await screen.findByRole("button", { name: "Create link" }));
+
+    expect(
+      await screen.findByText(/Sharing isn't available on this June server yet/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("sharing_unavailable")).not.toBeInTheDocument();
   });
 
   it("surfaces legacy invite shares without making them anonymous", async () => {
@@ -222,6 +361,6 @@ describe("ShareDialog", () => {
     mocks.shareInviteKeysGet.mockResolvedValue([]);
     render(<ShareDialog open onClose={vi.fn()} item={noteItem()} />);
     expect(await screen.findByText(/previous invite-only sharing model/i)).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Copy link" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create link" })).not.toBeInTheDocument();
   });
 });

--- a/src/test/share-link-copy-action.test.tsx
+++ b/src/test/share-link-copy-action.test.tsx
@@ -1,0 +1,71 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ShareLinkCopyAction } from "../components/share/ShareLinkCopyAction";
+import { BreadcrumbBar } from "../components/ui/BreadcrumbBar";
+
+const mocks = vi.hoisted(() => ({
+  writeClipboardText: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: mocks.writeClipboardText,
+}));
+
+describe("ShareLinkCopyAction", () => {
+  it("copies from the current breadcrumb and resets its icon feedback", async () => {
+    mocks.writeClipboardText.mockResolvedValue(undefined);
+    render(
+      <BreadcrumbBar
+        items={[
+          { label: "Meeting notes" },
+          {
+            label: "Weekly sync",
+            action: <ShareLinkCopyAction url="https://june.test/s/shr_1#link.key" />,
+          },
+        ]}
+      />,
+    );
+
+    const copyButton = screen.getByRole("button", { name: "Copy share link" });
+    const iconSwap = copyButton.querySelector(".t-icon-swap");
+    expect(iconSwap).toHaveAttribute("data-state", "a");
+    expect(iconSwap?.querySelectorAll(".t-icon")).toHaveLength(2);
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.focus(copyButton);
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Copy share link");
+
+      await act(async () => {
+        fireEvent.click(copyButton);
+        await Promise.resolve();
+      });
+
+      expect(mocks.writeClipboardText).toHaveBeenCalledWith("https://june.test/s/shr_1#link.key");
+      expect(copyButton).toHaveAccessibleName("Share link copied");
+      expect(iconSwap).toHaveAttribute("data-state", "b");
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Copied");
+
+      act(() => vi.advanceTimersByTime(1200));
+      await act(async () => {
+        fireEvent.click(copyButton);
+        await Promise.resolve();
+      });
+      expect(mocks.writeClipboardText).toHaveBeenCalledTimes(2);
+
+      act(() => vi.advanceTimersByTime(401));
+      expect(copyButton).toHaveAccessibleName("Share link copied");
+      expect(iconSwap).toHaveAttribute("data-state", "b");
+
+      act(() => vi.advanceTimersByTime(1198));
+      expect(copyButton).toHaveAccessibleName("Share link copied");
+
+      act(() => vi.advanceTimersByTime(1));
+      expect(copyButton).toHaveAccessibleName("Copy share link");
+      expect(iconSwap).toHaveAttribute("data-state", "a");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Simplifies the private-share dialog and anonymous viewer hierarchy while preserving the bearer-link encryption model.
- Copies a newly created share link through a write-only native clipboard capability, then keeps explicit Copy actions available.
- Adds one fixed-size animated copy/check affordance across share links, referrals, dictation, transcripts, agent messages, and trace export, with persistent accessible feedback and repeat-click timer resets.
- Adds direct share-link copying beside current note/session breadcrumbs and updates note action icons and reference wording.

## Root cause

The asynchronous create/encrypt/persist flow outlived WKWebView's transient activation window, so the final browser clipboard write could fail even though link creation succeeded. Copy controls had also evolved independently, producing inconsistent icons, typography, feedback durations, and button geometry. Existing share links required reopening the full Share dialog to copy them.

## Validation

- `pnpm typecheck`
- `pnpm exec biome check . --diagnostic-level=error`
- 150 focused frontend tests across sharing, referrals, dictation, transcripts, agent copy actions, note reliability, tooltips, and breadcrumbs
- `cargo check --manifest-path src-tauri/Cargo.toml --locked`
- `git diff --check`
- Native debug-bundle checks at 1180 x 780 covered automatic clipboard copying, explicit Copy feedback, viewer loading, and toolbar alignment.

- [x] Tested visually where it matters.
- [x] Needs a June API (backend) deploy before it works end to end. The anonymous viewer HTML/CSS/JS changes require a June API deploy; desktop interaction changes require a desktop release.

## Out of scope

- Changes to the bearer-link cryptographic model, share API contract, recipient tracking, or per-recipient revocation.
- Right-click-only breadcrumb actions; the new shortcut is visible on hover and keyboard focus.

## Followups

- Attach a refreshed screenshot or recording before marking the PR ready for review.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes are called out: the desktop gains only `clipboard-manager:allow-write-text`; the existing bearer-link model is unchanged.
- [x] Workflow action references are pinned to full-length commit SHAs (no workflow changes).
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. The write-only clipboard capability needs owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (none changed).
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786818739&installation_id=144203540&pr_number=800&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F800&signature=215c838785f66ca6eecb082f497b0201da7dc842101b55f51f6ce088ed840a26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->