### PR TITLE
fix: stage lipo-merged cua driver bin for universal tauri bundling

### DIFF
--- a/scripts/prepare-cua-driver.mjs
+++ b/scripts/prepare-cua-driver.mjs
@@ -49,6 +49,7 @@ if (preparedBundleMatches()) {
   console.error(
     `Reusing ${profile} Computer use helper for ${architectures.join("+")} from ${pin.sourceCommit}.`,
   );
+  stageUniversalCargoBin();
   process.exit(0);
 }
 
@@ -160,6 +161,27 @@ if (version.version !== pin.version || version.commit !== pin.sourceCommit) {
 console.error(
   `Prepared authenticated Computer use helper from cua-driver ${pin.version} (${pin.sourceCommit}).`,
 );
+stageUniversalCargoBin();
+
+// Tauri bundles every cargo binary of the crate and, for the pseudo-target
+// universal-apple-darwin, expects each one already lipo-merged under
+// target/universal-apple-darwin/<profile>/. Cargo only produces per-arch
+// binaries and Tauri merges only the main one, so stage the merged helper
+// executable there ourselves.
+function stageUniversalCargoBin() {
+  if (target !== "universal-apple-darwin") return;
+  const stagedBin = path.join(
+    rootDir,
+    "src-tauri",
+    "target",
+    "universal-apple-darwin",
+    profile,
+    pin.executable,
+  );
+  mkdirSync(path.dirname(stagedBin), { recursive: true });
+  cpSync(executable, stagedBin);
+  run("/bin/chmod", ["755", stagedBin]);
+}
 
 function helperVersion(file) {
   const result = spawnSync(file, ["--version"], { encoding: "utf8" });


### PR DESCRIPTION
## What

`prepare-cua-driver.mjs` now stages the lipo-merged `june-computer-use-driver` executable at `src-tauri/target/universal-apple-darwin/<profile>/` (fresh-build and reuse paths both).

## Root cause

rc.2 attempt 3 (run 29590099586) failed at bundling: Tauri v2 auto-bundles every cargo `[[bin]]` of the crate, and for the pseudo-target `universal-apple-darwin` it expects each extra binary already merged in that target dir. Cargo only produces per-arch binaries and Tauri lipo-merges only the main one, so the copy failed with "does not exist". Single-arch builds (dev, PR CI) never hit this because cargo itself writes the bin into the target dir — this surfaced on the first-ever universal release build.

## Testing

- Not tested visually - build tooling only.
- Local run of `node scripts/prepare-cua-driver.mjs -- --release --target universal-apple-darwin`: staged bin exists, `lipo -archs` reports `x86_64 arm64`; re-run hits the "Reusing" path and re-stages after deletion.
- End-to-end proof is the next rc-desktop-release run reaching notarization.

## June API deploy

Not needed.

## Out of scope

- Whether the raw driver bin belongs in `June.app/Contents/MacOS` at all (Tauri's auto-bundling behavior; single-arch builds already ship it) - worth a followup look.

## Followups

- Consider a `[[bin]]`-exclusion or explicit tauri `binaries` config if the raw MacOS/ copy is unwanted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786893725&installation_id=144203540&pr_number=822&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F822&signature=a9d2d62e065601680ee7ba167d86e9f1a93cf0b5b215cbc5b21659efb6c9b785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->