### PR TITLE
Allow downloading original Note audio

### DIFF
--- a/.agents/skills/repo-review/CALIBRATION.md
+++ b/.agents/skills/repo-review/CALIBRATION.md
@@ -148,3 +148,7 @@ data-driven: discount reviewer patterns with a bad true/findings ratio
 | #826 | Standards (codex, r1+final) | 0 | — | clean on the native cue sequencing, HUD state ownership, tests, and comments |
 | #826 | Spec (codex, r1+final) | 2 | 2 | found interrupted start cues losing normal stop feedback and the actionable HUD error being latched only after an await; final clean |
 | #826 | Adversarial (codex, iterative) | 3 | 3 | documented the deliberate 300 ms start-speaking boundary, then found the short-press discard bypass and a stale error continuation hiding a newer listening HUD; convergence approved |
+| JUN-272 (pre-PR) | Standards (codex, iterative+final) | 2 | 2 | caught unqualified Recording session identifiers and Rust syntax newer than the desktop crate's 1.80 MSRV; final pass clean |
+| JUN-272 (pre-PR) | Spec (codex, iterative+final) | 2 | 2 | caught pathname reopen TOCTOU and the ZIP crate's direct MSRV mismatch; final pass clean after retained handles and an exact compatible pin |
+| JUN-272 (pre-PR) | Adversarial (codex, iterative) | 7 | 7 | found Note/Recording-session ownership confinement, UI/backend eligibility drift, legacy layout compatibility, Unix and Windows validation-to-read races, and two MSRV blockers; two independent clean rounds followed |
+| JUN-272 (pre-PR) | Cross-harness (claude) | — | — | unavailable: the harness refused the private diff under its privacy policy; review continued with alternating fresh read-only Codex reviewers and never counted missing output as approval |

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7558,9 +7558,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.6.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+checksum = "95ab361742de920c5535880f89bbd611ee62002bf11341d16a5f057bb8ba6899"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3352,6 +3352,7 @@ dependencies = [
  "window-vibrancy",
  "windows 0.61.3",
  "zeroize",
+ "zip",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,7 +63,7 @@ tracing = "0.1"
 urlencoding = "2"
 uuid = { version = "1.11", features = ["serde", "v4"] }
 zeroize = { version = "1", features = ["derive"] }
-zip = { version = "4.6.1", default-features = false }
+zip = { version = "=4.2.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,11 +57,13 @@ tauri-plugin-process = "2.3.1"
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 tauri-plugin-updater = "2.10.1"
 thiserror = "2.0"
+tempfile = "3.14"
 tokio = { version = "1.42", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1"
 urlencoding = "2"
 uuid = { version = "1.11", features = ["serde", "v4"] }
 zeroize = { version = "1", features = ["derive"] }
+zip = { version = "4.6.1", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -121,6 +123,3 @@ windows = { version = "0.61", features = [
     "Win32_System_IO",
     "Win32_System_Threading",
 ] }
-
-[dev-dependencies]
-tempfile = "3.14"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -28,13 +28,14 @@ use crate::{
             CheckRecordingSourceReadinessRequest, CreateAgentTaskRequest,
             CreateDictionaryEntryRequest, CreateFolderRequest, CreateNoteRequest,
             DeleteDictionaryEntryRequest, DeleteFolderRequest, DeleteNoteRequest,
-            DeleteNotesRequest, DictionaryEntryDto, ExplainAgentApprovalRequest,
-            ExplainAgentApprovalResponse, FinishRecordingResponse, GetAgentTaskRequest,
-            GetNoteRequest, ListNotesRequest, ListNotesResponse, MemoryDto, MemorySettingsDto,
-            MicrophonePermissionResponse, NoteDto, OpenPrivacySettingsRequest, ProcessingStatus,
-            RecordingSessionDto, RecordingSource, RecordingSourceMode, RecordingSourceReadinessDto,
-            RecordingStatusDto, RemoveNoteFromFolderRequest, RemoveSessionFromFolderRequest,
-            RenameFolderRequest, RetryProcessingRequest, SaveAgentAssistantMessageRequest,
+            DeleteNotesRequest, DictionaryEntryDto, DownloadNoteAudioRequest,
+            DownloadNoteAudioResponse, ExplainAgentApprovalRequest, ExplainAgentApprovalResponse,
+            FinishRecordingResponse, GetAgentTaskRequest, GetNoteRequest, ListNotesRequest,
+            ListNotesResponse, MemoryDto, MemorySettingsDto, MicrophonePermissionResponse, NoteDto,
+            OpenPrivacySettingsRequest, ProcessingStatus, RecordingSessionDto, RecordingSource,
+            RecordingSourceMode, RecordingSourceReadinessDto, RecordingStatusDto,
+            RemoveNoteFromFolderRequest, RemoveSessionFromFolderRequest, RenameFolderRequest,
+            RetryProcessingRequest, SaveAgentAssistantMessageRequest,
             SaveAgentHermesSessionRequest, SendAgentMessageRequest, SessionFolderDto,
             SessionRequest, ShareAddInvitesRequest, ShareCreateRequest, ShareCreatedDto,
             ShareDeleteRequest, ShareDto, ShareGetRequest, ShareInviteKeyDto,
@@ -139,6 +140,29 @@ pub async fn get_note(app: AppHandle, request: GetNoteRequest) -> Result<NoteDto
     let mut note = repositories(&app).await?.get_note(&request.note_id).await?;
     note.queued_recordings = processing_queue::queued_behind(&request.note_id);
     Ok(note)
+}
+
+#[tauri::command]
+pub async fn download_note_audio(
+    app: AppHandle,
+    request: DownloadNoteAudioRequest,
+) -> Result<DownloadNoteAudioResponse, AppError> {
+    let selection = repositories(&app)
+        .await?
+        .note_audio_export_selection(&request.note_id)
+        .await?
+        .ok_or_else(crate::note_audio_export::unavailable_error)?;
+    let paths = app_paths(&app)?;
+    let downloads_dir = app
+        .path()
+        .download_dir()
+        .map_err(|error| AppError::new("note_audio_export_failed", error.to_string()))?;
+
+    tokio::task::spawn_blocking(move || {
+        crate::note_audio_export::export_note_audio(&paths, &downloads_dir, selection)
+    })
+    .await
+    .map_err(|error| AppError::new("note_audio_export_failed", error.to_string()))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -2059,7 +2059,7 @@ impl Repositories {
         note_id: &str,
     ) -> Result<Option<NoteAudioExportSelection>, sqlx::error::Error> {
         let rows = query(
-            "SELECT n.title, aa.path, aa.recording_session_id, aa.source
+            "SELECT n.id AS note_id, n.title, aa.path, aa.recording_session_id, aa.source
              FROM notes n
              INNER JOIN audio_artifacts aa ON aa.note_id = n.id
              INNER JOIN recording_sessions rs
@@ -2080,6 +2080,7 @@ impl Repositories {
         let Some(first) = rows.first() else {
             return Ok(None);
         };
+        let note_id = first.get("note_id");
         let title = first.get("title");
         let sources = rows
             .into_iter()
@@ -2089,7 +2090,11 @@ impl Repositories {
                 source: row.get("source"),
             })
             .collect();
-        Ok(Some(NoteAudioExportSelection { title, sources }))
+        Ok(Some(NoteAudioExportSelection {
+            note_id,
+            title,
+            sources,
+        }))
     }
 
     pub async fn audio_artifact_paths_for_notes(
@@ -5179,12 +5184,12 @@ mod tests {
     async fn export_artifact(
         repos: &Repositories,
         note_id: &str,
-        session_id: &str,
+        recording_session_id: &str,
         source: &str,
         path: &str,
     ) -> String {
         let artifact = repos
-            .create_pending_source_artifact(note_id, session_id, source, path, path)
+            .create_pending_source_artifact(note_id, recording_session_id, source, path, path)
             .await
             .expect("create export artifact");
         repos
@@ -5215,7 +5220,7 @@ mod tests {
             .await
             .expect("set title");
 
-        for (note_id, session_id) in [
+        for (note_id, recording_session_id) in [
             (&note.id, "session-b"),
             (&note.id, "session-a"),
             (&other_note.id, "session-other"),
@@ -5223,7 +5228,7 @@ mod tests {
             repos
                 .create_recording_session(
                     note_id,
-                    session_id,
+                    recording_session_id,
                     RecordingSourceMode::MicrophonePlusSystem,
                     "/tmp/source.partial.wav",
                     "/tmp/source.wav",
@@ -5323,6 +5328,7 @@ mod tests {
             .expect("selection query")
             .expect("eligible sources");
         assert_eq!(selection.title, "Product review");
+        assert_eq!(selection.note_id, note.id);
         assert_eq!(
             selection
                 .sources

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -14,6 +14,8 @@ use sqlx::row::Row;
 use sqlx_sqlite::SqlitePool;
 use uuid::Uuid;
 
+use crate::note_audio_export::{NoteAudioExportSelection, NoteAudioExportSource};
+
 const DICTATION_HISTORY_RETENTION_DAYS: i64 = 7;
 
 #[derive(Clone)]
@@ -2050,6 +2052,44 @@ impl Repositories {
             .fetch_all(&self.pool)
             .await?;
         Ok(rows.into_iter().map(|row| row.get("path")).collect())
+    }
+
+    pub(crate) async fn note_audio_export_selection(
+        &self,
+        note_id: &str,
+    ) -> Result<Option<NoteAudioExportSelection>, sqlx::error::Error> {
+        let rows = query(
+            "SELECT n.title, aa.path, aa.recording_session_id, aa.source
+             FROM notes n
+             INNER JOIN audio_artifacts aa ON aa.note_id = n.id
+             INNER JOIN recording_sessions rs
+               ON rs.id = aa.recording_session_id
+              AND rs.note_id = aa.note_id
+             WHERE n.id = ?
+               AND aa.status = 'valid'
+               AND aa.format = 'wav'
+               AND aa.size_bytes > 0
+             ORDER BY rs.started_at ASC,
+                      rs.id ASC,
+                      CASE aa.source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END,
+                      aa.id ASC",
+        )
+        .bind(note_id)
+        .fetch_all(&self.pool)
+        .await?;
+        let Some(first) = rows.first() else {
+            return Ok(None);
+        };
+        let title = first.get("title");
+        let sources = rows
+            .into_iter()
+            .map(|row| NoteAudioExportSource {
+                path: row.get::<String, _>("path").into(),
+                recording_session_id: row.get("recording_session_id"),
+                source: row.get("source"),
+            })
+            .collect();
+        Ok(Some(NoteAudioExportSelection { title, sources }))
     }
 
     pub async fn audio_artifact_paths_for_notes(
@@ -5134,6 +5174,188 @@ mod tests {
             .await
             .expect("count transcripts")
             .get("count")
+    }
+
+    async fn export_artifact(
+        repos: &Repositories,
+        note_id: &str,
+        session_id: &str,
+        source: &str,
+        path: &str,
+    ) -> String {
+        let artifact = repos
+            .create_pending_source_artifact(note_id, session_id, source, path, path)
+            .await
+            .expect("create export artifact");
+        repos
+            .finalize_source_artifact(
+                &artifact.id,
+                path,
+                "valid",
+                1_000,
+                10,
+                "checksum",
+                1_000,
+                None,
+                None,
+            )
+            .await
+            .expect("finalize export artifact");
+        artifact.id
+    }
+
+    #[tokio::test]
+    async fn note_audio_export_selection_enforces_eligibility_ownership_and_order() {
+        let repos = test_repositories().await;
+        let note = repos.create_note(None).await.expect("note");
+        let other_note = repos.create_note(None).await.expect("other note");
+        query("UPDATE notes SET title = 'Product review' WHERE id = ?")
+            .bind(&note.id)
+            .execute(&repos.pool)
+            .await
+            .expect("set title");
+
+        for (note_id, session_id) in [
+            (&note.id, "session-b"),
+            (&note.id, "session-a"),
+            (&other_note.id, "session-other"),
+        ] {
+            repos
+                .create_recording_session(
+                    note_id,
+                    session_id,
+                    RecordingSourceMode::MicrophonePlusSystem,
+                    "/tmp/source.partial.wav",
+                    "/tmp/source.wav",
+                    None,
+                )
+                .await
+                .expect("session");
+        }
+        query("UPDATE recording_sessions SET started_at = '2026-07-01T10:00:00.000Z' WHERE id IN ('session-a', 'session-b')")
+            .execute(&repos.pool)
+            .await
+            .expect("same start time");
+
+        export_artifact(
+            &repos,
+            &note.id,
+            "session-a",
+            "system",
+            "/recordings/a-system.wav",
+        )
+        .await;
+        export_artifact(
+            &repos,
+            &note.id,
+            "session-a",
+            "microphone",
+            "/recordings/a-microphone.wav",
+        )
+        .await;
+        export_artifact(
+            &repos,
+            &note.id,
+            "session-b",
+            "microphone",
+            "/recordings/b-microphone.wav",
+        )
+        .await;
+
+        let invalid_status = export_artifact(
+            &repos,
+            &note.id,
+            "session-a",
+            "system",
+            "/recordings/invalid-status.wav",
+        )
+        .await;
+        query("UPDATE audio_artifacts SET status = 'invalid' WHERE id = ?")
+            .bind(invalid_status)
+            .execute(&repos.pool)
+            .await
+            .expect("invalidate status");
+        let invalid_format = export_artifact(
+            &repos,
+            &note.id,
+            "session-a",
+            "system",
+            "/recordings/invalid-format.wav",
+        )
+        .await;
+        query("UPDATE audio_artifacts SET format = 'mp3' WHERE id = ?")
+            .bind(invalid_format)
+            .execute(&repos.pool)
+            .await
+            .expect("invalidate format");
+        let empty = export_artifact(
+            &repos,
+            &note.id,
+            "session-a",
+            "system",
+            "/recordings/empty.wav",
+        )
+        .await;
+        query("UPDATE audio_artifacts SET size_bytes = 0 WHERE id = ?")
+            .bind(empty)
+            .execute(&repos.pool)
+            .await
+            .expect("empty artifact");
+
+        let mismatched = export_artifact(
+            &repos,
+            &other_note.id,
+            "session-other",
+            "microphone",
+            "/recordings/cross-note.wav",
+        )
+        .await;
+        query("UPDATE audio_artifacts SET note_id = ? WHERE id = ?")
+            .bind(&note.id)
+            .bind(mismatched)
+            .execute(&repos.pool)
+            .await
+            .expect("make mismatched ownership row");
+
+        let selection = repos
+            .note_audio_export_selection(&note.id)
+            .await
+            .expect("selection query")
+            .expect("eligible sources");
+        assert_eq!(selection.title, "Product review");
+        assert_eq!(
+            selection
+                .sources
+                .iter()
+                .map(|source| (
+                    source.recording_session_id.as_str(),
+                    source.source.as_str(),
+                    source.path.to_string_lossy().into_owned(),
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    "session-a",
+                    "microphone",
+                    "/recordings/a-microphone.wav".to_string()
+                ),
+                (
+                    "session-a",
+                    "system",
+                    "/recordings/a-system.wav".to_string()
+                ),
+                (
+                    "session-b",
+                    "microphone",
+                    "/recordings/b-microphone.wav".to_string()
+                ),
+            ]
+        );
+        assert!(repos
+            .note_audio_export_selection(&other_note.id)
+            .await
+            .expect("other selection")
+            .is_none());
     }
 
     #[tokio::test]

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -163,6 +163,20 @@ pub struct GetNoteRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct DownloadNoteAudioRequest {
+    pub note_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadNoteAudioResponse {
+    pub path: String,
+    pub file_name: String,
+    pub source_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DeleteNoteRequest {
     pub note_id: String,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub mod macos_menu_icons;
 pub mod meeting_detection;
 pub mod meeting_hud;
 pub mod menu_bar;
+mod note_audio_export;
 pub mod notifications;
 pub mod os_accounts;
 pub mod p3a;
@@ -148,6 +149,7 @@ pub fn run() {
             commands::create_note,
             commands::list_notes,
             commands::get_note,
+            commands::download_note_audio,
             commands::update_note,
             commands::delete_note,
             commands::delete_notes,

--- a/src-tauri/src/note_audio_export.rs
+++ b/src-tauri/src/note_audio_export.rs
@@ -111,9 +111,14 @@ fn validate_source(
         .recordings_dir
         .canonicalize()
         .map_err(export_io_error)?;
-    let expected_canonical_dir = canonical_recordings_dir
-        .join(note_id)
-        .join(&source.recording_session_id);
+    let expected_note_dir = canonical_recordings_dir.join(note_id);
+    let expected_legacy_path =
+        expected_note_dir.join(format!("{}.wav", &source.recording_session_id));
+    if path == expected_legacy_path {
+        return validate_wav_file(source, path);
+    }
+
+    let expected_canonical_dir = expected_note_dir.join(&source.recording_session_id);
     if !path.starts_with(&expected_canonical_dir) {
         return Err(AppError::new(
             "note_audio_export_denied",
@@ -129,6 +134,13 @@ fn validate_source(
             "A selected audio file is outside its Recording session directory.",
         ));
     }
+    validate_wav_file(source, path)
+}
+
+fn validate_wav_file(
+    source: NoteAudioExportSource,
+    path: PathBuf,
+) -> Result<NoteAudioExportSource, AppError> {
     let metadata = fs::metadata(&path).map_err(export_io_error)?;
     if !metadata.is_file()
         || metadata.len() == 0
@@ -533,5 +545,30 @@ mod tests {
         .expect_err("symlink must fail");
         assert_eq!(error.code, "note_audio_export_denied");
         assert_eq!(fs::read_dir(&downloads).expect("downloads").count(), 0);
+    }
+
+    #[test]
+    fn exact_legacy_note_recording_path_is_exported() {
+        let (_temp, paths, downloads) = fixture();
+        let note_directory = paths.recordings_dir.join(NOTE_ID);
+        fs::create_dir_all(&note_directory).expect("legacy Note directory");
+        let legacy_path = note_directory.join("session-a.wav");
+        fs::write(&legacy_path, b"legacy exact bytes").expect("legacy Source");
+
+        let result = export_note_audio(
+            &paths,
+            &downloads,
+            selection(
+                "Legacy",
+                vec![source(legacy_path, "session-a", "microphone")],
+            ),
+        )
+        .expect("legacy export");
+
+        assert_eq!(result.file_name, "Legacy audio.wav");
+        assert_eq!(
+            fs::read(result.path).expect("legacy export bytes"),
+            b"legacy exact bytes"
+        );
     }
 }

--- a/src-tauri/src/note_audio_export.rs
+++ b/src-tauri/src/note_audio_export.rs
@@ -347,7 +347,7 @@ fn open_anchored_source(
         GetFileInformationByHandleEx(
             handle,
             FileAttributeTagInfo,
-            (&raw mut attributes).cast(),
+            std::ptr::addr_of_mut!(attributes).cast(),
             size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
         )
     }

--- a/src-tauri/src/note_audio_export.rs
+++ b/src-tauri/src/note_audio_export.rs
@@ -233,7 +233,143 @@ fn open_anchored_source(
     )
 }
 
-#[cfg(not(unix))]
+#[cfg(target_os = "windows")]
+fn open_anchored_source(
+    _app_paths: &AppPaths,
+    _note_id: &str,
+    _source: &NoteAudioExportSource,
+    path: &Path,
+    _legacy: bool,
+) -> io::Result<File> {
+    use std::{
+        ffi::OsString,
+        mem::size_of,
+        os::windows::{
+            ffi::{OsStrExt, OsStringExt},
+            fs::OpenOptionsExt,
+            io::AsRawHandle,
+        },
+    };
+    use windows::Win32::{
+        Foundation::HANDLE,
+        Storage::FileSystem::{
+            FileAttributeTagInfo, GetFileInformationByHandleEx, GetFinalPathNameByHandleW,
+            FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO, FILE_FLAG_OPEN_REPARSE_POINT,
+            VOLUME_NAME_DOS,
+        },
+    };
+
+    fn windows_error(error: windows::core::Error) -> io::Error {
+        io::Error::other(error.to_string())
+    }
+
+    fn final_path(file: &File) -> io::Result<PathBuf> {
+        let handle = HANDLE(file.as_raw_handle());
+        let mut buffer = vec![0u16; 512];
+        loop {
+            // SAFETY: `handle` remains owned by `file`, and `buffer` is a
+            // writable UTF-16 slice for the duration of the call.
+            let length = unsafe { GetFinalPathNameByHandleW(handle, &mut buffer, VOLUME_NAME_DOS) };
+            if length == 0 {
+                return Err(io::Error::last_os_error());
+            }
+            let length = length as usize;
+            if length < buffer.len() {
+                buffer.truncate(length);
+                return Ok(PathBuf::from(OsString::from_wide(&buffer)));
+            }
+            // When the buffer is too small, Windows returns the required size
+            // including the terminating NUL.
+            buffer.resize(length + 1, 0);
+        }
+    }
+
+    fn comparison_key(path: &Path) -> Vec<u16> {
+        const BACKSLASH: u16 = b'\\' as u16;
+        const FORWARD_SLASH: u16 = b'/' as u16;
+        const UNC_NAMESPACE: &[u16] = &[
+            BACKSLASH,
+            BACKSLASH,
+            b'?' as u16,
+            BACKSLASH,
+            b'U' as u16,
+            b'N' as u16,
+            b'C' as u16,
+            BACKSLASH,
+        ];
+        const DOS_NAMESPACE: &[u16] = &[BACKSLASH, BACKSLASH, b'?' as u16, BACKSLASH];
+
+        let mut normalized = path
+            .as_os_str()
+            .encode_wide()
+            .map(|unit| {
+                if unit == FORWARD_SLASH {
+                    BACKSLASH
+                } else {
+                    unit
+                }
+            })
+            .collect::<Vec<_>>();
+        if normalized.starts_with(UNC_NAMESPACE) {
+            normalized.splice(..UNC_NAMESPACE.len(), [BACKSLASH, BACKSLASH]);
+        } else if normalized.starts_with(DOS_NAMESPACE) {
+            normalized.drain(..DOS_NAMESPACE.len());
+        }
+        // The two path-producing Win32 APIs can disagree only on drive-letter
+        // casing. Keep every other code unit exact so case-sensitive Windows
+        // directories cannot compare as the same path.
+        if normalized.get(1) == Some(&(b':' as u16)) {
+            if let Some(drive) = normalized.first_mut() {
+                if (*drive >= b'a' as u16) && (*drive <= b'z' as u16) {
+                    *drive -= (b'a' - b'A') as u16;
+                }
+            }
+        }
+        while normalized.len() > 3 && normalized.last() == Some(&BACKSLASH) {
+            normalized.pop();
+        }
+        normalized
+    }
+
+    // OPEN_REPARSE_POINT prevents the final component from being followed.
+    // The handle attribute check rejects that component when it is a reparse
+    // point, while the handle-derived final path detects redirected ancestor
+    // directories. The retained handle then closes the validate-to-read race.
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT.0)
+        .open(path)?;
+    let handle = HANDLE(file.as_raw_handle());
+    let mut attributes = FILE_ATTRIBUTE_TAG_INFO::default();
+    // SAFETY: `handle` remains owned by `file`; `attributes` points to a
+    // correctly sized writable FILE_ATTRIBUTE_TAG_INFO value.
+    unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileAttributeTagInfo,
+            (&raw mut attributes).cast(),
+            size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+        )
+    }
+    .map_err(windows_error)?;
+    if attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT.0 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "audio path is a Windows reparse point",
+        ));
+    }
+
+    let opened_path = final_path(&file)?;
+    if comparison_key(&opened_path) != comparison_key(path) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "opened audio file no longer matches its validated path",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(not(any(unix, target_os = "windows")))]
 fn open_anchored_source(
     _app_paths: &AppPaths,
     _note_id: &str,

--- a/src-tauri/src/note_audio_export.rs
+++ b/src-tauri/src/note_audio_export.rs
@@ -15,6 +15,7 @@ const TITLE_MAX_BYTES: usize = 80;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct NoteAudioExportSelection {
+    pub note_id: String,
     pub title: String,
     pub sources: Vec<NoteAudioExportSource>,
 }
@@ -42,17 +43,22 @@ pub(crate) fn export_note_audio(
         return Err(unavailable_error());
     }
 
+    let NoteAudioExportSelection {
+        note_id,
+        title,
+        sources,
+    } = selection;
+
     // Validate the entire selection before creating an output file. Export is
     // all-or-nothing: a partial archive could look complete while silently
     // omitting one of a note's original Sources.
-    let sources = selection
-        .sources
+    let sources = sources
         .into_iter()
-        .map(|source| validate_source(app_paths, source))
+        .map(|source| validate_source(app_paths, &note_id, source))
         .collect::<Result<Vec<_>, _>>()?;
 
     fs::create_dir_all(downloads_dir).map_err(export_io_error)?;
-    let title = sanitized_title(&selection.title);
+    let title = sanitized_title(&title);
     let extension = if sources.len() == 1 { "wav" } else { "zip" };
     let base_name = format!("{title} audio");
     let mut temporary = NamedTempFile::new_in(downloads_dir).map_err(export_io_error)?;
@@ -85,6 +91,7 @@ pub(crate) fn export_note_audio(
 
 fn validate_source(
     app_paths: &AppPaths,
+    note_id: &str,
     source: NoteAudioExportSource,
 ) -> Result<NoteAudioExportSource, AppError> {
     let link_metadata = fs::symlink_metadata(&source.path).map_err(export_io_error)?;
@@ -97,6 +104,31 @@ fn validate_source(
     let path = app_paths
         .contained_recording_file(&source.path)
         .map_err(export_io_error)?;
+    let expected_recording_session_dir = app_paths
+        .recording_session_dir(note_id, &source.recording_session_id)
+        .map_err(export_io_error)?;
+    let canonical_recordings_dir = app_paths
+        .recordings_dir
+        .canonicalize()
+        .map_err(export_io_error)?;
+    let expected_canonical_dir = canonical_recordings_dir
+        .join(note_id)
+        .join(&source.recording_session_id);
+    if !path.starts_with(&expected_canonical_dir) {
+        return Err(AppError::new(
+            "note_audio_export_denied",
+            "A selected audio file is outside its Recording session directory.",
+        ));
+    }
+    let canonical_recording_session_dir = expected_recording_session_dir
+        .canonicalize()
+        .map_err(export_io_error)?;
+    if canonical_recording_session_dir != expected_canonical_dir {
+        return Err(AppError::new(
+            "note_audio_export_denied",
+            "A selected audio file is outside its Recording session directory.",
+        ));
+    }
     let metadata = fs::metadata(&path).map_err(export_io_error)?;
     if !metadata.is_file()
         || metadata.len() == 0
@@ -116,22 +148,22 @@ fn validate_source(
 fn write_archive(output: &mut File, sources: &[NoteAudioExportSource]) -> Result<(), AppError> {
     let mut archive = ZipWriter::new(output);
     let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
-    let mut session_number = 0usize;
-    let mut previous_session: Option<&str> = None;
-    let mut names_per_session = HashMap::<(usize, String), usize>::new();
+    let mut recording_session_number = 0usize;
+    let mut previous_recording_session: Option<&str> = None;
+    let mut names_per_recording_session = HashMap::<(usize, String), usize>::new();
 
     for source in sources {
-        if previous_session != Some(source.recording_session_id.as_str()) {
-            session_number += 1;
-            previous_session = Some(&source.recording_session_id);
+        if previous_recording_session != Some(source.recording_session_id.as_str()) {
+            recording_session_number += 1;
+            previous_recording_session = Some(&source.recording_session_id);
         }
         let stem = match source.source.as_str() {
             "microphone" => "microphone",
             "system" => "system",
             _ => "audio",
         };
-        let duplicate_number = names_per_session
-            .entry((session_number, stem.to_string()))
+        let duplicate_number = names_per_recording_session
+            .entry((recording_session_number, stem.to_string()))
             .and_modify(|count| *count += 1)
             .or_insert(1);
         let suffix = if *duplicate_number == 1 {
@@ -139,7 +171,7 @@ fn write_archive(output: &mut File, sources: &[NoteAudioExportSource]) -> Result
         } else {
             format!("-{}", duplicate_number)
         };
-        let entry_name = format!("recording-{session_number:03}/{stem}{suffix}.wav");
+        let entry_name = format!("recording-{recording_session_number:03}/{stem}{suffix}.wav");
         archive
             .start_file(entry_name, options)
             .map_err(export_zip_error)?;
@@ -241,10 +273,10 @@ mod tests {
     use super::*;
     use std::io::{Cursor, Read};
 
-    fn source(path: PathBuf, session: &str, source: &str) -> NoteAudioExportSource {
+    fn source(path: PathBuf, recording_session_id: &str, source: &str) -> NoteAudioExportSource {
         NoteAudioExportSource {
             path,
-            recording_session_id: session.to_string(),
+            recording_session_id: recording_session_id.to_string(),
             source: source.to_string(),
         }
     }
@@ -257,14 +289,27 @@ mod tests {
         (temp, paths, downloads)
     }
 
-    fn recording_file(paths: &AppPaths, name: &str, bytes: &[u8]) -> PathBuf {
-        let path = paths.recordings_dir.join(name);
+    const NOTE_ID: &str = "note-a";
+
+    fn recording_file(
+        paths: &AppPaths,
+        note_id: &str,
+        recording_session_id: &str,
+        name: &str,
+        bytes: &[u8],
+    ) -> PathBuf {
+        let directory = paths
+            .recording_session_dir(note_id, recording_session_id)
+            .expect("Recording session directory");
+        fs::create_dir_all(&directory).expect("create Recording session directory");
+        let path = directory.join(name);
         fs::write(&path, bytes).expect("write source");
         path
     }
 
     fn selection(title: &str, sources: Vec<NoteAudioExportSource>) -> NoteAudioExportSelection {
         NoteAudioExportSelection {
+            note_id: NOTE_ID.to_string(),
             title: title.to_string(),
             sources,
         }
@@ -273,7 +318,13 @@ mod tests {
     #[test]
     fn single_source_is_copied_exactly_and_never_overwrites() {
         let (_temp, paths, downloads) = fixture();
-        let wav = recording_file(&paths, "microphone.wav", b"exact wav bytes");
+        let wav = recording_file(
+            &paths,
+            NOTE_ID,
+            "session-a",
+            "microphone.wav",
+            b"exact wav bytes",
+        );
         fs::write(downloads.join("Planning audio.wav"), b"keep me").expect("collision");
 
         let result = export_note_audio(
@@ -298,10 +349,16 @@ mod tests {
     #[test]
     fn multi_source_archive_has_deterministic_names_and_exact_bytes() {
         let (_temp, paths, downloads) = fixture();
-        let microphone_a = recording_file(&paths, "mic-a.wav", b"mic a");
-        let microphone_a_duplicate = recording_file(&paths, "mic-a-duplicate.wav", b"mic a 2");
-        let system_a = recording_file(&paths, "system-a.wav", b"system a");
-        let microphone_b = recording_file(&paths, "mic-b.wav", b"mic b");
+        let microphone_a = recording_file(&paths, NOTE_ID, "session-a", "mic-a.wav", b"mic a");
+        let microphone_a_duplicate = recording_file(
+            &paths,
+            NOTE_ID,
+            "session-a",
+            "mic-a-duplicate.wav",
+            b"mic a 2",
+        );
+        let system_a = recording_file(&paths, NOTE_ID, "session-a", "system-a.wav", b"system a");
+        let microphone_b = recording_file(&paths, NOTE_ID, "session-b", "mic-b.wav", b"mic b");
 
         let result = export_note_audio(
             &paths,
@@ -360,8 +417,11 @@ mod tests {
     #[test]
     fn invalid_source_aborts_without_leaving_output_or_temporary_file() {
         let (_temp, paths, downloads) = fixture();
-        let valid = recording_file(&paths, "valid.wav", b"valid");
-        let missing = paths.recordings_dir.join("missing.wav");
+        let valid = recording_file(&paths, NOTE_ID, "session-a", "valid.wav", b"valid");
+        let missing = paths
+            .recording_session_dir(NOTE_ID, "session-a")
+            .expect("Recording session directory")
+            .join("missing.wav");
 
         let error = export_note_audio(
             &paths,
@@ -393,7 +453,7 @@ mod tests {
         .expect_err("outside must fail");
         assert_eq!(error.code, "note_audio_export_denied");
 
-        let wrong_extension = recording_file(&paths, "audio.mp3", b"not wav");
+        let wrong_extension = recording_file(&paths, NOTE_ID, "session-a", "audio.mp3", b"not wav");
         let error = export_note_audio(
             &paths,
             &downloads,
@@ -407,14 +467,62 @@ mod tests {
         assert_eq!(fs::read_dir(&downloads).expect("downloads").count(), 0);
     }
 
+    #[test]
+    fn source_must_stay_inside_the_requested_note_and_recording_session() {
+        let (_temp, paths, downloads) = fixture();
+        let other_note_source = recording_file(
+            &paths,
+            "note-b",
+            "session-a",
+            "microphone.wav",
+            b"other note",
+        );
+        let error = export_note_audio(
+            &paths,
+            &downloads,
+            selection(
+                "Cross-note",
+                vec![source(other_note_source, "session-a", "microphone")],
+            ),
+        )
+        .expect_err("cross-note Source must fail");
+        assert_eq!(error.code, "note_audio_export_denied");
+
+        let other_recording_session_source = recording_file(
+            &paths,
+            NOTE_ID,
+            "session-b",
+            "microphone.wav",
+            b"other Recording session",
+        );
+        let error = export_note_audio(
+            &paths,
+            &downloads,
+            selection(
+                "Cross-session",
+                vec![source(
+                    other_recording_session_source,
+                    "session-a",
+                    "microphone",
+                )],
+            ),
+        )
+        .expect_err("cross-Recording-session Source must fail");
+        assert_eq!(error.code, "note_audio_export_denied");
+        assert_eq!(fs::read_dir(&downloads).expect("downloads").count(), 0);
+    }
+
     #[cfg(unix)]
     #[test]
     fn symbolic_link_source_is_rejected() {
         use std::os::unix::fs::symlink;
 
         let (_temp, paths, downloads) = fixture();
-        let target = recording_file(&paths, "target.wav", b"target");
-        let link = paths.recordings_dir.join("link.wav");
+        let target = recording_file(&paths, NOTE_ID, "session-a", "target.wav", b"target");
+        let link = paths
+            .recording_session_dir(NOTE_ID, "session-a")
+            .expect("Recording session directory")
+            .join("link.wav");
         symlink(target, &link).expect("symlink");
 
         let error = export_note_audio(

--- a/src-tauri/src/note_audio_export.rs
+++ b/src-tauri/src/note_audio_export.rs
@@ -27,6 +27,12 @@ pub(crate) struct NoteAudioExportSource {
     pub source: String,
 }
 
+struct ValidatedSource {
+    file: File,
+    recording_session_id: String,
+    source: String,
+}
+
 pub(crate) fn unavailable_error() -> AppError {
     AppError::new(
         "note_audio_unavailable",
@@ -52,7 +58,7 @@ pub(crate) fn export_note_audio(
     // Validate the entire selection before creating an output file. Export is
     // all-or-nothing: a partial archive could look complete while silently
     // omitting one of a note's original Sources.
-    let sources = sources
+    let mut sources = sources
         .into_iter()
         .map(|source| validate_source(app_paths, &note_id, source))
         .collect::<Result<Vec<_>, _>>()?;
@@ -64,10 +70,9 @@ pub(crate) fn export_note_audio(
     let mut temporary = NamedTempFile::new_in(downloads_dir).map_err(export_io_error)?;
 
     if sources.len() == 1 {
-        let mut input = File::open(&sources[0].path).map_err(export_io_error)?;
-        io::copy(&mut input, temporary.as_file_mut()).map_err(export_io_error)?;
+        io::copy(&mut sources[0].file, temporary.as_file_mut()).map_err(export_io_error)?;
     } else {
-        write_archive(temporary.as_file_mut(), &sources)?;
+        write_archive(temporary.as_file_mut(), &mut sources)?;
     }
     temporary.as_file_mut().flush().map_err(export_io_error)?;
 
@@ -93,7 +98,7 @@ fn validate_source(
     app_paths: &AppPaths,
     note_id: &str,
     source: NoteAudioExportSource,
-) -> Result<NoteAudioExportSource, AppError> {
+) -> Result<ValidatedSource, AppError> {
     let link_metadata = fs::symlink_metadata(&source.path).map_err(export_io_error)?;
     if link_metadata.file_type().is_symlink() {
         return Err(AppError::new(
@@ -113,9 +118,11 @@ fn validate_source(
         .map_err(export_io_error)?;
     let expected_note_dir = canonical_recordings_dir.join(note_id);
     let expected_legacy_path =
-        expected_note_dir.join(format!("{}.wav", &source.recording_session_id));
+        expected_note_dir.join(format!("{}.wav", source.recording_session_id));
     if path == expected_legacy_path {
-        return validate_wav_file(source, path);
+        let file = open_anchored_source(app_paths, note_id, &source, &path, true)
+            .map_err(export_io_error)?;
+        return validate_wav_file(source, path, file);
     }
 
     let expected_canonical_dir = expected_note_dir.join(&source.recording_session_id);
@@ -134,14 +141,17 @@ fn validate_source(
             "A selected audio file is outside its Recording session directory.",
         ));
     }
-    validate_wav_file(source, path)
+    let file =
+        open_anchored_source(app_paths, note_id, &source, &path, false).map_err(export_io_error)?;
+    validate_wav_file(source, path, file)
 }
 
 fn validate_wav_file(
     source: NoteAudioExportSource,
     path: PathBuf,
-) -> Result<NoteAudioExportSource, AppError> {
-    let metadata = fs::metadata(&path).map_err(export_io_error)?;
+    file: File,
+) -> Result<ValidatedSource, AppError> {
+    let metadata = file.metadata().map_err(export_io_error)?;
     if !metadata.is_file()
         || metadata.len() == 0
         || path
@@ -154,20 +164,97 @@ fn validate_wav_file(
             "A selected audio file is not a non-empty WAV file.",
         ));
     }
-    Ok(NoteAudioExportSource { path, ..source })
+    Ok(ValidatedSource {
+        file,
+        recording_session_id: source.recording_session_id,
+        source: source.source,
+    })
 }
 
-fn write_archive(output: &mut File, sources: &[NoteAudioExportSource]) -> Result<(), AppError> {
+#[cfg(unix)]
+fn open_anchored_source(
+    app_paths: &AppPaths,
+    note_id: &str,
+    source: &NoteAudioExportSource,
+    path: &Path,
+    legacy: bool,
+) -> io::Result<File> {
+    use std::{
+        ffi::{CString, OsStr},
+        os::unix::{
+            ffi::OsStrExt,
+            fs::OpenOptionsExt,
+            io::{AsRawFd, FromRawFd, RawFd},
+        },
+    };
+
+    fn open_at(parent: RawFd, name: &OsStr, directory: bool) -> io::Result<File> {
+        let name = CString::new(name.as_bytes())
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains NUL"))?;
+        let flags = libc::O_RDONLY
+            | libc::O_CLOEXEC
+            | libc::O_NOFOLLOW
+            | if directory { libc::O_DIRECTORY } else { 0 };
+        // SAFETY: `parent` is a live directory descriptor, `name` is a
+        // NUL-terminated relative component, and the returned descriptor is
+        // immediately owned by `File` on success.
+        let descriptor = unsafe { libc::openat(parent, name.as_ptr(), flags) };
+        if descriptor < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            // SAFETY: `openat` returned a new owned descriptor.
+            Ok(unsafe { File::from_raw_fd(descriptor) })
+        }
+    }
+
+    let recordings = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW)
+        .open(&app_paths.recordings_dir)?;
+    let note_directory = open_at(recordings.as_raw_fd(), OsStr::new(note_id), true)?;
+    if legacy {
+        return open_at(
+            note_directory.as_raw_fd(),
+            path.file_name()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "missing filename"))?,
+            false,
+        );
+    }
+    let recording_session_directory = open_at(
+        note_directory.as_raw_fd(),
+        OsStr::new(&source.recording_session_id),
+        true,
+    )?;
+    open_at(
+        recording_session_directory.as_raw_fd(),
+        path.file_name()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "missing filename"))?,
+        false,
+    )
+}
+
+#[cfg(not(unix))]
+fn open_anchored_source(
+    _app_paths: &AppPaths,
+    _note_id: &str,
+    _source: &NoteAudioExportSource,
+    path: &Path,
+    _legacy: bool,
+) -> io::Result<File> {
+    File::open(path)
+}
+
+fn write_archive(output: &mut File, sources: &mut [ValidatedSource]) -> Result<(), AppError> {
     let mut archive = ZipWriter::new(output);
     let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
     let mut recording_session_number = 0usize;
-    let mut previous_recording_session: Option<&str> = None;
+    let mut previous_recording_session: Option<String> = None;
     let mut names_per_recording_session = HashMap::<(usize, String), usize>::new();
 
     for source in sources {
-        if previous_recording_session != Some(source.recording_session_id.as_str()) {
+        if previous_recording_session.as_deref() != Some(source.recording_session_id.as_str()) {
             recording_session_number += 1;
-            previous_recording_session = Some(&source.recording_session_id);
+            previous_recording_session = Some(source.recording_session_id.clone());
         }
         let stem = match source.source.as_str() {
             "microphone" => "microphone",
@@ -187,8 +274,7 @@ fn write_archive(output: &mut File, sources: &[NoteAudioExportSource]) -> Result
         archive
             .start_file(entry_name, options)
             .map_err(export_zip_error)?;
-        let mut input = File::open(&source.path).map_err(export_io_error)?;
-        io::copy(&mut input, &mut archive).map_err(export_io_error)?;
+        io::copy(&mut source.file, &mut archive).map_err(export_io_error)?;
     }
     archive.finish().map_err(export_zip_error)?;
     Ok(())
@@ -522,6 +608,38 @@ mod tests {
         .expect_err("cross-Recording-session Source must fail");
         assert_eq!(error.code, "note_audio_export_denied");
         assert_eq!(fs::read_dir(&downloads).expect("downloads").count(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validated_source_keeps_the_opened_file_when_the_path_is_replaced() {
+        use std::os::unix::fs::symlink;
+
+        let (temp, paths, _downloads) = fixture();
+        let wav = recording_file(
+            &paths,
+            NOTE_ID,
+            "session-a",
+            "microphone.wav",
+            b"original bytes",
+        );
+        let mut validated = validate_source(
+            &paths,
+            NOTE_ID,
+            source(wav.clone(), "session-a", "microphone"),
+        )
+        .expect("validated Source");
+        let outside = temp.path().join("outside.wav");
+        fs::write(&outside, b"replacement bytes").expect("outside Source");
+        fs::remove_file(&wav).expect("replace Source path");
+        symlink(&outside, &wav).expect("replacement symlink");
+
+        let mut bytes = Vec::new();
+        validated
+            .file
+            .read_to_end(&mut bytes)
+            .expect("read retained Source");
+        assert_eq!(bytes, b"original bytes");
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/note_audio_export.rs
+++ b/src-tauri/src/note_audio_export.rs
@@ -1,0 +1,429 @@
+use crate::{
+    app_paths::AppPaths,
+    domain::types::{AppError, DownloadNoteAudioResponse},
+};
+use std::{
+    collections::HashMap,
+    fs::{self, File},
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+use tempfile::NamedTempFile;
+use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
+
+const TITLE_MAX_BYTES: usize = 80;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct NoteAudioExportSelection {
+    pub title: String,
+    pub sources: Vec<NoteAudioExportSource>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct NoteAudioExportSource {
+    pub path: PathBuf,
+    pub recording_session_id: String,
+    pub source: String,
+}
+
+pub(crate) fn unavailable_error() -> AppError {
+    AppError::new(
+        "note_audio_unavailable",
+        "This note does not have audio available to download.",
+    )
+}
+
+pub(crate) fn export_note_audio(
+    app_paths: &AppPaths,
+    downloads_dir: &Path,
+    selection: NoteAudioExportSelection,
+) -> Result<DownloadNoteAudioResponse, AppError> {
+    if selection.sources.is_empty() {
+        return Err(unavailable_error());
+    }
+
+    // Validate the entire selection before creating an output file. Export is
+    // all-or-nothing: a partial archive could look complete while silently
+    // omitting one of a note's original Sources.
+    let sources = selection
+        .sources
+        .into_iter()
+        .map(|source| validate_source(app_paths, source))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    fs::create_dir_all(downloads_dir).map_err(export_io_error)?;
+    let title = sanitized_title(&selection.title);
+    let extension = if sources.len() == 1 { "wav" } else { "zip" };
+    let base_name = format!("{title} audio");
+    let mut temporary = NamedTempFile::new_in(downloads_dir).map_err(export_io_error)?;
+
+    if sources.len() == 1 {
+        let mut input = File::open(&sources[0].path).map_err(export_io_error)?;
+        io::copy(&mut input, temporary.as_file_mut()).map_err(export_io_error)?;
+    } else {
+        write_archive(temporary.as_file_mut(), &sources)?;
+    }
+    temporary.as_file_mut().flush().map_err(export_io_error)?;
+
+    let destination = persist_without_overwrite(temporary, downloads_dir, &base_name, extension)?;
+    let file_name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            AppError::new(
+                "note_audio_export_failed",
+                "The downloaded audio filename is not valid UTF-8.",
+            )
+        })?
+        .to_string();
+    Ok(DownloadNoteAudioResponse {
+        path: destination.to_string_lossy().into_owned(),
+        file_name,
+        source_count: sources.len(),
+    })
+}
+
+fn validate_source(
+    app_paths: &AppPaths,
+    source: NoteAudioExportSource,
+) -> Result<NoteAudioExportSource, AppError> {
+    let link_metadata = fs::symlink_metadata(&source.path).map_err(export_io_error)?;
+    if link_metadata.file_type().is_symlink() {
+        return Err(AppError::new(
+            "note_audio_export_denied",
+            "A selected audio file is a symbolic link.",
+        ));
+    }
+    let path = app_paths
+        .contained_recording_file(&source.path)
+        .map_err(export_io_error)?;
+    let metadata = fs::metadata(&path).map_err(export_io_error)?;
+    if !metadata.is_file()
+        || metadata.len() == 0
+        || path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .map_or(true, |extension| !extension.eq_ignore_ascii_case("wav"))
+    {
+        return Err(AppError::new(
+            "note_audio_export_failed",
+            "A selected audio file is not a non-empty WAV file.",
+        ));
+    }
+    Ok(NoteAudioExportSource { path, ..source })
+}
+
+fn write_archive(output: &mut File, sources: &[NoteAudioExportSource]) -> Result<(), AppError> {
+    let mut archive = ZipWriter::new(output);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let mut session_number = 0usize;
+    let mut previous_session: Option<&str> = None;
+    let mut names_per_session = HashMap::<(usize, String), usize>::new();
+
+    for source in sources {
+        if previous_session != Some(source.recording_session_id.as_str()) {
+            session_number += 1;
+            previous_session = Some(&source.recording_session_id);
+        }
+        let stem = match source.source.as_str() {
+            "microphone" => "microphone",
+            "system" => "system",
+            _ => "audio",
+        };
+        let duplicate_number = names_per_session
+            .entry((session_number, stem.to_string()))
+            .and_modify(|count| *count += 1)
+            .or_insert(1);
+        let suffix = if *duplicate_number == 1 {
+            String::new()
+        } else {
+            format!("-{}", duplicate_number)
+        };
+        let entry_name = format!("recording-{session_number:03}/{stem}{suffix}.wav");
+        archive
+            .start_file(entry_name, options)
+            .map_err(export_zip_error)?;
+        let mut input = File::open(&source.path).map_err(export_io_error)?;
+        io::copy(&mut input, &mut archive).map_err(export_io_error)?;
+    }
+    archive.finish().map_err(export_zip_error)?;
+    Ok(())
+}
+
+fn persist_without_overwrite(
+    mut temporary: NamedTempFile,
+    downloads_dir: &Path,
+    base_name: &str,
+    extension: &str,
+) -> Result<PathBuf, AppError> {
+    for collision in 0usize.. {
+        let suffix = if collision == 0 {
+            String::new()
+        } else {
+            format!(" ({collision})")
+        };
+        let destination = downloads_dir.join(format!("{base_name}{suffix}.{extension}"));
+        match temporary.persist_noclobber(&destination) {
+            Ok(_) => return Ok(destination),
+            Err(error) if error.error.kind() == io::ErrorKind::AlreadyExists => {
+                temporary = error.file;
+            }
+            Err(error) => return Err(export_io_error(error.error)),
+        }
+    }
+    unreachable!("the collision counter is unbounded")
+}
+
+fn sanitized_title(title: &str) -> String {
+    let normalized = title
+        .chars()
+        .map(|character| {
+            if character.is_control()
+                || matches!(
+                    character,
+                    '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*'
+                )
+            {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mut sanitized = String::new();
+    for character in normalized.trim_matches(['.', ' ']).chars() {
+        if sanitized.len() + character.len_utf8() > TITLE_MAX_BYTES {
+            break;
+        }
+        sanitized.push(character);
+    }
+    sanitized = sanitized.trim_end_matches(['.', ' ']).to_string();
+    if sanitized.is_empty() || is_windows_reserved_name(&sanitized) {
+        "Meeting notes".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn is_windows_reserved_name(value: &str) -> bool {
+    let stem = value
+        .split('.')
+        .next()
+        .unwrap_or(value)
+        .to_ascii_uppercase();
+    matches!(stem.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+        || stem
+            .strip_prefix("COM")
+            .or_else(|| stem.strip_prefix("LPT"))
+            .is_some_and(|suffix| suffix.len() == 1 && matches!(suffix.as_bytes()[0], b'1'..=b'9'))
+}
+
+fn export_io_error(error: io::Error) -> AppError {
+    if error.kind() == io::ErrorKind::PermissionDenied {
+        AppError::new("note_audio_export_denied", error.to_string())
+    } else {
+        AppError::new("note_audio_export_failed", error.to_string())
+    }
+}
+
+fn export_zip_error(error: zip::result::ZipError) -> AppError {
+    match error {
+        zip::result::ZipError::Io(error) => export_io_error(error),
+        error => AppError::new("note_audio_export_failed", error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Read};
+
+    fn source(path: PathBuf, session: &str, source: &str) -> NoteAudioExportSource {
+        NoteAudioExportSource {
+            path,
+            recording_session_id: session.to_string(),
+            source: source.to_string(),
+        }
+    }
+
+    fn fixture() -> (tempfile::TempDir, AppPaths, PathBuf) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = AppPaths::from_data_dir(temp.path().join("data")).expect("app paths");
+        let downloads = temp.path().join("downloads");
+        fs::create_dir_all(&downloads).expect("downloads");
+        (temp, paths, downloads)
+    }
+
+    fn recording_file(paths: &AppPaths, name: &str, bytes: &[u8]) -> PathBuf {
+        let path = paths.recordings_dir.join(name);
+        fs::write(&path, bytes).expect("write source");
+        path
+    }
+
+    fn selection(title: &str, sources: Vec<NoteAudioExportSource>) -> NoteAudioExportSelection {
+        NoteAudioExportSelection {
+            title: title.to_string(),
+            sources,
+        }
+    }
+
+    #[test]
+    fn single_source_is_copied_exactly_and_never_overwrites() {
+        let (_temp, paths, downloads) = fixture();
+        let wav = recording_file(&paths, "microphone.wav", b"exact wav bytes");
+        fs::write(downloads.join("Planning audio.wav"), b"keep me").expect("collision");
+
+        let result = export_note_audio(
+            &paths,
+            &downloads,
+            selection("Planning", vec![source(wav, "session-a", "microphone")]),
+        )
+        .expect("export");
+
+        assert_eq!(result.file_name, "Planning audio (1).wav");
+        assert_eq!(result.source_count, 1);
+        assert_eq!(
+            fs::read(result.path).expect("read export"),
+            b"exact wav bytes"
+        );
+        assert_eq!(
+            fs::read(downloads.join("Planning audio.wav")).expect("read existing"),
+            b"keep me"
+        );
+    }
+
+    #[test]
+    fn multi_source_archive_has_deterministic_names_and_exact_bytes() {
+        let (_temp, paths, downloads) = fixture();
+        let microphone_a = recording_file(&paths, "mic-a.wav", b"mic a");
+        let microphone_a_duplicate = recording_file(&paths, "mic-a-duplicate.wav", b"mic a 2");
+        let system_a = recording_file(&paths, "system-a.wav", b"system a");
+        let microphone_b = recording_file(&paths, "mic-b.wav", b"mic b");
+
+        let result = export_note_audio(
+            &paths,
+            &downloads,
+            selection(
+                "Weekly sync",
+                vec![
+                    source(microphone_a, "session-a", "microphone"),
+                    source(microphone_a_duplicate, "session-a", "microphone"),
+                    source(system_a, "session-a", "system"),
+                    source(microphone_b, "session-b", "microphone"),
+                ],
+            ),
+        )
+        .expect("export");
+
+        assert_eq!(result.file_name, "Weekly sync audio.zip");
+        assert_eq!(result.source_count, 4);
+        let bytes = fs::read(result.path).expect("read archive");
+        let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).expect("open archive");
+        let expected = [
+            ("recording-001/microphone.wav", b"mic a".as_slice()),
+            ("recording-001/microphone-2.wav", b"mic a 2".as_slice()),
+            ("recording-001/system.wav", b"system a".as_slice()),
+            ("recording-002/microphone.wav", b"mic b".as_slice()),
+        ];
+        assert_eq!(archive.len(), expected.len());
+        for (index, (name, expected_bytes)) in expected.iter().enumerate() {
+            let mut entry = archive.by_index(index).expect("entry");
+            let mut actual = Vec::new();
+            entry.read_to_end(&mut actual).expect("entry bytes");
+            assert_eq!(entry.name(), *name);
+            assert_eq!(actual, *expected_bytes);
+            assert_eq!(entry.compression(), CompressionMethod::Stored);
+        }
+    }
+
+    #[test]
+    fn unsafe_empty_long_and_reserved_titles_are_portable() {
+        assert_eq!(sanitized_title("  Team: sync?/now.  "), "Team sync now");
+        assert_eq!(sanitized_title("<>:\"/\\|?*\0"), "Meeting notes");
+        assert_eq!(sanitized_title("CON.txt"), "Meeting notes");
+        assert_eq!(sanitized_title(&"a".repeat(100)).len(), TITLE_MAX_BYTES);
+        assert!(sanitized_title(&"😀".repeat(100)).len() <= TITLE_MAX_BYTES);
+    }
+
+    #[test]
+    fn empty_selection_is_unavailable_without_creating_output() {
+        let (_temp, paths, downloads) = fixture();
+        let error = export_note_audio(&paths, &downloads, selection("Empty", Vec::new()))
+            .expect_err("empty selection");
+        assert_eq!(error.code, "note_audio_unavailable");
+        assert_eq!(fs::read_dir(downloads).expect("downloads").count(), 0);
+    }
+
+    #[test]
+    fn invalid_source_aborts_without_leaving_output_or_temporary_file() {
+        let (_temp, paths, downloads) = fixture();
+        let valid = recording_file(&paths, "valid.wav", b"valid");
+        let missing = paths.recordings_dir.join("missing.wav");
+
+        let error = export_note_audio(
+            &paths,
+            &downloads,
+            selection(
+                "Partial",
+                vec![
+                    source(valid, "session-a", "microphone"),
+                    source(missing, "session-a", "system"),
+                ],
+            ),
+        )
+        .expect_err("missing source must fail");
+
+        assert_eq!(error.code, "note_audio_export_failed");
+        assert_eq!(fs::read_dir(&downloads).expect("downloads").count(), 0);
+    }
+
+    #[test]
+    fn outside_and_non_wav_sources_are_rejected() {
+        let (temp, paths, downloads) = fixture();
+        let outside = temp.path().join("outside.wav");
+        fs::write(&outside, b"outside").expect("outside");
+        let error = export_note_audio(
+            &paths,
+            &downloads,
+            selection("Outside", vec![source(outside, "session-a", "microphone")]),
+        )
+        .expect_err("outside must fail");
+        assert_eq!(error.code, "note_audio_export_denied");
+
+        let wrong_extension = recording_file(&paths, "audio.mp3", b"not wav");
+        let error = export_note_audio(
+            &paths,
+            &downloads,
+            selection(
+                "Wrong format",
+                vec![source(wrong_extension, "session-a", "microphone")],
+            ),
+        )
+        .expect_err("non-wav must fail");
+        assert_eq!(error.code, "note_audio_export_failed");
+        assert_eq!(fs::read_dir(&downloads).expect("downloads").count(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symbolic_link_source_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let (_temp, paths, downloads) = fixture();
+        let target = recording_file(&paths, "target.wav", b"target");
+        let link = paths.recordings_dir.join("link.wav");
+        symlink(target, &link).expect("symlink");
+
+        let error = export_note_audio(
+            &paths,
+            &downloads,
+            selection("Link", vec![source(link, "session-a", "microphone")]),
+        )
+        .expect_err("symlink must fail");
+        assert_eq!(error.code, "note_audio_export_denied");
+        assert_eq!(fs::read_dir(&downloads).expect("downloads").count(), 0);
+    }
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -272,6 +272,15 @@ const ROUTINE_FUNDING_DISABLED_REASON = "Add credits before running a routine.";
 // crush it into a sliver — it always keeps a usable width plus its gutters.
 const MAIN_PANEL_MIN_WIDTH = 420;
 
+function noteHasDownloadableAudio(note: NoteDto): boolean {
+  const audioSources = note.audioSources?.length
+    ? note.audioSources
+    : note.audio
+      ? [note.audio]
+      : [];
+  return audioSources.some((audio) => audio.format === "wav" && audio.sizeBytes > 0);
+}
+
 // Largest the sidebar may grow given the live window width: never past its own
 // cap, and never so far that the main panel drops below its floor. Falls back
 // to the sidebar min on very narrow windows where both can't be satisfied.
@@ -1101,9 +1110,7 @@ export function App() {
       }
       onExportPdf={() => void handleExportNotePdf()}
       onDownloadAudio={
-        Boolean(selectedNote.audio || selectedNote.audioSources?.length)
-          ? () => void handleDownloadNoteAudio()
-          : undefined
+        noteHasDownloadableAudio(selectedNote) ? () => void handleDownloadNoteAudio() : undefined
       }
       onDelete={() => setConfirmDeleteNote(true)}
     />

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -30,6 +30,7 @@ import { MoveNoteToFolderDialog } from "../components/folders/MoveNoteToFolderDi
 import { MoveSessionToProjectDialog } from "../components/folders/MoveSessionToProjectDialog";
 import { NoteEditor } from "../components/note-editor/NoteEditor";
 import { NoteHeaderActions } from "../components/note-editor/NoteHeaderActions";
+import { toast } from "../components/ui/Toaster";
 import { exportNoteAsPdf } from "../lib/note-pdf";
 import { NoteChatPanel } from "../components/note-chat/NoteChatPanel";
 import { useNoteChat } from "../components/note-chat/useNoteChat";
@@ -75,6 +76,7 @@ import {
   deleteNote,
   deleteNotes,
   dictationHelperCommand,
+  downloadNoteAudio,
   ensureHermesBridgeSession,
   finishRecording,
   getRecordingStatus,
@@ -89,6 +91,7 @@ import {
   removeNoteFromFolder,
   removeSessionFromFolder,
   recoverRecording,
+  revealPath,
   renameFolder,
   resolveAgentRecorderRequest,
   resumeRecording,
@@ -1068,6 +1071,24 @@ export function App() {
           : undefined,
     });
   }
+  async function handleDownloadNoteAudio() {
+    if (!selectedNote) return;
+    try {
+      const result = await downloadNoteAudio(selectedNote.id);
+      toast.success("Audio downloaded", {
+        action: {
+          label: "Show file",
+          onClick: () => {
+            void revealPath(result.path).catch((err: unknown) => {
+              toast.error(messageFromError(err));
+            });
+          },
+        },
+      });
+    } catch (err) {
+      toast.error(messageFromError(err));
+    }
+  }
   const noteToolbarActions = selectedNote ? (
     <NoteHeaderActions
       noteId={selectedNote.id}
@@ -1079,6 +1100,11 @@ export function App() {
         noteReadyToShare(selectedNote.processingStatus) ? () => setShareNoteOpen(true) : undefined
       }
       onExportPdf={() => void handleExportNotePdf()}
+      onDownloadAudio={
+        Boolean(selectedNote.audio || selectedNote.audioSources?.length)
+          ? () => void handleDownloadNoteAudio()
+          : undefined
+      }
       onDelete={() => setConfirmDeleteNote(true)}
     />
   ) : null;

--- a/src/components/note-editor/NoteHeaderActions.tsx
+++ b/src/components/note-editor/NoteHeaderActions.tsx
@@ -1,5 +1,6 @@
 import { IconBubble3 } from "central-icons/IconBubble3";
 import { IconArrowShareRight } from "central-icons/IconArrowShareRight";
+import { IconAudio } from "central-icons/IconAudio";
 import { IconDotGrid1x3Horizontal } from "central-icons/IconDotGrid1x3Horizontal";
 import { IconFilePdf } from "central-icons/IconFilePdf";
 import { IconReference } from "central-icons/IconReference";
@@ -21,6 +22,7 @@ export function NoteHeaderActions({
   onAskJune,
   onShare,
   onExportPdf,
+  onDownloadAudio,
   onDelete,
 }: {
   noteId: string;
@@ -35,6 +37,8 @@ export function NoteHeaderActions({
   onShare?: () => void;
   /** Opens the system print sheet with a PDF-ready version of the note. */
   onExportPdf?: () => void;
+  /** Downloads the note's finalized audio artifacts. */
+  onDownloadAudio?: () => void;
   /** Opens the delete-note confirmation. */
   onDelete?: () => void;
 }) {
@@ -67,6 +71,7 @@ export function NoteHeaderActions({
         noteId={noteId}
         noteTitle={noteTitle}
         onExportPdf={onExportPdf}
+        onDownloadAudio={onDownloadAudio}
         onDelete={onDelete}
       />
     </div>
@@ -77,11 +82,13 @@ function NoteOverflowMenu({
   noteId,
   noteTitle,
   onExportPdf,
+  onDownloadAudio,
   onDelete,
 }: {
   noteId: string;
   noteTitle: string;
   onExportPdf?: () => void;
+  onDownloadAudio?: () => void;
   onDelete?: () => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -149,6 +156,19 @@ function NoteOverflowMenu({
             >
               <IconFilePdf size={14} />
               Export as PDF
+            </button>
+          ) : null}
+          {onDownloadAudio ? (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false);
+                onDownloadAudio();
+              }}
+            >
+              <IconAudio size={14} />
+              Download audio
             </button>
           ) : null}
           {onDelete ? (

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -387,7 +387,7 @@ export type RecordingSessionDto = {
 export type AudioArtifactDto = {
   id: string;
   source?: RecordingSource;
-  format: "wav";
+  format: string;
   durationMs: number;
   sizeBytes: number;
   checksum: string;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -394,6 +394,12 @@ export type AudioArtifactDto = {
   createdAt: string;
 };
 
+export type DownloadNoteAudioResponse = {
+  path: string;
+  fileName: string;
+  sourceCount: number;
+};
+
 export type NoteDto = NoteListItemDto & {
   generatedContent?: string;
   editedContent?: string;
@@ -1577,6 +1583,12 @@ export async function listNotes(folderId?: string, limit?: number) {
 
 export async function getNote(noteId: string) {
   return invoke<NoteDto>("get_note", { request: { noteId } });
+}
+
+export async function downloadNoteAudio(noteId: string) {
+  return invoke<DownloadNoteAudioResponse>("download_note_audio", {
+    request: { noteId },
+  });
 }
 
 export async function deleteNote(noteId: string) {

--- a/src/test/agent-note-entry-points.test.ts
+++ b/src/test/agent-note-entry-points.test.ts
@@ -185,6 +185,33 @@ describe("note header actions", () => {
 
     expect(onExportPdf).toHaveBeenCalledTimes(1);
   });
+
+  it("downloads audio once and closes the actions menu", async () => {
+    const user = userEvent.setup();
+    const onDownloadAudio = vi.fn();
+    render(
+      createElement(NoteHeaderActions, {
+        noteId: "note-1",
+        noteTitle: "Launch plan",
+        onDownloadAudio,
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Note actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Download audio" }));
+
+    expect(onDownloadAudio).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("omits audio download when no handler is provided", async () => {
+    const user = userEvent.setup();
+    render(createElement(NoteHeaderActions, { noteId: "note-1", noteTitle: "Launch plan" }));
+
+    await user.click(screen.getByRole("button", { name: "Note actions" }));
+
+    expect(screen.queryByRole("menuitem", { name: "Download audio" })).not.toBeInTheDocument();
+  });
 });
 
 describe("composer note reference trigger", () => {

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -38,6 +38,8 @@ const mocks = vi.hoisted(() => ({
   getNote: vi.fn(),
   deleteNote: vi.fn(),
   deleteNotes: vi.fn(),
+  downloadNoteAudio: vi.fn(),
+  revealPath: vi.fn(),
   updateNote: vi.fn(),
   checkRecordingSourceReadiness: vi.fn(),
   openPrivacySettings: vi.fn(),
@@ -67,6 +69,13 @@ const mocks = vi.hoisted(() => ({
   playRecordingSound: vi.fn(),
   preloadRecordingSounds: vi.fn(),
   preloadAgentSounds: vi.fn(),
+  toast: Object.assign(vi.fn(), {
+    dismiss: vi.fn(),
+    error: vi.fn(),
+    loading: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  }),
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -84,6 +93,10 @@ vi.mock("../lib/recording-sounds", () => ({
 
 vi.mock("../lib/agent-sounds", () => ({
   preloadAgentSounds: mocks.preloadAgentSounds,
+}));
+
+vi.mock("../components/ui/Toaster", () => ({
+  toast: mocks.toast,
 }));
 
 vi.mock("../lib/tauri", () => ({
@@ -117,6 +130,8 @@ vi.mock("../lib/tauri", () => ({
   getNote: mocks.getNote,
   deleteNote: mocks.deleteNote,
   deleteNotes: mocks.deleteNotes,
+  downloadNoteAudio: mocks.downloadNoteAudio,
+  revealPath: mocks.revealPath,
   updateNote: mocks.updateNote,
   checkRecordingSourceReadiness: mocks.checkRecordingSourceReadiness,
   openPrivacySettings: mocks.openPrivacySettings,
@@ -262,6 +277,12 @@ describe("notes recording reliability", () => {
     mocks.createNote.mockResolvedValue(first);
     mocks.deleteNote.mockResolvedValue(undefined);
     mocks.deleteNotes.mockResolvedValue(undefined);
+    mocks.downloadNoteAudio.mockResolvedValue({
+      path: "/Users/alex/Downloads/First note audio.wav",
+      fileName: "First note audio.wav",
+      sourceCount: 1,
+    });
+    mocks.revealPath.mockResolvedValue(undefined);
     mocks.listNotes.mockResolvedValue({ items: [first, second] });
     mocks.getNote.mockImplementation(async (noteId: string) =>
       noteId === "note-2" ? second : first,
@@ -358,6 +379,117 @@ describe("notes recording reliability", () => {
       expect(mocks.startRecording).toHaveBeenCalledWith("note-1", "microphonePlusSystem");
     });
   }
+
+  it("hides audio download when the selected note has no finalized audio", async () => {
+    render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    await userEvent.click(await screen.findByRole("button", { name: "Meeting notes" }));
+    await userEvent.click(screen.getByRole("button", { name: /First note Preview/ }));
+
+    await userEvent.click(screen.getByRole("button", { name: "Note actions" }));
+
+    expect(screen.queryByRole("menuitem", { name: "Download audio" })).not.toBeInTheDocument();
+  });
+
+  it("downloads selected note audio and reveals the saved file from the success toast", async () => {
+    const noteWithAudio = note({
+      audioSources: [
+        {
+          id: "audio-1",
+          source: "microphone",
+          format: "wav",
+          durationMs: 1000,
+          sizeBytes: 2048,
+          checksum: "abc",
+          createdAt: now,
+        },
+      ],
+    });
+    mocks.bootstrapApp.mockResolvedValue({
+      folders: [],
+      notes: [noteWithAudio, second],
+      activeRecoveries: [],
+      providerConfigured: true,
+    });
+    mocks.getNote.mockImplementation(async (noteId: string) =>
+      noteId === "note-2" ? second : noteWithAudio,
+    );
+
+    render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    await userEvent.click(await screen.findByRole("button", { name: "Meeting notes" }));
+    await userEvent.click(screen.getByRole("button", { name: /First note Preview/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Note actions" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Download audio" }));
+
+    await waitFor(() => expect(mocks.downloadNoteAudio).toHaveBeenCalledWith("note-1"));
+    expect(mocks.toast.success).toHaveBeenCalledWith("Audio downloaded", {
+      action: {
+        label: "Show file",
+        onClick: expect.any(Function),
+      },
+    });
+
+    const toastOptions = mocks.toast.success.mock.calls[0]?.[1] as {
+      action: { onClick: () => void };
+    };
+    toastOptions.action.onClick();
+
+    await waitFor(() =>
+      expect(mocks.revealPath).toHaveBeenCalledWith("/Users/alex/Downloads/First note audio.wav"),
+    );
+  });
+
+  it("shows download and reveal failures as error toasts", async () => {
+    const noteWithAudio = note({
+      audio: {
+        id: "audio-1",
+        source: "microphone",
+        format: "wav",
+        durationMs: 1000,
+        sizeBytes: 2048,
+        checksum: "abc",
+        createdAt: now,
+      },
+    });
+    mocks.bootstrapApp.mockResolvedValue({
+      folders: [],
+      notes: [noteWithAudio, second],
+      activeRecoveries: [],
+      providerConfigured: true,
+    });
+    mocks.getNote.mockImplementation(async (noteId: string) =>
+      noteId === "note-2" ? second : noteWithAudio,
+    );
+    mocks.downloadNoteAudio.mockRejectedValueOnce(new Error("Audio download failed"));
+
+    render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    await userEvent.click(await screen.findByRole("button", { name: "Meeting notes" }));
+    await userEvent.click(screen.getByRole("button", { name: /First note Preview/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Note actions" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Download audio" }));
+
+    await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith("Audio download failed"));
+
+    mocks.toast.error.mockClear();
+    mocks.downloadNoteAudio.mockResolvedValueOnce({
+      path: "/Users/alex/Downloads/First note audio.wav",
+      fileName: "First note audio.wav",
+      sourceCount: 1,
+    });
+    mocks.revealPath.mockRejectedValueOnce(new Error("Could not show file"));
+    await userEvent.click(screen.getByRole("button", { name: "Note actions" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Download audio" }));
+    await waitFor(() => expect(mocks.toast.success).toHaveBeenCalled());
+
+    const latestToastOptions = mocks.toast.success.mock.calls.at(-1)?.[1] as {
+      action: { onClick: () => void };
+    };
+    latestToastOptions.action.onClick();
+
+    await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith("Could not show file"));
+  });
 
   it("stays on meeting notes after deleting the last note", async () => {
     mocks.bootstrapApp.mockResolvedValue({

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -391,6 +391,42 @@ describe("notes recording reliability", () => {
     expect(screen.queryByRole("menuitem", { name: "Download audio" })).not.toBeInTheDocument();
   });
 
+  it.each([
+    { format: "wav", sizeBytes: 0, label: "an empty WAV" },
+    { format: "mp3", sizeBytes: 2048, label: "a non-WAV artifact" },
+  ])("hides audio download for $label", async ({ format, sizeBytes }) => {
+    const noteWithoutDownloadableAudio = note({
+      audioSources: [
+        {
+          id: "audio-1",
+          source: "microphone",
+          format,
+          durationMs: 1000,
+          sizeBytes,
+          checksum: "abc",
+          createdAt: now,
+        },
+      ],
+    });
+    mocks.bootstrapApp.mockResolvedValue({
+      folders: [],
+      notes: [noteWithoutDownloadableAudio, second],
+      activeRecoveries: [],
+      providerConfigured: true,
+    });
+    mocks.getNote.mockImplementation(async (noteId: string) =>
+      noteId === "note-2" ? second : noteWithoutDownloadableAudio,
+    );
+
+    render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    await userEvent.click(await screen.findByRole("button", { name: "Meeting notes" }));
+    await userEvent.click(screen.getByRole("button", { name: /First note Preview/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Note actions" }));
+
+    expect(screen.queryByRole("menuitem", { name: "Download audio" })).not.toBeInTheDocument();
+  });
+
   it("downloads selected note audio and reveals the saved file from the success toast", async () => {
     const noteWithAudio = note({
       audioSources: [

--- a/src/test/tauri-contract.test.ts
+++ b/src/test/tauri-contract.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   checkRecordingSourceReadiness,
+  downloadNoteAudio,
   ensureHermesBridgeGateway,
   finishRecording,
   getNote,
@@ -44,6 +45,20 @@ describe("Tauri command contracts", () => {
         editedContent: "Manual notes",
         activeTab: "transcription",
       },
+    });
+  });
+
+  it("downloads note audio through a note-scoped request", async () => {
+    const response = {
+      path: "/tmp/First note audio.wav",
+      fileName: "First note audio.wav",
+      sourceCount: 1,
+    };
+    mocks.invoke.mockResolvedValue(response);
+
+    await expect(downloadNoteAudio("note-1")).resolves.toEqual(response);
+    expect(mocks.invoke).toHaveBeenCalledWith("download_note_audio", {
+      request: { noteId: "note-1" },
     });
   });
 


### PR DESCRIPTION
## Summary

- Add a Note overflow action that downloads original finalized WAV audio when audio is available.
- Preserve exact bytes for one Source and create a deterministic, stored ZIP for multiple Sources across Recording sessions.
- Add security-sensitive Note ownership, path confinement, retained-handle, reparse/symlink, atomic-write, and no-overwrite protections across macOS, Linux, and Windows.

Closes JUN-272

## Root cause

The Note view exposed audio metadata for processing and retry behavior, but it had no Note-scoped export contract. Original audio is stored as separate Source artifacts across current and legacy Recording session layouts, so a safe download also needed deterministic aggregation, ownership checks, and path-safe file handling rather than a direct frontend path copy.

## Validation

- `make verify` - passed (Biome, typecheck, 2,955 frontend tests, native Rust fmt/clippy and 970 tests with 5 ignored, June API fmt/clippy/tests).
- `make local-ci` - passed and posted `signoff/frontend` and `signoff/rust-macos` for `39e6aa0e`.
- `python3 scripts/check-cargo-release-age.py --base origin/main` - passed with the system CA bundle.
- Rust 1.80 isolated compile checks passed for the Windows handle API and the exact stored-ZIP API.
- High-stakes local review battery converged with two consecutive clean adversarial passes, followed by clean final Standards and Spec passes.
- Agent-driven browser walkthrough verified hidden-without-audio, visible-with-audio, the exact `{ noteId }` IPC request, success feedback, and Show file behavior. The recording is attached in a PR comment.
- Full Windows application cross-compilation from macOS was blocked by the missing Windows C SDK in `ring`; the Windows-specific helper itself compiled for `x86_64-pc-windows-msvc`, and hosted Windows CI remains the end-to-end platform check.

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end. No June API deploy is required.

## Out of scope

- Mixing Sources into one audio file.
- Audio playback or Source selection in the Note view.
- Exporting recovery-only files that are not finalized Note audio artifacts.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs (no workflow actions changed).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (none changed).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (none changed).
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786897875&installation_id=144203540&pr_number=824&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F824&signature=87bfd81098b83bcf8d33615f58784163c0dade3a23242cec4a213ef857bfa150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->