### PR TITLE
ci: remove profile:write release attestation gate

### DIFF
--- a/.github/workflows/production-desktop-windows.yml
+++ b/.github/workflows/production-desktop-windows.yml
@@ -122,7 +122,6 @@ jobs:
           PRODUCTION_OS_ACCOUNTS_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_URL }}
           PRODUCTION_OS_ACCOUNTS_API_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_API_URL }}
           PRODUCTION_OS_ACCOUNTS_CLIENT_ID: ${{ secrets.PRODUCTION_OS_ACCOUNTS_CLIENT_ID }}
-          PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY: ${{ secrets.PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY }}
           PRODUCTION_GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_ID }}
           PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET }}
           PRODUCTION_JUNE_API_URL: ${{ secrets.PRODUCTION_JUNE_API_URL }}
@@ -150,11 +149,6 @@ jobs:
               Write-Host "::error::$name is required for a production Windows release."
               $missing = 1
             }
-          }
-
-          if ($env:PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY -ne "true") {
-            Write-Host "::error::Set PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY=true only after the June OAuth client allows profile:write and a fresh production sign-in succeeds."
-            $missing = 1
           }
 
           exit $missing

--- a/.github/workflows/promote-desktop.yml
+++ b/.github/workflows/promote-desktop.yml
@@ -159,7 +159,6 @@ jobs:
           PRODUCTION_OS_ACCOUNTS_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_URL }}
           PRODUCTION_OS_ACCOUNTS_API_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_API_URL }}
           PRODUCTION_OS_ACCOUNTS_CLIENT_ID: ${{ secrets.PRODUCTION_OS_ACCOUNTS_CLIENT_ID }}
-          PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY: ${{ secrets.PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY }}
           PRODUCTION_GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_ID }}
           PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET }}
           PRODUCTION_JUNE_API_URL: ${{ secrets.PRODUCTION_JUNE_API_URL }}
@@ -188,10 +187,6 @@ jobs:
               missing=1
             fi
           done
-          if [ "${PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY:-}" != "true" ]; then
-            echo "::error::Set PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY=true only after the June OAuth client allows profile:write and a fresh production sign-in succeeds."
-            missing=1
-          fi
           exit "$missing"
 
       - name: Stamp clean stable version

--- a/.github/workflows/rc-desktop-dmg.yml
+++ b/.github/workflows/rc-desktop-dmg.yml
@@ -116,7 +116,6 @@ jobs:
           PRODUCTION_OS_ACCOUNTS_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_URL }}
           PRODUCTION_OS_ACCOUNTS_API_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_API_URL }}
           PRODUCTION_OS_ACCOUNTS_CLIENT_ID: ${{ secrets.PRODUCTION_OS_ACCOUNTS_CLIENT_ID }}
-          PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY: ${{ secrets.PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY }}
           PRODUCTION_GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_ID }}
           PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.PRODUCTION_GOOGLE_OAUTH_CLIENT_SECRET }}
           PRODUCTION_JUNE_API_URL: ${{ secrets.PRODUCTION_JUNE_API_URL }}
@@ -147,10 +146,6 @@ jobs:
               missing=1
             fi
           done
-          if [ "${PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY:-}" != "true" ]; then
-            echo "::error::Set PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY=true only after the June OAuth client allows profile:write and a fresh production sign-in succeeds."
-            missing=1
-          fi
           exit "$missing"
 
       - name: Validate and compose rc version

--- a/.github/workflows/staging-desktop-dmg.yml
+++ b/.github/workflows/staging-desktop-dmg.yml
@@ -68,7 +68,6 @@ jobs:
           STAGING_OS_ACCOUNTS_URL: ${{ secrets.STAGING_OS_ACCOUNTS_URL }}
           STAGING_OS_ACCOUNTS_API_URL: ${{ secrets.STAGING_OS_ACCOUNTS_API_URL }}
           STAGING_OS_ACCOUNTS_CLIENT_ID: ${{ secrets.STAGING_OS_ACCOUNTS_CLIENT_ID }}
-          STAGING_OS_ACCOUNTS_PROFILE_WRITE_READY: ${{ secrets.STAGING_OS_ACCOUNTS_PROFILE_WRITE_READY }}
           STAGING_GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_ID }}
           STAGING_GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_SECRET }}
           STAGING_JUNE_API_URL: ${{ secrets.STAGING_JUNE_API_URL }}
@@ -94,10 +93,6 @@ jobs:
               missing=1
             fi
           done
-          if [ "${STAGING_OS_ACCOUNTS_PROFILE_WRITE_READY:-}" != "true" ]; then
-            echo "::error::Set STAGING_OS_ACCOUNTS_PROFILE_WRITE_READY=true only after the June OAuth client allows profile:write and a fresh staging sign-in succeeds."
-            missing=1
-          fi
           exit "$missing"
 
       - name: Build staging DMG

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -39,10 +39,6 @@ Create or confirm these before cutting the first updater release:
 - Production runtime secrets: `PRODUCTION_OS_ACCOUNTS_URL`,
   `PRODUCTION_OS_ACCOUNTS_API_URL`, `PRODUCTION_OS_ACCOUNTS_CLIENT_ID`, and
   `PRODUCTION_JUNE_API_URL`.
-- OS Accounts scope attestation:
-  `PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY=true`. Set it only after the June
-  OAuth client allowlist includes `profile:write` and a fresh production sign-in
-  succeeds. RC and stable workflows fail closed without this attestation.
 - Slack incoming-webhook secret: `SLACK_WEBHOOK_URL`, configured for the release
   announcements channel. An absent or failing webhook warns but does not fail an
   otherwise successful RC build.
@@ -72,11 +68,6 @@ Releases go through the release-candidate channel: build an RC, test it via the
 in-app updater, then promote it to stable. There is no direct stable-build path.
 
 ### 1. Build a release candidate
-
-Before cutting the first candidate that requests `profile:write`, sign out of a
-production-connected test build, sign in again, refresh the Avatar in General
-settings, and confirm the new pattern appears after a second fresh sign-in. Only
-then set `PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY=true`.
 
 ```text
 GitHub Actions -> rc-desktop-release -> Run workflow

--- a/docs/release-windows.md
+++ b/docs/release-windows.md
@@ -37,11 +37,6 @@ Create or confirm these before cutting the first Windows release:
 - Production runtime secrets: `PRODUCTION_OS_ACCOUNTS_URL`,
   `PRODUCTION_OS_ACCOUNTS_API_URL`, `PRODUCTION_OS_ACCOUNTS_CLIENT_ID`, and
   `PRODUCTION_JUNE_API_URL`.
-- OS Accounts scope attestation:
-  `PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY=true`, set only after the June
-  OAuth client allowlist includes `profile:write` and the macOS release-candidate
-  sign-in smoke test succeeds. The Windows workflow fails closed without it.
-
 Keep the Authenticode certificate separate from the Tauri updater key. The
 certificate establishes the Windows publisher signature. The updater key signs
 the update artifact that Tauri verifies before installation.


### PR DESCRIPTION
## What

Removes the `PRODUCTION_OS_ACCOUNTS_PROFILE_WRITE_READY` / `STAGING_OS_ACCOUNTS_PROFILE_WRITE_READY` fail-closed gates from all four release workflows (rc, promote, staging, Windows) and the corresponding runbook sections in `docs/release-macos.md` / `docs/release-windows.md`. Pure deletions, 35 lines.

## Why

The gate (added in 5b2b484b, PR #786) was a one-time attestation that the June OAuth client's production allowlist includes `profile:write` before shipping builds that request it. That condition is now satisfied: the scope has been added to the June client (`oauth_clients.allowed_scopes`) in the production OS Accounts database, and the OS Accounts backend with avatar-seed support (os-accounts PR #100) was promoted to production on 2026-07-17. With the underlying condition permanently true, the gate only adds a secret that must exist in three environments.

## Testing

- Not tested visually - CI-config and docs only, no app surface.
- `grep -rn PROFILE_WRITE_READY .github/ docs/` returns nothing.
- Real verification is the next `rc-desktop-release` run passing its "Validate release secrets" step (previously failed on this gate: run 29586942733).

## June API deploy

Not needed - no June API changes.

## Out of scope

- The remaining new release-workflow additions from the computer-use merge (mac-studio requirement, CUA self-test) - untouched.
- Removing the now-unused `PROFILE_WRITE_READY` secrets from GitHub org/repo settings, if any were set.

## Followups

- If a future scope addition needs the same protection, prefer re-adding a gate scoped to that rollout window rather than keeping one permanently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786890844&installation_id=144203540&pr_number=818&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F818&signature=eff8404f2390e9f12e52e62169fe53797a3def1507fa41fcf91a154b716379ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->