### PR TITLE
Make the test localStorage shim spec-faithful so storage enumeration works on Node 24/26 (JUN-355)

### DIFF
--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -154,6 +154,20 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: mocks.listen,
 }));
 
+// Enumerate storage the spec way (length + key(i)) rather than relying on
+// stored keys being own enumerable properties: portable across jsdom's
+// Storage, the setup.ts shim, and real browsers (see JUN-355).
+function storageKeys(): string[] {
+  const keys: string[] = [];
+  for (let i = 0; i < localStorage.length; i += 1) {
+    const key = localStorage.key(i);
+    if (key !== null) {
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
 const baseSettings: DictationSettingsDto = {
   pushToTalkShortcut: {
     keyCode: 0x02,
@@ -711,7 +725,7 @@ describe("AppSettings", () => {
 
     const refreshedStyle = avatar?.getAttribute("style");
     expect(refreshedStyle).not.toBe(initialStyle);
-    const pendingStorageKey = Object.keys(localStorage).find((key) =>
+    const pendingStorageKey = storageKeys().find((key) =>
       key.startsWith("june:account-avatar-pending:"),
     );
     expect(pendingStorageKey).toBeDefined();
@@ -734,9 +748,9 @@ describe("AppSettings", () => {
       refreshedStyle,
     );
     await waitFor(() =>
-      expect(
-        Object.keys(localStorage).some((key) => key.startsWith("june:account-avatar-pending:")),
-      ).toBe(false),
+      expect(storageKeys().some((key) => key.startsWith("june:account-avatar-pending:"))).toBe(
+        false,
+      ),
     );
     unmountSynced();
 
@@ -812,9 +826,7 @@ describe("AppSettings", () => {
     );
     expect(screen.getByText("This pattern is saved only on this device.")).toBeInTheDocument();
     expect(screen.queryByText(/account permissions/)).not.toBeInTheDocument();
-    expect(
-      Object.keys(localStorage).some((key) => key.startsWith("june:account-avatar-pending:")),
-    ).toBe(true);
+    expect(storageKeys().some((key) => key.startsWith("june:account-avatar-pending:"))).toBe(true);
     const localStyle = avatar?.getAttribute("style");
     expect(localStyle).not.toBe(remoteStyle);
     unmount();
@@ -878,9 +890,7 @@ describe("AppSettings", () => {
     const { rerender } = render(settings(signedInAccount));
 
     await user.click(screen.getByRole("button", { name: "Refresh" }));
-    expect(
-      Object.keys(localStorage).some((key) => key.startsWith("june:account-avatar-pending:")),
-    ).toBe(true);
+    expect(storageKeys().some((key) => key.startsWith("june:account-avatar-pending:"))).toBe(true);
 
     rerender(
       settings({
@@ -894,9 +904,9 @@ describe("AppSettings", () => {
       expect(avatar?.style.getPropertyValue(property)).toBe(value);
     }
     await waitFor(() =>
-      expect(
-        Object.keys(localStorage).some((key) => key.startsWith("june:account-avatar-pending:")),
-      ).toBe(false),
+      expect(storageKeys().some((key) => key.startsWith("june:account-avatar-pending:"))).toBe(
+        false,
+      ),
     );
     expect(
       screen.queryByText("This pattern is saved only on this device."),
@@ -935,9 +945,7 @@ describe("AppSettings", () => {
     const { rerender } = render(settings(accountWithRemoteSeed));
 
     await user.click(screen.getByRole("button", { name: "Refresh" }));
-    expect(
-      Object.keys(localStorage).some((key) => key.startsWith("june:account-avatar-pending:")),
-    ).toBe(true);
+    expect(storageKeys().some((key) => key.startsWith("june:account-avatar-pending:"))).toBe(true);
     expect(screen.getByText("This pattern is saved only on this device.")).toBeInTheDocument();
 
     const newerRemote = {
@@ -956,9 +964,9 @@ describe("AppSettings", () => {
       expect(avatar?.style.getPropertyValue(property)).toBe(value);
     }
     await waitFor(() =>
-      expect(
-        Object.keys(localStorage).some((key) => key.startsWith("june:account-avatar-pending:")),
-      ).toBe(false),
+      expect(storageKeys().some((key) => key.startsWith("june:account-avatar-pending:"))).toBe(
+        false,
+      ),
     );
     expect(
       screen.queryByText("This pattern is saved only on this device."),

--- a/src/test/local-storage-spec.test.ts
+++ b/src/test/local-storage-spec.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Regression guard for JUN-355: on Nodes that ship an unavailable Web Storage
+// global (24/26), the setup.ts shim replaces jsdom's Storage. These assertions
+// hold for a real Storage and must keep holding for the shim, so tests that
+// enumerate or spy on storage behave identically on every Node.
+describe("test-global localStorage is spec-faithful", () => {
+  // setup.ts pre-seeds the onboarding-complete key in a global beforeEach;
+  // start each test from an empty store so counts are deterministic.
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("exposes stored keys, not methods, to Object.keys", () => {
+    localStorage.setItem("june.spec-probe.alpha", "1");
+    localStorage.setItem("june.spec-probe.beta", "2");
+
+    const keys = Object.keys(localStorage);
+    expect(keys).toContain("june.spec-probe.alpha");
+    expect(keys).toContain("june.spec-probe.beta");
+    expect(keys).not.toContain("getItem");
+    expect(keys).not.toContain("setItem");
+    expect(keys).not.toContain("clear");
+  });
+
+  it("enumerates via length and key(i)", () => {
+    localStorage.setItem("june.spec-probe.alpha", "1");
+    localStorage.setItem("june.spec-probe.beta", "2");
+
+    expect(localStorage.length).toBe(2);
+    const keys = [localStorage.key(0), localStorage.key(1)].sort();
+    expect(keys).toEqual(["june.spec-probe.alpha", "june.spec-probe.beta"]);
+    expect(localStorage.key(2)).toBeNull();
+  });
+
+  it("round-trips items and clears", () => {
+    localStorage.setItem("june.spec-probe.alpha", "value");
+    expect(localStorage.getItem("june.spec-probe.alpha")).toBe("value");
+    expect(localStorage.getItem("june.spec-probe.missing")).toBeNull();
+
+    localStorage.removeItem("june.spec-probe.alpha");
+    expect(localStorage.getItem("june.spec-probe.alpha")).toBeNull();
+
+    localStorage.setItem("june.spec-probe.beta", "1");
+    localStorage.clear();
+    expect(localStorage.length).toBe(0);
+  });
+});

--- a/src/test/local-storage-spec.test.ts
+++ b/src/test/local-storage-spec.test.ts
@@ -37,6 +37,19 @@ describe("test-global localStorage is spec-faithful", () => {
     expect(localStorage.key(2)).toBeNull();
   });
 
+  it("never lets a method-named key shadow the interface member", () => {
+    localStorage.setItem("getItem", "x");
+
+    // WebIDL named-property semantics: the method stays callable, the value
+    // is retrievable via getItem, and the key is hidden from enumeration.
+    expect(typeof localStorage.getItem).toBe("function");
+    expect(localStorage.getItem("getItem")).toBe("x");
+    expect(Object.keys(localStorage)).not.toContain("getItem");
+
+    localStorage.removeItem("getItem");
+    expect(localStorage.getItem("getItem")).toBeNull();
+  });
+
   it("round-trips items and clears", () => {
     localStorage.setItem("june.spec-probe.alpha", "value");
     expect(localStorage.getItem("june.spec-probe.alpha")).toBe("value");

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -42,24 +42,47 @@ if (!window.matchMedia) {
   }));
 }
 
+// Web Storage polyfill for Nodes where jsdom's localStorage never reaches the
+// test global. Node 24+ ships its own `localStorage` global that is present
+// but unavailable without `--localstorage-file` (the getter returns undefined
+// and emits an ExperimentalWarning). Vitest's populateGlobal skips window keys
+// that already exist on the Node global, so jsdom's real Storage is shadowed
+// and unrecoverable there; this shim is the only storage the suite gets. It
+// must therefore be spec-faithful: stored keys live as own enumerable
+// properties (so `Object.keys(localStorage)` returns stored keys, like a real
+// Storage) and methods live on a prototype (so enumeration never sees them).
+// Note it is still not `instanceof Storage`; tests that spy on storage keep
+// the `instanceof Storage ? Storage.prototype : window.localStorage` branch.
 if (
   !("localStorage" in globalThis) ||
   !globalThis.localStorage ||
   typeof globalThis.localStorage.clear !== "function"
 ) {
-  const values = new Map<string, string>();
+  const storageProto = {
+    clear(this: Record<string, string>) {
+      for (const key of Object.keys(this)) {
+        delete this[key];
+      }
+    },
+    getItem(this: Record<string, string>, key: string) {
+      return Object.hasOwn(this, key) ? String(this[key]) : null;
+    },
+    key(this: Record<string, string>, index: number) {
+      return Object.keys(this)[index] ?? null;
+    },
+    get length() {
+      return Object.keys(this).length;
+    },
+    removeItem(this: Record<string, string>, key: string) {
+      delete this[key];
+    },
+    setItem(this: Record<string, string>, key: string, value: string) {
+      this[key] = String(value);
+    },
+  };
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,
-    value: {
-      clear: () => values.clear(),
-      getItem: (key: string) => values.get(key) ?? null,
-      key: (index: number) => Array.from(values.keys())[index] ?? null,
-      get length() {
-        return values.size;
-      },
-      removeItem: (key: string) => values.delete(key),
-      setItem: (key: string, value: string) => values.set(key, String(value)),
-    },
+    value: Object.create(storageProto),
   });
 }
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -48,9 +48,12 @@ if (!window.matchMedia) {
 // and emits an ExperimentalWarning). Vitest's populateGlobal skips window keys
 // that already exist on the Node global, so jsdom's real Storage is shadowed
 // and unrecoverable there; this shim is the only storage the suite gets. It
-// must therefore be spec-faithful: stored keys live as own enumerable
-// properties (so `Object.keys(localStorage)` returns stored keys, like a real
-// Storage) and methods live on a prototype (so enumeration never sees them).
+// must therefore be spec-faithful: an internal Map is the source of truth,
+// and stored keys are mirrored as own enumerable properties (so
+// `Object.keys(localStorage)` returns stored keys, like a real Storage) -
+// except keys that collide with an interface member (e.g. "getItem"), which
+// per WebIDL named-property semantics never shadow the method and stay hidden
+// from enumeration while remaining retrievable via getItem.
 // Note it is still not `instanceof Storage`; tests that spy on storage keep
 // the `instanceof Storage ? Storage.prototype : window.localStorage` branch.
 if (
@@ -58,26 +61,34 @@ if (
   !globalThis.localStorage ||
   typeof globalThis.localStorage.clear !== "function"
 ) {
+  const values = new Map<string, string>();
   const storageProto = {
     clear(this: Record<string, string>) {
+      values.clear();
       for (const key of Object.keys(this)) {
         delete this[key];
       }
     },
-    getItem(this: Record<string, string>, key: string) {
-      return Object.hasOwn(this, key) ? String(this[key]) : null;
+    getItem(key: string) {
+      return values.get(String(key)) ?? null;
     },
-    key(this: Record<string, string>, index: number) {
-      return Object.keys(this)[index] ?? null;
+    key(index: number) {
+      return Array.from(values.keys())[index] ?? null;
     },
     get length() {
-      return Object.keys(this).length;
+      return values.size;
     },
     removeItem(this: Record<string, string>, key: string) {
-      delete this[key];
+      values.delete(String(key));
+      if (!(key in storageProto)) {
+        delete this[key];
+      }
     },
     setItem(this: Record<string, string>, key: string, value: string) {
-      this[key] = String(value);
+      values.set(String(key), String(value));
+      if (!(key in storageProto)) {
+        this[key] = String(value);
+      }
     },
   };
   Object.defineProperty(globalThis, "localStorage", {


### PR DESCRIPTION
Closes JUN-355

## Summary

- Makes the `src/test/setup.ts` localStorage shim spec-faithful: stored keys are own enumerable properties (methods live on a prototype), so `Object.keys(localStorage)` returns stored keys like a real `Storage` instead of method names.
- Replaces the 7 `Object.keys(localStorage)` usages in `src/test/app-settings.test.tsx` with a `storageKeys()` helper that enumerates the spec way (`length` + `key(i)`) - portable across jsdom's `Storage`, the shim, and real browsers.
- Adds `src/test/local-storage-spec.test.ts` as a regression guard: the assertions hold for a real `Storage` (Node 22) and must keep holding for the shim (Node 24/26).

Test-infrastructure only; no product code changes.

## Root cause

On Node 24/26, Node ships its own `localStorage` global that is present but unavailable without `--localstorage-file` (the getter returns `undefined` and emits an ExperimentalWarning). Verified in this worktree: vitest's `populateGlobal` skips any window key that already exists on the Node global unless it is in vitest's KEYS list - and `localStorage` is not - so jsdom's real `Storage` is permanently shadowed and unrecoverable in the test global. The setup.ts guard then trips and installs a plain-object shim whose `Object.keys` returned method names, silently breaking any test that enumerates storage (4 failures in `app-settings.test.tsx` on Node 26).

Because jsdom's `Storage` cannot be restored on those Nodes (a vitest limitation, not a guard bug), the issue's "tighten the guard so jsdom wins" variant is not achievable; the shim is made spec-faithful instead. The `instanceof Storage ? Storage.prototype : window.localStorage` spy branches in `font-scale`/`referral-nudge` therefore stay (the shim is still not `instanceof Storage`); the shim comment documents why.

## Validation

- Full frontend suite (`pnpm test`): **178 files / 2906 passed on Node 22.23.1 AND on Node 26.5.0** (exit 0 both, zero failures). Previously 4 failures in `app-settings.test.tsx` on Node 26.
- Affected suites (`app-settings`, `font-scale`, `referral-nudge`, `hermes-session-model-selection`, new `local-storage-spec`) green on both Nodes.
- `pnpm check` (warnings-only parity with main) and `pnpm typecheck` green.
- Rust gates skipped: no Rust touched.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). <!-- no UI change; test-infra only, no live walkthrough useful -->
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Item 3 of JUN-355 (repo-level Node pin, `node-version-file:` in workflows, `local-ci.sh` Node guard): blocked on the issue's open question - whether Node 24 in the release workflows is deliberate. Needs a 22-vs-24 decision first.
- Item 4 (`NODE_OPTIONS=--no-experimental-webstorage` cleanup): nothing to drop - no such workaround exists in the repo.
- The `agent-workspace` load-correlated flakiness the issue explicitly excludes.

## Followups

- Decide 22 vs 24 and land the Node pin + workflow alignment (JUN-355 item 3) as its own PR.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [ ] Security-sensitive changes were called out in the summary. <!-- none -->
- [ ] Workflow action references are pinned to full-length commit SHAs. <!-- no workflow changes -->
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. <!-- none -->
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. <!-- none -->
- [ ] User-facing copy follows the repo UI conventions. <!-- no user-facing copy -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786878161&installation_id=144203540&pr_number=816&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F816&signature=9a286a74024dedde4b86a124e75b93dfc4f35acac4b00cdbd0c73227479c35fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->