### PR TITLE
Restore zero-credit live preview settlement

### DIFF
--- a/june-api/crates/services/src/charge_flow.rs
+++ b/june-api/crates/services/src/charge_flow.rs
@@ -144,6 +144,11 @@ pub(crate) struct ReleaseHoldParams<'a> {
     pub action_token: String,
 }
 
+pub(crate) enum ReleaseHoldOutcome {
+    Settled(Receipt),
+    DeferredToTtl,
+}
+
 /// Best-effort release of a Hold whose metered work failed: settles the grant
 /// at zero credits (os-accounts ADR-0032) so it stops counting against the
 /// user's concurrency cap and available balance. Before the release primitive,
@@ -152,7 +157,7 @@ pub(crate) struct ReleaseHoldParams<'a> {
 /// (the 2026-07-14 lost-transcript incident). Errors are logged, never
 /// propagated: the caller is already returning the provider failure, and an
 /// unreleased hold degrades to the old TTL-expiry behavior.
-pub(crate) async fn release_hold(params: ReleaseHoldParams<'_>) {
+pub(crate) async fn release_hold(params: ReleaseHoldParams<'_>) -> ReleaseHoldOutcome {
     // Grant-scoped key (token digest): a release can never collide with a
     // later charge of the same logical work under a fresh grant, and a
     // replayed release of the same grant settles idempotently.
@@ -169,15 +174,21 @@ pub(crate) async fn release_hold(params: ReleaseHoldParams<'_>) {
     })
     .await
     {
-        Ok(_) => tracing::info!(
-            action = params.action.as_str(),
-            "released unused hold after failed metered work"
-        ),
-        Err(error) => tracing::warn!(
-            %error,
-            action = params.action.as_str(),
-            "failed to release unused hold; it expires via TTL"
-        ),
+        Ok(receipt) => {
+            tracing::info!(
+                action = params.action.as_str(),
+                "released unused hold after failed metered work"
+            );
+            ReleaseHoldOutcome::Settled(receipt)
+        }
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                action = params.action.as_str(),
+                "failed to release unused hold; it expires via TTL"
+            );
+            ReleaseHoldOutcome::DeferredToTtl
+        }
     }
 }
 

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -627,7 +627,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn note_transcribe_preview_authorizes_dispatches_asr_and_charges_actual_credits() {
+    async fn note_transcribe_preview_settles_zero_and_identical_final_charges_actual_credits() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let transcriber = Arc::new(RecordingTranscriber::default());
         let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
@@ -645,25 +645,49 @@ mod tests {
             preview_max_audio_seconds: 30,
         });
 
-        let output = service
-            .transcribe(NoteTranscribeParams {
-                user_id: UserId("usr_123".to_string()),
-                note_id: "live-preview-session-1".to_string(),
-                audio: vec![1, 2, 3],
-                filename: "preview.wav".to_string(),
-                context: Some("Previous words".to_string()),
-                language: Some("en".to_string()),
-                model_id: ModelId("audio-model".to_string()),
-                preview: true,
-                provider_credentials: ProviderCredentials::default(),
-            })
+        let params = NoteTranscribeParams {
+            user_id: UserId("usr_123".to_string()),
+            note_id: "live-preview-session-1".to_string(),
+            audio: vec![1, 2, 3],
+            filename: "preview.wav".to_string(),
+            context: Some("Previous words".to_string()),
+            language: Some("en".to_string()),
+            model_id: ModelId("audio-model".to_string()),
+            preview: true,
+            provider_credentials: ProviderCredentials::default(),
+        };
+        let preview_output = service
+            .transcribe(params.clone())
             .await
             .expect("preview transcription succeeds");
+        let final_output = service
+            .transcribe(NoteTranscribeParams {
+                preview: false,
+                ..params
+            })
+            .await
+            .expect("final transcription succeeds");
 
-        assert_eq!(output.receipt.credits_charged.0, 4);
+        assert_eq!(preview_output.receipt.credits_charged.0, 0);
+        assert_eq!(final_output.receipt.credits_charged.0, 4);
         assert_eq!(
             os_accounts.events(),
             vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 4,
+                    hold_ttl: 60,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 0,
+                    idempotency_key: concat!(
+                        "note_transcribe_preview:usr_123:live-preview-session-1:",
+                        "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+                    )
+                    .to_string(),
+                },
                 RecordedCall::Authorize {
                     user_id: "usr_123".to_string(),
                     action: "note_transcribe".to_string(),
@@ -673,15 +697,11 @@ mod tests {
                 RecordedCall::Charge {
                     action_token: "agt_test".to_string(),
                     credits: 4,
-                    idempotency_key: concat!(
-                        "note_transcribe_preview:usr_123:live-preview-session-1:",
-                        "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
-                    )
-                    .to_string(),
+                    idempotency_key: "note_transcribe:usr_123:live-preview-session-1".to_string(),
                 },
             ]
         );
-        assert_eq!(transcriber.call_count(), 1);
+        assert_eq!(transcriber.call_count(), 2);
         assert_eq!(
             transcriber.last_context(),
             Some("Previous words".to_string())
@@ -719,7 +739,7 @@ mod tests {
                 context: None,
                 language: None,
                 model_id: ModelId("audio-model".to_string()),
-                preview: true,
+                preview: false,
                 provider_credentials: ProviderCredentials::default(),
             })
             .await
@@ -819,7 +839,7 @@ mod tests {
                 RecordedCall::Authorize {
                     user_id: "usr_123".to_string(),
                     action: "note_transcribe".to_string(),
-                    estimate: 1024,
+                    estimate: 4,
                     hold_ttl: 60,
                 },
                 release_charge_event("note_transcribe"),
@@ -997,7 +1017,7 @@ mod tests {
             vec![RecordedCall::Authorize {
                 user_id: "usr_123".to_string(),
                 action: "note_transcribe".to_string(),
-                estimate: 1024,
+                estimate: 4,
                 hold_ttl: 60,
             }]
         );

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -710,6 +710,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn note_transcribe_preview_zero_duration_keeps_a_positive_hold_gate() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: Arc::new(FixedTranscriber),
+            duration_probe: Arc::new(ZeroDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let output = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "zero-duration-preview".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "preview.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: true,
+                provider_credentials: ProviderCredentials::default(),
+            })
+            .await
+            .expect("zero-duration preview still settles successfully");
+
+        assert_eq!(output.receipt.credits_charged.0, 0);
+        assert!(matches!(
+            os_accounts.events().as_slice(),
+            [
+                RecordedCall::Authorize { estimate: 1, .. },
+                RecordedCall::Charge { credits: 0, .. }
+            ]
+        ));
+    }
+
+    #[tokio::test]
     async fn note_transcribe_hold_covers_actual_price_above_flat_estimate() {
         // Audio priced above the flat estimate must raise the hold to the
         // already-known price — otherwise the charge is clamped to the flat
@@ -1826,6 +1869,14 @@ mod tests {
     impl AudioDurationProbe for FixedDurationProbe {
         fn probe(&self, _audio: &[u8]) -> Result<Duration, DomainError> {
             Ok(Duration::from_millis(1500))
+        }
+    }
+
+    struct ZeroDurationProbe;
+
+    impl AudioDurationProbe for ZeroDurationProbe {
+        fn probe(&self, _audio: &[u8]) -> Result<Duration, DomainError> {
+            Ok(Duration::ZERO)
         }
     }
 

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -710,7 +710,123 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn note_transcribe_preview_zero_duration_keeps_a_positive_hold_gate() {
+    async fn note_transcribe_preview_charge_failure_propagates_after_transcription() {
+        let os_accounts = Arc::new(RecordingOsAccounts {
+            fail_charge: true,
+            ..RecordingOsAccounts::default()
+        });
+        let transcriber = Arc::new(RecordingTranscriber::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: transcriber.clone(),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let result = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "preview-settlement-failure".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "preview.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: true,
+                provider_credentials: ProviderCredentials::default(),
+            })
+            .await;
+
+        assert!(matches!(result, Err(ServiceError::MeteringProvider)));
+        assert_eq!(transcriber.call_count(), 1);
+        assert_eq!(
+            os_accounts.events(),
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 4,
+                    hold_ttl: 60,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 0,
+                    idempotency_key: concat!(
+                        "note_transcribe_preview:usr_123:preview-settlement-failure:",
+                        "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+                    )
+                    .to_string(),
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn note_transcribe_final_charge_failure_propagates_after_transcription() {
+        let os_accounts = Arc::new(RecordingOsAccounts {
+            fail_charge: true,
+            ..RecordingOsAccounts::default()
+        });
+        let transcriber = Arc::new(RecordingTranscriber::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: transcriber.clone(),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let result = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "final-settlement-failure".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "recording.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: false,
+                provider_credentials: ProviderCredentials::default(),
+            })
+            .await;
+
+        assert!(matches!(result, Err(ServiceError::MeteringProvider)));
+        assert_eq!(transcriber.call_count(), 1);
+        assert_eq!(
+            os_accounts.events(),
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 1024,
+                    hold_ttl: 60,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 4,
+                    idempotency_key: "note_transcribe:usr_123:final-settlement-failure".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn note_transcribe_preview_zero_duration_keeps_a_positive_hold() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
             pricing: Arc::new(PricingTable::new(models([(

--- a/june-api/crates/services/src/note_transcribe.rs
+++ b/june-api/crates/services/src/note_transcribe.rs
@@ -81,11 +81,13 @@ impl NoteTranscribeService {
             .pricing
             .price_audio_seconds(&params.model_id.0, seconds)?;
         // Preview is not charged, but its Hold remains an abuse gate sized to
-        // the already-known price. Final note transcription keeps the flat
-        // floor, and raises it when the computed price is higher so settlement
-        // cannot be silently clamped below actual usage.
+        // the already-known price. A valid header-only audio file can probe as
+        // zero seconds, so keep a one-credit minimum that still reserves an OS
+        // Accounts grant. Final note transcription keeps the flat floor, and
+        // raises it when the computed price is higher so settlement cannot be
+        // silently clamped below actual usage.
         let estimate = if params.preview {
-            actual
+            Credits(actual.0.max(1))
         } else {
             Credits(actual.0.max(self.flat_estimate_credits))
         };

--- a/june-api/crates/services/src/note_transcribe.rs
+++ b/june-api/crates/services/src/note_transcribe.rs
@@ -1,7 +1,7 @@
 use crate::{
     charge_flow::{
-        AuthorizeParams, ChargeParams, ReleaseHoldParams, authorize_or_deny, charge, clamp_to_cap,
-        log_settled, release_hold, zero_receipt,
+        AuthorizeParams, ChargeParams, ReleaseHoldOutcome, ReleaseHoldParams, authorize_or_deny,
+        charge, clamp_to_cap, release_hold, zero_receipt,
     },
     error::ServiceError,
     metering::{log_skipped_user_venice_key, uses_user_venice_key_for_model},
@@ -66,6 +66,7 @@ impl NoteTranscribeService {
             user_id = %params.user_id.0,
             note_id = %params.note_id,
             model = %params.model_id.0,
+            preview = params.preview,
             audio_bytes = params.audio.len(),
             audio_format = ?format,
             "note_transcribe: handler entered"
@@ -79,11 +80,15 @@ impl NoteTranscribeService {
         let actual = self
             .pricing
             .price_audio_seconds(&params.model_id.0, seconds)?;
-        // The Hold must cover the already-known price: the charge below is
-        // clamped to the Hold's cap, so a flat-only estimate would silently
-        // underbill any audio priced above it. The flat value remains the
-        // floor, keeping short-audio holds exactly as before.
-        let estimate = Credits(actual.0.max(self.flat_estimate_credits));
+        // Preview is not charged, but its Hold remains an abuse gate sized to
+        // the already-known price. Final note transcription keeps the flat
+        // floor, and raises it when the computed price is higher so settlement
+        // cannot be silently clamped below actual usage.
+        let estimate = if params.preview {
+            actual
+        } else {
+            Credits(actual.0.max(self.flat_estimate_credits))
+        };
         let prepared = PreparedNoteTranscription {
             params,
             format,
@@ -175,7 +180,9 @@ impl NoteTranscribeService {
         tracing::info!(
             note_id = %params.note_id,
             model = %params.model_id.0,
-            seconds,
+            preview = true,
+            probed_seconds = seconds,
+            computed_credits = actual.0,
             estimate_credits = estimate.0,
             "note_transcribe: preview request authorized"
         );
@@ -196,16 +203,29 @@ impl NoteTranscribeService {
             Err(error) => {
                 // Failed previews used to settle at the full audio price just
                 // to avoid stranding the hold; release bills nothing instead.
-                release_hold(ReleaseHoldParams {
+                let release_outcome = release_hold(ReleaseHoldParams {
                     os_accounts: self.os_accounts.as_ref(),
                     action: ActionSlug::NoteTranscribe,
                     action_token: authorization.action_token,
                 })
                 .await;
+                if let ReleaseHoldOutcome::Settled(receipt) = release_outcome {
+                    tracing::info!(
+                        user_id = %params.user_id.0,
+                        action = ActionSlug::NoteTranscribe.as_str(),
+                        note_id = %params.note_id,
+                        model = %params.model_id.0,
+                        preview = true,
+                        probed_seconds = seconds,
+                        computed_credits = actual.0,
+                        settled_credits = receipt.credits_charged.0,
+                        idempotent_replay = receipt.idempotent_replay,
+                        "settled failed note transcription"
+                    );
+                }
                 return Err(error.into());
             }
         };
-        let charge_credits = clamp_to_cap(actual, authorization.cap_credits);
         let idempotency_key = format!(
             "note_transcribe_preview:{}:{}:{}",
             params.user_id.0, params.note_id, audio_digest
@@ -213,14 +233,21 @@ impl NoteTranscribeService {
         let receipt = charge(ChargeParams {
             os_accounts: self.os_accounts.as_ref(),
             action_token: authorization.action_token,
-            credits: charge_credits,
+            credits: Credits(0),
             idempotency_key,
         })
         .await?;
         tracing::info!(
+            user_id = %params.user_id.0,
+            action = ActionSlug::NoteTranscribe.as_str(),
             note_id = %params.note_id,
-            credits_charged = receipt.credits_charged.0,
-            "note_transcribe: preview hold settled"
+            model = %params.model_id.0,
+            preview = true,
+            probed_seconds = seconds,
+            computed_credits = actual.0,
+            settled_credits = receipt.credits_charged.0,
+            idempotent_replay = receipt.idempotent_replay,
+            "settled note transcription"
         );
         Ok(NoteTranscribeOutput {
             transcript,
@@ -296,11 +323,17 @@ impl NoteTranscribeService {
             idempotency_key,
         })
         .await?;
-        log_settled(
-            ActionSlug::NoteTranscribe,
-            &params.user_id,
-            &params.model_id.0,
-            &receipt,
+        tracing::info!(
+            user_id = %params.user_id.0,
+            action = ActionSlug::NoteTranscribe.as_str(),
+            note_id = %params.note_id,
+            model = %params.model_id.0,
+            preview = false,
+            probed_seconds = seconds,
+            computed_credits = actual.0,
+            settled_credits = receipt.credits_charged.0,
+            idempotent_replay = receipt.idempotent_replay,
+            "settled note transcription",
         );
         Ok(NoteTranscribeOutput {
             transcript,

--- a/june-api/crates/services/src/note_transcribe.rs
+++ b/june-api/crates/services/src/note_transcribe.rs
@@ -80,12 +80,14 @@ impl NoteTranscribeService {
         let actual = self
             .pricing
             .price_audio_seconds(&params.model_id.0, seconds)?;
-        // Preview is not charged, but its Hold remains an abuse gate sized to
-        // the already-known price. A valid header-only audio file can probe as
-        // zero seconds, so keep a one-credit minimum that still reserves an OS
-        // Accounts grant. Final note transcription keeps the flat floor, and
-        // raises it when the computed price is higher so settlement cannot be
-        // silently clamped below actual usage.
+        // Preview is not charged, but it still takes an OS Accounts Hold sized
+        // to the already-known price. A valid header-only audio file can probe
+        // as zero seconds, so keep a one-credit minimum that reserves a grant.
+        // This preserves balance and generic open-grant checks; dedicated
+        // preview rate and concurrency limits are a separate control. Final
+        // note transcription keeps the flat floor, and raises it when the
+        // computed price is higher so settlement cannot be silently clamped
+        // below actual usage.
         let estimate = if params.preview {
             Credits(actual.0.max(1))
         } else {


### PR DESCRIPTION
## Summary

- Restore `preview=true` note transcription to a zero-credit settlement, as required by ADR-0002.
- Keep OS Accounts authorization, sizing preview Holds to the computed audio price with a one-credit minimum instead of the flat final-transcription floor. This preserves balance and generic open-grant checks, but does not bound successive free preview requests.
- Preserve normal final-transcription charging and add content-free billing-path logs for successful and failed settlement outcomes.
- Add regressions for successful preview, failed preview, an otherwise identical final request, preview denial, zero-duration audio, distinct preview chunk idempotency keys, and settlement failures after successful preview and final transcription.

Closes JUN-368

## Root cause

A prior June API change replaced the original zero-credit preview settlement with the computed audio charge while the app still submitted the saved final audio as paid transcription requests. Each live preview chunk and the later final transcription therefore settled independently under different idempotency keys. That silently contradicted ADR-0002 and charged the same recording workflow twice at the semantic level.

## Validation

- `cargo test --manifest-path june-api/Cargo.toml -p june-services note_transcribe_` - all 12 focused note-transcription regressions passed.
- `make june-api-test` - all 487 June API tests passed.
- `make june-api-fmt-check` and `make june-api-lint` - passed, including strict Clippy across all targets and features.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make verify` - full frontend, Tauri, and June API CI-parity gate passed.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make local-ci` on `8749ee8ed59b1eae8062576d0fdd4f79fbfd6bf9` - `signoff/frontend` and `signoff/rust-macos` posted as not applicable for the backend-only diff.
- High-stakes `repo-review` sizing: standards, spec-fidelity, and adversarial axes were completed locally and found no remaining material issue. Cross-harness review was not used because private-repository data sharing was not authorized; repository-native review bots are requested on this PR.
- Accepted Greptile's zero-duration Hold finding: preview authorization now has a one-credit minimum Hold while settlement remains zero, with a dedicated regression. The Hold is described narrowly as a balance and generic open-grant check, not a complete preview usage control.

- [x] Tested visually where it matters (not applicable: backend-only settlement behavior with no UI surface).
- [x] Needs a June API (backend) deploy before it works end to end: deploy the zero-credit preview settlement change.

## Out of scope

- VAD, echo rejection, or Source-processing changes.
- OS Accounts whole-credit precision.
- Note-generation pricing.
- A dedicated live-preview rate limit and concurrency budget, tracked in JUN-372.
- Executing the historical ledger audit or reporter refund from code.

## Followups

- JUN-371 tracks final-turn billing aggregation so per-turn whole-credit rounding does not inflate otherwise equivalent saved-audio duration.
- JUN-372 tracks a per-user live-preview rate limit and dedicated concurrency budget; the one-credit minimum Hold alone does not bound successive zero-credit ASR requests.
- After the June API deploy, audit and refund the reporter's historical `note_transcribe_preview:*` settlements using ledger evidence.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive billing and metering behavior is called out in the summary and root cause.
- [x] No workflow action references changed.
- [x] No desktop signing, updater, entitlement, capability, or release behavior changed.
- [ ] Backend billing, metering, and logging changes have owner review.
- [x] No user-facing copy changed.
