### PR TITLE
Fix attachment message presentation

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -4380,9 +4380,7 @@ fn validate_hermes_file_path(app: &AppHandle, path: &str) -> Result<PathBuf, App
     // roots so those references load; a path with directory components falls
     // through unchanged and the allow-list check below still gates whatever we
     // end up with.
-    let resolved = resolve_bare_image_filename(&hermes_home, path)
-        .or_else(|| resolve_bare_video_filename(&hermes_home, path))
-        .unwrap_or_else(|| PathBuf::from(path));
+    let resolved = resolve_hermes_file_candidate(&hermes_home, path);
     let requested = resolved.canonicalize().map_err(|error| {
         tracing::warn!(requested_path = %path, %error, "validate_hermes_file_path failed to canonicalize path");
         AppError::new("hermes_file_download_failed", error.to_string())
@@ -11050,6 +11048,24 @@ fn resolve_bare_video_filename(hermes_home: &Path, path: &str) -> Option<PathBuf
         .into_iter()
         .map(|relative| hermes_home.join(relative).join(&name))
         .find(|candidate| candidate.is_file())
+}
+
+/// Resolve the file reference June puts in a persisted prompt. Composer
+/// attachments use workspace-relative paths such as `uploads/photo.png`, while
+/// generated media may use a bare filename and tool output can carry an
+/// absolute path. The canonical-path allow-list in `validate_hermes_file_path`
+/// remains authoritative after this routing step, including for `..` input.
+fn resolve_hermes_file_candidate(hermes_home: &Path, path: &str) -> PathBuf {
+    resolve_bare_image_filename(hermes_home, path)
+        .or_else(|| resolve_bare_video_filename(hermes_home, path))
+        .unwrap_or_else(|| {
+            let literal = PathBuf::from(path.trim());
+            if literal.is_relative() {
+                hermes_home.join("workspace").join(literal)
+            } else {
+                literal
+            }
+        })
 }
 
 fn filesystem_roots(hermes_home: &Path) -> Result<Vec<FilesystemRootCandidate>, AppError> {
@@ -18598,6 +18614,26 @@ assert capped["has_more"] is True, capped
         assert_eq!(
             resolve_bare_image_filename(hermes_home, "../secrets.png"),
             None
+        );
+    }
+
+    #[test]
+    fn resolve_hermes_file_candidate_maps_relative_attachments_to_workspace() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let hermes_home = temp.path();
+        let absolute = hermes_home.join("images").join("attached.png");
+
+        assert_eq!(
+            resolve_hermes_file_candidate(hermes_home, "uploads/icon.png"),
+            hermes_home.join("workspace").join("uploads/icon.png"),
+        );
+        assert_eq!(
+            resolve_hermes_file_candidate(hermes_home, absolute.to_string_lossy().as_ref()),
+            absolute,
+        );
+        assert_eq!(
+            resolve_hermes_file_candidate(hermes_home, "../outside.txt"),
+            hermes_home.join("workspace").join("../outside.txt"),
         );
     }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -392,6 +392,7 @@ import {
   isGeneratedVideoFilename,
   stripRenderedMediaReferences,
   textFromHermesContent,
+  USER_ATTACHMENT_PROMPT_MARKER,
   type AgentApprovalChoice,
   type AgentChatPart,
   type AgentChatTurn,
@@ -13819,7 +13820,7 @@ function AgentUserAttachmentList({
   onOpen?: (artifact: AgentArtifact) => void;
 }) {
   return (
-    <div className="agent-user-attachments" aria-label="Attachments">
+    <div className="agent-user-attachments" role="group" aria-label="Attachments">
       {attachments.map((attachment) => (
         <AgentUserAttachment key={attachment.path} attachment={attachment} onOpen={onOpen} />
       ))}
@@ -16924,6 +16925,7 @@ function promptWithAttachments(message: string, attachments: AgentAttachment[]):
   return [
     message || "Use the attached file(s).",
     "",
+    USER_ATTACHMENT_PROMPT_MARKER,
     "Attached files copied into the June workspace:",
     ...attachments.map(
       (attachment) =>

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -13538,6 +13538,9 @@ function AgentChatTurnRow({
   const contextParts = turn.parts.filter(
     (part): part is Extract<AgentChatPart, { type: "context" }> => part.type === "context",
   );
+  const attachmentParts = turn.parts.filter(
+    (part): part is Extract<AgentChatPart, { type: "attachment" }> => part.type === "attachment",
+  );
   const nonTextParts = turn.parts.filter((part) => part.type !== "text");
   const concreteResponse = turnIsConcreteResponse(turn);
   const copyText = copyableTextForTurn(turn);
@@ -13649,14 +13652,20 @@ function AgentChatTurnRow({
           </span>
         ) : null}
         <div className="agent-user-turn-body">
-          {textParts.map((part, index) => (
-            <MarkdownContent
-              key={`${turn.id}:text:${index}`}
-              // Issue-report sessions open with the wrapped investigation
-              // prompt; the transcript shows only what the user typed.
-              markdown={displayedComposerUserMessageText(part.text)}
-            />
-          ))}
+          {textParts.map((part, index) => {
+            const markdown = displayedComposerUserMessageText(part.text);
+            return markdown ? (
+              <MarkdownContent
+                key={`${turn.id}:text:${index}`}
+                // Issue-report sessions open with the wrapped investigation
+                // prompt; the transcript shows only what the user typed.
+                markdown={markdown}
+              />
+            ) : null;
+          })}
+          {attachmentParts.length ? (
+            <AgentUserAttachmentList attachments={attachmentParts} onOpen={onOpenArtifact} />
+          ) : null}
         </div>
         {turnActions}
       </article>
@@ -13799,6 +13808,92 @@ function AgentChatTurnRow({
         )}
       </div>
     </article>
+  );
+}
+
+function AgentUserAttachmentList({
+  attachments,
+  onOpen,
+}: {
+  attachments: Extract<AgentChatPart, { type: "attachment" }>[];
+  onOpen?: (artifact: AgentArtifact) => void;
+}) {
+  return (
+    <div className="agent-user-attachments" aria-label="Attachments">
+      {attachments.map((attachment) => (
+        <AgentUserAttachment key={attachment.path} attachment={attachment} onOpen={onOpen} />
+      ))}
+    </div>
+  );
+}
+
+function AgentUserAttachment({
+  attachment,
+  onOpen,
+}: {
+  attachment: Extract<AgentChatPart, { type: "attachment" }>;
+  onOpen?: (artifact: AgentArtifact) => void;
+}) {
+  const [previewDataUrl, setPreviewDataUrl] = useState<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    if (attachment.kind !== "image") return;
+    let cancelled = false;
+    hermesBridgeFilePreview(attachment.path)
+      .then((dataUrl) => {
+        if (!cancelled) setPreviewDataUrl(dataUrl);
+      })
+      .catch(() => {
+        if (!cancelled) setPreviewDataUrl(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [attachment.kind, attachment.path]);
+
+  const artifact: AgentArtifact = {
+    name: attachment.name,
+    path: attachment.path,
+    rootLabel: "Workspace",
+  };
+  const content =
+    attachment.kind === "image" ? (
+      previewDataUrl ? (
+        <img src={previewDataUrl} alt="" aria-hidden="true" draggable={false} />
+      ) : previewDataUrl === undefined ? (
+        <span className="agent-user-attachment-loading text-shimmer shimmer">Loading image...</span>
+      ) : (
+        <>
+          <span className="agent-attachment-file-icon" aria-hidden="true">
+            <FileTypeIcon name={attachment.name} size={18} />
+          </span>
+          <span className="agent-user-attachment-name">{attachment.name}</span>
+        </>
+      )
+    ) : (
+      <>
+        <span className="agent-attachment-file-icon" aria-hidden="true">
+          <FileTypeIcon name={attachment.name} size={18} />
+        </span>
+        <span className="agent-user-attachment-name">{attachment.name}</span>
+      </>
+    );
+
+  return onOpen ? (
+    <button
+      type="button"
+      className="agent-user-attachment"
+      data-kind={attachment.kind}
+      aria-label={`Open ${attachment.name}`}
+      title={attachment.name}
+      onClick={() => onOpen(artifact)}
+    >
+      {content}
+    </button>
+  ) : (
+    <div className="agent-user-attachment" data-kind={attachment.kind} title={attachment.name}>
+      {content}
+    </div>
   );
 }
 

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -13,7 +13,11 @@ import { IconStop } from "central-icons/IconStop";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { PointerEvent as ReactPointerEvent, ReactNode } from "react";
 
-import type { AgentChatPart, AgentChatTurn } from "../../lib/agent-chat-runtime";
+import {
+  displayedComposerUserMessageText,
+  type AgentChatPart,
+  type AgentChatTurn,
+} from "../../lib/agent-chat-runtime";
 import { shouldBlockTextOnFunding, type TextFundingModelContext } from "../../lib/account-gate";
 import { messageFromError } from "../../lib/errors";
 import { attachmentStateFrom } from "../../lib/hermes-image-attach";
@@ -123,21 +127,12 @@ function stripLeadingNoteToken(text: string) {
   return text.replace(/^@note:[\w-]+(?: \("[^"]*"\))?\s*/, "");
 }
 
-/** The attachment path block is machinery for the agent, not the message the
- * user typed — same display strip the workspace composer applies. */
-function stripAttachmentBlock(text: string) {
-  return text
-    .replace(
-      /\n+Attached files copied into the June workspace:\n[\s\S]*?\n+Use these file paths when inspecting or operating on the files\.\s*$/i,
-      "",
-    )
-    .trim();
-}
-
 function userTurnText(turn: AgentChatTurn) {
   return turn.parts
     .map((part) =>
-      part.type === "text" ? stripAttachmentBlock(stripLeadingNoteToken(part.text)) : "",
+      part.type === "text"
+        ? displayedComposerUserMessageText(stripLeadingNoteToken(part.text))
+        : "",
     )
     .filter(Boolean)
     .join("\n");

--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { buildHermesSessionChatTurns, type AgentChatTurn } from "../../lib/agent-chat-runtime";
+import {
+  buildHermesSessionChatTurns,
+  USER_ATTACHMENT_PROMPT_MARKER,
+  type AgentChatTurn,
+} from "../../lib/agent-chat-runtime";
 import {
   getActiveHermesProfileName,
   refreshActiveHermesProfile,
@@ -75,6 +79,7 @@ function withAttachmentPaths(message: string, attachments: NoteChatAttachment[])
   return [
     message || "Use the attached file(s).",
     "",
+    USER_ATTACHMENT_PROMPT_MARKER,
     "Attached files copied into the June workspace:",
     ...attachments.map(
       (attachment) =>

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -166,6 +166,8 @@ export type AgentChatAttachmentPart = {
   kind: "image" | "file";
 };
 
+export const USER_ATTACHMENT_PROMPT_MARKER = "[June attachment manifest v1]";
+
 /** A built-in image generation result (the `/image` slash command). It lives as
  * an assistant part so the generated image renders inline in the thread — with
  * its own loader and error states — instead of being dropped into the composer
@@ -1521,25 +1523,20 @@ function stripImageAnalysisFailureNotice(content: string): string {
 }
 
 function stripAttachmentPromptBlock(content: string): string {
-  const stripped = content.replace(
-    /\n*Attached files copied into the June workspace:\n[\s\S]*?\n+Use these file paths when inspecting or operating on the files\./gi,
-    "",
-  );
+  const stripped = attachmentEnvelopeFromUserPrompt(content)?.message ?? content.trim();
   return stripped.trim() === "Use the attached file(s)." ? "" : stripped.trim();
 }
 
+const SYNTHETIC_IMAGE_ATTACHMENT_SUFFIX =
+  /\n*\[Image attached at:\s*[^\]]+\]\s*(?:\[[^\]\n]+\]\s*)*$/i;
+
 function stripSyntheticImageAttachmentMarker(content: string) {
-  return content.replace(/\n*\[Image attached at:\s*[^\]]+\]\s*(?:\[[^\]\n]+\]\s*)*$/i, "").trim();
+  return content.replace(SYNTHETIC_IMAGE_ATTACHMENT_SUFFIX, "").trim();
 }
 
 const USER_ATTACHMENT_IMAGE_EXTENSION = /\.(png|jpe?g|gif|webp|tiff?|bmp|avif)$/i;
 
-function attachmentPartsFromUserPrompt(content: string): AgentChatAttachmentPart[] {
-  const block = content.match(
-    /(?:^|\n)Attached files copied into the June workspace:\n([\s\S]*?)\n+Use these file paths when inspecting or operating on the files\./i,
-  )?.[1];
-  if (!block) return [];
-
+function attachmentPartsFromBlock(block: string): AgentChatAttachmentPart[] {
   const seenPaths = new Set<string>();
   return block.split("\n").flatMap((line) => {
     const match = /^\s*-\s+(.+?)\s+\([^\n)]+\):\s*(.+?)\s*$/.exec(line);
@@ -1556,6 +1553,36 @@ function attachmentPartsFromUserPrompt(content: string): AgentChatAttachmentPart
       },
     ];
   });
+}
+
+function attachmentEnvelopeFromUserPrompt(
+  content: string,
+): { message: string; attachments: AgentChatAttachmentPart[] } | undefined {
+  const syntheticImageSuffix = content.match(SYNTHETIC_IMAGE_ATTACHMENT_SUFFIX);
+  const prompt = syntheticImageSuffix?.index
+    ? content.slice(0, syntheticImageSuffix.index).trimEnd()
+    : content.trimEnd();
+  const marker = USER_ATTACHMENT_PROMPT_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const generated = new RegExp(
+    `^([\\s\\S]*?)(?:\\n\\n)?${marker}\\nAttached files copied into the June workspace:\\n([\\s\\S]+?)\\n\\nUse these file paths when inspecting or operating on the files\\.$`,
+    "i",
+  ).exec(prompt);
+  // Older image prompts predate the manifest marker. Their native image suffix
+  // is still an unambiguous signal that the preceding block was machine-added.
+  const legacyImage = syntheticImageSuffix
+    ? /^([\s\S]*?)(?:\n\n)?Attached files copied into the June workspace:\n([\s\S]+?)\n\nUse these file paths when inspecting or operating on the files\.$/i.exec(
+        prompt,
+      )
+    : undefined;
+  const match = generated ?? legacyImage;
+  if (!match?.[2]) return undefined;
+  const attachments = attachmentPartsFromBlock(match[2]);
+  if (!attachments.length) return undefined;
+  return { message: match[1] ?? "", attachments };
+}
+
+function attachmentPartsFromUserPrompt(content: string): AgentChatAttachmentPart[] {
+  return attachmentEnvelopeFromUserPrompt(content)?.attachments ?? [];
 }
 
 function isScheduledRunMessage(message: HermesSessionMessage) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -428,7 +428,13 @@ export function buildHermesSessionChatTurns(
   const sortedTurns = sortAgentChatTurns(turns);
   deduplicateGeneratedMediaWithinAgentRuns(sortedTurns);
   return sortedTurns.filter((turn) =>
-    turn.parts.some((part) => part.type === "tool" || partText(part).trim()),
+    turn.parts.some((part) => {
+      if (part.type === "tool") return true;
+      if (turn.role === "user" && part.type === "text") {
+        return Boolean(displayedComposerUserMessageText(part.text).trim());
+      }
+      return Boolean(partText(part).trim());
+    }),
   );
 }
 

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -156,6 +156,16 @@ export type AgentChatSteeringPart = {
   text: string;
 };
 
+/** A file the user submitted with this message. Hermes stores attachment
+ * routing as prompt text, but the transcript renders it as first-class UI so
+ * workspace paths and model instructions never appear as user-authored copy. */
+export type AgentChatAttachmentPart = {
+  type: "attachment";
+  name: string;
+  path: string;
+  kind: "image" | "file";
+};
+
 /** A built-in image generation result (the `/image` slash command). It lives as
  * an assistant part so the generated image renders inline in the thread — with
  * its own loader and error states — instead of being dropped into the composer
@@ -226,6 +236,7 @@ export type AgentChatPart =
   | AgentChatSecretPart
   | AgentChatNoticePart
   | AgentChatSteeringPart
+  | AgentChatAttachmentPart
   | AgentChatImagePart
   | AgentChatVideoPart;
 
@@ -396,6 +407,9 @@ export function buildHermesSessionChatTurns(
             status: "complete",
           },
         );
+      }
+      if (turn.role === "user") {
+        turn.parts.push(...attachmentPartsFromUserPrompt(content));
       }
       if (!contextPart && turn.role === "assistant") {
         appendImageParts(turn.parts, messageImageParts);
@@ -1494,8 +1508,8 @@ function displayedUserPromptText(content: string) {
 }
 
 export function displayedComposerUserMessageText(content: string): string {
-  return stripAttachmentPromptBlock(
-    displayedUserPromptText(stripImageAnalysisFailureNotice(content)),
+  return stripSyntheticImageAttachmentMarker(
+    stripAttachmentPromptBlock(displayedUserPromptText(stripImageAnalysisFailureNotice(content))),
   );
 }
 
@@ -1507,12 +1521,41 @@ function stripImageAnalysisFailureNotice(content: string): string {
 }
 
 function stripAttachmentPromptBlock(content: string): string {
-  return content
-    .replace(
-      /\n+Attached files copied into the June workspace:\n[\s\S]*?\n+Use these file paths when inspecting or operating on the files\.\s*$/i,
-      "",
-    )
-    .trim();
+  const stripped = content.replace(
+    /\n*Attached files copied into the June workspace:\n[\s\S]*?\n+Use these file paths when inspecting or operating on the files\./gi,
+    "",
+  );
+  return stripped.trim() === "Use the attached file(s)." ? "" : stripped.trim();
+}
+
+function stripSyntheticImageAttachmentMarker(content: string) {
+  return content.replace(/\n*\[Image attached at:\s*[^\]]+\]\s*(?:\[[^\]\n]+\]\s*)*$/i, "").trim();
+}
+
+const USER_ATTACHMENT_IMAGE_EXTENSION = /\.(png|jpe?g|gif|webp|tiff?|bmp|avif)$/i;
+
+function attachmentPartsFromUserPrompt(content: string): AgentChatAttachmentPart[] {
+  const block = content.match(
+    /(?:^|\n)Attached files copied into the June workspace:\n([\s\S]*?)\n+Use these file paths when inspecting or operating on the files\./i,
+  )?.[1];
+  if (!block) return [];
+
+  const seenPaths = new Set<string>();
+  return block.split("\n").flatMap((line) => {
+    const match = /^\s*-\s+(.+?)\s+\([^\n)]+\):\s*(.+?)\s*$/.exec(line);
+    const name = match?.[1]?.trim();
+    const path = match?.[2]?.trim();
+    if (!name || !path || seenPaths.has(path)) return [];
+    seenPaths.add(path);
+    return [
+      {
+        type: "attachment" as const,
+        name,
+        path,
+        kind: USER_ATTACHMENT_IMAGE_EXTENSION.test(name) ? ("image" as const) : ("file" as const),
+      },
+    ];
+  });
 }
 
 function isScheduledRunMessage(message: HermesSessionMessage) {
@@ -1900,6 +1943,7 @@ function partText(part: AgentChatPart) {
   // prompt so the turn isn't filtered out as empty and a copy reads sensibly.
   if (part.type === "image") return part.prompt;
   if (part.type === "video") return part.prompt;
+  if (part.type === "attachment") return `${part.name} ${part.path}`;
   return part.text;
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2232,6 +2232,9 @@ input:focus-visible,
 }
 
 .agent-user-turn-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
   max-width: 82%;
   padding: var(--sp-3) var(--sp-4);
   border-radius: var(--r-lg);
@@ -2239,6 +2242,62 @@ input:focus-visible,
   color: var(--foreground);
   font-size: var(--fs-lg);
   line-height: 1.55;
+}
+
+.agent-user-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
+}
+
+.agent-user-attachment {
+  display: inline-flex;
+  min-width: 0;
+  overflow: hidden;
+  align-items: center;
+  gap: var(--sp-2);
+  border: 0;
+  border-radius: var(--r-md);
+  padding: var(--sp-1);
+  background: color-mix(in oklch, var(--card) 70%, transparent);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+button.agent-user-attachment:hover {
+  background: var(--card);
+}
+
+.agent-user-attachment[data-kind="image"] {
+  width: calc(var(--sp-12) * 3);
+  height: calc(var(--sp-12) * 3);
+  padding: 0;
+  background: var(--surface-subtle);
+}
+
+.agent-user-attachment[data-kind="image"] img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.agent-user-attachment-loading {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  place-items: center;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.agent-user-attachment-name {
+  max-width: calc(var(--sp-12) * 5);
+  overflow: hidden;
+  padding-right: var(--sp-2);
+  font-size: var(--fs-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* A scheduled routine run opens with the cron prompt; stack a quiet eyebrow

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -762,6 +762,7 @@ describe("Agent chat runtime", () => {
           "",
           "wdyt?",
           "",
+          "[June attachment manifest v1]",
           "Attached files copied into the June workspace:",
           "- CleanShot.png (Workspace): uploads/CleanShot.png",
           "",
@@ -777,6 +778,7 @@ describe("Agent chat runtime", () => {
         text: [
           "wdyt?",
           "",
+          "[June attachment manifest v1]",
           "Attached files copied into the June workspace:",
           "- CleanShot.png (Workspace): uploads/CleanShot.png",
           "",
@@ -803,6 +805,7 @@ describe("Agent chat runtime", () => {
           "",
           "wdyt?",
           "",
+          "[June attachment manifest v1]",
           "Attached files copied into the June workspace:",
           "- CleanShot.png (Workspace): uploads/CleanShot.png",
           "",
@@ -850,6 +853,7 @@ describe("Agent chat runtime", () => {
     const content = [
       "Use the attached file(s).",
       "",
+      "[June attachment manifest v1]",
       "Attached files copied into the June workspace:",
       "- brief.pdf (Workspace): uploads/brief.pdf",
       "",
@@ -872,6 +876,29 @@ describe("Agent chat runtime", () => {
       path: "uploads/brief.pdf",
       kind: "file",
     });
+  });
+
+  it("preserves user-authored text that resembles the attachment scaffold", () => {
+    const content = [
+      "Here is the literal prompt text:",
+      "",
+      "Attached files copied into the June workspace:",
+      "- example.png (Workspace): uploads/example.png",
+      "",
+      "Use these file paths when inspecting or operating on the files.",
+    ].join("\n");
+
+    expect(displayedComposerUserMessageText(content)).toBe(content);
+    expect(
+      buildHermesSessionChatTurns([
+        {
+          id: "quoted-scaffold",
+          role: "user",
+          content,
+          timestamp: "2026-07-20T19:48:57.000Z",
+        },
+      ])[0]?.parts,
+    ).toEqual([{ type: "text", text: content, status: "complete" }]);
   });
 
   it("hides injected project context from persisted user turns", () => {
@@ -905,6 +932,7 @@ describe("Agent chat runtime", () => {
     const content = [
       "wdyt?",
       "",
+      "[June attachment manifest v1]",
       "Attached files copied into the June workspace:",
       "- screenshot.png (Workspace): uploads/screenshot.png",
       "",

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -784,6 +784,12 @@ describe("Agent chat runtime", () => {
         ].join("\n"),
         status: "complete",
       },
+      {
+        type: "attachment",
+        name: "CleanShot.png",
+        path: "uploads/CleanShot.png",
+        kind: "image",
+      },
     ]);
   });
 
@@ -804,6 +810,68 @@ describe("Agent chat runtime", () => {
         ].join("\n"),
       ),
     ).toBe("wdyt?");
+  });
+
+  it("turns persisted image prompt scaffolding into a user attachment", () => {
+    const content = [
+      "what is this math",
+      "",
+      "Attached files copied into the June workspace:",
+      "- CleanShot.png (Workspace): uploads/CleanShot.png",
+      "",
+      "Use these file paths when inspecting or operating on the files.",
+      "",
+      "[Image attached at: /Users/alex/Library/Application Support/June/images/upload.png]",
+      "[screenshot]",
+    ].join("\n");
+
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "image-message",
+        role: "user",
+        content,
+        timestamp: "2026-07-20T19:48:57.000Z",
+      },
+    ]);
+
+    expect(displayedComposerUserMessageText(content)).toBe("what is this math");
+    expect(turns[0]?.parts).toEqual([
+      { type: "text", text: content, status: "complete" },
+      {
+        type: "attachment",
+        name: "CleanShot.png",
+        path: "uploads/CleanShot.png",
+        kind: "image",
+      },
+    ]);
+  });
+
+  it("shows an attachment-only turn without synthetic fallback copy", () => {
+    const content = [
+      "Use the attached file(s).",
+      "",
+      "Attached files copied into the June workspace:",
+      "- brief.pdf (Workspace): uploads/brief.pdf",
+      "",
+      "Use these file paths when inspecting or operating on the files.",
+    ].join("\n");
+
+    expect(displayedComposerUserMessageText(content)).toBe("");
+    expect(
+      buildHermesSessionChatTurns([
+        {
+          id: "file-message",
+          role: "user",
+          content,
+          timestamp: "2026-07-20T19:48:57.000Z",
+        },
+      ])[0]?.parts.at(-1),
+    ).toEqual({
+      type: "attachment",
+      name: "brief.pdf",
+      path: "uploads/brief.pdf",
+      kind: "file",
+    });
   });
 
   it("hides injected project context from persisted user turns", () => {

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -901,6 +901,20 @@ describe("Agent chat runtime", () => {
     ).toEqual([{ type: "text", text: content, status: "complete" }]);
   });
 
+  it("drops a user turn containing only a synthetic image marker", () => {
+    expect(
+      buildHermesSessionChatTurns([
+        {
+          id: "synthetic-image-marker",
+          role: "user",
+          content:
+            "[Image attached at: /Users/alex/Library/Application Support/June/images/upload.png]",
+          timestamp: "2026-07-20T19:48:57.000Z",
+        },
+      ]),
+    ).toEqual([]);
+  });
+
   it("hides injected project context from persisted user turns", () => {
     const turns = buildHermesSessionChatTurns([
       {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -10605,6 +10605,7 @@ describe("AgentWorkspace", () => {
         content: [
           "Summarize this.",
           "",
+          "[June attachment manifest v1]",
           "Attached files copied into the June workspace:",
           "- june-context.md (Workspace): june-context.md",
           "",

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -10623,6 +10623,8 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
 
     expect(await screen.findByText(/Here's a summary/)).toBeInTheDocument();
+    expect(screen.getByLabelText("Attachments")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open june-context.md" })).toBeInTheDocument();
     expect(screen.queryByLabelText("Generated files")).not.toBeInTheDocument();
   });
 

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -413,6 +413,51 @@ describe("note chat session map", () => {
     window.removeEventListener(PROVIDER_MODEL_SETTINGS_CHANGED_EVENT, settingsChanged);
   });
 
+  it("hides attachment manifest metadata in a reloaded note chat user turn", () => {
+    render(
+      createElement(NoteChatPanel, {
+        note: { id: "note-1", title: "Launch planning" },
+        chat: noteChat({
+          turns: [
+            {
+              id: "user-attachment",
+              role: "user",
+              createdAt: "2026-07-20T19:48:57.000Z",
+              status: "complete",
+              parts: [
+                {
+                  type: "text",
+                  status: "complete",
+                  text: [
+                    '@note:note-1 ("Launch planning") What changed?',
+                    "",
+                    "[June attachment manifest v1]",
+                    "Attached files copied into the June workspace:",
+                    "- plan.png (Workspace): uploads/plan.png",
+                    "",
+                    "Use these file paths when inspecting or operating on the files.",
+                  ].join("\n"),
+                },
+                {
+                  type: "attachment",
+                  name: "plan.png",
+                  path: "uploads/plan.png",
+                  kind: "image",
+                },
+              ],
+            },
+          ],
+        }),
+        onClose: vi.fn(),
+        onOpenInAgent: vi.fn(),
+      }),
+    );
+
+    expect(screen.getByText("What changed?")).toBeInTheDocument();
+    expect(screen.queryByText(/June attachment manifest/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Attached files copied/)).not.toBeInTheDocument();
+  });
+
   it("shows the Auto billing note in the picker while a Venice key is saved", async () => {
     const user = userEvent.setup();
     mocks.providerModelSettings.mockResolvedValue({


### PR DESCRIPTION
## What

- render uploaded files as first-class attachments on the original user message
- hide June's internal workspace routing text and synthetic image markers from the transcript
- show image thumbnails with a click-through to the Files panel
- resolve persisted workspace-relative attachment paths in the native file bridge

## Why

Uploaded images currently appear as a second, oversized user bubble containing implementation details, absolute paths, and model instructions. The transcript should preserve what the user said and present the file as an attachment to that message.

## Validation

- `pnpm exec vitest run src/test/agent-chat-runtime.test.ts src/test/agent-workspace.test.tsx` (443 passed, 2 skipped)
- `pnpm run typecheck`
- `pnpm check` (no errors; existing warnings only)
- `pnpm build`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked resolve_hermes_file_candidate_maps_relative_attachments_to_workspace`
- native app walkthrough: sent an image, confirmed only the user text and thumbnail render, then opened the thumbnail in the Files panel

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787174983&installation_model_id=425925&pr_number=864&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F864&signature=e4169a6bdf61f3b2ba86997ffa3fb5c71e75464bb2f6421717e4dbbf98175664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->