### PR TITLE
Exclude helper binaries from Tauri bundle

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,10 +24,20 @@ path = "src/main.rs"
 [[bin]]
 name = "june-nm-shim"
 path = "src/bin/june_nm_shim.rs"
+required-features = ["helper-binaries"]
 
 [[bin]]
 name = "june-computer-use-driver"
 path = "src/computer_use_driver.rs"
+required-features = ["helper-binaries"]
+
+# Tauri bundles every Cargo binary whose required features appear in its
+# explicit feature list. Keep helper binaries enabled for ordinary Cargo
+# builds and tests via the default feature, while excluding them from Tauri's
+# app executable list so the signed resource copies remain authoritative.
+[features]
+default = ["helper-binaries"]
+helper-binaries = []
 
 [build-dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
## What changed

- Mark the native-messaging shim and Computer Use driver Cargo targets as helper binaries.
- Keep the helper feature enabled by default for ordinary Cargo builds and tests.
- Exclude the helpers from Tauri's explicit app-bundle executable list, where they do not belong.

## Why

The `0.0.35-rc.6` build compiled and signed the real native-messaging shim, then failed because Tauri also tried to copy that helper as an app executable from the synthetic `universal-apple-darwin` target directory. The helper is already shipped through the signed resource mapping.

Tauri filters Cargo binaries using explicitly requested features. A default-only required feature preserves normal Cargo behavior while preventing Tauri from treating resource-managed helpers as top-level app executables.

## Impact

Release packaging only. Runtime behavior and helper contents are unchanged.

## Validation

- `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` confirms both helpers require `helper-binaries` and that it is a default feature.
- `cargo test --manifest-path src-tauri/Cargo.toml --test browser_redaction --locked` (4 passed), including the native-messaging shim integration test.
- A local Tauri bundle attempt reached native Swift compilation but could not proceed inside the Codex sandbox because SwiftPM invokes `sandbox-exec`; CI remains the authoritative universal bundle verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787177510&installation_model_id=425925&pr_number=866&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F866&signature=d0b2139a1f55997924f2c9d69fb030aea472ce72c35d7e8e479315365fc29fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->