### PR TITLE
Fix model-aware funding gate for Venice BYOK text

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3919,10 +3919,16 @@ export function App() {
                   creditActionsDisabledReason={
                     fundingRequired ? COMPOSER_FUNDING_DISABLED_REASON : undefined
                   }
-                  fundingNotice={
-                    fundingRequired ? (
-                      <FundingNotice account={fundingAccount} onRefresh={refreshFundingAccount} />
-                    ) : undefined
+                  renderFundingNotice={
+                    fundingRequired
+                      ? (textFundingContext) => (
+                          <FundingNotice
+                            account={fundingAccount}
+                            onRefresh={refreshFundingAccount}
+                            textFundingContext={textFundingContext}
+                          />
+                        )
+                      : undefined
                   }
                   fundingTier={fundingTierOf(fundingAccount)}
                   topUpLabel={topUpLabel}
@@ -4374,10 +4380,16 @@ export function App() {
             creditActionsDisabledReason={
               fundingRequired ? COMPOSER_FUNDING_DISABLED_REASON : undefined
             }
-            fundingNotice={
-              fundingRequired ? (
-                <FundingNotice account={fundingAccount} onRefresh={refreshFundingAccount} />
-              ) : undefined
+            renderFundingNotice={
+              fundingRequired
+                ? (textFundingContext) => (
+                    <FundingNotice
+                      account={fundingAccount}
+                      onRefresh={refreshFundingAccount}
+                      textFundingContext={textFundingContext}
+                    />
+                  )
+                : undefined
             }
             onClose={() => setNoteChatOpen(false)}
             onOpenInAgent={(sessionId) => {

--- a/src/components/account/FundingNotice.tsx
+++ b/src/components/account/FundingNotice.tsx
@@ -1,7 +1,9 @@
 import { IconChevronTopSmall } from "central-icons/IconChevronTopSmall";
 import { useEffect, useRef, useState } from "react";
 import { hasLiveSubscription, isOnMaxPlan } from "../../lib/account-gate";
+import type { TextFundingModelContext } from "../../lib/account-gate";
 import { errorCode } from "../../lib/errors";
+import { AUTO_MODEL_ID } from "../../lib/hermes-session-model-selection";
 import {
   MAX_GRANT_HOSTED_POLL_TIMEOUT_MS,
   MAX_UPGRADE_BROWSER_STATUS,
@@ -37,10 +39,17 @@ import { Spinner } from "../ui/Spinner";
 type Props = {
   account: AccountStatus;
   onRefresh: () => Promise<AccountStatus | undefined>;
+  /** Active composer context. Only chat placements supply it; other funding
+   * surfaces keep the general account copy and action. */
+  textFundingContext?: TextFundingNoticeContext;
   /** False parks the notice's account poll (the chip keeps its collapsed
    * notice mounted for the height animation; only the expanded one should
    * poll). Defaults to true. */
   active?: boolean;
+};
+
+export type TextFundingNoticeContext = TextFundingModelContext & {
+  onSelectVeniceModel: () => void;
 };
 
 const POLL_INTERVAL_MS = 10_000;
@@ -111,10 +120,10 @@ export function TierMiniCard({ tier }: { tier: FundingTier }) {
 /** The persistent out-of-credits surface: a compact, non-dismissible notice
  * docked where credit-consuming actions live (above the chat composers, in
  * the sidebar chip's popover). Enforcement happens at the action layer in
- * App; this row only explains the state and offers the one way out of it.
+ * App; this row only explains the state and offers the applicable recovery.
  * Owns the checkout / billing / in-place-upgrade logic that FundingGate used
  * to hold so every placement stays behaviorally identical. */
-export function FundingNotice({ account, onRefresh, active = true }: Props) {
+export function FundingNotice({ account, onRefresh, textFundingContext, active = true }: Props) {
   const [openedPortal, setOpenedPortal] = useState(false);
   const [checking, setChecking] = useState(false);
   // The Max upgrade can end in a saved-card charge, so it only fires from an
@@ -355,6 +364,20 @@ export function FundingNotice({ account, onRefresh, active = true }: Props) {
 
   const upgradePending = awaitingBrowser || awaitingGrant;
   const waiting = upgradePending || openedPortal;
+  const autoVeniceRecovery = Boolean(
+    textFundingContext?.veniceApiKeyConfigured &&
+      textFundingContext.activeModelId === AUTO_MODEL_ID,
+  );
+
+  function handlePrimaryFundingAction() {
+    if (proUpgradeRequired) {
+      setConfirmError(undefined);
+      setChargeNowUpgrade(false);
+      setConfirmingUpgrade(true);
+      return;
+    }
+    void handleOpenPortal(offerMaxPlan ? "pro" : chosenPlan);
+  }
 
   return (
     <section className="funding-notice" role="status" aria-live="polite">
@@ -370,7 +393,9 @@ export function FundingNotice({ account, onRefresh, active = true }: Props) {
               ? maxUpgradeSlowStatus(maxGrantWait)
               : openedPortal
                 ? copy.waiting
-                : copy.body}
+                : autoVeniceRecovery
+                  ? "Auto can route beyond Venice, so it uses June credits. Your Venice API key applies only when you select a Venice model."
+                  : copy.body}
       </p>
       <div className="funding-notice-actions">
         {upgradePending ? (
@@ -428,6 +453,23 @@ export function FundingNotice({ account, onRefresh, active = true }: Props) {
               {checking ? "Checking..." : "Check again"}
             </button>
           </>
+        ) : autoVeniceRecovery ? (
+          <>
+            <button
+              type="button"
+              className="btn btn-ghost"
+              onClick={textFundingContext?.onSelectVeniceModel}
+            >
+              Select a Venice model
+            </button>
+            <button
+              type="button"
+              className="btn btn-secondary funding-notice-cta"
+              onClick={handlePrimaryFundingAction}
+            >
+              {copy.cta}
+            </button>
+          </>
         ) : (
           <>
             {offerMaxPlan ? (
@@ -442,15 +484,7 @@ export function FundingNotice({ account, onRefresh, active = true }: Props) {
             <button
               type="button"
               className="btn btn-secondary funding-notice-cta"
-              onClick={() => {
-                if (proUpgradeRequired) {
-                  setConfirmError(undefined);
-                  setChargeNowUpgrade(false);
-                  setConfirmingUpgrade(true);
-                  return;
-                }
-                void handleOpenPortal(offerMaxPlan ? "pro" : chosenPlan);
-              }}
+              onClick={handlePrimaryFundingAction}
             >
               {copy.cta}
             </button>

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -75,7 +75,7 @@ import {
 } from "react";
 import { BackButton } from "../ui/BackButton";
 import { TierMiniCard } from "../account/FundingNotice";
-import type { FundingTier } from "../account/FundingNotice";
+import type { FundingTier, TextFundingNoticeContext } from "../account/FundingNotice";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { CopyStateIcon } from "../ui/CopyStateIcon";
 import { Dialog } from "../ui/Dialog";
@@ -219,6 +219,7 @@ import { ShareLinkCopyAction } from "../share/ShareLinkCopyAction";
 import { recordPositiveFeedbackSent } from "../../lib/referral-nudge";
 import { useScrollFade } from "../../lib/use-scroll-fade";
 import { unsupportedEventStore } from "../../lib/hermes-unsupported-events";
+import { shouldBlockTextOnFunding, type TextFundingModelContext } from "../../lib/account-gate";
 import { pendingActionStore } from "../../lib/hermes-pending-actions";
 import { hermesActivityStore, type AgentActivityRecord } from "../../lib/hermes-activity-store";
 import {
@@ -1794,10 +1795,10 @@ type AgentWorkspaceProps = {
    * stored session id. */
   onMoveSessionToProject?: (sessionId: string) => void;
   creditActionsDisabledReason?: string;
-  /** The persistent out-of-credits notice, pre-wired by App. When present it
-   * replaces the plain composer-notice paragraph; the disabled reason keeps
-   * gating actions and tooltips. */
-  fundingNotice?: ReactNode;
+  /** App owns the account and billing action; the composer owns the active
+   * session model and picker. This typed boundary joins them without guessing
+   * from the app-wide setting. */
+  renderFundingNotice?: (context: TextFundingNoticeContext) => ReactNode;
   /** The user's current plan; the in-transcript stopped-turn credits card
    * leads with its tier card. */
   fundingTier?: FundingTier;
@@ -2354,7 +2355,7 @@ export function AgentWorkspace({
   resolveSessionProjectContext,
   onMoveSessionToProject,
   creditActionsDisabledReason,
-  fundingNotice,
+  renderFundingNotice,
   fundingTier,
   testOnlySlashCommandEntriesRef,
 }: AgentWorkspaceProps = {}) {
@@ -2686,6 +2687,7 @@ export function AgentWorkspace({
   // section can show its billing note (Auto meters June credits, never the
   // key). Refreshed with every provider-settings read.
   const [veniceApiKeyConfigured, setVeniceApiKeyConfigured] = useState(false);
+  const veniceApiKeyConfiguredRef = useRef(false);
   // Preference saves from the picker's drill-in: writes are chained so they
   // persist in click order, and versioned so only the newest call's outcome
   // touches the UI (mirrors Settings' saveCostQuality discipline). Rollback
@@ -3252,6 +3254,17 @@ export function AgentWorkspace({
   // treated as non-vision.
   const resolvedGenerationModel = activeGenerationModelId
     ? generationModels.find((model) => model.id === activeGenerationModelId)
+    : undefined;
+  const textFundingContext: TextFundingModelContext = {
+    activeModelId: activeGenerationModelId || undefined,
+    activeModel: resolvedGenerationModel,
+    veniceApiKeyConfigured,
+  };
+  const textActionsDisabledReason = shouldBlockTextOnFunding(
+    Boolean(creditActionsDisabledReason),
+    textFundingContext,
+  )
+    ? creditActionsDisabledReason
     : undefined;
   const composerHasPendingImage =
     pendingImageAttachments(attachments.map((attachment) => attachment.attach)).length > 0;
@@ -3848,6 +3861,7 @@ export function AgentWorkspace({
       confirmedCostQualityRef.current = settings.costQuality;
       generationCostQualityRef.current = settings.costQuality;
       setGenerationCostQuality(settings.costQuality);
+      veniceApiKeyConfiguredRef.current = settings.veniceApiKeyConfigured;
       setVeniceApiKeyConfigured(settings.veniceApiKeyConfigured);
       return selectedModelId;
     },
@@ -3868,6 +3882,7 @@ export function AgentWorkspace({
       modelsPromise.catch(() => {});
       const settingsResponse = await settingsPromise;
       if (requestId === generationModelRequestSequence.current) {
+        veniceApiKeyConfiguredRef.current = settingsResponse.settings.veniceApiKeyConfigured;
         setVeniceApiKeyConfigured(settingsResponse.settings.veniceApiKeyConfigured);
       }
       const modelsResponse = await modelsPromise;
@@ -5725,7 +5740,7 @@ export function AgentWorkspace({
       (!message && !attachments.length) ||
       submitting ||
       importingFiles ||
-      creditActionsDisabledReason ||
+      textActionsDisabledReason ||
       selectedHermesSessionIsProvisional ||
       imageSlashBlockedByModel
     )
@@ -6937,7 +6952,20 @@ export function AgentWorkspace({
       skipPrompt?: boolean;
     },
   ): Promise<string | undefined> {
-    if (creditActionsDisabledReason && !options?.skipPrompt) {
+    const modelTarget = options?.modelTarget ?? captureSessionModelTarget(explicitSession);
+    const targetCatalogModel = generationModelsRef.current.find(
+      (model) => model.id === modelTarget.selection.modelId,
+    );
+    const targetTextFundingContext: TextFundingModelContext = {
+      activeModelId: modelTarget.selection.modelId || undefined,
+      activeModel: targetCatalogModel,
+      veniceApiKeyConfigured: veniceApiKeyConfiguredRef.current,
+    };
+    if (
+      creditActionsDisabledReason &&
+      !options?.skipPrompt &&
+      shouldBlockTextOnFunding(true, targetTextFundingContext)
+    ) {
       throw new Error(creditActionsDisabledReason);
     }
     const displayContent = options?.displayContent ?? content;
@@ -6967,7 +6995,6 @@ export function AgentWorkspace({
         .replace(/[–—]/g, "-")
         .replace(/^([a-z])/, (match) => match.toUpperCase());
     }
-    const modelTarget = options?.modelTarget ?? captureSessionModelTarget(explicitSession);
     const targetStoredSessionId = modelTarget.targetStoredSessionId ?? undefined;
     let dispatchReservation =
       options?.dispatchReservation ??
@@ -10410,12 +10437,16 @@ export function AgentWorkspace({
         {heroMode ? null : (
           <AgentScrollToLatestButton scrollRef={agentScrollRef} onJump={scrollTranscriptToLatest} />
         )}
-        {fundingNotice ??
-          (creditActionsDisabledReason ? (
-            <p className="agent-composer-notice" role="status">
-              {creditActionsDisabledReason}
-            </p>
-          ) : null)}
+        {textActionsDisabledReason
+          ? (renderFundingNotice?.({
+              ...textFundingContext,
+              onSelectVeniceModel: openComposerModelPicker,
+            }) ?? (
+              <p className="agent-composer-notice" role="status">
+                {textActionsDisabledReason}
+              </p>
+            ))
+          : null}
         <AnimatePresence>
           {galleryErrors ? (
             // Dev gallery only: the busy nudge is a toast in real use (see
@@ -10786,7 +10817,7 @@ export function AgentWorkspace({
                   disabled={
                     submitting ||
                     importingFiles ||
-                    Boolean(creditActionsDisabledReason) ||
+                    Boolean(textActionsDisabledReason) ||
                     selectedHermesSessionIsProvisional ||
                     imageSlashBlockedByModel ||
                     (!draft.trim() && !attachments.length)

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { PointerEvent as ReactPointerEvent, ReactNode } from "react";
 
 import type { AgentChatPart, AgentChatTurn } from "../../lib/agent-chat-runtime";
+import { shouldBlockTextOnFunding, type TextFundingModelContext } from "../../lib/account-gate";
 import { messageFromError } from "../../lib/errors";
 import { attachmentStateFrom } from "../../lib/hermes-image-attach";
 import {
@@ -50,6 +51,7 @@ import {
 } from "../agent/composer/ModelPicker";
 import { autoPillDesignation } from "../../lib/suggested-models";
 import { AUTO_MODEL_ID, modelOptions, selectedModel } from "../settings/ModelPickerDialog";
+import type { TextFundingNoticeContext } from "../account/FundingNotice";
 import type { NoteChat, NoteChatAttachment } from "./useNoteChat";
 
 /** Note-tailored presets, shown as the main session view's preset chips (icon
@@ -175,7 +177,7 @@ export function NoteChatPanel({
   chat,
   recordingActive,
   creditActionsDisabledReason,
-  fundingNotice,
+  renderFundingNotice,
   onClose,
   onOpenInAgent,
 }: {
@@ -188,10 +190,9 @@ export function NoteChatPanel({
    * never lands in the note); this only tunes the tooltip to say so. */
   recordingActive?: boolean;
   creditActionsDisabledReason?: string;
-  /** The persistent out-of-credits notice, pre-wired by App. When present it
-   * replaces the plain composer-notice paragraph; the disabled reason keeps
-   * gating actions and tooltips. */
-  fundingNotice?: ReactNode;
+  /** App owns the account and billing action; the composer owns the active
+   * session model and picker. */
+  renderFundingNotice?: (context: TextFundingNoticeContext) => ReactNode;
   onClose: () => void;
   onOpenInAgent: (sessionId: string | undefined) => void;
 }) {
@@ -363,6 +364,18 @@ export function NoteChatPanel({
       ? selectedModel(models, modelId)
       : (unavailableLocalGenerationOption(modelId) ?? selectedModel(models, modelId))
     : undefined;
+  const resolvedTextModel = models.find((candidate) => candidate.id === modelId);
+  const textFundingContext: TextFundingModelContext = {
+    activeModelId: modelId || undefined,
+    activeModel: resolvedTextModel,
+    veniceApiKeyConfigured,
+  };
+  const textActionsDisabledReason = shouldBlockTextOnFunding(
+    Boolean(creditActionsDisabledReason),
+    textFundingContext,
+  )
+    ? creditActionsDisabledReason
+    : undefined;
 
   function saveGenerationSelection(write: () => Promise<unknown>): Promise<void> {
     const save = generationSelectionSaveChainRef.current.then(async () => {
@@ -529,7 +542,7 @@ export function NoteChatPanel({
   }, [turns.length, lastTurnSize, working, fade.update]);
 
   async function handleSend(text: string) {
-    if (working || importing || creditActionsDisabledReason) return;
+    if (working || importing || textActionsDisabledReason) return;
     setComposerError(null);
     const accepted = await submit(text, attachments);
     if (accepted) {
@@ -651,12 +664,20 @@ export function NoteChatPanel({
           ) : null}
         </div>
         <footer className="note-chat-composer">
-          {fundingNotice ??
-            (creditActionsDisabledReason ? (
-              <p className="agent-composer-notice" role="status">
-                {creditActionsDisabledReason}
-              </p>
-            ) : null)}
+          {textActionsDisabledReason
+            ? (renderFundingNotice?.({
+                ...textFundingContext,
+                onSelectVeniceModel: () => {
+                  setModelFlyout(null);
+                  setModelSearch("");
+                  setModelOpen(true);
+                },
+              }) ?? (
+                <p className="agent-composer-notice" role="status">
+                  {textActionsDisabledReason}
+                </p>
+              ))
+            : null}
           {/* The actual chatbox: the agent composer's box/attach/toolbar/model/
            * send classes, wired to the panel's session. */}
           <div className="agent-composer-box">
@@ -754,7 +775,7 @@ export function NoteChatPanel({
                     className="agent-composer-send"
                     aria-label="Send message"
                     disabled={
-                      Boolean(creditActionsDisabledReason) ||
+                      Boolean(textActionsDisabledReason) ||
                       importing ||
                       (draftEmpty && !attachments.length)
                     }

--- a/src/lib/account-gate.ts
+++ b/src/lib/account-gate.ts
@@ -1,4 +1,6 @@
-import type { AccountStatus } from "./tauri";
+import { AUTO_MODEL_ID } from "./hermes-session-model-selection";
+import { modelAvailableForMode } from "./model-privacy";
+import type { AccountStatus, VeniceModelDto } from "./tauri";
 
 // Single source of truth for whether an action that depends on OS Accounts
 // should be blocked behind the sign-in prompt. Keep this pure — it's called
@@ -82,4 +84,33 @@ export function shouldBlockOnFunding(account: AccountStatus): boolean {
 
   const credits = account.balance?.credits;
   return typeof credits === "number" && credits <= 0;
+}
+
+/** The active text route as known by a composer. `activeModel` must be the
+ * exact live-catalog entry for `activeModelId`; callers leave it undefined
+ * when the selection is unknown so the funding decision fails closed instead
+ * of trusting a synthetic picker stub or an id convention. */
+export type TextFundingModelContext = {
+  activeModelId?: string;
+  activeModel?: Pick<VeniceModelDto, "id" | "provider" | "capabilities">;
+  veniceApiKeyConfigured: boolean;
+};
+
+/** Split text generation from the general June-credit gate. Explicit Venice
+ * BYOK text can continue while June funding is unavailable, but only when the
+ * configured key and the active concrete catalog entry prove that route. */
+export function shouldBlockTextOnFunding(
+  fundingRequired: boolean,
+  context: TextFundingModelContext,
+): boolean {
+  if (!fundingRequired) return false;
+  const model = context.activeModel;
+  return !(
+    context.veniceApiKeyConfigured &&
+    context.activeModelId &&
+    context.activeModelId !== AUTO_MODEL_ID &&
+    model?.id === context.activeModelId &&
+    model.provider === "venice" &&
+    modelAvailableForMode("generation", model)
+  );
 }

--- a/src/test/account-gate.test.ts
+++ b/src/test/account-gate.test.ts
@@ -6,6 +6,7 @@ import {
   shouldOpenPortalForDepletedBalance,
   shouldBlockOnFunding,
   shouldBlockOnSignIn,
+  shouldBlockTextOnFunding,
 } from "../lib/account-gate";
 import type { AccountStatus } from "../lib/tauri";
 
@@ -159,6 +160,96 @@ describe("shouldBlockOnFunding", () => {
   it("allows unknown credit snapshots and lets metered actions decide", () => {
     expect(shouldBlockOnFunding(signedIn({ balance: { usdMillis: 0 } }))).toBe(false);
     expect(shouldBlockOnFunding(signedIn())).toBe(false);
+  });
+});
+
+describe("shouldBlockTextOnFunding", () => {
+  const veniceModel = {
+    id: "zai-org-glm-5-2",
+    provider: "venice",
+    capabilities: ["supportsFunctionCalling"],
+  };
+
+  it("allows an exact concrete Venice catalog model when a Venice key is configured", () => {
+    expect(
+      shouldBlockTextOnFunding(true, {
+        activeModelId: veniceModel.id,
+        activeModel: veniceModel,
+        veniceApiKeyConfigured: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps Auto on June credits even if its catalog provider were mislabeled", () => {
+    expect(
+      shouldBlockTextOnFunding(true, {
+        activeModelId: "open-software/auto",
+        activeModel: {
+          id: "open-software/auto",
+          provider: "venice",
+          capabilities: ["supportsFunctionCalling"],
+        },
+        veniceApiKeyConfigured: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("fails closed without a key or an exact matching Venice catalog entry", () => {
+    expect(
+      shouldBlockTextOnFunding(true, {
+        activeModelId: veniceModel.id,
+        activeModel: veniceModel,
+        veniceApiKeyConfigured: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockTextOnFunding(true, {
+        activeModelId: "venice/looks-valid-but-is-unknown",
+        veniceApiKeyConfigured: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockTextOnFunding(true, {
+        activeModelId: veniceModel.id,
+        activeModel: {
+          id: "another-model",
+          provider: "venice",
+          capabilities: ["supportsFunctionCalling"],
+        },
+        veniceApiKeyConfigured: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockTextOnFunding(true, {
+        activeModelId: "phala-model",
+        activeModel: {
+          id: "phala-model",
+          provider: "phala",
+          capabilities: ["supportsFunctionCalling"],
+        },
+        veniceApiKeyConfigured: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockTextOnFunding(true, {
+        activeModelId: "venice-without-tools",
+        activeModel: {
+          id: "venice-without-tools",
+          provider: "venice",
+          capabilities: [],
+        },
+        veniceApiKeyConfigured: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not invent a text block when the general funding gate is open", () => {
+    expect(
+      shouldBlockTextOnFunding(false, {
+        activeModelId: "unknown",
+        veniceApiKeyConfigured: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -14116,6 +14116,102 @@ describe("AgentWorkspace", () => {
       },
     ];
 
+    it("uses an explicit Venice model for a new chat while June-funded controls stay blocked", async () => {
+      const reason = "Add credits to send messages or generate images and videos.";
+      let generationModel = "open-software/auto";
+      window.sessionStorage.setItem(
+        AGENT_NEW_SESSION_PENDING_KEY,
+        JSON.stringify({ createdAt: Date.now() }),
+      );
+      mocks.providerModelSettings.mockImplementation(async () => ({
+        settings: {
+          transcriptionProvider: "venice",
+          transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+          generationModel,
+          remoteGenerationModel: generationModel,
+          costQuality: 100,
+          veniceApiKeyConfigured: true,
+        },
+      }));
+      mocks.setVeniceModel.mockImplementation(async (_mode: string, modelId: string) => {
+        generationModel = modelId;
+      });
+      mocks.listVeniceModels.mockResolvedValue({
+        mode: "generation",
+        modelType: "text",
+        selectedModel: "open-software/auto",
+        models: [
+          {
+            provider: "open-software",
+            id: "open-software/auto",
+            name: "Auto",
+            modelType: "text",
+            privacy: "private",
+            traits: [],
+            capabilities: ["functionCalling"],
+          },
+          ...toolCapableCatalog,
+        ],
+      });
+      const slashCommandEntriesRef: {
+        current: {
+          runImageSlashCommand: (argument: string, commandText: string) => Promise<void>;
+          runVideoSlashCommand: (argument: string, commandText: string) => Promise<void>;
+        } | null;
+      } = { current: null };
+      const user = userEvent.setup();
+
+      render(
+        <AgentWorkspace
+          creditActionsDisabledReason={reason}
+          renderFundingNotice={(context) => (
+            <button type="button" onClick={context.onSelectVeniceModel}>
+              Select a Venice model
+            </button>
+          )}
+          testOnlySlashCommandEntriesRef={slashCommandEntriesRef}
+        />,
+      );
+
+      const composer = await screen.findByRole("textbox", { name: "Message June" });
+      await screen.findByRole("button", { name: "Model: Auto (Higher)" });
+      await user.type(composer, "Use my Venice key");
+      expect(screen.getByRole("button", { name: "Start session" })).toBeDisabled();
+
+      await user.click(screen.getByRole("button", { name: "Select a Venice model" }));
+      const picker = await screen.findByRole("dialog", { name: "Choose text model" });
+      await user.click(within(picker).getByRole("button", { name: "All models" }));
+      await user.click(
+        within(screen.getByRole("group", { name: "All text models" })).getByRole("option", {
+          name: /GLM 5\.2/,
+        }),
+      );
+
+      expect(await screen.findByRole("button", { name: "Model: GLM 5.2" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Start session" })).toBeEnabled();
+      expect(screen.getByRole("button", { name: "Dictate" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Dictate" })).toHaveAttribute("title", reason);
+
+      const slashEntries = slashCommandEntriesRef.current;
+      if (!slashEntries) throw new Error("Agent workspace did not expose slash commands.");
+      await act(async () => {
+        await slashEntries.runImageSlashCommand("a red bicycle", "/image a red bicycle");
+      });
+      expect(mocks.generateImage).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole("button", { name: "Start session" }));
+      await waitFor(() =>
+        expect(mocks.gatewayRequest).toHaveBeenCalledWith(
+          "session.create",
+          expect.objectContaining({ model: "__june_remote_generation__:zai-org-glm-5-2" }),
+        ),
+      );
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith(
+        "prompt.submit",
+        expect.objectContaining({ text: "Use my Venice key" }),
+      );
+    });
+
     it("keeps the open session model picker interactive", async () => {
       mocks.listVeniceModels.mockResolvedValue({
         mode: "generation",

--- a/src/test/funding-notice.test.tsx
+++ b/src/test/funding-notice.test.tsx
@@ -79,6 +79,64 @@ describe("FundingNotice", () => {
     await screen.findByText("Waiting for your upgrade");
   });
 
+  it("explains Auto funding and offers the model picker beside the plan action", async () => {
+    const user = userEvent.setup();
+    const onSelectVeniceModel = vi.fn();
+    render(
+      <FundingNotice
+        account={baseAccount}
+        onRefresh={vi.fn(async () => baseAccount)}
+        textFundingContext={{
+          activeModelId: "open-software/auto",
+          activeModel: {
+            id: "open-software/auto",
+            provider: "open-software",
+            capabilities: ["supportsFunctionCalling"],
+          },
+          veniceApiKeyConfigured: true,
+          onSelectVeniceModel,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Auto can route beyond Venice, so it uses June credits. Your Venice API key applies only when you select a Venice model.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Or go Max" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Select a Venice model" }));
+    expect(onSelectVeniceModel).toHaveBeenCalledOnce();
+
+    await user.click(screen.getByRole("button", { name: "Upgrade to Pro" }));
+    expect(mocks.osAccountsUpgrade).toHaveBeenCalledWith("pro");
+  });
+
+  it("keeps the generic funding notice when no Venice key is configured", () => {
+    render(
+      <FundingNotice
+        account={baseAccount}
+        onRefresh={vi.fn(async () => baseAccount)}
+        textFundingContext={{
+          activeModelId: "open-software/auto",
+          activeModel: {
+            id: "open-software/auto",
+            provider: "open-software",
+            capabilities: ["supportsFunctionCalling"],
+          },
+          veniceApiKeyConfigured: false,
+          onSelectVeniceModel: vi.fn(),
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText("Your starter credits are used up. Upgrade to keep using June."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Select a Venice model" })).toBeNull();
+  });
+
   it("offers Max checkout for those who want to go beyond Pro", async () => {
     const user = userEvent.setup();
     renderFundingNotice();

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -450,6 +450,75 @@ describe("note chat session map", () => {
     ).toBeInTheDocument();
   });
 
+  it("unblocks existing-note text after selecting a concrete Venice model", async () => {
+    const reason = "Add credits to send messages or generate images and videos.";
+    const user = userEvent.setup();
+    mocks.providerModelSettings.mockResolvedValue({
+      settings: {
+        transcriptionProvider: "venice",
+        generationProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: autoModel.id,
+        remoteGenerationModel: autoModel.id,
+        costQuality: 100,
+        imageModel: "venice-sd35",
+        videoModel: "wan-2.2-a14b-text-to-video",
+        veniceApiKeyConfigured: true,
+        localGeneration: { baseUrl: "", modelId: "", apiKey: "" },
+        imageSafeMode: true,
+        imageSafeModePromptDismissed: false,
+      },
+    });
+    mocks.listVeniceModels.mockResolvedValue({
+      mode: "generation",
+      modelType: "text",
+      selectedModel: autoModel.id,
+      models: [autoModel, currentModel],
+    });
+    const submit = vi.fn(async () => true);
+    const chat = noteChat({
+      storedSessionId: "stored-note-chat",
+      modelSelection: { modelId: autoModel.id, costQuality: 100 },
+      submit,
+    });
+
+    render(
+      createElement(NoteChatPanel, {
+        note: { id: "note-1", title: "Launch planning" },
+        chat,
+        creditActionsDisabledReason: reason,
+        renderFundingNotice: (context) =>
+          createElement(
+            "button",
+            { type: "button", onClick: context.onSelectVeniceModel },
+            "Select a Venice model",
+          ),
+        onClose: vi.fn(),
+        onOpenInAgent: vi.fn(),
+      }),
+    );
+
+    const composer = await screen.findByRole("textbox");
+    await user.type(composer, "What changed?");
+    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Select a Venice model" }));
+    const picker = screen.getByRole("dialog", { name: "Choose text model" });
+    await user.click(within(picker).getByRole("button", { name: "All models" }));
+    await user.click(
+      within(screen.getByRole("group", { name: "All text models" })).getByRole("option", {
+        name: /GLM 5\.2/,
+      }),
+    );
+
+    expect(chat.setSessionModel).toHaveBeenCalledWith({ modelId: currentModel.id });
+    expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Dictate" })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(submit).toHaveBeenCalledWith("What changed?", []);
+  });
+
   it("keeps a first-run picker change session-local while session creation is pending", async () => {
     const user = userEvent.setup();
     const chat = noteChat({


### PR DESCRIPTION
## Summary

- Allow text prompts to continue after June credits are exhausted only when the active session/composer model resolves to an exact, tool-capable Venice catalog model and a Venice API key is configured.
- Keep Auto, unknown/delisted models, non-Venice models, recording, dictation, note generation/retries, image generation, and video generation behind the existing June funding gate.
- Give Auto users with a Venice key a contextual explanation plus actions to select a Venice model or add June credits, in both the agent workspace and note chat.
- Preserve the JUN-329 model-settings and pre-run guidance behavior.

This changes a billing-sensitive frontend gate. The shared predicate is fail closed and rechecks the target model at action time before sending.

Closes JUN-340

## Root cause

The desktop used one global out-of-credits predicate for every paid action. It could not distinguish June-funded text from an explicitly selected Venice model that should use the user's configured Venice key, so the global gate disabled both composer send paths even when that text request did not require June credits.

## Validation

- `make verify` with Node 22 and the repository Rust toolchain
- `make local-ci`
- Focused Vitest coverage for the shared gate, contextual notice, new and existing agent sessions, and note-chat sessions
- Browser-tested the depleted Auto state, recovery through the existing model picker, explicit Venice text send enablement, and continued microphone blocking; no console or page errors

- [x] Tested visually where it matters (UI changes: screenshots below).
- [ ] Needs a June API (backend) deploy before it works end to end. No - this uses the existing explicit Venice BYOK route.

### Browser evidence

| Auto with depleted credits | Existing model picker | Explicit Venice model selected |
| --- | --- | --- |
| ![Auto mode explains why June credits are required](https://app.opensoftware.co/api/v1/files/fil_qkEfADXZeoIE/download) | ![Existing model picker opened from the funding notice](https://app.opensoftware.co/api/v1/files/fil_q2EsLTUnRZpT/download) | ![Explicit Venice selection enables text while microphone remains blocked](https://app.opensoftware.co/api/v1/files/fil_4FlPT16xpitU/download) |

## Out of scope

- Changes to June API routing, metering, or billing contracts
- Relaxing the funding gate for non-text actions
- Reworking the JUN-329 settings and pre-run guidance

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow changes.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such changes.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend changes.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786875917&installation_id=144203540&pr_number=815&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F815&signature=09707a8ffff3eabc9978df3130d9ad84572e67f094a35287219fe4a6f285414c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->