### PR TITLE
Add Claude Code project import

### DIFF
--- a/src-tauri/src/claude_projects.rs
+++ b/src-tauri/src/claude_projects.rs
@@ -1,0 +1,216 @@
+use crate::domain::types::ClaudeProjectCandidateDto;
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use std::collections::{BTreeMap, HashSet};
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader, Read};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+const MAX_JSONL_LINES: usize = 200;
+const MAX_CONFIG_BYTES: u64 = 10 * 1024 * 1024;
+const MAX_HISTORY_BYTES: u64 = 512 * 1024;
+
+pub fn discover(home: &Path, already_added: &HashSet<PathBuf>) -> Vec<ClaudeProjectCandidateDto> {
+    let mut discovered: BTreeMap<PathBuf, Option<SystemTime>> = BTreeMap::new();
+    discover_from_config(home, &mut discovered);
+    discover_from_session_history(home, &mut discovered);
+
+    let mut candidates = discovered
+        .into_iter()
+        .filter_map(|(path, last_used)| {
+            let path = eligible_project_path(home, &path)?;
+            let name = path.file_name()?.to_string_lossy().trim().to_string();
+            if name.is_empty() {
+                return None;
+            }
+            Some(ClaudeProjectCandidateDto {
+                name,
+                path: path.to_string_lossy().into_owned(),
+                last_used_at: last_used.map(|value| DateTime::<Utc>::from(value).to_rfc3339()),
+                already_added: already_added.contains(&path),
+            })
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| {
+        right
+            .last_used_at
+            .cmp(&left.last_used_at)
+            .then_with(|| left.name.to_lowercase().cmp(&right.name.to_lowercase()))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    candidates
+}
+
+pub fn validate_import_path(home: &Path, path: &str) -> Option<PathBuf> {
+    eligible_project_path(home, Path::new(path))
+}
+
+fn discover_from_config(home: &Path, discovered: &mut BTreeMap<PathBuf, Option<SystemTime>>) {
+    let config_path = home.join(".claude.json");
+    if fs::metadata(&config_path)
+        .map(|metadata| metadata.len() > MAX_CONFIG_BYTES)
+        .unwrap_or(false)
+    {
+        return;
+    }
+    let Ok(bytes) = fs::read(&config_path) else {
+        return;
+    };
+    let Ok(config) = serde_json::from_slice::<Value>(&bytes) else {
+        return;
+    };
+    let modified = fs::metadata(config_path)
+        .and_then(|metadata| metadata.modified())
+        .ok();
+    let Some(projects) = config.get("projects").and_then(Value::as_object) else {
+        return;
+    };
+    for path in projects.keys() {
+        remember(discovered, PathBuf::from(path), modified);
+    }
+}
+
+fn discover_from_session_history(
+    home: &Path,
+    discovered: &mut BTreeMap<PathBuf, Option<SystemTime>>,
+) {
+    let projects_dir = home.join(".claude").join("projects");
+    let Ok(project_dirs) = fs::read_dir(projects_dir) else {
+        return;
+    };
+    for project_dir in project_dirs.flatten() {
+        let Ok(file_type) = project_dir.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let Ok(entries) = fs::read_dir(project_dir.path()) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let modified = entry
+                .metadata()
+                .and_then(|metadata| metadata.modified())
+                .ok();
+            let Ok(file) = File::open(path) else {
+                continue;
+            };
+            for line in BufReader::new(file)
+                .take(MAX_HISTORY_BYTES)
+                .lines()
+                .take(MAX_JSONL_LINES)
+                .flatten()
+            {
+                let Ok(value) = serde_json::from_str::<Value>(&line) else {
+                    continue;
+                };
+                let Some(cwd) = value.get("cwd").and_then(Value::as_str) else {
+                    continue;
+                };
+                remember(discovered, PathBuf::from(cwd), modified);
+                break;
+            }
+        }
+    }
+}
+
+fn remember(
+    discovered: &mut BTreeMap<PathBuf, Option<SystemTime>>,
+    path: PathBuf,
+    last_used: Option<SystemTime>,
+) {
+    discovered
+        .entry(path)
+        .and_modify(|current| {
+            if last_used > *current {
+                *current = last_used;
+            }
+        })
+        .or_insert(last_used);
+}
+
+fn eligible_project_path(home: &Path, path: &Path) -> Option<PathBuf> {
+    if !path.is_absolute() {
+        return None;
+    }
+    let canonical_home = home.canonicalize().ok()?;
+    let canonical = path.canonicalize().ok()?;
+    if !canonical.is_dir() || canonical == canonical_home || canonical.parent().is_none() {
+        return None;
+    }
+    if canonical.starts_with(canonical_home.join(".claude")) {
+        return None;
+    }
+    Some(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn discovers_config_and_history_paths_and_deduplicates_them() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path();
+        let alpha = home.join("code").join("alpha");
+        let beta = home.join("code").join("beta");
+        fs::create_dir_all(&alpha).expect("alpha");
+        fs::create_dir_all(&beta).expect("beta");
+        fs::write(
+            home.join(".claude.json"),
+            serde_json::json!({ "projects": { alpha.to_string_lossy(): {} } }).to_string(),
+        )
+        .expect("config");
+
+        let history_dir = home.join(".claude").join("projects").join("encoded-beta");
+        fs::create_dir_all(&history_dir).expect("history dir");
+        let mut history = File::create(history_dir.join("session.jsonl")).expect("history");
+        writeln!(
+            history,
+            "{{\"type\":\"user\",\"cwd\":{:?}}}",
+            beta.to_string_lossy()
+        )
+        .expect("history line");
+        writeln!(history, "{{\"cwd\":{:?}}}", alpha.to_string_lossy()).expect("duplicate line");
+
+        let candidates = discover(home, &HashSet::new());
+        let paths = candidates
+            .iter()
+            .map(|candidate| candidate.path.as_str())
+            .collect::<HashSet<_>>();
+        let alpha = alpha.canonicalize().expect("canonical alpha");
+        let beta = beta.canonicalize().expect("canonical beta");
+        assert_eq!(paths.len(), 2);
+        assert!(paths.contains(alpha.to_string_lossy().as_ref()));
+        assert!(paths.contains(beta.to_string_lossy().as_ref()));
+    }
+
+    #[test]
+    fn excludes_missing_home_root_and_claude_state_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path();
+        let claude_state = home.join(".claude").join("plugins");
+        fs::create_dir_all(&claude_state).expect("claude state");
+        fs::write(
+            home.join(".claude.json"),
+            serde_json::json!({
+                "projects": {
+                    home.to_string_lossy(): {},
+                    claude_state.to_string_lossy(): {},
+                    home.join("missing").to_string_lossy(): {}
+                }
+            })
+            .to_string(),
+        )
+        .expect("config");
+
+        assert!(discover(home, &HashSet::new()).is_empty());
+    }
+}

--- a/src-tauri/src/claude_projects.rs
+++ b/src-tauri/src/claude_projects.rs
@@ -48,10 +48,10 @@ pub fn validate_import_path(home: &Path, path: &str) -> Option<PathBuf> {
 
 fn discover_from_config(home: &Path, discovered: &mut BTreeMap<PathBuf, Option<SystemTime>>) {
     let config_path = home.join(".claude.json");
-    if fs::metadata(&config_path)
-        .map(|metadata| metadata.len() > MAX_CONFIG_BYTES)
-        .unwrap_or(false)
-    {
+    let Ok(metadata) = fs::metadata(&config_path) else {
+        return;
+    };
+    if metadata.len() > MAX_CONFIG_BYTES {
         return;
     }
     let Ok(bytes) = fs::read(&config_path) else {
@@ -60,14 +60,11 @@ fn discover_from_config(home: &Path, discovered: &mut BTreeMap<PathBuf, Option<S
     let Ok(config) = serde_json::from_slice::<Value>(&bytes) else {
         return;
     };
-    let modified = fs::metadata(config_path)
-        .and_then(|metadata| metadata.modified())
-        .ok();
     let Some(projects) = config.get("projects").and_then(Value::as_object) else {
         return;
     };
     for path in projects.keys() {
-        remember(discovered, PathBuf::from(path), modified);
+        remember(discovered, PathBuf::from(path), None);
     }
 }
 
@@ -190,6 +187,18 @@ mod tests {
         assert_eq!(paths.len(), 2);
         assert!(paths.contains(alpha.to_string_lossy().as_ref()));
         assert!(paths.contains(beta.to_string_lossy().as_ref()));
+        assert!(candidates
+            .iter()
+            .find(|candidate| candidate.path == alpha.to_string_lossy())
+            .expect("alpha candidate")
+            .last_used_at
+            .is_none());
+        assert!(candidates
+            .iter()
+            .find(|candidate| candidate.path == beta.to_string_lossy())
+            .expect("beta candidate")
+            .last_used_at
+            .is_some());
     }
 
     #[test]

--- a/src-tauri/src/claude_projects.rs
+++ b/src-tauri/src/claude_projects.rs
@@ -16,10 +16,16 @@ pub fn discover(home: &Path, already_added: &HashSet<PathBuf>) -> Vec<ClaudeProj
     discover_from_config(home, &mut discovered);
     discover_from_session_history(home, &mut discovered);
 
-    let mut candidates = discovered
+    let mut canonical_discovered: BTreeMap<PathBuf, Option<SystemTime>> = BTreeMap::new();
+    for (path, last_used) in discovered {
+        if let Some(path) = eligible_project_path(home, &path) {
+            remember(&mut canonical_discovered, path, last_used);
+        }
+    }
+
+    let mut candidates = canonical_discovered
         .into_iter()
         .filter_map(|(path, last_used)| {
-            let path = eligible_project_path(home, &path)?;
             let name = path.file_name()?.to_string_lossy().trim().to_string();
             if name.is_empty() {
                 return None;
@@ -221,5 +227,40 @@ mod tests {
         .expect("config");
 
         assert!(discover(home, &HashSet::new()).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deduplicates_project_aliases_after_canonicalizing() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path();
+        let project = home.join("code").join("project");
+        let alias = home.join("project-alias");
+        fs::create_dir_all(&project).expect("project");
+        symlink(&project, &alias).expect("project alias");
+        fs::write(
+            home.join(".claude.json"),
+            serde_json::json!({
+                "projects": {
+                    project.to_string_lossy(): {},
+                    alias.to_string_lossy(): {}
+                }
+            })
+            .to_string(),
+        )
+        .expect("config");
+
+        let candidates = discover(home, &HashSet::new());
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].path,
+            project
+                .canonicalize()
+                .expect("canonical project")
+                .to_string_lossy()
+        );
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -27,13 +27,14 @@ use crate::{
             AgentMessageRole, AgentTaskDto, AgentTaskListResponse, AgentTaskRequest,
             AgentTaskStatus, AgentToolEventDto, AgentToolEventStatus, AppError,
             AssignNoteToFolderRequest, AssignSessionToFolderRequest, AssignSessionToProfileRequest,
-            BootstrapResponse, CheckRecordingSourceReadinessRequest, CompletedSessionDto,
-            CreateAgentTaskRequest, CreateDictionaryEntryRequest, CreateFolderRequest,
-            CreateNoteRequest, DeleteDictionaryEntryRequest, DeleteFolderRequest,
-            DeleteNoteRequest, DeleteNotesRequest, DictionaryEntryDto, DownloadNoteAudioRequest,
-            DownloadNoteAudioResponse, ExplainAgentApprovalRequest, ExplainAgentApprovalResponse,
-            FinishRecordingResponse, GetAgentTaskRequest, GetNoteRequest, ListNotesRequest,
-            ListNotesResponse, MemoryDto, MemorySettingsDto, MicrophonePermissionResponse, NoteDto,
+            BootstrapResponse, CheckRecordingSourceReadinessRequest, ClaudeProjectCandidateDto,
+            CompletedSessionDto, CreateAgentTaskRequest, CreateDictionaryEntryRequest,
+            CreateFolderRequest, CreateNoteRequest, DeleteDictionaryEntryRequest,
+            DeleteFolderRequest, DeleteNoteRequest, DeleteNotesRequest, DictionaryEntryDto,
+            DownloadNoteAudioRequest, DownloadNoteAudioResponse, ExplainAgentApprovalRequest,
+            ExplainAgentApprovalResponse, FinishRecordingResponse, GetAgentTaskRequest,
+            GetNoteRequest, ImportClaudeProjectsRequest, ListNotesRequest, ListNotesResponse,
+            MemoryDto, MemorySettingsDto, MicrophonePermissionResponse, NoteDto,
             OpenPrivacySettingsRequest, ProcessingStatus, ProfileDataSummaryDto,
             RecordingSessionDto, RecordingSource, RecordingSourceMode, RecordingSourceReadinessDto,
             RecordingStatusDto, RemoveNoteFromFolderRequest, RemoveSessionFromFolderRequest,
@@ -322,6 +323,72 @@ pub async fn list_folders(
 ) -> Result<Vec<crate::domain::types::FolderDto>, AppError> {
     let profile = active_profile(&app);
     Ok(repositories(&app).await?.list_folders(&profile).await?)
+}
+
+#[tauri::command]
+pub async fn discover_claude_projects(
+    app: AppHandle,
+) -> Result<Vec<ClaudeProjectCandidateDto>, AppError> {
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|error| AppError::new("claude_projects_unavailable", error.to_string()))?;
+    let profile = active_profile(&app);
+    let folders = repositories(&app).await?.list_folders(&profile).await?;
+    let already_added = folders
+        .into_iter()
+        .filter_map(|folder| folder.local_path)
+        .filter_map(|path| PathBuf::from(path).canonicalize().ok())
+        .collect::<HashSet<_>>();
+    Ok(crate::claude_projects::discover(&home, &already_added))
+}
+
+#[tauri::command]
+pub async fn import_claude_projects(
+    app: AppHandle,
+    request: ImportClaudeProjectsRequest,
+) -> Result<Vec<crate::domain::types::FolderDto>, AppError> {
+    if request.paths.is_empty() {
+        return Ok(Vec::new());
+    }
+    if request.paths.len() > 500 {
+        return Err(AppError::new(
+            "claude_projects_too_many",
+            "Choose 500 project folders or fewer at a time.",
+        ));
+    }
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|error| AppError::new("claude_projects_unavailable", error.to_string()))?;
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+    for path in request.paths {
+        let Some(canonical) = crate::claude_projects::validate_import_path(&home, &path) else {
+            return Err(AppError::new(
+                "claude_project_invalid",
+                "One of the selected project folders is no longer available.",
+            ));
+        };
+        if seen.insert(canonical.clone()) {
+            paths.push(canonical);
+        }
+    }
+
+    let profile = active_profile(&app);
+    let repos = repositories(&app).await?;
+    let mut imported = Vec::with_capacity(paths.len());
+    for path in paths {
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            return Err(AppError::new(
+                "claude_project_invalid",
+                "One of the selected project folders has no usable name.",
+            ));
+        };
+        let path = path.to_string_lossy().into_owned();
+        imported.push(repos.create_linked_folder(&profile, name, &path).await?);
+    }
+    Ok(imported)
 }
 
 /// The sticky active profile, read straight from the Hermes home file. Gives

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -375,9 +375,7 @@ pub async fn import_claude_projects(
         }
     }
 
-    let profile = active_profile(&app);
-    let repos = repositories(&app).await?;
-    let mut imported = Vec::with_capacity(paths.len());
+    let mut projects = Vec::with_capacity(paths.len());
     for path in paths {
         let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
             return Err(AppError::new(
@@ -385,10 +383,13 @@ pub async fn import_claude_projects(
                 "One of the selected project folders has no usable name.",
             ));
         };
-        let path = path.to_string_lossy().into_owned();
-        imported.push(repos.create_linked_folder(&profile, name, &path).await?);
+        projects.push((name.to_string(), path.to_string_lossy().into_owned()));
     }
-    Ok(imported)
+    let profile = active_profile(&app);
+    Ok(repositories(&app)
+        .await?
+        .create_linked_folders(&profile, &projects)
+        .await?)
 }
 
 /// The sticky active profile, read straight from the Hermes home file. Gives

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -64,6 +64,7 @@ pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::error::Error
         "INTEGER NOT NULL DEFAULT 0",
     )
     .await?;
+    ensure_column(_pool, "folders", "local_path", "TEXT").await?;
     // Folder names don't need to be unique — each folder has a stable
     // UUID, and the user may legitimately want two "Inbox"es etc.
     drop_index_if_exists(_pool, "idx_folders_active_name").await?;
@@ -171,6 +172,13 @@ pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::error::Error
         "profile",
         "TEXT NOT NULL DEFAULT 'default'",
     )
+    .await?;
+    query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_folders_active_local_path
+         ON folders (profile, local_path)
+         WHERE deleted_at IS NULL AND local_path IS NOT NULL",
+    )
+    .execute(_pool)
     .await?;
     if !index_exists(_pool, "idx_notes_profile_created_at").await? {
         query(

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1164,7 +1164,7 @@ impl Repositories {
 
     pub async fn list_folders(&self, profile: &str) -> Result<Vec<FolderDto>, sqlx::error::Error> {
         let rows = query(
-            "SELECT id, name, description, instructions, memory_disabled, created_at, updated_at
+            "SELECT id, name, description, instructions, memory_disabled, local_path, created_at, updated_at
              FROM folders
              WHERE profile = ? AND deleted_at IS NULL
              ORDER BY lower(name) ASC",
@@ -1192,6 +1192,7 @@ impl Repositories {
             description: description.clone(),
             instructions: None,
             memory_disabled: false,
+            local_path: None,
             created_at: now.clone(),
             updated_at: now,
         };
@@ -1209,6 +1210,53 @@ impl Repositories {
         .execute(&self.pool)
         .await?;
 
+        Ok(folder)
+    }
+
+    pub async fn create_linked_folder(
+        &self,
+        profile: &str,
+        name: &str,
+        local_path: &str,
+    ) -> Result<FolderDto, sqlx::error::Error> {
+        if let Some(row) = query(
+            "SELECT id, name, description, instructions, memory_disabled, local_path, created_at, updated_at
+             FROM folders
+             WHERE profile = ? AND local_path = ? AND deleted_at IS NULL",
+        )
+        .bind(profile)
+        .bind(local_path)
+        .fetch_optional(&self.pool)
+        .await?
+        {
+            return Ok(folder_from_row(row));
+        }
+
+        let now = timestamp();
+        let folder = FolderDto {
+            id: Uuid::new_v4().to_string(),
+            name: name.trim().to_string(),
+            description: None,
+            instructions: None,
+            memory_disabled: false,
+            local_path: Some(local_path.to_string()),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        query(
+            "INSERT INTO folders
+             (id, name, description, profile, local_path, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&folder.id)
+        .bind(&folder.name)
+        .bind(&folder.description)
+        .bind(profile)
+        .bind(&folder.local_path)
+        .bind(&folder.created_at)
+        .bind(&folder.updated_at)
+        .execute(&self.pool)
+        .await?;
         Ok(folder)
     }
 
@@ -1240,7 +1288,7 @@ impl Repositories {
         }
 
         let row = query(
-            "SELECT id, name, description, instructions, memory_disabled, created_at, updated_at
+            "SELECT id, name, description, instructions, memory_disabled, local_path, created_at, updated_at
              FROM folders
              WHERE id = ? AND deleted_at IS NULL",
         )
@@ -1312,7 +1360,7 @@ impl Repositories {
 
     async fn get_folder(&self, folder_id: &str) -> Result<FolderDto, AppError> {
         let row = query(
-            "SELECT id, name, description, instructions, memory_disabled, created_at, updated_at
+            "SELECT id, name, description, instructions, memory_disabled, local_path, created_at, updated_at
              FROM folders
              WHERE id = ? AND deleted_at IS NULL",
         )
@@ -5698,6 +5746,17 @@ fn folder_from_row(row: sqlx_sqlite::SqliteRow) -> FolderDto {
                 }
             }),
         memory_disabled: row.try_get::<i64, _>("memory_disabled").unwrap_or_default() != 0,
+        local_path: row
+            .try_get::<Option<String>, _>("local_path")
+            .unwrap_or(None)
+            .and_then(|value| {
+                let trimmed = value.trim().to_string();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed)
+                }
+            }),
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
     }

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -2001,6 +2001,57 @@ impl Repositories {
             .bind(profile)
             .execute(&mut *transaction)
             .await?;
+        let duplicate_linked_folders = query(
+            "SELECT source.id AS source_id, target.id AS target_id
+             FROM folders source
+             INNER JOIN folders target
+               ON target.profile = 'default'
+              AND target.local_path = source.local_path
+              AND target.deleted_at IS NULL
+             WHERE source.profile = ?
+               AND source.local_path IS NOT NULL
+               AND source.deleted_at IS NULL",
+        )
+        .bind(profile)
+        .fetch_all(&mut *transaction)
+        .await?;
+        for row in duplicate_linked_folders {
+            let source_id = row.get::<String, _>("source_id");
+            let target_id = row.get::<String, _>("target_id");
+            query(
+                "INSERT OR IGNORE INTO note_folders (note_id, folder_id, assigned_at)
+                 SELECT note_id, ?, assigned_at FROM note_folders WHERE folder_id = ?",
+            )
+            .bind(&target_id)
+            .bind(&source_id)
+            .execute(&mut *transaction)
+            .await?;
+            query("DELETE FROM note_folders WHERE folder_id = ?")
+                .bind(&source_id)
+                .execute(&mut *transaction)
+                .await?;
+            query(
+                "INSERT OR IGNORE INTO session_folders (session_id, folder_id, assigned_at)
+                 SELECT session_id, ?, assigned_at FROM session_folders WHERE folder_id = ?",
+            )
+            .bind(&target_id)
+            .bind(&source_id)
+            .execute(&mut *transaction)
+            .await?;
+            query("DELETE FROM session_folders WHERE folder_id = ?")
+                .bind(&source_id)
+                .execute(&mut *transaction)
+                .await?;
+            query("UPDATE memories SET folder_id = ? WHERE folder_id = ?")
+                .bind(&target_id)
+                .bind(&source_id)
+                .execute(&mut *transaction)
+                .await?;
+            query("DELETE FROM folders WHERE id = ?")
+                .bind(&source_id)
+                .execute(&mut *transaction)
+                .await?;
+        }
         query("UPDATE folders SET profile = 'default' WHERE profile = ?")
             .bind(profile)
             .execute(&mut *transaction)
@@ -6010,6 +6061,62 @@ mod tests {
             .await
             .expect("list folders after rollback")
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn moving_profile_merges_duplicate_linked_folders() {
+        let repos = test_repositories().await;
+        let default_folder = repos
+            .create_linked_folders(
+                "default",
+                &[("Default project".to_string(), "/tmp/shared".to_string())],
+            )
+            .await
+            .expect("create default folder")
+            .remove(0);
+        let source_folder = repos
+            .create_linked_folders(
+                "work",
+                &[("Work project".to_string(), "/tmp/shared".to_string())],
+            )
+            .await
+            .expect("create source folder")
+            .remove(0);
+        let note = repos
+            .create_note("work", Some(source_folder.id.clone()))
+            .await
+            .expect("create source note");
+        let memory = repos
+            .create_memory("work", Some(&source_folder.id), "Remember this", "user")
+            .await
+            .expect("create source memory");
+
+        repos
+            .move_profile_data_to_default("work")
+            .await
+            .expect("move profile data");
+
+        let folders = repos
+            .list_folders("default")
+            .await
+            .expect("list default folders");
+        assert_eq!(folders.len(), 1);
+        assert_eq!(folders[0].id, default_folder.id);
+        assert_eq!(
+            repos
+                .get_note(&note.id)
+                .await
+                .expect("moved note")
+                .folder_ids,
+            vec![default_folder.id.clone()]
+        );
+        let memory_row = query("SELECT profile, folder_id FROM memories WHERE id = ?")
+            .bind(&memory.id)
+            .fetch_one(&repos.pool)
+            .await
+            .expect("moved memory");
+        assert_eq!(memory_row.get::<String, _>("profile"), "default");
+        assert_eq!(memory_row.get::<String, _>("folder_id"), default_folder.id);
     }
 
     fn transcription_plan(

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1213,51 +1213,57 @@ impl Repositories {
         Ok(folder)
     }
 
-    pub async fn create_linked_folder(
+    pub async fn create_linked_folders(
         &self,
         profile: &str,
-        name: &str,
-        local_path: &str,
-    ) -> Result<FolderDto, sqlx::error::Error> {
-        if let Some(row) = query(
-            "SELECT id, name, description, instructions, memory_disabled, local_path, created_at, updated_at
-             FROM folders
-             WHERE profile = ? AND local_path = ? AND deleted_at IS NULL",
-        )
-        .bind(profile)
-        .bind(local_path)
-        .fetch_optional(&self.pool)
-        .await?
-        {
-            return Ok(folder_from_row(row));
-        }
+        projects: &[(String, String)],
+    ) -> Result<Vec<FolderDto>, sqlx::error::Error> {
+        let mut tx = self.pool.begin().await?;
+        let mut folders = Vec::with_capacity(projects.len());
+        for (name, local_path) in projects {
+            if let Some(row) = query(
+                "SELECT id, name, description, instructions, memory_disabled, local_path, created_at, updated_at
+                 FROM folders
+                 WHERE profile = ? AND local_path = ? AND deleted_at IS NULL",
+            )
+            .bind(profile)
+            .bind(local_path)
+            .fetch_optional(&mut *tx)
+            .await?
+            {
+                folders.push(folder_from_row(row));
+                continue;
+            }
 
-        let now = timestamp();
-        let folder = FolderDto {
-            id: Uuid::new_v4().to_string(),
-            name: name.trim().to_string(),
-            description: None,
-            instructions: None,
-            memory_disabled: false,
-            local_path: Some(local_path.to_string()),
-            created_at: now.clone(),
-            updated_at: now,
-        };
-        query(
-            "INSERT INTO folders
-             (id, name, description, profile, local_path, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?)",
-        )
-        .bind(&folder.id)
-        .bind(&folder.name)
-        .bind(&folder.description)
-        .bind(profile)
-        .bind(&folder.local_path)
-        .bind(&folder.created_at)
-        .bind(&folder.updated_at)
-        .execute(&self.pool)
-        .await?;
-        Ok(folder)
+            let now = timestamp();
+            let folder = FolderDto {
+                id: Uuid::new_v4().to_string(),
+                name: name.trim().to_string(),
+                description: None,
+                instructions: None,
+                memory_disabled: false,
+                local_path: Some(local_path.to_string()),
+                created_at: now.clone(),
+                updated_at: now,
+            };
+            query(
+                "INSERT INTO folders
+                 (id, name, description, profile, local_path, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&folder.id)
+            .bind(&folder.name)
+            .bind(&folder.description)
+            .bind(profile)
+            .bind(&folder.local_path)
+            .bind(&folder.created_at)
+            .bind(&folder.updated_at)
+            .execute(&mut *tx)
+            .await?;
+            folders.push(folder);
+        }
+        tx.commit().await?;
+        Ok(folders)
     }
 
     pub async fn rename_folder(
@@ -5976,6 +5982,34 @@ mod tests {
             .await
             .expect("finalize audio artifact");
         (note.id, artifact.id)
+    }
+
+    #[tokio::test]
+    async fn linked_folder_batch_rolls_back_when_any_insert_fails() {
+        let repos = test_repositories().await;
+        query(
+            "CREATE TRIGGER reject_linked_folder
+             BEFORE INSERT ON folders
+             WHEN NEW.local_path = '/tmp/reject'
+             BEGIN SELECT RAISE(ABORT, 'rejected for test'); END",
+        )
+        .execute(&repos.pool)
+        .await
+        .expect("create rejection trigger");
+
+        let projects = vec![
+            ("Accepted".to_string(), "/tmp/accepted".to_string()),
+            ("Rejected".to_string(), "/tmp/reject".to_string()),
+        ];
+        assert!(repos
+            .create_linked_folders("default", &projects)
+            .await
+            .is_err());
+        assert!(repos
+            .list_folders("default")
+            .await
+            .expect("list folders after rollback")
+            .is_empty());
     }
 
     fn transcription_plan(

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -53,8 +53,20 @@ pub struct FolderDto {
     pub instructions: Option<String>,
     #[serde(default)]
     pub memory_disabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_path: Option<String>,
     pub created_at: String,
     pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaudeProjectCandidateDto {
+    pub name: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_used_at: Option<String>,
+    pub already_added: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -214,6 +226,12 @@ pub struct CreateFolderRequest {
     pub name: String,
     #[serde(default)]
     pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportClaudeProjectsRequest {
+    pub paths: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ pub mod app_paths;
 pub mod audio;
 pub mod browser;
 mod browser_broker;
+pub mod claude_projects;
 pub mod commands;
 pub mod computer_use;
 mod computer_use_permission_drag;
@@ -159,6 +160,8 @@ pub fn run() {
             commands::delete_note,
             commands::delete_notes,
             commands::create_folder,
+            commands::discover_claude_projects,
+            commands::import_claude_projects,
             commands::list_folders,
             commands::delete_folder,
             commands::rename_folder,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2959,6 +2959,13 @@ export function App() {
     }
   }
 
+  function handleFoldersImported(folders: FolderDto[]) {
+    for (const folder of folders) {
+      dispatch({ type: "folderCreated", folder });
+    }
+    toast.success(`${folders.length} ${folders.length === 1 ? "project" : "projects"} added`);
+  }
+
   async function handleRenameFolder(folderId: string, name: string, description?: string) {
     try {
       const folder = await renameFolder(folderId, name, description);
@@ -4260,6 +4267,7 @@ export function App() {
                   onEnableAccessibility={handleEnableAccessibility}
                   onEnableSystemAudio={handleEnableSystemAudio}
                   folders={state.folders}
+                  onFoldersImported={handleFoldersImported}
                   memoryFolderFilter={memoryFolderFilter}
                   onOpenProject={(folderId) => {
                     handleSelectFolder(folderId);
@@ -4352,6 +4360,7 @@ export function App() {
                           id: folder.id,
                           name: folder.name,
                           instructions: folder.instructions,
+                          localPath: folder.localPath,
                         }
                       : undefined;
                   }}
@@ -4361,6 +4370,7 @@ export function App() {
                           id: agentProjectContextFolder.id,
                           name: agentProjectContextFolder.name,
                           instructions: agentProjectContextFolder.instructions,
+                          localPath: agentProjectContextFolder.localPath,
                         }
                       : undefined
                   }
@@ -4495,6 +4505,7 @@ export function App() {
                   }
                   onSelectFolder={(folderId) => handleSelectFolder(folderId)}
                   onCreateFolder={(name, description) => handleCreateFolder(name, description)}
+                  onFoldersImported={handleFoldersImported}
                   onRenameFolder={(folderId, name, description) =>
                     handleRenameFolder(folderId, name, description)
                   }

--- a/src/app/state/app-state.ts
+++ b/src/app/state/app-state.ts
@@ -98,7 +98,10 @@ export function notesReducer(state: NotesState, action: NotesAction): NotesState
     case "folderCreated":
       return {
         ...state,
-        folders: sortFolders([...state.folders, action.folder]),
+        folders: sortFolders([
+          ...state.folders.filter((folder) => folder.id !== action.folder.id),
+          action.folder,
+        ]),
       };
     case "folderRenamed":
     case "folderUpdated":

--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -1,6 +1,7 @@
 import { IconCheckmark2 } from "central-icons-filled/IconCheckmark2";
 import { IconBubble3 } from "central-icons/IconBubble3";
 import { IconBubbleAnnotation3 } from "central-icons/IconBubbleAnnotation3";
+import { IconCodeAssistant } from "central-icons/IconCodeAssistant";
 import { IconProjects } from "central-icons/IconProjects";
 import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
 import { IconDotGrid1x3Horizontal } from "central-icons/IconDotGrid1x3Horizontal";
@@ -39,6 +40,7 @@ import { AddSessionsToProjectDialog } from "./AddSessionsToProjectDialog";
 import { CreateFolderDialog } from "./CreateFolderDialog";
 import { EditFolderDialog } from "./EditFolderDialog";
 import { ProjectSettingsDialog } from "./ProjectSettingsDialog";
+import { ImportClaudeProjectsDialog } from "./ImportClaudeProjectsDialog";
 
 const NO_FOLDERS: FolderDto[] = [];
 
@@ -56,6 +58,7 @@ type FoldersWorkspaceProps = {
   };
   onSelectFolder: (folderId?: string) => void;
   onCreateFolder: (name: string, description?: string) => Promise<FolderDto | undefined> | void;
+  onFoldersImported?: (folders: FolderDto[]) => void;
   onRenameFolder: (folderId: string, name: string, description?: string) => Promise<unknown> | void;
   onFolderUpdated: (folder: FolderDto) => void;
   onDeleteFolder: (folderId: string, deleteNotes: boolean) => Promise<unknown> | void;
@@ -106,6 +109,7 @@ function FolderList({
   sessionFolderIds,
   onSelectFolder,
   onCreateFolder,
+  onFoldersImported,
   onRenameFolder,
   onDeleteFolder,
   onAssignNoteToFolder,
@@ -114,6 +118,7 @@ function FolderList({
   // install would see it, real data untouched underneath.
   const folders = useForcedEmptyStates() ? NO_FOLDERS : allFolders;
   const [createOpen, setCreateOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [sort, setSort] = useState<SortKey>("updated");
   const [menu, setMenu] = useState<MenuState | null>(null);
@@ -206,14 +211,20 @@ function FolderList({
         title="Give your work a home"
         description="A project collects the meeting notes and agent sessions for one effort, so everything about it lives in one place."
         action={
-          <button
-            type="button"
-            className="primary-action primary-solid"
-            onClick={() => setCreateOpen(true)}
-          >
-            <IconFolderAddRight size={14} />
-            Create your first project
-          </button>
+          <div className="folders-empty-actions">
+            <button
+              type="button"
+              className="primary-action primary-solid"
+              onClick={() => setImportOpen(true)}
+            >
+              <IconCodeAssistant size={14} />
+              Add Claude Code projects
+            </button>
+            <button type="button" className="primary-action" onClick={() => setCreateOpen(true)}>
+              <IconFolderAddRight size={14} />
+              Create a new project
+            </button>
+          </div>
         }
       />
     ) : (
@@ -231,14 +242,20 @@ function FolderList({
             Group meeting notes and agent sessions around the work they belong to.
           </p>
         </div>
-        <button
-          type="button"
-          className="primary-action primary-solid folders-create"
-          onClick={() => setCreateOpen(true)}
-        >
-          <IconFolderAddRight size={14} />
-          New project
-        </button>
+        <div className="folders-header-actions">
+          <button type="button" className="primary-action" onClick={() => setImportOpen(true)}>
+            <IconCodeAssistant size={14} />
+            Add existing
+          </button>
+          <button
+            type="button"
+            className="primary-action primary-solid folders-create"
+            onClick={() => setCreateOpen(true)}
+          >
+            <IconFolderAddRight size={14} />
+            New project
+          </button>
+        </div>
       </header>
 
       <div className="folders-controls">
@@ -296,6 +313,11 @@ function FolderList({
         onCreate={async (name, description) => {
           await onCreateFolder(name, description);
         }}
+      />
+      <ImportClaudeProjectsDialog
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onImported={onFoldersImported ?? (() => {})}
       />
       {editFolderTarget ? (
         <EditFolderDialog
@@ -459,6 +481,11 @@ function FolderCard({
         <div className="folder-card-text">
           <h3 className="folder-card-title">{folder.name}</h3>
           {folder.description ? <p className="folder-card-meta">{folder.description}</p> : null}
+          {folder.localPath ? (
+            <p className="folder-card-path" title={folder.localPath}>
+              {folder.localPath}
+            </p>
+          ) : null}
         </div>
         <p className="folder-card-footer">
           <span className="folder-card-footer-item">
@@ -744,6 +771,12 @@ function FolderDetail({
           )}
           {folder.description ? (
             <p className="folder-detail-description">{folder.description}</p>
+          ) : null}
+          {folder.localPath ? (
+            <p className="folder-detail-path" title={folder.localPath}>
+              <IconFolder1 size={12} aria-hidden />
+              <span>{folder.localPath}</span>
+            </p>
           ) : null}
           <p className="folder-detail-meta">
             <span className="folder-detail-meta-pill" aria-hidden>

--- a/src/components/folders/ImportClaudeProjectsDialog.tsx
+++ b/src/components/folders/ImportClaudeProjectsDialog.tsx
@@ -1,8 +1,9 @@
 import { IconCheckmark2 } from "central-icons-filled/IconCheckmark2";
 import { IconCodeAssistant } from "central-icons/IconCodeAssistant";
 import { IconFolder1 } from "central-icons/IconFolder1";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { messageFromError } from "../../lib/errors";
+import { useScrollFade } from "../../lib/use-scroll-fade";
 import {
   discoverClaudeProjects,
   importClaudeProjects,
@@ -24,6 +25,8 @@ export function ImportClaudeProjectsDialog({
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string>();
   const [importing, setImporting] = useState(false);
+  const listRef = useRef<HTMLUListElement>(null);
+  const listFade = useScrollFade(listRef);
 
   useEffect(() => {
     if (!open) return;
@@ -169,7 +172,11 @@ export function ImportClaudeProjectsDialog({
                 {selected.size === available.length ? "Clear selection" : "Select all"}
               </button>
             </div>
-            <ul className="claude-projects-list">
+            <ul
+              ref={listRef}
+              className="claude-projects-list scroll-fade-mask"
+              {...listFade.props}
+            >
               {available.map((candidate) => (
                 <li key={candidate.path}>
                   <label className="claude-project-row">

--- a/src/components/folders/ImportClaudeProjectsDialog.tsx
+++ b/src/components/folders/ImportClaudeProjectsDialog.tsx
@@ -1,0 +1,211 @@
+import { IconCheckmark2 } from "central-icons-filled/IconCheckmark2";
+import { IconCodeAssistant } from "central-icons/IconCodeAssistant";
+import { IconFolder1 } from "central-icons/IconFolder1";
+import { useEffect, useMemo, useState } from "react";
+import { messageFromError } from "../../lib/errors";
+import {
+  discoverClaudeProjects,
+  importClaudeProjects,
+  type ClaudeProjectCandidate,
+  type FolderDto,
+} from "../../lib/tauri";
+import { Dialog } from "../ui/Dialog";
+
+export function ImportClaudeProjectsDialog({
+  open,
+  onClose,
+  onImported,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onImported: (folders: FolderDto[]) => void;
+}) {
+  const [candidates, setCandidates] = useState<ClaudeProjectCandidate[] | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string>();
+  const [importing, setImporting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setCandidates(null);
+    setSelected(new Set());
+    setError(undefined);
+    discoverClaudeProjects()
+      .then((items) => {
+        if (cancelled) return;
+        setCandidates(items);
+        setSelected(new Set(items.filter((item) => !item.alreadyAdded).map((item) => item.path)));
+      })
+      .catch((caught: unknown) => {
+        if (!cancelled) setError(messageFromError(caught));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const available = useMemo(
+    () => candidates?.filter((candidate) => !candidate.alreadyAdded) ?? [],
+    [candidates],
+  );
+
+  function toggle(path: string) {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }
+
+  async function submit() {
+    if (selected.size === 0 || importing) return;
+    setImporting(true);
+    setError(undefined);
+    try {
+      const folders = await importClaudeProjects([...selected]);
+      onImported(folders);
+      onClose();
+    } catch (caught) {
+      setError(messageFromError(caught));
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  const count = selected.size;
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Add projects from Claude Code"
+      description="Choose project folders to add to June. Your files stay where they are."
+      leading={<IconCodeAssistant size={16} />}
+      width={600}
+      className="claude-projects-dialog"
+      disableBackdropClose={importing}
+      footer={
+        <>
+          <button type="button" className="btn" onClick={onClose} disabled={importing}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="primary-action primary-solid"
+            disabled={count === 0 || importing}
+            onClick={() => void submit()}
+          >
+            {importing
+              ? "Adding projects..."
+              : `Add ${count} ${count === 1 ? "project" : "projects"}`}
+          </button>
+        </>
+      }
+    >
+      <div className="dialog-body claude-projects-body">
+        {candidates === null && !error ? (
+          <p className="claude-projects-status">Looking for Claude Code projects...</p>
+        ) : null}
+        {error ? (
+          <div className="claude-projects-error" role="alert">
+            <p>{error}</p>
+            {candidates === null ? (
+              <button
+                type="button"
+                className="btn"
+                onClick={() => {
+                  setError(undefined);
+                  setCandidates(null);
+                  discoverClaudeProjects()
+                    .then((items) => {
+                      setCandidates(items);
+                      setSelected(
+                        new Set(
+                          items.filter((item) => !item.alreadyAdded).map((item) => item.path),
+                        ),
+                      );
+                    })
+                    .catch((caught: unknown) => setError(messageFromError(caught)));
+                }}
+              >
+                Try again
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+        {candidates && candidates.length === 0 ? (
+          <div className="claude-projects-empty">
+            <IconFolder1 size={20} />
+            <div>
+              <strong>No Claude Code projects found</strong>
+              <p>Open a local folder with Claude Code, then scan again.</p>
+            </div>
+          </div>
+        ) : null}
+        {candidates && candidates.length > 0 && available.length === 0 ? (
+          <div className="claude-projects-empty">
+            <IconCheckmark2 size={20} />
+            <div>
+              <strong>Everything is already here</strong>
+              <p>All available Claude Code projects have been added to June.</p>
+            </div>
+          </div>
+        ) : null}
+        {available.length > 0 ? (
+          <>
+            <div className="claude-projects-selection-bar">
+              <span>{available.length} found</span>
+              <button
+                type="button"
+                onClick={() =>
+                  setSelected(
+                    selected.size === available.length
+                      ? new Set()
+                      : new Set(available.map((item) => item.path)),
+                  )
+                }
+              >
+                {selected.size === available.length ? "Clear selection" : "Select all"}
+              </button>
+            </div>
+            <ul className="claude-projects-list">
+              {available.map((candidate) => (
+                <li key={candidate.path}>
+                  <label className="claude-project-row">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(candidate.path)}
+                      onChange={() => toggle(candidate.path)}
+                    />
+                    <span className="claude-project-row-icon" aria-hidden>
+                      <IconFolder1 size={14} />
+                    </span>
+                    <span className="claude-project-row-copy">
+                      <strong>{candidate.name}</strong>
+                      <span title={candidate.path}>{candidate.path}</span>
+                    </span>
+                    {candidate.lastUsedAt ? (
+                      <time dateTime={candidate.lastUsedAt}>
+                        {formatLastUsed(candidate.lastUsedAt)}
+                      </time>
+                    ) : null}
+                  </label>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : null}
+      </div>
+    </Dialog>
+  );
+}
+
+function formatLastUsed(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}

--- a/src/components/folders/ImportClaudeProjectsDialog.tsx
+++ b/src/components/folders/ImportClaudeProjectsDialog.tsx
@@ -1,7 +1,7 @@
 import { IconCheckmark2 } from "central-icons-filled/IconCheckmark2";
 import { IconCodeAssistant } from "central-icons/IconCodeAssistant";
 import { IconFolder1 } from "central-icons/IconFolder1";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { messageFromError } from "../../lib/errors";
 import { useScrollFade } from "../../lib/use-scroll-fade";
 import {
@@ -26,27 +26,35 @@ export function ImportClaudeProjectsDialog({
   const [error, setError] = useState<string>();
   const [importing, setImporting] = useState(false);
   const listRef = useRef<HTMLUListElement>(null);
+  const discoveryRequestRef = useRef(0);
   const listFade = useScrollFade(listRef);
 
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
+  const loadCandidates = useCallback(() => {
+    const request = ++discoveryRequestRef.current;
     setCandidates(null);
     setSelected(new Set());
     setError(undefined);
     discoverClaudeProjects()
       .then((items) => {
-        if (cancelled) return;
+        if (request !== discoveryRequestRef.current) return;
         setCandidates(items);
         setSelected(new Set(items.filter((item) => !item.alreadyAdded).map((item) => item.path)));
       })
       .catch((caught: unknown) => {
-        if (!cancelled) setError(messageFromError(caught));
+        if (request === discoveryRequestRef.current) setError(messageFromError(caught));
       });
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      discoveryRequestRef.current += 1;
+      return;
+    }
+    loadCandidates();
     return () => {
-      cancelled = true;
+      discoveryRequestRef.current += 1;
     };
-  }, [open]);
+  }, [loadCandidates, open]);
 
   const available = useMemo(
     () => candidates?.filter((candidate) => !candidate.alreadyAdded) ?? [],
@@ -117,20 +125,7 @@ export function ImportClaudeProjectsDialog({
               <button
                 type="button"
                 className="btn"
-                onClick={() => {
-                  setError(undefined);
-                  setCandidates(null);
-                  discoverClaudeProjects()
-                    .then((items) => {
-                      setCandidates(items);
-                      setSelected(
-                        new Set(
-                          items.filter((item) => !item.alreadyAdded).map((item) => item.path),
-                        ),
-                      );
-                    })
-                    .catch((caught: unknown) => setError(messageFromError(caught)));
-                }}
+                onClick={loadCandidates}
               >
                 Try again
               </button>

--- a/src/components/folders/ImportClaudeProjectsDialog.tsx
+++ b/src/components/folders/ImportClaudeProjectsDialog.tsx
@@ -122,11 +122,7 @@ export function ImportClaudeProjectsDialog({
           <div className="claude-projects-error" role="alert">
             <p>{error}</p>
             {candidates === null ? (
-              <button
-                type="button"
-                className="btn"
-                onClick={loadCandidates}
-              >
+              <button type="button" className="btn" onClick={loadCandidates}>
                 Try again
               </button>
             ) : null}
@@ -167,11 +163,7 @@ export function ImportClaudeProjectsDialog({
                 {selected.size === available.length ? "Clear selection" : "Select all"}
               </button>
             </div>
-            <ul
-              ref={listRef}
-              className="claude-projects-list scroll-fade-mask"
-              {...listFade.props}
-            >
+            <ul ref={listRef} className="claude-projects-list scroll-fade-mask" {...listFade.props}>
               {available.map((candidate) => (
                 <li key={candidate.path}>
                   <label className="claude-project-row">

--- a/src/components/settings/AgentSettingsSection.tsx
+++ b/src/components/settings/AgentSettingsSection.tsx
@@ -22,6 +22,7 @@ import {
   type HermesMessagingPlatformInfo,
   type HermesFilesystemSnapshot,
   type JuneCharacterStatus,
+  type FolderDto,
 } from "../../lib/tauri";
 import {
   AGENT_HUD_VISIBILITY_CHANGED_EVENT,
@@ -41,6 +42,7 @@ import {
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS,
 } from "../../lib/hermes-messaging";
 import { Switch } from "../ui/Switch";
+import { ImportClaudeProjectsDialog } from "../folders/ImportClaudeProjectsDialog";
 import { SettingsPageHeader } from "./AppSettings";
 
 type AgentSettingsPanel = "messaging" | "files";
@@ -49,6 +51,8 @@ export function AgentSettingsSection({
   selectedPlatformId,
   onSelectPlatform,
   onBackFromPlatform,
+  folders = [],
+  onFoldersImported,
 }: {
   /** The messaging platform whose detail is open, lifted into AppSettings so the
    * drill-in can pin at the very top of the settings surface (replacing the
@@ -58,6 +62,8 @@ export function AgentSettingsSection({
   onSelectPlatform?: (platformId: string) => void;
   /** Return to the platform list. */
   onBackFromPlatform?: () => void;
+  folders?: FolderDto[];
+  onFoldersImported?: (folders: FolderDto[]) => void;
 } = {}) {
   // Messaging / Files present as the system underline tabs (same pattern as
   // the routine detail tabs), with the active panel's content beneath.
@@ -82,6 +88,8 @@ export function AgentSettingsSection({
   const [cliAccessEnabled, setCliAccessEnabled] = useState<boolean | null>(null);
   const [cliAccessSaving, setCliAccessSaving] = useState(false);
   const [cliAccessLoadFailed, setCliAccessLoadFailed] = useState(false);
+  const [projectImportOpen, setProjectImportOpen] = useState(false);
+  const linkedProjectCount = folders.filter((folder) => folder.localPath).length;
 
   useEffect(() => {
     let cancelled = false;
@@ -451,8 +459,28 @@ export function AgentSettingsSection({
                 )}
               </div>
             </div>
+            <div className="settings-row">
+              <div className="settings-row-info">
+                <h3 className="settings-row-title">Claude Code projects</h3>
+                <p className="settings-row-description">
+                  {linkedProjectCount > 0
+                    ? `${linkedProjectCount} ${linkedProjectCount === 1 ? "project folder is" : "project folders are"} linked. Scan again to add folders you used with Claude Code more recently.`
+                    : "Add local project folders you have used with Claude Code. Files stay in their current locations."}
+                </p>
+              </div>
+              <div className="settings-row-control">
+                <button type="button" className="btn" onClick={() => setProjectImportOpen(true)}>
+                  {linkedProjectCount > 0 ? "Scan again" : "Add projects"}
+                </button>
+              </div>
+            </div>
           </div>
         </div>
+        <ImportClaudeProjectsDialog
+          open={projectImportOpen}
+          onClose={() => setProjectImportOpen(false)}
+          onImported={onFoldersImported ?? (() => {})}
+        />
         {error ? <p className="settings-row-error">{error}</p> : null}
       </section>
       <CharacterGroup />

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -421,6 +421,7 @@ export function SettingsPageHeader({
 
 type AppSettingsProps = {
   folders?: FolderDto[];
+  onFoldersImported?: (folders: FolderDto[]) => void;
   /** When Memory is opened from a project, the manager pre-filters to it. */
   memoryFolderFilter?: string;
   /** Drill from a memory's project tag into that project. */
@@ -468,6 +469,7 @@ type AppSettingsProps = {
 
 export function AppSettings({
   folders = [],
+  onFoldersImported,
   memoryFolderFilter,
   onOpenProject,
   account,
@@ -2485,6 +2487,8 @@ export function AppSettings({
             selectedPlatformId={agentPlatformId}
             onSelectPlatform={setAgentPlatformId}
             onBackFromPlatform={() => setAgentPlatformId(undefined)}
+            folders={folders}
+            onFoldersImported={onFoldersImported}
           />
         ) : null}
 

--- a/src/lib/agent-project-context.ts
+++ b/src/lib/agent-project-context.ts
@@ -2,6 +2,7 @@ export type AgentProjectContext = {
   id: string;
   name: string;
   instructions?: string;
+  localPath?: string;
 };
 
 export type PreparedProjectPrompt = {
@@ -56,11 +57,23 @@ function sanitizeContextPayload(value: string): string {
 }
 
 function projectContextSignature(project: AgentProjectContext): string {
-  return JSON.stringify([project.id, project.name, project.instructions ?? ""]);
+  return JSON.stringify([
+    project.id,
+    project.name,
+    project.instructions ?? "",
+    project.localPath ?? "",
+  ]);
 }
 
 function renderProjectContext(project: AgentProjectContext): string {
-  const instructions = sanitizeContextPayload(project.instructions?.trim() ?? "") || "(none)";
+  const localPath = sanitizeContextPayload(project.localPath?.trim() ?? "").replace(/\n/g, " ");
+  const linkedFolderContext = localPath
+    ? `Linked local folder: ${localPath}\nUse this as the primary working folder for this project. Respect the session's current file access mode.`
+    : "";
+  const instructions =
+    sanitizeContextPayload(
+      [linkedFolderContext, project.instructions?.trim() ?? ""].filter(Boolean).join("\n\n"),
+    ) || "(none)";
   const name = sanitizeContextPayload(project.name).replace(/\n/g, " ");
   return [
     CONTEXT_OPEN_MARKER,
@@ -103,7 +116,11 @@ export function prepareProjectPrompt(
         contextSignature: CLEARED_CONTEXT_SIGNATURE,
       };
     }
-    return { text: prompt, injected: false, contextSignature: previousContextSignature ?? null };
+    return {
+      text: prompt,
+      injected: false,
+      contextSignature: previousContextSignature ?? null,
+    };
   }
 
   const contextSignature = projectContextSignature(project);

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -26,8 +26,16 @@ export type FolderDto = {
   description?: string;
   instructions?: string;
   memoryDisabled: boolean;
+  localPath?: string;
   createdAt: string;
   updatedAt: string;
+};
+
+export type ClaudeProjectCandidate = {
+  name: string;
+  path: string;
+  lastUsedAt?: string;
+  alreadyAdded: boolean;
 };
 
 export type MemoryDto = {
@@ -848,6 +856,14 @@ export async function renameFolder(folderId: string, name: string, description?:
 
 export async function listFolders() {
   return invoke<FolderDto[]>("list_folders");
+}
+
+export async function discoverClaudeProjects() {
+  return invoke<ClaudeProjectCandidate[]>("discover_claude_projects");
+}
+
+export async function importClaudeProjects(paths: string[]) {
+  return invoke<FolderDto[]>("import_claude_projects", { request: { paths } });
 }
 
 export async function assignNoteToFolder(noteId: string, folderId: string) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -19899,6 +19899,152 @@ button.memory-project:hover {
   flex-shrink: 0;
 }
 
+.folders-header-actions,
+.folders-empty-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+.folders-header-actions {
+  flex-shrink: 0;
+}
+
+.folders-empty-actions {
+  flex-wrap: wrap;
+}
+
+.claude-projects-body {
+  gap: var(--sp-3);
+}
+
+.claude-projects-status,
+.claude-projects-error p,
+.claude-projects-empty p {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+}
+
+.claude-projects-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-4);
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--r-md);
+  background: var(--destructive-soft);
+}
+
+.claude-projects-empty {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-3);
+  padding: var(--sp-5);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  color: var(--muted-foreground);
+}
+
+.claude-projects-empty strong {
+  display: block;
+  margin-bottom: var(--sp-1);
+  color: var(--foreground);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-medium);
+}
+
+.claude-projects-selection-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.claude-projects-selection-bar button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--foreground);
+  font: inherit;
+  cursor: pointer;
+}
+
+.claude-projects-list {
+  max-height: min(430px, 52vh);
+  margin: 0;
+  padding: 0;
+  overflow: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  list-style: none;
+}
+
+.claude-project-row {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
+}
+
+.claude-project-row:last-child {
+  border-bottom: 0;
+}
+
+.claude-project-row:hover {
+  background: color-mix(in oklch, var(--muted) 38%, transparent);
+}
+
+.claude-project-row input {
+  width: var(--sp-4);
+  height: var(--sp-4);
+  margin: 0;
+  accent-color: var(--primary);
+}
+
+.claude-project-row-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 54%, transparent);
+  color: var(--muted-foreground);
+}
+
+.claude-project-row-copy {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.claude-project-row-copy strong,
+.claude-project-row-copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.claude-project-row-copy strong {
+  color: var(--foreground);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-medium);
+}
+
+.claude-project-row-copy span,
+.claude-project-row time {
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.claude-project-row time {
+  white-space: nowrap;
+}
+
 /* Folders controls row — short search left, sort right ---------- */
 
 .folders-controls {
@@ -20477,6 +20623,16 @@ button.memory-project:hover {
   overflow: hidden;
 }
 
+.folder-card-path {
+  margin: 0;
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Card footer — pinned to the bottom of the card via the body's
  * space-between flex. Subtle file icon + count + updated date. */
 .folder-card-footer {
@@ -20665,6 +20821,23 @@ button.memory-project:hover {
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--fs-md);
+}
+
+.folder-detail-path {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  max-width: min(100%, 680px);
+  margin: 0;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+}
+
+.folder-detail-path span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Quiet meta row — folder icon in a soft pill, then count, then date. */

--- a/src/test/agent-project-context.test.ts
+++ b/src/test/agent-project-context.test.ts
@@ -82,6 +82,18 @@ describe("agent project context", () => {
     expect(changed.text).toContain("instructions:\nUse primary sources.");
   });
 
+  it("adds a linked local folder to the hidden project context", () => {
+    const linked = prepareProjectPrompt(
+      "Inspect the repository",
+      { ...project, localPath: "/Users/alex/code/launch" },
+      undefined,
+    );
+
+    expect(linked.text).toContain("Linked local folder: /Users/alex/code/launch");
+    expect(linked.text).toContain("Use this as the primary working folder for this project.");
+    expect(stripProjectContext(linked.text)).toBe("Inspect the repository");
+  });
+
   it("does not inject for a session outside a project", () => {
     expect(prepareProjectPrompt("Global question", undefined, undefined)).toEqual({
       text: "Global question",

--- a/src/test/app-state.test.ts
+++ b/src/test/app-state.test.ts
@@ -40,6 +40,26 @@ describe("notesReducer", () => {
     expect(state.providerConfigured).toBe(true);
   });
 
+  it("upserts a folder when a concurrent import returns an existing folder", () => {
+    const folder = {
+      id: "folder-1",
+      name: "Project",
+      memoryDisabled: false,
+      localPath: "/Users/alex/code/project",
+      createdAt: now,
+      updatedAt: now,
+    };
+    const initial = { ...createInitialState(), folders: [folder] };
+
+    const state = notesReducer(initial, {
+      type: "folderCreated",
+      folder: { ...folder, name: "Updated project" },
+    });
+
+    expect(state.folders).toHaveLength(1);
+    expect(state.folders[0].name).toBe("Updated project");
+  });
+
   it("updates the selected note after autosave", () => {
     const initial = notesReducer(createInitialState(), {
       type: "noteLoaded",

--- a/src/test/import-claude-projects-dialog.test.tsx
+++ b/src/test/import-claude-projects-dialog.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ImportClaudeProjectsDialog } from "../components/folders/ImportClaudeProjectsDialog";
+import { discoverClaudeProjects, importClaudeProjects, type FolderDto } from "../lib/tauri";
+
+vi.mock("../lib/tauri", () => ({
+  discoverClaudeProjects: vi.fn(),
+  importClaudeProjects: vi.fn(),
+}));
+
+const importedFolder: FolderDto = {
+  id: "folder-1",
+  name: "alpha",
+  memoryDisabled: false,
+  localPath: "/Users/alex/code/alpha",
+  createdAt: "2026-07-20T12:00:00Z",
+  updatedAt: "2026-07-20T12:00:00Z",
+};
+
+describe("ImportClaudeProjectsDialog", () => {
+  beforeEach(() => {
+    vi.mocked(discoverClaudeProjects).mockReset();
+    vi.mocked(importClaudeProjects).mockReset();
+  });
+
+  it("preselects every available Claude Code project and imports the selection", async () => {
+    vi.mocked(discoverClaudeProjects).mockResolvedValue([
+      {
+        name: "alpha",
+        path: "/Users/alex/code/alpha",
+        lastUsedAt: "2026-07-20T12:00:00Z",
+        alreadyAdded: false,
+      },
+      {
+        name: "beta",
+        path: "/Users/alex/code/beta",
+        alreadyAdded: false,
+      },
+      {
+        name: "existing",
+        path: "/Users/alex/code/existing",
+        alreadyAdded: true,
+      },
+    ]);
+    vi.mocked(importClaudeProjects).mockResolvedValue([importedFolder]);
+    const onClose = vi.fn();
+    const onImported = vi.fn();
+
+    render(<ImportClaudeProjectsDialog open onClose={onClose} onImported={onImported} />);
+
+    expect(await screen.findByText("alpha")).toBeInTheDocument();
+    expect(screen.getByText("beta")).toBeInTheDocument();
+    expect(screen.queryByText("existing")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add 2 projects" })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add 2 projects" }));
+    await waitFor(() =>
+      expect(importClaudeProjects).toHaveBeenCalledWith([
+        "/Users/alex/code/alpha",
+        "/Users/alex/code/beta",
+      ]),
+    );
+    expect(onImported).toHaveBeenCalledWith([importedFolder]);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("lets the user review and clear the default selection", async () => {
+    vi.mocked(discoverClaudeProjects).mockResolvedValue([
+      { name: "alpha", path: "/Users/alex/code/alpha", alreadyAdded: false },
+    ]);
+
+    render(<ImportClaudeProjectsDialog open onClose={vi.fn()} onImported={vi.fn()} />);
+
+    expect(await screen.findByRole("button", { name: "Add 1 project" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: "Clear selection" }));
+    expect(screen.getByRole("button", { name: "Add 0 projects" })).toBeDisabled();
+  });
+
+  it("shows a calm completed state when every discovered folder is linked", async () => {
+    vi.mocked(discoverClaudeProjects).mockResolvedValue([
+      { name: "alpha", path: "/Users/alex/code/alpha", alreadyAdded: true },
+    ]);
+
+    render(<ImportClaudeProjectsDialog open onClose={vi.fn()} onImported={vi.fn()} />);
+
+    expect(await screen.findByText("Everything is already here")).toBeInTheDocument();
+    expect(screen.getByText(/All available Claude Code projects/)).toBeInTheDocument();
+  });
+});

--- a/src/test/import-claude-projects-dialog.test.tsx
+++ b/src/test/import-claude-projects-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ImportClaudeProjectsDialog } from "../components/folders/ImportClaudeProjectsDialog";
 import { discoverClaudeProjects, importClaudeProjects, type FolderDto } from "../lib/tauri";
@@ -85,5 +85,32 @@ describe("ImportClaudeProjectsDialog", () => {
 
     expect(await screen.findByText("Everything is already here")).toBeInTheDocument();
     expect(screen.getByText(/All available Claude Code projects/)).toBeInTheDocument();
+  });
+
+  it("ignores a retry result after the dialog closes and reopens", async () => {
+    let resolveRetry: (value: Awaited<ReturnType<typeof discoverClaudeProjects>>) => void = () => {};
+    const retry = new Promise<Awaited<ReturnType<typeof discoverClaudeProjects>>>((resolve) => {
+      resolveRetry = resolve;
+    });
+    vi.mocked(discoverClaudeProjects)
+      .mockRejectedValueOnce(new Error("Scan failed"))
+      .mockReturnValueOnce(retry)
+      .mockResolvedValueOnce([
+        { name: "new project", path: "/Users/alex/code/new-project", alreadyAdded: false },
+      ]);
+    const props = { onClose: vi.fn(), onImported: vi.fn() };
+    const { rerender } = render(<ImportClaudeProjectsDialog open {...props} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+    rerender(<ImportClaudeProjectsDialog open={false} {...props} />);
+    rerender(<ImportClaudeProjectsDialog open {...props} />);
+    expect(await screen.findByText("new project")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveRetry([
+        { name: "stale project", path: "/Users/alex/code/stale-project", alreadyAdded: false },
+      ]);
+    });
+    expect(screen.queryByText("stale project")).not.toBeInTheDocument();
   });
 });

--- a/src/test/import-claude-projects-dialog.test.tsx
+++ b/src/test/import-claude-projects-dialog.test.tsx
@@ -88,7 +88,8 @@ describe("ImportClaudeProjectsDialog", () => {
   });
 
   it("ignores a retry result after the dialog closes and reopens", async () => {
-    let resolveRetry: (value: Awaited<ReturnType<typeof discoverClaudeProjects>>) => void = () => {};
+    let resolveRetry: (value: Awaited<ReturnType<typeof discoverClaudeProjects>>) => void =
+      () => {};
     const retry = new Promise<Awaited<ReturnType<typeof discoverClaudeProjects>>>((resolve) => {
       resolveRetry = resolve;
     });


### PR DESCRIPTION
## Summary

- discover valid local project folders from Claude Code config and session history on demand
- let users review and add those folders from Projects, with a quiet rescan entry in Agent settings
- persist canonical linked paths on June projects and include the linked folder in hidden agent project context
- keep files in place, preserve the existing Sandboxed or Unrestricted access model, and deduplicate prior imports

## Why

People moving from Claude Code should be able to continue their existing local work in June without recreating projects or copying source folders. The review sheet keeps that transition explicit and avoids a launch-time interruption.

## Validation

- `pnpm test` (full suite passed)
- `pnpm build`
- `pnpm run typecheck`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked` (987 tests passed before rebasing)
- focused Claude discovery Rust tests passed before rebasing
- live visual walkthrough passed in an isolated web preview: empty state, review sheet, selection controls, import completion, and linked-path card

## Validation gap

After rebasing, latest `origin/main` fails Rust test compilation in unchanged `src-tauri/src/hermes_bridge.rs`: two `provider_proxy_required_token` test calls from the Obsidian merge omit the newly required seventh argument. This branch does not touch that file. TypeScript validation still passes on the rebased branch.

Native visual targeting was blocked because the already-running production June app shares the same bundle identity as the development build. I left the user's production app undisturbed and used the web preview for visual QA. No QA video was uploaded or retained.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787167074&installation_model_id=425925&pr_number=859&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F859&signature=76bc9159b472330071fb69cdfb07fb46d1413f527be892561aab0a5686ab3565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->