### PR TITLE
Re-arm dictation shortcut on finalized discards

### DIFF
--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -1783,11 +1783,14 @@ final class DictationController {
     func discard() {
         // Cancel any start still waiting on the permission prompt — the
         // graze is over, so a later grant must not open the microphone.
-        // The HUD shows on listening_started, so a discard that interrupts a
-        // live recording (a grazed push-to-talk key, a signed-out session)
-        // must announce itself or the HUD stays stuck on "Listening".
-        let wasListening = cancelAndResetRecording()
-        if wasListening {
+        // A discard can also arrive after recording_ready, while the helper is
+        // finalizing a no-speech, quarantined, or failed transcription. Rust
+        // suppresses new shortcuts until it sees a terminal helper event, so
+        // announce every active discard. Otherwise that gate only recovers
+        // when its 30-second safety timeout expires.
+        let hadActiveDictation = startPending || isListening || isFinalizing
+        cancelAndResetRecording()
+        if hadActiveDictation {
             emit("recording_discarded")
         }
     }

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3495,6 +3495,12 @@ fn deliver_dictation_outcome(
         let _ = std::fs::remove_file(audio_path);
         return;
     }
+    // The terminal command and any shortcut command written after it are
+    // consumed by the helper in order. Re-arm as soon as that handoff
+    // succeeds instead of waiting for the helper to echo a terminal event:
+    // discard outcomes used to emit no echo once recording had finalized,
+    // leaving Fn suppressed until the 30-second safety timeout expired.
+    update_shortcut_helper_finalizing(app, false);
     if let Some(event) = outcome.event {
         emit_dictation_event_value(app, event);
     }
@@ -6574,6 +6580,32 @@ mod tests {
                 ShortcutKeyEdge::Down,
                 DictationShortcutKind::PushToTalk,
                 now + FINALIZING_SUPPRESSION_EXPIRY
+            ),
+            Some(DictationCommand::StartListening)
+        );
+    }
+
+    #[test]
+    fn completed_outcome_immediately_rearms_push_to_talk() {
+        let mut controller = ShortcutActivationController::default();
+        let now = Instant::now();
+
+        controller.mark_helper_finalizing();
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::PushToTalk,
+                now
+            ),
+            None
+        );
+
+        controller.clear_helper_finalizing();
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::PushToTalk,
+                now + Duration::from_millis(1)
             ),
             Some(DictationCommand::StartListening)
         );


### PR DESCRIPTION
## Summary

Pressing the dictation shortcut (Fn / push-to-talk) again after a discarded recording could leave dictation unresponsive for up to 30 seconds.

- The mac helper only emitted `recording_discarded` when a discard interrupted a *live* recording. Discards that arrived after `recording_ready`, while finalizing a no-speech, quarantined, or failed transcription, emitted no terminal event, so the Rust shortcut gate stayed suppressed until its 30-second safety timeout.
- The helper now announces every active discard (`startPending || isListening || isFinalizing`).
- On the Rust side, `deliver_dictation_outcome` re-arms the shortcut gate as soon as the outcome handoff succeeds instead of waiting for the helper echo.

## Testing

- `cargo test --lib dictation`: 115 passed
- New unit test `completed_outcome_immediately_rearms_push_to_talk` covers the re-arm path

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787161361&installation_model_id=425925&pr_number=852&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F852&signature=03efdce4f525bb4f98ddfaeefb9ab032aaf84837995ae2fd11cf8041d43ae21d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->