### PR TITLE
fix(skills): strip Windows verbatim path prefix from external dirs

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3348,6 +3348,7 @@ dependencies = [
  "cpal",
  "cua-driver-core",
  "dotenvy",
+ "dunce",
  "hound",
  "keyring",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,9 @@ dotenvy = "0.15"
 hound = "3.5"
 # fd plumbing (pipe/dup2) for the managed browser's CDP pipe transport.
 libc = "0.2"
+# Strips the Windows `\\?\` verbatim path prefix canonicalize() adds so it
+# never leaks into config.yaml or the UI. No-op on non-Windows.
+dunce = "1.0"
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls", "stream"] }
 # Pure-Rust FFT for the echo-rejection similarity gate (GCC-PHAT lag estimation).

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -10188,6 +10188,11 @@ fn push_external_skill_dir(dirs: &mut Vec<PathBuf>, dir: PathBuf, relative_base:
     if dir.as_os_str().is_empty() {
         return;
     }
+    // Strip the Windows verbatim path prefix (`\\?\`) so it never leaks into
+    // config.yaml or the UI. `canonicalize()` (and some Tauri path resolvers)
+    // add this prefix on Windows; `dunce::simplified` removes it when it is
+    // safe to do so (a no-op on non-Windows).
+    let dir = dunce::simplified(&dir).to_path_buf();
     let identity = external_skill_dir_identity(&dir, relative_base);
     if dirs
         .iter()

--- a/src/lib/hermes-admin/external-dirs-view.ts
+++ b/src/lib/hermes-admin/external-dirs-view.ts
@@ -17,7 +17,7 @@
  */
 
 import type { ExternalDirStatus } from "../tauri";
-import type { HermesSkillInfo } from "./schemas";
+import { stripWindowsVerbatimPrefix, type HermesSkillInfo } from "./schemas";
 import type { HermesAdminMode } from "./target";
 
 /** The advisory above the list, accurate to the runtime being viewed. In the
@@ -220,9 +220,11 @@ export type AddDirValidation = { ok: true; value: string } | { ok: false; reason
  * string, since the same path written two ways is still two config entries).
  * Resolution/existence is NOT required here: a path may legitimately be added
  * before it exists (it is created later, or lives on a not-yet-mounted volume),
- * and missing dirs are non-fatal. */
+ * and missing dirs are non-fatal. The Windows `\\?\` verbatim prefix is
+ * stripped before the dedup check so a picker-returned prefixed path matches
+ * an already-cleaned entry and is written clean. */
 export function validateNewDir(candidate: string, existing: readonly string[]): AddDirValidation {
-  const value = candidate.trim();
+  const value = stripWindowsVerbatimPrefix(candidate.trim());
   if (!value) {
     return { ok: false, reason: "Enter a directory path." };
   }

--- a/src/lib/hermes-admin/schemas.ts
+++ b/src/lib/hermes-admin/schemas.ts
@@ -1413,7 +1413,21 @@ export const EXTERNAL_DIRS_CONFIG_PATH = ["skills", "external_dirs"] as const;
  * `skills.external_dirs` is a list of raw path strings (which may contain `~`
  * and `${VAR}`). Tolerates the key being absent, a bare string (single dir), or
  * a list; non-string entries are dropped. Returns the raw configured strings in
- * declared order — resolution/expansion happens June-side, never here. */
+ * declared order — resolution/expansion happens June-side, never here. The
+ * Windows `\\?\` verbatim prefix is stripped so it never reaches the UI. */
+function stripWindowsVerbatimPrefix(path: string): string {
+  // `\\?\UNC\server\share` → `\\server\share` (check UNC first since it also
+  // starts with `\\?\`).
+  if (path.startsWith("\\\\?\\UNC\\")) {
+    return `\\\\${path.slice(8)}`;
+  }
+  // `\\?\C:\path` → `C:\path`
+  if (path.startsWith("\\\\?\\")) {
+    return path.slice(4);
+  }
+  return path;
+}
+
 export function readExternalDirs(config: Record<string, unknown>): string[] {
   let cursor: unknown = config;
   for (const segment of EXTERNAL_DIRS_CONFIG_PATH) {
@@ -1423,13 +1437,13 @@ export function readExternalDirs(config: Record<string, unknown>): string[] {
   }
   if (typeof cursor === "string") {
     const single = cursor.trim();
-    return single.length > 0 ? [single] : [];
+    return single.length > 0 ? [stripWindowsVerbatimPrefix(single)] : [];
   }
   if (!Array.isArray(cursor)) return [];
   const out: string[] = [];
   for (const entry of cursor) {
     const str = nonEmptyString(entry);
-    if (str) out.push(str);
+    if (str) out.push(stripWindowsVerbatimPrefix(str));
   }
   return out;
 }

--- a/src/lib/hermes-admin/schemas.ts
+++ b/src/lib/hermes-admin/schemas.ts
@@ -1415,15 +1415,28 @@ export const EXTERNAL_DIRS_CONFIG_PATH = ["skills", "external_dirs"] as const;
  * a list; non-string entries are dropped. Returns the raw configured strings in
  * declared order — resolution/expansion happens June-side, never here. The
  * Windows `\\?\` verbatim prefix is stripped so it never reaches the UI. */
-function stripWindowsVerbatimPrefix(path: string): string {
+
+/** Strips the Windows verbatim path prefix (`\\?\`) when it is safe to do so:
+ * only the drive-letter form (`\\?\X:\…` → `X:\…`) and the UNC form
+ * (`\\?\UNC\server\share` → `\\server\share`), matched case-insensitively.
+ * Other verbatim namespaces (`\\?\GLOBALROOT\…`, `\\?\Volume{…}\…`) are left
+ * unchanged because stripping the prefix can change whether the path works.
+ * Non-Windows paths are returned unchanged (the prefixes are Windows-only). */
+export function stripWindowsVerbatimPrefix(path: string): string {
+  const lower = path.toLowerCase();
   // `\\?\UNC\server\share` → `\\server\share` (check UNC first since it also
-  // starts with `\\?\`).
-  if (path.startsWith("\\\\?\\UNC\\")) {
+  // starts with `\\?\`). Case-insensitive: Windows treats `\\?\unc\` the same.
+  if (lower.startsWith("\\\\?\\unc\\")) {
     return `\\\\${path.slice(8)}`;
   }
-  // `\\?\C:\path` → `C:\path`
-  if (path.startsWith("\\\\?\\")) {
-    return path.slice(4);
+  // `\\?\X:\path` → `X:\path` — drive-letter form only. Leaves
+  // `\\?\GLOBALROOT`, `\\?\Volume{…}`, and other non-drive verbatim paths
+  // unchanged so they remain operable.
+  if (lower.startsWith("\\\\?\\")) {
+    const rest = path.slice(4);
+    if (/^[a-z]:\\/i.test(rest)) {
+      return rest;
+    }
   }
   return path;
 }

--- a/src/test/external-dirs.test.tsx
+++ b/src/test/external-dirs.test.tsx
@@ -56,6 +56,25 @@ describe("external dirs — config read", () => {
     expect(readExternalDirs({ skills: { external_dirs: "~/one" } })).toEqual(["~/one"]);
     expect(readExternalDirs({ skills: { external_dirs: ["ok", 42, "", null] } })).toEqual(["ok"]);
   });
+  it("strips the Windows verbatim path prefix from configured dirs", () => {
+    expect(
+      readExternalDirs({
+        skills: {
+          external_dirs: [
+            "\\\\?\\C:\\Users\\dev\\skills",
+            "\\\\?\\UNC\\server\\share\\skills",
+            "~/normal-skills",
+          ],
+        },
+      }),
+    ).toEqual(["C:\\Users\\dev\\skills", "\\\\server\\share\\skills", "~/normal-skills"]);
+  });
+
+  it("strips the verbatim prefix from a bare-string external_dirs entry", () => {
+    expect(readExternalDirs({ skills: { external_dirs: "\\\\?\\E:\\team-skills" } })).toEqual([
+      "E:\\team-skills",
+    ]);
+  });
 });
 
 describe("external dirs — path expansion display", () => {

--- a/src/test/external-dirs.test.tsx
+++ b/src/test/external-dirs.test.tsx
@@ -75,6 +75,25 @@ describe("external dirs — config read", () => {
       "E:\\team-skills",
     ]);
   });
+  it("strips lowercase and mixed-case verbatim prefixes", () => {
+    expect(
+      readExternalDirs({
+        skills: {
+          external_dirs: ["\\\\?\\c:\\lower", "\\\\?\\unc\\server\\share"],
+        },
+      }),
+    ).toEqual(["c:\\lower", "\\\\server\\share"]);
+  });
+
+  it("leaves non-drive verbatim namespaces unchanged", () => {
+    expect(
+      readExternalDirs({
+        skills: {
+          external_dirs: ["\\\\?\\GLOBALROOT\\Device\\Foo", "\\\\?\\Volume{guid}\\skills"],
+        },
+      }),
+    ).toEqual(["\\\\?\\GLOBALROOT\\Device\\Foo", "\\\\?\\Volume{guid}\\skills"]);
+  });
 });
 
 describe("external dirs — path expansion display", () => {
@@ -225,6 +244,12 @@ describe("external dirs — add/remove list math", () => {
     expect(validateNewDir("~/skills", ["~/skills"]).ok).toBe(false);
     const ok = validateNewDir("  ~/new  ", ["~/old"]);
     expect(ok).toEqual({ ok: true, value: "~/new" });
+  });
+  it("strips the Windows verbatim prefix and dedupes against clean paths", () => {
+    const result = validateNewDir("\\\\?\\C:\\skills", ["C:\\skills"]);
+    expect(result.ok).toBe(false);
+    const ok = validateNewDir("\\\\?\\E:\\new-skills", ["C:\\skills"]);
+    expect(ok).toEqual({ ok: true, value: "E:\\new-skills" });
   });
 
   it("adds and removes without mutating the source array", () => {


### PR DESCRIPTION
## Summary

On Windows, `Path::canonicalize()` and some Tauri path resolvers (e.g. `app.path().resource_dir()`) add the `\\?\` verbatim path prefix. These paths flowed into `config.yaml`'s `skills.external_dirs` list and accumulated across dev sessions, then rendered as weird question marks in the External skill directories settings page.

Strips the prefix in three places so it never reaches config.yaml or the UI:

- **Rust** (`push_external_skill_dir`): the single choke point where all external skill dir paths enter the merged list rendered into config.yaml. Uses `dunce::simplified` (no-op on non-Windows). `dunce` was already a transitive dependency; this promotes it to direct.
- **TS read** (`readExternalDirs`): strips on read so already-polluted config entries display clean immediately, without waiting for a Hermes restart. Only the drive-letter (`\\?\X:\...`) and UNC (`\\?\UNC\server\share`) forms are stripped, case-insensitively; other verbatim namespaces (`\\?\GLOBALROOT`, `\\?\Volume{...}`) are left unchanged to match `dunce::simplified` semantics.
- **TS add** (`validateNewDir`): strips a picker-returned candidate before the dedup check, so a `\\?\`-prefixed picker result is written clean and deduped against the already-clean `rawDirs`.

## Root cause

Windows `Path::canonicalize()` and some Tauri path resolvers add the `\\?\` verbatim (extended-length) path prefix. Bundled skill dirs from `app.path().resource_dir()` carried it, and `push_external_skill_dir` stored them verbatim into the merged list that `render_hermes_config` writes to `config.yaml`. The UI read those raw strings back and displayed the `\\?\` prefix as question marks.

## Validation

- `npx vitest run src/test/external-dirs.test.tsx` - 25/25 pass (3 new test cases: lowercase prefixes, non-drive namespaces, `validateNewDir` dedup).
- `cargo check` and `cargo fmt --check` pass.
- Biome format/lint clean on changed files.

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording). - Not yet; manual visual verification pending on macOS. Bug evidence: the screenshot in the linked thread shows `\\?\` prefixes in the External skill directories list on Windows.
- [ ] Needs a June API (backend) deploy before it works end to end. - No, pure desktop change (Rust shell + frontend), no backend contract change.

Before:
<img width="2360" height="1521" alt="image" src="https://github.com/user-attachments/assets/f248fe2a-3da4-4c17-8b24-0cf3ae042669" />

After:
<img width="2364" height="1620" alt="image" src="https://github.com/user-attachments/assets/e75a6c18-c0af-4c70-9902-fe823d006f08" />


## Out of scope

- No on-disk migration of already-polluted `config.yaml` entries. The TS read-side strip handles display; the next Hermes sync repairs drive-letter entries via `dunce`; UNC entries are display-cleaned only (stable cycle, no data loss).
- No Rust-side `\\?\UNC\` strip (`dunce::simplified` only strips `VerbatimDisk`). UNC external skill dirs are extremely rare; the TS side still strips them for display.

## Followups

None tracked.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. - None; this is a path-display fix.
- [x] Workflow action references are pinned to full-length commit SHAs. - No workflow changes.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. - Adds one direct Cargo dependency (`dunce`, already transitive); no signing/entitlement/capability change.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. - No backend changes.
- [x] User-facing copy follows the repo UI conventions. - No new user-facing copy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787220754&installation_model_id=425925&pr_number=873&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F873&signature=b5b8e1a59824b983b88837f70cc814521536b8bded011686c56336751d0c5c61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->