### PR TITLE
Fix wrapped titles in meeting PDF exports

### DIFF
--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -352,6 +352,9 @@ export function NoteEditor({
           value={note.title}
           onChange={(event) => onTitleChange(event.currentTarget.value)}
         />
+        <div className="note-title-print" aria-hidden="true">
+          {note.title.trim() || "New note"}
+        </div>
         {/* Metadata reads as the title's caption: sits below it, above the
             Notes/Transcription toggle. Navigation lives in the toolbar above. */}
         <div className="note-overline">

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -91,6 +91,7 @@ const TABS = [
   { value: "notes", label: "Notes" },
   { value: "transcription", label: "Transcription" },
 ] as const;
+const NOTE_TITLE_PLACEHOLDER = "New note";
 
 function sourceLabel(source?: string) {
   return source === "system" ? "System" : "Microphone";
@@ -348,12 +349,12 @@ export function NoteEditor({
         <input
           className="note-title"
           aria-label="Note title"
-          placeholder="New note"
+          placeholder={NOTE_TITLE_PLACEHOLDER}
           value={note.title}
           onChange={(event) => onTitleChange(event.currentTarget.value)}
         />
         <div className="note-title-print" aria-hidden="true">
-          {note.title.trim() || "New note"}
+          {note.title.trim() || NOTE_TITLE_PLACEHOLDER}
         </div>
         {/* Metadata reads as the title's caption: sits below it, above the
             Notes/Transcription toggle. Navigation lives in the toolbar above. */}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -10484,7 +10484,8 @@ input:focus-visible,
   font-size: var(--fs-sm);
 }
 
-.note-title {
+.note-title,
+.note-title-print {
   width: 100%;
   border: 0;
   background: transparent;
@@ -10494,6 +10495,14 @@ input:focus-visible,
   font-weight: 400;
   letter-spacing: 0;
   line-height: 1.15;
+}
+
+.note-title-print {
+  display: none;
+  max-width: 100%;
+  margin: 0;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .note-title::placeholder {
@@ -27375,6 +27384,11 @@ button.connector-approvals-info {
   }
 
   .note-title {
+    display: none;
+  }
+
+  .note-title-print {
+    display: block;
     color: black !important;
     -webkit-text-fill-color: black !important;
   }

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -99,6 +99,17 @@ describe("NoteEditor", () => {
     expect(screen.getByText("First point")).toBeInTheDocument();
   });
 
+  it("renders the note title as multiline print content", () => {
+    const title = "Retour d'expérience Mago vs. pipeline interne, approche et conclusions";
+    const { container } = render(<NoteEditor {...props} note={note({ title })} />);
+
+    expect(screen.getByLabelText("Note title")).toHaveValue(title);
+    const printTitle = container.querySelector(".note-title-print");
+    expect(printTitle?.tagName).toBe("DIV");
+    expect(printTitle).toHaveTextContent(title);
+    expect(printTitle).toHaveAttribute("aria-hidden", "true");
+  });
+
   it("shows raw transcript in transcription tab", () => {
     render(
       <NoteEditor

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -110,6 +110,13 @@ describe("NoteEditor", () => {
     expect(printTitle).toHaveAttribute("aria-hidden", "true");
   });
 
+  it("uses the note placeholder for an empty print title", () => {
+    const { container } = render(<NoteEditor {...props} note={note({ title: "" })} />);
+
+    expect(screen.getByLabelText("Note title")).toHaveAttribute("placeholder", "New note");
+    expect(container.querySelector(".note-title-print")).toHaveTextContent("New note");
+  });
+
   it("shows raw transcript in transcription tab", () => {
     render(
       <NoteEditor


### PR DESCRIPTION
## Summary

- render a dedicated print-only copy of the meeting title instead of printing the single-line title input
- allow PDF titles to wrap at spaces and inside long unbroken text
- keep the interactive editor title and accessibility surface unchanged
- add regression coverage for the printable title

## Why

The browser renders the editable title as an `<input>`, which is always single-line. Long titles therefore overflow and are clipped by the printable page instead of continuing onto a second line.

Fixes [JUN-358](https://app.opensoftware.co/june/issues/JUN-358).

## Validation

- `pnpm exec vitest run src/test/note-editor.test.tsx` (44 passed)
- `pnpm exec biome check src/components/note-editor/NoteEditor.tsx src/styles/app.css src/test/note-editor.test.tsx --max-diagnostics=20` (passes with pre-existing warnings)
- `pnpm run build`
- `git diff --check`

## Known gaps

- Did not save a PDF through the native macOS print sheet in the automated test environment. The regression test covers the separate printable title node, and the production build verifies the print CSS integration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786891554&installation_id=144203540&pr_number=819&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F819&signature=627f94b18fe06a5713dc16e5ed14b1dc567f8d0106742372bf52110f7968526f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->