### PR TITLE
Add one-click morning brief opt-in to onboarding

### DIFF
--- a/onboarding-preview.html
+++ b/onboarding-preview.html
@@ -351,6 +351,24 @@
               }
               case "p3a_record":
                 return null;
+              // Routine machinery behind the morning brief step. The stub
+              // pretends the bridge is up and creation succeeds, so the
+              // final screen can be exercised end to end in the preview.
+              case "hermes_bridge_status":
+                return { running: true };
+              case "start_hermes_bridge":
+                return { running: true };
+              case "ensure_hermes_bridge_gateway":
+                return null;
+              case "create_hermes_bridge_cron_job":
+                return {
+                  id: "job-morning-brief",
+                  name: args.request && args.request.name,
+                  prompt: args.request && args.request.prompt,
+                  schedule_display: args.request && args.request.schedule,
+                  enabled: true,
+                  state: "scheduled",
+                };
               default:
                 return null;
             }

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -6,12 +6,19 @@ import { dictationSettings, p3aRecord, setDictationShortcut } from "../../lib/ta
 import type { AccountStatus, DictationShortcutSetting } from "../../lib/tauri";
 import { PermissionsStep } from "./steps/PermissionSteps";
 import { DictationPracticeStep } from "./steps/PracticeStep";
+import { MorningBriefStep } from "./steps/MorningBriefStep";
 import { SignInStep } from "./steps/SignInStep";
 import { TelemetryConsentStep } from "./steps/TelemetryConsentStep";
 import { UsageIntentStep } from "./steps/UsageIntentStep";
 import { usePermissionStatuses, useSystemAudioStatus } from "./use-permission-status";
 
-type StepId = "sign-in" | "telemetry" | "usage-intent" | "permissions" | "dictation-practice";
+type StepId =
+  | "sign-in"
+  | "telemetry"
+  | "usage-intent"
+  | "permissions"
+  | "dictation-practice"
+  | "morning-brief";
 
 // The product default: bare fn, mirroring DictationShortcutSetting::bare_fn()
 // on the Rust side.
@@ -47,6 +54,7 @@ const MAC_STEPS: StepId[] = [
   "usage-intent",
   "permissions",
   "dictation-practice",
+  "morning-brief",
 ];
 const WINDOWS_STEPS: StepId[] = [
   "sign-in",
@@ -54,8 +62,15 @@ const WINDOWS_STEPS: StepId[] = [
   "usage-intent",
   "permissions",
   "dictation-practice",
+  "morning-brief",
 ];
-const NON_DICTATION_STEPS: StepId[] = ["sign-in", "telemetry", "usage-intent", "permissions"];
+const NON_DICTATION_STEPS: StepId[] = [
+  "sign-in",
+  "telemetry",
+  "usage-intent",
+  "permissions",
+  "morning-brief",
+];
 
 type Props = {
   account: AccountStatus;
@@ -82,7 +97,8 @@ function browserOnboardingDemoStep(): StepId | null {
     step === "telemetry" ||
     step === "usage-intent" ||
     step === "permissions" ||
-    step === "dictation-practice"
+    step === "dictation-practice" ||
+    step === "morning-brief"
     ? step
     : null;
 }
@@ -234,8 +250,10 @@ export function OnboardingFlow({ account, onAccountChanged, onComplete }: Props)
           <DictationPracticeStep
             shortcutLabel={shortcutLabel}
             onShortcutLabelChange={setShortcutLabel}
-            onContinue={completeOnboarding}
+            onContinue={goNext}
           />
+        ) : stepId === "morning-brief" ? (
+          <MorningBriefStep onContinue={completeOnboarding} />
         ) : null}
       </div>
     </div>

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -253,7 +253,7 @@ export function OnboardingFlow({ account, onAccountChanged, onComplete }: Props)
             onContinue={goNext}
           />
         ) : stepId === "morning-brief" ? (
-          <MorningBriefStep onContinue={completeOnboarding} />
+          <MorningBriefStep onContinue={goNext} />
         ) : null}
       </div>
     </div>

--- a/src/components/onboarding/steps/MorningBriefStep.tsx
+++ b/src/components/onboarding/steps/MorningBriefStep.tsx
@@ -1,6 +1,6 @@
 import { IconCloudySun } from "central-icons/IconCloudySun";
 import { useEffect, useState } from "react";
-import { createRoutine, listRoutines } from "../../../lib/hermes-routines";
+import { createRoutine, listRoutines, resumeRoutine } from "../../../lib/hermes-routines";
 import { humanizeSchedule } from "../../../lib/routine-schedule";
 import { ROUTINE_TEMPLATES } from "../../routines/routine-templates";
 import { p3aRecord } from "../../../lib/tauri";
@@ -44,8 +44,12 @@ export function MorningBriefStep({ onContinue }: { onContinue: () => void }) {
       // proceeds (a duplicate is recoverable under Routines, a hard block
       // here is not).
       const existing = await listRoutines().catch(() => []);
-      const alreadySetUp = existing.some((routine) => routine.name === template.name);
-      if (!alreadySetUp) {
+      const match = existing.find((routine) => routine.name === template.name);
+      if (match && match.state !== "scheduled") {
+        // The user paused (or a run exhausted) an earlier copy; clicking
+        // Enable means "make it run again", not "leave it dormant".
+        await resumeRoutine(match.job_id);
+      } else if (!match) {
         await createRoutine({
           prompt: template.prompt,
           schedule: template.schedule,

--- a/src/components/onboarding/steps/MorningBriefStep.tsx
+++ b/src/components/onboarding/steps/MorningBriefStep.tsx
@@ -44,12 +44,17 @@ export function MorningBriefStep({ onContinue }: { onContinue: () => void }) {
       // proceeds (a duplicate is recoverable under Routines, a hard block
       // here is not).
       const existing = await listRoutines().catch(() => []);
-      const match = existing.find((routine) => routine.name === template.name);
-      if (match && match.state !== "scheduled") {
+      const matches = existing.filter((routine) => routine.name === template.name);
+      const scheduled = matches.find((routine) => routine.state === "scheduled");
+      const dormant = matches.find((routine) => routine.state !== "scheduled");
+      if (scheduled) {
+        // Already running: nothing to do (and never resume a dormant
+        // duplicate next to an active copy).
+      } else if (dormant) {
         // The user paused (or a run exhausted) an earlier copy; clicking
         // Enable means "make it run again", not "leave it dormant".
-        await resumeRoutine(match.job_id);
-      } else if (!match) {
+        await resumeRoutine(dormant.job_id);
+      } else {
         await createRoutine({
           prompt: template.prompt,
           schedule: template.schedule,

--- a/src/components/onboarding/steps/MorningBriefStep.tsx
+++ b/src/components/onboarding/steps/MorningBriefStep.tsx
@@ -1,6 +1,6 @@
 import { IconCloudySun } from "central-icons/IconCloudySun";
 import { useEffect, useState } from "react";
-import { createRoutine } from "../../../lib/hermes-routines";
+import { createRoutine, listRoutines } from "../../../lib/hermes-routines";
 import { humanizeSchedule } from "../../../lib/routine-schedule";
 import { ROUTINE_TEMPLATES } from "../../routines/routine-templates";
 import { p3aRecord } from "../../../lib/tauri";
@@ -38,11 +38,20 @@ export function MorningBriefStep({ onContinue }: { onContinue: () => void }) {
     setCreating(true);
     setError(undefined);
     try {
-      await createRoutine({
-        prompt: template.prompt,
-        schedule: template.schedule,
-        name: template.name,
-      });
+      // Wizard replays (ONBOARDING_VERSION bumps) walk existing users
+      // through this step again; enabling must not stack a second copy of
+      // the routine. Best-effort: if the lookup itself fails, creation
+      // proceeds (a duplicate is recoverable under Routines, a hard block
+      // here is not).
+      const existing = await listRoutines().catch(() => []);
+      const alreadySetUp = existing.some((routine) => routine.name === template.name);
+      if (!alreadySetUp) {
+        await createRoutine({
+          prompt: template.prompt,
+          schedule: template.schedule,
+          name: template.name,
+        });
+      }
       setCreated(true);
       void p3aRecord("onboarding.morning-brief.enabled");
       onContinue();

--- a/src/components/onboarding/steps/MorningBriefStep.tsx
+++ b/src/components/onboarding/steps/MorningBriefStep.tsx
@@ -1,0 +1,84 @@
+import { IconCloudySun } from "central-icons/IconCloudySun";
+import { useEffect, useState } from "react";
+import { createRoutine } from "../../../lib/hermes-routines";
+import { humanizeSchedule } from "../../../lib/routine-schedule";
+import { ROUTINE_TEMPLATES } from "../../routines/routine-templates";
+import { p3aRecord } from "../../../lib/tauri";
+import { StepActions, StepCard } from "../StepChrome";
+
+/** The one starter routine whose prompt is fully self-contained (no
+ * [placeholder] the user must fill in), which is what makes a one-click
+ * opt-in honest: what you enable is exactly what will run. */
+const template = ROUTINE_TEMPLATES.find((candidate) => candidate.id === "morning-brief");
+
+/**
+ * Last onboarding screen: a one-click daily reason to come back. June's
+ * pillars are all pull-based (the user must remember to record, dictate, or
+ * ask), so a fresh install otherwise ends with nothing scheduled and no
+ * future touchpoint. Opting in creates the sandboxed "Morning brief" routine
+ * through the normal Routines machinery; declining is a first-class quiet
+ * path, not a dark pattern.
+ */
+export function MorningBriefStep({ onContinue }: { onContinue: () => void }) {
+  const [creating, setCreating] = useState(false);
+  const [created, setCreated] = useState(false);
+  const [error, setError] = useState<string>();
+
+  // Template lookup is static; a missing entry is a programming error but
+  // must not strand the user inside onboarding. Advance from an effect, not
+  // during render.
+  useEffect(() => {
+    if (!template) onContinue();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  if (!template) return null;
+
+  async function enable() {
+    if (!template || creating || created) return;
+    setCreating(true);
+    setError(undefined);
+    try {
+      await createRoutine({
+        prompt: template.prompt,
+        schedule: template.schedule,
+        name: template.name,
+      });
+      setCreated(true);
+      void p3aRecord("onboarding.morning-brief.enabled");
+      onContinue();
+    } catch {
+      setError("Could not set it up right now. You can add it later under Routines.");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <StepCard
+      title="Start tomorrow with a brief"
+      subtitle="June can prepare a short morning brief on weekdays: open loops, todos, and anything new that matters."
+      wide
+    >
+      <div className="onboarding-brief-card">
+        <span className="onboarding-brief-icon" aria-hidden>
+          <IconCloudySun size={18} />
+        </span>
+        <span className="onboarding-brief-body">
+          <span className="onboarding-brief-name">{template.name}</span>
+          <span className="onboarding-brief-meta">
+            {humanizeSchedule(template.schedule)}. You can edit or remove it any time under
+            Routines.
+          </span>
+        </span>
+      </div>
+      {error ? <p className="welcome-status">{error}</p> : null}
+      <StepActions
+        continueLabel={creating ? "Setting up..." : "Enable morning brief"}
+        continueDisabled={creating}
+        onContinue={() => void enable()}
+        onSkip={onContinue}
+        skipLabel="Not now"
+      />
+    </StepCard>
+  );
+}

--- a/src/components/onboarding/steps/PracticeStep.tsx
+++ b/src/components/onboarding/steps/PracticeStep.tsx
@@ -110,7 +110,7 @@ export function DictationPracticeStep({
       </div>
       {capture.error ? <p className="welcome-status">{capture.error}</p> : null}
       <StepActions
-        continueLabel="Start using June"
+        continueLabel="Continue"
         onContinue={onContinue}
         continueDisabled={!succeeded}
         onSkip={onContinue}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -23657,6 +23657,50 @@ button.memory-project:hover {
   box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
+/* Morning brief opt-in: one bordered card previewing the routine that a
+ * click will create — icon chip, name, schedule line. Mirrors the intent
+ * grid's card idiom so the step reads as part of the same flow. */
+.onboarding-brief-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-3);
+  margin-block-start: var(--sp-3);
+  padding: var(--sp-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-lg);
+  background: var(--card);
+  text-align: left;
+}
+
+.onboarding-brief-icon {
+  flex: 0 0 auto;
+  display: inline-grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--r-md);
+  background: color-mix(in oklch, var(--warm-soft) 34%, var(--card));
+  color: var(--warm-strong);
+}
+
+.onboarding-brief-body {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.onboarding-brief-name {
+  color: var(--foreground);
+  font-size: var(--fs-md);
+  font-weight: 500;
+}
+
+.onboarding-brief-meta {
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
 /* Permissions: one bordered card, one row per permission — icon chip, a
  * line of copy, the grant affordance. A granted row trades its icon for a
  * check and tints terracotta. */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -23693,7 +23693,7 @@ button.memory-project:hover {
 .onboarding-brief-name {
   color: var(--foreground);
   font-size: var(--fs-md);
-  font-weight: 500;
+  font-weight: var(--fw-medium);
 }
 
 .onboarding-brief-meta {

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   listen: vi.fn(),
   createRoutine: vi.fn(),
   listRoutines: vi.fn(),
+  resumeRoutine: vi.fn(),
 }));
 
 vi.mock("../lib/tauri", () => ({
@@ -71,6 +72,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 vi.mock("../lib/hermes-routines", () => ({
   createRoutine: mocks.createRoutine,
   listRoutines: mocks.listRoutines,
+  resumeRoutine: mocks.resumeRoutine,
 }));
 
 const account: AccountStatus = {
@@ -291,13 +293,34 @@ describe("OnboardingFlow", () => {
     const user = userEvent.setup();
     const onComplete = vi.fn();
     setOnboardingResumeStep("morning-brief");
-    mocks.listRoutines.mockResolvedValue([{ job_id: "job-1", name: "Morning brief" }]);
+    mocks.listRoutines.mockResolvedValue([
+      { job_id: "job-1", name: "Morning brief", state: "scheduled" },
+    ]);
     render(<OnboardingFlow {...flowProps({ onComplete })} />);
 
     await screen.findByRole("heading", { name: "Start tomorrow with a brief" });
     await user.click(screen.getByRole("button", { name: "Enable morning brief" }));
 
     await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+    expect(mocks.createRoutine).not.toHaveBeenCalled();
+    expect(mocks.resumeRoutine).not.toHaveBeenCalled();
+  });
+
+  it("resumes a paused morning brief instead of leaving it dormant", async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    setOnboardingResumeStep("morning-brief");
+    mocks.listRoutines.mockResolvedValue([
+      { job_id: "job-1", name: "Morning brief", state: "paused" },
+    ]);
+    mocks.resumeRoutine.mockResolvedValue(undefined);
+    render(<OnboardingFlow {...flowProps({ onComplete })} />);
+
+    await screen.findByRole("heading", { name: "Start tomorrow with a brief" });
+    await user.click(screen.getByRole("button", { name: "Enable morning brief" }));
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+    expect(mocks.resumeRoutine).toHaveBeenCalledWith("job-1");
     expect(mocks.createRoutine).not.toHaveBeenCalled();
   });
 

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => ({
   osAccountsOpenPortal: vi.fn(),
   listen: vi.fn(),
   createRoutine: vi.fn(),
+  listRoutines: vi.fn(),
 }));
 
 vi.mock("../lib/tauri", () => ({
@@ -69,6 +70,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 vi.mock("../lib/hermes-routines", () => ({
   createRoutine: mocks.createRoutine,
+  listRoutines: mocks.listRoutines,
 }));
 
 const account: AccountStatus = {
@@ -177,6 +179,7 @@ describe("OnboardingFlow", () => {
       }),
     );
     mocks.p3aRecord.mockResolvedValue(undefined);
+    mocks.listRoutines.mockResolvedValue([]);
     mocks.dictationSettings.mockResolvedValue({
       settings: {
         pushToTalkShortcut: shortcut("fn"),
@@ -282,6 +285,20 @@ describe("OnboardingFlow", () => {
     expect(mocks.p3aRecord).toHaveBeenCalledWith("onboarding.use-case.work");
     // Completion is the caller's job (App marks it), not the flow's.
     expect(isOnboardingComplete()).toBe(false);
+  });
+
+  it("does not create a duplicate routine on a wizard replay", async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    setOnboardingResumeStep("morning-brief");
+    mocks.listRoutines.mockResolvedValue([{ job_id: "job-1", name: "Morning brief" }]);
+    render(<OnboardingFlow {...flowProps({ onComplete })} />);
+
+    await screen.findByRole("heading", { name: "Start tomorrow with a brief" });
+    await user.click(screen.getByRole("button", { name: "Enable morning brief" }));
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+    expect(mocks.createRoutine).not.toHaveBeenCalled();
   });
 
   it("completes without a routine when the morning brief is declined", async () => {

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -324,6 +324,24 @@ describe("OnboardingFlow", () => {
     expect(mocks.createRoutine).not.toHaveBeenCalled();
   });
 
+  it("prefers an already scheduled copy over resuming a dormant duplicate", async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    setOnboardingResumeStep("morning-brief");
+    mocks.listRoutines.mockResolvedValue([
+      { job_id: "job-old", name: "Morning brief", state: "paused" },
+      { job_id: "job-live", name: "Morning brief", state: "scheduled" },
+    ]);
+    render(<OnboardingFlow {...flowProps({ onComplete })} />);
+
+    await screen.findByRole("heading", { name: "Start tomorrow with a brief" });
+    await user.click(screen.getByRole("button", { name: "Enable morning brief" }));
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+    expect(mocks.resumeRoutine).not.toHaveBeenCalled();
+    expect(mocks.createRoutine).not.toHaveBeenCalled();
+  });
+
   it("completes without a routine when the morning brief is declined", async () => {
     const user = userEvent.setup();
     const onComplete = vi.fn();

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   osAccountsCancelLogin: vi.fn(),
   osAccountsOpenPortal: vi.fn(),
   listen: vi.fn(),
+  createRoutine: vi.fn(),
 }));
 
 vi.mock("../lib/tauri", () => ({
@@ -64,6 +65,10 @@ vi.mock("../lib/tauri", () => ({
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: mocks.listen,
+}));
+
+vi.mock("../lib/hermes-routines", () => ({
+  createRoutine: mocks.createRoutine,
 }));
 
 const account: AccountStatus = {
@@ -257,13 +262,57 @@ describe("OnboardingFlow", () => {
     const input = await screen.findByPlaceholderText(/Tell June what to do/i);
     await user.type(input, "hello there");
     await screen.findByRole("status", { name: "Dictation is working" });
-    await user.click(screen.getByRole("button", { name: "Start using June" }));
+    await user.click(screen.getByRole("button", { name: "Continue" }));
 
-    expect(onComplete).toHaveBeenCalledOnce();
+    // Final screen: the one-click morning brief opt-in. Enabling creates the
+    // starter routine and completes onboarding.
+    await screen.findByRole("heading", { name: "Start tomorrow with a brief" });
+    mocks.createRoutine.mockResolvedValue({ job_id: "job-1" });
+    await user.click(screen.getByRole("button", { name: "Enable morning brief" }));
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+    expect(mocks.createRoutine).toHaveBeenCalledWith({
+      name: "Morning brief",
+      prompt: expect.stringContaining("morning brief"),
+      schedule: "0 8 * * 1-5",
+    });
+    expect(mocks.p3aRecord).toHaveBeenCalledWith("onboarding.morning-brief.enabled");
+
     expect(mocks.p3aRecord).toHaveBeenCalledWith("onboarding.completed");
     expect(mocks.p3aRecord).toHaveBeenCalledWith("onboarding.use-case.work");
     // Completion is the caller's job (App marks it), not the flow's.
     expect(isOnboardingComplete()).toBe(false);
+  });
+
+  it("completes without a routine when the morning brief is declined", async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    setOnboardingResumeStep("morning-brief");
+    render(<OnboardingFlow {...flowProps({ onComplete })} />);
+
+    await screen.findByRole("heading", { name: "Start tomorrow with a brief" });
+    await user.click(screen.getByRole("button", { name: "Not now" }));
+
+    expect(onComplete).toHaveBeenCalledOnce();
+    expect(mocks.createRoutine).not.toHaveBeenCalled();
+  });
+
+  it("keeps the user on the brief step when routine creation fails", async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    setOnboardingResumeStep("morning-brief");
+    render(<OnboardingFlow {...flowProps({ onComplete })} />);
+
+    await screen.findByRole("heading", { name: "Start tomorrow with a brief" });
+    mocks.createRoutine.mockRejectedValue(new Error("gateway down"));
+    await user.click(screen.getByRole("button", { name: "Enable morning brief" }));
+
+    await screen.findByText(/Could not set it up right now/);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    // The quiet path still works after a failure.
+    await user.click(screen.getByRole("button", { name: "Not now" }));
+    expect(onComplete).toHaveBeenCalledOnce();
   });
 
   it("keeps anonymous usage statistics off by default", async () => {
@@ -361,9 +410,7 @@ describe("OnboardingFlow", () => {
     await renderFlow();
     await walkToPractice(user);
 
-    const startButton = screen.getByRole("button", {
-      name: "Start using June",
-    });
+    const startButton = screen.getByRole("button", { name: "Continue" });
     expect(startButton).toBeDisabled();
 
     await user.type(screen.getByPlaceholderText(/Tell June what to do/i), "h");
@@ -600,7 +647,7 @@ describe("OnboardingFlow", () => {
     expect(screen.queryByRole("option")).toBeNull();
 
     await user.type(screen.getByPlaceholderText(/Tell June what to do/i), "hello there");
-    await user.click(screen.getByRole("button", { name: "Start using June" }));
+    await user.click(screen.getByRole("button", { name: "Continue" }));
   });
 
   it("resets only onboarding progress when replaying the wizard", () => {


### PR DESCRIPTION
## What changed
- New final onboarding step (`MorningBriefStep`): a one-click opt-in that creates the existing sandboxed "Morning brief" starter routine (weekdays 8:00 AM) through the normal `createRoutine` path. "Not now" is a first-class quiet path.
- The dictation practice step's button becomes "Continue" since it is no longer the last screen.
- Onboarding preview stub gains the bridge/cron commands so the step can be exercised in a plain browser.
- New CSS for the routine preview card, using existing tokens and the intent-grid card idiom.

## Why
1W retention work: all three June pillars are pull-based, so a fresh install ends with nothing scheduled and no reason to return. The morning brief is the only starter routine whose prompt is fully self-contained (no [placeholder]), which makes a one-click opt-in honest: what you enable is exactly what will run. It manufactures a genuine daily touchpoint on day 1.

## Validation
- `tsc --noEmit` clean
- `pnpm test`: 191 files, 3058 passed
- `src/test/onboarding.test.tsx` extended: full-flow walk now exercises the new step (createRoutine payload asserted), plus decline path and creation-failure path (user stays on the step, error copy shows, quiet path still works)
- Live walkthrough (web preview via in-app browser): step renders at 6/6 with correct copy and schedule ("Weekdays at 8:00 AM"), "Enable morning brief" completes the wizard, "Not now" completes without creating a routine. Screenshot below.


## Known gaps
- Live creation against a real Hermes gateway not exercised in the preview (stubbed); covered by the existing createRoutine plumbing used by Routines templates.

<!-- codesmith:footer -->
---
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->