### PR TITLE
Add Google Calendar context to meeting notes

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -63,7 +63,7 @@ use std::{
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::{sync::OnceCell, time::sleep};
 
 const MEMORY_CONTENT_MAX_CHARS: usize = 4_000;
@@ -1443,19 +1443,31 @@ pub async fn start_recording(
     let expected_title = note.title.clone();
     let recording_started_at = Utc::now();
     tokio::spawn(async move {
-        if let Err(error) = crate::meeting_calendar_context::enrich_note_for_recording(
-            calendar_app,
-            calendar_repos,
-            calendar_note_id,
+        let enrichment = crate::meeting_calendar_context::enrich_note_for_recording(
+            &calendar_app,
+            calendar_repos.clone(),
+            calendar_note_id.clone(),
             expected_title,
             recording_started_at,
         )
-        .await
-        {
-            eprintln!(
+        .await;
+        match enrichment {
+            Ok(true) => match calendar_repos.get_note(&calendar_note_id).await {
+                Ok(note) => {
+                    let _ = calendar_app.emit(
+                        crate::meeting_calendar_context::NOTE_CALENDAR_CONTEXT_UPDATED_EVENT,
+                        note,
+                    );
+                }
+                Err(error) => {
+                    eprintln!("calendar context was saved but could not be reloaded: {error}")
+                }
+            },
+            Ok(false) => {}
+            Err(error) => eprintln!(
                 "calendar context lookup failed without interrupting recording: {}: {}",
                 error.code, error.message
-            );
+            ),
         }
     });
     if let Err(error) = repos

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1453,7 +1453,8 @@ pub async fn start_recording(
         .await;
         match enrichment {
             Ok(true) => match calendar_repos.get_note(&calendar_note_id).await {
-                Ok(note) => {
+                Ok(mut note) => {
+                    note.queued_recordings = processing_queue::queued_behind(&calendar_note_id);
                     let _ = calendar_app.emit(
                         crate::meeting_calendar_context::NOTE_CALENDAR_CONTEXT_UPDATED_EVENT,
                         note,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1423,6 +1423,7 @@ pub async fn start_recording(
     finish_active_capture_before_start(&repos).await?;
     let capture_paths = paths.clone();
     let capture_note_id = note.id.clone();
+    let calendar_app = app.clone();
     let started = start_capture_with_timeout(move |abandoned| {
         start_capture_with_cancel(app, &capture_paths, capture_note_id, source_mode, abandoned)
     })
@@ -1437,6 +1438,26 @@ pub async fn start_recording(
             started.device_label.clone(),
         )
         .await?;
+    let calendar_repos = repos.clone();
+    let calendar_note_id = note.id.clone();
+    let expected_title = note.title.clone();
+    let recording_started_at = Utc::now();
+    tokio::spawn(async move {
+        if let Err(error) = crate::meeting_calendar_context::enrich_note_for_recording(
+            calendar_app,
+            calendar_repos,
+            calendar_note_id,
+            expected_title,
+            recording_started_at,
+        )
+        .await
+        {
+            eprintln!(
+                "calendar context lookup failed without interrupting recording: {}: {}",
+                error.code, error.message
+            );
+        }
+    });
     if let Err(error) = repos
         .add_checkpoint(
             &started.session_id,

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -153,6 +153,11 @@ pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::error::Error
     .await?;
     ensure_column(_pool, "p3a_counters", "reported_at", "TEXT").await?;
     ensure_column(_pool, "notes", "profile", "TEXT NOT NULL DEFAULT 'default'").await?;
+    ensure_column(_pool, "notes", "calendar_event_id", "TEXT").await?;
+    ensure_column(_pool, "notes", "calendar_event_title", "TEXT").await?;
+    ensure_column(_pool, "notes", "calendar_event_start_at", "TEXT").await?;
+    ensure_column(_pool, "notes", "calendar_event_end_at", "TEXT").await?;
+    ensure_column(_pool, "notes", "calendar_account_email", "TEXT").await?;
     ensure_column(
         _pool,
         "dictation_history",

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -2,8 +2,8 @@ use crate::domain::types::{
     AgentMessageDto, AgentMessageRole, AgentSafetyProfile, AgentTaskDto, AgentTaskListResponse,
     AgentTaskStatus, AgentToolEventDto, AgentToolEventStatus, AppError, AudioArtifactDto,
     AudioValidationDto, CompletedSessionDto, DictationHistoryItemDto, DictionaryEntryDto,
-    FolderDto, ListDictationHistoryResponse, ListNotesResponse, MemoryDto, NoteDto,
-    NoteListItemDto, NoteTranscriptionJobKind, NoteTranscriptionJobPlan,
+    FolderDto, ListDictationHistoryResponse, ListNotesResponse, MemoryDto, NoteCalendarEventDto,
+    NoteDto, NoteListItemDto, NoteTranscriptionJobKind, NoteTranscriptionJobPlan,
     NoteTranscriptionJobRecord, NoteTranscriptionJobStatus, ProcessingStatus,
     ProfileDataSummaryDto, RecordingSourceMode, RecordingState, SessionFolderDto,
     SessionProfileDto, TranscriptCoverageDto, TranscriptDto,
@@ -1327,7 +1327,10 @@ impl Repositories {
 
     pub async fn get_note(&self, note_id: &str) -> Result<NoteDto, sqlx::error::Error> {
         let row = query(
-            "SELECT id, title, generated_content, edited_content, active_tab, processing_status, created_at, updated_at, last_error FROM notes WHERE id = ?",
+            "SELECT id, title, generated_content, edited_content, active_tab, processing_status, created_at, updated_at, last_error,
+                    calendar_event_id, calendar_event_title, calendar_event_start_at,
+                    calendar_event_end_at, calendar_account_email
+             FROM notes WHERE id = ?",
         )
         .bind(note_id)
         .fetch_one(&self.pool)
@@ -1364,6 +1367,7 @@ impl Repositories {
             created_at: row.get("created_at"),
             updated_at: row.get("updated_at"),
             duration_ms: None,
+            calendar_event: note_calendar_event_from_row(&row),
             generated_content: row.get("generated_content"),
             edited_content: row.get("edited_content"),
             transcript: self.latest_transcript(note_id).await?,
@@ -1377,6 +1381,38 @@ impl Repositories {
             queued_recordings: 0,
             retry_recording_session_id,
         })
+    }
+
+    /// Persist the event provenance even when the user has already supplied a
+    /// title. The calendar title only fills an untouched note title, so a
+    /// background match can never clobber text typed while the request ran.
+    pub async fn associate_note_with_calendar_event(
+        &self,
+        note_id: &str,
+        expected_title: &str,
+        event: &NoteCalendarEventDto,
+    ) -> Result<(), sqlx::error::Error> {
+        query(
+            "UPDATE notes
+             SET title = CASE WHEN ? = 1 AND title = ? THEN ? ELSE title END,
+                 calendar_event_id = ?, calendar_event_title = ?,
+                 calendar_event_start_at = ?, calendar_event_end_at = ?,
+                 calendar_account_email = ?, updated_at = ?
+             WHERE id = ? AND calendar_event_id IS NULL",
+        )
+        .bind(i64::from(expected_title.trim().is_empty()))
+        .bind(expected_title)
+        .bind(&event.title)
+        .bind(&event.event_id)
+        .bind(&event.title)
+        .bind(&event.start_at)
+        .bind(&event.end_at)
+        .bind(&event.account_email)
+        .bind(timestamp())
+        .bind(note_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 
     pub async fn list_notes(
@@ -5250,6 +5286,31 @@ fn connector_account_from_row(row: sqlx_sqlite::SqliteRow) -> ConnectorAccountRe
     }
 }
 
+fn note_calendar_event_from_row(row: &sqlx_sqlite::SqliteRow) -> Option<NoteCalendarEventDto> {
+    Some(NoteCalendarEventDto {
+        event_id: row
+            .try_get::<Option<String>, _>("calendar_event_id")
+            .ok()
+            .flatten()?,
+        title: row
+            .try_get::<Option<String>, _>("calendar_event_title")
+            .ok()
+            .flatten()?,
+        start_at: row
+            .try_get::<Option<String>, _>("calendar_event_start_at")
+            .ok()
+            .flatten()?,
+        end_at: row
+            .try_get::<Option<String>, _>("calendar_event_end_at")
+            .ok()
+            .flatten()?,
+        account_email: row
+            .try_get::<Option<String>, _>("calendar_account_email")
+            .ok()
+            .flatten()?,
+    })
+}
+
 fn selected_team_from_row(row: sqlx_sqlite::SqliteRow) -> SelectedTeamRecord {
     SelectedTeamRecord {
         team_id: row.get("team_id"),
@@ -5443,8 +5504,8 @@ fn validation_summary_recorded_silence(summary: Option<&str>) -> bool {
 mod tests {
     use super::Repositories;
     use crate::domain::types::{
-        NoteTranscriptionJobKind, NoteTranscriptionJobPlan, NoteTranscriptionJobStatus,
-        ProcessingStatus, RecordingSourceMode,
+        NoteCalendarEventDto, NoteTranscriptionJobKind, NoteTranscriptionJobPlan,
+        NoteTranscriptionJobStatus, ProcessingStatus, RecordingSourceMode,
     };
     use sqlx::query::query;
     use sqlx::row::Row;
@@ -5463,6 +5524,44 @@ mod tests {
 
     fn scopes(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[tokio::test]
+    async fn calendar_event_titles_only_untouched_notes_and_hydrates_context() {
+        let repos = test_repositories().await;
+        let untouched = repos.create_note("default", None).await.expect("note");
+        let named = repos
+            .create_note("default", None)
+            .await
+            .expect("named note");
+        query("UPDATE notes SET title = 'My own title' WHERE id = ?")
+            .bind(&named.id)
+            .execute(&repos.pool)
+            .await
+            .expect("name note");
+        let event = NoteCalendarEventDto {
+            event_id: "event-1".to_string(),
+            title: "Product review".to_string(),
+            start_at: "2026-07-20T14:00:00Z".to_string(),
+            end_at: "2026-07-20T14:30:00Z".to_string(),
+            account_email: "june@example.com".to_string(),
+        };
+
+        repos
+            .associate_note_with_calendar_event(&untouched.id, "", &event)
+            .await
+            .expect("associate untouched note");
+        repos
+            .associate_note_with_calendar_event(&named.id, "My own title", &event)
+            .await
+            .expect("associate named note");
+
+        let untouched = repos.get_note(&untouched.id).await.expect("untouched");
+        let named = repos.get_note(&named.id).await.expect("named");
+        assert_eq!(untouched.title, "Product review");
+        assert_eq!(untouched.calendar_event, Some(event.clone()));
+        assert_eq!(named.title, "My own title");
+        assert_eq!(named.calendar_event, Some(event));
     }
 
     async fn recording_fixture(

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1391,8 +1391,8 @@ impl Repositories {
         note_id: &str,
         expected_title: &str,
         event: &NoteCalendarEventDto,
-    ) -> Result<(), sqlx::error::Error> {
-        query(
+    ) -> Result<bool, sqlx::error::Error> {
+        let result = query(
             "UPDATE notes
              SET title = CASE WHEN ? = 1 AND title = ? THEN ? ELSE title END,
                  calendar_event_id = ?, calendar_event_title = ?,
@@ -1412,7 +1412,7 @@ impl Repositories {
         .bind(note_id)
         .execute(&self.pool)
         .await?;
-        Ok(())
+        Ok(result.rows_affected() > 0)
     }
 
     pub async fn list_notes(

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -110,6 +110,8 @@ pub struct NoteDto {
     pub created_at: String,
     pub updated_at: String,
     pub duration_ms: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub calendar_event: Option<NoteCalendarEventDto>,
     pub generated_content: Option<String>,
     pub edited_content: Option<String>,
     pub transcript: Option<TranscriptDto>,
@@ -131,6 +133,16 @@ pub struct NoteDto {
     /// Exact recording session selected by the durable retry policy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retry_recording_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NoteCalendarEventDto {
+    pub event_id: String,
+    pub title: String,
+    pub start_at: String,
+    pub end_at: String,
+    pub account_email: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub mod hermes_bridge;
 pub mod image_safety;
 pub mod june_api;
 pub mod macos_menu_icons;
+pub mod meeting_calendar_context;
 pub mod meeting_detection;
 pub mod meeting_hud;
 pub mod menu_bar;

--- a/src-tauri/src/meeting_calendar_context.rs
+++ b/src-tauri/src/meeting_calendar_context.rs
@@ -1,0 +1,242 @@
+//! Best-effort Google Calendar context for newly started meeting recordings.
+//!
+//! This never blocks capture startup and never sends calendar data through the
+//! June API. It reads each connected Google primary calendar directly, selects
+//! the timed event closest to the recording start, and stores only the small
+//! event identity shown on the local note.
+
+use crate::{
+    connectors::{
+        self,
+        google::{self, EventSummary, GoogleApiError, ListEventsParams},
+        scopes::{CALENDAR_EVENTS, CALENDAR_READONLY},
+    },
+    db::repositories::Repositories,
+    domain::types::{AppError, NoteCalendarEventDto},
+};
+use chrono::{DateTime, Duration, SecondsFormat, Utc};
+use tauri::AppHandle;
+
+const EVENT_WINDOW_HOURS: i64 = 6;
+const EVENT_GRACE_MINUTES: i64 = 10;
+
+#[derive(Debug)]
+struct Candidate {
+    event: NoteCalendarEventDto,
+    distance_ms: i64,
+    start_distance_ms: i64,
+}
+
+pub async fn enrich_note_for_recording(
+    app: AppHandle,
+    repos: Repositories,
+    note_id: String,
+    expected_title: String,
+    recording_started_at: DateTime<Utc>,
+) -> Result<(), AppError> {
+    let accounts = repos.list_connector_accounts().await?;
+    let mut best: Option<Candidate> = None;
+    let params = ListEventsParams {
+        time_min: Some(
+            (recording_started_at - Duration::hours(EVENT_WINDOW_HOURS))
+                .to_rfc3339_opts(SecondsFormat::Secs, true),
+        ),
+        time_max: Some(
+            (recording_started_at + Duration::hours(EVENT_WINDOW_HOURS))
+                .to_rfc3339_opts(SecondsFormat::Secs, true),
+        ),
+        max_results: Some(50),
+        ..Default::default()
+    };
+
+    for account in accounts.into_iter().filter(|account| {
+        account.provider == "google"
+            && account.status == "connected"
+            && account
+                .scopes
+                .iter()
+                .any(|scope| scope == CALENDAR_READONLY || scope == CALENDAR_EVENTS)
+    }) {
+        let Ok(token) = connectors::google_access_token(&app, &account.account_id).await else {
+            continue;
+        };
+        let page = match google::list_events(&token, &params).await {
+            Ok(page) => page,
+            Err(GoogleApiError::Unauthorized) => {
+                let Ok(token) =
+                    connectors::force_refresh_google_access_token(&app, &account.account_id).await
+                else {
+                    continue;
+                };
+                match google::list_events(&token, &params).await {
+                    Ok(page) => page,
+                    Err(_) => continue,
+                }
+            }
+            Err(_) => continue,
+        };
+
+        for event in page.items {
+            let Some(candidate) = candidate_for_event(event, &account.email, recording_started_at)
+            else {
+                continue;
+            };
+            let is_better = best.as_ref().is_none_or(|current| {
+                (candidate.distance_ms, candidate.start_distance_ms)
+                    < (current.distance_ms, current.start_distance_ms)
+            });
+            if is_better {
+                best = Some(candidate);
+            }
+        }
+    }
+
+    if let Some(candidate) = best {
+        repos
+            .associate_note_with_calendar_event(&note_id, &expected_title, &candidate.event)
+            .await?;
+    }
+    Ok(())
+}
+
+fn candidate_for_event(
+    event: EventSummary,
+    account_email: &str,
+    recording_started_at: DateTime<Utc>,
+) -> Option<Candidate> {
+    if event.status.as_deref() == Some("cancelled")
+        || event.attendees.iter().any(|attendee| {
+            attendee.is_self && attendee.response_status.as_deref() == Some("declined")
+        })
+    {
+        return None;
+    }
+    let title = event.summary?.trim().to_string();
+    if title.is_empty() {
+        return None;
+    }
+    // Date-only values are all-day events. They are intentionally skipped:
+    // they rarely identify the call being recorded and would create false
+    // confidence in the note header.
+    let start = DateTime::parse_from_rfc3339(event.start.as_deref()?)
+        .ok()?
+        .with_timezone(&Utc);
+    let end = DateTime::parse_from_rfc3339(event.end.as_deref()?)
+        .ok()?
+        .with_timezone(&Utc);
+    if end <= start
+        || recording_started_at < start - Duration::minutes(EVENT_GRACE_MINUTES)
+        || recording_started_at > end + Duration::minutes(EVENT_GRACE_MINUTES)
+    {
+        return None;
+    }
+
+    let distance_ms = if recording_started_at < start {
+        (start - recording_started_at).num_milliseconds()
+    } else if recording_started_at > end {
+        (recording_started_at - end).num_milliseconds()
+    } else {
+        0
+    };
+    Some(Candidate {
+        event: NoteCalendarEventDto {
+            event_id: event.id,
+            title,
+            start_at: start.to_rfc3339_opts(SecondsFormat::Secs, true),
+            end_at: end.to_rfc3339_opts(SecondsFormat::Secs, true),
+            account_email: account_email.to_string(),
+        },
+        distance_ms,
+        start_distance_ms: (recording_started_at - start).num_milliseconds().abs(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connectors::google::EventAttendee;
+    use chrono::TimeZone;
+
+    fn event(title: &str, start: &str, end: &str) -> EventSummary {
+        EventSummary {
+            id: "event-1".to_string(),
+            summary: Some(title.to_string()),
+            start: Some(start.to_string()),
+            end: Some(end.to_string()),
+            attendees: Vec::new(),
+            location: None,
+            organizer: None,
+            html_link: None,
+            status: Some("confirmed".to_string()),
+        }
+    }
+
+    #[test]
+    fn matches_an_event_in_progress_and_keeps_provenance() {
+        let started = Utc.with_ymd_and_hms(2026, 7, 20, 14, 15, 0).unwrap();
+        let candidate = candidate_for_event(
+            event(
+                "Product review",
+                "2026-07-20T14:00:00Z",
+                "2026-07-20T14:30:00Z",
+            ),
+            "june@example.com",
+            started,
+        )
+        .unwrap();
+
+        assert_eq!(candidate.distance_ms, 0);
+        assert_eq!(candidate.event.title, "Product review");
+        assert_eq!(candidate.event.account_email, "june@example.com");
+    }
+
+    #[test]
+    fn allows_joining_ten_minutes_early_but_not_unrelated_events() {
+        let event = || {
+            event(
+                "Design sync",
+                "2026-07-20T14:00:00Z",
+                "2026-07-20T14:30:00Z",
+            )
+        };
+        assert!(candidate_for_event(
+            event(),
+            "june@example.com",
+            Utc.with_ymd_and_hms(2026, 7, 20, 13, 50, 0).unwrap(),
+        )
+        .is_some());
+        assert!(candidate_for_event(
+            event(),
+            "june@example.com",
+            Utc.with_ymd_and_hms(2026, 7, 20, 13, 49, 59).unwrap(),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn rejects_all_day_cancelled_and_declined_events() {
+        let started = Utc.with_ymd_and_hms(2026, 7, 20, 14, 0, 0).unwrap();
+        let mut all_day = event("Conference", "2026-07-20", "2026-07-21");
+        assert!(candidate_for_event(all_day, "june@example.com", started).is_none());
+
+        let mut cancelled = event(
+            "Cancelled sync",
+            "2026-07-20T14:00:00Z",
+            "2026-07-20T14:30:00Z",
+        );
+        cancelled.status = Some("cancelled".to_string());
+        assert!(candidate_for_event(cancelled, "june@example.com", started).is_none());
+
+        all_day = event(
+            "Declined sync",
+            "2026-07-20T14:00:00Z",
+            "2026-07-20T14:30:00Z",
+        );
+        all_day.attendees = vec![EventAttendee {
+            email: Some("june@example.com".to_string()),
+            response_status: Some("declined".to_string()),
+            is_self: true,
+        }];
+        assert!(candidate_for_event(all_day, "june@example.com", started).is_none());
+    }
+}

--- a/src-tauri/src/meeting_calendar_context.rs
+++ b/src-tauri/src/meeting_calendar_context.rs
@@ -19,6 +19,9 @@ use tauri::AppHandle;
 
 const EVENT_WINDOW_HOURS: i64 = 6;
 const EVENT_GRACE_MINUTES: i64 = 10;
+const MAX_EVENT_PAGES: usize = 10;
+
+pub const NOTE_CALENDAR_CONTEXT_UPDATED_EVENT: &str = "june://note-calendar-context-updated";
 
 #[derive(Debug)]
 struct Candidate {
@@ -28,12 +31,12 @@ struct Candidate {
 }
 
 pub async fn enrich_note_for_recording(
-    app: AppHandle,
+    app: &AppHandle,
     repos: Repositories,
     note_id: String,
     expected_title: String,
     recording_started_at: DateTime<Utc>,
-) -> Result<(), AppError> {
+) -> Result<bool, AppError> {
     let accounts = repos.list_connector_accounts().await?;
     let mut best: Option<Candidate> = None;
     let params = ListEventsParams {
@@ -57,46 +60,58 @@ pub async fn enrich_note_for_recording(
                 .iter()
                 .any(|scope| scope == CALENDAR_READONLY || scope == CALENDAR_EVENTS)
     }) {
-        let Ok(token) = connectors::google_access_token(&app, &account.account_id).await else {
+        let Ok(mut token) = connectors::google_access_token(app, &account.account_id).await else {
             continue;
         };
-        let page = match google::list_events(&token, &params).await {
-            Ok(page) => page,
-            Err(GoogleApiError::Unauthorized) => {
-                let Ok(token) =
-                    connectors::force_refresh_google_access_token(&app, &account.account_id).await
+        let mut page_token = None;
+        for _ in 0..MAX_EVENT_PAGES {
+            let mut page_params = params.clone();
+            page_params.page_token = page_token;
+            let page = match google::list_events(&token, &page_params).await {
+                Ok(page) => page,
+                Err(GoogleApiError::Unauthorized) => {
+                    let Ok(refreshed) =
+                        connectors::force_refresh_google_access_token(app, &account.account_id)
+                            .await
+                    else {
+                        break;
+                    };
+                    token = refreshed;
+                    match google::list_events(&token, &page_params).await {
+                        Ok(page) => page,
+                        Err(_) => break,
+                    }
+                }
+                Err(_) => break,
+            };
+            page_token = page.next_page_token;
+
+            for event in page.items {
+                let Some(candidate) =
+                    candidate_for_event(event, &account.email, recording_started_at)
                 else {
                     continue;
                 };
-                match google::list_events(&token, &params).await {
-                    Ok(page) => page,
-                    Err(_) => continue,
+                let is_better = best.as_ref().is_none_or(|current| {
+                    (candidate.distance_ms, candidate.start_distance_ms)
+                        < (current.distance_ms, current.start_distance_ms)
+                });
+                if is_better {
+                    best = Some(candidate);
                 }
             }
-            Err(_) => continue,
-        };
-
-        for event in page.items {
-            let Some(candidate) = candidate_for_event(event, &account.email, recording_started_at)
-            else {
-                continue;
-            };
-            let is_better = best.as_ref().is_none_or(|current| {
-                (candidate.distance_ms, candidate.start_distance_ms)
-                    < (current.distance_ms, current.start_distance_ms)
-            });
-            if is_better {
-                best = Some(candidate);
+            if page_token.is_none() {
+                break;
             }
         }
     }
 
     if let Some(candidate) = best {
-        repos
+        return Ok(repos
             .associate_note_with_calendar_event(&note_id, &expected_title, &candidate.event)
-            .await?;
+            .await?);
     }
-    Ok(())
+    Ok(false)
 }
 
 fn candidate_for_event(

--- a/src-tauri/tests/processing.rs
+++ b/src-tauri/tests/processing.rs
@@ -15,6 +15,7 @@ fn note(overrides: impl FnOnce(&mut NoteDto)) -> NoteDto {
         created_at: NOW.to_string(),
         updated_at: NOW.to_string(),
         duration_ms: None,
+        calendar_event: None,
         generated_content: None,
         edited_content: None,
         transcript: None,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1514,7 +1514,7 @@ export function App() {
     void listen<NoteDto>(NOTE_CALENDAR_CONTEXT_UPDATED_EVENT, (event) => {
       const noteProfile = calendarContextNoteProfilesRef.current.get(event.payload.id);
       calendarContextNoteProfilesRef.current.delete(event.payload.id);
-      if (noteProfile && noteProfile !== getActiveHermesProfileName()) return;
+      if (noteProfile !== getActiveHermesProfileName()) return;
       dispatch({ type: "noteUpdated", note: event.payload });
     }).then((cleanup) => {
       if (aborted) cleanup();

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -610,6 +610,10 @@ export function App() {
   // switches profiles. Remember that exception so stopping the take can remove
   // the old-profile note and its tab snapshots immediately.
   const crossProfileRecordingNoteIdRef = useRef<string | undefined>(undefined);
+  // Calendar matching finishes in the background and emits a global event.
+  // Remember which profile started each lookup so a late result cannot upsert
+  // an old-profile note into whichever profile is visible when it arrives.
+  const calendarContextNoteProfilesRef = useRef(new Map<string, string>());
   // Reactive mirror of recordingNoteIdRef. The ref serves the async finish/HUD
   // paths that need the latest value synchronously; this state drives render
   // decisions — which note shows the in-note RecorderBar, and whether the
@@ -1508,6 +1512,9 @@ export function App() {
     let aborted = false;
     let unlisten: (() => void) | undefined;
     void listen<NoteDto>(NOTE_CALENDAR_CONTEXT_UPDATED_EVENT, (event) => {
+      const noteProfile = calendarContextNoteProfilesRef.current.get(event.payload.id);
+      calendarContextNoteProfilesRef.current.delete(event.payload.id);
+      if (noteProfile && noteProfile !== getActiveHermesProfileName()) return;
       dispatch({ type: "noteUpdated", note: event.payload });
     }).then((cleanup) => {
       if (aborted) cleanup();
@@ -3374,6 +3381,7 @@ export function App() {
       if (!startAlreadyClaimed) {
         recordingStartInFlightRef.current = true;
       }
+      const recordingProfile = getActiveHermesProfileName();
       setRecordingNote(noteId);
       const startingStatus = startingRecordingStatus(noteId, requestedSourceMode);
       recordingStatusRef.current = startingStatus;
@@ -3405,6 +3413,7 @@ export function App() {
             ? "microphoneOnly"
             : requestedSourceMode;
 
+        calendarContextNoteProfilesRef.current.set(noteId, recordingProfile);
         const recording = await startRecording(noteId, effectiveMode);
         setRecordingNote(noteId);
         const status = recordingToStatus(recording);
@@ -3416,6 +3425,7 @@ export function App() {
         playRecordingSound("start");
         return true;
       } catch (err) {
+        calendarContextNoteProfilesRef.current.delete(noteId);
         // The ref was set optimistically above; a failed start must not leave
         // the meeting HUD's reopen path pointing at a note with no recording.
         setRecordingNote(undefined);

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -90,6 +90,7 @@ import {
   getRecordingStatus,
   getNote,
   LIVE_TRANSCRIPT_EVENT,
+  NOTE_CALENDAR_CONTEXT_UPDATED_EVENT,
   listCompletedSessions,
   listFolders,
   listNotes,
@@ -1502,6 +1503,21 @@ export function App() {
       unlisten?.();
     };
   }, [closeTab]);
+
+  useEffect(() => {
+    let aborted = false;
+    let unlisten: (() => void) | undefined;
+    void listen<NoteDto>(NOTE_CALENDAR_CONTEXT_UPDATED_EVENT, (event) => {
+      dispatch({ type: "noteUpdated", note: event.payload });
+    }).then((cleanup) => {
+      if (aborted) cleanup();
+      else unlisten = cleanup;
+    });
+    return () => {
+      aborted = true;
+      unlisten?.();
+    };
+  }, []);
 
   // Tab keyboard shortcuts: ⌘T new, ⌘W close, ⌘[ / ⌘] cycle, ⌘1-9 jump
   // (9 = last).

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -5,6 +5,7 @@ import { IconMicrophoneOff } from "central-icons/IconMicrophoneOff";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconMicrophone as IconMicrophoneLine } from "central-icons/IconMicrophone";
 import { IconVolumeFull } from "central-icons/IconVolumeFull";
+import { IconCalendar3 } from "central-icons/IconCalendar3";
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconChevronBottom } from "central-icons-filled/IconChevronBottom";
 import { IconMicrophone } from "central-icons-filled/IconMicrophone";
@@ -134,6 +135,18 @@ function formatTurnTime(startMs?: number, endMs?: number) {
     return `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
   };
   return `${format(startMs)}-${format(endMs)}`;
+}
+
+function formatCalendarEventTime(startAt: string, endAt: string) {
+  const start = new Date(startAt);
+  const end = new Date(endAt);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null;
+  const day = new Intl.DateTimeFormat(undefined, { weekday: "short" }).format(start);
+  const time = new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${day}, ${time.format(start)} to ${time.format(end)}`;
 }
 
 export function NoteEditor({
@@ -342,6 +355,9 @@ export function NoteEditor({
   const queuedRecordings = note.queuedRecordings ?? 0;
   const queuedTooltipId = useId();
   const updatedAtLabel = formatFullDate(note.updatedAt);
+  const calendarEventTime = note.calendarEvent
+    ? formatCalendarEventTime(note.calendarEvent.startAt, note.calendarEvent.endAt)
+    : null;
 
   return (
     <article className="note-editor">
@@ -372,6 +388,24 @@ export function NoteEditor({
             />
           </div>
         </div>
+        {note.calendarEvent ? (
+          <div
+            className="note-calendar-context"
+            aria-label={`Matched to ${note.calendarEvent.title} in Google Calendar`}
+            title={`Matched from ${note.calendarEvent.accountEmail}`}
+          >
+            <IconCalendar3 aria-hidden="true" />
+            <span className="note-calendar-source">Google Calendar</span>
+            {calendarEventTime ? (
+              <>
+                <span className="note-overline-dot" aria-hidden="true" />
+                <span>{calendarEventTime}</span>
+              </>
+            ) : null}
+            <span className="note-overline-dot" aria-hidden="true" />
+            <span className="note-calendar-account">{note.calendarEvent.accountEmail}</span>
+          </div>
+        ) : null}
         <SegmentedControl
           aria-label="Note views"
           value={activeTab}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -429,6 +429,7 @@ export type DownloadNoteAudioResponse = {
 };
 
 export type NoteDto = NoteListItemDto & {
+  calendarEvent?: NoteCalendarEventDto;
   generatedContent?: string;
   editedContent?: string;
   transcript?: TranscriptDto;
@@ -443,6 +444,14 @@ export type NoteDto = NoteListItemDto & {
   retryRecordingSessionId?: string;
   /** Recordings queued behind the one currently processing (0 when none). */
   queuedRecordings?: number;
+};
+
+export type NoteCalendarEventDto = {
+  eventId: string;
+  title: string;
+  startAt: string;
+  endAt: string;
+  accountEmail: string;
 };
 
 export type TranscriptCoverageDto = {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -105,6 +105,7 @@ export type TranscriptDto = {
 };
 
 export const LIVE_TRANSCRIPT_EVENT = "live-transcript-event";
+export const NOTE_CALENDAR_CONTEXT_UPDATED_EVENT = "june://note-calendar-context-updated";
 
 export type LiveTranscriptEventDto = {
   noteId: string;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -10349,6 +10349,35 @@ input:focus-visible,
   opacity: 0.45;
 }
 
+.note-calendar-context {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 100%;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-sm);
+}
+
+.note-calendar-context > svg {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  margin-right: var(--sp-2);
+  color: var(--foreground);
+}
+
+.note-calendar-source {
+  color: var(--foreground);
+  font-weight: 500;
+}
+
+.note-calendar-account {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .folder-chip-wrap {
   position: relative;
   display: inline-flex;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -10369,7 +10369,7 @@ input:focus-visible,
 
 .note-calendar-source {
   color: var(--foreground);
-  font-weight: 500;
+  font-weight: var(--fw-medium);
 }
 
 .note-calendar-account {

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -127,6 +127,7 @@ vi.mock("../lib/tauri", () => ({
   computerUseEndRun: vi.fn().mockResolvedValue(undefined),
   computerUseStop: vi.fn().mockResolvedValue(undefined),
   LIVE_TRANSCRIPT_EVENT: "live-transcript-event",
+  NOTE_CALENDAR_CONTEXT_UPDATED_EVENT: "june://note-calendar-context-updated",
   bootstrapApp: mocks.bootstrapApp,
   createNote: mocks.createNote,
   createFolder: mocks.createFolder,
@@ -416,6 +417,36 @@ describe("notes recording reliability", () => {
     await userEvent.click(await screen.findByRole("button", { name: "Meeting notes" }));
     expect(await screen.findByText("Work profile note")).toBeInTheDocument();
     expect(screen.queryByText("First note")).toBeNull();
+  });
+
+  it("shows calendar context as soon as the backend matches the open note", async () => {
+    render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    await userEvent.click(await screen.findByRole("button", { name: "Meeting notes" }));
+    await userEvent.click(await screen.findByRole("button", { name: /First note Preview/ }));
+    expect(await screen.findByDisplayValue("First note")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.listeners.has("june://note-calendar-context-updated")).toBe(true),
+    );
+
+    await act(async () => {
+      await mocks.listeners.get("june://note-calendar-context-updated")?.({
+        payload: {
+          ...first,
+          title: "Product review",
+          calendarEvent: {
+            eventId: "event-1",
+            title: "Product review",
+            startAt: "2026-07-20T14:00:00Z",
+            endAt: "2026-07-20T14:30:00Z",
+            accountEmail: "june@example.com",
+          },
+        },
+      });
+    });
+
+    expect(await screen.findByText("Google Calendar")).toBeInTheDocument();
+    expect(screen.getByText("june@example.com")).toBeInTheDocument();
   });
 
   it("retires an old-profile recording note as soon as the recording stops", async () => {

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -485,6 +485,25 @@ describe("notes recording reliability", () => {
     await userEvent.click(screen.getByRole("button", { name: "Meeting notes" }));
     expect(await screen.findByText("Work profile note")).toBeInTheDocument();
     expect(screen.queryByText("First note")).toBeNull();
+
+    await act(async () => {
+      await mocks.listeners.get("june://note-calendar-context-updated")?.({
+        payload: {
+          ...first,
+          title: "Old profile calendar note",
+          calendarEvent: {
+            eventId: "event-old-profile",
+            title: "Old profile calendar note",
+            startAt: "2026-07-20T14:00:00Z",
+            endAt: "2026-07-20T14:30:00Z",
+            accountEmail: "personal@example.com",
+          },
+        },
+      });
+    });
+
+    expect(screen.queryByText("Old profile calendar note")).toBeNull();
+    expect(screen.queryByText("First note")).toBeNull();
   });
 
   it("hides audio download when the selected note has no finalized audio", async () => {

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -420,8 +420,7 @@ describe("notes recording reliability", () => {
   });
 
   it("shows calendar context as soon as the backend matches the open note", async () => {
-    render(<App />);
-    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    await startRecordingOnFirstNote();
     await userEvent.click(await screen.findByRole("button", { name: "Meeting notes" }));
     await userEvent.click(await screen.findByRole("button", { name: /First note Preview/ }));
     expect(await screen.findByDisplayValue("First note")).toBeInTheDocument();
@@ -447,6 +446,35 @@ describe("notes recording reliability", () => {
 
     expect(await screen.findByText("Google Calendar")).toBeInTheDocument();
     expect(screen.getByText("june@example.com")).toBeInTheDocument();
+  });
+
+  it("ignores calendar context without profile provenance after a renderer reload", async () => {
+    render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    await waitFor(() =>
+      expect(mocks.listeners.has("june://note-calendar-context-updated")).toBe(true),
+    );
+
+    await act(async () => {
+      await mocks.listeners.get("june://note-calendar-context-updated")?.({
+        payload: {
+          ...first,
+          title: "Stale calendar note",
+          calendarEvent: {
+            eventId: "event-stale",
+            title: "Stale calendar note",
+            startAt: "2026-07-20T14:00:00Z",
+            endAt: "2026-07-20T14:30:00Z",
+            accountEmail: "unknown-profile@example.com",
+          },
+        },
+      });
+    });
+
+    await userEvent.click(await screen.findByRole("button", { name: "Meeting notes" }));
+    expect(screen.queryByText("Stale calendar note")).toBeNull();
+    expect(screen.queryByText("unknown-profile@example.com")).toBeNull();
+    expect(await screen.findByText("First note")).toBeInTheDocument();
   });
 
   it("retires an old-profile recording note as soon as the recording stops", async () => {

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -117,6 +117,30 @@ describe("NoteEditor", () => {
     expect(container.querySelector(".note-title-print")).toHaveTextContent("New note");
   });
 
+  it("shows the Google Calendar event matched to the recording", () => {
+    render(
+      <NoteEditor
+        {...props}
+        note={note({
+          title: "Product review",
+          calendarEvent: {
+            eventId: "event-1",
+            title: "Product review",
+            startAt: "2026-05-19T14:00:00Z",
+            endAt: "2026-05-19T14:30:00Z",
+            accountEmail: "june@example.com",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Google Calendar")).toBeInTheDocument();
+    expect(screen.getByText("june@example.com")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Matched to Product review in Google Calendar"),
+    ).toBeInTheDocument();
+  });
+
   it("shows raw transcript in transcription tab", () => {
     render(
       <NoteEditor


### PR DESCRIPTION
## What changed

- match a newly started recording to the closest overlapping timed event from connected Google primary calendars
- use the calendar event title for an untouched note while preserving any user-authored title
- persist the event title, time, and connected account locally on the note
- show a clear Google Calendar context row in meeting details
- exclude cancelled, declined, all-day, and non-overlapping events

## Why

Meeting notes should make it obvious that June understands the user's calendar and can connect a recording to the meeting that was happening at that time.

## Validation

- `pnpm test` (3,048 passed, 2 skipped)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib --locked` (984 passed, 5 ignored)
- `cargo check --manifest-path src-tauri/Cargo.toml --tests --locked`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run check` (completed with the repository's existing warning baseline)
- focused matcher, persistence, and NoteEditor tests

## Live walkthrough

PASS on a local Vite preview using synthetic calendar metadata. The meeting detail visibly showed the calendar source, event time, and connected account without overflow at the tested editor width.

Local screenshot: `.tmp/qa-recordings/calendar-meeting-context.png`

No public video was attached because the available fallback browser surface did not provide recording. The walkthrough intentionally did not use a real Google account, private calendar data, microphone, or OS permissions.

## Known gaps

- real Google OAuth/calendar retrieval was not exercised locally
- matching currently uses each connected account's primary calendar, consistent with the existing connector API

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787163836&installation_model_id=425925&pr_number=854&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F854&signature=d0c4bd7e598a3c440e12a3653596b1cf761482ec2a198ca40582ad6b03cf61db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->