### PR TITLE
ci: drop computer-use release self-test, validate via rc channel

### DIFF
--- a/.github/workflows/promote-desktop.yml
+++ b/.github/workflows/promote-desktop.yml
@@ -38,12 +38,6 @@ jobs:
     runs-on: ${{ fromJSON(inputs.macos-runner == 'mac-studio' && '["self-hosted","macOS","ARM64","desktop-release"]' || '["blacksmith-6vcpu-macos-15"]') }}
     environment: production
     steps:
-      - name: Require the live Computer use release runner
-        if: inputs.macos-runner != 'mac-studio'
-        run: |
-          echo "::error::Computer use promotion requires the pre-granted Mac Studio so capture and background input are tested before publication."
-          exit 1
-
       - name: Mint release token (GitHub App)
         id: app-token
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
@@ -275,9 +269,6 @@ jobs:
         with:
           args: --bundles app,dmg --target universal-apple-darwin -- --locked
           includeUpdaterJson: false
-
-      - name: Run signed Computer use release self-test
-        run: ./scripts/computer-use-release-self-test.sh --live --target universal-apple-darwin
 
       - name: Notarize, verify, and publish stable release assets
         env:

--- a/.github/workflows/rc-desktop-dmg.yml
+++ b/.github/workflows/rc-desktop-dmg.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ${{ fromJSON(inputs.macos-runner == 'mac-studio' && '["self-hosted","macOS","ARM64","desktop-release"]' || '["blacksmith-6vcpu-macos-15"]') }}
     environment: production
     steps:
-      - name: Require the live Computer use release runner
-        if: inputs.macos-runner != 'mac-studio'
-        run: |
-          echo "::error::Computer use releases require the pre-granted Mac Studio so capture and background input are tested before publication."
-          exit 1
-
       # Same release App identity as production: it publishes to os-june-releases.
       - name: Mint release token (GitHub App)
         id: app-token
@@ -339,9 +333,6 @@ jobs:
           # The DMG is notarized after the build, so don't let tauri-action
           # publish anything itself.
           includeUpdaterJson: false
-
-      - name: Run signed Computer use release self-test
-        run: ./scripts/computer-use-release-self-test.sh --live --target universal-apple-darwin
 
       - name: Notarize, verify, and publish rc release assets
         env:

--- a/docs/computer-use-support.md
+++ b/docs/computer-use-support.md
@@ -115,8 +115,9 @@ remains frontmost, verifies the real pointer and current-Space window flags did
 not change, kills both fixtures, and exits the private driver. The manual
 Stage Manager pass additionally verifies that the exact shelf window joins
 June's current group without moving the pointer or showing another decision.
-RC and stable workflows run this before notarization. A failure blocks
-publication.
+The release workflows do not run this fixture; computer use is validated on the
+release-candidate channel before promotion. Run it manually when validating a
+release runner or diagnosing a signed-build regression.
 
 ## OS update or regression
 
@@ -127,8 +128,7 @@ publication.
   Never attach the screenshot, AX tree, typed value, app title, or approval text
   to analytics or an issue without explicit user attachment.
 - If focus, pointer, Space, target binding, or unapproved-mutation behavior
-  regresses, stop the RC/stable workflow and keep the previous release live.
-  Do not bypass the release self-test.
+  regresses, hold the promotion and keep the previous release live.
 
 ## Emergency rollout
 

--- a/docs/qa/computer-use-parity.md
+++ b/docs/qa/computer-use-parity.md
@@ -36,7 +36,7 @@ policy where the PRD requires it.
 | Recover from driver failure | A failed driver call discards and kills the child. The next eligible request starts a new private child; version/stamp mismatches fail closed. | Native lifecycle code, pin tests, self-test failure modes. |
 | Keep routines out | The app-owned MCP server is never included in routine toolsets or earned-autonomy servers. | Rust config tests and `hermes-routines.test.ts`. |
 | Stop a bad rollout | June API can disable the capability globally or for an exact/prefix June or macOS version. The desktop fails closed on its first unavailable decision and stops active work when readiness is lost. | API decision/unit and HTTP-boundary tests, desktop native gate, rollout UI test. |
-| Ship only proven builds | RC and stable workflows require the pre-granted Mac Studio and run the signed capture/background-action fixture before notarization and publication. Staging also verifies the signed bundle and contract. | `computer-use-release-self-test.sh` and desktop release workflows. |
+| Ship only proven builds | Computer use is validated by testing the release candidate in the RC channel before promotion; the signed capture/background-action fixture (`computer-use-release-self-test.sh`) remains available for manual runs. Staging also verifies the signed bundle and contract. | RC-channel validation and desktop release workflows. |
 
 ## Deliberately stricter than the baseline
 

--- a/scripts/prepare-cua-driver.mjs
+++ b/scripts/prepare-cua-driver.mjs
@@ -254,6 +254,10 @@ function parseArguments(values) {
   let target;
   for (let index = 0; index < values.length; index += 1) {
     const argument = values[index];
+    // pnpm forwards the conventional `--` separator verbatim (npm strips it).
+    if (argument === "--") {
+      continue;
+    }
     if (argument === "--release") {
       release = true;
       continue;


### PR DESCRIPTION
## What

Removes the live computer-use release self-test and the mac-studio runner requirement from `rc-desktop-dmg.yml` and `promote-desktop.yml`, and updates `docs/computer-use-support.md` + `docs/qa/computer-use-parity.md` to match. The self-test script itself stays (manual runs, local `build-signed-dmg.sh` fallback still uses it).

## Why

The RC channel is the validation stage: candidates are installed and exercised by humans (including computer use) before promotion. Running the live TCC-dependent fixture in CI additionally hard-locked all releases to the single pre-granted Mac Studio, making it a release SPOF - the `github-hosted` blacksmith fallback documented in `desktop-release-runner.md` was dead code.

## Trade-off (deliberate)

`promote-desktop-release` rebuilds and re-signs from the RC's commit, so the stable artifact is not byte-identical to the tested RC. With this change, a signing/entitlement regression introduced at promote build time ships without an automated computer-use check. Accepted: the promote build uses the same workflow, signing identity, and pinned toolchain as the RC build minutes-to-days earlier, and the Hermes runtime audit + `codesign --verify --deep --strict` still run on the promoted app.

## Also in this PR

Fixes the rc.2 release failure (run 29588799884): the "Prepare universal Computer use helper" step calls `pnpm computer-use:prepare -- --release ...`, and pnpm (unlike npm) forwards the literal `--` separator to the script, which rejected it as an unknown argument. `prepare-cua-driver.mjs` now skips a bare `--`. Root cause: first-ever execution of this step in the release workflow; `build-signed-dmg.sh` passes the same literal `--` and is fixed by the same change.

## Testing

- Not tested visually - CI config and docs only.
- Verification is the next rc-desktop-release / promote run completing without the removed steps.

## June API deploy

Not needed.

## Out of scope

- Staging workflow (never ran the self-test).
- The Hermes runtime audit and codesign verification steps - retained.

## Followups

- If promote-time regressions ever bite, consider making promote republish the RC's exact notarized bytes instead of rebuilding - that would restore "users get the tested artifact" without any CI TCC dependency.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786891566&installation_id=144203540&pr_number=820&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F820&signature=d7ce224a00df198d833f96f2e321cb371b65f5a1cad9031944fc6ac2a214d87e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->