### PR TITLE
Update bundled Hermes runtime to 0.19

### DIFF
--- a/.agents/skills/agent-e2e-qa/scripts/run_background_agent_prompt.mjs
+++ b/.agents/skills/agent-e2e-qa/scripts/run_background_agent_prompt.mjs
@@ -12,7 +12,7 @@ import {
   statSync,
 } from "node:fs";
 import { createServer } from "node:net";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
@@ -34,6 +34,7 @@ function parseArgs(argv) {
     headless: true,
     video: true,
     keepHermesHome: false,
+    expectText: "",
     hermesCommand: process.env.JUNE_HERMES_COMMAND || "",
     sourceHermesHome: process.env.JUNE_HERMES_HOME || "",
     chromeExecutable: process.env.CHROME_EXECUTABLE || "",
@@ -53,6 +54,7 @@ function parseArgs(argv) {
     else if (arg === "--out-dir") args.outDir = next();
     else if (arg === "--hermes-command") args.hermesCommand = next();
     else if (arg === "--source-hermes-home") args.sourceHermesHome = next();
+    else if (arg === "--expect-text") args.expectText = next();
     else if (arg === "--chrome-executable") args.chromeExecutable = next();
     else if (arg === "--headed") args.headless = false;
     else if (arg === "--no-video") args.video = false;
@@ -83,6 +85,7 @@ Options:
   --out-dir <path>               Artifact directory. Default: .tmp/qa-recordings
   --hermes-command <path>        Hermes binary. Default: JUNE_HERMES_COMMAND or app dev runtime
   --source-hermes-home <path>    Hermes home to copy config from. Default: JUNE_HERMES_HOME or app dev home
+  --expect-text <text>           Require the visible assistant reply to contain this text
   --chrome-executable <path>     Chrome executable. Default: CHROME_EXECUTABLE or common macOS paths
   --headed                       Run a visible browser instead of headless
   --no-video                     Disable Playwright video recording
@@ -325,9 +328,11 @@ function browserInitScript() {
           window.__qaWsEvents.push(type);
           if (
             type === "message.complete" ||
+            type === "error" ||
             type === "session.idle" ||
             type === "turn.complete" ||
             type === "turn.completed" ||
+            type === "turn.error" ||
             type === "session.completed"
           ) {
             window.__qaComplete = true;
@@ -350,10 +355,12 @@ function browserInitScript() {
       if (
         cmd === "plugin:event|unlisten" ||
         cmd === "plugin:event|emit" ||
-        cmd === "dictation_helper_command"
+        cmd === "dictation_helper_command" ||
+        cmd === "computer_use_begin_run"
       ) {
         return undefined;
       }
+      if (cmd === "plugin:window|is_focused") return true;
       if (cmd === "bootstrap_app") {
         return {
           folders: [],
@@ -432,6 +439,7 @@ function browserInitScript() {
       }
       if (cmd === "hermes_bridge_sessions") return { sessions: [], items: [] };
       if (cmd === "hermes_bridge_session_messages") return { messages: [], items: [] };
+      if (cmd === "list_completed_sessions") return [];
       if (cmd === "hermes_agent_cli_access") return { enabled: false };
       if (cmd === "suggest_agent_session_title") {
         return { title: prompt.slice(0, 40) || "Agent session" };
@@ -533,7 +541,9 @@ async function main() {
   const host = DEFAULT_HOST;
   const port = await allocatePort(host);
   const token = randomToken();
-  const hermesHome = mkdtempSync(join(root, ".tmp/qa-hermes-"));
+  // Hermes syncs bundled skills into its home. Keep that churn outside Vite's
+  // watched workspace so a QA turn cannot trigger a full-page reload.
+  const hermesHome = mkdtempSync(join(tmpdir(), "june-qa-hermes-"));
   const childRef = { current: null };
   const unregisterCleanup = registerHermesCleanup({
     hermesHome,
@@ -609,9 +619,11 @@ async function main() {
       throw new Error(`Start session stayed disabled for prompt ${JSON.stringify(args.prompt)}`);
     }
     await startButton.click();
-    await page.waitForFunction(() => window.__qaComplete === true, {
-      timeout: args.timeoutMs,
-    });
+    await page.waitForFunction(
+      () => window.__qaComplete === true,
+      undefined,
+      { timeout: args.timeoutMs },
+    );
     await page.waitForFunction(
       () =>
         Array.from(document.querySelectorAll(".agent-assistant-turn-body")).some((element) => {
@@ -626,6 +638,7 @@ async function main() {
             rect.height > 0
           );
         }),
+      undefined,
       { timeout: args.timeoutMs },
     );
 
@@ -636,9 +649,43 @@ async function main() {
     if (!assistantText) {
       throw new Error("No visible assistant reply rendered after completion");
     }
-    completed = true;
     screenshotPath = join(outDir, `${stamp}-background-agent-${slugFor(args.prompt)}.png`);
     await page.screenshot({ path: screenshotPath, fullPage: true });
+    if (args.expectText && !assistantText.includes(args.expectText)) {
+      throw new Error(
+        `Visible assistant reply did not contain expected text ${JSON.stringify(args.expectText)}: ` +
+          JSON.stringify(assistantText),
+      );
+    }
+    completed = true;
+  } catch (error) {
+    if (page) {
+      const failureScreenshotPath = join(
+        outDir,
+        `${stamp}-background-agent-${slugFor(args.prompt)}-failure.png`,
+      );
+      await page.screenshot({ path: failureScreenshotPath, fullPage: true }).catch(() => {});
+      if (existsSync(failureScreenshotPath)) {
+        screenshotPath = failureScreenshotPath;
+        console.error(`failure_screenshot_path=${failureScreenshotPath}`);
+      }
+      const diagnostics = await page
+        .evaluate(() => ({
+          invokes: window.__qaInvokes || [],
+          wsEvents: window.__qaWsEvents || [],
+        }))
+        .catch(() => undefined);
+      if (diagnostics) {
+        console.error(`browser_diagnostics=${JSON.stringify(diagnostics)}`);
+      }
+    }
+    if (consoleMessages.length) {
+      console.error(`browser_console=${JSON.stringify(consoleMessages.slice(-20))}`);
+    }
+    if (hermesStderr) {
+      console.error(`hermes_stderr=${hermesStderr}`);
+    }
+    throw error;
   } finally {
     const video = page?.video?.();
     if (page) await page.close().catch(() => {});

--- a/docs/hermes-gateway-gotchas.md
+++ b/docs/hermes-gateway-gotchas.md
@@ -115,7 +115,7 @@ falls back to the config's `oauth` marker and OAuth-shaped probe errors.
 ## Events
 
 **MCP approvals are identity-addressed, not FIFO.** The pinned runtime carries
-June's checksum-gated `june-approval-memory-v13` patch. MCP elicitation preserves the
+June's checksum-gated `june-approval-memory-v14` patch. MCP elicitation preserves the
 SDK request id and emits an opaque stable `request_id` on `approval.request`.
 While unanswered, the same logical request retried after an MCP transport
 reconnect joins the existing entry; separate requests on one transport remain

--- a/docs/hermes-upgrade-checklist.md
+++ b/docs/hermes-upgrade-checklist.md
@@ -27,11 +27,11 @@ The concrete tools this checklist drives:
 
 ## Version
 
-Pinned Hermes version: `v2026.6.19`.
+Pinned Hermes version: `v2026.7.20`.
 
 This is the version `PINNED_HERMES_VERSION` in
 `src/lib/hermes-control-plane/compatibility/matrix.ts` records and
-`docs/hermes-upstream-v2026.6.19.md` pins. `pnpm hermes:upgrade-check` fails if
+`docs/hermes-upstream-v2026.7.20.md` pins. `pnpm hermes:upgrade-check` fails if
 these three drift apart.
 
 On a bump, set the new version here, in the matrix constant, and in a new pin
@@ -40,8 +40,8 @@ note (copy `docs/hermes-upstream-template.md` to
 
 ## June compatibility patch set
 
-The current pin also carries the checksum-gated `june-approval-memory-v13` patch set
-documented in `docs/hermes-upstream-v2026.6.19.md`. Its targeted-approval portion
+The current pin also carries the checksum-gated `june-approval-memory-v14` patch set
+documented in `docs/hermes-upstream-v2026.7.20.md`. Its targeted-approval portion
 follows ADR 0025. On every pin bump:
 
 1. Check whether upstream now preserves MCP request identity, deduplicates one
@@ -112,7 +112,7 @@ unit test together. The smoke test will fail to start otherwise.
 
 Re-confirm every dashboard REST endpoint June consumes still exists on the new
 build. The authoritative list is in the pin note's "Compatibility checked"
-section (`docs/hermes-upstream-v2026.6.19.md`). For each endpoint:
+section (`docs/hermes-upstream-v2026.7.20.md`). For each endpoint:
 
 - still present and unchanged: no action.
 - changed shape: update the June caller and its test.
@@ -225,7 +225,7 @@ record an explicit decision and reflect it on the matrix:
   the rough plan.
 - `unsupported`: June deliberately will not expose it. Note why.
 
-Carry forward the pending decisions from `docs/hermes-upstream-v2026.6.19.md`
+Carry forward the pending decisions from `docs/hermes-upstream-v2026.7.20.md`
 ("Additional June integration work") and resolve or restate each: Photon
 iMessage setup UI, Raft profile and wake-event mapping, WhatsApp Cloud
 credentials, Automation Blueprints vs the Routines editor, inline rendering of
@@ -264,9 +264,8 @@ dashes, plain hyphens for ranges. Cover only what users can actually rely on
 from June UI (matrix `supported`), not raw upstream capabilities June has not
 exposed. Keep it short and concrete, for example:
 
-> Updated the bundled agent runtime to Hermes v2026.6.19. Background subagents
-> now show per-agent progress in the activity drawer, and you can attach an
-> imported image to an agent turn.
+> Updated June's bundled agent runtime to Hermes 0.19. Agent responses start
+> faster, and mid-task updates stay visible while June verifies its work.
 
 ## CI guard
 

--- a/docs/hermes-upstream-template.md
+++ b/docs/hermes-upstream-template.md
@@ -101,7 +101,7 @@ Run it against the new bundled runtime BEFORE flipping any matrix entry to
 pnpm test:hermes-smoke
 ```
 
-See `docs/hermes-upstream-v2026.6.19.md` for the smoke test's two phases
+See `docs/hermes-upstream-v2026.7.20.md` for the smoke test's two phases
 (protocol vs model), its environment variables, and its skip behavior.
 
 ## Version agreement

--- a/docs/hermes-upstream-v2026.7.20.md
+++ b/docs/hermes-upstream-v2026.7.20.md
@@ -47,7 +47,7 @@ fresh upstream tree and the resulting patched tree.
 | `agent/agent_init.py` | `a3f6f64cc7932df2de66c4a93bcaef3cfe1cccd20a927e48e023c2185c8da5a5` |
 | `tools/approval.py` | `c0d941fd952b578739afff0096b8896f4d7f742d66518aefef0a9c9b3b344900` |
 | `tools/mcp_tool.py` | `764758773737bc1c1c46d244857198eea83dfbf52c0a1460ed0bc3418c1ceb7a` |
-| `tui_gateway/server.py` | `b562a6c91ce242d0d1d7b268ef9135deb633e4227e3b21c090b0f26e1a9ae923` |
+| `tui_gateway/server.py` | `54011ceed51ee22662ad1ae7bd72a91155263cc82c0aa1c10d90aac3dbd08829` |
 | `utils.py` | `0795233ec93398fe0f13e785d8b7c66768f60ee83b29d853c24009e1558e0174` |
 | `plugins/platforms/telegram/adapter.py` | `b4fab048d4986ab49615a1b5abb0dafeade4a25196578bf93cb065b793d67c8b` |
 | `cron/scheduler.py` | `ea54407dddebec57a184f1dbdf1076f8abe94f132da1e619c476cbf1266ed239` |

--- a/docs/hermes-upstream-v2026.7.20.md
+++ b/docs/hermes-upstream-v2026.7.20.md
@@ -40,6 +40,7 @@ redundant transforms while preserving the remaining checksum-gated changes:
 - immediate byte-image attachment and reset/build race protection
 - global Memory deny propagation across interactive, background, and cron agents
 - cross-process config writer locking and final disabled-toolset subtraction
+- manual-only interactive approvals with fail-closed cron denial
 
 Every upstream and patched source hash was refreshed for the exact 0.19 tree.
 The patch state machine accepts only the audited upstream or patched bytes and
@@ -51,7 +52,7 @@ fresh upstream tree and the resulting patched tree.
 | `agent/agent_init.py` | `a3f6f64cc7932df2de66c4a93bcaef3cfe1cccd20a927e48e023c2185c8da5a5` |
 | `tools/approval.py` | `c0d941fd952b578739afff0096b8896f4d7f742d66518aefef0a9c9b3b344900` |
 | `tools/mcp_tool.py` | `764758773737bc1c1c46d244857198eea83dfbf52c0a1460ed0bc3418c1ceb7a` |
-| `tui_gateway/server.py` | `54011ceed51ee22662ad1ae7bd72a91155263cc82c0aa1c10d90aac3dbd08829` |
+| `tui_gateway/server.py` | `750a80a72e7310295f7b9a32624be56fa348c49412442853f26813fb848e7367` |
 | `utils.py` | `0795233ec93398fe0f13e785d8b7c66768f60ee83b29d853c24009e1558e0174` |
 | `plugins/platforms/telegram/adapter.py` | `b4fab048d4986ab49615a1b5abb0dafeade4a25196578bf93cb065b793d67c8b` |
 | `cron/scheduler.py` | `ea54407dddebec57a184f1dbdf1076f8abe94f132da1e619c476cbf1266ed239` |

--- a/docs/hermes-upstream-v2026.7.20.md
+++ b/docs/hermes-upstream-v2026.7.20.md
@@ -25,6 +25,10 @@ and `messages` database fields June reads remain compatible.
 The upstream installer still has bare `$UV_CMD` calls. June's quoting patch
 remains required for app data paths containing spaces.
 
+The dashboard now imports the `@hermes/shared` workspace from `apps/shared`.
+June's macOS and Windows bundlers retain that workspace until the dashboard
+assets are compiled, then prune the rest of `apps/` from the shipped runtime.
+
 ## Sealed June patch set
 
 Hermes 0.19 moved Telegram into `plugins/platforms/telegram/adapter.py` and

--- a/docs/hermes-upstream-v2026.7.20.md
+++ b/docs/hermes-upstream-v2026.7.20.md
@@ -1,0 +1,110 @@
+# Hermes upstream v2026.7.20
+
+## Pin
+
+- Previous June pin: `v2026.6.19`, commit `2bd1977d8fad185c9b4be47884f7e87f1add0ce3`
+- New June pin: `v2026.7.20`, commit `3ef6bbd201263d354fd83ec55b3c306ded2eb72a`
+- Archive checksum: `335c2249b6b2e58be397e12d542788f3315ede84394c0082b339a4ddde6a27d0`
+- Upstream release: Hermes Agent v0.19.0, the Quicksilver Release
+- Comparison: `https://github.com/NousResearch/hermes-agent/compare/v2026.6.19...v2026.7.20`
+
+## Compatibility checked
+
+June still starts Hermes through:
+
+```text
+hermes dashboard --no-open --host 127.0.0.1 --port <port>
+```
+
+The dashboard still exposes the API surfaces June consumes, including status,
+sessions, messages, skills, messaging platforms, routines, toolsets, and the
+authenticated `/api/ws` gateway. Session message pagination is additive:
+omitting `limit` still returns the complete list June expects. The `sessions`
+and `messages` database fields June reads remain compatible.
+
+The upstream installer still has bare `$UV_CMD` calls. June's quoting patch
+remains required for app data paths containing spaces.
+
+## Sealed June patch set
+
+Hermes 0.19 moved Telegram into `plugins/platforms/telegram/adapter.py` and
+incorporated June's prompt image-batch ownership and atomic Telegram config
+write fixes upstream. Patch set `june-approval-memory-v14` retires those
+redundant transforms while preserving the remaining checksum-gated changes:
+
+- targeted approval request identity, deduplication, expiry, and fail-closed queues
+- immediate byte-image attachment and reset/build race protection
+- global Memory deny propagation across interactive, background, and cron agents
+- cross-process config writer locking and final disabled-toolset subtraction
+
+Every upstream and patched source hash was refreshed for the exact 0.19 tree.
+The patch state machine accepts only the audited upstream or patched bytes and
+rejects tampering. The complete compatibility smoke passes against both the
+fresh upstream tree and the resulting patched tree.
+
+| Source | Sealed patched or policy SHA-256 |
+| --- | --- |
+| `agent/agent_init.py` | `a3f6f64cc7932df2de66c4a93bcaef3cfe1cccd20a927e48e023c2185c8da5a5` |
+| `tools/approval.py` | `c0d941fd952b578739afff0096b8896f4d7f742d66518aefef0a9c9b3b344900` |
+| `tools/mcp_tool.py` | `764758773737bc1c1c46d244857198eea83dfbf52c0a1460ed0bc3418c1ceb7a` |
+| `tui_gateway/server.py` | `b562a6c91ce242d0d1d7b268ef9135deb633e4227e3b21c090b0f26e1a9ae923` |
+| `utils.py` | `0795233ec93398fe0f13e785d8b7c66768f60ee83b29d853c24009e1558e0174` |
+| `plugins/platforms/telegram/adapter.py` | `b4fab048d4986ab49615a1b5abb0dafeade4a25196578bf93cb065b793d67c8b` |
+| `cron/scheduler.py` | `ea54407dddebec57a184f1dbdf1076f8abe94f132da1e619c476cbf1266ed239` |
+| `model_tools.py` | `30a2dcb33685783935f66abef6839d06736c90196a89dd034c91c4e6eb65c2db` |
+
+## Gateway catalog diff
+
+Hermes 0.19 keeps every JSON-RPC method June calls. It adds learning, project,
+pet, subscription, usage, verification, one-shot LLM, and
+`session.context_breakdown` methods.
+
+It also adds `message.interim`, `moa.reference`, `moa.aggregating`,
+`tool.output_risk`, `reaction`, `terminal.close`, `turn.start`, and `turn.error`
+events. June classifies and renders `message.interim` as a sealed assistant
+segment so later completion text cannot overwrite mid-turn commentary. Other
+new families remain planned or deliberately unsupported in the compatibility
+matrix and flow through June's sanitized unsupported-event path.
+
+## Runtime capabilities
+
+- Faster cold first-token latency and reasoning streaming by default
+- Durable background delegation and completion delivery
+- Smart approvals and explicit hard deny rules
+- Bitwarden and 1Password secret sources
+- Multi-format session export with optional secret redaction
+- Fireworks AI and DeepInfra providers
+- Max and ultra reasoning tiers with per-model overrides
+- Multiplexed gateway profile routing and durable messaging delivery
+
+These are runtime capabilities. June only advertises surfaces marked supported
+in its compatibility matrix.
+
+## Additional June integration work
+
+- Add context inspection UI before exposing `session.context_breakdown`.
+- Reconcile tool risk and smart approvals with June's human approval cards.
+- Add vault connection and provenance UI before exposing secret sources.
+- Add export format, scope, and redaction controls.
+- Add Mixture of Agents transcript treatment.
+- Add reasoning effort controls before advertising max or ultra.
+- Keep Nous subscription controls hidden because June uses Open Software billing.
+
+The existing replay corpus remains labeled `v2026.6.19` because it is a
+historical capture. Focused tests cover the new `message.interim` shape and
+preview settlement behavior.
+
+## Release-gate smoke test
+
+Run the protocol phase against the patched exact runtime:
+
+```text
+JUNE_HERMES_COMMAND=/absolute/path/to/hermes pnpm test:hermes-smoke
+```
+
+The optional provider-backed phase remains gated behind `HERMES_SMOKE_MODEL=1`.
+
+## Release note copy
+
+> Updated June's bundled agent runtime to Hermes 0.19. Agent responses start
+> faster, and mid-task updates stay visible while June verifies its work.

--- a/scripts/bundle-hermes-runtime-windows.ps1
+++ b/scripts/bundle-hermes-runtime-windows.ps1
@@ -189,7 +189,8 @@ if ($null -eq $unpacked) {
 Move-Item -Path $unpacked.FullName -Destination (Join-Path $out "hermes-agent")
 $agentDir = Join-Path $out "hermes-agent"
 
-foreach ($prune in @("tests", "website", "apps", ".github")) {
+# Hermes 0.19 web imports apps/shared, so apps must remain through the build.
+foreach ($prune in @("tests", "website", ".github")) {
   Remove-Item -Recurse -Force -ErrorAction SilentlyContinue (Join-Path $agentDir $prune)
 }
 
@@ -233,7 +234,8 @@ try {
 Remove-Item -Recurse -Force -ErrorAction SilentlyContinue `
   (Join-Path $agentDir "node_modules"),
   (Join-Path $agentDir "web\node_modules"),
-  (Join-Path $agentDir "ui-tui\node_modules")
+  (Join-Path $agentDir "ui-tui\node_modules"),
+  (Join-Path $agentDir "apps")
 if (!(Test-Path -LiteralPath (Join-Path $agentDir "hermes_cli\web_dist\index.html") -PathType Leaf)) {
   Fail "web_dist missing after build."
 }

--- a/scripts/bundle-hermes-runtime.sh
+++ b/scripts/bundle-hermes-runtime.sh
@@ -249,9 +249,10 @@ cp -R "$out/hermes-agent" "$upstream_smoke"
 rm -rf "$upstream_smoke"
 
 # Dev-only weight the runtime never imports. Conservative on purpose: web/ and
-# ui-tui/ stay (hermes resolves them relative to its project root), and they
-# are small without node_modules, which we never ship.
-for prune in tests website apps .github; do
+# ui-tui/ stay (hermes resolves them relative to its project root), and apps/
+# stays until the dashboard build because Hermes 0.19 web imports apps/shared.
+# They are small without node_modules, which we never ship.
+for prune in tests website .github; do
   rm -rf "$out/hermes-agent/$prune"
 done
 
@@ -295,7 +296,8 @@ fi
 # June never launches.
 rm -rf "$out/hermes-agent/node_modules" \
   "$out/hermes-agent/web/node_modules" \
-  "$out/hermes-agent/ui-tui/node_modules"
+  "$out/hermes-agent/ui-tui/node_modules" \
+  "$out/hermes-agent/apps"
 [ -f "$out/hermes-agent/hermes_cli/web_dist/index.html" ] || die "web_dist missing after build"
 
 # ---- two relocatable CPythons + target-selected dependency trees ------------

--- a/scripts/hermes-approval-patch-smoke.py
+++ b/scripts/hermes-approval-patch-smoke.py
@@ -375,6 +375,7 @@ def verify_new_session_image_attach_is_immediate(root: Path) -> None:
         obsolete_build_release = threading.Event()
         obsolete_build_closed = threading.Event()
         reset_during_build_calls = 0
+        reset_build_kwargs = []
 
         class ObsoleteHermes:
             def close(self) -> None:
@@ -385,6 +386,7 @@ def verify_new_session_image_attach_is_immediate(root: Path) -> None:
         def make_reset_during_obsolete_build(*_args, **_kwargs):
             nonlocal reset_during_build_calls
             reset_during_build_calls += 1
+            reset_build_kwargs.append(_kwargs)
             if reset_during_build_calls == 1:
                 obsolete_build_started.set()
                 assert obsolete_build_release.wait(2), (
@@ -416,6 +418,10 @@ def verify_new_session_image_attach_is_immediate(root: Path) -> None:
             "history_lock": threading.Lock(),
             "history_version": 0,
             "image_counter": 1,
+            "model_override": "selected-model",
+            "create_reasoning_override": {"effort": "high"},
+            "create_service_tier_override": "priority",
+            "one_turn_model_restore": "previous-model",
             "prompt_generation": 0,
             "reset_generation": 0,
             "running": False,
@@ -431,6 +437,10 @@ def verify_new_session_image_attach_is_immediate(root: Path) -> None:
         )
         assert reset_info == {"model": "replacement-model"}
         assert reset_during_build_session["agent"] is replacement_hermes
+        assert reset_build_kwargs[-1]["model_override"] == "selected-model"
+        assert reset_build_kwargs[-1]["reasoning_config_override"] == {"effort": "high"}
+        assert reset_build_kwargs[-1]["service_tier_override"] == "priority"
+        assert "one_turn_model_restore" not in reset_during_build_session
         assert reset_during_build_session["agent_ready"].is_set(), (
             "successful reset did not publish Hermes readiness"
         )

--- a/scripts/hermes-approval-patch-smoke.py
+++ b/scripts/hermes-approval-patch-smoke.py
@@ -35,6 +35,13 @@ def load_approval(root: Path):
     utils.is_truthy_value = lambda value: str(value).lower() in {"1", "true", "yes"}
     sys.modules["utils"] = utils
 
+    tools = types.ModuleType("tools")
+    tools.__path__ = []
+    interrupt = types.ModuleType("tools.interrupt")
+    interrupt.is_interrupted = lambda: False
+    sys.modules["tools"] = tools
+    sys.modules["tools.interrupt"] = interrupt
+
     path = root / "tools" / "approval.py"
     if not path.is_file():
         raise RuntimeError("patched Hermes approval module is missing: %s" % path)
@@ -229,6 +236,8 @@ def verify_new_session_image_attach_is_immediate(root: Path) -> None:
             "_sessions_lock": threading.Lock(),
             "_set_session_context": lambda _key: None,
             "_clear_session_context": lambda _tokens: None,
+            "_session_source": lambda _session: "tui",
+            "_emit": lambda *_args: None,
         }
         exec(compile(source, str(root / "tui_gateway" / "server.py"), "exec"), namespace)
         response = namespace["_image_attach_bytes"](
@@ -658,6 +667,43 @@ def verify_new_session_image_attach_is_immediate(root: Path) -> None:
         namespace["_reset_session_agent"]("reset-session", reset_session)
         assert reset_session["agent_error"] is None, reset_session
 
+    # Hermes 0.19 moved queue ownership into _run_prompt_submit after the lazy
+    # agent is ready. The function detaches one immutable batch while holding
+    # history_lock, so later attachments remain queued for the next turn.
+    run_prompt_submit = _function(tree, "_run_prompt_submit")
+    run_lock_blocks = [
+        node
+        for node in run_prompt_submit.body
+        if isinstance(node, ast.With)
+        and any(
+            _session_subscript(item.context_expr, "history_lock")
+            for item in node.items
+        )
+    ]
+    assert len(run_lock_blocks) == 1, len(run_lock_blocks)
+    run_lock = run_lock_blocks[0]
+    image_batch_assigns = [
+        node
+        for node in ast.walk(run_lock)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "images" for target in node.targets)
+    ]
+    queue_clears = [
+        node
+        for node in ast.walk(run_lock)
+        if isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.List)
+        and not node.value.elts
+        and any(_session_subscript(target, "attached_images") for target in node.targets)
+    ]
+    assert len(image_batch_assigns) == len(queue_clears) == 1, (
+        len(image_batch_assigns),
+        len(queue_clears),
+    )
+    return
+
+    # Legacy pre-0.19 ownership checks retained as documentation for the
+    # older patch shape. Hermes 0.19 takes the verified path above.
     # Lock the queue ownership boundary across prompt.submit. Acceptance must
     # detach an immutable batch under the same history lock used by queue writes,
     # then hand only that batch to the asynchronous success path. Initialization
@@ -1045,6 +1091,11 @@ def verify_cross_process_config_writer(root: Path) -> None:
         # with a bare host Python too by using JSON, which is a YAML subset.
         yaml_stub = types.ModuleType("yaml")
         yaml_stub.YAMLError = ValueError
+        yaml_stub.SafeDumper = type(
+            "SafeDumper",
+            (),
+            {"increase_indent": lambda self, flow=False, indentless=False: None},
+        )
         yaml_stub.safe_load = lambda source: json.loads(
             source.read() if hasattr(source, "read") else source
         )
@@ -1228,7 +1279,7 @@ def verify_cross_process_config_writer(root: Path) -> None:
             encoding="utf-8",
         )
         telegram_tree = ast.parse(
-            (root / "gateway" / "platforms" / "telegram.py").read_text(
+            (root / "plugins" / "platforms" / "telegram" / "adapter.py").read_text(
                 encoding="utf-8"
             )
         )
@@ -1250,7 +1301,11 @@ def verify_cross_process_config_writer(root: Path) -> None:
             )
         }
         exec(
-            compile(module, str(root / "gateway" / "platforms" / "telegram.py"), "exec"),
+            compile(
+                module,
+                str(root / "plugins" / "platforms" / "telegram" / "adapter.py"),
+                "exec",
+            ),
             namespace,
         )
 
@@ -1269,10 +1324,18 @@ def verify_cross_process_config_writer(root: Path) -> None:
         patched_utils.atomic_yaml_write = atomic_after_june_disable
         hermes_constants = types.ModuleType("hermes_constants")
         hermes_constants.get_hermes_home = lambda: config_path.parent
+        hermes_cli = types.ModuleType("hermes_cli")
+        hermes_config = types.ModuleType("hermes_cli.config")
+        hermes_config.atomic_config_write = atomic_after_june_disable
+        hermes_cli.config = hermes_config
         previous_utils = sys.modules.get("utils")
         previous_constants = sys.modules.get("hermes_constants")
+        previous_hermes_cli = sys.modules.get("hermes_cli")
+        previous_hermes_config = sys.modules.get("hermes_cli.config")
         sys.modules["utils"] = patched_utils
         sys.modules["hermes_constants"] = hermes_constants
+        sys.modules["hermes_cli"] = hermes_cli
+        sys.modules["hermes_cli.config"] = hermes_config
         try:
             writer = namespace["TelegramWriter"]()
             writer.name = "telegram"
@@ -1287,6 +1350,14 @@ def verify_cross_process_config_writer(root: Path) -> None:
                 sys.modules.pop("hermes_constants", None)
             else:
                 sys.modules["hermes_constants"] = previous_constants
+            if previous_hermes_config is None:
+                sys.modules.pop("hermes_cli.config", None)
+            else:
+                sys.modules["hermes_cli.config"] = previous_hermes_config
+            if previous_hermes_cli is None:
+                sys.modules.pop("hermes_cli", None)
+            else:
+                sys.modules["hermes_cli"] = previous_hermes_cli
 
         telegram_saved = patched_utils.yaml.safe_load(
             config_path.read_text(encoding="utf-8")
@@ -1344,12 +1415,23 @@ def verify_model_deny_wins(root: Path) -> None:
         ),
         namespace,
     )
-    definitions = namespace["_compute_tool_definitions"](
-        enabled_toolsets=["memory", "web"],
-        disabled_toolsets=["memory"],
-        quiet_mode=True,
-        skip_tool_search_assembly=True,
-    )
+    toolsets_module = types.ModuleType("toolsets")
+    toolsets_module.bundle_non_core_tools = lambda _name: set()
+    toolsets_module.get_toolset = lambda _name: {}
+    previous_toolsets = sys.modules.get("toolsets")
+    sys.modules["toolsets"] = toolsets_module
+    try:
+        definitions = namespace["_compute_tool_definitions"](
+            enabled_toolsets=["memory", "web"],
+            disabled_toolsets=["memory"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+    finally:
+        if previous_toolsets is None:
+            sys.modules.pop("toolsets", None)
+        else:
+            sys.modules["toolsets"] = previous_toolsets
     names = {definition["function"]["name"] for definition in definitions}
     assert names == {"web_search"}, (
         "disabled memory toolset did not win over the enabled allowlist: %s" % names

--- a/src-tauri/src/hermes/apply_june_patches.py
+++ b/src-tauri/src/hermes/apply_june_patches.py
@@ -30,7 +30,7 @@ PATCHED_SHA256: Dict[str, str] = {
     "agent/agent_init.py": "a3f6f64cc7932df2de66c4a93bcaef3cfe1cccd20a927e48e023c2185c8da5a5",
     "tools/approval.py": "c0d941fd952b578739afff0096b8896f4d7f742d66518aefef0a9c9b3b344900",
     "tools/mcp_tool.py": "764758773737bc1c1c46d244857198eea83dfbf52c0a1460ed0bc3418c1ceb7a",
-    "tui_gateway/server.py": "54011ceed51ee22662ad1ae7bd72a91155263cc82c0aa1c10d90aac3dbd08829",
+    "tui_gateway/server.py": "750a80a72e7310295f7b9a32624be56fa348c49412442853f26813fb848e7367",
     "utils.py": "0795233ec93398fe0f13e785d8b7c66768f60ee83b29d853c24009e1558e0174",
     "plugins/platforms/telegram/adapter.py": "b4fab048d4986ab49615a1b5abb0dafeade4a25196578bf93cb065b793d67c8b",
 }
@@ -1248,7 +1248,7 @@ def _queue_attached_image(
 ''',
         '''            register_gateway_notify(
                 new_session_id,
-                lambda data: _emit("approval.request", sid, data),
+                lambda data: _emit_approval_request(sid, data),
                 lambda data: _emit("approval.expire", sid, data),
             )
 ''',

--- a/src-tauri/src/hermes/apply_june_patches.py
+++ b/src-tauri/src/hermes/apply_june_patches.py
@@ -13,26 +13,26 @@ import sys
 from typing import Callable, Dict
 
 
-PATCH_SET = "june-approval-memory-v13"
+PATCH_SET = "june-approval-memory-v14"
 
 UPSTREAM_SHA256: Dict[str, str] = {
-    "agent/agent_init.py": "7e90d8202794bec74c05285018a211e596abdf66b75b662d1b6b1618da2a7f7b",
-    "tools/approval.py": "e31abc88357afa28c05f3a4753ea9908b540b0dfef8dab2fa62960ae19a63c85",
-    "tools/mcp_tool.py": "3f0aca90d076a1b0aa5daffd7bb39b0d1a4fee83265f855e68d556e5c8a29d01",
-    "tui_gateway/server.py": "1743cec5c6684651d2b7cb18b7b73a37ea99538a4f56bcd8476700ce23d4f01a",
-    "utils.py": "572b08bcbdf4a37116f49d1fc72d22854897a5fd8968c2d358103a97589c206c",
-    "gateway/platforms/telegram.py": "3943dc748827f81bf4e40a2a6711e4dfb6f65304bff552474ffbc23fd91e23a6",
+    "agent/agent_init.py": "85b7cb13d6e6306e75d5eec46f193433df680425533b7d35ee99e0f7eab9512a",
+    "tools/approval.py": "f35c78aa0b56c82cafe0242bb886c4f9679bf55219776a105131dceba2ce9672",
+    "tools/mcp_tool.py": "a7328f3f3762ae43f6a9426646b0c28c17ec8663aa391506f48d628035ad5460",
+    "tui_gateway/server.py": "5d00832327e4362ac75032f95003e1fa49aead4756cf7927dcfd66447b205a59",
+    "utils.py": "a60c651a682f739c8e7e167de939c5bb060c8c2b049ce28d65f12ff1f649b207",
+    "plugins/platforms/telegram/adapter.py": "b4fab048d4986ab49615a1b5abb0dafeade4a25196578bf93cb065b793d67c8b",
 }
 
 # Filled after applying the transformations to the exact upstream files. These
 # hashes are part of the runtime provenance contract, not best-effort checks.
 PATCHED_SHA256: Dict[str, str] = {
-    "agent/agent_init.py": "58e0f7294cea8d778b15827af4e0a1d5c2d9e0a2db27b2a6697f30811053629e",
-    "tools/approval.py": "56e88034ebcac8cff8c579c56345e4cb3fe2fe597360687d40b68daefd402e3d",
-    "tools/mcp_tool.py": "48a2fddfee5d5a8c33723e27639907e9f2cf062c82e7beeb844f457e6a372cfa",
-    "tui_gateway/server.py": "f375627e61af5e61434592d4d17d39c20e7ba1a7e1280715b0e5a7387a0f26a1",
-    "utils.py": "08a0a0203bdee74eb8bc4f8bc31e97eb7621913deca2d087fb56c722b1304ef5",
-    "gateway/platforms/telegram.py": "fd996e2deaebe3ca2856167876f8ff498735744ff7c884eedd85736a7fd2c318",
+    "agent/agent_init.py": "a3f6f64cc7932df2de66c4a93bcaef3cfe1cccd20a927e48e023c2185c8da5a5",
+    "tools/approval.py": "c0d941fd952b578739afff0096b8896f4d7f742d66518aefef0a9c9b3b344900",
+    "tools/mcp_tool.py": "764758773737bc1c1c46d244857198eea83dfbf52c0a1460ed0bc3418c1ceb7a",
+    "tui_gateway/server.py": "b562a6c91ce242d0d1d7b268ef9135deb633e4227e3b21c090b0f26e1a9ae923",
+    "utils.py": "0795233ec93398fe0f13e785d8b7c66768f60ee83b29d853c24009e1558e0174",
+    "plugins/platforms/telegram/adapter.py": "b4fab048d4986ab49615a1b5abb0dafeade4a25196578bf93cb065b793d67c8b",
 }
 
 # These policy files are not transformed, but their exact bytes are part of
@@ -40,8 +40,8 @@ PATCHED_SHA256: Dict[str, str] = {
 # layering and final deny subtraction to make agent.disabled_toolsets win over
 # every stored per-job allowlist.
 POLICY_SHA256: Dict[str, str] = {
-    "cron/scheduler.py": "2d82e4958494b52bcae27527e8ad64f0b730d22906e725609fda7725b410abfa",
-    "model_tools.py": "d7628473ee72f7ac1395f9f2fe43dc2956523b186545bf6abece1b834ac6892d",
+    "cron/scheduler.py": "ea54407dddebec57a184f1dbdf1076f8abe94f132da1e619c476cbf1266ed239",
+    "model_tools.py": "30a2dcb33685783935f66abef6839d06736c90196a89dd034c91c4e6eb65c2db",
 }
 
 
@@ -49,7 +49,21 @@ def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+UPSTREAMED_IN_019 = {
+    "prompt image batch ownership",
+    "prompt image batch handoff",
+    "failed prompt image batch restoration",
+    "prompt image batch consumption",
+    "notification prompt image isolation",
+    "goal continuation image isolation",
+    "completion prompt image isolation",
+    "telegram DM topic config writer",
+}
+
+
 def replace_once(source: str, old: str, new: str, label: str) -> str:
+    if label in UPSTREAMED_IN_019:
+        return source
     count = source.count(old)
     if count != 1:
         raise RuntimeError("%s: expected one match, found %d" % (label, count))
@@ -59,6 +73,8 @@ def replace_once(source: str, old: str, new: str, label: str) -> str:
 def replace_count(
     source: str, old: str, new: str, expected: int, label: str
 ) -> str:
+    if label in UPSTREAMED_IN_019:
+        return source
     count = source.count(old)
     if count != expected:
         raise RuntimeError(
@@ -68,6 +84,8 @@ def replace_count(
 
 
 def replace_region(source: str, start: str, end: str, replacement: str, label: str) -> str:
+    if label in UPSTREAMED_IN_019:
+        return source
     start_index = source.find(start)
     if start_index < 0:
         raise RuntimeError("%s: start marker not found" % label)
@@ -1118,6 +1136,17 @@ def _queue_attached_image(
             # after this lock is released and must not mutate the reset session.
             previous_prompt_generation = int(session.get("prompt_generation", 0))
             previous_reset_generation = int(session.get("reset_generation", 0))
+            runtime_override_keys = (
+                "model_override",
+                "create_reasoning_override",
+                "create_service_tier_override",
+                "one_turn_model_restore",
+            )
+            previous_runtime_overrides = {
+                key: session[key] for key in runtime_override_keys if key in session
+            }
+            for key in runtime_override_keys:
+                session.pop(key, None)
             session["prompt_generation"] = previous_prompt_generation + 1
             session["reset_generation"] = previous_reset_generation + 1
             tokens = _set_session_context(session["session_key"])
@@ -1126,17 +1155,15 @@ def _queue_attached_image(
                     sid,
                     session["session_key"],
                     session_id=session["session_key"],
-                    # Preserve this session's chosen model across /new so a reset
-                    # doesn't silently revert to global config (or to a model another
-                    # session set). See the cross-session-contamination note in
-                    # _apply_model_switch.
-                    model_override=session.get("model_override"),
+                    platform_override=_session_source(session),
                 )
             except Exception:
                 # The original lazy build and prompt still own the session when a
                 # requested reset cannot construct its replacement Hermes instance.
                 session["prompt_generation"] = previous_prompt_generation
                 session["reset_generation"] = previous_reset_generation
+                for key, value in previous_runtime_overrides.items():
+                    session[key] = value
                 raise
             finally:
                 _clear_session_context(tokens)
@@ -1207,12 +1234,12 @@ def _queue_attached_image(
     source = replace_once(
         source,
         '''                register_gateway_notify(
-                    key, lambda data: _emit("approval.request", sid, data)
+                    key, lambda data: _emit_approval_request(sid, data)
                 )
 ''',
         '''                register_gateway_notify(
                     key,
-                    lambda data: _emit("approval.request", sid, data),
+                    lambda data: _emit_approval_request(sid, data),
                     lambda data: _emit("approval.expire", sid, data),
                 )
 ''',
@@ -1222,7 +1249,7 @@ def _queue_attached_image(
         source,
         '''            register_gateway_notify(
                 new_session_id,
-                lambda data: _emit("approval.request", sid, data),
+                lambda data: _emit_approval_request(sid, data),
             )
 ''',
         '''            register_gateway_notify(
@@ -1235,11 +1262,11 @@ def _queue_attached_image(
     )
     source = replace_once(
         source,
-        '''        register_gateway_notify(key, lambda data: _emit("approval.request", sid, data))
+        '''        register_gateway_notify(key, lambda data: _emit_approval_request(sid, data))
 ''',
         '''        register_gateway_notify(
             key,
-            lambda data: _emit("approval.request", sid, data),
+            lambda data: _emit_approval_request(sid, data),
             lambda data: _emit("approval.expire", sid, data),
         )
 ''',
@@ -1682,7 +1709,7 @@ PATCHERS: Dict[str, Callable[[str], str]] = {
     "tools/mcp_tool.py": patch_mcp_tool,
     "tui_gateway/server.py": patch_server,
     "utils.py": patch_utils,
-    "gateway/platforms/telegram.py": patch_telegram,
+    "plugins/platforms/telegram/adapter.py": patch_telegram,
 }
 
 

--- a/src-tauri/src/hermes/apply_june_patches.py
+++ b/src-tauri/src/hermes/apply_june_patches.py
@@ -30,7 +30,7 @@ PATCHED_SHA256: Dict[str, str] = {
     "agent/agent_init.py": "a3f6f64cc7932df2de66c4a93bcaef3cfe1cccd20a927e48e023c2185c8da5a5",
     "tools/approval.py": "c0d941fd952b578739afff0096b8896f4d7f742d66518aefef0a9c9b3b344900",
     "tools/mcp_tool.py": "764758773737bc1c1c46d244857198eea83dfbf52c0a1460ed0bc3418c1ceb7a",
-    "tui_gateway/server.py": "b562a6c91ce242d0d1d7b268ef9135deb633e4227e3b21c090b0f26e1a9ae923",
+    "tui_gateway/server.py": "54011ceed51ee22662ad1ae7bd72a91155263cc82c0aa1c10d90aac3dbd08829",
     "utils.py": "0795233ec93398fe0f13e785d8b7c66768f60ee83b29d853c24009e1558e0174",
     "plugins/platforms/telegram/adapter.py": "b4fab048d4986ab49615a1b5abb0dafeade4a25196578bf93cb065b793d67c8b",
 }
@@ -1136,17 +1136,10 @@ def _queue_attached_image(
             # after this lock is released and must not mutate the reset session.
             previous_prompt_generation = int(session.get("prompt_generation", 0))
             previous_reset_generation = int(session.get("reset_generation", 0))
-            runtime_override_keys = (
-                "model_override",
-                "create_reasoning_override",
-                "create_service_tier_override",
-                "one_turn_model_restore",
-            )
-            previous_runtime_overrides = {
-                key: session[key] for key in runtime_override_keys if key in session
-            }
-            for key in runtime_override_keys:
-                session.pop(key, None)
+            # /new starts fresh history but June keeps the session's explicit
+            # model, reasoning, and service-tier selections. Only a one-turn
+            # override expires at this boundary.
+            session.pop("one_turn_model_restore", None)
             session["prompt_generation"] = previous_prompt_generation + 1
             session["reset_generation"] = previous_reset_generation + 1
             tokens = _set_session_context(session["session_key"])
@@ -1156,14 +1149,15 @@ def _queue_attached_image(
                     session["session_key"],
                     session_id=session["session_key"],
                     platform_override=_session_source(session),
+                    model_override=session.get("model_override"),
+                    reasoning_config_override=session.get("create_reasoning_override"),
+                    service_tier_override=session.get("create_service_tier_override"),
                 )
             except Exception:
                 # The original lazy build and prompt still own the session when a
                 # requested reset cannot construct its replacement Hermes instance.
                 session["prompt_generation"] = previous_prompt_generation
                 session["reset_generation"] = previous_reset_generation
-                for key, value in previous_runtime_overrides.items():
-                    session[key] = value
                 raise
             finally:
                 _clear_session_context(tokens)

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -70,7 +70,7 @@ const HERMES_RUNTIME_PATCHED_SOURCE_HASHES: &[(&str, &str)] = &[
     ),
     (
         "tui_gateway/server.py",
-        "b562a6c91ce242d0d1d7b268ef9135deb633e4227e3b21c090b0f26e1a9ae923",
+        "54011ceed51ee22662ad1ae7bd72a91155263cc82c0aa1c10d90aac3dbd08829",
     ),
     (
         "cron/scheduler.py",

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -70,7 +70,7 @@ const HERMES_RUNTIME_PATCHED_SOURCE_HASHES: &[(&str, &str)] = &[
     ),
     (
         "tui_gateway/server.py",
-        "54011ceed51ee22662ad1ae7bd72a91155263cc82c0aa1c10d90aac3dbd08829",
+        "750a80a72e7310295f7b9a32624be56fa348c49412442853f26813fb848e7367",
     ),
     (
         "cron/scheduler.py",
@@ -10256,6 +10256,9 @@ fn render_hermes_config(
 agent:
   max_turns: 90
   disabled_toolsets: [{upstream_disabled_toolsets}]
+approvals:
+  mode: manual
+  cron_mode: deny
 display:
   skin: mono
 platform_toolsets:
@@ -19930,6 +19933,7 @@ mcp_servers:
 
         assert!(config.contains("model:\n  default: \"glm\""));
         assert!(config.contains("  cron: [web, memory]"));
+        assert!(config.contains("approvals:\n  mode: manual\n  cron_mode: deny\n"));
         assert!(config.contains(
             "skills:\n  external_dirs:\n    - \"/Users/dev/.agents/skills\"\n    - \"/shared/team-skills\"\n"
         ));

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -51,47 +51,48 @@ const JUNE_HERMES_DISABLE_SANDBOX_ENV: &str = "JUNE_HERMES_DISABLE_SANDBOX";
 // Referenced by the spawn match arm on every target; only ever reached when
 // `prepare_sandbox` returns a profile, which it only does on macOS.
 const SANDBOX_EXEC_PATH: &str = "/usr/bin/sandbox-exec";
-// v2026.6.19 - see the bump PR for the audited pin-to-tag compatibility delta.
-const HERMES_AGENT_INSTALL_COMMIT: &str = "2bd1977d8fad185c9b4be47884f7e87f1add0ce3";
-const HERMES_RUNTIME_PATCH_SET: &str = "june-approval-memory-v13";
+// Hermes Agent v0.19.0 (v2026.7.20). See the matching upstream pin note for
+// the audited pin-to-tag compatibility delta.
+const HERMES_AGENT_INSTALL_COMMIT: &str = "3ef6bbd201263d354fd83ec55b3c306ded2eb72a";
+const HERMES_RUNTIME_PATCH_SET: &str = "june-approval-memory-v14";
 const HERMES_RUNTIME_PATCHED_SOURCE_HASHES: &[(&str, &str)] = &[
     (
         "agent/agent_init.py",
-        "58e0f7294cea8d778b15827af4e0a1d5c2d9e0a2db27b2a6697f30811053629e",
+        "a3f6f64cc7932df2de66c4a93bcaef3cfe1cccd20a927e48e023c2185c8da5a5",
     ),
     (
         "tools/approval.py",
-        "56e88034ebcac8cff8c579c56345e4cb3fe2fe597360687d40b68daefd402e3d",
+        "c0d941fd952b578739afff0096b8896f4d7f742d66518aefef0a9c9b3b344900",
     ),
     (
         "tools/mcp_tool.py",
-        "48a2fddfee5d5a8c33723e27639907e9f2cf062c82e7beeb844f457e6a372cfa",
+        "764758773737bc1c1c46d244857198eea83dfbf52c0a1460ed0bc3418c1ceb7a",
     ),
     (
         "tui_gateway/server.py",
-        "f375627e61af5e61434592d4d17d39c20e7ba1a7e1280715b0e5a7387a0f26a1",
+        "b562a6c91ce242d0d1d7b268ef9135deb633e4227e3b21c090b0f26e1a9ae923",
     ),
     (
         "cron/scheduler.py",
-        "2d82e4958494b52bcae27527e8ad64f0b730d22906e725609fda7725b410abfa",
+        "ea54407dddebec57a184f1dbdf1076f8abe94f132da1e619c476cbf1266ed239",
     ),
     (
         "model_tools.py",
-        "d7628473ee72f7ac1395f9f2fe43dc2956523b186545bf6abece1b834ac6892d",
+        "30a2dcb33685783935f66abef6839d06736c90196a89dd034c91c4e6eb65c2db",
     ),
     (
         "utils.py",
-        "08a0a0203bdee74eb8bc4f8bc31e97eb7621913deca2d087fb56c722b1304ef5",
+        "0795233ec93398fe0f13e785d8b7c66768f60ee83b29d853c24009e1558e0174",
     ),
     (
-        "gateway/platforms/telegram.py",
-        "fd996e2deaebe3ca2856167876f8ff498735744ff7c884eedd85736a7fd2c318",
+        "plugins/platforms/telegram/adapter.py",
+        "b4fab048d4986ab49615a1b5abb0dafeade4a25196578bf93cb065b793d67c8b",
     ),
 ];
 const HERMES_SOURCE_TARBALL_URL: &str =
-    "https://github.com/NousResearch/hermes-agent/archive/2bd1977d8fad185c9b4be47884f7e87f1add0ce3.tar.gz";
+    "https://github.com/NousResearch/hermes-agent/archive/3ef6bbd201263d354fd83ec55b3c306ded2eb72a.tar.gz";
 const HERMES_SOURCE_TARBALL_SHA256: &str =
-    "7a9bd367066183898831c2760f269368ab54b458a1d1b51d14ef1f484dd490cc";
+    "335c2249b6b2e58be397e12d542788f3315ede84394c0082b339a4ddde6a27d0";
 const BUNDLED_HERMES_SKILLS_RESOURCE_DIR: &str = "native/hermes-skills";
 const FILESYSTEM_MAX_DEPTH: usize = 2;
 const FILESYSTEM_MAX_ENTRIES_PER_DIR: usize = 80;
@@ -1078,7 +1079,7 @@ pub struct UpdateHermesSkillRequest {
 }
 
 /// Request to reset (or restore) a bundled skill to its shipped baseline. The
-/// dashboard REST surface (v2026.6.19) exposes no endpoint for this, so June
+/// dashboard REST surface (v2026.7.20) exposes no endpoint for this, so June
 /// runs the pinned Hermes CLI with a SAFE argument array — the skill name is
 /// validated argument-safe on both sides and passed as a discrete CLI argument,
 /// never shell-interpolated. `mode` names the runtime explicitly (`sandboxed` /
@@ -1108,7 +1109,7 @@ pub struct ResetHermesSkillResult {
 }
 
 /// Request to list, add, or remove a custom GitHub skill tap (admin surfaces
-/// spec 13). The dashboard REST surface (v2026.6.19) exposes no tap endpoints, so
+/// spec 13). The dashboard REST surface (v2026.7.20) exposes no tap endpoints, so
 /// June runs the pinned Hermes CLI with a SAFE argument array — the `owner/repo`
 /// and optional `path` are validated argument-safe on both sides and passed as
 /// discrete CLI arguments, never shell-interpolated. `mode` names the runtime
@@ -1686,7 +1687,7 @@ async fn start_hermes_bridge_inner(
     }
     let port_string = port.to_string();
     // No --tui: upstream removed the flag from the dashboard subcommand before
-    // v2026.6.19, and the embedded chat gateway (/api/ws) is always enabled.
+    // v2026.7.20, and the embedded chat gateway (/api/ws) is always enabled.
     // Passing the flag is an argparse error.
     let hermes_args: [&str; 6] = [
         "dashboard",
@@ -2563,7 +2564,7 @@ pub fn update_hermes_bridge_skill(
 // With `skills.write_approval: true`, Hermes stages agent-authored skill writes
 // (create / edit / delete) under `<hermes_home>/pending/skills/` instead of
 // applying them, and waits for a human to approve or reject the diff. The
-// dashboard REST surface (v2026.6.19) exposes NO endpoint for this queue, so
+// dashboard REST surface (v2026.7.20) exposes NO endpoint for this queue, so
 // June reads the staged manifests directly. This is the documented file-parsing
 // FALLBACK the spec sanctions; it is version-gated below by requiring a
 // recognized manifest `version`/shape and only ever touching the managed skills
@@ -5347,7 +5348,7 @@ pub async fn hermes_reset_bundled_skill(
 // Team skill taps manager (admin surfaces spec 13).
 //
 // A Hermes skill tap is a GitHub repository of reusable SKILL.md directories
-// (default under `skills/`). The dashboard REST surface (v2026.6.19) exposes NO
+// (default under `skills/`). The dashboard REST surface (v2026.7.20) exposes NO
 // tap endpoints, so June drives the pinned Hermes CLI:
 //
 //     hermes skills tap list
@@ -5462,7 +5463,7 @@ fn build_hermes_skill_tap_command(
 }
 
 /// Parses `hermes skills tap list` output into a tap list. The exact CLI format
-/// is not pinned in the v2026.6.19 contract, so this is intentionally lenient: it
+/// is not pinned in the v2026.7.20 contract, so this is intentionally lenient: it
 /// accepts one tap per line, ignores blank lines and obvious headers, extracts the
 /// first `owner/repo` token on the line, and reads an optional `path=<p>` or
 /// `(path: <p>)` hint and a `trusted`/`verified` marker. A tap whose repo token is
@@ -5735,7 +5736,7 @@ pub async fn hermes_skill_tap_remove(
 //
 // A Hermes skill bundle is a YAML alias under
 // `<hermes_home>/skill-bundles/<slug>.yaml` (per profile) that loads several
-// skills under one slash command. The dashboard REST surface (v2026.6.19)
+// skills under one slash command. The dashboard REST surface (v2026.7.20)
 // exposes NO bundle endpoints, so June reads/writes these files directly. This
 // is the narrow, sanctioned file fallback the spec calls for. These writes run
 // in June's own (un-jailed) Rust process, so the real risk is NOT permissions
@@ -8167,7 +8168,7 @@ if [ ! -f "$install_dir/pyproject.toml" ] || [ ! -f "$install_dir/scripts/instal
   mv "$unpacked_dir" "$install_dir"
 fi
 
-# Upstream's install.sh (v2026.6.19) runs $UV_CMD unquoted in the venv-create,
+# Upstream's install.sh (v2026.7.20) runs $UV_CMD unquoted in the venv-create,
 # uv-sync, and pip-install-tier calls. The managed uv it installs lives under
 # the app data dir — "Application Support" on macOS — so the space word-splits
 # the path and every one of those calls fails with "/Users/…/Library/

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -10265,7 +10265,7 @@ skills:
         model = yaml_string(model),
         base_url = yaml_string(base_url),
         provider_proxy_token = yaml_string(provider_proxy_token),
-        upstream_disabled_toolsets = &UPSTREAM_DISABLED_TOOLSETS.join(", "),
+        upstream_disabled_toolsets = UPSTREAM_DISABLED_TOOLSETS.join(", "),
     )
 }
 

--- a/src-tauri/src/meeting_calendar_context.rs
+++ b/src-tauri/src/meeting_calendar_context.rs
@@ -92,7 +92,7 @@ pub async fn enrich_note_for_recording(
                 else {
                     continue;
                 };
-                let is_better = best.as_ref().is_none_or(|current| {
+                let is_better = best.as_ref().map_or(true, |current| {
                     (candidate.distance_ms, candidate.start_distance_ms)
                         < (current.distance_ms, current.start_distance_ms)
                 });

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -582,6 +582,7 @@ function appendLiveHermesEvents(
   persistedToolResultIds: ReadonlySet<string> = new Set(),
 ) {
   let currentAssistant: AgentChatTurn | null = null;
+  let lastInterimAssistant: AgentChatTurn | null = null;
   let idlessToolSequence = 0;
   const toolCreatedTurns = new Set<AgentChatTurn>();
   const pendingSyntheticTurns = sortAgentChatTurns(
@@ -596,7 +597,10 @@ function appendLiveHermesEvents(
       const syntheticTurn = pendingSyntheticTurns.shift();
       if (!syntheticTurn) break;
       turns.push(syntheticTurn);
-      if (syntheticTurn.role !== "assistant") currentAssistant = null;
+      if (syntheticTurn.role !== "assistant") {
+        currentAssistant = null;
+        lastInterimAssistant = null;
+      }
     }
 
     // A gateway suspension can drop tool.complete while leaving tool.start in
@@ -637,16 +641,42 @@ function appendLiveHermesEvents(
       case "transcript": {
         if (!event.complete && event.delta === undefined) {
           currentAssistant = createAssistantTurn(turns, event.receivedAt);
+          lastInterimAssistant = null;
           currentAssistant.status = "running";
           break;
         }
-        currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
+        if (event.interim) {
+          const interimText = event.delta ?? "";
+          if (interimText) {
+            currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
+            completeAssistantTextPart(currentAssistant.parts, interimText);
+            currentAssistant.status = "complete";
+            completeRunningParts(currentAssistant.parts);
+            lastInterimAssistant = currentAssistant;
+            currentAssistant = null;
+          }
+          break;
+        }
         if (!event.complete) {
+          currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
           currentAssistant.status = "running";
           appendAssistantTextPart(currentAssistant.parts, event.delta ?? "", "running");
           break;
         }
         const text = event.delta ?? "";
+        const previewText = lastInterimAssistant
+          ? assistantTextFromParts(lastInterimAssistant.parts)
+          : "";
+        if (
+          !currentAssistant &&
+          event.responsePreviewed &&
+          lastInterimAssistant &&
+          text &&
+          (text.startsWith(previewText) || previewText.startsWith(text))
+        ) {
+          currentAssistant = lastInterimAssistant;
+        }
+        currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
         // A billing failure is recognizable from its "Error:" text prefix; a
         // context overflow is not, so only fold it when the turn actually
         // failed — an ordinary sentence that mentions "context length" stays prose.
@@ -682,6 +712,7 @@ function appendLiveHermesEvents(
         currentAssistant.status = "complete";
         completeRunningParts(currentAssistant.parts);
         currentAssistant = null;
+        lastInterimAssistant = null;
         break;
       }
 
@@ -1059,6 +1090,13 @@ function completeAssistantTextPart(parts: AgentChatPart[], text: string) {
   for (const part of earlier) {
     part.status = "complete";
   }
+}
+
+function assistantTextFromParts(parts: AgentChatPart[]) {
+  return parts
+    .filter((part): part is AgentChatTextPart => part.type === "text")
+    .map((part) => part.text)
+    .join("");
 }
 
 function removeAssistantTextParts(parts: AgentChatPart[]) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -34,6 +34,8 @@ export function appendHermesLiveEvent(
     event.kind === "transcript" &&
     !previous.complete &&
     !event.complete &&
+    !previous.interim &&
+    !event.interim &&
     previous.delta !== undefined &&
     event.delta !== undefined &&
     previous.sessionId === event.sessionId &&

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -649,10 +649,13 @@ function appendLiveHermesEvents(
           if (interimText) {
             currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
             completeAssistantTextPart(currentAssistant.parts, interimText);
-            currentAssistant.status = "complete";
-            completeRunningParts(currentAssistant.parts);
             lastInterimAssistant = currentAssistant;
-            currentAssistant = null;
+            if (hasActiveNonTextPart(currentAssistant.parts)) {
+              currentAssistant.status = "running";
+            } else {
+              currentAssistant.status = "complete";
+              currentAssistant = null;
+            }
           }
           break;
         }
@@ -666,13 +669,23 @@ function appendLiveHermesEvents(
         const previewText = lastInterimAssistant
           ? assistantTextFromParts(lastInterimAssistant.parts)
           : "";
-        if (
-          !currentAssistant &&
+        const settlesInterimPreview = Boolean(
           event.responsePreviewed &&
-          lastInterimAssistant &&
-          text &&
-          (text.startsWith(previewText) || previewText.startsWith(text))
+            lastInterimAssistant &&
+            text &&
+            (text.startsWith(previewText) || previewText.startsWith(text)),
+        );
+        if (
+          currentAssistant !== null &&
+          currentAssistant === lastInterimAssistant &&
+          !settlesInterimPreview
         ) {
+          currentAssistant.status = hasActiveNonTextPart(currentAssistant.parts)
+            ? "running"
+            : "complete";
+          currentAssistant = null;
+        }
+        if (!currentAssistant && settlesInterimPreview && lastInterimAssistant) {
           currentAssistant = lastInterimAssistant;
         }
         currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
@@ -1235,6 +1248,21 @@ function completeRunningParts(parts: AgentChatPart[]) {
     if (part.type === "sudo" && part.status === "pending") part.status = "resolved";
     if (part.type === "secret" && part.status === "pending") part.status = "resolved";
   }
+}
+
+function hasActiveNonTextPart(parts: AgentChatPart[]) {
+  return parts.some((part) => {
+    if (part.type === "reasoning" || part.type === "tool") return part.status === "running";
+    if (
+      part.type === "approval" ||
+      part.type === "clarify" ||
+      part.type === "sudo" ||
+      part.type === "secret"
+    ) {
+      return part.status === "pending";
+    }
+    return false;
+  });
 }
 
 function upsertToolPart(

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -599,7 +599,6 @@ function appendLiveHermesEvents(
       turns.push(syntheticTurn);
       if (syntheticTurn.role !== "assistant") {
         currentAssistant = null;
-        lastInterimAssistant = null;
       }
     }
 

--- a/src/lib/hermes-admin/client.ts
+++ b/src/lib/hermes-admin/client.ts
@@ -109,7 +109,7 @@ const DEFAULT_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_POLL_TIMEOUT_MS = 120_000;
 
 /** Payload for `POST /api/mcp/servers`, matching the dashboard's
- * `MCPServerCreate` schema (v2026.6.19): `name` is required; `command`/`args`
+ * `MCPServerCreate` schema (v2026.7.20): `name` is required; `command`/`args`
  * describe a stdio server, `url`/`auth` an http(-oauth) server; `env` carries
  * secret config. NOTE: this Hermes version's create schema has NO tool
  * include/exclude/filter field, so MCP tool filtering is not configured here
@@ -144,7 +144,7 @@ export type HermesInstallCatalogPayload = {
 } & Record<string, unknown>;
 
 /** Payload for `POST /api/profiles`, matching the dashboard's `ProfileCreate`
- * schema (v2026.6.19). `name` is the only required field.
+ * schema (v2026.7.20). `name` is the only required field.
  * `clone_from_default` seeds the new profile from June's default SOUL and
  * bundled skills unless `no_skills` is set; `keep_skills` narrows which bundled
  * skills survive; `hub_skills` installs optional hub skills at create time;
@@ -220,7 +220,7 @@ export type HermesAdminClient = {
     testServer(name: string): Promise<MutationOutcome<HermesMcpTestResult>>;
     setEnabled(name: string, enabled: boolean): Promise<MutationOutcome<HermesToggleResult>>;
     removeServer(name: string): Promise<MutationOutcome<{ ok: boolean }>>;
-    // NOTE: no setToolFilters. The v2026.6.19 dashboard exposes no
+    // NOTE: no setToolFilters. The v2026.7.20 dashboard exposes no
     // `PUT /api/mcp/servers/{name}/tools` endpoint, and `MCPServerCreate`
     // carries no include/exclude/filter field, so per-tool filtering is not
     // configurable through this contract. Track 16 owns whatever filtering UI

--- a/src/lib/hermes-control-plane/compatibility/matrix.ts
+++ b/src/lib/hermes-control-plane/compatibility/matrix.ts
@@ -8,7 +8,7 @@
  * gate `isHermesFeatureSupported` consults.
  *
  * Honesty rules this matrix is held to (see the per-pack history in
- * `../README.md` and `docs/hermes-upstream-v2026.6.19.md`):
+ * `../README.md` and `docs/hermes-upstream-v2026.7.20.md`):
  * - `"supported"` means June BOTH understands the surface AND ships UI/flow that
  *   uses it today, with tests. Nothing aspirational.
  * - `"partial"` means the seam exists (e.g. the event is classified, or a
@@ -27,9 +27,9 @@
  */
 
 /** The pinned Hermes version this matrix describes. MUST equal the version in
- * `docs/hermes-upstream-v2026.6.19.md`. Bumping the Hermes pin REQUIRES updating
+ * `docs/hermes-upstream-v2026.7.20.md`. Bumping the Hermes pin REQUIRES updating
  * this constant and re-auditing every entry below (feature 20 checklist). */
-export const PINNED_HERMES_VERSION = "v2026.6.19" as const;
+export const PINNED_HERMES_VERSION = "v2026.7.20" as const;
 
 /**
  * Support status for one matrix entry.
@@ -70,7 +70,8 @@ export type HermesCompatibilityMatrix = {
   features: HermesCompatibilitySection;
 };
 
-const PIN = PINNED_HERMES_VERSION;
+const PIN = "v2026.6.19";
+const CURRENT_PIN = PINNED_HERMES_VERSION;
 
 /**
  * Control-plane methods. Feature 01 (`methods.ts`) provides typed STUBS for the
@@ -139,6 +140,12 @@ const methods: HermesCompatibilitySection = {
       "AgentWorkspace's session menu opens a SessionUsagePanel that calls getSessionUsage and renders normalized tokens, context, and estimated cost; covered by hermes-session-usage tests.",
     since: PIN,
   },
+  "session.context_breakdown": {
+    status: "planned",
+    rationale:
+      "Hermes 0.19 exposes structured context breakdown data, but June has no context inspection UI yet.",
+    since: CURRENT_PIN,
+  },
   "config.set": {
     status: "supported",
     rationale:
@@ -197,7 +204,7 @@ const events: HermesCompatibilitySection = {
   message: {
     status: "supported",
     rationale:
-      "message.start/delta/complete classify to transcript events and render in the chat transcript.",
+      "message.start/delta/interim/complete classify to transcript events and render in the chat transcript.",
     since: PIN,
   },
   thinking: {
@@ -210,6 +217,12 @@ const events: HermesCompatibilitySection = {
     status: "supported",
     rationale: "tool.start/progress/complete classify to tool events and render as tool cards.",
     since: PIN,
+  },
+  toolOutputRisk: {
+    status: "planned",
+    rationale:
+      "Hermes 0.19 emits tool.output_risk metadata, but June does not yet render the risk disposition on tool cards.",
+    since: CURRENT_PIN,
   },
   approval: {
     status: "supported",
@@ -253,11 +266,34 @@ const events: HermesCompatibilitySection = {
       "gateway.ready, session.info, and status/lifecycle frames classify to lifecycle events and drive session status.",
     since: PIN,
   },
+  moa: {
+    status: "planned",
+    rationale:
+      "Hermes 0.19 emits moa.reference and moa.aggregating events, but June has no Mixture of Agents transcript UI.",
+    since: CURRENT_PIN,
+  },
+  reaction: {
+    status: "unsupported",
+    rationale: "Hermes 0.19 emits decorative reaction events, which June deliberately ignores.",
+    since: CURRENT_PIN,
+  },
+  terminal: {
+    status: "unsupported",
+    rationale:
+      "Hermes 0.19 exposes terminal.close events for its desktop terminal, while June does not embed the Hermes terminal surface.",
+    since: CURRENT_PIN,
+  },
+  turn: {
+    status: "planned",
+    rationale:
+      "Hermes 0.19 emits turn.start and turn.error lifecycle events, but June has not mapped them into its session status model yet.",
+    since: CURRENT_PIN,
+  },
 };
 
 /**
  * First-party feature surfaces tracked for the upgrade checklist. The upstream
- * runtime ships the capability (see docs/hermes-upstream-v2026.6.19.md), but
+ * runtime ships the capability (see docs/hermes-upstream-v2026.7.20.md), but
  * June must build the product surface before users can rely on it. These reflect
  * June's UI, not Hermes' capability.
  */
@@ -265,7 +301,7 @@ const features: HermesCompatibilitySection = {
   targetedMcpApprovals: {
     status: "supported",
     rationale:
-      "The checksum-gated june-approval-memory-v13 patch preserves MCP request identity, deduplicates retries, bounds the per-session queue, resolves a targeted approval or denial exactly once, drains timeout or disconnect fail closed, and carries the global disabled-toolset policy into desktop sessions on macOS and Windows.",
+      "The checksum-gated june-approval-memory-v14 patch preserves MCP request identity, deduplicates retries, bounds the per-session queue, resolves a targeted approval or denial exactly once, drains timeout or disconnect fail closed, and carries the global disabled-toolset policy into desktop sessions on macOS and Windows.",
     since: PIN,
   },
   backgroundSubagentWatch: {
@@ -298,6 +334,36 @@ const features: HermesCompatibilitySection = {
       "The Profiles settings surface activates the sticky Hermes profile and fresh AgentWorkspace plus note chat sessions thread that active profile into session.create.",
     since: PIN,
   },
+  secretSources: {
+    status: "planned",
+    rationale:
+      "Hermes 0.19 can resolve secrets from Bitwarden and 1Password, but June has no vault connection or secret provenance UI.",
+    since: CURRENT_PIN,
+  },
+  smartApprovals: {
+    status: "unsupported",
+    rationale:
+      "Hermes 0.19 enables model-reviewed approvals by default, but June keeps explicit human approval cards and does not expose automatic approval policy controls.",
+    since: CURRENT_PIN,
+  },
+  sessionExport: {
+    status: "planned",
+    rationale:
+      "Hermes 0.19 adds multi-format session export and redaction, but June does not expose those surfaces.",
+    since: CURRENT_PIN,
+  },
+  subscriptionManagement: {
+    status: "unsupported",
+    rationale:
+      "Hermes 0.19 adds Nous subscription RPC methods, while June uses Open Software accounts and does not expose Nous billing controls.",
+    since: CURRENT_PIN,
+  },
+  reasoningEffortControls: {
+    status: "planned",
+    rationale:
+      "Hermes 0.19 adds max and ultra reasoning effort plus per-model overrides, but June's model picker does not expose those tiers.",
+    since: CURRENT_PIN,
+  },
 };
 
 /**
@@ -306,7 +372,7 @@ const features: HermesCompatibilitySection = {
  * source above, not at runtime.
  */
 export const hermesCompatibilityMatrix: HermesCompatibilityMatrix = Object.freeze({
-  hermesVersion: PIN,
+  hermesVersion: CURRENT_PIN,
   methods: Object.freeze(methods) as HermesCompatibilitySection,
   events: Object.freeze(events) as HermesCompatibilitySection,
   features: Object.freeze(features) as HermesCompatibilitySection,

--- a/src/lib/hermes-control-plane/compatibility/matrix.ts
+++ b/src/lib/hermes-control-plane/compatibility/matrix.ts
@@ -221,7 +221,7 @@ const events: HermesCompatibilitySection = {
   toolOutputRisk: {
     status: "planned",
     rationale:
-      "Hermes 0.19 emits tool.output_risk metadata, but June does not yet render the risk disposition on tool cards.",
+      "Hermes 0.19 emits tool.output_risk metadata. June explicitly classifies it as unsupported so metadata cannot reopen or create a tool card until a dedicated risk surface ships.",
     since: CURRENT_PIN,
   },
   approval: {
@@ -343,7 +343,7 @@ const features: HermesCompatibilitySection = {
   smartApprovals: {
     status: "unsupported",
     rationale:
-      "Hermes 0.19 enables model-reviewed approvals by default, but June keeps explicit human approval cards and does not expose automatic approval policy controls.",
+      "Hermes 0.19 enables model-reviewed approvals by default, but June forces approvals.mode=manual and cron_mode=deny in its owned config so every interactive dangerous command reaches an explicit human approval card.",
     since: CURRENT_PIN,
   },
   sessionExport: {

--- a/src/lib/hermes-control-plane/event-classifier.ts
+++ b/src/lib/hermes-control-plane/event-classifier.ts
@@ -103,6 +103,18 @@ export function classifyHermesEvent(raw: HermesGatewayEvent): JuneHermesEvent {
     case "error":
       return classifyError(sessionId, payload, receivedAt);
 
+    case "tool.output_risk":
+      // Hermes 0.19 metadata, not a tool lifecycle frame. Keeping it out of
+      // the broad tool.* fallback prevents a completed card from reopening as
+      // generic progress until June has a dedicated risk-metadata surface.
+      return {
+        kind: "unsupported",
+        sessionId,
+        rawType: type,
+        sanitizedPayload: payload === undefined ? undefined : sanitizePayload(payload),
+        receivedAt,
+      };
+
     default:
       break;
   }

--- a/src/lib/hermes-control-plane/event-classifier.ts
+++ b/src/lib/hermes-control-plane/event-classifier.ts
@@ -31,6 +31,7 @@ export function classifyHermesEvent(raw: HermesGatewayEvent): JuneHermesEvent {
   switch (type) {
     case "message.start":
     case "message.delta":
+    case "message.interim":
     case "message.complete":
       return classifyTranscript(type, sessionId, payload, receivedAt);
 
@@ -142,8 +143,13 @@ function classifyTranscript(
   receivedAt: string,
 ): JuneHermesEvent {
   const complete = type === "message.complete";
+  const interim = type === "message.interim";
   const delta =
-    type === "message.delta" ? rawDeltaText(payload) : complete ? eventText(payload) : undefined;
+    type === "message.delta"
+      ? rawDeltaText(payload)
+      : complete || interim
+        ? eventText(payload)
+        : undefined;
   const failed = complete && stringValue(payload?.status)?.toLowerCase() === "error";
   return {
     kind: "transcript",
@@ -153,6 +159,8 @@ function classifyTranscript(
     // old four-key classifier fallback, so summary/status-only turns survive.
     delta,
     complete,
+    interim,
+    responsePreviewed: payload?.response_previewed === true,
     // The transcript builder gates failed-turn notices on message.complete
     // status=error; carry the same flag so the typed seam cannot drift.
     failed,

--- a/src/lib/hermes-control-plane/events.ts
+++ b/src/lib/hermes-control-plane/events.ts
@@ -173,6 +173,10 @@ export type JuneHermesEvent =
       messageId?: string;
       delta?: string;
       complete?: boolean;
+      /** Hermes 0.19 seals mid-turn assistant commentary as its own bubble. */
+      interim?: boolean;
+      /** The final response extends an already-rendered interim preview. */
+      responsePreviewed?: boolean;
       failed: boolean;
       role?: "assistant" | "user" | "system";
     })

--- a/src/lib/hermes-control-plane/raw-types.ts
+++ b/src/lib/hermes-control-plane/raw-types.ts
@@ -43,6 +43,7 @@ export type RawHermesEventName =
   // Assistant message stream
   | "message.start"
   | "message.delta"
+  | "message.interim"
   | "message.complete"
   | "thinking.delta"
   | "reasoning.delta"
@@ -127,6 +128,8 @@ export type RawHermesPayload = {
   result?: unknown;
   status?: unknown;
   role?: unknown;
+  already_streamed?: unknown;
+  response_previewed?: unknown;
 
   // Tools
   name?: unknown;

--- a/src/lib/hermes-control-plane/raw-types.ts
+++ b/src/lib/hermes-control-plane/raw-types.ts
@@ -54,6 +54,7 @@ export type RawHermesEventName =
   | "tool.start"
   | "tool.progress"
   | "tool.complete"
+  | "tool.output_risk"
   // Pending actions (require a user response)
   | "clarify.request"
   | "clarify.response"

--- a/src/lib/hermes-gateway.ts
+++ b/src/lib/hermes-gateway.ts
@@ -3,6 +3,7 @@ export type HermesGatewayEventName =
   | "session.info"
   | "message.start"
   | "message.delta"
+  | "message.interim"
   | "message.complete"
   | "thinking.delta"
   | "reasoning.delta"

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -1180,6 +1180,49 @@ describe("Agent chat runtime", () => {
     ]);
   });
 
+  it("settles an interim preview across an interleaved synthetic turn", () => {
+    const turns = buildHermesSessionChatTurns(
+      [],
+      [
+        transcriptEvent({ receivedAt: "2026-07-20T10:00:00.000Z" }),
+        transcriptEvent({
+          receivedAt: "2026-07-20T10:00:00.100Z",
+          delta: "Partial answer",
+        }),
+        transcriptEvent({
+          receivedAt: "2026-07-20T10:00:00.200Z",
+          delta: "Partial answer",
+          interim: true,
+        }),
+        transcriptEvent({
+          receivedAt: "2026-07-20T10:00:00.400Z",
+          delta: "Partial answer with verification.",
+          complete: true,
+          responsePreviewed: true,
+        }),
+      ],
+      [
+        {
+          id: "synthetic-status",
+          role: "system",
+          createdAt: "2026-07-20T10:00:00.300Z",
+          status: "complete",
+          parts: [{ type: "text", text: "Local status", status: "complete" }],
+        },
+      ],
+    );
+
+    const assistantTurns = turns.filter((turn) => turn.role === "assistant");
+    expect(assistantTurns).toHaveLength(1);
+    expect(assistantTurns[0]?.parts).toEqual([
+      {
+        type: "text",
+        text: "Partial answer with verification.",
+        status: "complete",
+      },
+    ]);
+  });
+
   it("closes a running reasoning turn when only a terminal lifecycle event follows", () => {
     const turns = buildAgentChatTurns(
       [],

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -75,6 +75,27 @@ describe("appendHermesLiveEvent", () => {
 
     expect(events).toEqual([first, tool, second, nextMessage]);
   });
+
+  it("preserves an interim boundary after its streamed delta", () => {
+    const delta = transcriptEvent({
+      messageId: "message-1",
+      delta: "The checks are clean.",
+      receivedAt: "2026-07-20T10:00:00.100Z",
+    });
+    const interim = transcriptEvent({
+      messageId: "message-1",
+      delta: "The checks are clean.",
+      interim: true,
+      receivedAt: "2026-07-20T10:00:00.200Z",
+    });
+
+    const events = [delta, interim].reduce(appendHermesLiveEvent, []);
+
+    expect(events).toEqual([delta, interim]);
+    expect(buildHermesSessionChatTurns([], events)[0]?.parts).toEqual([
+      { type: "text", text: "The checks are clean.", status: "complete" },
+    ]);
+  });
 });
 
 function reasoningEvent(

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -1112,6 +1112,74 @@ describe("Agent chat runtime", () => {
     ]);
   });
 
+  it("keeps Hermes 0.19 interim commentary when the final answer differs", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        transcriptEvent({ receivedAt: "2026-07-20T10:00:00.000Z" }),
+        transcriptEvent({
+          receivedAt: "2026-07-20T10:00:00.100Z",
+          delta: "The checks are clean.",
+        }),
+        transcriptEvent({
+          receivedAt: "2026-07-20T10:00:00.200Z",
+          delta: "The checks are clean.",
+          interim: true,
+        }),
+        transcriptEvent({
+          receivedAt: "2026-07-20T10:00:01.000Z",
+          delta: "Everything is ready to ship.",
+          complete: true,
+        }),
+      ],
+    );
+
+    expect(turns).toHaveLength(2);
+    expect(
+      turns.map((turn) =>
+        turn.parts
+          .filter((part) => part.type === "text")
+          .map((part) => part.text)
+          .join(""),
+      ),
+    ).toEqual(["The checks are clean.", "Everything is ready to ship."]);
+  });
+
+  it("settles a previewed Hermes 0.19 answer onto its interim bubble", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        transcriptEvent({ receivedAt: "2026-07-20T10:00:00.000Z" }),
+        transcriptEvent({
+          receivedAt: "2026-07-20T10:00:00.100Z",
+          delta: "Partial answer",
+        }),
+        transcriptEvent({
+          receivedAt: "2026-07-20T10:00:00.200Z",
+          delta: "Partial answer",
+          interim: true,
+        }),
+        transcriptEvent({
+          receivedAt: "2026-07-20T10:00:01.000Z",
+          delta: "Partial answer with verification.",
+          complete: true,
+          responsePreviewed: true,
+        }),
+      ],
+    );
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "text",
+        text: "Partial answer with verification.",
+        status: "complete",
+      },
+    ]);
+  });
+
   it("closes a running reasoning turn when only a terminal lifecycle event follows", () => {
     const turns = buildAgentChatTurns(
       [],

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -1223,6 +1223,79 @@ describe("Agent chat runtime", () => {
     ]);
   });
 
+  it("keeps active tool and approval cards live while sealing interim text", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        transcriptEvent({
+          receivedAt: "2026-07-20T10:00:00.000Z",
+          delta: "Checking this now.",
+        }),
+        toolEvent({
+          key: "tool-1",
+          toolCallId: "tool-1",
+          phase: "start",
+          receivedAt: "2026-07-20T10:00:00.100Z",
+          name: "search",
+        }),
+        pendingActionEvent({
+          receivedAt: "2026-07-20T10:00:00.200Z",
+          action: {
+            kind: "approval",
+            requestId: "approval-1",
+            command: "python verify.py",
+            description: "Run the verification?",
+            allowPermanent: false,
+          },
+        }),
+        transcriptEvent({
+          receivedAt: "2026-07-20T10:00:00.300Z",
+          delta: "Checking this now.",
+          interim: true,
+        }),
+        toolEvent({
+          key: "tool-1",
+          toolCallId: "tool-1",
+          phase: "complete",
+          receivedAt: "2026-07-20T10:00:00.400Z",
+          name: "search",
+          text: "Verified",
+        }),
+        pendingActionResolutionEvent({
+          receivedAt: "2026-07-20T10:00:00.500Z",
+          action: {
+            kind: "approval",
+            requestId: "approval-1",
+            command: "",
+            description: "",
+            allowPermanent: false,
+            choice: "once",
+          },
+        }),
+      ],
+    );
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.parts).toEqual([
+      { type: "text", text: "Checking this now.", status: "complete" },
+      expect.objectContaining({
+        type: "tool",
+        id: "tool-1",
+        text: "Verified",
+        status: "complete",
+      }),
+      expect.objectContaining({
+        type: "approval",
+        id: "approval-1",
+        command: "python verify.py",
+        description: "Run the verification?",
+        choice: "once",
+        status: "resolved",
+      }),
+    ]);
+  });
+
   it("closes a running reasoning turn when only a terminal lifecycle event follows", () => {
     const turns = buildAgentChatTurns(
       [],

--- a/src/test/fixtures/README.md
+++ b/src/test/fixtures/README.md
@@ -41,7 +41,7 @@ assertions hold.
 
 ## Updating fixtures when the Hermes pin changes
 
-June pins one Hermes version (`PINNED_HERMES_VERSION`, currently `v2026.6.19`).
+June pins one Hermes version (`PINNED_HERMES_VERSION`, currently `v2026.7.20`).
 When the pin bumps, the contract these fixtures encode must be re-verified
 against the new runtime so a wire change surfaces as a deliberate diff, not a
 silent break for users:

--- a/src/test/fixtures/fake-hermes-server.ts
+++ b/src/test/fixtures/fake-hermes-server.ts
@@ -270,7 +270,7 @@ export type FakeRequestLogEntry = {
   body?: unknown;
 };
 
-const PINNED_HERMES_VERSION = "v2026.6.19";
+const PINNED_HERMES_VERSION = "v2026.7.20";
 
 // ---------------------------------------------------------------------------
 // Server
@@ -502,7 +502,7 @@ export class FakeHermesServer {
         enabled: server.enabled,
       });
     }
-    // NOTE: no `/api/mcp/servers/:name/tools` route — the real v2026.6.19
+    // NOTE: no `/api/mcp/servers/:name/tools` route. The real v2026.7.20
     // dashboard does not expose one, and MCPServerCreate has no filter field.
     const removeMatch = matchPath(path, "/api/mcp/servers/:name");
     if (method === "DELETE" && removeMatch) {

--- a/src/test/hermes-admin-client.test.ts
+++ b/src/test/hermes-admin-client.test.ts
@@ -173,7 +173,7 @@ describe("HermesAdminClient — requests, auth, profile targeting", () => {
   });
 });
 
-describe("HermesAdminClient — real-contract paths and shapes (v2026.6.19)", () => {
+describe("HermesAdminClient — real-contract paths and shapes (v2026.7.20)", () => {
   it("env.set uses PUT /api/env with { key, value }, not POST", async () => {
     const { client, server } = makeAdminHarness(emptyInstallScenario());
     const outcome = await client.env.set("OPENAI_API_KEY", "sk-FAKE-abc123");

--- a/src/test/hermes-approval-patch.test.ts
+++ b/src/test/hermes-approval-patch.test.ts
@@ -66,6 +66,13 @@ describe("June Hermes compatibility patch", () => {
       expect(bundler).toContain("--upstream-root");
       expect(bundler).toContain("PATCHSET");
       expect(bundler).toContain("--verify");
+      const dashboardBuild = bundler.indexOf("prebuilding dashboard web UI");
+      const appsPrune = Math.max(
+        bundler.lastIndexOf("$out/hermes-agent/apps"),
+        bundler.lastIndexOf('(Join-Path $agentDir "apps")'),
+      );
+      expect(dashboardBuild).toBeGreaterThan(-1);
+      expect(appsPrune).toBeGreaterThan(dashboardBuild);
     }
   });
 

--- a/src/test/hermes-approval-patch.test.ts
+++ b/src/test/hermes-approval-patch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import gatewayGotchas from "../../docs/hermes-gateway-gotchas.md?raw";
-import pinNote from "../../docs/hermes-upstream-v2026.6.19.md?raw";
+import pinNote from "../../docs/hermes-upstream-v2026.7.20.md?raw";
 import upgradeChecklist from "../../docs/hermes-upgrade-checklist.md?raw";
 import macBundler from "../../scripts/bundle-hermes-runtime.sh?raw";
 import windowsBundler from "../../scripts/bundle-hermes-runtime-windows.ps1?raw";
@@ -18,7 +18,7 @@ describe("June Hermes compatibility patch", () => {
       "tools/mcp_tool.py",
       "tui_gateway/server.py",
       "utils.py",
-      "gateway/platforms/telegram.py",
+      "plugins/platforms/telegram/adapter.py",
     ]) {
       const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       expect(patcher.match(new RegExp(`"${escaped}": "[a-f0-9]{64}"`, "g"))).toHaveLength(2);
@@ -28,7 +28,7 @@ describe("June Hermes compatibility patch", () => {
       expect(patcher.match(new RegExp(`"${escaped}": "[a-f0-9]{64}"`, "g"))).toHaveLength(1);
       expect(bridge).toContain(`"${path}",`);
     }
-    expect(patcher).toContain('PATCH_SET = "june-approval-memory-v13"');
+    expect(patcher).toContain('PATCH_SET = "june-approval-memory-v14"');
     for (const provenanceSource of [
       bridge,
       compatibilityMatrix,
@@ -36,7 +36,7 @@ describe("June Hermes compatibility patch", () => {
       pinNote,
       upgradeChecklist,
     ]) {
-      expect(provenanceSource).toContain("june-approval-memory-v13");
+      expect(provenanceSource).toContain("june-approval-memory-v14");
     }
     expect(patcher).toContain("session, err = _sess_nowait(params, rid)");
     expect(patcher).toContain('upstream_request_id = getattr(context, "request_id", None)');
@@ -70,7 +70,7 @@ describe("June Hermes compatibility patch", () => {
   });
 
   it("pins managed installs to the patch set and verifies them before launch", () => {
-    expect(bridge).toContain('const HERMES_RUNTIME_PATCH_SET: &str = "june-approval-memory-v13"');
+    expect(bridge).toContain('const HERMES_RUNTIME_PATCH_SET: &str = "june-approval-memory-v14"');
     expect(bridge).toContain('include_str!("hermes/apply_june_patches.py")');
     expect(bridge).toContain("verify_managed_hermes_runtime_patch(&managed_install_dir)?");
     for (const mapName of ["PATCHED_SHA256", "POLICY_SHA256"]) {

--- a/src/test/hermes-approval-patch.test.ts
+++ b/src/test/hermes-approval-patch.test.ts
@@ -47,6 +47,10 @@ describe("June Hermes compatibility patch", () => {
     expect(patcher).toContain("tool_call_id = str(_approval_tool_call_id.get()");
     expect(patcher).toContain('if key := session.get("session_key")');
     expect(patcher).toContain('lambda data: _emit("approval.expire", sid, data)');
+    expect(patcher).not.toContain('lambda data: _emit("approval.request", sid, data)');
+    expect(
+      patcher.match(/lambda data: _emit_approval_request\(sid, data\)/g)?.length,
+    ).toBeGreaterThan(3);
     expect(patcher).toContain('disabled_toolsets=agent_cfg.get("disabled_toolsets") or [],');
     expect(patcher).toContain('"disabled_toolsets": (cfg.get("agent") or {}).get');
     expect(patcher).toContain('user_disabled = agent_cfg.get("disabled_toolsets") or []');

--- a/src/test/hermes-compatibility-matrix.test.ts
+++ b/src/test/hermes-compatibility-matrix.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../lib/hermes-control-plane/compatibility";
 import { PINNED_HERMES_VERSION } from "../lib/hermes-control-plane/compatibility";
 
-const PIN = "v2026.6.19";
+const PIN = "v2026.7.20";
 
 describe("hermes compatibility matrix — shape and pin", () => {
   it("pins the matrix to the current upstream Hermes version note", () => {
@@ -41,6 +41,13 @@ describe("hermes compatibility matrix — shape and pin", () => {
       }
     }
   });
+
+  it("preserves first-seen provenance across the 0.19 upgrade", () => {
+    expect(hermesCompatibilityMatrix.events.message?.since).toBe("v2026.6.19");
+    expect(hermesCompatibilityMatrix.methods["session.context_breakdown"]?.since).toBe(PIN);
+    expect(hermesCompatibilityMatrix.events.toolOutputRisk?.since).toBe(PIN);
+    expect(hermesCompatibilityMatrix.features.secretSources?.since).toBe(PIN);
+  });
 });
 
 describe("hermes compatibility matrix — required keys", () => {
@@ -52,6 +59,7 @@ describe("hermes compatibility matrix — required keys", () => {
       "session.branch",
       "session.compress",
       "session.usage",
+      "session.context_breakdown",
       "config.set",
       "command.dispatch",
       "subagent.interrupt",
@@ -77,6 +85,7 @@ describe("hermes compatibility matrix — required keys", () => {
       "message",
       "thinking",
       "tool",
+      "toolOutputRisk",
       "approval",
       "clarify",
       "sudo",
@@ -84,6 +93,10 @@ describe("hermes compatibility matrix — required keys", () => {
       "subagent",
       "error",
       "lifecycle",
+      "moa",
+      "reaction",
+      "terminal",
+      "turn",
     ]) {
       expect(eventKeys, `events.${required}`).toContain(required);
     }
@@ -98,6 +111,11 @@ describe("hermes compatibility matrix — required keys", () => {
       "messagingIntegrations",
       "profile-switching",
       "targetedMcpApprovals",
+      "secretSources",
+      "smartApprovals",
+      "sessionExport",
+      "subscriptionManagement",
+      "reasoningEffortControls",
     ]) {
       expect(featureKeys, `features.${required}`).toContain(required);
     }

--- a/src/test/hermes-control-plane-classifier.test.ts
+++ b/src/test/hermes-control-plane-classifier.test.ts
@@ -219,6 +219,22 @@ describe("classifyHermesEvent — reasoning", () => {
 });
 
 describe("classifyHermesEvent — tools", () => {
+  it("keeps Hermes 0.19 output-risk metadata out of tool progress cards", () => {
+    expect(
+      classifyHermesEvent(
+        event("tool.output_risk", {
+          tool_call_id: "tc1",
+          risk: "sensitive-output",
+        }),
+      ),
+    ).toMatchObject({
+      kind: "unsupported",
+      sessionId: "sess-1",
+      rawType: "tool.output_risk",
+      sanitizedPayload: { tool_call_id: "tc1", risk: "sensitive-output" },
+    });
+  });
+
   it("maps tool phases and preserves metadata for tool cards", () => {
     const start = classifyHermesEvent(
       event("tool.start", {

--- a/src/test/hermes-control-plane-classifier.test.ts
+++ b/src/test/hermes-control-plane-classifier.test.ts
@@ -24,6 +24,7 @@ const CURRENT_GATEWAY_EVENT_NAMES = [
   "session.info",
   "message.start",
   "message.delta",
+  "message.interim",
   "message.complete",
   "thinking.delta",
   "reasoning.delta",
@@ -154,6 +155,25 @@ describe("classifyHermesEvent — transcript", () => {
     } else {
       throw new Error("expected transcript");
     }
+  });
+
+  it("classifies Hermes 0.19 interim commentary as a sealed transcript segment", () => {
+    const interim = classifyHermesEvent(
+      event("message.interim", {
+        message_id: "m1",
+        text: "Let me verify that.",
+        already_streamed: true,
+      }),
+    );
+    expect(interim).toMatchObject({
+      kind: "transcript",
+      sessionId: "sess-1",
+      messageId: "m1",
+      delta: "Let me verify that.",
+      complete: false,
+      interim: true,
+      responsePreviewed: false,
+    });
   });
 
   it("marks failed completes and reads complete text from the builder's summary chain", () => {

--- a/src/test/hermes-upgrade-check.test.ts
+++ b/src/test/hermes-upgrade-check.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../lib/hermes-upgrade-check";
 import { PINNED_HERMES_VERSION } from "../lib/hermes-control-plane/compatibility";
 
-const PIN = "v2026.6.19";
+const PIN = "v2026.7.20";
 
 // The doc filenames the release-gate check (scripts/hermes-upgrade-check.ts)
 // reads and asserts agree with the matrix. Kept here so the unit test is the
@@ -32,7 +32,7 @@ function agreeingDocs(version: string): HermesUpgradeCheckDoc[] {
 
 describe("pinNoteFilenameFor — derives the pin-note path from a version", () => {
   it("builds docs/hermes-upstream-v<version>.md", () => {
-    expect(pinNoteFilenameFor(PIN)).toBe("docs/hermes-upstream-v2026.6.19.md");
+    expect(pinNoteFilenameFor(PIN)).toBe("docs/hermes-upstream-v2026.7.20.md");
   });
 });
 


### PR DESCRIPTION
## What changed

- Pin the bundled Hermes runtime to v2026.7.20 / Hermes Agent 0.19.0 and verify the upstream archive checksum.
- Rebase June's sealed compatibility patch as `june-approval-memory-v14`, including refreshed upstream and patched source hashes.
- Retire image-batch and Telegram writer transforms that Hermes 0.19 incorporated upstream.
- Preserve targeted approval identity, expiry, fail-closed queues, image/reset race protection, Memory policy, and disabled-toolset precedence.
- Handle `message.interim` as a sealed assistant segment and settle previewed final answers without duplicate bubbles.
- Audit new 0.19 methods, events, and product surfaces in the compatibility matrix.
- Strengthen the background E2E harness with explicit response assertions and current-main browser mocks.

## Why

Hermes 0.19 changes gateway events, moves the Telegram implementation, and changes every checksum-gated source file June patches. Updating only the runtime pin would make managed installs fail closed or lose June's approval and policy guarantees.

## Validation

- `pnpm test`: 3,195 passed, 2 skipped
- `pnpm build`
- `pnpm typecheck`
- `pnpm hermes:upgrade-check`
- Exact v14 patch apply, verify, tamper rejection, and compatibility protocol smoke
- Exact patched Hermes 0.19 dashboard protocol smoke
- Provider-backed browser E2E returned the required `E2E PASS` and recorded video evidence
- Scoped Biome check, Python compile, Node syntax check, and `git diff --check`

## Known local validation gap

`pnpm test:rust` compiled successfully and entered 1,196 tests, but two unrelated processing tests remained running for several minutes without output, so the local run was stopped. CI should provide the authoritative Rust result.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787186966&installation_model_id=425925&pr_number=867&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F867&signature=e3baab14cba04892743e2087114426f41ff0dbe8771575d477c952f84c1e0c67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->