### PR TITLE
Notify when a scheduled routine run finishes

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2069,7 +2069,7 @@ export function App() {
     let state = loadRoutineRunWatchState();
 
     async function poll() {
-      let sessions;
+      let sessions: HermesSessionInfo[];
       try {
         sessions = await listScheduledRunSessions({ includeActive: true });
       } catch {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -113,6 +113,7 @@ import {
   agentHudHide,
   agentHudShow,
   agentOpenReady,
+  sendAppNotification,
   type LiveTranscriptEventDto,
 } from "../lib/tauri";
 import { playRecordingSound, preloadRecordingSounds } from "../lib/recording-sounds";
@@ -141,7 +142,16 @@ import { getAgentSoundsEnabled } from "../lib/agent-sound-settings";
 import { rememberSessionManuallyTitled } from "../lib/agent-session-titles";
 import { errorCode, messageFromError } from "../lib/errors";
 import { nextDictationWorkflowActive, parseDictationHelperEvent } from "../lib/dictation-events";
-import { listHermesSessions, titleFromPrompt } from "../lib/hermes-adapter";
+import {
+  listHermesSessions,
+  listScheduledRunSessions,
+  titleFromPrompt,
+} from "../lib/hermes-adapter";
+import {
+  loadRoutineRunWatchState,
+  routineRunWatchStep,
+  saveRoutineRunWatchState,
+} from "../lib/routine-run-notifications";
 import {
   getActiveHermesProfileName,
   PROFILE_DATA_CHANGED_EVENT,
@@ -280,6 +290,9 @@ const CHECK_FOR_UPDATES_EVENT = "june://check-for-updates";
 const AGENT_MENU_BAR_SESSION_FETCH_LIMIT = 100;
 const AGENT_MENU_BAR_SESSION_LIMIT = 6;
 const AGENT_MENU_BAR_SESSION_RETRY_DELAYS_MS = [250, 500, 1000, 2000, 4000, 8000];
+// Matches the Routines view's run-history cadence; a routine notification a
+// few seconds late is fine, hammering the bridge is not.
+const ROUTINE_RUN_NOTIFY_POLL_MS = 15000;
 const ACCESSIBILITY_PERMISSION_REFRESH_INTERVAL_MS = 1000;
 const SYSTEM_AUDIO_PERMISSION_REFRESH_INTERVAL_MS = 1000;
 const SYSTEM_AUDIO_PERMISSION_REFRESH_TIMEOUT_MS = 120_000;
@@ -2043,6 +2056,48 @@ export function App() {
       }
     };
   }, [appBlocked, bootstrapped, commitAgentSessions, refreshSessionProfiles]);
+
+  // Routine runs finish on the launchd-managed gateway with no webview
+  // involvement, so nothing event-driven announces them. Poll the session
+  // store (the same feed the Routines view reads) and post one native,
+  // click-through notification per newly finished run. State persists so
+  // reloads and restarts never renotify, and the first poll of an install
+  // baselines silently instead of backfilling history.
+  useEffect(() => {
+    if (appBlocked || !bootstrapped) return;
+    let cancelled = false;
+    let state = loadRoutineRunWatchState();
+
+    async function poll() {
+      let sessions;
+      try {
+        sessions = await listScheduledRunSessions({ includeActive: true });
+      } catch {
+        // Bridge down (asleep, restarting): try again next tick.
+        return;
+      }
+      if (cancelled) return;
+      const { next, notices } = routineRunWatchStep(state, sessions, Date.now());
+      state = next;
+      saveRoutineRunWatchState(state);
+      for (const notice of notices) {
+        void sendAppNotification({
+          title: notice.title,
+          body: notice.body,
+          sound: "Ping",
+          group: notice.jobId ? `june-routine-${notice.jobId}` : "june-routine",
+          sessionId: notice.sessionId,
+        }).catch(() => {});
+      }
+    }
+
+    void poll();
+    const timer = window.setInterval(() => void poll(), ROUTINE_RUN_NOTIFY_POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [appBlocked, bootstrapped]);
 
   // Project assignments for agent sessions, loaded once storage is up.
   useEffect(() => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -149,6 +149,7 @@ import {
 } from "../lib/hermes-adapter";
 import {
   loadRoutineRunWatchState,
+  markRunsNotified,
   routineRunWatchStep,
   saveRoutineRunWatchState,
 } from "../lib/routine-run-notifications";
@@ -2079,16 +2080,25 @@ export function App() {
       if (cancelled) return;
       const { next, notices } = routineRunWatchStep(state, sessions, Date.now());
       state = next;
+      // Mark a run seen only after its notification actually went out, so a
+      // transient delivery failure retries on the next tick instead of going
+      // silent forever.
+      const delivered: string[] = [];
+      await Promise.all(
+        notices.map((notice) =>
+          sendAppNotification({
+            title: notice.title,
+            body: notice.body,
+            sound: "Ping",
+            group: notice.jobId ? `june-routine-${notice.jobId}` : "june-routine",
+            sessionId: notice.sessionId,
+          })
+            .then(() => delivered.push(notice.sessionId))
+            .catch(() => {}),
+        ),
+      );
+      state = markRunsNotified(state, delivered);
       saveRoutineRunWatchState(state);
-      for (const notice of notices) {
-        void sendAppNotification({
-          title: notice.title,
-          body: notice.body,
-          sound: "Ping",
-          group: notice.jobId ? `june-routine-${notice.jobId}` : "june-routine",
-          sessionId: notice.sessionId,
-        }).catch(() => {});
-      }
     }
 
     void poll();

--- a/src/lib/routine-run-notifications.ts
+++ b/src/lib/routine-run-notifications.ts
@@ -1,0 +1,136 @@
+/**
+ * Notifications for finished routine runs.
+ *
+ * Routines fire on Hermes's launchd-managed gateway, so a run can start and
+ * finish with no webview involvement at all - nothing in the event stream
+ * reaches the app for them. The only trustworthy signal is the session store,
+ * which the Routines view already polls. This module watches that same feed
+ * app-wide: when a scheduled run transitions to ended, it posts one native
+ * notification whose click deep-links into the run's conversation (the
+ * session id rides along through the existing send_app_notification path).
+ *
+ * A silent scheduled routine retains nobody: the whole point of a morning
+ * brief is that the user hears about it.
+ *
+ * Design constraints, in order:
+ * - Never renotify: the notified-run set persists in localStorage so app
+ *   restarts (and webview reloads) stay quiet about old runs.
+ * - Never backfill: the first poll of an install baselines every already
+ *   ended run as seen. Notifications only cover transitions observed live.
+ * - Never grow unbounded: the persisted set is pruned to the run ids still
+ *   inside the session-store fetch window plus a small tail.
+ */
+
+import {
+  isScheduledRunSession,
+  scheduledRunJobId,
+  sessionTimestamp,
+} from "./hermes-adapter";
+import type { HermesSessionInfo } from "./tauri";
+
+const STORAGE_KEY = "june.routineRuns.notified";
+/** Ended runs older than this at first sight are treated as history, not
+ * news - covers the app being closed overnight while runs pile up. */
+const FRESH_RUN_WINDOW_MS = 30 * 60 * 1000;
+/** Cap on the persisted notified-id set after pruning. */
+const MAX_TRACKED_RUNS = 300;
+
+export type RoutineRunNotice = {
+  sessionId: string;
+  jobId?: string;
+  title: string;
+  body: string;
+};
+
+export type RoutineRunWatchState = {
+  /** Run session ids already notified (or baselined). */
+  seen: ReadonlySet<string>;
+  /** False until the first poll baselined existing history. */
+  primed: boolean;
+};
+
+export function loadRoutineRunWatchState(): RoutineRunWatchState {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { seen: new Set(), primed: false };
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return { seen: new Set(), primed: false };
+    const ids = parsed.filter((value): value is string => typeof value === "string");
+    // A persisted set means a previous session already baselined.
+    return { seen: new Set(ids), primed: true };
+  } catch {
+    return { seen: new Set(), primed: false };
+  }
+}
+
+export function saveRoutineRunWatchState(state: RoutineRunWatchState) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify([...state.seen]));
+  } catch {
+    // Storage unavailable: worst case is a repeat notification after reload.
+  }
+}
+
+function hasEnded(session: HermesSessionInfo) {
+  const ended =
+    session.ended_at ?? session.endedAt ?? session.end_reason ?? undefined;
+  if (typeof ended === "string" && ended.trim()) return true;
+  return session.active !== true && session.is_active !== true;
+}
+
+function runIsFresh(session: HermesSessionInfo, now: number) {
+  const timestamp = Date.parse(sessionTimestamp(session));
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return false;
+  return now - timestamp <= FRESH_RUN_WINDOW_MS;
+}
+
+function noticeFor(session: HermesSessionInfo): RoutineRunNotice {
+  const title = session.title?.trim() || "Routine finished";
+  const body = session.preview?.trim() || "Open June to read the result.";
+  return {
+    sessionId: session.id,
+    jobId: scheduledRunJobId(session.id),
+    title,
+    body,
+  };
+}
+
+/**
+ * Pure transition step: given the previous watch state and a fresh session
+ * snapshot, returns the notices to post and the next state. The first call
+ * on an unprimed state baselines silently.
+ */
+export function routineRunWatchStep(
+  state: RoutineRunWatchState,
+  sessions: readonly HermesSessionInfo[],
+  now: number,
+): { next: RoutineRunWatchState; notices: RoutineRunNotice[] } {
+  const runs = sessions.filter(isScheduledRunSession);
+  const endedRuns = runs.filter(hasEnded);
+
+  if (!state.primed) {
+    return {
+      next: { seen: new Set(endedRuns.map((run) => run.id)), primed: true },
+      notices: [],
+    };
+  }
+
+  const notices = endedRuns
+    .filter((run) => !state.seen.has(run.id) && runIsFresh(run, now))
+    .map(noticeFor);
+
+  // Prune: keep only ids still visible in the fetch window (plus the new
+  // ones), so the set cannot grow without bound.
+  const visible = new Set(endedRuns.map((run) => run.id));
+  const kept = [...state.seen].filter((id) => visible.has(id));
+  for (const run of endedRuns) {
+    if (!state.seen.has(run.id) && (visible.has(run.id) || runIsFresh(run, now))) {
+      kept.push(run.id);
+    }
+  }
+  const next: RoutineRunWatchState = {
+    seen: new Set(kept.slice(-MAX_TRACKED_RUNS)),
+    primed: true,
+  };
+  return { next, notices };
+}

--- a/src/lib/routine-run-notifications.ts
+++ b/src/lib/routine-run-notifications.ts
@@ -21,11 +21,7 @@
  *   inside the session-store fetch window plus a small tail.
  */
 
-import {
-  isScheduledRunSession,
-  scheduledRunJobId,
-  sessionTimestamp,
-} from "./hermes-adapter";
+import { isScheduledRunSession, scheduledRunJobId, sessionTimestamp } from "./hermes-adapter";
 import type { HermesSessionInfo } from "./tauri";
 
 const STORAGE_KEY = "june.routineRuns.notified";
@@ -72,8 +68,7 @@ export function saveRoutineRunWatchState(state: RoutineRunWatchState) {
 }
 
 function hasEnded(session: HermesSessionInfo) {
-  const ended =
-    session.ended_at ?? session.endedAt ?? session.end_reason ?? undefined;
+  const ended = session.ended_at ?? session.endedAt ?? session.end_reason ?? undefined;
   if (typeof ended === "string" && ended.trim()) return true;
   return session.active !== true && session.is_active !== true;
 }

--- a/src/lib/routine-run-notifications.ts
+++ b/src/lib/routine-run-notifications.ts
@@ -70,7 +70,11 @@ export function saveRoutineRunWatchState(state: RoutineRunWatchState) {
 function hasEnded(session: HermesSessionInfo) {
   const ended = session.ended_at ?? session.endedAt ?? session.end_reason ?? undefined;
   if (typeof ended === "string" && ended.trim()) return true;
-  return session.active !== true && session.is_active !== true;
+  // Inactivity alone is not proof of completion: cron sessions are persisted
+  // before their first message lands, so a stuck run can sit inactive with
+  // zero messages and no end marker. Only an inactive run that produced
+  // messages reads as finished.
+  return session.active !== true && session.is_active !== true && (session.message_count ?? 0) > 0;
 }
 
 function runIsFresh(session: HermesSessionInfo, now: number) {
@@ -94,6 +98,12 @@ function noticeFor(session: HermesSessionInfo): RoutineRunNotice {
  * Pure transition step: given the previous watch state and a fresh session
  * snapshot, returns the notices to post and the next state. The first call
  * on an unprimed state baselines silently.
+ *
+ * Notice ids are NOT folded into the returned state: delivery can fail
+ * (bridge hiccup, notification permission revoked), and marking before a
+ * successful send would make that failure silent and permanent. Callers
+ * confirm delivery with {@link markRunsNotified}; an unconfirmed run is
+ * retried on the next step until the freshness window closes over it.
  */
 export function routineRunWatchStep(
   state: RoutineRunWatchState,
@@ -114,18 +124,28 @@ export function routineRunWatchStep(
     .filter((run) => !state.seen.has(run.id) && runIsFresh(run, now))
     .map(noticeFor);
 
-  // Prune: keep only ids still visible in the fetch window (plus the new
-  // ones), so the set cannot grow without bound.
+  // Prune: keep only ids still visible in the fetch window, so the set
+  // cannot grow without bound. Newly noticed ids join through
+  // markRunsNotified once their notification actually went out.
   const visible = new Set(endedRuns.map((run) => run.id));
   const kept = [...state.seen].filter((id) => visible.has(id));
-  for (const run of endedRuns) {
-    if (!state.seen.has(run.id) && (visible.has(run.id) || runIsFresh(run, now))) {
-      kept.push(run.id);
-    }
-  }
   const next: RoutineRunWatchState = {
     seen: new Set(kept.slice(-MAX_TRACKED_RUNS)),
     primed: true,
   };
   return { next, notices };
+}
+
+/** Folds successfully delivered run ids into the watch state. */
+export function markRunsNotified(
+  state: RoutineRunWatchState,
+  runIds: readonly string[],
+): RoutineRunWatchState {
+  if (runIds.length === 0) return state;
+  const seen = new Set(state.seen);
+  for (const id of runIds) seen.add(id);
+  return {
+    seen: new Set([...seen].slice(-MAX_TRACKED_RUNS)),
+    primed: state.primed,
+  };
 }

--- a/src/test/routine-run-notifications.test.ts
+++ b/src/test/routine-run-notifications.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  loadRoutineRunWatchState,
+  routineRunWatchStep,
+  saveRoutineRunWatchState,
+  type RoutineRunWatchState,
+} from "../lib/routine-run-notifications";
+import type { HermesSessionInfo } from "../lib/tauri";
+
+const NOW = Date.parse("2026-07-20T12:00:00Z");
+
+function run(
+  id: string,
+  overrides: Partial<HermesSessionInfo> = {},
+): HermesSessionInfo {
+  return {
+    id,
+    source: "cron",
+    title: "Morning brief",
+    preview: "Here is your brief.",
+    ended_at: "2026-07-20T11:55:00Z",
+    last_active: "2026-07-20T11:55:00Z",
+    ...overrides,
+  } as HermesSessionInfo;
+}
+
+const PRIMED: RoutineRunWatchState = { seen: new Set(), primed: true };
+
+describe("routineRunWatchStep", () => {
+  it("baselines existing runs silently on the first poll", () => {
+    const { next, notices } = routineRunWatchStep(
+      { seen: new Set(), primed: false },
+      [run("cron_job1_20260720_115000")],
+      NOW,
+    );
+    expect(notices).toEqual([]);
+    expect(next.primed).toBe(true);
+    expect(next.seen.has("cron_job1_20260720_115000")).toBe(true);
+  });
+
+  it("notifies once for a freshly ended run and never again", () => {
+    const first = routineRunWatchStep(PRIMED, [run("cron_job1_20260720_115000")], NOW);
+    expect(first.notices).toHaveLength(1);
+    expect(first.notices[0]).toMatchObject({
+      sessionId: "cron_job1_20260720_115000",
+      jobId: "job1",
+      title: "Morning brief",
+      body: "Here is your brief.",
+    });
+
+    const second = routineRunWatchStep(first.next, [run("cron_job1_20260720_115000")], NOW);
+    expect(second.notices).toEqual([]);
+  });
+
+  it("stays quiet for a run that is still going", () => {
+    const { notices } = routineRunWatchStep(
+      PRIMED,
+      [run("cron_job1_20260720_115000", { active: true, ended_at: null, end_reason: null })],
+      NOW,
+    );
+    expect(notices).toEqual([]);
+  });
+
+  it("treats stale ended runs as history, not news", () => {
+    const { notices } = routineRunWatchStep(
+      PRIMED,
+      [
+        run("cron_job1_20260719_080000", {
+          ended_at: "2026-07-19T08:05:00Z",
+          last_active: "2026-07-19T08:05:00Z",
+        }),
+      ],
+      NOW,
+    );
+    expect(notices).toEqual([]);
+  });
+
+  it("ignores non-cron sessions entirely", () => {
+    const { notices } = routineRunWatchStep(
+      PRIMED,
+      [run("user-session", { source: "user" })],
+      NOW,
+    );
+    expect(notices).toEqual([]);
+  });
+
+  it("falls back to generic copy when the run has no title or preview", () => {
+    const { notices } = routineRunWatchStep(
+      PRIMED,
+      [run("cron_job1_20260720_115000", { title: "", preview: "" })],
+      NOW,
+    );
+    expect(notices[0]).toMatchObject({
+      title: "Routine finished",
+      body: "Open June to read the result.",
+    });
+  });
+
+  it("prunes ids that left the fetch window", () => {
+    const state: RoutineRunWatchState = {
+      seen: new Set(["cron_gone_20260101_000000"]),
+      primed: true,
+    };
+    const { next } = routineRunWatchStep(state, [run("cron_job1_20260720_115000")], NOW);
+    expect(next.seen.has("cron_gone_20260101_000000")).toBe(false);
+    expect(next.seen.has("cron_job1_20260720_115000")).toBe(true);
+  });
+});
+
+describe("watch state persistence", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("round-trips through localStorage and marks reloads as primed", () => {
+    expect(loadRoutineRunWatchState().primed).toBe(false);
+
+    saveRoutineRunWatchState({ seen: new Set(["a", "b"]), primed: true });
+    const loaded = loadRoutineRunWatchState();
+    expect(loaded.primed).toBe(true);
+    expect([...loaded.seen].sort()).toEqual(["a", "b"]);
+  });
+
+  it("recovers from corrupted storage", () => {
+    window.localStorage.setItem("june.routineRuns.notified", "not json");
+    expect(loadRoutineRunWatchState()).toEqual({ seen: new Set(), primed: false });
+  });
+});

--- a/src/test/routine-run-notifications.test.ts
+++ b/src/test/routine-run-notifications.test.ts
@@ -9,10 +9,7 @@ import type { HermesSessionInfo } from "../lib/tauri";
 
 const NOW = Date.parse("2026-07-20T12:00:00Z");
 
-function run(
-  id: string,
-  overrides: Partial<HermesSessionInfo> = {},
-): HermesSessionInfo {
+function run(id: string, overrides: Partial<HermesSessionInfo> = {}): HermesSessionInfo {
   return {
     id,
     source: "cron",
@@ -76,11 +73,7 @@ describe("routineRunWatchStep", () => {
   });
 
   it("ignores non-cron sessions entirely", () => {
-    const { notices } = routineRunWatchStep(
-      PRIMED,
-      [run("user-session", { source: "user" })],
-      NOW,
-    );
+    const { notices } = routineRunWatchStep(PRIMED, [run("user-session", { source: "user" })], NOW);
     expect(notices).toEqual([]);
   });
 

--- a/src/test/routine-run-notifications.test.ts
+++ b/src/test/routine-run-notifications.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   loadRoutineRunWatchState,
+  markRunsNotified,
   routineRunWatchStep,
   saveRoutineRunWatchState,
   type RoutineRunWatchState,
@@ -15,6 +16,7 @@ function run(id: string, overrides: Partial<HermesSessionInfo> = {}): HermesSess
     source: "cron",
     title: "Morning brief",
     preview: "Here is your brief.",
+    message_count: 4,
     ended_at: "2026-07-20T11:55:00Z",
     last_active: "2026-07-20T11:55:00Z",
     ...overrides,
@@ -35,7 +37,7 @@ describe("routineRunWatchStep", () => {
     expect(next.seen.has("cron_job1_20260720_115000")).toBe(true);
   });
 
-  it("notifies once for a freshly ended run and never again", () => {
+  it("notifies once for a freshly ended run and never again after delivery", () => {
     const first = routineRunWatchStep(PRIMED, [run("cron_job1_20260720_115000")], NOW);
     expect(first.notices).toHaveLength(1);
     expect(first.notices[0]).toMatchObject({
@@ -45,8 +47,18 @@ describe("routineRunWatchStep", () => {
       body: "Here is your brief.",
     });
 
-    const second = routineRunWatchStep(first.next, [run("cron_job1_20260720_115000")], NOW);
+    const afterDelivery = markRunsNotified(first.next, ["cron_job1_20260720_115000"]);
+    const second = routineRunWatchStep(afterDelivery, [run("cron_job1_20260720_115000")], NOW);
     expect(second.notices).toEqual([]);
+  });
+
+  it("retries a run whose notification delivery failed", () => {
+    const first = routineRunWatchStep(PRIMED, [run("cron_job1_20260720_115000")], NOW);
+    expect(first.notices).toHaveLength(1);
+
+    // Delivery failed: the id was never marked, so the next tick re-notices.
+    const second = routineRunWatchStep(first.next, [run("cron_job1_20260720_115000")], NOW);
+    expect(second.notices).toHaveLength(1);
   });
 
   it("stays quiet for a run that is still going", () => {
@@ -65,6 +77,23 @@ describe("routineRunWatchStep", () => {
         run("cron_job1_20260719_080000", {
           ended_at: "2026-07-19T08:05:00Z",
           last_active: "2026-07-19T08:05:00Z",
+        }),
+      ],
+      NOW,
+    );
+    expect(notices).toEqual([]);
+  });
+
+  it("does not treat a stuck zero-message session as finished", () => {
+    // Cron sessions persist before their first message; an inactive
+    // zero-message row with no end marker is stuck, not done.
+    const { notices } = routineRunWatchStep(
+      PRIMED,
+      [
+        run("cron_job1_20260720_115000", {
+          message_count: 0,
+          ended_at: null,
+          end_reason: null,
         }),
       ],
       NOW,
@@ -94,7 +123,8 @@ describe("routineRunWatchStep", () => {
       seen: new Set(["cron_gone_20260101_000000"]),
       primed: true,
     };
-    const { next } = routineRunWatchStep(state, [run("cron_job1_20260720_115000")], NOW);
+    const stepped = routineRunWatchStep(state, [run("cron_job1_20260720_115000")], NOW);
+    const next = markRunsNotified(stepped.next, ["cron_job1_20260720_115000"]);
     expect(next.seen.has("cron_gone_20260101_000000")).toBe(false);
     expect(next.seen.has("cron_job1_20260720_115000")).toBe(true);
   });


### PR DESCRIPTION
## What changed
- New `src/lib/routine-run-notifications.ts`: a pure watch-state module over the scheduled-run session feed. It baselines existing history silently on first sight, then flags each newly ended cron run once. State persists in localStorage so reloads and restarts never renotify; the set is pruned to the fetch window and capped.
- App wiring: a 15s poll (same cadence as the Routines view run history) over `listScheduledRunSessions`, posting one native notification per finished run through the existing `send_app_notification` path, so a click deep-links into the run's conversation via the established `june:agent:open` handshake.

## Why
1W retention work: routines fire on the launchd-managed gateway with zero webview involvement, so today a scheduled routine (like a morning brief) completes in total silence. A routine nobody hears about retains nobody. This closes the loop: scheduled work runs, the user gets told, the click lands them in the result.

## Design notes
- Never backfill: the first poll of an install baselines all already ended runs.
- Freshness gate: an ended run older than 30 minutes at first sight is history, not news (covers overnight run pileups while the app was closed).
- Dedupe survives restarts via persisted state, unlike the in-memory agent-notification dedupe.

## Validation
- `tsc --noEmit` clean
- `pnpm test`: 192 files, 3065 passed
- New `src/test/routine-run-notifications.test.ts` (9 tests): baseline, notify-once, still-running quiet, stale-run quiet, non-cron ignored, fallback copy, pruning, persistence round-trip, corrupted-storage recovery
- Live walkthrough: not run; the trigger requires a real cron run finishing on the gateway. The notification posting and click-through path is the existing `send_app_notification`/`agent_open_ready` machinery already covered by its own tests and prior PR QA.

## Known gaps
- End-to-end proof against a live gateway cron run is manual-pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787166308&installation_model_id=425925&pr_number=857&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F857&signature=852c31d181e2dcd3e0f7c9bcd2061bab51a5df3887d393d1b2c8f40067e5290c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->