### PR TITLE
Fix chat command menu clipping

### DIFF
--- a/src/components/agent/composer/categoryChip.ts
+++ b/src/components/agent/composer/categoryChip.ts
@@ -182,41 +182,54 @@ export function createCategoryChip(options: CategoryChipOptions = {}) {
           clientRect?: (() => DOMRect | null) | null;
         } | null = null;
         let ownerDocument: Document | null = null;
+        let ownerWindow: Window | null = null;
 
         function position(props: { clientRect?: (() => DOMRect | null) | null; editor: Editor }) {
           if (!host || !props.clientRect) return;
           const rect = props.clientRect();
           if (!rect) return;
+          const viewport = props.editor.view.dom.ownerDocument.defaultView ?? window;
           const gap = 6;
           const pad = 8;
           const composerBox = props.editor.view.dom.closest<HTMLElement>(".agent-composer-box");
           const composerRect = composerBox?.getBoundingClientRect();
           const width = Math.min(
             composerRect?.width ?? host.getBoundingClientRect().width,
-            window.innerWidth - pad * 2,
+            viewport.innerWidth - pad * 2,
           );
           host.style.setProperty("--agent-category-menu-width", `${width}px`);
-          const maxLeft = window.innerWidth - width - pad;
+          const maxLeft = viewport.innerWidth - width - pad;
           const left = Math.min(
             Math.max(composerRect?.left ?? rect.left, pad),
             Math.max(pad, maxLeft),
           );
           const anchorRect = composerRect ?? rect;
           const belowTop = anchorRect.bottom + gap;
-          const belowSpace = window.innerHeight - belowTop - pad;
+          const belowSpace = viewport.innerHeight - belowTop - pad;
           const aboveSpace = anchorRect.top - gap - pad;
           const hostRect = host.getBoundingClientRect();
-          const fitsBelow = belowSpace >= hostRect.height;
-          const placeBelow = fitsBelow || belowSpace >= aboveSpace;
-          const maxHeight = Math.max(88, Math.min(placeBelow ? belowSpace : aboveSpace, 280));
-          const top = placeBelow
-            ? belowTop
-            : Math.max(anchorRect.top - Math.min(hostRect.height, maxHeight) - gap, pad);
+          const hasMeasuredHeight = hostRect.height > 0;
+          const fitsBelow = hasMeasuredHeight && belowSpace >= hostRect.height;
+          const fitsAbove = hasMeasuredHeight && aboveSpace >= hostRect.height;
+          const placeBelow = fitsBelow || (!fitsAbove && belowSpace >= aboveSpace);
+          const maxHeight = Math.max(0, Math.min(placeBelow ? belowSpace : aboveSpace, 280));
 
           host.style.setProperty("--agent-category-menu-max-height", `${maxHeight}px`);
-          host.style.bottom = "";
-          host.style.top = `${Math.max(top, pad)}px`;
+          if (placeBelow) {
+            host.style.bottom = "";
+            host.style.top = `${Math.max(belowTop, pad)}px`;
+          } else {
+            // Anchor the menu's composer-facing edge instead of deriving its
+            // top from a height that can be stale while async skills render.
+            // The portal then grows upward and remains inside short webviews.
+            host.style.top = "";
+            host.style.bottom = `${Math.max(viewport.innerHeight - anchorRect.top + gap, pad)}px`;
+          }
           host.style.left = `${left}px`;
+        }
+
+        function positionLatest() {
+          if (latestProps) position(latestProps);
         }
 
         function updateLatestProps(props: {
@@ -256,11 +269,14 @@ export function createCategoryChip(options: CategoryChipOptions = {}) {
           renderer?.destroy();
           host?.removeEventListener(CATEGORY_SKILLS_CHANGED_EVENT, refreshItems);
           ownerDocument?.removeEventListener("pointerdown", dismissFromPointerDown, true);
+          ownerWindow?.removeEventListener("resize", positionLatest);
+          ownerWindow?.visualViewport?.removeEventListener("resize", positionLatest);
           host?.remove();
           renderer = null;
           host = null;
           latestProps = null;
           ownerDocument = null;
+          ownerWindow = null;
         }
 
         return {
@@ -276,7 +292,10 @@ export function createCategoryChip(options: CategoryChipOptions = {}) {
             host.appendChild(renderer.element);
             document.body.appendChild(host);
             ownerDocument = props.editor.view.dom.ownerDocument;
+            ownerWindow = ownerDocument.defaultView;
             ownerDocument.addEventListener("pointerdown", dismissFromPointerDown, true);
+            ownerWindow?.addEventListener("resize", positionLatest);
+            ownerWindow?.visualViewport?.addEventListener("resize", positionLatest);
             position(props);
           },
           onUpdate(props) {

--- a/src/components/agent/composer/noteReference.ts
+++ b/src/components/agent/composer/noteReference.ts
@@ -202,41 +202,51 @@ export function createNoteReference(options: NoteReferenceOptions = {}) {
           clientRect?: (() => DOMRect | null) | null;
         } | null = null;
         let ownerDocument: Document | null = null;
+        let ownerWindow: Window | null = null;
 
         function position(props: { clientRect?: (() => DOMRect | null) | null; editor: Editor }) {
           if (!host || !props.clientRect) return;
           const rect = props.clientRect();
           if (!rect) return;
+          const viewport = props.editor.view.dom.ownerDocument.defaultView ?? window;
           const gap = 6;
           const pad = 8;
           const composerBox = props.editor.view.dom.closest<HTMLElement>(".agent-composer-box");
           const composerRect = composerBox?.getBoundingClientRect();
           const width = Math.min(
             composerRect?.width ?? host.getBoundingClientRect().width,
-            window.innerWidth - pad * 2,
+            viewport.innerWidth - pad * 2,
           );
           host.style.setProperty("--agent-category-menu-width", `${width}px`);
-          const maxLeft = window.innerWidth - width - pad;
+          const maxLeft = viewport.innerWidth - width - pad;
           const left = Math.min(
             Math.max(composerRect?.left ?? rect.left, pad),
             Math.max(pad, maxLeft),
           );
           const anchorRect = composerRect ?? rect;
           const belowTop = anchorRect.bottom + gap;
-          const belowSpace = window.innerHeight - belowTop - pad;
+          const belowSpace = viewport.innerHeight - belowTop - pad;
           const aboveSpace = anchorRect.top - gap - pad;
           const hostRect = host.getBoundingClientRect();
-          const fitsBelow = belowSpace >= hostRect.height;
-          const placeBelow = fitsBelow || belowSpace >= aboveSpace;
-          const maxHeight = Math.max(88, Math.min(placeBelow ? belowSpace : aboveSpace, 280));
-          const top = placeBelow
-            ? belowTop
-            : Math.max(anchorRect.top - Math.min(hostRect.height, maxHeight) - gap, pad);
+          const hasMeasuredHeight = hostRect.height > 0;
+          const fitsBelow = hasMeasuredHeight && belowSpace >= hostRect.height;
+          const fitsAbove = hasMeasuredHeight && aboveSpace >= hostRect.height;
+          const placeBelow = fitsBelow || (!fitsAbove && belowSpace >= aboveSpace);
+          const maxHeight = Math.max(0, Math.min(placeBelow ? belowSpace : aboveSpace, 280));
 
           host.style.setProperty("--agent-category-menu-max-height", `${maxHeight}px`);
-          host.style.bottom = "";
-          host.style.top = `${Math.max(top, pad)}px`;
+          if (placeBelow) {
+            host.style.bottom = "";
+            host.style.top = `${Math.max(belowTop, pad)}px`;
+          } else {
+            host.style.top = "";
+            host.style.bottom = `${Math.max(viewport.innerHeight - anchorRect.top + gap, pad)}px`;
+          }
           host.style.left = `${left}px`;
+        }
+
+        function positionLatest() {
+          if (latestProps) position(latestProps);
         }
 
         function updateLatestProps(props: {
@@ -265,11 +275,14 @@ export function createNoteReference(options: NoteReferenceOptions = {}) {
         function cleanupPopover() {
           renderer?.destroy();
           ownerDocument?.removeEventListener("pointerdown", dismissFromPointerDown, true);
+          ownerWindow?.removeEventListener("resize", positionLatest);
+          ownerWindow?.visualViewport?.removeEventListener("resize", positionLatest);
           host?.remove();
           renderer = null;
           host = null;
           latestProps = null;
           ownerDocument = null;
+          ownerWindow = null;
           clearPaletteSession();
         }
 
@@ -287,7 +300,10 @@ export function createNoteReference(options: NoteReferenceOptions = {}) {
             host.appendChild(renderer.element);
             document.body.appendChild(host);
             ownerDocument = props.editor.view.dom.ownerDocument;
+            ownerWindow = ownerDocument.defaultView;
             ownerDocument.addEventListener("pointerdown", dismissFromPointerDown, true);
+            ownerWindow?.addEventListener("resize", positionLatest);
+            ownerWindow?.visualViewport?.addEventListener("resize", positionLatest);
             position(props);
           },
           onUpdate(props) {

--- a/src/test/composer-editor-slash-menu.test.tsx
+++ b/src/test/composer-editor-slash-menu.test.tsx
@@ -15,6 +15,63 @@ const skills: HermesSkillInfo[] = [
 ];
 
 describe("composer slash menu", () => {
+  it("keeps an asynchronously growing menu above a short viewport composer", async () => {
+    const user = userEvent.setup();
+    const innerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight");
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 174 });
+    const rect = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        if (this.classList.contains("agent-composer-box")) {
+          return new DOMRect(20, 80, 600, 80);
+        }
+        // WKWebView can report a zero-height portal on the synchronous first
+        // placement pass, before React has painted the suggestion rows.
+        if (this.classList.contains("agent-category-menu-host")) {
+          return new DOMRect(20, 0, 600, 0);
+        }
+        return new DOMRect();
+      });
+
+    try {
+      const composer = (availableSkills: HermesSkillInfo[] | null) => (
+        <div className="agent-composer-box">
+          <ComposerEditor
+            placeholder="Message June"
+            skills={availableSkills}
+            onChange={vi.fn()}
+            onSubmit={vi.fn()}
+          />
+        </div>
+      );
+      const view = render(composer(null));
+
+      await user.type(await screen.findByRole("textbox", { name: "Message June" }), "/");
+      const host = await waitFor(() => {
+        const element = document.querySelector<HTMLElement>(".agent-category-menu-host");
+        expect(element).toBeTruthy();
+        return element as HTMLElement;
+      });
+      view.rerender(
+        composer(
+          Array.from({ length: 12 }, (_, index) => ({
+            name: `skill-${index}`,
+            description: `Skill ${index}`,
+            enabled: true,
+          })),
+        ),
+      );
+      await screen.findByRole("option", { name: "skill-11" });
+
+      expect(host.style.top).toBe("");
+      expect(host.style.bottom).toBe("100px");
+      expect(host.style.getPropertyValue("--agent-category-menu-max-height")).toBe("66px");
+    } finally {
+      rect.mockRestore();
+      if (innerHeight) Object.defineProperty(window, "innerHeight", innerHeight);
+    }
+  });
+
   it("dismisses on outside click without removing or retriggering the slash", async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
## Summary

- Keep the chat composer slash-command menu inside short viewports as asynchronously loaded skills expand it.
- Apply the same placement behavior to note-reference suggestions.
- Reposition open composer palettes when the window or visual viewport changes size.
- Add a regression test for a zero-height first measurement, async skill loading, and less than 88px of available space.

## Root cause

The slash-command menu calculated its top edge from the portal's measured height. The menu initially rendered the built-in commands, then loaded skills asynchronously; when the content grew, the stale top let it expand downward past a short webview boundary. The previous 88px minimum height could also exceed the space actually available.

## Validation

- `pnpm test` - 176 test files passed; 2,858 tests passed and 2 skipped.
- `pnpm typecheck`
- `pnpm check` - exits successfully with the repository's existing warning set.
- Focused composer palette tests - 23 passed.
- Tested the real browser preview at a 274 CSS-pixel viewport height with 12 asynchronously loaded skills, then resized from a taller viewport; the menu stayed above the composer, scrolled internally, and produced no console errors.

- [x] Tested visually where it matters (constrained-height browser preview).
- [ ] Needs a June API (backend) deploy before it works end to end. No, this is desktop frontend-only.

## Out of scope

- The separate overlay command prompt is unchanged.
- This does not introduce a shared app-wide popover positioning primitive.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. No security-sensitive behavior changed.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow files changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such files changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend files changed.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786825227&installation_id=144203540&pr_number=805&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F805&signature=1fb2d177f965a65f4f3ccc7ed4bb21b9d2550fe372c0fae44c39f3156c12e5da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->