### PR TITLE
Polish model filter spacing

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6697,7 +6697,7 @@ input:focus-visible,
   /* Bleed past the surface padding so the hairline runs the panel's full
    * width; the widened padding keeps the label on the shared content gutter. */
   margin: 0 calc(-1 * var(--sp-1));
-  padding: 0 calc(var(--sp-1) + var(--sp-2));
+  padding: var(--sp-2) calc(var(--sp-1) + var(--sp-2));
   border-bottom: 1px solid color-mix(in oklch, var(--border-subtle) 50%, transparent);
   color: var(--popover-foreground);
   font-size: var(--fs-md);


### PR DESCRIPTION
## Summary

- Add vertical breathing room to the Private model-catalog filter.
- Preserve the existing shared left gutter and full-width divider.

## Root cause

The filter row explicitly used zero vertical padding, which left its label and switch crowded against the search field and model list.

## Validation

- `make check` (passes with the repository's existing warnings)
- `make local-ci` (TypeScript and 2,857 frontend tests passed; 2 skipped)
- `git diff --check`
- Local Chromium preview of the catalog and Suggested popovers side by side

- [x] Tested visually where it matters. The updated catalog filter was verified in a local Chromium preview.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Model-selection behavior, filtering logic, and the Suggested popover's Auto-row spacing are unchanged.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. This change is not security-sensitive.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow files changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. None changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. None changed.
- [x] User-facing copy follows the repo UI conventions. No copy changed.
