### PR TITLE
Restore push-to-talk start feedback

### DIFF
--- a/.agents/skills/repo-review/CALIBRATION.md
+++ b/.agents/skills/repo-review/CALIBRATION.md
@@ -145,3 +145,6 @@ data-driven: discount reviewer patterns with a bad true/findings ratio
 | #825 | Standards (publication convergence) | 1 | 1 | caught unqualified agent terminology in new lock-order prose and smoke identifiers; renamed it to Hermes instance and slash worker vocabulary before final provenance sealing |
 | #825 | Spec (reset readiness convergence) | 1 | 1 | reproduced successful reset publishing a replacement while obsolete lazy construction kept agent_ready unset; drove reset-owned readiness after slash worker publication plus a slow-build regression |
 | #825 | Codex (bot, reset attachment convergence) | 1 | 1 | found image byte attachment read stale agent_error before joining reset's history lock; drove an atomic error check inside queue ownership plus stale-error reset interleaving coverage |
+| #826 | Standards (codex, r1+final) | 0 | — | clean on the native cue sequencing, HUD state ownership, tests, and comments |
+| #826 | Spec (codex, r1+final) | 2 | 2 | found interrupted start cues losing normal stop feedback and the actionable HUD error being latched only after an await; final clean |
+| #826 | Adversarial (codex, iterative) | 3 | 3 | documented the deliberate 300 ms start-speaking boundary, then found the short-press discard bypass and a stale error continuation hiding a newer listening HUD; convergence approved |

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -1709,12 +1709,7 @@ final class DictationController {
         // never calling back); erroring not_listening here would wedge the
         // pending flag until a helper restart.
         if startPending && !isListening {
-            dictationStartGeneration += 1
-            let interruptedStartCue = RecordingCuePlayer.cancel(.start)
-            resetRecordingState()
-            if interruptedStartCue {
-                RecordingCuePlayer.play(.stop)
-            }
+            cancelAndResetRecording()
             emit("recording_discarded", ["reason": "start_cancelled"])
             return
         }
@@ -1788,13 +1783,10 @@ final class DictationController {
     func discard() {
         // Cancel any start still waiting on the permission prompt — the
         // graze is over, so a later grant must not open the microphone.
-        dictationStartGeneration += 1
-        startPending = false
         // The HUD shows on listening_started, so a discard that interrupts a
         // live recording (a grazed push-to-talk key, a signed-out session)
         // must announce itself or the HUD stays stuck on "Listening".
-        let wasListening = isListening
-        resetRecordingState()
+        let wasListening = cancelAndResetRecording()
         if wasListening {
             emit("recording_discarded")
         }
@@ -2158,6 +2150,18 @@ final class DictationController {
         }
         try? FileManager.default.removeItem(at: micTestSampleURL)
         self.micTestSampleURL = nil
+    }
+
+    @discardableResult
+    private func cancelAndResetRecording() -> Bool {
+        dictationStartGeneration += 1
+        let interruptedStartCue = RecordingCuePlayer.cancel(.start)
+        let wasListening = isListening
+        resetRecordingState()
+        if interruptedStartCue {
+            RecordingCuePlayer.play(.stop)
+        }
+        return wasListening
     }
 
     private func resetRecordingState(keepRecordingFile: Bool = false) {

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -238,13 +238,15 @@ enum RecordingCuePlayer {
         }
     }
 
-    static func cancel(_ cue: RecordingCueSound) {
-        completions.removeValue(forKey: cue)?.cancel()
+    @discardableResult
+    static func cancel(_ cue: RecordingCueSound) -> Bool {
+        let wasWaitingForCompletion = completions.removeValue(forKey: cue) != nil
         guard let sound = sounds[cue] else {
-            return
+            return wasWaitingForCompletion
         }
         sound.delegate = nil
         sound.stop()
+        return wasWaitingForCompletion
     }
 
     private static func load(_ cue: RecordingCueSound) -> NSSound? {
@@ -1708,8 +1710,11 @@ final class DictationController {
         // pending flag until a helper restart.
         if startPending && !isListening {
             dictationStartGeneration += 1
-            RecordingCuePlayer.cancel(.start)
+            let interruptedStartCue = RecordingCuePlayer.cancel(.start)
             resetRecordingState()
+            if interruptedStartCue {
+                RecordingCuePlayer.play(.stop)
+            }
             emit("recording_discarded", ["reason": "start_cancelled"])
             return
         }

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -1656,7 +1656,7 @@ final class DictationController {
     /// sees the mismatch and does nothing.
     private var dictationStartGeneration = 0
 
-    func start(playCue: Bool) {
+    func start() {
         if startPending {
             return
         }
@@ -1693,16 +1693,10 @@ final class DictationController {
                     self.startPending = false
                     self.startRecording(purpose: .dictation, durationSeconds: nil)
                 }
-                if playCue {
-                    // Toggle dictation has no key-up timing contract, so its
-                    // cue can finish before capture starts without entering
-                    // the recording. Push-to-talk skips this cue and calls
-                    // beginRecording immediately so the down edge remains
-                    // the start of capture.
-                    RecordingCuePlayer.play(.start, completion: beginRecording)
-                } else {
-                    beginRecording()
-                }
+                // The cue defines the start-speaking boundary and finishes
+                // before capture begins, keeping June's own sound out of the
+                // recording while providing feedback for every start mode.
+                RecordingCuePlayer.play(.start, completion: beginRecording)
             }
         }
     }
@@ -1733,7 +1727,7 @@ final class DictationController {
             stop()
         } else if !isFinalizing {
             emit("hotkey_trigger", ["action": "start", "shortcut": shortcut])
-            start(playCue: true)
+            start()
         }
     }
 
@@ -2409,7 +2403,7 @@ func handleCommandLine(_ line: String) {
         }
     case "start_listening":
         runOnMain {
-            dictation.start(playCue: false)
+            dictation.start()
         }
     case "stop_and_paste":
         runOnMain {

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -205,11 +205,15 @@ let lastHoldAt = 0; // performance.now() of the previous peak-hold update
 
 type HudTransition = {
   changed: boolean;
+  id: number;
   previous?: string;
 };
 
+let hudTransitionId = 0;
+
 function setHud(state: string, status: string): HudTransition {
-  if (!hud || !statusText) return { changed: false };
+  const id = ++hudTransitionId;
+  if (!hud || !statusText) return { changed: false, id };
   const previous = hud.dataset.state;
   hud.dataset.state = state;
   statusText.textContent = status;
@@ -251,7 +255,7 @@ function setHud(state: string, status: string): HudTransition {
     }
     if (state === "meeting") clearStopHover();
   }
-  return { changed: state !== previous, previous };
+  return { changed: state !== previous, id, previous };
 }
 
 async function updateErrorPlacement() {
@@ -937,11 +941,13 @@ async function handleDictationEventPayload(payload: unknown) {
     // can arrive during that IPC call, and its secondary not_listening error
     // must not dismiss the actionable start failure.
     await updateErrorPlacement();
+    if (transition.id !== hudTransitionId) return;
     // Render the pill with the message layer drawn in, snap the window to
     // the full (layer-included) size with no native motion, then draw the
     // layer out in CSS — the pill never moves and nothing clips.
     hud?.classList.add("hud-reveal-collapsed");
     await showHud({ fresh: pillIsBlank(transition.previous) });
+    if (transition.id !== hudTransitionId) return;
     playErrorReveal();
     triggerShake();
     // Hold long enough for the shake to finish and the message to read.

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -909,8 +909,12 @@ async function handleDictationEventPayload(payload: unknown) {
     // Stop with nothing running (a stop racing a session that already
     // ended, or the demo pill's stop button hitting the real helper): the
     // desired end state — not listening — is already true, so there is
-    // nothing to tell the user. Take the quiet exit.
+    // nothing to tell the user. If key-down already produced a useful error
+    // (for example, missing microphone permission), preserve that error until
+    // its normal timeout instead of letting the secondary key-up failure hide
+    // it immediately.
     if (dictationEvent.payload?.code === "not_listening") {
+      if (hud?.dataset.state === "error") return;
       void hideHud();
       return;
     }

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -932,8 +932,11 @@ async function handleDictationEventPayload(payload: unknown) {
       return;
     }
     const message = String(dictationEvent.payload?.message ?? "Dictation failed.").trim();
-    await updateErrorPlacement();
     const transition = setHud("error", message || "Dictation failed.");
+    // Latch the error state before awaiting native placement. A key-up event
+    // can arrive during that IPC call, and its secondary not_listening error
+    // must not dismiss the actionable start failure.
+    await updateErrorPlacement();
     // Render the pill with the message layer drawn in, snap the window to
     // the full (layer-included) size with no native motion, then draw the
     // layer out in CSS — the pill never moves and nothing clips.

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -424,11 +424,31 @@ describe("meeting detection HUD", () => {
     vi.useFakeTimers();
     await loadHud();
 
-    await emit("dictation-event", {
+    let resolvePlacement: ((placement: string) => void) | undefined;
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "dictation_hud_preferred_error_placement") {
+        return new Promise<string>((resolve) => {
+          resolvePlacement = resolve;
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const startError = emit("dictation-event", {
       type: "error",
       payload: {
         code: "microphone_permission_missing",
         message: "Microphone permission is required.",
+      },
+    });
+
+    // The key-up error can arrive before native window placement resolves.
+    expect(hudElement().dataset.state).toBe("error");
+    await emit("dictation-event", {
+      type: "error",
+      payload: {
+        code: "not_listening",
+        message: "Dictation is not listening.",
       },
     });
 
@@ -438,13 +458,8 @@ describe("meeting detection HUD", () => {
     );
     mocks.hide.mockClear();
 
-    await emit("dictation-event", {
-      type: "error",
-      payload: {
-        code: "not_listening",
-        message: "Dictation is not listening.",
-      },
-    });
+    resolvePlacement?.("below");
+    await startError;
 
     expect(hudElement().dataset.state).toBe("error");
     expect(document.querySelector("#hud-error-text")).toHaveTextContent(

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -420,6 +420,43 @@ describe("meeting detection HUD", () => {
     expect(mocks.hide).toHaveBeenCalledOnce();
   });
 
+  it("preserves the actionable start error when key-up finds nothing listening", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+
+    await emit("dictation-event", {
+      type: "error",
+      payload: {
+        code: "microphone_permission_missing",
+        message: "Microphone permission is required.",
+      },
+    });
+
+    expect(hudElement().dataset.state).toBe("error");
+    expect(document.querySelector("#hud-error-text")).toHaveTextContent(
+      "Microphone permission is required.",
+    );
+    mocks.hide.mockClear();
+
+    await emit("dictation-event", {
+      type: "error",
+      payload: {
+        code: "not_listening",
+        message: "Dictation is not listening.",
+      },
+    });
+
+    expect(hudElement().dataset.state).toBe("error");
+    expect(document.querySelector("#hud-error-text")).toHaveTextContent(
+      "Microphone permission is required.",
+    );
+    expect(mocks.hide).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1_800);
+    await vi.advanceTimersByTimeAsync(320);
+    expect(mocks.hide).toHaveBeenCalledOnce();
+  });
+
   it("uses agent-style frostless chrome for the compact listening pill", async () => {
     await loadHud();
 

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -472,6 +472,41 @@ describe("meeting detection HUD", () => {
     expect(mocks.hide).toHaveBeenCalledOnce();
   });
 
+  it("does not let a delayed start error hide a newer listening state", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+    mocks.hide.mockClear();
+
+    let resolvePlacement: ((placement: string) => void) | undefined;
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "dictation_hud_preferred_error_placement") {
+        return new Promise<string>((resolve) => {
+          resolvePlacement = resolve;
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const startError = emit("dictation-event", {
+      type: "error",
+      payload: {
+        code: "microphone_permission_missing",
+        message: "Microphone permission is required.",
+      },
+    });
+    expect(hudElement().dataset.state).toBe("error");
+
+    void emit("dictation-event", { type: "listening_started" });
+    expect(hudElement().dataset.state).toBe("listening");
+
+    resolvePlacement?.("below");
+    await startError;
+    await vi.advanceTimersByTimeAsync(2_200);
+
+    expect(hudElement().dataset.state).toBe("listening");
+    expect(mocks.hide).not.toHaveBeenCalled();
+  });
+
   it("uses agent-style frostless chrome for the compact listening pill", async () => {
     await loadHud();
 


### PR DESCRIPTION
## What changed

- Restore the audible start cue for push-to-talk dictation.
- Finish the start cue before microphone capture begins so June's own sound is not transcribed.
- Preserve normal stop feedback when either the stop or short-press discard path interrupts a start cue.
- Keep actionable HUD errors visible through release-edge and retry races.
- Add regression coverage for concurrent error placement, key-up, and a newer listening state.

## Why

June already had macOS microphone permission. The primary regression was introduced when push-to-talk deliberately skipped the start cue to prevent June from recording its own sound. That removed the user's start-speaking signal.

The updated flow treats the 300 ms cue as the start-speaking boundary, then begins capture. It preserves the phantom-text protection while restoring clear feedback.

## Validation

- `make local-ci` (frontend and Rust macOS signoffs green on `ac7271ca`)
- `pnpm exec vitest run src/test/hud-meeting.test.ts` (34 passed)
- `cargo check --manifest-path src-tauri/Cargo.toml` (native macOS dictation helper compiled)
- Independent Standards review: clean
- Independent Spec review: clean
- Independent Adversarial convergence review: approve, no material findings
- Browser walkthrough against `hud.html` with synthetic permission and key-up events: PASS. The actionable error remained visible, with no browser console errors.

## QA evidence

- Local no-audio recording: `.tmp/qa-recordings/push-to-talk-error/page@c977d27e8eab84148857c14b49a8110f.compressed.mp4`
- Local screenshot: `.tmp/qa-screenshots/push-to-talk-error-preserved.png`
- The artifacts were not uploaded publicly because public QA sharing was not explicitly authorized.

## Gaps

- Native push-to-talk audio was not recorded during QA because microphone capture requires explicit approval.
- The start cue and sequencing were verified through the compiled native helper, source-level event ordering, deterministic tests, and review. A user-device audio check remains the final hardware confirmation.
