### PR TITLE
fix: restore connectors settings tab, nest plugins under it

### DIFF
--- a/src/components/plugins/PluginsView.tsx
+++ b/src/components/plugins/PluginsView.tsx
@@ -10,9 +10,9 @@ export function PluginsView({
   return (
     <section className="settings-group" aria-labelledby="plugins-view-heading">
       <header className="settings-page-header">
-        <h2 id="plugins-view-heading" className="settings-page-title">
+        <h3 id="plugins-view-heading" className="settings-row-title">
           Plugins
-        </h2>
+        </h3>
         <p className="settings-page-blurb">
           Give June carefully scoped ways to work in other apps and services.
         </p>

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -118,6 +118,7 @@ import { DEFAULT_IMAGE_MODEL, IMAGE_MODELS } from "../../lib/image-models";
 import { IMAGE_GENERATION_ENABLED, VIDEO_GENERATION_ENABLED } from "../../lib/feature-flags";
 import { DEFAULT_VIDEO_MODEL, VIDEO_MODELS } from "../../lib/video-models";
 import { AgentSettingsSection } from "./AgentSettingsSection";
+import { ConnectorsSection } from "./ConnectorsSection";
 import { PluginsView } from "../plugins/PluginsView";
 import { ExternalDirsSection } from "./ExternalDirsSection";
 import { InstalledSkillsSection } from "./InstalledSkillsSection";
@@ -302,7 +303,7 @@ export type SettingsTab =
   | "models"
   | "agent"
   | "memory"
-  | "plugins"
+  | "connectors"
   | "skills"
   | "external-dirs"
   | "skill-review"
@@ -329,7 +330,7 @@ export const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
   { id: "models", label: "Models" },
   { id: "agent", label: "Agent" },
   { id: "memory", label: "Memory" },
-  { id: "plugins", label: "Plugins" },
+  { id: "connectors", label: "Connectors" },
   { id: "skills", label: "Installed skills" },
   { id: "external-dirs", label: "External skill directories" },
   { id: "skill-review", label: "Pending skill changes" },
@@ -2357,11 +2358,16 @@ export function AppSettings({
           />
         ) : null}
 
-        {activeTab === "plugins" ? (
-          <PluginsView
-            onOpenModels={() => setActiveTab("models")}
-            onOpenBilling={() => setActiveTab("billing")}
-          />
+        {activeTab === "connectors" ? (
+          <>
+            <ConnectorsSection />
+            {/* Plugins live inside Connectors until polished enough to graduate
+                back to a top-level page. */}
+            <PluginsView
+              onOpenModels={() => setActiveTab("models")}
+              onOpenBilling={() => setActiveTab("billing")}
+            />
+          </>
         ) : null}
 
         {activeTab === "skills" ? <InstalledSkillsSection onOpenSkill={setOpenSkill} /> : null}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -274,8 +274,8 @@ const SETTINGS_SIDEBAR_GROUPS: {
         icon: <IconBrainSideview size={16} />,
       },
       {
-        id: "plugins",
-        label: "Plugins",
+        id: "connectors",
+        label: "Connectors",
         icon: <IconPlugin1 size={16} />,
       },
       {
@@ -683,12 +683,12 @@ export function Sidebar({
         action: () => onChangeView("routines"),
       },
       {
-        id: "quick:plugins",
-        label: "Go to plugins",
+        id: "quick:connectors",
+        label: "Go to connectors",
         icon: <IconPlugin1 size={15} />,
-        searchText: normalizeCommandQuery("plugins computer use go to"),
+        searchText: normalizeCommandQuery("connectors plugins computer use google linear go to"),
         action: () => {
-          onSettingsTabChange?.("plugins");
+          onSettingsTabChange?.("connectors");
           onChangeView("settings");
         },
       },

--- a/src/test/computer-use-control.test.tsx
+++ b/src/test/computer-use-control.test.tsx
@@ -168,13 +168,13 @@ describe("ComputerUseControl", () => {
     expect(screen.queryByText("Bundled driver unavailable")).not.toBeInTheDocument();
   });
 
-  it("exposes Computer use from the Plugins settings page", async () => {
+  it("exposes Computer use as a plugins subsection of the Connectors settings page", async () => {
     render(<PluginsView onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
 
     expect(screen.getByRole("heading", { name: "Plugins" })).toBeInTheDocument();
     expect(await screen.findByRole("switch", { name: "Enable Computer use" })).toBeInTheDocument();
-    expect(SETTINGS_TABS).toContainEqual({ id: "plugins", label: "Plugins" });
-    expect(SETTINGS_TABS.some((tab) => tab.label === "Connectors")).toBe(false);
+    expect(SETTINGS_TABS).toContainEqual({ id: "connectors", label: "Connectors" });
+    expect(SETTINGS_TABS.some((tab) => tab.label === "Plugins")).toBe(false);
     expect(
       screen.queryByRole("button", { name: "Open Computer use settings" }),
     ).not.toBeInTheDocument();


### PR DESCRIPTION
## What

Restores the Connectors settings tab (Google + Linear via `ConnectorsSection`) that commit 48750ab7 accidentally replaced, and nests the plugins surface (`PluginsView` with the Computer use control) beneath it as a subsection of the same page. Sidebar settings-nav entry and the quick command follow (`Go to connectors`, searchable by connectors/plugins/computer use/google/linear).

## Root cause

48750ab7 ("move computer use into plugin settings") retargeted the existing `connectors` settings tab to render `PluginsView` instead of adding alongside it - `ConnectorsSection` became unreachable, removing Google/Linear connector management from the app.

## Design note

Per current direction: plugins are under development and live inside the Connectors settings page for now; when polished they graduate back to a top-level Plugins page. `PluginsView`'s header is downgraded to a subsection heading accordingly.

## Testing

- Tested visually: faked-bridge browser preview of the composed tab - Connectors header, Google row (connected state), Linear row, Plugins subsection with the Computer use tile.
- `pnpm vitest run` on `computer-use-control`, `connectors-section`, `app-settings`: 122 passed.
- `pnpm typecheck` clean; `make local-ci` green, signoffs posted.

## June API deploy

Not needed for this change. Related but separate: the RC's Computer use "Temporarily unavailable" state is the missing June API production deploy (computer_use decision endpoint merged 13:37, last promote 02:05) - resolved by running promote-june-api, no desktop change involved.

## Out of scope

- Graduating plugins back to a top-level page (planned once polished).
- The June API production promote itself.

## Followups

- Top-level Plugins page restoration when the surface is ready.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786896895&installation_id=144203540&pr_number=823&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F823&signature=86c5071f356135c6e4ff9f8ad3b02946899a9358e75ec8d20f40f8df5033beef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->