### PR TITLE
Redesign sidebar update status card with June spinner and soft dismiss

### DIFF
--- a/.agents/skills/repo-review/CALIBRATION.md
+++ b/.agents/skills/repo-review/CALIBRATION.md
@@ -107,3 +107,8 @@ data-driven: discount reviewer patterns with a bad true/findings ratio
 | #798 | Spec (codex, r1+final) | 0 | — | clean against the RC Slack announcement contract and documented amendments |
 | #798 | Adversarial (codex, r1-r5) | 5 | 3.5 | found mutable historical download links, fail-open provenance guards, and duplicate non-idempotent webhook retries; the notification-only recovery request was partly deliberate, and fixed-alias atomicity was verified as origin/main parity; final approve |
 | #798 | Cross-harness convergence (claude + codex CLI) | — | — | both runner attempts produced no usable verdict; the cycle continued with fresh read-only reviewers rather than treating missing output as approval |
+| #804 | Standards (codex, r1+final) | 4 | 4 | caught three design-token violations in the new CSS, then stale comments after the state-lifecycle fix; final clean |
+| #804 | Spec (codex, r1+final) | 0 | — | clean against the chronological design-feedback transcript before and after the review fixes |
+| #804 | Adversarial (codex, r1+convergence) | 2 | 2 | found periodic checks animating stale failures and new statuses inheriting the success exit phase; convergence approved the guarded reducer and manual-only spinner |
+| #804 | Adversarial (claude, cross-harness) | 0 | — | two detailed approve passes traced timer ordering, explicit failure propagation, reduced motion, demo cleanup, and exact spinner/mark geometry |
+| #804 | Greptile (stale initial SHA) | 2 | 2 | both real: raw mark sizing duplicated the Standards finding and failure styling depended on message wording; precise despite reviewing the initial commit |

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,3 @@
-import { IconArrowInbox } from "central-icons/IconArrowInbox";
 import { IconChevronRightSmall } from "central-icons/IconChevronRightSmall";
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { listen } from "@tauri-apps/api/event";
@@ -62,6 +61,7 @@ import {
 import { markReferralNudgeClickedThrough, recordDictationFinished } from "../lib/referral-nudge";
 import { useReferralNudgeTriggers } from "./referral-nudge-triggers";
 import { Dialog } from "../components/ui/Dialog";
+import { Spinner } from "../components/ui/Spinner";
 import {
   assignNoteToFolder,
   assignSessionToFolder,
@@ -227,10 +227,18 @@ import {
   checkForJuneUpdate,
   prepareJuneUpdate,
   startPeriodicJuneUpdateChecks,
+  UP_TO_DATE_STATUS,
   type UpdateCheckMode,
   type UpdateInstallProgress,
   type UpdatePromptPayload,
 } from "./update-decision";
+
+// "June is up to date." is a confirmation, not a call to action: linger, then
+// hide on its own. Failures and busy statuses persist until dismissed.
+const UP_TO_DATE_DISMISS_MS = 4000;
+// Soft-exit window: the update-popover-out animation runs var(--t-med) (160ms);
+// the status clears just after it finishes.
+const UP_TO_DATE_EXIT_MS = 220;
 
 const SIDEBAR_DEFAULT_WIDTH = 240;
 const SIDEBAR_MIN_WIDTH = 188;
@@ -494,7 +502,14 @@ export function App() {
   const [microphoneStatus, setMicrophoneStatus] = useState<string>();
   const [readyUpdate, setReadyUpdate] = useState<UpdatePromptPayload<JuneUpdate> | null>(null);
   const [updateStatus, setUpdateStatus] = useState<string | null>(null);
+  // True while the up-to-date status plays its timed soft exit (see the
+  // auto-dismiss effect next to runUpdateCheck).
+  const [updateStatusLeaving, setUpdateStatusLeaving] = useState(false);
   const [preparingUpdate, setPreparingUpdate] = useState(false);
+  // Mirrors checkingUpdateRef for render: drives the status card's busy spinner
+  // while a manual "Checking for updates..." round-trip is in flight. The ref
+  // stays the source of truth for the re-entrancy guards in runUpdateCheck.
+  const [checkingUpdate, setCheckingUpdate] = useState(false);
   const [relaunchingUpdate, setRelaunchingUpdate] = useState(false);
   const [updateProgress, setUpdateProgress] = useState<UpdateInstallProgress | null>(null);
   // `ready` only says this device is capable of system capture; the platform
@@ -673,6 +688,9 @@ export function App() {
         setReadyUpdate,
         setStatus: setUpdateStatus,
         setRelaunching: setRelaunchingUpdate,
+        setPreparing: setPreparingUpdate,
+        setChecking: setCheckingUpdate,
+        setProgress: setUpdateProgress,
       });
     });
     return () => {
@@ -1607,6 +1625,7 @@ export function App() {
         return;
       }
       checkingUpdateRef.current = true;
+      setCheckingUpdate(true);
       if (mode === "manual") setUpdateStatus("Checking for updates...");
       else if (mode === "launch") setUpdateStatus(null);
       void checkForJuneUpdate(
@@ -1615,7 +1634,7 @@ export function App() {
           prompt: (payload) => {
             prepareUpdate(payload, mode);
           },
-          reportNoUpdate: () => setUpdateStatus("June is up to date."),
+          reportNoUpdate: () => setUpdateStatus(UP_TO_DATE_STATUS),
           reportFailure: (message) => {
             if (mode !== "periodic") {
               setUpdateStatus(`Update check failed: ${message}`);
@@ -1625,10 +1644,33 @@ export function App() {
         mode,
       ).finally(() => {
         checkingUpdateRef.current = false;
+        setCheckingUpdate(false);
       });
     },
     [prepareUpdate],
   );
+
+  // Auto-dismiss ONLY the up-to-date confirmation: linger, play the soft exit,
+  // then clear. Any status change (a new check, a failure, a manual dismiss)
+  // or unmount runs the cleanup, cancelling the pending hide; failures and
+  // busy statuses never match, so they persist until the user dismisses them.
+  useEffect(() => {
+    if (updateStatus !== UP_TO_DATE_STATUS) {
+      setUpdateStatusLeaving(false);
+      return;
+    }
+    const leaveTimer = window.setTimeout(() => {
+      setUpdateStatusLeaving(true);
+    }, UP_TO_DATE_DISMISS_MS);
+    const clearTimer = window.setTimeout(() => {
+      setUpdateStatusLeaving(false);
+      setUpdateStatus(null);
+    }, UP_TO_DATE_DISMISS_MS + UP_TO_DATE_EXIT_MS);
+    return () => {
+      window.clearTimeout(leaveTimer);
+      window.clearTimeout(clearTimer);
+    };
+  }, [updateStatus]);
 
   // Confirmed in Settings after switching off the rc channel: re-check with
   // reconcile=true (which re-stashes the Rust-side pending update, so a periodic
@@ -3687,6 +3729,8 @@ export function App() {
             <UpdateHub
               readyUpdate={readyUpdate}
               status={updateStatus}
+              statusLeaving={updateStatusLeaving}
+              checking={checkingUpdate}
               preparing={preparingUpdate}
               relaunching={relaunchingUpdate}
               progress={updateProgress}
@@ -4493,6 +4537,8 @@ function updateMenuBarSessionStatus(
 function UpdateHub({
   readyUpdate,
   status,
+  statusLeaving,
+  checking,
   preparing,
   relaunching,
   progress,
@@ -4501,6 +4547,8 @@ function UpdateHub({
 }: {
   readyUpdate: UpdatePromptPayload<JuneUpdate> | null;
   status: string | null;
+  statusLeaving: boolean;
+  checking: boolean;
   preparing: boolean;
   relaunching: boolean;
   progress: UpdateInstallProgress | null;
@@ -4522,6 +4570,8 @@ function UpdateHub({
   return (
     <UpdateStatusCard
       status={status}
+      leaving={statusLeaving}
+      checking={checking}
       preparing={preparing}
       progress={progress}
       onDismiss={onDismissStatus}
@@ -4552,11 +4602,13 @@ function UpdateRelaunchCard({
         aria-label={`Relaunch to update to June ${payload.version}`}
         onClick={onRelaunch}
       >
+        {/* One motion cue per card: while relaunching the mark slot swaps to the
+         * dot spinner (no title shimmer) and the title stays plain text. */}
         <span className="update-relaunch-mark" aria-hidden>
-          <JuneMark />
+          {relaunching ? <Spinner size="sm" aria-hidden /> : <JuneMark />}
         </span>
         <span className="update-relaunch-copy">
-          <span className={relaunching ? "update-relaunch-title shimmer" : "update-relaunch-title"}>
+          <span className="update-relaunch-title">
             {relaunching ? "Relaunching..." : "Relaunch to update"}
           </span>
           <span className={status ? "update-relaunch-status" : undefined}>{meta}</span>
@@ -4571,11 +4623,15 @@ function UpdateRelaunchCard({
 
 function UpdateStatusCard({
   status,
+  leaving,
+  checking,
   preparing,
   progress,
   onDismiss,
 }: {
   status: string;
+  leaving: boolean;
+  checking: boolean;
   preparing: boolean;
   progress: UpdateInstallProgress | null;
   onDismiss: () => void;
@@ -4584,18 +4640,27 @@ function UpdateStatusCard({
   const progressWidth =
     progress?.state === "installing" && percent === undefined ? "100%" : `${percent ?? 0}%`;
   const failed = status.toLowerCase().includes("failed");
+  // Explicit flags, never string-sniffed: checking covers the manual
+  // "Checking for updates..." round-trip, preparing covers download + install.
+  // The spinner is decorative; the status text announces the state to AT.
+  const busy = checking || preparing;
 
   return (
     <aside
       className="update-popover update-status-card"
+      data-leaving={leaving || undefined}
       role={failed ? "alert" : "status"}
       aria-live="polite"
     >
       <div className="update-status-row">
-        <span className="update-status-icon" aria-hidden>
-          <IconArrowInbox size={15} />
+        <span className="update-status-mark" aria-hidden>
+          {busy ? <Spinner size="sm" aria-hidden /> : <JuneMark />}
         </span>
-        <span className="update-status-text">{status}</span>
+        <span
+          className={failed ? "update-status-text update-status-text-failed" : "update-status-text"}
+        >
+          {status}
+        </span>
         <button
           type="button"
           className="update-status-close"
@@ -4611,7 +4676,21 @@ function UpdateStatusCard({
             <div className="update-progress-fill" style={{ width: progressWidth }} />
           </div>
           {percent !== undefined ? (
-            <span className="update-progress-percent">{percent}%</span>
+            <span className="update-progress-percent update-digit-group">
+              {/* Each digit keyed by position+character: only a digit whose
+               * character changed remounts and replays the pop-in, so the ones
+               * digit ticks each percent while the tens digit only rolls over.
+               * The % sign stays static. */}
+              {String(percent)
+                .split("")
+                .map((char, i) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: the position-plus-character key is the mechanism — a changed digit remounts to replay the pop-in.
+                  <span key={`${i}-${char}`} className="update-digit">
+                    {char}
+                  </span>
+                ))}
+              <span>%</span>
+            </span>
           ) : null}
         </div>
       ) : null}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -225,9 +225,12 @@ import { createInitialState, notesReducer } from "./state/app-state";
 import { handleSidebarResizeStart } from "./sidebar-resize";
 import {
   checkForJuneUpdate,
+  INITIAL_UPDATE_STATUS_DISPLAY,
   prepareJuneUpdate,
   startPeriodicJuneUpdateChecks,
   UP_TO_DATE_STATUS,
+  updateCheckShowsStatus,
+  updateStatusDisplayReducer,
   type UpdateCheckMode,
   type UpdateInstallProgress,
   type UpdatePromptPayload,
@@ -501,14 +504,18 @@ export function App() {
   const [systemAudioRefreshRequest, setSystemAudioRefreshRequest] = useState(0);
   const [microphoneStatus, setMicrophoneStatus] = useState<string>();
   const [readyUpdate, setReadyUpdate] = useState<UpdatePromptPayload<JuneUpdate> | null>(null);
-  const [updateStatus, setUpdateStatus] = useState<string | null>(null);
-  // True while the up-to-date status plays its timed soft exit (see the
-  // auto-dismiss effect next to runUpdateCheck).
-  const [updateStatusLeaving, setUpdateStatusLeaving] = useState(false);
+  const [updateStatusDisplay, dispatchUpdateStatusDisplay] = useReducer(
+    updateStatusDisplayReducer,
+    INITIAL_UPDATE_STATUS_DISPLAY,
+  );
+  const updateStatus = updateStatusDisplay.status;
+  const updateStatusLeaving = updateStatusDisplay.leaving;
+  const setUpdateStatus = useCallback((status: string | null) => {
+    dispatchUpdateStatusDisplay({ type: "show", status });
+  }, []);
   const [preparingUpdate, setPreparingUpdate] = useState(false);
-  // Mirrors checkingUpdateRef for render: drives the status card's busy spinner
-  // while a manual "Checking for updates..." round-trip is in flight. The ref
-  // stays the source of truth for the re-entrancy guards in runUpdateCheck.
+  // Render-only flag for a visible manual check. checkingUpdateRef separately
+  // guards every check mode, including silent launch and periodic checks.
   const [checkingUpdate, setCheckingUpdate] = useState(false);
   const [relaunchingUpdate, setRelaunchingUpdate] = useState(false);
   const [updateProgress, setUpdateProgress] = useState<UpdateInstallProgress | null>(null);
@@ -698,7 +705,7 @@ export function App() {
       updateCardDemoRef.current?.dispose();
       updateCardDemoRef.current = null;
     };
-  }, []);
+  }, [setUpdateStatus]);
   // Dev console driver (window.__toastDemo) that fires each toast variant so
   // the toast styling can be inspected without walking a real flow.
   useEffect(() => {
@@ -1608,7 +1615,7 @@ export function App() {
         },
       });
     },
-    [],
+    [setUpdateStatus],
   );
 
   const runUpdateCheck = useCallback(
@@ -1625,9 +1632,11 @@ export function App() {
         return;
       }
       checkingUpdateRef.current = true;
-      setCheckingUpdate(true);
-      if (mode === "manual") setUpdateStatus("Checking for updates...");
-      else if (mode === "launch") setUpdateStatus(null);
+      const showsStatus = updateCheckShowsStatus(mode);
+      if (showsStatus) {
+        setCheckingUpdate(true);
+        setUpdateStatus("Checking for updates...");
+      } else if (mode === "launch") setUpdateStatus(null);
       void checkForJuneUpdate(
         {
           check,
@@ -1644,10 +1653,10 @@ export function App() {
         mode,
       ).finally(() => {
         checkingUpdateRef.current = false;
-        setCheckingUpdate(false);
+        if (showsStatus) setCheckingUpdate(false);
       });
     },
-    [prepareUpdate],
+    [prepareUpdate, setUpdateStatus],
   );
 
   // Auto-dismiss ONLY the up-to-date confirmation: linger, play the soft exit,
@@ -1655,16 +1664,12 @@ export function App() {
   // or unmount runs the cleanup, cancelling the pending hide; failures and
   // busy statuses never match, so they persist until the user dismisses them.
   useEffect(() => {
-    if (updateStatus !== UP_TO_DATE_STATUS) {
-      setUpdateStatusLeaving(false);
-      return;
-    }
+    if (updateStatus !== UP_TO_DATE_STATUS) return;
     const leaveTimer = window.setTimeout(() => {
-      setUpdateStatusLeaving(true);
+      dispatchUpdateStatusDisplay({ type: "beginUpToDateExit" });
     }, UP_TO_DATE_DISMISS_MS);
     const clearTimer = window.setTimeout(() => {
-      setUpdateStatusLeaving(false);
-      setUpdateStatus(null);
+      dispatchUpdateStatusDisplay({ type: "clearUpToDate" });
     }, UP_TO_DATE_DISMISS_MS + UP_TO_DATE_EXIT_MS);
     return () => {
       window.clearTimeout(leaveTimer);
@@ -1690,7 +1695,7 @@ export function App() {
       setRelaunchingUpdate(false);
       setUpdateStatus(`Relaunch failed: ${messageFromError(error)}`);
     });
-  }, []);
+  }, [setUpdateStatus]);
 
   // Launch check: silent by design — a "no update" result shows nothing so it
   // never interrupts the user (PRD user story 7) — and fired at most once per

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -511,8 +511,8 @@ export function App() {
   );
   const updateStatus = updateStatusDisplay.status;
   const updateStatusLeaving = updateStatusDisplay.leaving;
-  const setUpdateStatus = useCallback((status: string | null) => {
-    dispatchUpdateStatusDisplay({ type: "show", status });
+  const setUpdateStatus = useCallback((status: string | null, failed = false) => {
+    dispatchUpdateStatusDisplay({ type: "show", status, failed });
   }, []);
   const [preparingUpdate, setPreparingUpdate] = useState(false);
   // Render-only flag for a visible manual check. checkingUpdateRef separately
@@ -1612,7 +1612,7 @@ export function App() {
           updateProgressHiddenRef.current = false;
           setPreparingUpdate(false);
           setUpdateProgress(null);
-          setUpdateStatus(`Update failed: ${message}`);
+          setUpdateStatus(`Update failed: ${message}`, true);
         },
       });
     },
@@ -1647,7 +1647,7 @@ export function App() {
           reportNoUpdate: () => setUpdateStatus(UP_TO_DATE_STATUS),
           reportFailure: (message) => {
             if (mode !== "periodic") {
-              setUpdateStatus(`Update check failed: ${message}`);
+              setUpdateStatus(`Update check failed: ${message}`, true);
             }
           },
         },
@@ -1694,7 +1694,7 @@ export function App() {
     void relaunchJune().catch((error) => {
       relaunchingUpdateRef.current = false;
       setRelaunchingUpdate(false);
-      setUpdateStatus(`Relaunch failed: ${messageFromError(error)}`);
+      setUpdateStatus(`Relaunch failed: ${messageFromError(error)}`, true);
     });
   }, [setUpdateStatus]);
 
@@ -3735,6 +3735,7 @@ export function App() {
             <UpdateHub
               readyUpdate={readyUpdate}
               status={updateStatus}
+              failed={updateStatusDisplay.failed}
               statusLeaving={updateStatusLeaving}
               checking={checkingUpdate}
               preparing={preparingUpdate}
@@ -4543,6 +4544,7 @@ function updateMenuBarSessionStatus(
 function UpdateHub({
   readyUpdate,
   status,
+  failed,
   statusLeaving,
   checking,
   preparing,
@@ -4553,6 +4555,7 @@ function UpdateHub({
 }: {
   readyUpdate: UpdatePromptPayload<JuneUpdate> | null;
   status: string | null;
+  failed: boolean;
   statusLeaving: boolean;
   checking: boolean;
   preparing: boolean;
@@ -4566,6 +4569,7 @@ function UpdateHub({
       <UpdateRelaunchCard
         payload={readyUpdate}
         status={status}
+        failed={failed}
         relaunching={relaunching}
         onRelaunch={onRelaunch}
       />
@@ -4576,6 +4580,7 @@ function UpdateHub({
   return (
     <UpdateStatusCard
       status={status}
+      failed={failed}
       leaving={statusLeaving}
       checking={checking}
       preparing={preparing}
@@ -4588,16 +4593,17 @@ function UpdateHub({
 function UpdateRelaunchCard({
   payload,
   status,
+  failed,
   relaunching,
   onRelaunch,
 }: {
   payload: UpdatePromptPayload<JuneUpdate>;
   status: string | null;
+  failed: boolean;
   relaunching: boolean;
   onRelaunch: () => void;
 }) {
   const meta = status ?? updateVersionLabel(payload.version);
-  const failed = status?.toLowerCase().includes("failed") ?? false;
 
   return (
     <aside className="update-popover" role={failed ? "alert" : "status"} aria-live="polite">
@@ -4629,6 +4635,7 @@ function UpdateRelaunchCard({
 
 function UpdateStatusCard({
   status,
+  failed,
   leaving,
   checking,
   preparing,
@@ -4636,6 +4643,7 @@ function UpdateStatusCard({
   onDismiss,
 }: {
   status: string;
+  failed: boolean;
   leaving: boolean;
   checking: boolean;
   preparing: boolean;
@@ -4645,7 +4653,6 @@ function UpdateStatusCard({
   const percent = updateProgressPercent(progress);
   const progressWidth =
     progress?.state === "installing" && percent === undefined ? "100%" : `${percent ?? 0}%`;
-  const failed = status.toLowerCase().includes("failed");
   // Explicit flags, never string-sniffed: checking covers the manual
   // "Checking for updates..." round-trip, preparing covers download + install.
   // The spinner is decorative; the status text announces the state to AT.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -237,7 +237,8 @@ import {
 } from "./update-decision";
 
 // "June is up to date." is a confirmation, not a call to action: linger, then
-// hide on its own. Failures and busy statuses persist until dismissed.
+// hide on its own. Failures persist until dismissed; busy statuses advance
+// when their operation resolves and may also be dismissed while in flight.
 const UP_TO_DATE_DISMISS_MS = 4000;
 // Soft-exit window: the update-popover-out animation runs var(--t-med) (160ms);
 // the status clears just after it finishes.
@@ -682,9 +683,9 @@ export function App() {
       dispose?.();
     };
   }, []);
-  // Dev console driver for the sidebar "Relaunch to update" card
-  // (window.__updateCard). Pushes synthetic values into the real update state
-  // so the card's styling can be parked and inspected without a live update.
+  // Dev console driver for the sidebar update cards (window.__updateCard).
+  // Pushes synthetic values into the real update state so each card's styling
+  // can be parked and inspected without a live update.
   const updateCardDemoRef = useRef<UpdateCardDemoApi | null>(null);
   useEffect(() => {
     if (!import.meta.env.DEV) return;
@@ -1661,8 +1662,8 @@ export function App() {
 
   // Auto-dismiss ONLY the up-to-date confirmation: linger, play the soft exit,
   // then clear. Any status change (a new check, a failure, a manual dismiss)
-  // or unmount runs the cleanup, cancelling the pending hide; failures and
-  // busy statuses never match, so they persist until the user dismisses them.
+  // or unmount runs the cleanup and cancels the pending hide. Other statuses
+  // never match, so this effect does not control their lifecycle.
   useEffect(() => {
     if (updateStatus !== UP_TO_DATE_STATUS) return;
     const leaveTimer = window.setTimeout(() => {

--- a/src/app/update-decision.ts
+++ b/src/app/update-decision.ts
@@ -13,6 +13,10 @@ export type UpdateCheckMode = "launch" | "manual" | "periodic";
 
 export const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 
+// The manual-check success status. Shared so the reporter and the auto-dismiss
+// effect that matches on it (App), plus the dev demo, can't drift apart.
+export const UP_TO_DATE_STATUS = "June is up to date.";
+
 export type UpdaterUpdate = {
   version: string;
   body?: string;

--- a/src/app/update-decision.ts
+++ b/src/app/update-decision.ts
@@ -20,16 +20,18 @@ export const UP_TO_DATE_STATUS = "June is up to date.";
 export type UpdateStatusDisplayState = {
   status: string | null;
   leaving: boolean;
+  failed: boolean;
 };
 
 export type UpdateStatusDisplayAction =
-  | { type: "show"; status: string | null }
+  | { type: "show"; status: string | null; failed?: boolean }
   | { type: "beginUpToDateExit" }
   | { type: "clearUpToDate" };
 
 export const INITIAL_UPDATE_STATUS_DISPLAY: UpdateStatusDisplayState = {
   status: null,
   leaving: false,
+  failed: false,
 };
 
 // Status changes reset the exit phase synchronously. Timed exit actions are
@@ -40,8 +42,9 @@ export function updateStatusDisplayReducer(
   action: UpdateStatusDisplayAction,
 ): UpdateStatusDisplayState {
   if (action.type === "show") {
-    if (state.status === action.status && !state.leaving) return state;
-    return { status: action.status, leaving: false };
+    const failed = action.status !== null && action.failed === true;
+    if (state.status === action.status && state.failed === failed && !state.leaving) return state;
+    return { status: action.status, leaving: false, failed };
   }
   if (state.status !== UP_TO_DATE_STATUS) return state;
   if (action.type === "beginUpToDateExit") {

--- a/src/app/update-decision.ts
+++ b/src/app/update-decision.ts
@@ -17,6 +17,45 @@ export const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 // effect that matches on it (App), plus the dev demo, can't drift apart.
 export const UP_TO_DATE_STATUS = "June is up to date.";
 
+export type UpdateStatusDisplayState = {
+  status: string | null;
+  leaving: boolean;
+};
+
+export type UpdateStatusDisplayAction =
+  | { type: "show"; status: string | null }
+  | { type: "beginUpToDateExit" }
+  | { type: "clearUpToDate" };
+
+export const INITIAL_UPDATE_STATUS_DISPLAY: UpdateStatusDisplayState = {
+  status: null,
+  leaving: false,
+};
+
+// Status changes reset the exit phase synchronously. Timed exit actions are
+// guarded by the current value, so a stale success timer cannot fade or clear
+// a newer check/failure status if its effect cleanup is delayed.
+export function updateStatusDisplayReducer(
+  state: UpdateStatusDisplayState,
+  action: UpdateStatusDisplayAction,
+): UpdateStatusDisplayState {
+  if (action.type === "show") {
+    if (state.status === action.status && !state.leaving) return state;
+    return { status: action.status, leaving: false };
+  }
+  if (state.status !== UP_TO_DATE_STATUS) return state;
+  if (action.type === "beginUpToDateExit") {
+    return { ...state, leaving: true };
+  }
+  return INITIAL_UPDATE_STATUS_DISPLAY;
+}
+
+// Launch and periodic checks are silent unless they discover an update. Only
+// manual checks render the transient checking status and its spinner.
+export function updateCheckShowsStatus(mode: UpdateCheckMode): boolean {
+  return mode === "manual";
+}
+
 export type UpdaterUpdate = {
   version: string;
   body?: string;

--- a/src/lib/update-card-demo.ts
+++ b/src/lib/update-card-demo.ts
@@ -1,18 +1,28 @@
-// Dev-only console driver for the sidebar "Relaunch to update" card.
+// Dev-only console driver for the sidebar update cards — both the "Relaunch to
+// update" card and the update status card.
 //
 //   window.__updateCard("ready")          fresh update available (v0.0.25)
 //   window.__updateCard("ready", "1.2.3") pick the version label shown
 //   window.__updateCard("relaunching")    the mid-relaunch "Relaunching..." state
 //   window.__updateCard("failed")         the destructive "Update failed" status
+//   window.__updateCard("checking")       status card, busy "Checking for updates..."
+//   window.__updateCard("uptodate")       status card, "June is up to date." (auto-hides)
+//   window.__updateCard("downloading")    status card, busy + ticking progress bar
+//   window.__updateCard("checkfailed")    status card, destructive failed check
 //   window.__updateCard("clear")          dismiss the card
 //
-// The card is React state in the main window (App's readyUpdate / updateStatus /
-// relaunchingUpdate), so the driver pushes synthetic values straight into those
-// setters rather than waiting on a real updater round-trip. In dev there is no
-// live update to clobber it. Never bundled in production: App gates the dynamic
-// import on import.meta.env.DEV.
+// The cards are React state in the main window (App's readyUpdate / updateStatus
+// / relaunchingUpdate / preparingUpdate / checkingUpdate / updateProgress), so
+// the driver pushes synthetic values straight into those setters rather than
+// waiting on a real updater round-trip. In dev there is no live update to
+// clobber it. Never bundled in production: App gates the dynamic import on
+// import.meta.env.DEV.
 
-import type { UpdatePromptPayload } from "../app/update-decision";
+import {
+  UP_TO_DATE_STATUS,
+  type UpdateInstallProgress,
+  type UpdatePromptPayload,
+} from "../app/update-decision";
 import type { JuneUpdate } from "./updater";
 
 export type UpdateCardDemoApi = {
@@ -22,12 +32,25 @@ export type UpdateCardDemoApi = {
 
 const DEFAULT_VERSION = "0.0.25";
 
+// A synthetic in-flight download: starts around 40% so the progress bar and the
+// percent readout both render, then ticks upward a few percent at a time so the
+// digit pop-in animation is visible in the browser demo.
+const DOWNLOAD_CONTENT_LENGTH = 100_000_000;
+const DOWNLOAD_START_BYTES = 40_000_000;
+const DOWNLOAD_TICK_BYTES = 3_000_000;
+const DOWNLOAD_CAP_BYTES = 96_000_000;
+const DOWNLOAD_TICK_MS = 800;
+
 const HELP = [
-  'Sidebar "Relaunch to update" card demo:',
+  "Sidebar update card demo:",
   '  __updateCard("ready")          update available, ready to relaunch',
   '  __updateCard("ready", "1.2.3") same, with a chosen version label',
   '  __updateCard("relaunching")    the "Relaunching..." in-flight state',
   '  __updateCard("failed")         the destructive failed-update status',
+  '  __updateCard("checking")       status card, busy "Checking for updates..."',
+  '  __updateCard("uptodate")       status card, "June is up to date." (auto-hides after a few seconds)',
+  '  __updateCard("downloading")    status card, busy + ticking progress bar',
+  '  __updateCard("checkfailed")    status card, destructive failed check',
   '  __updateCard("clear")          dismiss the card',
   "",
   "Parks the card on any view, no real update needed. Dev only.",
@@ -37,10 +60,16 @@ export function registerUpdateCardDemo({
   setReadyUpdate,
   setStatus,
   setRelaunching,
+  setPreparing,
+  setChecking,
+  setProgress,
 }: {
   setReadyUpdate: (payload: UpdatePromptPayload<JuneUpdate> | null) => void;
   setStatus: (status: string | null) => void;
   setRelaunching: (value: boolean) => void;
+  setPreparing: (value: boolean) => void;
+  setChecking: (value: boolean) => void;
+  setProgress: (progress: UpdateInstallProgress | null) => void;
 }): UpdateCardDemoApi {
   // The card only reads payload.version; a bare stub stands in for the real
   // tauri Update instance so the demo needs no live updater handle.
@@ -48,28 +77,78 @@ export function registerUpdateCardDemo({
     return { update: {} as JuneUpdate, version };
   }
 
-  function ready(version = DEFAULT_VERSION) {
+  let downloadTimer: number | undefined;
+
+  function stopDownloadTicker() {
+    if (downloadTimer === undefined) return;
+    window.clearInterval(downloadTimer);
+    downloadTimer = undefined;
+  }
+
+  // Reset every update-card flag before parking a fresh state so switching
+  // between states never leaves a stale spinner, timer, or progress bar behind.
+  function reset() {
+    stopDownloadTicker();
     setRelaunching(false);
+    setPreparing(false);
+    setChecking(false);
+    setProgress(null);
     setStatus(null);
+    setReadyUpdate(null);
+  }
+
+  function ready(version = DEFAULT_VERSION) {
+    reset();
     setReadyUpdate(makePayload(version));
   }
 
   function relaunching(version = DEFAULT_VERSION) {
-    setStatus(null);
+    reset();
     setReadyUpdate(makePayload(version));
     setRelaunching(true);
   }
 
   function failed(version = DEFAULT_VERSION) {
-    setRelaunching(false);
+    reset();
     setReadyUpdate(makePayload(version));
     setStatus("Update failed. Try again.");
   }
 
-  function clear() {
-    setRelaunching(false);
-    setStatus(null);
-    setReadyUpdate(null);
+  function checking() {
+    reset();
+    setChecking(true);
+    setStatus("Checking for updates...");
+  }
+
+  // Sets the real success status string, so App's auto-dismiss effect gives the
+  // parked card the true linger-then-soft-exit behavior.
+  function upToDate() {
+    reset();
+    setStatus(UP_TO_DATE_STATUS);
+  }
+
+  function downloading() {
+    reset();
+    setPreparing(true);
+    setStatus("Downloading update...");
+    let downloadedBytes = DOWNLOAD_START_BYTES;
+    const report = () =>
+      setProgress({
+        state: "downloading",
+        downloadedBytes,
+        contentLength: DOWNLOAD_CONTENT_LENGTH,
+      });
+    report();
+    downloadTimer = window.setInterval(() => {
+      downloadedBytes = Math.min(DOWNLOAD_CAP_BYTES, downloadedBytes + DOWNLOAD_TICK_BYTES);
+      report();
+      if (downloadedBytes >= DOWNLOAD_CAP_BYTES) stopDownloadTicker();
+    }, DOWNLOAD_TICK_MS);
+  }
+
+  function checkFailed() {
+    reset();
+    setStatus("Update check failed: network unreachable.");
   }
 
   const hook = (state?: string, version?: string) => {
@@ -83,9 +162,21 @@ export function registerUpdateCardDemo({
       case "failed":
         failed(version || undefined);
         return 'Failed status parked. __updateCard("ready") to reset.';
+      case "checking":
+        checking();
+        return 'Checking state parked. __updateCard("clear") to dismiss.';
+      case "uptodate":
+        upToDate();
+        return 'Up-to-date status parked. __updateCard("clear") to dismiss.';
+      case "downloading":
+        downloading();
+        return 'Downloading state parked. __updateCard("clear") to dismiss.';
+      case "checkfailed":
+        checkFailed();
+        return 'Check-failed status parked. __updateCard("clear") to dismiss.';
       case "clear":
       case "stop":
-        clear();
+        reset();
         return "Update card dismissed.";
       default:
         return HELP;
@@ -95,6 +186,7 @@ export function registerUpdateCardDemo({
   (window as unknown as Record<string, unknown>).__updateCard = hook;
 
   function dispose() {
+    stopDownloadTicker();
     delete (window as unknown as Record<string, unknown>).__updateCard;
   }
 

--- a/src/lib/update-card-demo.ts
+++ b/src/lib/update-card-demo.ts
@@ -65,7 +65,7 @@ export function registerUpdateCardDemo({
   setProgress,
 }: {
   setReadyUpdate: (payload: UpdatePromptPayload<JuneUpdate> | null) => void;
-  setStatus: (status: string | null) => void;
+  setStatus: (status: string | null, failed?: boolean) => void;
   setRelaunching: (value: boolean) => void;
   setPreparing: (value: boolean) => void;
   setChecking: (value: boolean) => void;
@@ -111,7 +111,7 @@ export function registerUpdateCardDemo({
   function failed(version = DEFAULT_VERSION) {
     reset();
     setReadyUpdate(makePayload(version));
-    setStatus("Update failed. Try again.");
+    setStatus("Update failed. Try again.", true);
   }
 
   function checking() {
@@ -148,7 +148,7 @@ export function registerUpdateCardDemo({
 
   function checkFailed() {
     reset();
-    setStatus("Update check failed: network unreachable.");
+    setStatus("Update check failed: network unreachable.", true);
   }
 
   const hook = (state?: string, version?: string) => {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -21938,22 +21938,21 @@ button.memory-project:hover {
   cursor: default;
 }
 
-/* Bare June mark, no tile: faint at rest, warms to brand on hover. Fixed 10px
- * box (mirroring .update-status-mark) so swapping to the dot spinner while
- * relaunching never reflows the copy; the spinner ignores this faint tint and
- * keeps its darker --spinner-neutral default. */
+/* Bare June mark, no tile: faint at rest, warms to brand on hover. The fixed
+ * mark-sized box mirrors .update-status-mark, so swapping to the dot spinner
+ * never reflows the copy; the spinner keeps its darker --spinner-neutral. */
 .update-relaunch-mark {
   display: inline-grid;
   place-items: center;
-  width: 10px;
-  height: 10px;
+  width: var(--sp-4);
+  height: var(--sp-4);
   margin-top: 2px;
   color: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
   transition: color var(--t-slow) var(--ease-spring);
 }
 
 .update-relaunch-mark svg {
-  width: 10px;
+  width: var(--sp-4);
   height: auto;
 }
 
@@ -22023,20 +22022,19 @@ button.memory-project:hover {
   gap: var(--sp-3);
 }
 
-/* Fixed 10px box so the busy dot spinner and the settled June mark occupy the
- * exact same footprint — swapping them never reflows the status text. The
- * static mark takes the muted tint matching .update-relaunch-mark; the spinner
- * keeps its darker --spinner-neutral default so the busy state reads clearly. */
+/* The fixed mark-sized box gives the busy dot spinner and settled June mark
+ * the same footprint, so swapping them never reflows the status text. The
+ * static mark is muted; the spinner keeps its darker --spinner-neutral. */
 .update-status-mark {
   display: inline-grid;
   place-items: center;
-  width: 10px;
-  height: 10px;
+  width: var(--sp-4);
+  height: var(--sp-4);
   color: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
 }
 
 .update-status-mark svg {
-  width: 10px;
+  width: var(--sp-4);
   height: auto;
 }
 
@@ -22080,9 +22078,9 @@ button.memory-project:hover {
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--sp-3);
-  /* Start the track under the copy column (10px mark slot + row gap) so it
+  /* Start the track under the copy column (mark slot + row gap) so it
    * lines up with the status text rather than the mark. */
-  padding-left: calc(10px + var(--sp-3));
+  padding-left: calc(var(--sp-4) + var(--sp-3));
 }
 
 .update-progress-track {
@@ -22114,10 +22112,10 @@ button.memory-project:hover {
  * Vars are scoped here (flat global stylesheet), tuned short for a 1%-per-tick
  * counter but kept tunable. */
 .update-digit-group {
-  --update-digit-dur: 320ms;
-  --update-digit-distance: 8px;
-  --update-digit-blur: 2px;
-  --update-digit-ease: cubic-bezier(0.34, 1.45, 0.64, 1);
+  --update-digit-dur: calc(var(--t-med) + var(--t-med));
+  --update-digit-distance: var(--sp-3);
+  --update-digit-blur: var(--sp-px);
+  --update-digit-ease: var(--ease-pop);
 
   display: inline-flex;
   align-items: baseline;
@@ -22145,7 +22143,7 @@ button.memory-project:hover {
 @keyframes update-popover-in {
   from {
     opacity: 0;
-    transform: translateY(6px) scale(0.98);
+    transform: translateY(var(--sp-2)) scale(0.98);
   }
   to {
     opacity: 1;
@@ -22168,7 +22166,7 @@ button.memory-project:hover {
   }
   to {
     opacity: 0;
-    transform: translateY(6px) scale(0.98);
+    transform: translateY(var(--sp-2)) scale(0.98);
   }
 }
 
@@ -22178,6 +22176,10 @@ button.memory-project:hover {
   .update-popover,
   .update-popover[data-leaving="true"] {
     animation: none;
+  }
+
+  .update-popover[data-leaving="true"] {
+    visibility: hidden;
   }
 
   .update-digit {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -21938,10 +21938,15 @@ button.memory-project:hover {
   cursor: default;
 }
 
-/* Bare June mark, no tile: faint at rest, warms to brand on hover. */
+/* Bare June mark, no tile: faint at rest, warms to brand on hover. Fixed 10px
+ * box (mirroring .update-status-mark) so swapping to the dot spinner while
+ * relaunching never reflows the copy; the spinner ignores this faint tint and
+ * keeps its darker --spinner-neutral default. */
 .update-relaunch-mark {
   display: inline-grid;
   place-items: center;
+  width: 10px;
+  height: 10px;
   margin-top: 2px;
   color: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
   transition: color var(--t-slow) var(--ease-spring);
@@ -21966,7 +21971,7 @@ button.memory-project:hover {
   overflow: hidden;
   color: var(--foreground);
   font-size: var(--fs-md);
-  font-weight: var(--fw-medium);
+  font-weight: 400;
   line-height: 1.2;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -21996,33 +22001,43 @@ button.memory-project:hover {
   transform: translateX(3px);
 }
 
+/* Same card chrome as .update-relaunch-card, minus the hover shadow: this is a
+ * non-interactive status card (only the close button acts). Left padding sits
+ * a step wider so the mark/spinner slot doesn't hug the card edge. */
 .update-status-card {
   display: grid;
-  gap: var(--sp-3);
+  gap: var(--sp-2);
   width: 100%;
-  padding: var(--sp-3);
-  border: 1px solid var(--popover-border);
+  padding: var(--sp-2);
+  padding-left: var(--sp-3);
+  border: 1px solid color-mix(in oklch, var(--foreground) 15%, transparent);
   border-radius: var(--r-md);
-  background: var(--popover);
-  color: var(--popover-foreground);
-  box-shadow: var(--shadow-md);
+  background: var(--card);
+  color: var(--foreground);
 }
 
 .update-status-row {
   display: grid;
-  grid-template-columns: 22px minmax(0, 1fr) 24px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: var(--sp-2);
+  gap: var(--sp-3);
 }
 
-.update-status-icon {
+/* Fixed 10px box so the busy dot spinner and the settled June mark occupy the
+ * exact same footprint — swapping them never reflows the status text. The
+ * static mark takes the muted tint matching .update-relaunch-mark; the spinner
+ * keeps its darker --spinner-neutral default so the busy state reads clearly. */
+.update-status-mark {
   display: inline-grid;
   place-items: center;
-  width: 22px;
-  height: 22px;
-  border-radius: var(--r-sm);
-  background: var(--surface-subtle);
-  color: var(--muted-foreground);
+  width: 10px;
+  height: 10px;
+  color: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
+}
+
+.update-status-mark svg {
+  width: 10px;
+  height: auto;
 }
 
 .update-status-text {
@@ -22030,10 +22045,16 @@ button.memory-project:hover {
   overflow: hidden;
   color: var(--foreground);
   font-size: var(--fs-md);
-  font-weight: var(--fw-medium);
+  font-weight: 400;
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Failed checks/downloads tint the text destructive, like .update-relaunch-status;
+ * the mark stays muted. */
+.update-status-text-failed {
+  color: color-mix(in oklch, var(--destructive) 70%, var(--foreground));
 }
 
 .update-status-close {
@@ -22059,6 +22080,9 @@ button.memory-project:hover {
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--sp-3);
+  /* Start the track under the copy column (10px mark slot + row gap) so it
+   * lines up with the status text rather than the mark. */
+  padding-left: calc(10px + var(--sp-3));
 }
 
 .update-progress-track {
@@ -22072,7 +22096,9 @@ button.memory-project:hover {
   height: 100%;
   min-width: 8px;
   border-radius: inherit;
-  background: var(--foreground);
+  /* Lighter than --foreground so the bar reads quiet; --muted-foreground stays
+   * clearly ahead of the --surface-subtle track in both themes. */
+  background: var(--muted-foreground);
   transition: width var(--t-fast) var(--ease-out);
 }
 
@@ -22080,6 +22106,40 @@ button.memory-project:hover {
   color: var(--muted-foreground);
   font-size: var(--fs-xs);
   line-height: 1;
+}
+
+/* Number pop-in for the download percent: each digit is keyed by
+ * position+character in React, so only a digit that actually changed remounts
+ * and replays the rise — the ones digit ticks, the tens digit only rolls over.
+ * Vars are scoped here (flat global stylesheet), tuned short for a 1%-per-tick
+ * counter but kept tunable. */
+.update-digit-group {
+  --update-digit-dur: 320ms;
+  --update-digit-distance: 8px;
+  --update-digit-blur: 2px;
+  --update-digit-ease: cubic-bezier(0.34, 1.45, 0.64, 1);
+
+  display: inline-flex;
+  align-items: baseline;
+}
+
+.update-digit {
+  display: inline-block;
+  animation: update-digit-pop-in var(--update-digit-dur) var(--update-digit-ease) both;
+  will-change: transform, opacity, filter;
+}
+
+@keyframes update-digit-pop-in {
+  from {
+    transform: translateY(var(--update-digit-distance));
+    opacity: 0;
+    filter: blur(var(--update-digit-blur));
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+    filter: blur(0);
+  }
 }
 
 @keyframes update-popover-in {
@@ -22093,8 +22153,34 @@ button.memory-project:hover {
   }
 }
 
+/* Timed auto-dismiss of the up-to-date confirmation: mirror the entrance so
+ * the card fades and slides back down instead of blinking out. The status
+ * clears just after this finishes (UP_TO_DATE_EXIT_MS in App.tsx). Manual
+ * close-button dismisses stay instant. */
+.update-popover[data-leaving="true"] {
+  animation: update-popover-out var(--t-med) var(--ease-out) both;
+}
+
+@keyframes update-popover-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(6px) scale(0.98);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .update-popover {
+  /* The attribute selector outranks the bare class, so the exit needs its own
+   * entry here: the timed hide becomes an instant disappearance. */
+  .update-popover,
+  .update-popover[data-leaving="true"] {
+    animation: none;
+  }
+
+  .update-digit {
     animation: none;
   }
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -350,6 +350,7 @@
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
   --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
   --ease-spring: cubic-bezier(0.32, 0.72, 0, 1);
+  --ease-pop: cubic-bezier(0.34, 1.45, 0.64, 1);
   --t-fast: 100ms;
   --t-med: 160ms;
   --t-slow: 240ms;

--- a/src/test/update-decision.test.ts
+++ b/src/test/update-decision.test.ts
@@ -31,8 +31,22 @@ describe("update status display", () => {
       type: "show",
       status: "Checking for updates...",
     });
-    expect(checking).toEqual({ status: "Checking for updates...", leaving: false });
+    expect(checking).toEqual({
+      status: "Checking for updates...",
+      leaving: false,
+      failed: false,
+    });
     expect(updateStatusDisplayReducer(checking, { type: "clearUpToDate" })).toBe(checking);
+  });
+
+  it("carries failure styling independently of message wording", () => {
+    const failure = updateStatusDisplayReducer(INITIAL_UPDATE_STATUS_DISPLAY, {
+      type: "show",
+      status: "Could not check for updates.",
+      failed: true,
+    });
+
+    expect(failure.failed).toBe(true);
   });
 });
 

--- a/src/test/update-decision.test.ts
+++ b/src/test/update-decision.test.ts
@@ -1,12 +1,40 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  INITIAL_UPDATE_STATUS_DISPLAY,
+  UP_TO_DATE_STATUS,
   UPDATE_CHECK_INTERVAL_MS,
   checkForJuneUpdate,
   installJuneUpdate,
   prepareJuneUpdate,
   startPeriodicJuneUpdateChecks,
+  updateCheckShowsStatus,
+  updateStatusDisplayReducer,
   type UpdaterUpdate,
 } from "../app/update-decision";
+
+describe("update status display", () => {
+  it("only exposes manual checks as visible busy statuses", () => {
+    expect(updateCheckShowsStatus("manual")).toBe(true);
+    expect(updateCheckShowsStatus("launch")).toBe(false);
+    expect(updateCheckShowsStatus("periodic")).toBe(false);
+  });
+
+  it("does not let stale success timers fade or clear a newer status", () => {
+    const success = updateStatusDisplayReducer(INITIAL_UPDATE_STATUS_DISPLAY, {
+      type: "show",
+      status: UP_TO_DATE_STATUS,
+    });
+    const leaving = updateStatusDisplayReducer(success, { type: "beginUpToDateExit" });
+    expect(leaving.leaving).toBe(true);
+
+    const checking = updateStatusDisplayReducer(leaving, {
+      type: "show",
+      status: "Checking for updates...",
+    });
+    expect(checking).toEqual({ status: "Checking for updates...", leaving: false });
+    expect(updateStatusDisplayReducer(checking, { type: "clearUpToDate" })).toBe(checking);
+  });
+});
 
 function update(body?: string): UpdaterUpdate {
   return {


### PR DESCRIPTION
## Summary

- Restyles the sidebar update status card ("Checking for updates...", "Downloading update...", "June is up to date.", failures) to the relaunch card's anatomy - June mark slot, `var(--card)` surface, hairline border - so the sidebar footer attention cards read as one family.
- Busy states (checking, downloading, installing, and now relaunching) show the app-wide June dot spinner at its default `--spinner-neutral` tint in the mark slot; settled states show the static mark. The relaunch card's "Relaunching..." text shimmer is removed - the spinner is the single motion cue per card.
- Download percent renders as per-digit spans keyed by position + character, so only a changed digit replays a short rise-and-blur pop-in (`update-digit-*`, 320ms, reduced-motion safe, no tabular-nums). Progress fill lightens from `--foreground` to `--muted-foreground`.
- All update-card text drops to regular weight (400); status card gains left padding so the mark slot doesn't hug the edge.
- "June is up to date." auto-hides after 4s via a two-step timer (linger, then a 160ms exit animation mirroring `update-popover-in`); the shared `UP_TO_DATE_STATUS` constant lives in `update-decision.ts` so the reporter, the effect, and the demo can't drift. Failures and busy states still persist until dismissed.
- The dev-only `__updateCard` driver gains `checking` / `uptodate` / `downloading` (progress ticks +3% per 800ms so the digit pop-in is visible) / `checkfailed` states, with a shared reset so states can't leak into each other.

## Validation

- `pnpm typecheck`, `pnpm check`, and `pnpm test src/test/update-decision.test.ts -- --run` pass (11/11 focused tests; Biome errors 0, remaining warnings pre-existing). A full frontend run reported zero failures before the documented teardown hang.
- Traced launch, periodic, manual, reconcile, dismiss-during-download, and relaunch-failure flows. Only manual checks surface the visible checking state; the guarded display-state reducer prevents stale timers and outgoing success animation phases from affecting newer statuses. Failure styling is explicit state, not copy inspection.

- [x] Tested visually where it matters (iterated in-browser against the `__updateCard` demo states across several feedback rounds).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- The funding chip and other sidebar footer cards (already in the target style).
- The Settings > About "Check for updates" row and release-channel UI.
- The shared `.shimmer` class and its other consumers (transcription states).

## Followups

- None planned; `--update-digit-*` custom properties are tunable if the pop-in timing needs adjustment.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. (None - frontend styling/behavior only; updater plumbing and guard logic unchanged.)
- [x] Workflow action references are pinned to full-length commit SHAs. (No workflow changes.)
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. <!-- UI-only changes around update state; no updater plumbing, signing, or release changes -->
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (No backend changes.)
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786823919&installation_id=144203540&pr_number=804&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F804&signature=9874857760b6eef046c0ea514cf3e8ac16264aef6ef6b2d0985c105bb418aa45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->