### PR TITLE
Fix HUD click interception outside visible bounds

### DIFF
--- a/src-tauri/src/agent_hud.rs
+++ b/src-tauri/src/agent_hud.rs
@@ -25,6 +25,8 @@ pub struct AgentHudLayoutRequest {
     expanded: bool,
     card_count: Option<u32>,
     context_menu_open: Option<bool>,
+    width: Option<f64>,
+    height: Option<f64>,
 }
 
 pub fn setup(app: &mut tauri::App) {
@@ -94,14 +96,19 @@ pub fn agent_hud_set_layout(app: AppHandle, request: AgentHudLayoutRequest) -> R
         request.expanded,
         request.card_count.unwrap_or(0),
         request.context_menu_open.unwrap_or(false),
+        request.width,
+        request.height,
     );
-    // The HUD is top-right anchored with a fixed native width, so resizing
-    // only changes height and does not need an immediate reposition. If the
-    // width becomes dynamic, reposition with the requested size here instead
-    // of reading outer_size(), which can lag behind set_size() on macOS.
+    let logical_size = LogicalSize::new(width, height);
+    let scale = window.scale_factor().map_err(|error| error.to_string())?;
+    let physical_size: PhysicalSize<u32> = logical_size.to_physical(scale);
     window
-        .set_size(Size::Logical(LogicalSize::new(width, height)))
-        .map_err(|error| error.to_string())
+        .set_size(Size::Logical(logical_size))
+        .map_err(|error| error.to_string())?;
+    // Width now follows the rendered surface so the transparent part of the
+    // native panel cannot cover nearby controls. Re-anchor from the requested
+    // size instead of outer_size(), which can lag behind set_size() on macOS.
+    position_agent_hud_window_with_size(&window, physical_size)
 }
 
 #[tauri::command]
@@ -117,11 +124,16 @@ pub fn agent_hud_open_agent(
         .map_err(|error| error.to_string())
 }
 
-/// Mirrors the CSS in agent-hud.css: 248px surface width plus transparent
-/// gutter for the top-right offset and shadow. Keep the native width constant
-/// so layout changes grow downward like a notification instead of resizing and
-/// re-anchoring horizontally.
-fn agent_hud_window_size(expanded: bool, card_count: u32, context_menu_open: bool) -> (f64, f64) {
+/// The webview reports the rendered interactive bounds so the native panel can
+/// match them exactly. The calculated dimensions are retained as a startup and
+/// compatibility fallback while the page is loading.
+fn agent_hud_window_size(
+    expanded: bool,
+    card_count: u32,
+    context_menu_open: bool,
+    requested_width: Option<f64>,
+    requested_height: Option<f64>,
+) -> (f64, f64) {
     let height: f64 = if !expanded || card_count == 0 {
         AGENT_HUD_COLLAPSED_WINDOW_HEIGHT
     } else {
@@ -130,11 +142,19 @@ fn agent_hud_window_size(expanded: bool, card_count: u32, context_menu_open: boo
         8.0 + surface_height + 14.0
     };
 
-    if context_menu_open {
-        (AGENT_HUD_WINDOW_WIDTH, height.max(104.0))
+    let fallback_height = if context_menu_open {
+        height.max(104.0)
     } else {
-        (AGENT_HUD_WINDOW_WIDTH, height)
-    }
+        height
+    };
+    (
+        valid_hud_dimension(requested_width).unwrap_or(AGENT_HUD_WINDOW_WIDTH),
+        valid_hud_dimension(requested_height).unwrap_or(fallback_height),
+    )
+}
+
+fn valid_hud_dimension(value: Option<f64>) -> Option<f64> {
+    value.filter(|value| value.is_finite() && *value > 0.0 && *value <= 2048.0)
 }
 
 fn configure_agent_hud_window(app: &AppHandle) -> Result<(), String> {
@@ -155,7 +175,9 @@ fn configure_agent_hud_window(app: &AppHandle) -> Result<(), String> {
         .set_skip_taskbar(true)
         .map_err(|error| error.to_string())?;
     window
-        .set_shadow(false)
+        // A native shadow sits outside the hit-tested window bounds. CSS
+        // shadow gutters would make transparent pixels intercept clicks.
+        .set_shadow(true)
         .map_err(|error| error.to_string())?;
 
     #[cfg(target_os = "macos")]
@@ -173,8 +195,10 @@ fn position_agent_hud_window_with_size(
     window: &WebviewWindow,
     size: PhysicalSize<u32>,
 ) -> Result<(), String> {
-    const MARGIN_X: f64 = 16.0;
-    const MARGIN_Y: f64 = 12.0;
+    // Keep the visible surface at its previous screen position. The old
+    // oversized webview placed it 10px from the right and 8px from the top.
+    const MARGIN_X: f64 = 26.0;
+    const MARGIN_Y: f64 = 20.0;
 
     let scale = window.scale_factor().map_err(|error| error.to_string())?;
     // Pin the HUD to the primary monitor; picking the monitor from the
@@ -318,20 +342,32 @@ mod tests {
 
     #[test]
     fn agent_hud_layout_keeps_width_stable_across_states() {
-        assert_eq!(agent_hud_window_size(false, 0, false).0, 304.0);
-        assert_eq!(agent_hud_window_size(true, 1, false).0, 304.0);
-        assert_eq!(agent_hud_window_size(true, 3, false).0, 304.0);
-        assert_eq!(agent_hud_window_size(false, 0, true).0, 304.0);
+        assert_eq!(agent_hud_window_size(false, 0, false, None, None).0, 304.0);
+        assert_eq!(agent_hud_window_size(true, 1, false, None, None).0, 304.0);
+        assert_eq!(agent_hud_window_size(true, 3, false, None, None).0, 304.0);
+        assert_eq!(agent_hud_window_size(false, 0, true, None, None).0, 304.0);
     }
 
     #[test]
     fn agent_hud_layout_grows_downward_for_expanded_content() {
-        let collapsed = agent_hud_window_size(false, 0, false);
-        let expanded = agent_hud_window_size(true, 1, false);
-        let expanded_more = agent_hud_window_size(true, 3, false);
+        let collapsed = agent_hud_window_size(false, 0, false, None, None);
+        let expanded = agent_hud_window_size(true, 1, false, None, None);
+        let expanded_more = agent_hud_window_size(true, 3, false, None, None);
 
         assert_eq!(collapsed.1, AGENT_HUD_COLLAPSED_WINDOW_HEIGHT);
         assert!(expanded.1 > collapsed.1);
         assert!(expanded_more.1 > expanded.1);
+    }
+
+    #[test]
+    fn agent_hud_layout_uses_rendered_interactive_bounds() {
+        assert_eq!(
+            agent_hud_window_size(false, 0, false, Some(112.0), Some(32.0)),
+            (112.0, 32.0)
+        );
+        assert_eq!(
+            agent_hud_window_size(false, 0, false, Some(0.0), Some(f64::INFINITY)),
+            (AGENT_HUD_WINDOW_WIDTH, AGENT_HUD_COLLAPSED_WINDOW_HEIGHT)
+        );
     }
 }

--- a/src-tauri/src/agent_hud.rs
+++ b/src-tauri/src/agent_hud.rs
@@ -42,7 +42,9 @@ pub fn agent_hud_show(app: AppHandle) -> Result<(), String> {
     let Some(window) = app.get_webview_window(AGENT_HUD_WINDOW_LABEL) else {
         return Ok(());
     };
-    position_agent_hud_window(&window)?;
+    // agent_hud_set_layout sizes and positions the panel before every show.
+    // Re-reading outer_size() here can briefly return the previous width on
+    // macOS and undo that right-edge anchoring.
     #[cfg(target_os = "macos")]
     {
         // The HUD is a passive status surface. Tauri's show() does

--- a/src-tauri/src/agent_hud.rs
+++ b/src-tauri/src/agent_hud.rs
@@ -110,7 +110,7 @@ pub fn agent_hud_set_layout(app: AppHandle, request: AgentHudLayoutRequest) -> R
     // Width now follows the rendered surface so the transparent part of the
     // native panel cannot cover nearby controls. Re-anchor from the requested
     // size instead of outer_size(), which can lag behind set_size() on macOS.
-    position_agent_hud_window_with_size(&window, physical_size)
+    position_agent_hud_window_with_size(&window, physical_size, scale)
 }
 
 #[tauri::command]
@@ -190,19 +190,20 @@ fn configure_agent_hud_window(app: &AppHandle) -> Result<(), String> {
 
 fn position_agent_hud_window(window: &WebviewWindow) -> Result<(), String> {
     let size = window.outer_size().map_err(|error| error.to_string())?;
-    position_agent_hud_window_with_size(window, size)
+    let scale = window.scale_factor().map_err(|error| error.to_string())?;
+    position_agent_hud_window_with_size(window, size, scale)
 }
 
 fn position_agent_hud_window_with_size(
     window: &WebviewWindow,
     size: PhysicalSize<u32>,
+    scale: f64,
 ) -> Result<(), String> {
     // Keep the visible surface at its previous screen position. The old
     // oversized webview placed it 10px from the right and 8px from the top.
     const MARGIN_X: f64 = 26.0;
     const MARGIN_Y: f64 = 20.0;
 
-    let scale = window.scale_factor().map_err(|error| error.to_string())?;
     // Pin the HUD to the primary monitor; picking the monitor from the
     // cursor made it hop between displays whenever a layout change fired
     // while the mouse was on another screen.

--- a/src/agent-hud.ts
+++ b/src/agent-hud.ts
@@ -760,7 +760,8 @@ function statusSubject(record: StatusRecord) {
 async function syncWindowLayout(expanded: boolean, rowCount: number, hasEntries: boolean) {
   const menuOpen = state.menuOpen;
   const visible = state.enabled && hasEntries;
-  const key = `${visible}:${expanded}:${rowCount}:${menuOpen}`;
+  const bounds = visibleHudBounds();
+  const key = `${visible}:${expanded}:${rowCount}:${menuOpen}:${bounds.width ?? 0}:${bounds.height ?? 0}`;
   if (key === lastLayoutKey) return;
   lastLayoutKey = key;
   if (!visible) {
@@ -770,12 +771,13 @@ async function syncWindowLayout(expanded: boolean, rowCount: number, hasEntries:
   }
   cancelWindowHide();
   cancelPendingResize();
-  const height = nativeWindowHeight(expanded, rowCount, menuOpen);
+  const height = bounds.height ?? nativeWindowHeight(expanded, rowCount, menuOpen);
   const apply = async () => {
     await agentHudSetLayout({
       expanded,
       cardCount: rowCount,
       ...(menuOpen ? { contextMenuOpen: menuOpen } : {}),
+      ...bounds,
     }).catch(() => {});
     if (!windowShown) {
       await agentHudShow().catch(() => {});
@@ -795,6 +797,17 @@ async function syncWindowLayout(expanded: boolean, rowCount: number, hasEntries:
     await apply();
   }
   lastWindowHeight = height;
+}
+
+function visibleHudBounds(): { width?: number; height?: number } {
+  if (!surface) return {};
+  const interactiveElements = state.menuOpen && menu ? [surface, menu] : [surface];
+  const width = Math.max(...interactiveElements.map((element) => element.offsetWidth));
+  const height = Math.max(
+    ...interactiveElements.map((element) => element.offsetTop + element.offsetHeight),
+  );
+  if (width <= 0 || height <= 0) return {};
+  return { width: Math.ceil(width), height: Math.ceil(height) };
 }
 
 /* Mirrors agent_hud_window_size in agent_hud.rs, only to tell growth from

--- a/src/agent-hud.ts
+++ b/src/agent-hud.ts
@@ -811,7 +811,16 @@ function visibleHudBounds(): { width?: number; height?: number } {
   // exposes the final row height even while offsetHeight is still mid-
   // transition, so the native window grows before the reveal can be clipped.
   const surfaceHeight = Math.max(surface.offsetHeight, expandedSurfaceHeight);
-  const width = Math.max(surface.offsetWidth, state.menuOpen && menu ? menu.offsetWidth : 0);
+  // FLIP writes the final expanded width inline before the transition starts.
+  // offsetWidth reports an in-flight value during that transition, so prefer
+  // the known target to keep the native window from clipping the reveal.
+  const animatedExpandedWidth =
+    hud?.dataset.expanded === "true" ? Number.parseFloat(surface.style.width) : 0;
+  const surfaceWidth = Math.max(
+    surface.offsetWidth,
+    Number.isFinite(animatedExpandedWidth) ? animatedExpandedWidth : 0,
+  );
+  const width = Math.max(surfaceWidth, state.menuOpen && menu ? menu.offsetWidth : 0);
   const height = Math.max(
     surface.offsetTop + surfaceHeight,
     state.menuOpen && menu ? menu.offsetTop + menu.offsetHeight : 0,

--- a/src/agent-hud.ts
+++ b/src/agent-hud.ts
@@ -773,16 +773,18 @@ async function syncWindowLayout(expanded: boolean, rowCount: number, hasEntries:
   cancelPendingResize();
   const height = bounds.height ?? nativeWindowHeight(expanded, rowCount, menuOpen);
   const apply = async () => {
+    const latestBounds = visibleHudBounds();
     await agentHudSetLayout({
       expanded,
       cardCount: rowCount,
       ...(menuOpen ? { contextMenuOpen: menuOpen } : {}),
-      ...bounds,
+      ...latestBounds,
     }).catch(() => {});
     if (!windowShown) {
       await agentHudShow().catch(() => {});
       windowShown = true;
     }
+    lastWindowHeight = latestBounds.height ?? nativeWindowHeight(expanded, rowCount, menuOpen);
   };
   // Growing: the window must be at full size before the CSS reveal plays.
   // Shrinking: the reveal collapses first, then the window snaps down under
@@ -796,11 +798,11 @@ async function syncWindowLayout(expanded: boolean, rowCount: number, hasEntries:
   } else {
     await apply();
   }
-  lastWindowHeight = height;
 }
 
 function visibleHudBounds(): { width?: number; height?: number } {
   if (!surface) return {};
+  if (state.menuOpen && (!menu || menu.offsetWidth <= 0 || menu.offsetHeight <= 0)) return {};
   const interactiveElements = state.menuOpen && menu ? [surface, menu] : [surface];
   const width = Math.max(...interactiveElements.map((element) => element.offsetWidth));
   const height = Math.max(

--- a/src/agent-hud.ts
+++ b/src/agent-hud.ts
@@ -803,10 +803,18 @@ async function syncWindowLayout(expanded: boolean, rowCount: number, hasEntries:
 function visibleHudBounds(): { width?: number; height?: number } {
   if (!surface) return {};
   if (state.menuOpen && (!menu || menu.offsetWidth <= 0 || menu.offsetHeight <= 0)) return {};
-  const interactiveElements = state.menuOpen && menu ? [surface, menu] : [surface];
-  const width = Math.max(...interactiveElements.map((element) => element.offsetWidth));
+  const expandedSurfaceHeight =
+    hud?.dataset.expanded === "true" && pill && stack
+      ? pill.offsetHeight + stack.scrollHeight
+      : surface.offsetHeight;
+  // grid-template-rows animates the reveal from 0fr to 1fr. scrollHeight
+  // exposes the final row height even while offsetHeight is still mid-
+  // transition, so the native window grows before the reveal can be clipped.
+  const surfaceHeight = Math.max(surface.offsetHeight, expandedSurfaceHeight);
+  const width = Math.max(surface.offsetWidth, state.menuOpen && menu ? menu.offsetWidth : 0);
   const height = Math.max(
-    ...interactiveElements.map((element) => element.offsetTop + element.offsetHeight),
+    surface.offsetTop + surfaceHeight,
+    state.menuOpen && menu ? menu.offsetTop + menu.offsetHeight : 0,
   );
   if (width <= 0 || height <= 0) return {};
   return { width: Math.ceil(width), height: Math.ceil(height) };

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -917,6 +917,8 @@ export async function agentHudSetLayout(input: {
   expanded: boolean;
   cardCount?: number;
   contextMenuOpen?: boolean;
+  width?: number;
+  height?: number;
 }) {
   return invoke<void>("agent_hud_set_layout", { request: input });
 }

--- a/src/styles/agent-hud.css
+++ b/src/styles/agent-hud.css
@@ -74,10 +74,10 @@ body {
   pointer-events: none;
 }
 
-/* Shared surface recipe: near-opaque dark glass, borderless. The box-shadow
- * below does the edge definition; CSS backdrop-filter can't sample other
- * apps' pixels, so opacity does the legibility work. Matches the dictation
- * and recording pills, which are likewise borderless over their vibrancy.
+/* Shared surface recipe: near-opaque dark glass, borderless. CSS
+ * backdrop-filter can't sample other apps' pixels, so opacity does the
+ * legibility work. The native window owns the shadow so its hit-tested bounds
+ * can match this surface exactly.
  *
  * Shared geometry: the header and every row place their leading icon in
  * the same 14px column at the same inset, so the header label and row
@@ -89,17 +89,17 @@ body {
   --hud-expanded-w: 248px;
 
   position: absolute;
-  top: var(--sp-3);
-  right: var(--sp-4);
+  top: 0;
+  right: 0;
   display: grid;
   width: fit-content;
-  max-width: min(var(--hud-expanded-w), calc(100vw - 2 * var(--sp-4)));
+  max-width: var(--hud-expanded-w);
   overflow: hidden;
   /* Half the collapsed pill height, NOT --r-pill: a 999px radius
    * interpolating down to 14px mid-expansion produced blob shapes. */
   border-radius: 16px;
   background: color-mix(in oklch, var(--popover) 92%, transparent);
-  box-shadow: var(--shadow-md);
+  box-shadow: none;
   opacity: 0;
   pointer-events: none;
   transform: translateY(-3px) scale(0.98);
@@ -126,7 +126,10 @@ body {
 }
 
 .agent-hud[data-expanded="true"] .agent-hud-surface {
-  width: min(var(--hud-expanded-w), calc(100vw - 2 * var(--sp-4)));
+  /* Deliberately independent of 100vw: while collapsed the native window is
+   * pill-width, so viewport-relative sizing would prevent this surface from
+   * measuring its expanded width and growing the window. */
+  width: var(--hud-expanded-w);
   border-radius: var(--r-xl);
 }
 
@@ -476,7 +479,7 @@ body {
 .agent-hud-menu {
   position: absolute;
   top: 44px;
-  right: var(--sp-4);
+  right: 0;
   min-width: 148px;
   padding: var(--sp-1);
   border: 1px solid var(--border);

--- a/src/styles/agent-hud.css
+++ b/src/styles/agent-hud.css
@@ -102,7 +102,8 @@ body {
   box-shadow: none;
   opacity: 0;
   pointer-events: none;
-  transform: translateY(-3px) scale(0.98);
+  transform: scale(0.98);
+  transform-origin: top right;
   /* Out (base state): a longer, calmer fade; agent-hud.ts keeps the last
    * content rendered underneath it and delays the native hide to match.
    * Width is in the list for the JS FLIP that animates expand/collapse. */
@@ -485,7 +486,7 @@ body {
   border: 1px solid var(--border);
   border-radius: var(--r-md);
   background: color-mix(in oklch, var(--popover) 96%, transparent);
-  box-shadow: var(--shadow-md);
+  box-shadow: none;
   pointer-events: auto;
 }
 

--- a/src/test/agent-hud.test.ts
+++ b/src/test/agent-hud.test.ts
@@ -61,6 +61,24 @@ describe("agent HUD", () => {
     expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_show");
   });
 
+  it("fits the native window to the visible HUD surface", async () => {
+    const surface = surfaceElement();
+    vi.spyOn(surface, "offsetWidth", "get").mockReturnValue(112);
+    vi.spyOn(surface, "offsetHeight", "get").mockReturnValue(32);
+    await loadAgentHud();
+
+    emitStatus({
+      status: "running",
+      title: "Review the branch.",
+      summary: "Working.",
+    });
+    await flushPromises();
+
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_set_layout", {
+      request: { expanded: false, cardCount: 0, width: 112, height: 32 },
+    });
+  });
+
   it("shortens the collapsed label when multiple agents are running", async () => {
     await loadAgentHud();
 
@@ -850,6 +868,12 @@ function stackElement() {
   const stack = document.querySelector<HTMLElement>("#agent-hud-stack");
   expect(stack).toBeTruthy();
   return stack as HTMLElement;
+}
+
+function surfaceElement() {
+  const surface = document.querySelector<HTMLElement>(".agent-hud-surface");
+  expect(surface).toBeTruthy();
+  return surface as HTMLElement;
 }
 
 function menuElement() {

--- a/src/test/agent-hud.test.ts
+++ b/src/test/agent-hud.test.ts
@@ -79,6 +79,63 @@ describe("agent HUD", () => {
     });
   });
 
+  it("remeasures the HUD before a deferred collapse resize", async () => {
+    const surface = surfaceElement();
+    let width = 248;
+    let height = 180;
+    vi.spyOn(surface, "offsetWidth", "get").mockImplementation(() => width);
+    vi.spyOn(surface, "offsetHeight", "get").mockImplementation(() => height);
+    await loadAgentHud();
+
+    emitStatus({
+      status: "waitingForUser",
+      title: "Review the branch.",
+      summary: "Needs input.",
+    });
+    await flushPromises();
+    expect(hudElement().dataset.expanded).toBe("true");
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_show");
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    width = 112;
+    height = 32;
+    vi.useFakeTimers();
+    mocks.invoke.mockClear();
+    pillElement().dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, cancelable: true }));
+    await flushPromises();
+
+    width = 96;
+    await vi.advanceTimersByTimeAsync(200);
+    await flushPromises();
+
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_set_layout", {
+      request: { expanded: false, cardCount: 0, width: 96, height: 32 },
+    });
+  });
+
+  it("uses the context-menu fallback until the menu has measurable bounds", async () => {
+    const surface = surfaceElement();
+    vi.spyOn(surface, "offsetWidth", "get").mockReturnValue(112);
+    vi.spyOn(surface, "offsetHeight", "get").mockReturnValue(32);
+    await loadAgentHud();
+
+    emitStatus({
+      status: "running",
+      title: "Review the branch.",
+      summary: "Working.",
+    });
+    await flushPromises();
+    mocks.invoke.mockClear();
+
+    const openMenuFromNative = mocks.listeners.get("june:agent-hud:context-menu");
+    openMenuFromNative?.({ payload: undefined });
+    await flushPromises();
+
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_set_layout", {
+      request: { expanded: false, cardCount: 0, contextMenuOpen: true },
+    });
+  });
+
   it("shortens the collapsed label when multiple agents are running", async () => {
     await loadAgentHud();
 

--- a/src/test/agent-hud.test.ts
+++ b/src/test/agent-hud.test.ts
@@ -113,6 +113,26 @@ describe("agent HUD", () => {
     });
   });
 
+  it("sizes the native window to the final expanded height during the reveal", async () => {
+    const surface = surfaceElement();
+    vi.spyOn(surface, "offsetWidth", "get").mockReturnValue(248);
+    vi.spyOn(surface, "offsetHeight", "get").mockReturnValue(36);
+    vi.spyOn(pillElement(), "offsetHeight", "get").mockReturnValue(36);
+    vi.spyOn(stackElement(), "scrollHeight", "get").mockReturnValue(50);
+    await loadAgentHud();
+
+    emitStatus({
+      status: "waitingForUser",
+      title: "Review the branch.",
+      summary: "Needs input.",
+    });
+    await flushPromises();
+
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_set_layout", {
+      request: { expanded: true, cardCount: 1, width: 248, height: 86 },
+    });
+  });
+
   it("uses the context-menu fallback until the menu has measurable bounds", async () => {
     const surface = surfaceElement();
     vi.spyOn(surface, "offsetWidth", "get").mockReturnValue(112);

--- a/src/test/agent-hud.test.ts
+++ b/src/test/agent-hud.test.ts
@@ -133,6 +133,35 @@ describe("agent HUD", () => {
     });
   });
 
+  it("sizes the native window to the final expanded width during the reveal", async () => {
+    const surface = surfaceElement();
+    const rectWithWidth = (width: number) => ({ width }) as DOMRect;
+    vi.spyOn(surface, "offsetWidth", "get").mockReturnValue(112);
+    vi.spyOn(surface, "offsetHeight", "get").mockReturnValue(32);
+    vi.spyOn(surface, "getBoundingClientRect").mockImplementation(() => {
+      const inlineWidth = Number.parseFloat(surface.style.width);
+      if (Number.isFinite(inlineWidth)) return rectWithWidth(inlineWidth);
+      return rectWithWidth(hudElement().dataset.expanded === "true" ? 248 : 112);
+    });
+    await loadAgentHud();
+
+    emitStatus({
+      status: "running",
+      title: "Review the branch.",
+      summary: "Working.",
+    });
+    await flushPromises();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    mocks.invoke.mockClear();
+
+    pillElement().dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, cancelable: true }));
+    await flushPromises();
+
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_set_layout", {
+      request: { expanded: true, cardCount: 1, width: 248, height: 32 },
+    });
+  });
+
   it("uses the context-menu fallback until the menu has measurable bounds", async () => {
     const surface = surfaceElement();
     vi.spyOn(surface, "offsetWidth", "get").mockReturnValue(112);

--- a/src/test/agent-hud.test.ts
+++ b/src/test/agent-hud.test.ts
@@ -136,6 +136,39 @@ describe("agent HUD", () => {
     });
   });
 
+  it("fits the native window to a measurable context menu", async () => {
+    const surface = surfaceElement();
+    const menu = menuElement();
+    vi.spyOn(surface, "offsetWidth", "get").mockReturnValue(112);
+    vi.spyOn(surface, "offsetHeight", "get").mockReturnValue(32);
+    vi.spyOn(menu, "offsetWidth", "get").mockReturnValue(148);
+    vi.spyOn(menu, "offsetHeight", "get").mockReturnValue(36);
+    vi.spyOn(menu, "offsetTop", "get").mockReturnValue(44);
+    await loadAgentHud();
+
+    emitStatus({
+      status: "running",
+      title: "Review the branch.",
+      summary: "Working.",
+    });
+    await flushPromises();
+    mocks.invoke.mockClear();
+
+    const openMenuFromNative = mocks.listeners.get("june:agent-hud:context-menu");
+    openMenuFromNative?.({ payload: undefined });
+    await flushPromises();
+
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_set_layout", {
+      request: {
+        expanded: false,
+        cardCount: 0,
+        contextMenuOpen: true,
+        width: 148,
+        height: 80,
+      },
+    });
+  });
+
   it("shortens the collapsed label when multiple agents are running", async () => {
     await loadAgentHud();
 


### PR DESCRIPTION
## Summary

- resize the native agent HUD window to the rendered interactive surface
- re-anchor the window when its width changes so the visible HUD stays fixed at the top right
- move shadow rendering outside the hit-tested window and cover the bounds contract in frontend and Rust tests

## Why

Fixes JUN-357. The transparent portion of the fixed 304 x 58 native panel intercepted clicks in Chrome even though the DOM gutter used `pointer-events: none`.

## Validation

- `pnpm exec vitest run src/test/agent-hud.test.ts` (33 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml --locked agent_hud --lib` (3 passed)
- `pnpm test` (2,948 passed, 2 skipped)
- `pnpm run build`
- `pnpm run check` (passes with existing repository warnings)
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- focused Biome check for changed frontend files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786892083&installation_id=144203540&pr_number=821&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F821&signature=e439f57c25bdd2128a0957c6447057a7c04581a1ed41519ba0b087f98e2a6c38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->