### PR TITLE
Fix share viewer June link

### DIFF
--- a/june-api/crates/api/src/handlers/share_viewer_page.html
+++ b/june-api/crates/api/src/handlers/share_viewer_page.html
@@ -10,7 +10,7 @@
 <body data-accounts-url="__ACCOUNTS_URL__" data-client-id="__CLIENT_ID__">
 <header id="topbar" hidden>
   <span id="topbar-title">June</span>
-  <a id="download-cta" href="https://june.opensoftware.co" rel="noreferrer">Get June</a>
+  <a id="download-cta" href="https://opensoftware.co/june" rel="noreferrer">Get June</a>
 </header>
 <main id="main">
   <section id="status" role="status">Loading&hellip;</section>

--- a/june-api/crates/api/tests/share_boundary.rs
+++ b/june-api/crates/api/tests/share_boundary.rs
@@ -880,6 +880,9 @@ async fn viewer_shell_is_static_noindex_and_identical_for_any_id() {
     let shell = std::str::from_utf8(&pages[0]).expect("viewer shell is utf-8");
     assert!(shell.contains("[hidden] { display: none !important; }"));
     assert!(shell.contains("Passcode required"));
+    assert!(shell.contains(
+        "<a id=\"download-cta\" href=\"https://opensoftware.co/june\" rel=\"noreferrer\">Get June</a>"
+    ));
     assert!(!shell.contains("Maybe later"));
 }
 


### PR DESCRIPTION
## What changed
- Point the share viewer’s **Get June** CTA to `https://opensoftware.co/june`.
- Add a boundary-test assertion for the rendered viewer shell URL.

## Why
The viewer currently links to the obsolete `june.opensoftware.co` destination instead of the canonical June product page.

## Impact
Recipients opening an encrypted share will land on the correct June page when they select **Get June**.

## Validation
- `cargo test -p june-api --test share_boundary` (13 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786821185&installation_id=144203540&pr_number=801&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F801&signature=e8ea116624e9e009cad2acb252c54bf122ca3dd94a00c81884edcf9539d72d5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->