### PR TITLE
fix(settings): hide system audio action button on Windows

### DIFF
--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -2863,9 +2863,6 @@ function PermissionsSettingsSection({
               title="System audio"
               description="Record audio from other apps when system audio is enabled."
               status={sourcePermissionStatus(systemReadiness, macLikePlatform)}
-              onManage={onEnableSystemAudio}
-              actionLabel="Open sound settings"
-              actionText="Open"
             />
           ) : null}
         </div>
@@ -2906,15 +2903,17 @@ function PermissionRow({
         >
           <PermissionStatusIcon tone={status.tone} />
         </span>
-        <button
-          type="button"
-          className="btn btn-secondary"
-          disabled={actionDisabled}
-          aria-label={actionLabel ?? `Manage ${title} permission`}
-          onClick={onManage}
-        >
-          {actionText}
-        </button>
+        {onManage ? (
+          <button
+            type="button"
+            className="btn btn-secondary"
+            disabled={actionDisabled}
+            aria-label={actionLabel ?? `Manage ${title} permission`}
+            onClick={onManage}
+          >
+            {actionText}
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -2518,12 +2518,10 @@ describe("AppSettings", () => {
       const systemAudioRow = screen.getByText("System audio").closest(".settings-row");
       expect(systemAudioRow).not.toBeNull();
       expect(within(systemAudioRow as HTMLElement).getByLabelText("Available")).toBeInTheDocument();
-      await userEvent.click(
-        within(systemAudioRow as HTMLElement).getByRole("button", {
-          name: "Open sound settings",
-        }),
-      );
-      expect(onEnableSystemAudio).toHaveBeenCalledTimes(1);
+      // Windows has no per-app system-audio permission to grant, so the row
+      // is informational only: the "Open sound settings" action is not rendered.
+      expect(within(systemAudioRow as HTMLElement).queryByRole("button")).not.toBeInTheDocument();
+      expect(onEnableSystemAudio).not.toHaveBeenCalled();
 
       await userEvent.click(screen.getByRole("tab", { name: "Audio" }));
       await userEvent.click(


### PR DESCRIPTION
## Summary

- On Windows, the Settings → General → System audio permission row showed an "Open sound settings" / "Open" button that did nothing useful. Windows has no per-app system-audio permission to grant (June captures system audio via WASAPI loopback on the default render endpoint, not a per-app OS permission), so the button was misleading — and worse, it was only enabled when capture was already working, disabled in the one state where Sound settings might actually help.
- The Windows System audio row is now informational only: it shows the Available/Unavailable status indicator with no action button. `PermissionRow` renders the manage button only when an `onManage` handler is provided.
- macOS is unchanged — the Microphone, Accessibility, and System audio rows still pass their handlers and render their manage buttons exactly as before.

## Root cause

Windows does not have a per-app system-audio permission model. June captures system audio via WASAPI loopback on the default render endpoint (`src-tauri/src/audio/system_windows.rs`), and the readiness check returns `granted` when a default endpoint exists or `unsupported` when none does. There is no OS-level permission to grant in Settings, so an "Open sound settings" recovery action was a no-op at best. The `PermissionRow` disabled-when-`unsupported` rule also meant the button was clickable only when capture was already working, and disabled in the one case (no default output) where Sound settings could actually help.

## Validation

- Manual Windows test: confirmed the General → System audio row now shows status only, with no "Open" button.
- `pnpm vitest run src/test/app-settings.test.tsx` — 96/96 pass (Windows test updated to assert no button renders and `onEnableSystemAudio` is not called).
- `pnpm vitest run src/test/app-shortcut.test.tsx` — 39/39 pass (macOS system-audio click → `openPrivacySettings("systemAudio")` → readiness-poll flow unchanged).
- `pnpm typecheck` — clean.
- `pnpm exec biome check` on changed files — no errors (only pre-existing ratcheted warnings elsewhere).

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- check if yes; say which change -->

Before
<img width="2360" height="1521" alt="image" src="https://github.com/user-attachments/assets/d9c28b70-8bf8-4a43-910e-2cd0e56b2046" />

since  windows do not have any explicit setting about system audio this button is not responding in windows

After
<img width="2360" height="1521" alt="image" src="https://github.com/user-attachments/assets/706c0bf8-3b40-4de8-bc16-e5ae38de0899" />
hide the button

Make sure macos is not broken
<img width="2314" height="941" alt="image" src="https://github.com/user-attachments/assets/7bbbb69d-96ae-41c9-ae0a-f1ebc5040fe3" />


## Out of scope

- Optional cleanup of the now-unused `actionLabel`/`actionText` props on `PermissionRow` (flagged in review as non-blocking).
- The Rust `open_privacy_settings` Windows `systemAudio` arm intentionally stays as defensive rejection — protects against direct IPC, devtools, or stale callers.

## Followups

- Optional `PermissionRow` prop cleanup (`actionLabel`/`actionText` and the redundant `!onManage` check in `actionDisabled`) in a separate change.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787222647&installation_model_id=425925&pr_number=874&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F874&signature=aa39f0f119f760138d57aa9d4b27e4261b0ff74a74672779879a7dcc730df6b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->