### PR TITLE
Simplify Computer use permission setup

### DIFF
--- a/src/components/plugins/ComputerUseControl.tsx
+++ b/src/components/plugins/ComputerUseControl.tsx
@@ -9,7 +9,6 @@ import { messageFromError } from "../../lib/errors";
 import {
   COMPUTER_USE_STATUS_CHANGED_EVENT,
   type ComputerUseStatusDto,
-  computerUseRequestPermissions,
   computerUseStatus,
   computerUseStop,
   openPrivacySettings,
@@ -41,6 +40,12 @@ function statusLabel(status?: ComputerUseStatusDto) {
 function requirementState(ready: boolean, enabled: boolean) {
   if (!enabled) return "Required when enabled";
   return ready ? "Allowed" : "Not allowed";
+}
+
+type MacOSPermission = "accessibility" | "screenRecording";
+
+function permissionLabel(permission: MacOSPermission) {
+  return permission === "accessibility" ? "Accessibility" : "Screen recording";
 }
 
 /**
@@ -104,7 +109,7 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
         publish(next);
         setMessage(
           enabled
-            ? "Computer use is enabled. Continue when you are ready for the macOS prompts."
+            ? undefined
             : "Computer use is off. Active work and pending actions were stopped.",
         );
       } catch (error) {
@@ -116,19 +121,6 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
     },
     [publish, refresh],
   );
-
-  const requestPermissions = useCallback(async () => {
-    setBusy(true);
-    setMessage(undefined);
-    try {
-      publish(await computerUseRequestPermissions());
-    } catch (error) {
-      setMessage(messageFromError(error));
-      await refresh();
-    } finally {
-      setBusy(false);
-    }
-  }, [publish, refresh]);
 
   const stop = useCallback(async () => {
     setBusy(true);
@@ -161,6 +153,10 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
     rolloutDisabled || (supported && planEligible && !driverReady && status !== undefined);
   const permissionsMissing =
     enabled && status !== undefined && (!status.accessibility || !status.screenRecording);
+  const nextPermission: MacOSPermission = status?.accessibility
+    ? "screenRecording"
+    : "accessibility";
+  const permissionStep = nextPermission === "accessibility" ? 1 : 2;
 
   useEffect(() => {
     const element = permissionDragRef.current;
@@ -290,32 +286,47 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
                 className="computer-use-permission-assistant"
                 aria-labelledby="add-june-macos"
               >
-                <div className="computer-use-permission-assistant-copy">
-                  <h4 id="add-june-macos">Add June to macOS</h4>
-                  <p>
-                    Open each missing permission, then drag the helper into the open list. No Finder
-                    browsing needed.
-                  </p>
+                <div className="computer-use-permission-assistant-header">
+                  <div className="computer-use-permission-assistant-copy">
+                    <span className="computer-use-permission-step">Step {permissionStep} of 2</span>
+                    <h4 id="add-june-macos">Allow {permissionLabel(nextPermission)}</h4>
+                    <p>
+                      Open System Settings, find <strong>June Computer Use Driver</strong>, and turn
+                      it on. Then return to June. This page updates automatically.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="btn btn-primary computer-use-permission-primary-action"
+                    onClick={() => void openPermissionSettings(nextPermission)}
+                  >
+                    Open {permissionLabel(nextPermission)} settings
+                  </button>
                 </div>
-                <button
-                  ref={permissionDragRef}
-                  type="button"
-                  className="computer-use-permission-drag-card"
-                  aria-label="Drag June Computer Use Driver to the open System Settings list"
-                  onClick={() =>
-                    void openPermissionSettings(
-                      status?.accessibility ? "screenRecording" : "accessibility",
-                    )
-                  }
-                >
-                  <span className="computer-use-permission-drag-icon" aria-hidden>
-                    <IconTelevision size={20} />
-                  </span>
-                  <span className="computer-use-permission-drag-copy">
-                    <strong>June Computer Use Driver</strong>
-                    <span>Drag to the open list</span>
-                  </span>
-                </button>
+
+                <div className="computer-use-permission-helper">
+                  <div className="computer-use-permission-helper-copy">
+                    <strong>June is not in the list?</strong>
+                    <p>
+                      Drag the helper below into the open System Settings list, then turn it on.
+                    </p>
+                  </div>
+                  <button
+                    ref={permissionDragRef}
+                    type="button"
+                    className="computer-use-permission-drag-card"
+                    aria-label="Drag June Computer Use Driver to the open System Settings list"
+                    onClick={() => void openPermissionSettings(nextPermission)}
+                  >
+                    <span className="computer-use-permission-drag-icon" aria-hidden>
+                      <IconTelevision size={20} />
+                    </span>
+                    <span className="computer-use-permission-drag-copy">
+                      <strong>June Computer Use Driver</strong>
+                      <span>Drag into System Settings</span>
+                    </span>
+                  </button>
+                </div>
               </section>
             ) : null}
 
@@ -324,7 +335,7 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
               aria-labelledby="computer-use-requirements"
             >
               <h4 id="computer-use-requirements" className="computer-use-requirements-heading">
-                Requirements
+                Setup progress
               </h4>
               <div className="computer-use-requirement">
                 <span className="computer-use-requirement-icon" data-ready={status?.accessibility}>
@@ -338,16 +349,6 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
                   <strong>Accessibility</strong>
                   <span>{requirementState(status?.accessibility === true, enabled)}</span>
                 </span>
-                {!status?.accessibility ? (
-                  <button
-                    type="button"
-                    className="btn btn-ghost computer-use-inline-action"
-                    aria-label="Open Accessibility settings"
-                    onClick={() => void openPermissionSettings("accessibility")}
-                  >
-                    Open settings
-                  </button>
-                ) : null}
               </div>
               <div className="computer-use-requirement">
                 <span
@@ -364,16 +365,6 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
                   <strong>Screen recording</strong>
                   <span>{requirementState(status?.screenRecording === true, enabled)}</span>
                 </span>
-                {!status?.screenRecording ? (
-                  <button
-                    type="button"
-                    className="btn btn-ghost computer-use-inline-action"
-                    aria-label="Open Screen Recording settings"
-                    onClick={() => void openPermissionSettings("screenRecording")}
-                  >
-                    Open settings
-                  </button>
-                ) : null}
               </div>
               <div className="computer-use-requirement">
                 <span
@@ -403,16 +394,6 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
             </section>
 
             <div className="computer-use-actions">
-              {permissionsMissing ? (
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  disabled={busy}
-                  onClick={() => void requestPermissions()}
-                >
-                  Continue to macOS access
-                </button>
-              ) : null}
               <button
                 type="button"
                 className="btn btn-ghost"
@@ -426,7 +407,8 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
           </div>
         ) : null}
 
-        {message || (!statusErrorShownInline && status?.error) ? (
+        {message ||
+        (status?.state !== "permission_missing" && !statusErrorShownInline && status?.error) ? (
           <p className="computer-use-message" role="status">
             {message || status?.error}
           </p>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12800,13 +12800,18 @@ input:focus-visible,
 
 .computer-use-permission-assistant {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: var(--sp-5);
+  gap: var(--sp-4);
   padding: var(--sp-4);
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-md);
   background: var(--surface-subtle);
+}
+
+.computer-use-permission-assistant-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--sp-5);
 }
 
 .computer-use-permission-assistant-copy {
@@ -12822,13 +12827,64 @@ input:focus-visible,
 
 .computer-use-permission-assistant-copy h4 {
   color: var(--foreground);
-  font-size: var(--fs-md);
+  font-size: var(--fs-lg);
   font-weight: var(--fw-medium);
 }
 
 .computer-use-permission-assistant-copy p {
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
+  line-height: 1.5;
+}
+
+.computer-use-permission-assistant-copy p strong {
+  color: var(--foreground);
+  font-weight: var(--fw-medium);
+}
+
+.computer-use-permission-step {
+  color: var(--accent-foreground);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-medium);
+}
+
+.btn.computer-use-permission-primary-action {
+  background: var(--foreground);
+  color: var(--primary-foreground);
+  white-space: nowrap;
+}
+
+.btn.computer-use-permission-primary-action:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--foreground) 86%, transparent);
+}
+
+.computer-use-permission-helper {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--sp-4);
+  padding-top: var(--sp-4);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.computer-use-permission-helper-copy {
+  display: grid;
+  gap: var(--sp-1);
+}
+
+.computer-use-permission-helper-copy strong,
+.computer-use-permission-helper-copy p {
+  margin: 0;
+  font-size: var(--fs-sm);
+}
+
+.computer-use-permission-helper-copy strong {
+  color: var(--foreground);
+  font-weight: var(--fw-medium);
+}
+
+.computer-use-permission-helper-copy p {
+  color: var(--muted-foreground);
   line-height: 1.5;
 }
 
@@ -12970,9 +13026,15 @@ input:focus-visible,
 
 @media (max-width: 720px) {
   .computer-use-permission-assistant {
+    padding: var(--sp-3);
+  }
+
+  .computer-use-permission-assistant-header,
+  .computer-use-permission-helper {
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .computer-use-permission-primary-action,
   .computer-use-permission-drag-card {
     justify-self: stretch;
   }

--- a/src/test/computer-use-control.test.tsx
+++ b/src/test/computer-use-control.test.tsx
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const tauriMocks = vi.hoisted(() => ({
   computerUseStatus: vi.fn(),
   setComputerUseGrant: vi.fn(),
-  computerUseRequestPermissions: vi.fn(),
   computerUseStop: vi.fn(),
   openPrivacySettings: vi.fn(),
   setComputerUsePermissionDragBounds: vi.fn(),
@@ -15,7 +14,6 @@ vi.mock("../lib/tauri", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../lib/tauri")>()),
   computerUseStatus: tauriMocks.computerUseStatus,
   setComputerUseGrant: tauriMocks.setComputerUseGrant,
-  computerUseRequestPermissions: tauriMocks.computerUseRequestPermissions,
   computerUseStop: tauriMocks.computerUseStop,
   openPrivacySettings: tauriMocks.openPrivacySettings,
   setComputerUsePermissionDragBounds: tauriMocks.setComputerUsePermissionDragBounds,
@@ -47,15 +45,6 @@ beforeEach(() => {
   tauriMocks.setComputerUseGrant.mockResolvedValue(
     status({ grantEnabled: true, state: "permission_missing" }),
   );
-  tauriMocks.computerUseRequestPermissions.mockResolvedValue(
-    status({
-      grantEnabled: true,
-      accessibility: true,
-      screenRecording: true,
-      ready: true,
-      state: "ready",
-    }),
-  );
   tauriMocks.computerUseStop.mockResolvedValue({ stopped: true });
   tauriMocks.openPrivacySettings.mockResolvedValue(undefined);
   tauriMocks.setComputerUsePermissionDragBounds.mockResolvedValue(undefined);
@@ -74,26 +63,60 @@ describe("ComputerUseControl", () => {
     await userEvent.click(toggle);
 
     expect(tauriMocks.setComputerUseGrant).toHaveBeenCalledWith(true);
-    expect(tauriMocks.computerUseRequestPermissions).not.toHaveBeenCalled();
+    expect(tauriMocks.openPrivacySettings).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Computer use is enabled/)).toBeNull();
   });
 
-  it("explains both permissions before the explicit macOS request", async () => {
+  it("guides the user through Accessibility as the first macOS step", async () => {
     tauriMocks.computerUseStatus.mockResolvedValue(
       status({ grantEnabled: true, state: "permission_missing" }),
     );
     render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
 
-    expect(await screen.findByText("Accessibility")).toBeInTheDocument();
+    expect(await screen.findByText("Allow Accessibility")).toBeInTheDocument();
     expect(screen.getByText("Screen recording")).toBeInTheDocument();
     expect(screen.queryByText(/Captures are never analytics/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText((_, element) =>
+        Boolean(
+          element?.tagName === "P" &&
+            element.textContent?.includes(
+              "Open System Settings, find June Computer Use Driver, and turn it on.",
+            ),
+        ),
+      ),
+    ).toBeInTheDocument();
 
     await userEvent.hover(
       screen.getByRole("button", { name: "Computer use privacy and permissions" }),
     );
     expect(await screen.findByRole("tooltip")).toHaveTextContent(/Captures are never analytics/);
 
-    await userEvent.click(screen.getByRole("button", { name: "Continue to macOS access" }));
-    expect(tauriMocks.computerUseRequestPermissions).toHaveBeenCalledTimes(1);
+    await userEvent.click(screen.getByRole("button", { name: "Open Accessibility settings" }));
+    expect(tauriMocks.openPrivacySettings).toHaveBeenCalledWith("accessibility");
+    expect(screen.queryByRole("button", { name: "Continue to macOS access" })).toBeNull();
+  });
+
+  it("advances to Screen recording after Accessibility is allowed", async () => {
+    tauriMocks.computerUseStatus.mockResolvedValue(
+      status({ grantEnabled: true, accessibility: true, state: "permission_missing" }),
+    );
+    render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
+
+    expect(await screen.findByText("Step 2 of 2")).toBeInTheDocument();
+    expect(screen.getByText("Allow Screen recording")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Open Screen recording settings" }));
+    expect(tauriMocks.openPrivacySettings).toHaveBeenCalledWith("screenRecording");
+  });
+
+  it("keeps Accessibility labeled as step 1 when Screen recording was allowed first", async () => {
+    tauriMocks.computerUseStatus.mockResolvedValue(
+      status({ grantEnabled: true, screenRecording: true, state: "permission_missing" }),
+    );
+    render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
+
+    expect(await screen.findByText("Step 1 of 2")).toBeInTheDocument();
+    expect(screen.getByText("Allow Accessibility")).toBeInTheDocument();
   });
 
   it("offers the real helper app as a drag source when macOS access is missing", async () => {
@@ -102,13 +125,40 @@ describe("ComputerUseControl", () => {
     );
     render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
 
-    expect(await screen.findByText("Add June to macOS")).toBeInTheDocument();
+    expect(await screen.findByText("June is not in the list?")).toBeInTheDocument();
     expect(
       screen.getByRole("button", {
         name: "Drag June Computer Use Driver to the open System Settings list",
       }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/No Finder browsing needed/)).toBeInTheDocument();
+    expect(screen.getByText(/Drag the helper below/)).toBeInTheDocument();
+  });
+
+  it("does not expose helper transport errors while permissions are incomplete", async () => {
+    tauriMocks.computerUseStatus.mockResolvedValue(
+      status({
+        grantEnabled: true,
+        state: "permission_missing",
+        error: "Broken pipe (os error 32)",
+      }),
+    );
+    render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
+
+    expect(await screen.findByText("Allow Accessibility")).toBeInTheDocument();
+    expect(screen.queryByText(/Broken pipe/)).toBeNull();
+  });
+
+  it("shows helper errors that are not permission setup failures", async () => {
+    tauriMocks.computerUseStatus.mockResolvedValue(
+      status({
+        grantEnabled: true,
+        state: "error",
+        error: "The Computer use driver did not respond in time.",
+      }),
+    );
+    render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
+
+    expect(await screen.findByText(/driver did not respond in time/)).toBeInTheDocument();
   });
 
   it("routes a model mismatch to the model picker", async () => {


### PR DESCRIPTION
## What changed

- replace the competing macOS permission actions with a sequential two-step setup assistant
- tell users exactly what to do after System Settings opens and advance automatically after Accessibility is allowed
- keep the helper drag source as a clearly labeled fallback when June is missing from the list
- hide raw helper transport errors while permission setup is incomplete

## Why

The previous screen presented two Open settings actions, a Continue action, and a draggable helper at the same time. It did not explain the next action inside System Settings, and setup failures could expose raw errors such as `Broken pipe (os error 32)`.

## Validation

- `pnpm exec vitest run src/test/computer-use-control.test.tsx` (10 tests passed)
- `pnpm exec biome check src/components/plugins/ComputerUseControl.tsx src/test/computer-use-control.test.tsx`
- `pnpm exec biome format src/styles/app.css`
- `pnpm typecheck`
- `pnpm build`
- agent-driven Chromium walkthrough of Accessibility step 1, automatic progression to Screen recording step 2, correct settings-pane routing, raw-error suppression, responsive visual hierarchy, and browser error checks

## Live walkthrough evidence

The compressed walkthrough will be attached in a PR comment after creation. Real macOS privacy settings were not changed during QA. Native permission granting remains an RC/manual check because it requires OS-level side effects.

## Known gaps

- did not grant or revoke real Accessibility or Screen recording permissions during automated QA
- production build retains the repository existing chunk-size warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787168684&installation_model_id=425925&pr_number=861&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F861&signature=2bdb7ec18e562cfcb5ff1bfe8421dd0261909f03a5abac5faf04c40b05db53c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->