### PR TITLE
Add launch at login

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@react-three/drei": "^9",
     "@react-three/fiber": "^8",
     "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-dialog": "^2.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.1
         version: 2.11.1
+      '@tauri-apps/plugin-autostart':
+        specifier: ^2.5.1
+        version: 2.5.1
       '@tauri-apps/plugin-clipboard-manager':
         specifier: ^2.3.2
         version: 2.3.2
@@ -979,6 +982,9 @@ packages:
     resolution: {integrity: sha512-EElQe8z8uD7Pi5++tJ/UfEwWuK08rd3oCDYdeIbJAb6pZRrxlqmoF5gh5H5YvzmUPhS4IRCaLSsQhvWkrfK+GQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-autostart@2.5.1':
+    resolution: {integrity: sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==}
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
@@ -3023,6 +3029,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.3
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.3
       '@tauri-apps/cli-win32-x64-msvc': 2.11.3
+
+  '@tauri-apps/plugin-autostart@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -305,6 +305,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,11 +1054,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1058,7 +1089,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1222,7 +1253,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -3336,6 +3367,7 @@ dependencies = [
  "sqlx-sqlite",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
@@ -3919,6 +3951,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5053,7 +5096,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -5105,7 +5148,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -5173,6 +5216,20 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5305,7 +5362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -5911,7 +5968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2 0.6.4",
@@ -7155,6 +7212,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -7291,7 +7357,7 @@ dependencies = [
  "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -78,6 +78,7 @@ urlencoding = "2"
 uuid = { version = "1.11", features = ["serde", "v4"] }
 zeroize = { version = "1", features = ["derive"] }
 zip = { version = "=4.2.0", default-features = false }
+tauri-plugin-autostart = "2.5.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -10,6 +10,7 @@
     "notification:default",
     "dialog:allow-open",
     "clipboard-manager:allow-write-text",
-    "process:allow-restart"
+    "process:allow-restart",
+    "autostart:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -129,6 +129,15 @@ pub fn run() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        // Launch-at-login. LaunchAgent (not AppleScript) so the entry
+        // survives macOS upgrades and shows up under System Settings ->
+        // General -> Login Items. Enabling/disabling stays a user action in
+        // Settings and onboarding; registering the plugin alone changes
+        // nothing.
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ))
         .on_menu_event(|app, event| {
             if event.id().as_ref() == CHECK_FOR_UPDATES_MENU_ID {
                 let _ = app.emit(CHECK_FOR_UPDATES_EVENT, ());

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -210,6 +210,7 @@ import type {
   RecordingSourceReadinessDto,
 } from "../lib/tauri";
 import { useAccountStatus } from "../lib/account-status";
+import { applyAutostartDefaultOnce } from "../lib/autostart";
 import {
   applyOnboardingReplayFlag,
   isOnboardingComplete,
@@ -4056,6 +4057,10 @@ export function App() {
           onAccountChanged={handleAccountChanged}
           onComplete={() => {
             markOnboardingComplete();
+            // A background assistant only works while it runs; make sure a
+            // fresh install starts at login. One-shot: a user who later
+            // turns the login item off stays off.
+            void applyAutostartDefaultOnce();
             setOnboardingDone(true);
           }}
         />

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -210,7 +210,7 @@ import type {
   RecordingSourceReadinessDto,
 } from "../lib/tauri";
 import { useAccountStatus } from "../lib/account-status";
-import { applyAutostartDefaultOnce } from "../lib/autostart";
+import { applyAutostartDefaultOnce, retryPendingAutostartDefault } from "../lib/autostart";
 import {
   applyOnboardingReplayFlag,
   hasCompletedAnyOnboardingVersion,
@@ -2182,6 +2182,16 @@ export function App() {
       cancelled = true;
     };
   }, [appBlocked, bootstrapped]);
+
+  // A fresh install whose automatic launch-at-login enable failed during
+  // onboarding completion gets another chance on every normal startup:
+  // completion hides the wizard, so without this the retry would wait for
+  // an onboarding version bump. No-ops once the default has been settled
+  // (applied, or overridden by an explicit Settings toggle).
+  useEffect(() => {
+    if (appBlocked) return;
+    void retryPendingAutostartDefault();
+  }, [appBlocked]);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -213,6 +213,7 @@ import { useAccountStatus } from "../lib/account-status";
 import { applyAutostartDefaultOnce } from "../lib/autostart";
 import {
   applyOnboardingReplayFlag,
+  hasCompletedAnyOnboardingVersion,
   isOnboardingComplete,
   markOnboardingComplete,
   shouldReplayOnboarding,
@@ -4056,11 +4057,15 @@ export function App() {
           account={account}
           onAccountChanged={handleAccountChanged}
           onComplete={() => {
+            // Read before marking complete: marking writes the completion
+            // key that distinguishes a fresh install from a wizard replay.
+            const firstOnboardingCompletion = !hasCompletedAnyOnboardingVersion();
             markOnboardingComplete();
             // A background assistant only works while it runs; make sure a
-            // fresh install starts at login. One-shot: a user who later
-            // turns the login item off stays off.
-            void applyAutostartDefaultOnce();
+            // fresh install starts at login. One-shot and first-run only: a
+            // user who later turns the login item off stays off, and wizard
+            // replays never re-enroll existing users.
+            void applyAutostartDefaultOnce({ firstOnboardingCompletion });
             setOnboardingDone(true);
           }}
         />

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -34,6 +34,7 @@ import {
   setVeniceModel,
 } from "../../lib/tauri";
 import { LANGUAGE_OPTIONS, languageLabel } from "../../lib/dictation-languages";
+import { autostartEnabled, autostartSupported, setAutostartEnabled } from "../../lib/autostart";
 import { replayOnboarding } from "../../lib/onboarding";
 import type {
   AccountStatus,
@@ -1700,6 +1701,8 @@ export function AppSettings({
               onEnableSystemAudio={onEnableSystemAudio}
             />
 
+            <StartupSettingsSection />
+
             <PrivacySettingsSection />
           </>
         ) : null}
@@ -2721,6 +2724,79 @@ type PermissionStatusView = {
   label: string;
   tone: PermissionStatusTone;
 };
+
+/** Launch-at-login toggle. Reads and writes the OS login item directly (the
+ * LaunchAgent is the single source of truth), so state here can never drift
+ * from what System Settings shows. Hidden in browser previews, where no
+ * autostart backend exists. */
+function StartupSettingsSection() {
+  const [enabled, setEnabled] = useState<boolean>();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    if (!autostartSupported()) return;
+    let cancelled = false;
+    autostartEnabled()
+      .then((value) => {
+        if (!cancelled) setEnabled(value);
+      })
+      .catch(() => {
+        if (!cancelled) setError("Could not read the login item state.");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function toggle(next: boolean) {
+    setSaving(true);
+    setError(undefined);
+    try {
+      await setAutostartEnabled(next);
+      setEnabled(next);
+    } catch {
+      setError("Could not update the login item. Try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!autostartSupported() || (enabled === undefined && !error)) return null;
+
+  return (
+    <section className="settings-group" aria-labelledby="startup-heading">
+      <h2 id="startup-heading" className="settings-group-heading">
+        Startup
+      </h2>
+      <p className="settings-group-description">
+        Dictation shortcuts, meeting detection, and scheduled routines only work while June is
+        running.
+      </p>
+      <div className="settings-card">
+        <div className="settings-rows">
+          <div className="settings-row">
+            <div className="settings-row-info">
+              <h3 className="settings-row-title">Open June at login</h3>
+              <p className="settings-row-description">
+                Start June automatically when you sign in to your computer.
+              </p>
+            </div>
+            <div className="settings-row-control">
+              <Switch
+                checked={enabled === true}
+                disabled={saving || enabled === undefined}
+                aria-label="Open June at login"
+                onCheckedChange={(next) => void toggle(next)}
+              />
+            </div>
+          </div>
+          {error ? <p className="settings-row-description">{error}</p> : null}
+        </div>
+      </div>
+    </section>
+  );
+}
 
 function PermissionsSettingsSection({
   microphonePermissionStatus,

--- a/src/lib/autostart.ts
+++ b/src/lib/autostart.ts
@@ -35,12 +35,18 @@ export async function setAutostartEnabled(enabled: boolean): Promise<void> {
   else await plugin.disable();
 }
 
-/** Applies the launch-at-login default exactly once per machine. Called when
- * onboarding completes; safe to call again (it no-ops after the first run).
+/** Applies the launch-at-login default exactly once per machine, and only
+ * for a first-ever onboarding completion. Wizard replays (ONBOARDING_VERSION
+ * bumps re-run onboarding for existing users) must not silently enroll
+ * people who may have deliberately turned the login item off, so callers
+ * pass whether this machine had completed onboarding before this run.
  * Failures are swallowed: a login item is a convenience, never worth
  * blocking the end of onboarding over. */
-export async function applyAutostartDefaultOnce(): Promise<void> {
+export async function applyAutostartDefaultOnce(options: {
+  firstOnboardingCompletion: boolean;
+}): Promise<void> {
   if (!inTauri()) return;
+  if (!options.firstOnboardingCompletion) return;
   try {
     if (window.localStorage.getItem(DEFAULT_APPLIED_KEY) !== null) return;
   } catch {

--- a/src/lib/autostart.ts
+++ b/src/lib/autostart.ts
@@ -86,3 +86,23 @@ export async function applyAutostartDefaultOnce(options: {
     // Storage write failed; the worst case is a redundant enable() later.
   }
 }
+
+/** Consumes a leftover eligibility marker on normal app startup. Onboarding
+ * completion is the only place the default is first attempted, and a failed
+ * enable there would otherwise wait for an ONBOARDING_VERSION bump to retry
+ * (completion hides the wizard from every later launch). No-ops unless a
+ * prior first-run attempt left the marker behind. */
+export async function retryPendingAutostartDefault(): Promise<void> {
+  if (!inTauri()) return;
+  try {
+    if (window.localStorage.getItem(DEFAULT_APPLIED_KEY) !== null) return;
+    if (window.localStorage.getItem(DEFAULT_ELIGIBLE_KEY) === null) return;
+  } catch {
+    return;
+  }
+  try {
+    await setAutostartEnabled(true);
+  } catch {
+    // Still failing; the marker stays for the next launch.
+  }
+}

--- a/src/lib/autostart.ts
+++ b/src/lib/autostart.ts
@@ -39,6 +39,15 @@ export async function setAutostartEnabled(enabled: boolean): Promise<void> {
   const plugin = await import("@tauri-apps/plugin-autostart");
   if (enabled) await plugin.enable();
   else await plugin.disable();
+  // Any explicit user choice settles the first-run default: mark it applied
+  // and drop retry eligibility so no later onboarding replay can override
+  // what the user just decided (in particular, re-enroll after a disable).
+  try {
+    window.localStorage.setItem(DEFAULT_APPLIED_KEY, "1");
+    window.localStorage.removeItem(DEFAULT_ELIGIBLE_KEY);
+  } catch {
+    // Storage unavailable; the OS login item still reflects the choice.
+  }
 }
 
 /** Applies the launch-at-login default exactly once per machine, and only

--- a/src/lib/autostart.ts
+++ b/src/lib/autostart.ts
@@ -11,6 +11,12 @@
  */
 
 const DEFAULT_APPLIED_KEY = "june.autostart.defaultApplied";
+/** Set on a first-ever onboarding completion, cleared once the default
+ * lands. Keeps a failed enable retryable across replays: completion is
+ * marked before this helper runs, so without this marker a retry could
+ * never distinguish "fresh install whose enable failed" from "existing
+ * user who must not be enrolled". */
+const DEFAULT_ELIGIBLE_KEY = "june.autostart.defaultEligible";
 
 function inTauri() {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
@@ -46,21 +52,27 @@ export async function applyAutostartDefaultOnce(options: {
   firstOnboardingCompletion: boolean;
 }): Promise<void> {
   if (!inTauri()) return;
-  if (!options.firstOnboardingCompletion) return;
   try {
     if (window.localStorage.getItem(DEFAULT_APPLIED_KEY) !== null) return;
+    if (options.firstOnboardingCompletion) {
+      window.localStorage.setItem(DEFAULT_ELIGIBLE_KEY, "1");
+    } else if (window.localStorage.getItem(DEFAULT_ELIGIBLE_KEY) === null) {
+      // Wizard replay for an existing user: never enroll.
+      return;
+    }
   } catch {
     return;
   }
   try {
     await setAutostartEnabled(true);
   } catch {
-    // Leave the marker unset so a transient failure retries on the next
-    // completion (onboarding re-runs after version bumps).
+    // Leave the applied marker unset (and eligibility in place) so a
+    // transient failure retries on the next completion.
     return;
   }
   try {
     window.localStorage.setItem(DEFAULT_APPLIED_KEY, "1");
+    window.localStorage.removeItem(DEFAULT_ELIGIBLE_KEY);
   } catch {
     // Storage write failed; the worst case is a redundant enable() later.
   }

--- a/src/lib/autostart.ts
+++ b/src/lib/autostart.ts
@@ -1,0 +1,61 @@
+/**
+ * Launch-at-login state, backed by tauri-plugin-autostart (a LaunchAgent on
+ * macOS, registry entry on Windows).
+ *
+ * June is a background assistant: dictation hotkeys, meeting detection, and
+ * scheduled routines only work while the app is running, so a fresh install
+ * enables launch at login once during onboarding completion. The OS login
+ * item itself stays the single source of truth; the one-shot marker below
+ * only records that the default was applied, so a user who later turns the
+ * login item off (in Settings or System Settings) is never re-opted-in.
+ */
+
+const DEFAULT_APPLIED_KEY = "june.autostart.defaultApplied";
+
+function inTauri() {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+/** Whether an autostart backend exists at all (false in browser previews,
+ * where the Settings row should not render). */
+export function autostartSupported() {
+  return inTauri();
+}
+
+export async function autostartEnabled(): Promise<boolean> {
+  if (!inTauri()) return false;
+  const { isEnabled } = await import("@tauri-apps/plugin-autostart");
+  return isEnabled();
+}
+
+export async function setAutostartEnabled(enabled: boolean): Promise<void> {
+  if (!inTauri()) return;
+  const plugin = await import("@tauri-apps/plugin-autostart");
+  if (enabled) await plugin.enable();
+  else await plugin.disable();
+}
+
+/** Applies the launch-at-login default exactly once per machine. Called when
+ * onboarding completes; safe to call again (it no-ops after the first run).
+ * Failures are swallowed: a login item is a convenience, never worth
+ * blocking the end of onboarding over. */
+export async function applyAutostartDefaultOnce(): Promise<void> {
+  if (!inTauri()) return;
+  try {
+    if (window.localStorage.getItem(DEFAULT_APPLIED_KEY) !== null) return;
+  } catch {
+    return;
+  }
+  try {
+    await setAutostartEnabled(true);
+  } catch {
+    // Leave the marker unset so a transient failure retries on the next
+    // completion (onboarding re-runs after version bumps).
+    return;
+  }
+  try {
+    window.localStorage.setItem(DEFAULT_APPLIED_KEY, "1");
+  } catch {
+    // Storage write failed; the worst case is a redundant enable() later.
+  }
+}

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -55,6 +55,20 @@ export function isOnboardingComplete(): boolean {
   }
 }
 
+/** Whether this machine has ever finished onboarding, at any version.
+ * Distinguishes a genuinely fresh install from a wizard replay after an
+ * ONBOARDING_VERSION bump, so one-time first-run defaults (like enabling
+ * launch at login) never re-apply to existing users. */
+export function hasCompletedAnyOnboardingVersion(): boolean {
+  try {
+    return window.localStorage.getItem(COMPLETED_KEY) !== null;
+  } catch {
+    // Storage unavailable reads as "not a fresh install": err on the side
+    // of not applying first-run defaults.
+    return true;
+  }
+}
+
 export function markOnboardingComplete() {
   try {
     window.localStorage.setItem(COMPLETED_KEY, String(ONBOARDING_VERSION));

--- a/src/test/autostart.test.ts
+++ b/src/test/autostart.test.ts
@@ -8,7 +8,12 @@ const pluginMocks = vi.hoisted(() => ({
 
 vi.mock("@tauri-apps/plugin-autostart", () => pluginMocks);
 
-import { applyAutostartDefaultOnce, autostartEnabled, setAutostartEnabled } from "../lib/autostart";
+import {
+  applyAutostartDefaultOnce,
+  autostartEnabled,
+  retryPendingAutostartDefault,
+  setAutostartEnabled,
+} from "../lib/autostart";
 
 const DEFAULT_APPLIED_KEY = "june.autostart.defaultApplied";
 
@@ -96,6 +101,35 @@ describe("autostart", () => {
     await applyAutostartDefaultOnce({ firstOnboardingCompletion: false });
     expect(pluginMocks.enable).toHaveBeenCalledTimes(2);
     expect(window.localStorage.getItem(DEFAULT_APPLIED_KEY)).toBe("1");
+  });
+
+  it("retries a pending default on a normal startup", async () => {
+    // Onboarding completion is the only first-attempt site; a failure there
+    // must not strand the default until a version bump replays the wizard.
+    pluginMocks.enable.mockRejectedValueOnce(new Error("no launch agent dir"));
+    await applyAutostartDefaultOnce({ firstOnboardingCompletion: true });
+    expect(window.localStorage.getItem(DEFAULT_APPLIED_KEY)).toBeNull();
+
+    await retryPendingAutostartDefault();
+    expect(pluginMocks.enable).toHaveBeenCalledTimes(2);
+    expect(window.localStorage.getItem(DEFAULT_APPLIED_KEY)).toBe("1");
+
+    // Settled: later startups no-op.
+    pluginMocks.enable.mockClear();
+    await retryPendingAutostartDefault();
+    expect(pluginMocks.enable).not.toHaveBeenCalled();
+  });
+
+  it("startup retry never runs without a pending marker", async () => {
+    // Existing user, no first-run attempt ever recorded.
+    await retryPendingAutostartDefault();
+    expect(pluginMocks.enable).not.toHaveBeenCalled();
+
+    // Explicitly disabled user: settled, still no retry.
+    await setAutostartEnabled(false);
+    pluginMocks.enable.mockClear();
+    await retryPendingAutostartDefault();
+    expect(pluginMocks.enable).not.toHaveBeenCalled();
   });
 
   it("retries the default on the next run after a failed enable", async () => {

--- a/src/test/autostart.test.ts
+++ b/src/test/autostart.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const pluginMocks = vi.hoisted(() => ({
+  isEnabled: vi.fn(),
+  enable: vi.fn(),
+  disable: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-autostart", () => pluginMocks);
+
+import {
+  applyAutostartDefaultOnce,
+  autostartEnabled,
+  setAutostartEnabled,
+} from "../lib/autostart";
+
+const DEFAULT_APPLIED_KEY = "june.autostart.defaultApplied";
+
+function markTauri() {
+  (window as typeof window & { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__ = {};
+}
+
+function unmarkTauri() {
+  delete (window as typeof window & { __TAURI_INTERNALS__?: object }).__TAURI_INTERNALS__;
+}
+
+describe("autostart", () => {
+  beforeEach(() => {
+    markTauri();
+    window.localStorage.clear();
+    pluginMocks.isEnabled.mockResolvedValue(false);
+    pluginMocks.enable.mockResolvedValue(undefined);
+    pluginMocks.disable.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    unmarkTauri();
+    vi.clearAllMocks();
+  });
+
+  it("reads the login item state from the plugin", async () => {
+    pluginMocks.isEnabled.mockResolvedValue(true);
+    await expect(autostartEnabled()).resolves.toBe(true);
+  });
+
+  it("reports disabled outside Tauri without touching the plugin", async () => {
+    unmarkTauri();
+    await expect(autostartEnabled()).resolves.toBe(false);
+    expect(pluginMocks.isEnabled).not.toHaveBeenCalled();
+  });
+
+  it("routes enable and disable to the plugin", async () => {
+    await setAutostartEnabled(true);
+    expect(pluginMocks.enable).toHaveBeenCalledTimes(1);
+    await setAutostartEnabled(false);
+    expect(pluginMocks.disable).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the launch-at-login default exactly once", async () => {
+    await applyAutostartDefaultOnce();
+    expect(pluginMocks.enable).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(DEFAULT_APPLIED_KEY)).toBe("1");
+
+    // Second completion (onboarding version bump): no re-enable, so a user
+    // who turned the login item off is not opted back in.
+    await applyAutostartDefaultOnce();
+    expect(pluginMocks.enable).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the default on the next run after a failed enable", async () => {
+    pluginMocks.enable.mockRejectedValueOnce(new Error("no launch agent dir"));
+    await applyAutostartDefaultOnce();
+    expect(window.localStorage.getItem(DEFAULT_APPLIED_KEY)).toBeNull();
+
+    await applyAutostartDefaultOnce();
+    expect(pluginMocks.enable).toHaveBeenCalledTimes(2);
+    expect(window.localStorage.getItem(DEFAULT_APPLIED_KEY)).toBe("1");
+  });
+
+  it("does nothing outside Tauri", async () => {
+    unmarkTauri();
+    await applyAutostartDefaultOnce();
+    expect(pluginMocks.enable).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/autostart.test.ts
+++ b/src/test/autostart.test.ts
@@ -53,29 +53,37 @@ describe("autostart", () => {
   });
 
   it("applies the launch-at-login default exactly once", async () => {
-    await applyAutostartDefaultOnce();
+    await applyAutostartDefaultOnce({ firstOnboardingCompletion: true });
     expect(pluginMocks.enable).toHaveBeenCalledTimes(1);
     expect(window.localStorage.getItem(DEFAULT_APPLIED_KEY)).toBe("1");
 
     // Second completion (onboarding version bump): no re-enable, so a user
     // who turned the login item off is not opted back in.
-    await applyAutostartDefaultOnce();
+    await applyAutostartDefaultOnce({ firstOnboardingCompletion: true });
     expect(pluginMocks.enable).toHaveBeenCalledTimes(1);
+  });
+
+  it("never enrolls existing users on a wizard replay", async () => {
+    // An ONBOARDING_VERSION bump replays the wizard for users who already
+    // completed onboarding before this feature shipped (no marker set).
+    await applyAutostartDefaultOnce({ firstOnboardingCompletion: false });
+    expect(pluginMocks.enable).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(DEFAULT_APPLIED_KEY)).toBeNull();
   });
 
   it("retries the default on the next run after a failed enable", async () => {
     pluginMocks.enable.mockRejectedValueOnce(new Error("no launch agent dir"));
-    await applyAutostartDefaultOnce();
+    await applyAutostartDefaultOnce({ firstOnboardingCompletion: true });
     expect(window.localStorage.getItem(DEFAULT_APPLIED_KEY)).toBeNull();
 
-    await applyAutostartDefaultOnce();
+    await applyAutostartDefaultOnce({ firstOnboardingCompletion: true });
     expect(pluginMocks.enable).toHaveBeenCalledTimes(2);
     expect(window.localStorage.getItem(DEFAULT_APPLIED_KEY)).toBe("1");
   });
 
   it("does nothing outside Tauri", async () => {
     unmarkTauri();
-    await applyAutostartDefaultOnce();
+    await applyAutostartDefaultOnce({ firstOnboardingCompletion: true });
     expect(pluginMocks.enable).not.toHaveBeenCalled();
   });
 });

--- a/src/test/autostart.test.ts
+++ b/src/test/autostart.test.ts
@@ -52,6 +52,21 @@ describe("autostart", () => {
     expect(pluginMocks.disable).toHaveBeenCalledTimes(1);
   });
 
+  it("never re-enrolls after an explicit disable, even with a pending retry", async () => {
+    // Fresh install whose automatic enable failed leaves retry eligibility
+    // behind. The user then enables and disables by hand; a later replay
+    // must respect the disable rather than resume the retry.
+    pluginMocks.enable.mockRejectedValueOnce(new Error("no launch agent dir"));
+    await applyAutostartDefaultOnce({ firstOnboardingCompletion: true });
+
+    await setAutostartEnabled(true);
+    await setAutostartEnabled(false);
+    pluginMocks.enable.mockClear();
+
+    await applyAutostartDefaultOnce({ firstOnboardingCompletion: false });
+    expect(pluginMocks.enable).not.toHaveBeenCalled();
+  });
+
   it("applies the launch-at-login default exactly once", async () => {
     await applyAutostartDefaultOnce({ firstOnboardingCompletion: true });
     expect(pluginMocks.enable).toHaveBeenCalledTimes(1);

--- a/src/test/autostart.test.ts
+++ b/src/test/autostart.test.ts
@@ -71,6 +71,18 @@ describe("autostart", () => {
     expect(window.localStorage.getItem(DEFAULT_APPLIED_KEY)).toBeNull();
   });
 
+  it("retries a fresh install's failed enable on a later replay", async () => {
+    // First completion fails to enable; completion is already marked by the
+    // caller, so the retry arrives as a replay. Eligibility must survive.
+    pluginMocks.enable.mockRejectedValueOnce(new Error("no launch agent dir"));
+    await applyAutostartDefaultOnce({ firstOnboardingCompletion: true });
+    expect(window.localStorage.getItem(DEFAULT_APPLIED_KEY)).toBeNull();
+
+    await applyAutostartDefaultOnce({ firstOnboardingCompletion: false });
+    expect(pluginMocks.enable).toHaveBeenCalledTimes(2);
+    expect(window.localStorage.getItem(DEFAULT_APPLIED_KEY)).toBe("1");
+  });
+
   it("retries the default on the next run after a failed enable", async () => {
     pluginMocks.enable.mockRejectedValueOnce(new Error("no launch agent dir"));
     await applyAutostartDefaultOnce({ firstOnboardingCompletion: true });

--- a/src/test/autostart.test.ts
+++ b/src/test/autostart.test.ts
@@ -8,11 +8,7 @@ const pluginMocks = vi.hoisted(() => ({
 
 vi.mock("@tauri-apps/plugin-autostart", () => pluginMocks);
 
-import {
-  applyAutostartDefaultOnce,
-  autostartEnabled,
-  setAutostartEnabled,
-} from "../lib/autostart";
+import { applyAutostartDefaultOnce, autostartEnabled, setAutostartEnabled } from "../lib/autostart";
 
 const DEFAULT_APPLIED_KEY = "june.autostart.defaultApplied";
 


### PR DESCRIPTION
## What changed
- Adds `tauri-plugin-autostart` (LaunchAgent on macOS, registry entry on Windows) registered in the Tauri builder, with `autostart:default` capability for the main window.
- New `src/lib/autostart.ts`: read/toggle helpers plus `applyAutostartDefaultOnce()`, which enables the login item exactly once when onboarding completes. A user who later disables it is never re-opted-in (one-shot localStorage marker; failed enables retry on the next onboarding completion).
- New Startup section in Settings > General with an "Open June at login" switch. The OS login item is the single source of truth; the section hides in browser previews where no backend exists.

## Why
1W retention work: June is a background assistant (dictation hotkeys, meeting detection, scheduled routines) that only works while running. Without a login item the app is effectively uninstalled after the first reboot, so every other retention loop starves.

## Validation
- `tsc --noEmit` clean
- `pnpm test`: 192 files, 3062 passed
- New `src/test/autostart.test.ts` (6 tests): plugin routing, one-shot default, retry after failure, non-Tauri no-op
- `cargo check --manifest-path src-tauri/Cargo.toml` clean
- Live walkthrough: not run for the toggle UI; the Settings row uses the existing Switch/settings-row idiom and the autostart behavior itself requires an installed bundle (LaunchAgent registration does not exercise meaningfully in `tauri dev`). Flagging this as the main manual QA item for a release build.

## Known gaps
- LaunchAgent enable/disable not exercised against a signed .app bundle in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787166245&installation_model_id=425925&pr_number=855&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F855&signature=c45968106959ba1e0bdf983ba35528161845a1ba129f5142b2b77486b72a43c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->