### PR TITLE
Add logos to macOS helper apps

### DIFF
--- a/scripts/computer-use-self-test.mjs
+++ b/scripts/computer-use-self-test.mjs
@@ -162,6 +162,7 @@ function validateBundle() {
   for (const [key, expected] of [
     ["CFBundleIdentifier", expectedBundleIdentifier],
     ["CFBundleDisplayName", "June Computer Use Driver"],
+    ["CFBundleIconFile", "June.icns"],
     ["CFBundleName", "June Computer Use Driver"],
     ["LSMinimumSystemVersion", pin.minimumMacOSVersion],
   ]) {
@@ -169,6 +170,14 @@ function validateBundle() {
     if (actual !== expected) {
       throw new Error(`Computer use helper ${key} is ${actual}; expected ${expected}.`);
     }
+  }
+  const bundledIcon = path.join(bundleDir, "Contents", "Resources", "June.icns");
+  if (
+    readFileSync(bundledIcon).compare(
+      readFileSync(path.join(rootDir, "src-tauri", "icons", "icon.icns")),
+    ) !== 0
+  ) {
+    throw new Error("Computer use helper is missing June's app icon.");
   }
   const screenReason = run("/usr/bin/plutil", [
     "-extract",

--- a/scripts/computer-use-self-test.mjs
+++ b/scripts/computer-use-self-test.mjs
@@ -177,7 +177,7 @@ function validateBundle() {
       readFileSync(path.join(rootDir, "src-tauri", "icons", "icon.icns")),
     ) !== 0
   ) {
-    throw new Error("Computer use helper is missing June's app icon.");
+    throw new Error("Computer use helper icon does not match June's app icon.");
   }
   const screenReason = run("/usr/bin/plutil", [
     "-extract",

--- a/scripts/prepare-cua-driver.mjs
+++ b/scripts/prepare-cua-driver.mjs
@@ -12,6 +12,8 @@ const pinPath = path.join(rootDir, "src-tauri", "cua-driver-pin.json");
 const pin = JSON.parse(readFileSync(pinPath, "utf8"));
 const sbomSource = path.join(rootDir, "src-tauri", "cua-driver-sbom.spdx.json");
 const licenseSource = path.join(rootDir, "src-tauri", "cua-driver-LICENSE.md");
+const iconSource = path.join(rootDir, "src-tauri", "icons", "icon.icns");
+const iconFileName = "June.icns";
 
 const tauriPlatform = process.env.TAURI_ENV_PLATFORM?.trim();
 if (process.platform !== "darwin" || (tauriPlatform && tauriPlatform !== "darwin")) {
@@ -44,6 +46,7 @@ const executableDir = path.join(contentsDir, "MacOS");
 const resourcesDir = path.join(contentsDir, "Resources");
 const executable = path.join(executableDir, pin.executable);
 const stampPath = path.join(resourcesDir, "june-cua-driver-pin.json");
+const iconDestination = path.join(resourcesDir, iconFileName);
 
 if (preparedBundleMatches()) {
   console.error(
@@ -115,6 +118,7 @@ writeFileSync(
   <key>CFBundleDisplayName</key><string>June Computer Use Driver</string>
   <key>CFBundleExecutable</key><string>${pin.executable}</string>
   <key>CFBundleIdentifier</key><string>${bundleIdentifier}</string>
+  <key>CFBundleIconFile</key><string>${iconFileName}</string>
   <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
   <key>CFBundleName</key><string>June Computer Use Driver</string>
   <key>CFBundlePackageType</key><string>APPL</string>
@@ -142,6 +146,7 @@ writeFileSync(
 );
 cpSync(sbomSource, path.join(resourcesDir, "june-cua-driver.spdx.json"));
 cpSync(licenseSource, path.join(resourcesDir, "cua-driver-LICENSE.md"));
+cpSync(iconSource, iconDestination);
 run("/usr/bin/codesign", [
   "--force",
   "--deep",
@@ -231,8 +236,21 @@ function preparedBundleMatches() {
     architectures.every((architecture) => actualArchitectures.has(architecture)) &&
     version.version === pin.version &&
     version.commit === pin.sourceCommit &&
+    bundleIconMatches() &&
     bundleSignatureMatches()
   );
+}
+
+function bundleIconMatches() {
+  if (!existsSync(iconDestination)) return false;
+  if (!readFileSync(iconDestination).equals(readFileSync(iconSource))) return false;
+  const plist = path.join(contentsDir, "Info.plist");
+  const result = spawnSync(
+    "/usr/bin/plutil",
+    ["-extract", "CFBundleIconFile", "raw", "-o", "-", plist],
+    { encoding: "utf8" },
+  );
+  return result.status === 0 && result.stdout.trim() === iconFileName;
 }
 
 function bundleSignatureMatches() {

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -643,6 +643,8 @@ fn build_dictation_helper() {
     std::fs::create_dir_all(&resources_dir)
         .expect("dictation helper resources dir should be created");
     let executable = macos_dir.join("june-dictation-helper");
+    let icon_source = manifest_dir.join("icons").join("icon.icns");
+    let icon_destination = resources_dir.join("June.icns");
 
     let executable_current = swift_helper_executable_current(&source, &executable);
     let mut should_sign = false;
@@ -684,6 +686,8 @@ fn build_dictation_helper() {
   <string>june-dictation-helper</string>
   <key>CFBundleIdentifier</key>
   <string>co.opensoftware.june.dictation-helper</string>
+  <key>CFBundleIconFile</key>
+  <string>June.icns</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>
@@ -709,6 +713,23 @@ fn build_dictation_helper() {
     if !plist_current {
         std::fs::write(plist, &plist_contents)
             .expect("dictation helper Info.plist should be written");
+        should_sign = true;
+    }
+
+    let icon_bytes = std::fs::read(&icon_source).unwrap_or_else(|error| {
+        panic!(
+            "June app icon {} should be readable: {error}",
+            icon_source.display()
+        )
+    });
+    let icon_current = std::fs::read(&icon_destination).is_ok_and(|current| current == icon_bytes);
+    if !icon_current {
+        std::fs::write(&icon_destination, icon_bytes).unwrap_or_else(|error| {
+            panic!(
+                "June app icon should be copied to dictation helper resources at {}: {error}",
+                icon_destination.display()
+            )
+        });
         should_sign = true;
     }
 


### PR DESCRIPTION
## What changed

- Add June's generated macOS app icon to the Computer Use Driver bundle.
- Add the same icon to the Dictation Helper bundle.
- Declare `CFBundleIconFile` in both helper plists.
- Reject stale cached Computer Use bundles that are missing the correct icon.
- Extend the Computer Use bundle self-test to verify the plist and icon bytes.

## Why

macOS System Settings and Finder fell back to the generic application icon because the two helper app bundles had no icon resource or plist declaration.

## Validation

- `pnpm exec biome check scripts/prepare-cua-driver.mjs scripts/computer-use-self-test.mjs`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `node --check scripts/prepare-cua-driver.mjs`
- `node --check scripts/computer-use-self-test.mjs`
- `pnpm computer-use:prepare`
- `pnpm computer-use:self-test`
- `cargo build --manifest-path src-tauri/Cargo.toml --locked --bin os-june`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked --bin june-computer-use-driver` (7 passed)
- Inspected both generated helper plists and verified their `June.icns` files match `src-tauri/icons/icon.icns` byte for byte.
- Native Finder walkthrough: both helper apps visibly render June's orange logo. No permissions, microphone, accounts, or privacy settings were used or changed.

## Known baseline issue

The full `cargo test --manifest-path src-tauri/Cargo.toml --locked` command is currently blocked on `origin/main` by two existing `hermes_bridge` test call sites that pass six arguments to the seven-argument `provider_proxy_required_token` function. This PR does not touch that code. The production host build and scoped Computer Use tests pass.

## QA evidence

- Local screenshot: `.tmp/qa-recordings/helper-app-logos.jpeg`
- Local safe visual proof clip: `.tmp/qa-recordings/helper-app-logos-safe-evidence.compressed.mp4`
- Public upload is blocked in this clean worktree because neither `OS_PLATFORM_API_KEY` nor `JUNE__ISSUE_REPORTS__OS_PLATFORM_API_KEY` is configured. The original longer recording was intentionally not published because it included unrelated local filenames during Finder navigation.
