### PR TITLE
security: refuse non-loopback bind with default dev token; harden staging compose

### DIFF
--- a/june-api/.env.example
+++ b/june-api/.env.example
@@ -10,6 +10,13 @@
 # Enabled by default so a cloned repo can run without OS Accounts or billing.
 # Keep the bearer token in sync with OS_JUNE_LOCAL_DEV_BEARER_TOKEN in the
 # root .env file.
+#
+# WARNING: the default bearer token below is a publicly known placeholder. That
+# is safe only while JUNE__SERVER__HOST stays on loopback (127.0.0.0/8 or ::1).
+# If you rebind the server to a non-loopback address, anyone who can reach the
+# port can authenticate with this token (local mode also skips metering), and
+# June API refuses to start in that combination. Set a random token instead,
+# e.g. `openssl rand -hex 32`, and keep it in sync with the root .env.
 JUNE__SERVER__HOST=127.0.0.1
 JUNE__LOCAL_DEV__ENABLED=true
 JUNE__LOCAL_DEV__BEARER_TOKEN=local-dev-token

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
     fmt::{self, Debug},
+    net::IpAddr,
 };
 use thiserror::Error;
 use url::Url;
@@ -1528,20 +1529,48 @@ fn validate_image_pricing(config: &AppConfig) -> Result<(), ConfigError> {
     Ok(())
 }
 
+/// Local-dev mode skips real OS Accounts auth and metering, so its bearer
+/// token is the only credential on the API. The placeholder default is publicly
+/// known (it ships in `.env.example` and in the desktop shell), which is safe
+/// only while the server binds a loopback address. On a non-loopback bind the
+/// placeholder is rejected at startup (security audit 2026-07-17): anyone who
+/// could reach the port would otherwise authenticate as the local dev user.
 fn validate_local_dev_bearer_token(config: &AppConfig) -> Result<(), ConfigError> {
+    validate_required_text("local_dev.bearer_token", &config.local_dev.bearer_token)?;
     if is_loopback_host(&config.server.host) {
-        validate_required_text("local_dev.bearer_token", &config.local_dev.bearer_token)
-    } else {
-        validate_required_secret(
-            "local_dev.bearer_token",
-            &config.local_dev.bearer_token,
-            LOCAL_DEV_BEARER_TOKEN_PLACEHOLDERS,
-        )
+        return Ok(());
     }
+    if LOCAL_DEV_BEARER_TOKEN_PLACEHOLDERS
+        .iter()
+        .any(|placeholder| config.local_dev.bearer_token.trim() == *placeholder)
+    {
+        return Err(ConfigError::InvalidRequired {
+            field: "local_dev.bearer_token",
+            reason: "the default placeholder token is publicly known, and local-dev mode skips \
+                metering, so binding a non-loopback host with it lets anyone who can reach this \
+                port authenticate as the local dev user; set JUNE__LOCAL_DEV__BEARER_TOKEN to a \
+                random value (e.g. `openssl rand -hex 32`) or bind server.host to a loopback \
+                address (127.0.0.0/8 or ::1)",
+        });
+    }
+    Ok(())
 }
 
+/// Loopback is the whole IPv4 127.0.0.0/8 range or IPv6 `::1`, not just
+/// 127.0.0.1: any of them keeps the API unreachable from off-host. Hostnames
+/// other than `localhost` and unparseable values are treated as non-loopback
+/// (fail closed) — the placeholder token check then applies.
 fn is_loopback_host(host: &str) -> bool {
-    matches!(host.trim(), "127.0.0.1" | "localhost" | "::1")
+    let host = host.trim();
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    // Accept the bracketed IPv6 form ("[::1]") as written in some configs.
+    let host = host
+        .strip_prefix('[')
+        .and_then(|inner| inner.strip_suffix(']'))
+        .unwrap_or(host);
+    host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
 }
 
 fn validate_required_text(field: &'static str, value: &str) -> Result<(), ConfigError> {
@@ -1631,7 +1660,7 @@ mod tests {
         OS_ACCOUNTS_APP_API_KEY_PLACEHOLDERS, OS_ACCOUNTS_AUTHORIZE_TIMEOUT_BUDGET_SECS,
         OS_ACCOUNTS_MAX_HOLD_TTL_SECS, PriceUnit, VENICE_API_KEY_PLACEHOLDERS,
         VIDEO_CLIENT_POLL_WINDOW_SECS, VIDEO_SETTLEMENT_TIMEOUT_MARGIN_SECS,
-        image_client_timeout_secs, validate, validate_request_limits,
+        image_client_timeout_secs, is_loopback_host, validate, validate_request_limits,
     };
     use pretty_assertions::assert_eq;
     use std::collections::BTreeMap;
@@ -2474,6 +2503,87 @@ mod tests {
         let result = validate(&config);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn loopback_hosts_cover_the_full_ipv4_range_and_ipv6() {
+        for host in [
+            "127.0.0.1",
+            "127.0.0.2",
+            "127.255.255.255",
+            "localhost",
+            "LOCALHOST",
+            "::1",
+            "[::1]",
+        ] {
+            assert!(is_loopback_host(host), "{host} should be loopback");
+        }
+        for host in [
+            "0.0.0.0",
+            "10.0.0.1",
+            "192.168.1.1",
+            "::",
+            "::2",
+            "example.com",
+        ] {
+            assert!(!is_loopback_host(host), "{host} should not be loopback");
+        }
+    }
+
+    #[test]
+    fn validate_local_dev_allows_placeholder_bearer_token_on_loopback_host() {
+        // The publicly known placeholder is acceptable only while the bind
+        // address keeps the API off the network: any 127.0.0.0/8 address or ::1.
+        for host in ["127.0.0.1", "127.0.0.2", "::1"] {
+            let mut config = AppConfig::default();
+            config.local_dev.enabled = true;
+            config.server.host = host.to_string();
+
+            let result = validate(&config);
+
+            assert!(result.is_ok(), "loopback host {host} rejected: {result:?}");
+        }
+    }
+
+    #[test]
+    fn validate_local_dev_rejects_placeholder_bearer_token_on_non_loopback_host_with_guidance() {
+        // The fail-fast error must explain the risk and the fix, not just name
+        // the field (security audit 2026-07-17).
+        let mut config = AppConfig::default();
+        config.local_dev.enabled = true;
+        config.server.host = "0.0.0.0".to_string();
+
+        let result = validate(&config);
+
+        assert!(matches!(
+            &result,
+            Err(ConfigError::InvalidRequired {
+                field: "local_dev.bearer_token",
+                ..
+            })
+        ));
+        if let Err(ConfigError::InvalidRequired { reason, .. }) = &result {
+            assert!(
+                reason.contains("openssl rand"),
+                "error should explain how to set a random token: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_local_dev_allows_random_bearer_token_on_non_loopback_host() {
+        let mut config = AppConfig::default();
+        config.local_dev.enabled = true;
+        config.server.host = "0.0.0.0".to_string();
+        config.local_dev.bearer_token =
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08".to_string();
+
+        let result = validate(&config);
+
+        assert!(
+            result.is_ok(),
+            "random token on non-loopback rejected: {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Implements fixes from the security audit of 2026-07-17. One commit per finding.
- **[Low] Predictable default local-dev bearer token:** `june-api` now fails fast at startup when local-dev mode is bound to a non-loopback host while the bearer token is still the publicly known placeholder, with an error that explains the risk and the fix. Commit `ffde8481`.
- **[Info] Staging compose publishes `8080:8080`:** verified **already fixed on `main`** before this PR — no commit needed. See the finding section below for the evidence.

## Finding 1 — [Low] Predictable default local-dev bearer token authenticates the local June API

**What/where:** `june-api/.env.example` ships `JUNE__LOCAL_DEV__BEARER_TOKEN=local-dev-token` and `src-tauri/src/os_accounts.rs` mirrors it as `DEFAULT_LOCAL_DEV_BEARER_TOKEN`. Local-dev mode skips real OS Accounts auth and metering, so if a developer rebinds the local June API off 127.0.0.1 without rotating the token, anyone who can reach the port can authenticate with a publicly known credential.

**How fixed** (`june-api/crates/config/src/lib.rs`, `june-api/.env.example`):

- The config crate already had a fail-fast check (`validate_local_dev_bearer_token`) rejecting the placeholder on a non-loopback `server.host`; this PR completes the audit's requirements:
  - `is_loopback_host` now parses the host as an IP and treats the full `127.0.0.0/8` range and `::1` (plus the bracketed `[::1]` form) as loopback, instead of exact-matching only `127.0.0.1`/`localhost`/`::1`. Unparseable hosts fail closed (placeholder rejected).
  - The startup `ConfigError` now explains the risk and remediation — set `JUNE__LOCAL_DEV__BEARER_TOKEN` to a random value (e.g. `openssl rand -hex 32`) or bind a loopback address — instead of the generic "placeholder value must be replaced".
  - New unit tests: loopback + placeholder (allowed, incl. `127.0.0.2` to pin the /8 semantics), non-loopback + placeholder (rejected, error guidance asserted), non-loopback + random token (allowed), and the loopback matcher itself.
- `june-api/.env.example` carries a warning comment next to the placeholder token.
- `src-tauri` is unchanged: the desktop default only ever talks to a loopback local server, which remains allowed, so no alignment change is required.

Behavior compatibility note: the only loosened case is binds to non-`.1` loopback addresses (e.g. `127.0.0.2`) with the placeholder token — previously rejected, now allowed, per the audit's definition of loopback. Every previously-accepted configuration still validates.

## Finding 2 — [Info] Staging compose publishes `8080:8080` directly

**Already fixed on `main`; no commit in this PR.** The audit ran against the checked-out branch `codex/readme-june-website-link`, which predates the fix. Evidence:

- Commit `574001da` ("infra: staging june-api gets dstack-ingress on june-api-staging.opensoftware.co (JUN-247)") removed the `ports: - "8080:8080"` block from `june-api/deploy/docker-compose.staging.yml` and added the `dstack-ingress` TLS terminator, mirroring production.
- On current `main`, both `docker-compose.staging.yml` and `docker-compose.production.yml` publish only `443:443` on `dstack-ingress`; the `june-api` service publishes nothing and carries the comment: "No published ports: dstack-ingress is the sole external entry point… The ingress reaches the app over the internal compose network via TARGET_ENDPOINT=http://june-api:8080." `git merge-base` confirms the audit branch lacks `574001da`.

## Root cause

Finding 1: the placeholder token default predates the loopback guard, and the guard's error message/loopback definition had not been brought up to the audit's bar (full 127.0.0.0/8 + actionable remediation text).

## Validation

- `cargo test -p june-config` (in `june-api/`) — **51 passed, 0 failed**, including the 4 new tests:
  - `loopback_hosts_cover_the_full_ipv4_range_and_ipv6`
  - `validate_local_dev_allows_placeholder_bearer_token_on_loopback_host`
  - `validate_local_dev_rejects_placeholder_bearer_token_on_non_loopback_host_with_guidance`
  - `validate_local_dev_allows_random_bearer_token_on_non_loopback_host`
- `cargo clippy -p june-config --all-targets` — clean, 0 warnings.
- `cargo fmt -p june-config` — applied.
- `docker compose -f june-api/deploy/docker-compose.staging.yml config` — file parses (only fails on the deploy-injected `JUNE_IMAGE` var being unset locally, as expected; the compose file is unmodified in this PR).
- [ ] Tested visually where it matters (no UI changes).
- [x] Needs a June API (backend) deploy before it works end to end — the startup validation ships with the backend; deployed staging/production do not run local-dev mode, so this is a no-op there and only affects self-hosted/local runs.

## Out of scope

Audit items deliberately left as follow-ups (accepted or not committable):

- Local untracked `scribe-api/.env` with live provider keys — local-machine hygiene, nothing to commit.
- Dev plaintext token store option — accepted, debug-only.
- Tauri CSP `style-src 'unsafe-inline'` — accepted.
- Application-level rate limiting on june-api — optional ingress concern.

## Followups

- None beyond the accepted audit items above.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs (no workflow changes).
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review (no such changes).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review — requested: this touches backend startup auth validation (local-dev mode only; metering behavior unchanged).
- [x] User-facing copy follows the repo UI conventions (no user-facing copy changes).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786849016&installation_id=144203540&pr_number=810&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F810&signature=c9bd35cdb908406cf007529ac2ef2736b6c085da5ae45efb41e3f5499dd3d652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->