### PR TITLE
Remove usage credit markup

### DIFF
--- a/docs/june-api-prd.md
+++ b/docs/june-api-prd.md
@@ -47,8 +47,8 @@ call is billed against the signed-in user's OS Accounts wallet at the
 configured **credit price** for the chosen **upstream model**, and the
 existing "Top up credits" affordance in the Account settings becomes the only
 way to fund usage. Users see "Insufficient credits → Top up" instead of a
-generic provider error when they run dry. Usage credit prices are retail
-prices; June's current policy is a 1.2x multiplier over upstream cost.
+generic provider error when they run dry. Usage credit prices pass through
+upstream cost without an additional June markup.
 
 ## User Stories
 
@@ -134,11 +134,11 @@ prices; June's current policy is a 1.2x multiplier over upstream cost.
     swap or add a provider without changing the orchestration code.
 23. As a **June API maintainer**, I want a typed pricing table loaded from
     config, so that adding or repricing an upstream model is a config diff
-    not a code change. Usage prices include the chosen 1.2x retail
-    multiplier over upstream cost.
+    not a code change. Usage prices pass through upstream cost without an
+    additional June markup.
 24. As a **June API maintainer**, I want unknown models (no credit price)
     to be rejected at the API boundary with a clear error code, so that we
-    never silently charge $0 or absorb a margin we didn't choose.
+    never silently charge $0 or absorb unpriced usage.
 25. As a **June API maintainer**, I want structured `tracing` logs with
     `usr_…`, action, model, and credits charged on every settled request, so
     that I can investigate billing disputes without re-deriving anything.
@@ -305,8 +305,8 @@ defaults + `config.toml` + env, no `std::env::var` calls outside):
 - `[upstreams.openai]` — `api_key` (env-only), `base_url`.
 - `[upstreams.venice]` — `api_key` (env-only), `base_url`.
 - `[pricing]` — table keyed by `model_id`, each entry `{ unit: "seconds" |
-  "tokens", credits_per_unit: u64 }`. Values are retail credit prices,
-  currently 1.2x upstream cost for usage-priced models. Loaded from
+  "tokens", credits_per_unit: u64 }`. Values pass through upstream cost
+  without an additional June markup. Loaded from
   `config.toml` baked into the image; `JUNE__PRICING__…` env overrides
   supported via figment for per-env tweaking.
 

--- a/june-api/config.toml
+++ b/june-api/config.toml
@@ -100,12 +100,12 @@ base_url = "https://api.venice.ai/api/v1"
 # Venice's public API (https://api.venice.ai/api/v1).
 # byok_base_url = "https://api.venice.ai/api/v1"
 
-# Usage credit prices include June's 1.2x retail multiplier over upstream cost.
+# Usage credit prices pass through upstream cost without a June markup.
 # OpenAI lists ASR prices per MINUTE of audio ($0.003/min mini, $0.006/min 4o);
-# these are the per-second conversions: $/min ÷ 60 × 1.2 × 1000 credits/$ × 1e6.
+# these are the per-second conversions: $/min ÷ 60 × 1000 credits/$ × 1e6.
 [pricing."gpt-4o-mini-transcribe"]
 unit = "seconds"
-credits_per_million_seconds = 60000
+credits_per_million_seconds = 50000
 provider = "openai"
 model_type = "asr"
 display_name = "GPT-4o mini transcribe"
@@ -117,7 +117,7 @@ capabilities = []
 
 [pricing."gpt-4o-transcribe"]
 unit = "seconds"
-credits_per_million_seconds = 120000
+credits_per_million_seconds = 100000
 provider = "openai"
 model_type = "asr"
 display_name = "GPT-4o transcribe"
@@ -129,7 +129,7 @@ capabilities = []
 
 [pricing."nvidia/parakeet-tdt-0.6b-v3"]
 unit = "seconds"
-credits_per_million_seconds = 120000
+credits_per_million_seconds = 100000
 provider = "venice"
 model_type = "asr"
 display_name = "Parakeet TDT 0.6B v3"
@@ -137,12 +137,12 @@ privacy = "private"
 
 # Credit prices for June's legacy text-model ids. os-api's live catalog uses
 # canonical ids, so it does not replace these aliases. The values include
-# June's 1.2x multiplier over the most expensive enabled private route.
+# the upstream cost of the most expensive enabled private route.
 # Keep GLM 5.2 in sync with DEFAULT_GENERATION_MODEL in the Tauri providers module.
 [pricing."zai-org-glm-5-2"]
 unit = "tokens"
-input_credits_per_million_tokens = 1680
-output_credits_per_million_tokens = 5280
+input_credits_per_million_tokens = 1400
+output_credits_per_million_tokens = 4400
 provider = "venice"
 model_type = "text"
 display_name = "GLM 5.2"
@@ -158,8 +158,8 @@ capabilities = [
 
 [pricing."kimi-k2-6"]
 unit = "tokens"
-input_credits_per_million_tokens = 1308
-output_credits_per_million_tokens = 5520
+input_credits_per_million_tokens = 1090
+output_credits_per_million_tokens = 4600
 provider = "venice"
 model_type = "text"
 display_name = "Kimi K2.6"
@@ -178,8 +178,8 @@ capabilities = [
 
 [pricing."zai-org-glm-5-1"]
 unit = "tokens"
-input_credits_per_million_tokens = 1680
-output_credits_per_million_tokens = 5280
+input_credits_per_million_tokens = 1400
+output_credits_per_million_tokens = 4400
 provider = "venice"
 model_type = "text"
 display_name = "GLM 5.1"
@@ -195,8 +195,8 @@ capabilities = [
 
 [pricing."zai-org-glm-5"]
 unit = "tokens"
-input_credits_per_million_tokens = 1680
-output_credits_per_million_tokens = 5280
+input_credits_per_million_tokens = 1400
+output_credits_per_million_tokens = 4400
 provider = "venice"
 model_type = "text"
 display_name = "GLM 5"
@@ -206,8 +206,8 @@ capabilities = ["supportsFunctionCalling"]
 
 [pricing."nvidia-nemotron-3-nano-30b-a3b"]
 unit = "tokens"
-input_credits_per_million_tokens = 84
-output_credits_per_million_tokens = 360
+input_credits_per_million_tokens = 70
+output_credits_per_million_tokens = 300
 provider = "venice"
 model_type = "text"
 display_name = "Nemotron Nano 30B (dictation cleanup)"

--- a/june-api/crates/api/src/handlers/models.rs
+++ b/june-api/crates/api/src/handlers/models.rs
@@ -81,7 +81,7 @@ fn to_dto(id: &str, model: &ModelPriceConfig) -> ModelDto {
 
 fn price_description(model: &ModelPriceConfig) -> String {
     // `pricing` may contain raw upstream metadata. The user-facing description
-    // must come from June's configured credit price, including margin.
+    // must come from June's configured credit price.
     match model.unit {
         june_config::PriceUnit::Seconds => format!(
             "{} per second audio",
@@ -129,7 +129,7 @@ mod tests {
             unit: PriceUnit::Seconds,
             // gpt-4o-mini-transcribe's packaged price; also pins the display
             // string default_pricing() carries for the same model.
-            credits_per_million_seconds: Some(60_000),
+            credits_per_million_seconds: Some(50_000),
             input_credits_per_million_tokens: None,
             output_credits_per_million_tokens: None,
             provider: ModelProvider::Openai,
@@ -143,6 +143,6 @@ mod tests {
             capabilities: Vec::new(),
         };
 
-        assert_eq!(price_description(&model), "$0.00006 per second audio");
+        assert_eq!(price_description(&model), "$0.00005 per second audio");
     }
 }

--- a/june-api/crates/app/src/main.rs
+++ b/june-api/crates/app/src/main.rs
@@ -142,11 +142,11 @@ async fn load_pricing(
 /// sold below cost. Remove this once settlement is authenticated per route.
 fn apply_private_route_price_floors(pricing: &mut BTreeMap<String, ModelPriceConfig>) {
     for (model_id, input_floor, output_floor) in [
-        ("openai/gpt-oss-120b", 180, 720),
-        ("google/gemma-3-27b-it", 180, 552),
-        ("z-ai/glm-5.2", 1_680, 5_280),
-        ("qwen/qwen3.6-27b", 390, 3_900),
-        ("moonshotai/kimi-k2.6", 1_308, 5_520),
+        ("openai/gpt-oss-120b", 150, 600),
+        ("google/gemma-3-27b-it", 150, 460),
+        ("z-ai/glm-5.2", 1_400, 4_400),
+        ("qwen/qwen3.6-27b", 325, 3_250),
+        ("moonshotai/kimi-k2.6", 1_090, 4_600),
     ] {
         let Some(model) = pricing.get_mut(model_id) else {
             continue;
@@ -590,11 +590,11 @@ mod tests {
         apply_private_route_price_floors(&mut pricing);
 
         for (model_id, input, output) in [
-            ("openai/gpt-oss-120b", 180, 720),
-            ("google/gemma-3-27b-it", 180, 552),
-            ("z-ai/glm-5.2", 1_680, 5_280),
-            ("qwen/qwen3.6-27b", 390, 3_900),
-            ("moonshotai/kimi-k2.6", 1_308, 5_520),
+            ("openai/gpt-oss-120b", 150, 600),
+            ("google/gemma-3-27b-it", 150, 460),
+            ("z-ai/glm-5.2", 1_400, 4_400),
+            ("qwen/qwen3.6-27b", 325, 3_250),
+            ("moonshotai/kimi-k2.6", 1_090, 4_600),
         ] {
             let canonical = &pricing[model_id];
             assert_eq!(

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -764,8 +764,8 @@ struct TextModelFallback {
 /// authoritative numbers and extends over this on every boot. Split out of
 /// `AppConfig::default` to keep that constructor under the line limit.
 ///
-/// Usage credit prices include June's 1.2x retail multiplier over upstream
-/// cost. `$1 = 1000 credits`.
+/// Usage credit prices pass through upstream cost without a June markup.
+/// `$1 = 1000 credits`.
 fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
     let mut pricing = BTreeMap::new();
     pricing.insert(
@@ -773,8 +773,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         ModelPriceConfig {
             unit: PriceUnit::Seconds,
             // OpenAI lists ASR prices per MINUTE ($0.003/min for mini);
-            // converted per second with the 1.2x retail multiplier.
-            credits_per_million_seconds: Some(60_000),
+            // converted per second at upstream cost.
+            credits_per_million_seconds: Some(50_000),
             input_credits_per_million_tokens: None,
             output_credits_per_million_tokens: None,
             provider: ModelProvider::Openai,
@@ -784,7 +784,7 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
             privacy: Some("anonymized".to_string()),
             // Matches what `models.rs::price_description` derives from the
             // credit price above (raw metadata only — the API recomputes it).
-            pricing: Some(serde_json::json!({ "display": "$0.00006 per second audio" })),
+            pricing: Some(serde_json::json!({ "display": "$0.00005 per second audio" })),
             context_tokens: Some(16_000),
             traits: vec!["prompt".to_string()],
             capabilities: Vec::new(),
@@ -794,7 +794,7 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         "nvidia/parakeet-tdt-0.6b-v3".to_string(),
         ModelPriceConfig {
             unit: PriceUnit::Seconds,
-            credits_per_million_seconds: Some(120_000),
+            credits_per_million_seconds: Some(100_000),
             input_credits_per_million_tokens: None,
             output_credits_per_million_tokens: None,
             provider: ModelProvider::Venice,
@@ -817,8 +817,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         TextModelFallback {
             id: "zai-org-glm-5-2",
             display_name: "GLM 5.2",
-            input_credits_per_million_tokens: 1_680,
-            output_credits_per_million_tokens: 5_280,
+            input_credits_per_million_tokens: 1_400,
+            output_credits_per_million_tokens: 4_400,
             context_tokens: 200_000,
             capabilities: &[
                 "supportsFunctionCalling",
@@ -831,8 +831,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         TextModelFallback {
             id: "kimi-k2-6",
             display_name: "Kimi K2.6",
-            input_credits_per_million_tokens: 1_308,
-            output_credits_per_million_tokens: 5_520,
+            input_credits_per_million_tokens: 1_090,
+            output_credits_per_million_tokens: 4_600,
             context_tokens: 256_000,
             // Kimi K2.6 is natively multimodal (Venice `supportsVision`), so it
             // is the image-input fallback the frontend switches to when an image
@@ -848,8 +848,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         TextModelFallback {
             id: "zai-org-glm-5-1",
             display_name: "GLM 5.1",
-            input_credits_per_million_tokens: 1_680,
-            output_credits_per_million_tokens: 5_280,
+            input_credits_per_million_tokens: 1_400,
+            output_credits_per_million_tokens: 4_400,
             context_tokens: 200_000,
             capabilities: &[
                 "supportsFunctionCalling",
@@ -862,8 +862,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         TextModelFallback {
             id: "zai-org-glm-5",
             display_name: "GLM 5",
-            input_credits_per_million_tokens: 1_680,
-            output_credits_per_million_tokens: 5_280,
+            input_credits_per_million_tokens: 1_400,
+            output_credits_per_million_tokens: 4_400,
             context_tokens: 198_000,
             capabilities: &["supportsFunctionCalling"],
         },
@@ -1690,67 +1690,67 @@ mod tests {
     }
 
     #[test]
-    fn packaged_config_toml_includes_usage_margin() {
+    fn packaged_config_toml_passes_through_upstream_cost() {
         let config = packaged_config_toml();
 
         // Per-second conversions of OpenAI's per-MINUTE ASR list prices
-        // ($0.003/min mini, $0.006/min 4o) with the 1.2x retail multiplier.
+        // ($0.003/min mini, $0.006/min 4o) at upstream cost.
         assert_eq!(
             config
                 .pricing
                 .get("gpt-4o-mini-transcribe")
                 .and_then(|model| model.credits_per_million_seconds),
-            Some(60_000)
+            Some(50_000)
         );
         assert_eq!(
             config
                 .pricing
                 .get("gpt-4o-transcribe")
                 .and_then(|model| model.credits_per_million_seconds),
-            Some(120_000)
+            Some(100_000)
         );
         assert_eq!(
             config
                 .pricing
                 .get("zai-org-glm-5-2")
                 .and_then(|model| model.input_credits_per_million_tokens),
-            Some(1_680)
+            Some(1_400)
         );
         assert_eq!(
             config
                 .pricing
                 .get("zai-org-glm-5-2")
                 .and_then(|model| model.output_credits_per_million_tokens),
-            Some(5_280)
+            Some(4_400)
         );
         for model_id in ["zai-org-glm-5-1", "zai-org-glm-5"] {
             let model = config.pricing.get(model_id);
             assert_eq!(
                 model.and_then(|model| model.input_credits_per_million_tokens),
-                Some(1_680),
+                Some(1_400),
                 "{model_id} must use the routed GLM 5.2 input price"
             );
             assert_eq!(
                 model.and_then(|model| model.output_credits_per_million_tokens),
-                Some(5_280),
+                Some(4_400),
                 "{model_id} must use the routed GLM 5.2 output price"
             );
         }
         let kimi = config.pricing.get("kimi-k2-6");
         assert_eq!(
             kimi.and_then(|model| model.input_credits_per_million_tokens),
-            Some(1_308)
+            Some(1_090)
         );
         assert_eq!(
             kimi.and_then(|model| model.output_credits_per_million_tokens),
-            Some(5_520)
+            Some(4_600)
         );
         assert_eq!(
             config
                 .pricing
                 .get("nvidia-nemotron-3-nano-30b-a3b")
                 .and_then(|model| model.input_credits_per_million_tokens),
-            Some(84)
+            Some(70)
         );
     }
 

--- a/june-api/crates/providers/src/venice.rs
+++ b/june-api/crates/providers/src/venice.rs
@@ -63,8 +63,6 @@ const RATE_SCALE: f64 = 1_000_000.0;
 const STREAM_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 #[cfg(test)]
 const STREAM_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
-/// A 20% markup over upstream cost is a 1.2x retail price.
-const RETAIL_PRICE_MULTIPLIER: f64 = 1.2;
 
 /// Standing safety policy injected as the leading system message on every
 /// Venice chat completion — note generation, dictation cleanup, and agent
@@ -1494,11 +1492,11 @@ fn usd_at_path(value: &serde_json::Value, path: &[&str]) -> Option<f64> {
 }
 
 fn credits_per_million_units(usd_per_million_units: f64) -> Option<u64> {
-    ceil_positive_u64(usd_per_million_units * CREDITS_PER_USD * RETAIL_PRICE_MULTIPLIER)
+    ceil_positive_u64(usd_per_million_units * CREDITS_PER_USD)
 }
 
 fn credits_per_million_seconds(usd_per_second: f64) -> Option<u64> {
-    ceil_positive_u64(usd_per_second * CREDITS_PER_USD * RATE_SCALE * RETAIL_PRICE_MULTIPLIER)
+    ceil_positive_u64(usd_per_second * CREDITS_PER_USD * RATE_SCALE)
 }
 
 fn ceil_positive_u64(value: f64) -> Option<u64> {
@@ -2921,8 +2919,8 @@ mod tests {
             model.capabilities,
             vec!["nested.enabled", "supportsFunctionCalling"]
         );
-        assert_eq!(model.input_credits_per_million_tokens, Some(84));
-        assert_eq!(model.output_credits_per_million_tokens, Some(360));
+        assert_eq!(model.input_credits_per_million_tokens, Some(70));
+        assert_eq!(model.output_credits_per_million_tokens, Some(300));
         assert!(model.pricing.is_some());
     }
 
@@ -2948,6 +2946,6 @@ mod tests {
         let models = venice_priced_model_items(response, ModelType::Asr);
         let model = models.get("asr-model").expect("asr model");
 
-        assert_eq!(model.credits_per_million_seconds, Some(120_000));
+        assert_eq!(model.credits_per_million_seconds, Some(100_000));
     }
 }


### PR DESCRIPTION
## Summary

- remove the 1.2x multiplier from live Venice catalog pricing
- lower packaged ASR and text fallbacks plus private-route floors to upstream cost
- keep user-facing price descriptions, tests, and the June API PRD aligned

## Why

The recently added 20% usage markup makes early product usage more expensive while acquisition is the priority. This change restores pass-through usage pricing without reverting the unrelated OpenAI ASR unit correction or authorization-hold fixes that landed with the original margin work.

## Impact

Usage-priced text and ASR models are billed at upstream cost, rounded to whole credits. Existing flat image, image-edit, and web-tool prices are unchanged.

## Validation

- `cargo fmt --all -- --check`
- focused `june-config`, `june-providers`, `june-api`, and `june` pricing tests
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786831480&installation_id=144203540&pr_number=806&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F806&signature=308fb10552dcf844d4091217de4461496853913faa34faa8c23c0a77b9f33d5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->