### PR TITLE
Keep long streamed responses from losing their opening

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -361,6 +361,7 @@ import {
   stripAgentCliAccessRequest,
 } from "../../lib/agent-cli-access";
 import {
+  appendHermesLiveEvent,
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
   displayedComposerUserMessageText,
@@ -6852,10 +6853,10 @@ export function AgentWorkspace({
       // unconditional call is safe for every kind. Mode rides along so each
       // artifact can show its blast radius (sandboxed copy vs unrestricted path).
       hermesArtifactStore.record(storedClassified, hermesModeFor(storedSessionId));
-      const nextSessionEvents = [
-        ...(liveEventsRef.current[storedSessionId] ?? []),
+      const nextSessionEvents = appendHermesLiveEvent(
+        liveEventsRef.current[storedSessionId] ?? [],
         classified,
-      ].slice(-200);
+      );
       liveEventsRef.current = {
         ...liveEventsRef.current,
         [storedSessionId]: nextSessionEvents,
@@ -8510,7 +8511,7 @@ export function AgentWorkspace({
   }
 
   function pushLiveEvent(key: string, event: JuneHermesEvent) {
-    const nextEvents = [...(liveEventsRef.current[key] ?? []), event].slice(-200);
+    const nextEvents = appendHermesLiveEvent(liveEventsRef.current[key] ?? [], event);
     liveEventsRef.current = {
       ...liveEventsRef.current,
       [key]: nextEvents,

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -16,6 +16,42 @@ import type { JuneHermesEvent } from "./hermes-control-plane";
 import { generatedMediaToolKind, toolActivityLabel } from "./agent-tool-labels";
 import { stripProjectContext } from "./agent-project-context";
 
+const HERMES_LIVE_EVENT_LIMIT = 200;
+
+/**
+ * Adds an event to the bounded transcript-rendering tail. Consecutive message
+ * deltas are one logical append-only value, so compact them before enforcing
+ * the event-count limit. Otherwise a long response evicts its own opening
+ * chunks and the missing prefix only returns with `message.complete`.
+ */
+export function appendHermesLiveEvent(
+  events: JuneHermesEvent[],
+  event: JuneHermesEvent,
+): JuneHermesEvent[] {
+  const previous = events.at(-1);
+  if (
+    previous?.kind === "transcript" &&
+    event.kind === "transcript" &&
+    !previous.complete &&
+    !event.complete &&
+    previous.delta !== undefined &&
+    event.delta !== undefined &&
+    previous.sessionId === event.sessionId &&
+    previous.messageId === event.messageId &&
+    previous.role === event.role
+  ) {
+    return [
+      ...events.slice(0, -1),
+      {
+        ...previous,
+        delta: previous.delta + event.delta,
+      },
+    ];
+  }
+
+  return [...events, event].slice(-HERMES_LIVE_EVENT_LIMIT);
+}
+
 export type AgentChatTextPart = {
   type: "text";
   text: string;

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { isTerminalHermesEvent, type JuneHermesEvent } from "../lib/hermes-control-plane";
 import {
   type AgentChatToolPart,
+  appendHermesLiveEvent,
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
   completedHermesMessageText,
@@ -38,6 +39,43 @@ function transcriptEvent(event: Partial<TranscriptEvent> = {}): TranscriptEvent 
     ...event,
   };
 }
+
+describe("appendHermesLiveEvent", () => {
+  it("preserves an in-progress response beyond the live event limit", () => {
+    const chunks = Array.from({ length: 250 }, (_, index) => `chunk-${index} `);
+    let events: JuneHermesEvent[] = [
+      transcriptEvent({ messageId: "long-response", delta: undefined }),
+    ];
+
+    for (const delta of chunks) {
+      events = appendHermesLiveEvent(
+        events,
+        transcriptEvent({ messageId: "long-response", delta }),
+      );
+    }
+
+    const turns = buildHermesSessionChatTurns([], events);
+    expect(events).toHaveLength(2);
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "text",
+        text: chunks.join(""),
+        status: "running",
+      },
+    ]);
+  });
+
+  it("keeps separate messages and tool boundaries in event order", () => {
+    const first = transcriptEvent({ messageId: "first", delta: "Before tool." });
+    const tool = toolEvent({ key: "lookup", phase: "start" });
+    const second = transcriptEvent({ messageId: "first", delta: "After tool." });
+    const nextMessage = transcriptEvent({ messageId: "second", delta: "Next message." });
+
+    const events = [first, tool, second, nextMessage].reduce(appendHermesLiveEvent, []);
+
+    expect(events).toEqual([first, tool, second, nextMessage]);
+  });
+});
 
 function reasoningEvent(
   event: Pick<ReasoningEvent, "delta"> & Partial<ReasoningEvent>,


### PR DESCRIPTION
## Summary

- preserve the full in-progress assistant response when a stream emits more than 200 gateway events
- compact consecutive deltas for the same message before enforcing the bounded live-event tail
- keep separate messages and tool boundaries in their original event order

## Root cause

Agent chat rebuilt the running turn from a live-event array capped to the latest 200 events. Long responses could exceed that cap before `message.complete`, so early `message.delta` events were evicted while later chunks kept appending. The authoritative completion payload then restored the full text all at once.

## Validation

- `pnpm exec vitest run src/test/agent-chat-runtime.test.ts src/test/smoothed-streaming-markdown.test.tsx` (115 passed)
- `pnpm test` (2,951 passed, 2 skipped)
- `pnpm typecheck`
- `pnpm check` (passes with the repository's existing warnings)
- `pnpm build`
- background browser walkthrough with fake Tauri IPC and fake Hermes WebSocket: the opening sentence remained rendered at deltas 205 and 230, the midstream response retained 260 characters, and completion matched the exact 277-character response

- [x] Tested visually where it matters. [QA recording](https://app.opensoftware.co/api/v1/files/fil_rAoSRwdl0OSQ/download) is attached in a PR comment.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- changing the streaming reveal cadence or Markdown renderer
- changing the sanitized diagnostic trace buffer

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. No security-sensitive behavior changed.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow files changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such files changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend files changed.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.
