### PR TITLE
Polish generated video session artifacts

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -64,6 +64,8 @@ const IMAGE_SOURCE_CAPABILITY_HMAC_PREFIX: &[u8] = b"june-image-source-v2\0";
 const IMAGE_SOURCE_MARKER: &str = ".june-source-";
 const IMAGE_SOURCE_SIGNATURE_HEX_LEN: usize = 64;
 const LEGACY_IMAGE_SOURCE_SECRET_FILE: &str = ".images.june-image-source-secret";
+const GENERATED_IMAGE_ROOTS: [&str; 2] = ["image_cache", "images"];
+const GENERATED_VIDEO_ROOTS: [&str; 2] = ["video_cache", "videos"];
 const HERMES_IMPORT_MAX_BYTES: u64 = HERMES_IMAGE_EDIT_SOURCE_MAX_BYTES as u64;
 const HERMES_IMAGE_PREVIEW_MAX_BYTES: u64 = 5 * 1024 * 1024;
 const HERMES_TEXT_PREVIEW_MAX_BYTES: u64 = 2 * 1024 * 1024;
@@ -3359,8 +3361,9 @@ fn validate_hermes_file_path(app: &AppHandle, path: &str) -> Result<PathBuf, App
     // video dirs now; QA must confirm the exact runtime cache dir for inline
     // generated-video rendering once the frontend/MCP chunks land.
     extended_allowed_roots.extend(
-        ["images", "image_cache", "videos", "video_cache"]
+        GENERATED_IMAGE_ROOTS
             .into_iter()
+            .chain(GENERATED_VIDEO_ROOTS)
             .filter_map(|relative| hermes_home.join(relative).canonicalize().ok()),
     );
     let allowed = extended_allowed_roots
@@ -8421,7 +8424,7 @@ fn resolve_bare_image_filename(hermes_home: &Path, path: &str) -> Option<PathBuf
     let storage_name = parse_image_source_reference(name)
         .map(|(_signature, expected_name)| expected_name)
         .unwrap_or_else(|| name.to_string());
-    ["image_cache", "images"]
+    GENERATED_IMAGE_ROOTS
         .into_iter()
         .map(|relative| hermes_home.join(relative).join(&storage_name))
         .find(|candidate| candidate.is_file())
@@ -8432,20 +8435,17 @@ fn resolve_bare_image_filename(hermes_home: &Path, path: &str) -> Option<PathBuf
 /// use the same bare `MEDIA:<filename>` reference that inline playback accepts,
 /// while the downstream canonical-path allow-list remains authoritative.
 fn resolve_bare_video_filename(hermes_home: &Path, path: &str) -> Option<PathBuf> {
-    let name = bare_filename(path.trim())?;
-    let normalized = name.to_ascii_lowercase();
-    let (id, extension) = normalized
-        .strip_prefix("generated-video-")?
-        .rsplit_once('.')?;
+    let name = bare_filename(path.trim())?.to_ascii_lowercase();
+    let (id, extension) = name.strip_prefix("generated-video-")?.rsplit_once('.')?;
     if id.is_empty()
         || !id.chars().all(|character| character.is_ascii_hexdigit())
         || !matches!(extension, "m4v" | "mov" | "mp4" | "webm")
     {
         return None;
     }
-    ["video_cache", "videos"]
+    GENERATED_VIDEO_ROOTS
         .into_iter()
-        .map(|relative| hermes_home.join(relative).join(name))
+        .map(|relative| hermes_home.join(relative).join(&name))
         .find(|candidate| candidate.is_file())
 }
 
@@ -12904,6 +12904,12 @@ assert capped["has_more"] is True, capped
         );
         assert_eq!(
             resolve_bare_video_filename(hermes_home, "generated-video-cd34.mp4"),
+            Some(videos_path.clone()),
+        );
+        // A mixed-case reference resolves to the lowercase on-disk file: the
+        // writer always emits lowercase, so the lookup must lowercase too.
+        assert_eq!(
+            resolve_bare_video_filename(hermes_home, "Generated-Video-CD34.MP4"),
             Some(videos_path),
         );
         assert_eq!(

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -3321,14 +3321,15 @@ fn validate_dropped_file_name(raw: &str) -> Result<String, AppError> {
 
 fn validate_hermes_file_path(app: &AppHandle, path: &str) -> Result<PathBuf, AppError> {
     let hermes_home = resolve_june_hermes_home(app)?;
-    // The assistant often references a generated image by its bare filename
-    // (`MEDIA:img_ae9ed1ffc669.png`) rather than its absolute path: the
-    // june_image tool returns a `filename`, and the model echoes that. Resolve a
-    // bare name against the generated-image roots so those references load; a
-    // path with directory components falls through unchanged and the allow-list
-    // check below still gates whatever we end up with.
-    let resolved =
-        resolve_bare_image_filename(&hermes_home, path).unwrap_or_else(|| PathBuf::from(path));
+    // The assistant often references generated media by its bare filename
+    // rather than its absolute path: the generation tools return a `filename`,
+    // and the model echoes that. Resolve a bare name against the generated-media
+    // roots so those references load; a path with directory components falls
+    // through unchanged and the allow-list check below still gates whatever we
+    // end up with.
+    let resolved = resolve_bare_image_filename(&hermes_home, path)
+        .or_else(|| resolve_bare_video_filename(&hermes_home, path))
+        .unwrap_or_else(|| PathBuf::from(path));
     let requested = resolved.canonicalize().map_err(|error| {
         tracing::warn!(requested_path = %path, %error, "validate_hermes_file_path failed to canonicalize path");
         AppError::new("hermes_file_download_failed", error.to_string())
@@ -8426,6 +8427,28 @@ fn resolve_bare_image_filename(hermes_home: &Path, path: &str) -> Option<PathBuf
         .find(|candidate| candidate.is_file())
 }
 
+/// Resolve a strict generated-video filename to the native video roots. Keeping
+/// this lookup beside `validate_hermes_file_path` lets Files preview/download
+/// use the same bare `MEDIA:<filename>` reference that inline playback accepts,
+/// while the downstream canonical-path allow-list remains authoritative.
+fn resolve_bare_video_filename(hermes_home: &Path, path: &str) -> Option<PathBuf> {
+    let name = bare_filename(path.trim())?;
+    let normalized = name.to_ascii_lowercase();
+    let (id, extension) = normalized
+        .strip_prefix("generated-video-")?
+        .rsplit_once('.')?;
+    if id.is_empty()
+        || !id.chars().all(|character| character.is_ascii_hexdigit())
+        || !matches!(extension, "m4v" | "mov" | "mp4" | "webm")
+    {
+        return None;
+    }
+    ["video_cache", "videos"]
+        .into_iter()
+        .map(|relative| hermes_home.join(relative).join(name))
+        .find(|candidate| candidate.is_file())
+}
+
 fn filesystem_roots(hermes_home: &Path) -> Result<Vec<FilesystemRootCandidate>, AppError> {
     let mut roots = Vec::new();
     for (id, label, relative, description) in [
@@ -12859,6 +12882,41 @@ assert capped["has_more"] is True, capped
         assert_eq!(
             resolve_bare_image_filename(hermes_home, "../secrets.png"),
             None
+        );
+    }
+
+    #[test]
+    fn resolve_bare_video_filename_maps_only_generated_names_to_video_roots() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let hermes_home = temp.path();
+        let cache_path = hermes_home
+            .join("video_cache")
+            .join("generated-video-ab12.webm");
+        let videos_path = hermes_home.join("videos").join("generated-video-cd34.mp4");
+        fs::create_dir_all(cache_path.parent().expect("cache parent")).expect("cache dir");
+        fs::create_dir_all(videos_path.parent().expect("videos parent")).expect("videos dir");
+        fs::write(&cache_path, b"cache").expect("cache video");
+        fs::write(&videos_path, b"video").expect("generated video");
+
+        assert_eq!(
+            resolve_bare_video_filename(hermes_home, "generated-video-ab12.webm"),
+            Some(cache_path),
+        );
+        assert_eq!(
+            resolve_bare_video_filename(hermes_home, "generated-video-cd34.mp4"),
+            Some(videos_path),
+        );
+        assert_eq!(
+            resolve_bare_video_filename(hermes_home, "generated-video-not-hex.mp4"),
+            None,
+        );
+        assert_eq!(
+            resolve_bare_video_filename(hermes_home, "../generated-video-cd34.mp4"),
+            None,
+        );
+        assert_eq!(
+            resolve_bare_video_filename(hermes_home, "generated-video-cd34.txt"),
+            None,
         );
     }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -361,6 +361,7 @@ import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
   displayedComposerUserMessageText,
+  isGeneratedVideoFilename,
   stripRenderedMediaReferences,
   textFromHermesContent,
   type AgentApprovalChoice,
@@ -1016,8 +1017,6 @@ type PersistedVideoSlashTurn = {
   requestId?: string;
   model?: string;
   jobId?: string;
-  averageExecutionMs?: number;
-  executionMs?: number;
   /** True once the generation completed but its context has not yet ridden a
    * follow-up prompt (the video fold; see storedPendingVideoSlashContexts). */
   contextPending?: boolean;
@@ -1145,8 +1144,6 @@ function videoSlashAssistantTurn(
     | "requestId"
     | "model"
     | "jobId"
-    | "averageExecutionMs"
-    | "executionMs"
   >,
 ): AgentChatTurn {
   if (turn.pending) {
@@ -1165,8 +1162,6 @@ function videoSlashAssistantTurn(
           jobId: turn.jobId,
           userCreatedAt: turn.createdAt,
           videoCreatedAt: turn.videoCreatedAt,
-          averageExecutionMs: turn.averageExecutionMs,
-          executionMs: turn.executionMs,
           error: turn.jobId ? undefined : "Generation was interrupted. Try again to resume.",
         },
       ],
@@ -1453,12 +1448,6 @@ function persistedVideoSlashTurn(
           requestId: candidate.requestId,
           model: typeof candidate.model === "string" ? candidate.model : undefined,
           jobId: typeof candidate.jobId === "string" ? candidate.jobId : undefined,
-          averageExecutionMs:
-            typeof candidate.averageExecutionMs === "number"
-              ? candidate.averageExecutionMs
-              : undefined,
-          executionMs:
-            typeof candidate.executionMs === "number" ? candidate.executionMs : undefined,
         }
       : {
           model: typeof candidate.model === "string" ? candidate.model : undefined,
@@ -5200,8 +5189,6 @@ export function AgentWorkspace({
               onProgress: (progress) => {
                 updateVideoSlashPart(sessionId, assistantTurnId, {
                   jobId: progress.jobId,
-                  averageExecutionMs: progress.averageExecutionMs,
-                  executionMs: progress.executionMs,
                 });
                 upsertStoredVideoSlashTurn({
                   id: turnId,
@@ -5215,8 +5202,6 @@ export function AgentWorkspace({
                   requestId,
                   model: input.model,
                   jobId: progress.jobId,
-                  averageExecutionMs: progress.averageExecutionMs,
-                  executionMs: progress.executionMs,
                 });
               },
             },
@@ -5300,8 +5285,6 @@ export function AgentWorkspace({
       onProgress: (progress) => {
         updateVideoSlashPart(input.sessionId, `${input.turnId}:assistant`, {
           jobId: progress.jobId,
-          averageExecutionMs: progress.averageExecutionMs,
-          executionMs: progress.executionMs,
         });
         upsertStoredVideoSlashTurn({
           id: input.turnId,
@@ -5315,8 +5298,6 @@ export function AgentWorkspace({
           requestId: input.requestId,
           model: input.model,
           jobId: input.jobId,
-          averageExecutionMs: progress.averageExecutionMs,
-          executionMs: progress.executionMs,
         });
       },
     });
@@ -5337,14 +5318,10 @@ export function AgentWorkspace({
         updateVideoSlashPart(turn.sessionId, assistantTurnId, {
           status: "running",
           jobId: progress.jobId,
-          averageExecutionMs: progress.averageExecutionMs,
-          executionMs: progress.executionMs,
         });
         upsertStoredVideoSlashTurn({
           ...turn,
           pending: true,
-          averageExecutionMs: progress.averageExecutionMs,
-          executionMs: progress.executionMs,
         });
       },
     });
@@ -14312,6 +14289,20 @@ function AgentGeneratedVideo({
     (capturedPoster && capturedPoster.src === src ? capturedPoster.dataUrl : undefined);
   const revealing = useGeneratedMediaReveal(part.status, Boolean(src));
 
+  useEffect(() => {
+    // Capture the poster off an offscreen element so the visible player can stay
+    // in no-CORS mode: the asset protocol omits `Access-Control-Allow-Origin` on
+    // 416 range responses, and only the canvas capture needs CORS.
+    if (!src || part.posterDataUrl || poster) return;
+    let mounted = true;
+    void capturedGeneratedVideoPoster(src).then((dataUrl) => {
+      if (mounted && dataUrl) setCapturedPoster({ src, dataUrl });
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [src, part.posterDataUrl, poster]);
+
   if (part.status === "running") {
     return (
       <div
@@ -14356,18 +14347,7 @@ function AgentGeneratedVideo({
     >
       <div className="agent-generated-video-frame">
         {src ? (
-          <video
-            controls
-            crossOrigin="anonymous"
-            src={part.posterDataUrl ? src : firstFrameVideoSource(src)}
-            poster={poster}
-            preload="metadata"
-            onLoadedData={(event) => {
-              if (poster) return;
-              const dataUrl = firstFramePosterDataUrl(event.currentTarget);
-              if (dataUrl) setCapturedPoster({ src, dataUrl });
-            }}
-          />
+          <video controls src={firstFrameVideoSource(src)} poster={poster} preload="metadata" />
         ) : (
           <span className="agent-generated-image-loading text-shimmer shimmer">
             Loading video...
@@ -14402,6 +14382,39 @@ function AgentGeneratedVideo({
 
 function firstFrameVideoSource(src: string) {
   return src.includes("#") ? src : `${src}#t=0.001`;
+}
+
+// Poster capture is CORS-mode work (canvas.toDataURL taints without it), so it
+// runs on a throwaway offscreen element rather than the visible player. Cache
+// the in-flight promise per src so the capture runs at most once per app run,
+// even across remounts.
+const generatedVideoPosterCache = new Map<string, Promise<string | undefined>>();
+
+export function resetGeneratedVideoPosterCacheForTest() {
+  generatedVideoPosterCache.clear();
+}
+
+function capturedGeneratedVideoPoster(src: string): Promise<string | undefined> {
+  const cached = generatedVideoPosterCache.get(src);
+  if (cached) return cached;
+  const capture = new Promise<string | undefined>((resolve) => {
+    const video = document.createElement("video");
+    video.crossOrigin = "anonymous";
+    video.preload = "auto";
+    video.muted = true;
+    const finish = (dataUrl?: string) => {
+      video.removeAttribute("src");
+      video.load();
+      resolve(dataUrl);
+    };
+    video.addEventListener("loadeddata", () => finish(firstFramePosterDataUrl(video)), {
+      once: true,
+    });
+    video.addEventListener("error", () => finish(), { once: true });
+    video.src = firstFrameVideoSource(src);
+  });
+  generatedVideoPosterCache.set(src, capture);
+  return capture;
 }
 
 function firstFramePosterDataUrl(video: HTMLVideoElement): string | undefined {
@@ -16433,7 +16446,16 @@ function surfacedArtifactsFromTurns(
         // A bare MEDIA reference can arrive before the filesystem snapshot or
         // a later absolute MEDIA reference. Keep the canonical path so Files
         // preview/download actions reach the native validator successfully.
-        if (isBareMediaPath(existingPath) && !isBareMediaPath(artifact.path)) {
+        // Only video aliases are strict generated-video-<hex> filenames (1:1
+        // with files); image aliases can derive from tool-supplied display
+        // names, so two different files can be alias-equal — never upgrade
+        // (and erase) a surfaced image row on that basis.
+        let canonicalPath = existingPath;
+        if (
+          part.type === "video" &&
+          isBareMediaPath(existingPath) &&
+          !isBareMediaPath(artifact.path)
+        ) {
           const index = surfaced.findIndex((item) => item.path === existingPath);
           if (index >= 0) {
             if (surfacedPaths.has(artifact.path)) surfaced.splice(index, 1);
@@ -16445,8 +16467,12 @@ function surfacedArtifactsFromTurns(
             for (const [alias, path] of surfacedMediaAliases) {
               if (path === existingPath) surfacedMediaAliases.set(alias, artifact.path);
             }
+            canonicalPath = artifact.path;
           }
         }
+        // Register this part's own aliases against the surviving row so a later
+        // bare reference through an unregistered alias doesn't push a duplicate.
+        for (const alias of aliases) surfacedMediaAliases.set(alias, canonicalPath);
         continue;
       }
       addArtifact(artifact);
@@ -16463,8 +16489,7 @@ function isBareMediaPath(path: string): boolean {
 
 export function generatedImagePathAliases(path: string, displayName?: string): string[] {
   const normalized = path.replaceAll("\\", "/");
-  const isBare = !normalized.includes("/");
-  if (!isBare && !/\/(?:image_cache|images)\//i.test(normalized)) return [];
+  if (!isBareMediaPath(path) && !/\/(?:image_cache|images)\//i.test(normalized)) return [];
   const aliases = new Set<string>();
   const pathName = normalized.split("/").at(-1);
   if (pathName) aliases.add(normalizedGeneratedImageName(pathName));
@@ -16481,12 +16506,9 @@ function normalizedGeneratedImageName(name: string): string {
 
 function generatedVideoPathAliases(path: string): string[] {
   const normalized = path.replaceAll("\\", "/");
-  const isBare = !normalized.includes("/");
-  if (!isBare && !/\/(?:generated-videos|video_cache|videos)\//i.test(normalized)) return [];
+  if (!isBareMediaPath(path) && !/\/(?:video_cache|videos)\//i.test(normalized)) return [];
   const name = normalized.split("/").at(-1);
-  return name && /^generated-video-[0-9a-f]+\.(?:m4v|mov|mp4|webm)$/i.test(name)
-    ? [name.toLowerCase()]
-    : [];
+  return name && isGeneratedVideoFilename(name) ? [name.toLowerCase()] : [];
 }
 
 function includesQuery(value: unknown, query: string) {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -14306,10 +14306,13 @@ function AgentGeneratedVideo({
   retryDisabledReason?: string;
 }) {
   const src = part.status === "complete" && part.path ? localVideoFileSrc(part.path) : undefined;
+  const [capturedPoster, setCapturedPoster] = useState<{ src: string; dataUrl: string }>();
+  const poster =
+    part.posterDataUrl ??
+    (capturedPoster && capturedPoster.src === src ? capturedPoster.dataUrl : undefined);
   const revealing = useGeneratedMediaReveal(part.status, Boolean(src));
 
   if (part.status === "running") {
-    const progress = videoProgressLabel(part);
     return (
       <div
         className="agent-generated-video"
@@ -14319,9 +14322,6 @@ function AgentGeneratedVideo({
         aria-live="polite"
       >
         <AgentGeneratedMediaPlaceholder kind="video" />
-        <div className="agent-generated-media-caption">
-          <span className="agent-generated-media-note">{progress ?? "This can take a minute"}</span>
-        </div>
       </div>
     );
   }
@@ -14356,7 +14356,18 @@ function AgentGeneratedVideo({
     >
       <div className="agent-generated-video-frame">
         {src ? (
-          <video controls src={src} poster={part.posterDataUrl} preload="metadata" />
+          <video
+            controls
+            crossOrigin="anonymous"
+            src={part.posterDataUrl ? src : firstFrameVideoSource(src)}
+            poster={poster}
+            preload="metadata"
+            onLoadedData={(event) => {
+              if (poster) return;
+              const dataUrl = firstFramePosterDataUrl(event.currentTarget);
+              if (dataUrl) setCapturedPoster({ src, dataUrl });
+            }}
+          />
         ) : (
           <span className="agent-generated-image-loading text-shimmer shimmer">
             Loading video...
@@ -14389,14 +14400,25 @@ function AgentGeneratedVideo({
   );
 }
 
-function videoProgressLabel(part: Extract<AgentChatPart, { type: "video" }>) {
-  if (typeof part.executionMs !== "number" || part.executionMs <= 0) return undefined;
-  const elapsed = Math.max(1, Math.round(part.executionMs / 1000));
-  if (typeof part.averageExecutionMs !== "number" || part.averageExecutionMs <= 0) {
-    return `${elapsed}s elapsed`;
+function firstFrameVideoSource(src: string) {
+  return src.includes("#") ? src : `${src}#t=0.001`;
+}
+
+function firstFramePosterDataUrl(video: HTMLVideoElement): string | undefined {
+  if (!video.videoWidth || !video.videoHeight) return undefined;
+  const scale = Math.min(1, 960 / Math.max(video.videoWidth, video.videoHeight));
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.max(1, Math.round(video.videoWidth * scale));
+  canvas.height = Math.max(1, Math.round(video.videoHeight * scale));
+  const context = canvas.getContext("2d");
+  if (!context) return undefined;
+  try {
+    context.drawImage(video, 0, 0, canvas.width, canvas.height);
+    return canvas.toDataURL("image/jpeg", 0.82);
+  } catch {
+    // Asset-protocol or codec restrictions should never block video playback.
+    return undefined;
   }
-  const total = Math.max(elapsed, Math.round(part.averageExecutionMs / 1000));
-  return `${elapsed}s of about ${total}s`;
 }
 
 /** A resolved action card renders as a quiet, expandable one-line row instead
@@ -16355,11 +16377,10 @@ function assignArtifactsToTurns(
   return byTurn;
 }
 
-// The inline media renderer owns generated-image cards, so
+// The inline media renderer owns generated image and video cards, so
 // assignArtifactsToTurns deliberately excludes their workspace files. The
-// Files panel still needs those path-backed images: collect them beside the
-// ordinary per-turn artifacts, preserving conversation order and listing each
-// file once.
+// Files panel still needs that path-backed media: collect it beside the ordinary
+// per-turn artifacts, preserving conversation order and listing each file once.
 function surfacedArtifactsFromTurns(
   turns: AgentChatTurn[],
   artifactsByTurn: Map<string, AgentArtifact[]>,
@@ -16367,7 +16388,7 @@ function surfacedArtifactsFromTurns(
 ): AgentArtifact[] {
   const surfaced: AgentArtifact[] = [];
   const surfacedPaths = new Set<string>();
-  const surfacedImageAliases = new Set<string>();
+  const surfacedMediaAliases = new Map<string, string>();
 
   function addArtifact(artifact: AgentArtifact) {
     if (surfacedPaths.has(artifact.path)) return;
@@ -16378,29 +16399,66 @@ function surfacedArtifactsFromTurns(
   for (const turn of turns) {
     for (const artifact of artifactsByTurn.get(turn.id) ?? []) addArtifact(artifact);
     for (const part of turn.parts) {
-      if (part.type !== "image" || part.status !== "complete") continue;
-      const imagePath = part.path?.trim();
-      if (!imagePath) continue;
-      const aliases = generatedImagePathAliases(imagePath, part.name);
-      if (aliases.some((alias) => surfacedImageAliases.has(alias))) continue;
-      const matchingArtifacts = availableArtifacts.filter(
-        (artifact) => artifact.path === imagePath,
-      );
-      const matchedArtifact = matchingArtifacts.length === 1 ? matchingArtifacts[0] : undefined;
-      if (matchedArtifact) {
-        addArtifact(matchedArtifact);
-      } else {
-        addArtifact({
-          name: part.name?.trim() || "Generated image",
-          path: imagePath,
-          rootLabel: "Workspace",
-        });
+      if ((part.type !== "image" && part.type !== "video") || part.status !== "complete") {
+        continue;
       }
-      for (const alias of aliases) surfacedImageAliases.add(alias);
+      const mediaPath = part.path?.trim();
+      if (!mediaPath) continue;
+      const aliases =
+        part.type === "image"
+          ? generatedImagePathAliases(mediaPath, part.name)
+          : generatedVideoPathAliases(mediaPath);
+      const matchingArtifacts = availableArtifacts.filter(
+        (artifact) => artifact.path === mediaPath,
+      );
+      let matchedArtifact = matchingArtifacts.length === 1 ? matchingArtifacts[0] : undefined;
+      if (!matchedArtifact && part.type === "video" && isBareMediaPath(mediaPath)) {
+        const aliasMatches = availableArtifacts.filter((artifact) =>
+          generatedVideoPathAliases(artifact.path).some((alias) => aliases.includes(alias)),
+        );
+        if (aliasMatches.length === 1) matchedArtifact = aliasMatches[0];
+      }
+      const artifact =
+        matchedArtifact ??
+        ({
+          name:
+            part.name?.trim() || (part.type === "image" ? "Generated image" : "Generated video"),
+          path: mediaPath,
+          rootLabel: "Workspace",
+        } satisfies AgentArtifact);
+      const existingPath = aliases
+        .map((alias) => surfacedMediaAliases.get(alias))
+        .find((path) => path !== undefined);
+      if (existingPath) {
+        // A bare MEDIA reference can arrive before the filesystem snapshot or
+        // a later absolute MEDIA reference. Keep the canonical path so Files
+        // preview/download actions reach the native validator successfully.
+        if (isBareMediaPath(existingPath) && !isBareMediaPath(artifact.path)) {
+          const index = surfaced.findIndex((item) => item.path === existingPath);
+          if (index >= 0) {
+            if (surfacedPaths.has(artifact.path)) surfaced.splice(index, 1);
+            else {
+              surfaced[index] = artifact;
+              surfacedPaths.add(artifact.path);
+            }
+            surfacedPaths.delete(existingPath);
+            for (const [alias, path] of surfacedMediaAliases) {
+              if (path === existingPath) surfacedMediaAliases.set(alias, artifact.path);
+            }
+          }
+        }
+        continue;
+      }
+      addArtifact(artifact);
+      for (const alias of aliases) surfacedMediaAliases.set(alias, artifact.path);
     }
   }
 
   return surfaced;
+}
+
+function isBareMediaPath(path: string): boolean {
+  return !path.replaceAll("\\", "/").includes("/");
 }
 
 export function generatedImagePathAliases(path: string, displayName?: string): string[] {
@@ -16419,6 +16477,16 @@ export function generatedImagePathAliases(path: string, displayName?: string): s
 
 function normalizedGeneratedImageName(name: string): string {
   return name.replace(/\.june-source-[^.]+(?=\.[^.]+$)/i, "").toLowerCase();
+}
+
+function generatedVideoPathAliases(path: string): string[] {
+  const normalized = path.replaceAll("\\", "/");
+  const isBare = !normalized.includes("/");
+  if (!isBare && !/\/(?:generated-videos|video_cache|videos)\//i.test(normalized)) return [];
+  const name = normalized.split("/").at(-1);
+  return name && /^generated-video-[0-9a-f]+\.(?:m4v|mov|mp4|webm)$/i.test(name)
+    ? [name.toLowerCase()]
+    : [];
 }
 
 function includesQuery(value: unknown, query: string) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -169,9 +169,6 @@ export type AgentChatVideoPart = {
   videoCreatedAt?: string;
   /** June API video job id, set once queueing succeeds. */
   jobId?: string;
-  /** Last processing progress from the status poll. */
-  averageExecutionMs?: number;
-  executionMs?: number;
   /** Local mp4 path; set once `status === "complete"`. */
   path?: string;
   /** Optional poster preview, reserved for future June API support. */
@@ -238,6 +235,13 @@ const MEDIA_VIDEO_REFERENCE_PATTERN = new RegExp(
 );
 export const mediaVideoReferencePattern = () =>
   new RegExp(MEDIA_VIDEO_REFERENCE_PATTERN.source, MEDIA_VIDEO_REFERENCE_PATTERN.flags);
+const GENERATED_VIDEO_FILENAME_PATTERN = new RegExp(
+  `^generated-video-[0-9a-f]+\\.(?:${MEDIA_VIDEO_EXTENSION_PATTERN})$`,
+  "i",
+);
+export function isGeneratedVideoFilename(name: string): boolean {
+  return GENERATED_VIDEO_FILENAME_PATTERN.test(name);
+}
 
 function sortAgentChatTurns(turns: AgentChatTurn[]) {
   return turns

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3203,16 +3203,6 @@ input:focus-visible,
   font-size: var(--fs-lg);
 }
 
-/* Caption under a generating frame (video's elapsed-time note). */
-.agent-generated-media-caption {
-  margin-top: var(--sp-2);
-}
-
-.agent-generated-media-note {
-  color: var(--muted-foreground);
-  font-size: var(--fs-xs);
-}
-
 .agent-generated-image-error {
   margin: 0;
   border: 1px solid var(--border-subtle);

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -2431,7 +2431,7 @@ describe("Agent chat runtime", () => {
       {
         id: "assistant-2",
         role: "assistant",
-        content: `MEDIA:/tmp/generated-videos/${name}`,
+        content: `MEDIA:/tmp/videos/${name}`,
         timestamp: "2026-06-04T10:00:01.000Z",
       },
     ]);
@@ -2522,8 +2522,7 @@ describe("Agent chat runtime", () => {
   });
 
   it("hands a live video tool result from its placeholder to an inline video", () => {
-    const path =
-      "/Users/alex/Library/Application Support/June/generated-videos/generated-video-ab12.mp4";
+    const path = "/Users/alex/Library/Application Support/June/videos/generated-video-ab12.mp4";
     const turns = buildHermesSessionChatTurns(
       [],
       [

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -10414,6 +10414,126 @@ describe("AgentWorkspace", () => {
     expect(within(panel).getByText(mediaName)).toBeInTheDocument();
   });
 
+  it("registers a generated video in the session Files panel", async () => {
+    const user = userEvent.setup();
+    const mediaPath =
+      "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/videos/generated-video-ab12.mp4";
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content: `MEDIA:${mediaPath}`,
+        timestamp: "2026-06-04T18:39:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByRole("button", { name: "Download video" })).toBeInTheDocument();
+    const video = document.querySelector<HTMLVideoElement>(".agent-generated-video video");
+    expect(video).not.toBeNull();
+    expect(video).toHaveAttribute("crossorigin", "anonymous");
+    expect(video).toHaveAttribute("preload", "metadata");
+    expect(video?.getAttribute("src")).toMatch(/#t=0\.001$/);
+    const drawImage = vi.fn();
+    const getContext = vi
+      .spyOn(HTMLCanvasElement.prototype, "getContext")
+      .mockReturnValue({ drawImage } as unknown as CanvasRenderingContext2D);
+    const toDataUrl = vi
+      .spyOn(HTMLCanvasElement.prototype, "toDataURL")
+      .mockReturnValue("data:image/jpeg;base64,cG9zdGVy");
+    Object.defineProperties(video, {
+      videoWidth: { configurable: true, value: 1280 },
+      videoHeight: { configurable: true, value: 720 },
+    });
+    fireEvent.loadedData(video as HTMLVideoElement);
+    getContext.mockRestore();
+    toDataUrl.mockRestore();
+    await waitFor(() => expect(video).toHaveAttribute("poster", "data:image/jpeg;base64,cG9zdGVy"));
+    expect(drawImage).toHaveBeenCalledWith(video, 0, 0, 960, 540);
+
+    await user.click(screen.getByRole("button", { name: "View files (1)" }));
+    const panel = await screen.findByRole("complementary", { name: "Files" });
+    expect(within(panel).getByText("generated-video-ab12.mp4")).toBeInTheDocument();
+  });
+
+  it("lists bare and absolute references to the same generated video once", async () => {
+    const user = userEvent.setup();
+    const mediaName = "generated-video-ab12.mp4";
+    const mediaPath =
+      "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/videos/generated-video-ab12.mp4";
+    mocks.hermesBridgeFileText.mockResolvedValue(null);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content: `MEDIA:${mediaName}`,
+        timestamp: "2026-06-04T18:39:00Z",
+      },
+      {
+        id: "message-2",
+        role: "assistant",
+        content: `MEDIA:${mediaPath}`,
+        timestamp: "2026-06-04T18:39:01Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByRole("button", { name: "View files (1)" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "View files (1)" }));
+    const panel = await screen.findByRole("complementary", { name: "Files" });
+    const fileRow = within(panel).getByText(mediaName).closest("button");
+    expect(fileRow).not.toBeNull();
+    await user.click(fileRow as HTMLButtonElement);
+    await waitFor(() => expect(mocks.hermesBridgeFileText).toHaveBeenCalledWith(mediaName));
+    await user.click(within(panel).getByRole("button", { name: `Download ${mediaName}` }));
+    expect(mocks.downloadHermesBridgeFile).toHaveBeenCalledWith(mediaName);
+  });
+
+  it("keeps a bare-only generated video usable in Files", async () => {
+    const user = userEvent.setup();
+    const mediaName = "generated-video-ab12.mp4";
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/workspace",
+          description: "Hermes scratch files and generated outputs.",
+          entries: [],
+        },
+        {
+          id: "memory",
+          label: "Memory",
+          path: "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/memories",
+          description: "Persistent Hermes memory files and stores.",
+          entries: [],
+        },
+      ],
+    });
+    mocks.hermesBridgeFileText.mockResolvedValue(null);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content: `MEDIA:${mediaName}`,
+        timestamp: "2026-06-04T18:39:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    await user.click(await screen.findByRole("button", { name: "View files (1)" }));
+    const panel = await screen.findByRole("complementary", { name: "Files" });
+    const fileRow = within(panel).getByText(mediaName).closest("button");
+    expect(fileRow).not.toBeNull();
+    await user.click(fileRow as HTMLButtonElement);
+    await waitFor(() => expect(mocks.hermesBridgeFileText).toHaveBeenCalledWith(mediaName));
+    await user.click(within(panel).getByRole("button", { name: `Download ${mediaName}` }));
+    expect(mocks.downloadHermesBridgeFile).toHaveBeenCalledWith(mediaName);
+  });
+
   it("does not remap a bare-filename MEDIA image to a same-named Workspace file", async () => {
     const user = userEvent.setup();
     const mediaName = "img_ae9ed1ffc669.png";
@@ -11689,6 +11809,7 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByRole("dialog", { name: "Safe mode is on" })).not.toBeInTheDocument();
     expect(mocks.imagePromptMayBeExplicit).toHaveBeenCalledWith("a red bicycle");
     expect(mocks.videoGenerate).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "View files (1)" })).toBeInTheDocument();
   });
 
   it("removes the persisted /video pending turn after a terminal submit failure", async () => {
@@ -11767,9 +11888,8 @@ describe("AgentWorkspace", () => {
       await settleUnderFakeTimers(() =>
         expect(screen.getByText("Generating video…")).toHaveClass("text-shimmer", "shimmer"),
       );
-      // The note under the frame carries either the fallback copy or, once the
-      // first status poll lands, the elapsed-time progress.
-      expect(document.querySelector(".agent-generated-media-note")).not.toBeNull();
+      expect(screen.queryByText("This can take a minute")).not.toBeInTheDocument();
+      expect(document.querySelector(".agent-generated-media-caption")).toBeNull();
       await act(async () => {
         await vi.advanceTimersByTimeAsync(900_000);
       });

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -15,6 +15,7 @@ import {
   generatedImagePathAliases,
   projectAgentActivityLevels,
   resetAgentSessionContinuity,
+  resetGeneratedVideoPosterCacheForTest,
   seedAgentComposerDraftForTest,
   type AgentSessionsChangedDetail,
 } from "../components/agent/AgentWorkspace";
@@ -473,6 +474,7 @@ describe("AgentWorkspace", () => {
     // any still-working session for the next mount — across tests that would
     // leak one test's mid-run session into the next.
     resetAgentSessionContinuity();
+    resetGeneratedVideoPosterCacheForTest();
     // Feature 14: the artifact store is a process-wide singleton; drop the
     // session rows these tests touch so one test's artifacts don't leak into
     // the next.
@@ -10427,14 +10429,18 @@ describe("AgentWorkspace", () => {
       },
     ]);
 
-    render(<AgentWorkspace />);
-
-    expect(await screen.findByRole("button", { name: "Download video" })).toBeInTheDocument();
-    const video = document.querySelector<HTMLVideoElement>(".agent-generated-video video");
-    expect(video).not.toBeNull();
-    expect(video).toHaveAttribute("crossorigin", "anonymous");
-    expect(video).toHaveAttribute("preload", "metadata");
-    expect(video?.getAttribute("src")).toMatch(/#t=0\.001$/);
+    // The poster is captured off an offscreen CORS-mode element so the visible
+    // player can stay in no-CORS mode; track the videos React and the capture
+    // effect create so the test can drive the offscreen one.
+    const realCreateElement = document.createElement.bind(document);
+    const createdVideos: HTMLVideoElement[] = [];
+    const createElementSpy = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tag: string, options?: ElementCreationOptions) => {
+        const element = realCreateElement(tag, options);
+        if (tag === "video") createdVideos.push(element as HTMLVideoElement);
+        return element;
+      });
     const drawImage = vi.fn();
     const getContext = vi
       .spyOn(HTMLCanvasElement.prototype, "getContext")
@@ -10442,15 +10448,32 @@ describe("AgentWorkspace", () => {
     const toDataUrl = vi
       .spyOn(HTMLCanvasElement.prototype, "toDataURL")
       .mockReturnValue("data:image/jpeg;base64,cG9zdGVy");
-    Object.defineProperties(video, {
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByRole("button", { name: "Download video" })).toBeInTheDocument();
+    const video = document.querySelector<HTMLVideoElement>(".agent-generated-video video");
+    expect(video).not.toBeNull();
+    // Playback stays in no-CORS mode.
+    expect(video).not.toHaveAttribute("crossorigin");
+    expect(video).toHaveAttribute("preload", "metadata");
+    expect(video?.getAttribute("src")).toMatch(/#t=0\.001$/);
+
+    await waitFor(() =>
+      expect(createdVideos.some((candidate) => candidate.crossOrigin === "anonymous")).toBe(true),
+    );
+    const posterVideo = createdVideos.find((candidate) => candidate.crossOrigin === "anonymous");
+    expect(posterVideo).toBeDefined();
+    Object.defineProperties(posterVideo, {
       videoWidth: { configurable: true, value: 1280 },
       videoHeight: { configurable: true, value: 720 },
     });
-    fireEvent.loadedData(video as HTMLVideoElement);
+    fireEvent.loadedData(posterVideo as HTMLVideoElement);
+    await waitFor(() => expect(video).toHaveAttribute("poster", "data:image/jpeg;base64,cG9zdGVy"));
+    expect(drawImage).toHaveBeenCalledWith(posterVideo, 0, 0, 960, 540);
+    createElementSpy.mockRestore();
     getContext.mockRestore();
     toDataUrl.mockRestore();
-    await waitFor(() => expect(video).toHaveAttribute("poster", "data:image/jpeg;base64,cG9zdGVy"));
-    expect(drawImage).toHaveBeenCalledWith(video, 0, 0, 960, 540);
 
     await user.click(screen.getByRole("button", { name: "View files (1)" }));
     const panel = await screen.findByRole("complementary", { name: "Files" });
@@ -10640,6 +10663,61 @@ describe("AgentWorkspace", () => {
         role: "assistant",
         content: `MEDIA:${signedName}`,
         timestamp: "2026-06-04T18:41:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByRole("button", { name: "View files (1)" })).toBeInTheDocument();
+  });
+
+  it("lists an image reached through an unregistered cache-name alias only once", async () => {
+    const absolutePath = "/Users/alex/.hermes/image_cache/img_cff5d542a4d2.png";
+    const signedName = "generated-image-abc.june-source-deadbeef.png";
+    const bareCacheName = "img_cff5d542a4d2.png";
+    // The absolute image_cache result carries the signed display name, so its
+    // aliases are {img_cff5d542a4d2.png, generated-image-abc.png} — the second
+    // links it to the bare signed reference, the first to the bare cache ref.
+    const namedAbsoluteResult = JSON.stringify({
+      result: `MEDIA:${absolutePath}`,
+      filename: signedName,
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      // 1) A bare, signed reference surfaces the Files row first. The user turns
+      // between the assistant turns keep each inline image in its own agent run
+      // so the within-run media dedup does not collapse them first.
+      {
+        id: "message-1",
+        role: "assistant",
+        content: `MEDIA:${signedName}`,
+        timestamp: "2026-06-04T18:39:00Z",
+      },
+      {
+        id: "message-2",
+        role: "user",
+        content: "Show it again.",
+        timestamp: "2026-06-04T18:39:01Z",
+      },
+      // 3) An absolute image_cache result whose display name aliases to (1).
+      {
+        id: "message-3",
+        role: "assistant",
+        content: namedAbsoluteResult,
+        timestamp: "2026-06-04T18:39:02Z",
+      },
+      {
+        id: "message-4",
+        role: "user",
+        content: "One more time.",
+        timestamp: "2026-06-04T18:39:03Z",
+      },
+      // 5) A later bare cache-name reference must reuse the same row rather than
+      // push a duplicate synthetic one.
+      {
+        id: "message-5",
+        role: "assistant",
+        content: `MEDIA:${bareCacheName}`,
+        timestamp: "2026-06-04T18:39:04Z",
       },
     ]);
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -10480,12 +10480,17 @@ describe("AgentWorkspace", () => {
     expect(within(panel).getByText("generated-video-ab12.mp4")).toBeInTheDocument();
   });
 
-  it("lists bare and absolute references to the same generated video once", async () => {
+  it("collapses a bare then absolute video reference within one agent run to the bare part", async () => {
     const user = userEvent.setup();
     const mediaName = "generated-video-ab12.mp4";
     const mediaPath =
       "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/videos/generated-video-ab12.mp4";
     mocks.hermesBridgeFileText.mockResolvedValue(null);
+    // Both references land in the same agent run (no user/system turn between),
+    // so deduplicateGeneratedMediaWithinAgentRuns collapses them to the first
+    // (bare) part before the Files-panel logic ever sees the absolute one — the
+    // surfaced row therefore keeps the bare name. The cross-run upgrade branch
+    // is covered separately below.
     mocks.listHermesSessionMessages.mockResolvedValue([
       {
         id: "message-1",
@@ -10512,6 +10517,50 @@ describe("AgentWorkspace", () => {
     await waitFor(() => expect(mocks.hermesBridgeFileText).toHaveBeenCalledWith(mediaName));
     await user.click(within(panel).getByRole("button", { name: `Download ${mediaName}` }));
     expect(mocks.downloadHermesBridgeFile).toHaveBeenCalledWith(mediaName);
+  });
+
+  it("upgrades a bare video row to its absolute path across agent runs", async () => {
+    const user = userEvent.setup();
+    const mediaName = "generated-video-ab12.mp4";
+    const mediaPath =
+      "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/videos/generated-video-ab12.mp4";
+    mocks.hermesBridgeFileText.mockResolvedValue(null);
+    // The user turn between the two references puts them in separate agent runs,
+    // so both parts survive the within-run collapse and reach the Files-panel
+    // logic. surfacedArtifactsFromTurns then upgrades the bare row to the
+    // absolute canonical path so preview/download reach the native validator.
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content: `MEDIA:${mediaName}`,
+        timestamp: "2026-06-04T18:39:00Z",
+      },
+      {
+        id: "message-2",
+        role: "user",
+        content: "Show it again.",
+        timestamp: "2026-06-04T18:39:01Z",
+      },
+      {
+        id: "message-3",
+        role: "assistant",
+        content: `MEDIA:${mediaPath}`,
+        timestamp: "2026-06-04T18:39:02Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByRole("button", { name: "View files (1)" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "View files (1)" }));
+    const panel = await screen.findByRole("complementary", { name: "Files" });
+    const fileRow = within(panel).getByText(mediaName).closest("button");
+    expect(fileRow).not.toBeNull();
+    await user.click(fileRow as HTMLButtonElement);
+    await waitFor(() => expect(mocks.hermesBridgeFileText).toHaveBeenCalledWith(mediaPath));
+    await user.click(within(panel).getByRole("button", { name: `Download ${mediaName}` }));
+    expect(mocks.downloadHermesBridgeFile).toHaveBeenCalledWith(mediaPath);
   });
 
   it("keeps a bare-only generated video usable in Files", async () => {
@@ -10622,16 +10671,26 @@ describe("AgentWorkspace", () => {
       "generated-image-abc.png",
     ]);
     expect(generatedImagePathAliases(signedName, signedName)).toEqual(["generated-image-abc.png"]);
+    const user = userEvent.setup();
     const envelope = {
-      result: `MEDIA:${absolutePath}\n${JSON.stringify({ filename: signedName })}`,
+      result: `MEDIA:${absolutePath}`,
       structuredContent: { filename: signedName, mimeType: "image/png" },
     };
+    // Hermes separates the untrusted-result header from its JSON payload with a
+    // blank line; without it parseUntrustedToolResultEnvelope declines and the
+    // MEDIA ref never becomes an inline image part.
     const wrappedResult = [
       '<untrusted_tool_result source="mcp_june_image_generate_image">',
+      "",
       JSON.stringify(envelope),
+      "",
       "</untrusted_tool_result>",
     ].join("\n");
     mocks.listHermesSessionMessages.mockResolvedValue([
+      // The absolute image_cache result and the later bare signed reference land
+      // in separate agent runs (the user turn between them resets the within-run
+      // media dedup), so both survive as parts and the Files-panel logic dedups
+      // them by alias into a single row keyed on the absolute canonical path.
       {
         id: "message-1",
         role: "assistant",
@@ -10669,6 +10728,12 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
 
     expect(await screen.findByRole("button", { name: "View files (1)" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "View files (1)" }));
+    const panel = await screen.findByRole("complementary", { name: "Files" });
+    const fileRow = within(panel).getByText(signedName).closest("button");
+    expect(fileRow).not.toBeNull();
+    await user.click(fileRow as HTMLButtonElement);
+    await waitFor(() => expect(mocks.hermesBridgeFilePreview).toHaveBeenCalledWith(absolutePath));
   });
 
   it("lists an image reached through an unregistered cache-name alias only once", async () => {

--- a/src/test/hermes-control-plane-classifier.test.ts
+++ b/src/test/hermes-control-plane-classifier.test.ts
@@ -307,7 +307,7 @@ describe("classifyHermesEvent — tools", () => {
 
   it("preserves a video MEDIA result without forwarding unrelated tool text", () => {
     const mediaText =
-      "MEDIA:/Users/alex/Library/Application Support/June/generated-videos/generated-video-ab12.mp4";
+      "MEDIA:/Users/alex/Library/Application Support/June/videos/generated-video-ab12.mp4";
     const result = classifyHermesEvent(
       event("tool.complete", {
         tool_call_id: "video1",


### PR DESCRIPTION
## Summary

- Surface completed generated videos in the session Files panel, including filename-only `MEDIA:` references.
- Capture the video's opening frame as a best-effort poster while preserving normal playback when capture is unavailable.
- Remove the detached timing caption from the in-progress video card.
- Resolve strict bare generated-video filenames at the native file-validation boundary so Files preview and download actions work.

## Root cause

The conversation artifact collector deliberately excluded inline media from ordinary file assignment and then only added generated images back to the Files panel. Generated videos therefore remained playable inline but were absent from Files. Separately, native file validation resolved bare generated-image names but not the filename-only generated-video references commonly returned by the video tool.

## Validation

- `make check typecheck test-web` - 175 files passed, 2,851 tests passed, 2 existing skips.
- `pnpm test:rust` - 806 unit tests plus all Rust integration suites passed.
- Focused generated-video session tests - 5 passed.
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`.
- Live browser QA confirmed the opening-frame poster, one Files entry, and removal of the timing caption with no console or page errors.
- Independent standards, feature-spec, and adversarial reviews are clean.

- [x] Tested visually where it matters. A QA recording will be attached in a PR comment.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Changes to video generation models, billing, duration, resolution, or June API contracts.
- A dedicated video player inside the Files panel; binary video files continue to use the existing file-preview fallback and download affordance.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. Bare video resolution accepts only generated-video names with supported extensions and remains behind canonical allowed-root validation.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow files changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such files changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend files changed.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786821642&installation_id=144203540&pr_number=802&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F802&signature=92ea1c258a274c7c84b58b044d494fe6d31abec25b37cbcacb450278795908d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->