### PR TITLE
Fix intermittent blank window on startup

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,7 +5,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import type { CSSProperties, PointerEvent as ReactPointerEvent, ReactNode } from "react";
-import { AccountGate, JuneMark } from "../components/account/AccountGate";
+import { AccountGate, AccountStatusFailure, JuneMark } from "../components/account/AccountGate";
 import { FundingChip, FundingNotice, fundingTierOf } from "../components/account/FundingNotice";
 import { OnboardingFlow } from "../components/onboarding/OnboardingFlow";
 import {
@@ -3922,7 +3922,24 @@ export function App() {
           data-tauri-drag-region
           onPointerDown={handleTitlebarPointerDown}
         />
-        <div className="welcome-screen welcome-screen-loading" aria-label="Loading account" />
+        <div className="welcome-screen welcome-screen-loading">
+          <Spinner size="lg" aria-label="Starting June" />
+          <p>Starting June...</p>
+        </div>
+      </main>
+    );
+  }
+
+  if (accountError && !account.signedIn && !devAccountsUnconfigured) {
+    return (
+      <main className="account-gate-shell">
+        <div
+          className="titlebar-drag"
+          aria-hidden
+          data-tauri-drag-region
+          onPointerDown={handleTitlebarPointerDown}
+        />
+        <AccountStatusFailure message={accountError} onRetry={refreshAccount} />
       </main>
     );
   }

--- a/src/components/account/AccountGate.tsx
+++ b/src/components/account/AccountGate.tsx
@@ -11,6 +11,41 @@ type Props = {
   onAccountChanged: (next: AccountStatus) => void;
 };
 
+type AccountStatusFailureProps = {
+  message: string;
+  onRetry: () => Promise<unknown>;
+};
+
+export function AccountStatusFailure({ message, onRetry }: AccountStatusFailureProps) {
+  const [retrying, setRetrying] = useState(false);
+
+  async function handleRetry() {
+    setRetrying(true);
+    try {
+      await onRetry();
+    } finally {
+      setRetrying(false);
+    }
+  }
+
+  return (
+    <div className="welcome-screen">
+      <div className="welcome-card">
+        <span className="welcome-mark-glass" aria-hidden>
+          <JuneGlassMark />
+        </span>
+        <h1 className="welcome-title">June could not finish starting</h1>
+        <p className="welcome-subtitle">{message}</p>
+        <div className="welcome-providers">
+          <BrandPrimaryButton disabled={retrying} onClick={() => void handleRetry()}>
+            {retrying ? "Trying again..." : "Try again"}
+          </BrandPrimaryButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function AccountGate({ account, loading, onAccountChanged }: Props) {
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState<string>();

--- a/src/lib/account-status.ts
+++ b/src/lib/account-status.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
+import { withTimeout } from "./async-timeout";
 import { osAccountsLogout, osAccountsStatus, osAccountsStatusLocal } from "./tauri";
 import type { AccountStatus } from "./tauri";
+
+export const LOCAL_ACCOUNT_STATUS_TIMEOUT_MS = 2_000;
+export const ACCOUNT_STATUS_TIMEOUT_MS = 8_000;
+const ACCOUNT_STATUS_TIMEOUT_MESSAGE = "Account status took too long. Please try again.";
 
 const EMPTY_STATUS: AccountStatus = { signedIn: false, configured: false };
 const DEMO_ACCOUNT: AccountStatus = {
@@ -40,7 +45,11 @@ export function useAccountStatus(options: UseAccountStatusOptions = {}): UseAcco
       return DEMO_ACCOUNT;
     }
     try {
-      const next = await osAccountsStatus();
+      const next = await withTimeout(
+        osAccountsStatus(),
+        ACCOUNT_STATUS_TIMEOUT_MS,
+        ACCOUNT_STATUS_TIMEOUT_MESSAGE,
+      );
       setAccount(next);
       setError(undefined);
       return next;
@@ -62,7 +71,11 @@ export function useAccountStatus(options: UseAccountStatusOptions = {}): UseAcco
       // branch has no native backend, so leave it to `refresh()`.
       if (!browserOnboardingDemoEnabled()) {
         try {
-          const localStatus = await osAccountsStatusLocal();
+          const localStatus = await withTimeout(
+            osAccountsStatusLocal(),
+            LOCAL_ACCOUNT_STATUS_TIMEOUT_MS,
+            ACCOUNT_STATUS_TIMEOUT_MESSAGE,
+          );
           if (!cancelled) {
             setAccount(localStatus);
             setLoading(false);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -22927,6 +22927,22 @@ button.memory-project:hover {
   );
 }
 
+.welcome-screen-loading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  color: var(--muted-foreground);
+}
+
+.welcome-screen-loading .spinner {
+  color: var(--brand);
+}
+
+.welcome-screen-loading p {
+  margin: 0;
+  font-size: var(--fs-sm);
+}
+
 .welcome-card {
   width: min(100%, 320px);
   display: flex;

--- a/src/test/account-status.test.tsx
+++ b/src/test/account-status.test.tsx
@@ -1,6 +1,10 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { useAccountStatus } from "../lib/account-status";
+import {
+  ACCOUNT_STATUS_TIMEOUT_MS,
+  LOCAL_ACCOUNT_STATUS_TIMEOUT_MS,
+  useAccountStatus,
+} from "../lib/account-status";
 import type { AccountStatus } from "../lib/tauri";
 
 const mocks = vi.hoisted(() => ({
@@ -27,11 +31,12 @@ vi.mock("../lib/tauri", () => ({
 }));
 
 function StatusProbe({ forceLogoutOnMount = false }: { forceLogoutOnMount?: boolean }) {
-  const { account, loading } = useAccountStatus({ forceLogoutOnMount });
+  const { account, error, loading } = useAccountStatus({ forceLogoutOnMount });
   return (
     <div>
       <div>{account.signedIn ? "Signed in" : "Signed out"}</div>
       <div>{loading ? "Loading" : "Ready"}</div>
+      {error ? <div>{error}</div> : null}
     </div>
   );
 }
@@ -70,5 +75,37 @@ describe("useAccountStatus", () => {
 
     await screen.findByText("Signed in");
     await waitFor(() => expect(screen.getByText("Ready")).toBeInTheDocument());
+  });
+
+  it("falls through to the full status when the local keychain lookup stalls", async () => {
+    vi.useFakeTimers();
+    const signedIn: AccountStatus = { signedIn: true, configured: true };
+    mocks.osAccountsStatusLocal.mockImplementation(() => new Promise<AccountStatus>(() => {}));
+    mocks.osAccountsStatus.mockResolvedValue(signedIn);
+
+    render(<StatusProbe />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LOCAL_ACCOUNT_STATUS_TIMEOUT_MS);
+    });
+
+    expect(screen.getByText("Signed in")).toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it("leaves the loading gate with a retryable error when account lookups stall", async () => {
+    vi.useFakeTimers();
+    mocks.osAccountsStatusLocal.mockImplementation(() => new Promise<AccountStatus>(() => {}));
+    mocks.osAccountsStatus.mockImplementation(() => new Promise<AccountStatus>(() => {}));
+
+    render(<StatusProbe />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LOCAL_ACCOUNT_STATUS_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(ACCOUNT_STATUS_TIMEOUT_MS);
+    });
+
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("Account status took too long. Please try again.")).toBeInTheDocument();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

The app could intermittently launch to a blank window: the account gate rendered an empty loading shell while account status lookups ran, and a stalled keychain or network call hung forever with no feedback.

- Bound the local keychain status lookup to 2 seconds and the full account status lookup to 8 seconds using `withTimeout`.
- The loading shell now shows a spinner and "Starting June..." copy instead of an empty screen.
- When both lookups stall, the app shows a retryable error card ("June could not finish starting") with a Try again button wired to `refreshAccount`.

## Testing

- `npx vitest run src/test/account-status.test.tsx src/test/account-gate.test.ts`: 33 passed, including new fake-timer tests for the local-lookup fallthrough and the retryable stall error
- `npx tsc --noEmit`: clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787161420&installation_model_id=425925&pr_number=853&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F853&signature=d7eff87395e07210d8f41716ddc74faba40415eca3f0f04c752fa421b9246802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->