### PR TITLE
feat(connectors): align Notion row with other plugin rows

### DIFF
--- a/docs/plugins/notion-prd.md
+++ b/docs/plugins/notion-prd.md
@@ -94,6 +94,24 @@ the product promise above: shipped UI must keep the preview caveat visible,
 disclose the hosted-search scope, and the connector must not claim
 selected-page-only access until the boundary is proven or enforced in Rust.
 
+Preview note, 2026-07-21 (supersedes the "keep the preview caveat visible"
+clause above for the Plugins row only): the two standing disclosure lines
+("Access may extend beyond selected pages." and "Search may include
+Notion-connected sources.") now render behind an info (i) tooltip on the
+Notion plugin row, next to the row title, instead of as always-visible
+subtitle lines. The caveat text itself is unchanged and remains reachable on
+the same row the user connects from, via the same (i) affordance pattern
+Computer use uses for its permission disclosures. The connector still must not
+claim selected-page-only access until the boundary is proven or enforced in
+Rust. A Notion connect dialog now carries both disclosure lines at the moment
+of grant, which is the stronger disclosure point: OAuth does not start until
+the user sees the access-scope and hosted-search caveats and clicks
+"Continue." The Plugins row tooltip is a directory-surface discoverability
+hint; the connect dialog is the consent surface. A visually-hidden copy of
+the disclosure text is associated with the (i) button via aria-describedby so
+screen readers encounter the caveat when navigating the row, before the dialog
+opens.
+
 ## Business model
 
 Local reads and approved publishing are Hobby if the auth design preserves the

--- a/src/components/settings/ConnectorsSection.tsx
+++ b/src/components/settings/ConnectorsSection.tsx
@@ -572,13 +572,17 @@ export function ConnectorsSection({
       // OAuth succeeded: tokens are stored. Close the consent dialog now,
       // before the runtime apply/refresh that can fail independently. A
       // runtime-apply failure after a successful grant is a transient
-      // infra issue, not a reason to re-prompt for OAuth.
+      // infra issue, not a reason to re-prompt for OAuth. The success
+      // toast is deferred until the full chain completes so the user
+      // never sees "connected" followed by an error.
       if (operationId === notionOperationIdRef.current) {
         setNotionConnectOpen(false);
-        toast.success("Notion connected");
       }
       await connectorsApplyRuntime();
       await refresh();
+      if (operationId === notionOperationIdRef.current) {
+        toast.success("Notion connected");
+      }
     } catch (err) {
       if (operationId === notionOperationIdRef.current) toast.error(messageFromError(err));
     } finally {

--- a/src/components/settings/ConnectorsSection.tsx
+++ b/src/components/settings/ConnectorsSection.tsx
@@ -1,6 +1,7 @@
 import { listen } from "@tauri-apps/api/event";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Fragment } from "react";
 import { ConnectorProviderIcon } from "../connectors/ConnectorProviderIcon";
 import { ComputerUseControl } from "../plugins/ComputerUseControl";
 import {
@@ -35,10 +36,12 @@ import {
 import { Checkbox } from "../ui/Checkbox";
 import { Dialog } from "../ui/Dialog";
 import { InlineNotice } from "../ui/InlineNotice";
+import { HoverTip } from "../ui/HoverTip";
 import { toast } from "../ui/Toaster";
 import { SettingsPageHeader } from "./AppSettings";
 import { BROWSER_USE_ENABLED } from "../../lib/feature-flags";
 import { BrowserUseCapabilityRow } from "./BrowserExtensionSettings";
+import { IconCircleInfo } from "central-icons/IconCircleInfo";
 
 // Read-only by default: Google gets mail read and calendar read, Linear gets
 // workspace read. Write scopes are opt-in checkboxes, so a fresh connect
@@ -76,20 +79,27 @@ const NOTION_SCOPE_DISCLOSURE = "Access may extend beyond selected pages.";
 
 const NOTION_SEARCH_DISCLOSURE = "Search may include Notion-connected sources.";
 
+const NOTION_CONNECT_DIALOG_DESCRIPTION =
+  "You'll sign in to Notion and approve June's access in your browser. June reads pages and workspace content for briefs and search, and creates or updates pages only with your approval.";
+
+const NOTION_CONNECT_DIALOG_TITLE = "Connect Notion";
+
+const NOTION_RECONNECT_DIALOG_TITLE = "Reconnect Notion";
+
 type NotionConnectorRowProps = {
   account: ConnectorAccount | null;
   connecting: boolean;
   disconnecting: boolean;
-  onConnect: () => void;
-  onReconnect: () => void;
   onDisconnect: () => void;
+  onOpenConnectDialog: () => void;
+  onOpenReconnectDialog: () => void;
 };
 
 type NotionConnectorState = "disconnected" | "connected" | "reconnect_required" | "unavailable";
 
 type NotionConnectorActionsProps = Pick<
   NotionConnectorRowProps,
-  "connecting" | "disconnecting" | "onConnect" | "onReconnect" | "onDisconnect"
+  "connecting" | "disconnecting" | "onDisconnect" | "onOpenConnectDialog" | "onOpenReconnectDialog"
 > & {
   state: NotionConnectorState;
 };
@@ -105,9 +115,9 @@ function NotionConnectorActions({
   state,
   connecting,
   disconnecting,
-  onConnect,
-  onReconnect,
   onDisconnect,
+  onOpenConnectDialog,
+  onOpenReconnectDialog,
 }: NotionConnectorActionsProps) {
   const busy = connecting || disconnecting;
   const disconnectButton = (
@@ -133,7 +143,7 @@ function NotionConnectorActions({
           aria-label="Reconnect Notion"
           disabled={busy}
           aria-busy={connecting || undefined}
-          onClick={onReconnect}
+          onClick={onOpenReconnectDialog}
         >
           {connecting ? "Waiting for browser…" : "Reconnect"}
         </button>
@@ -148,7 +158,7 @@ function NotionConnectorActions({
       aria-label="Connect Notion"
       disabled={busy}
       aria-busy={connecting || undefined}
-      onClick={onConnect}
+      onClick={onOpenConnectDialog}
     >
       {connecting ? "Waiting for browser…" : "Connect"}
     </button>
@@ -159,9 +169,9 @@ function NotionConnectorRow({
   account,
   connecting,
   disconnecting,
-  onConnect,
-  onReconnect,
   onDisconnect,
+  onOpenConnectDialog,
+  onOpenReconnectDialog,
 }: NotionConnectorRowProps) {
   const state = notionConnectorState(account);
   const details = {
@@ -190,12 +200,32 @@ function NotionConnectorRow({
         <ConnectorProviderIcon provider="notion" />
       </span>
       <div className="connector-main">
-        <span className="connector-name">Notion</span>
+        <span className="connector-title-line">
+          <span className="connector-name">Notion</span>
+          <HoverTip
+            tip={
+              <>
+                {NOTION_SCOPE_DISCLOSURE} {NOTION_SEARCH_DISCLOSURE}
+              </>
+            }
+            width={360}
+          >
+            <button
+              type="button"
+              className="settings-row-info-affordance"
+              aria-label="Notion privacy and access scope"
+              aria-describedby="notion-scope-disclosure"
+            >
+              <IconCircleInfo size={13} ariaHidden />
+            </button>
+          </HoverTip>
+          <span id="notion-scope-disclosure" className="visually-hidden">
+            {NOTION_SCOPE_DISCLOSURE} {NOTION_SEARCH_DISCLOSURE}
+          </span>
+        </span>
         <p className="connector-subtitle" title={subtitle}>
           {subtitle}
         </p>
-        <p className="connector-disclosure">{NOTION_SCOPE_DISCLOSURE}</p>
-        <p className="connector-disclosure">{NOTION_SEARCH_DISCLOSURE}</p>
       </div>
       <div className="connector-actions">
         {statusLabel ? (
@@ -207,9 +237,9 @@ function NotionConnectorRow({
           state={state}
           connecting={connecting}
           disconnecting={disconnecting}
-          onConnect={onConnect}
-          onReconnect={onReconnect}
           onDisconnect={onDisconnect}
+          onOpenConnectDialog={onOpenConnectDialog}
+          onOpenReconnectDialog={onOpenReconnectDialog}
         />
       </div>
     </li>
@@ -359,6 +389,8 @@ export function ConnectorsSection({
   const [obsidianDisconnecting, setObsidianDisconnecting] = useState(false);
   const [notionConnecting, setNotionConnecting] = useState(false);
   const [notionDisconnecting, setNotionDisconnecting] = useState(false);
+  const [notionConnectOpen, setNotionConnectOpen] = useState(false);
+  const [notionDialogMode, setNotionDialogMode] = useState<"connect" | "reconnect">("connect");
   const notionOperationIdRef = useRef(0);
   // Linear team-selection dialog: the account id it's open for (null =
   // closed). Kept separate from the fetched team list/selection so a fetch
@@ -539,7 +571,10 @@ export function ConnectorsSection({
       await notionConnectorConnect();
       await connectorsApplyRuntime();
       await refresh();
-      if (operationId === notionOperationIdRef.current) toast.success("Notion connected");
+      if (operationId === notionOperationIdRef.current) {
+        setNotionConnectOpen(false);
+        toast.success("Notion connected");
+      }
     } catch (err) {
       if (operationId === notionOperationIdRef.current) toast.error(messageFromError(err));
     } finally {
@@ -894,9 +929,15 @@ export function ConnectorsSection({
             account={accounts?.find((entry) => entry.provider === "notion") ?? null}
             connecting={accounts === null || notionConnecting}
             disconnecting={notionDisconnecting}
-            onConnect={() => void connectNotion()}
-            onReconnect={() => void reconnectNotion()}
             onDisconnect={() => void disconnectNotion()}
+            onOpenConnectDialog={() => {
+              setNotionDialogMode("connect");
+              setNotionConnectOpen(true);
+            }}
+            onOpenReconnectDialog={() => {
+              setNotionDialogMode("reconnect");
+              setNotionConnectOpen(true);
+            }}
           />
           <ComputerUseControl onOpenModels={onOpenModels} onOpenBilling={onOpenBilling} />
         </ul>
@@ -1092,6 +1133,51 @@ export function ConnectorsSection({
             </div>
           </>
         )}
+      </Dialog>
+      <Dialog
+        open={notionConnectOpen}
+        onClose={() => {
+          if (!notionConnecting) setNotionConnectOpen(false);
+        }}
+        title={
+          notionDialogMode === "reconnect"
+            ? NOTION_RECONNECT_DIALOG_TITLE
+            : NOTION_CONNECT_DIALOG_TITLE
+        }
+        description={NOTION_CONNECT_DIALOG_DESCRIPTION}
+        disableBackdropClose={notionConnecting}
+        footer={
+          <Fragment>
+            <button
+              type="button"
+              className="primary-action"
+              onClick={() => setNotionConnectOpen(false)}
+              disabled={notionConnecting}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="primary-action primary-solid"
+              disabled={notionConnecting}
+              aria-busy={notionConnecting || undefined}
+              onClick={() => {
+                if (notionDialogMode === "reconnect") {
+                  void reconnectNotion();
+                } else {
+                  void connectNotion();
+                }
+              }}
+            >
+              {notionConnecting ? "Waiting for browser…" : "Continue"}
+            </button>
+          </Fragment>
+        }
+      >
+        <div className="connectors-notion-disclosures">
+          <p className="connectors-notion-disclosure">{NOTION_SCOPE_DISCLOSURE}</p>
+          <p className="connectors-notion-disclosure">{NOTION_SEARCH_DISCLOSURE}</p>
+        </div>
       </Dialog>
     </section>
   );

--- a/src/components/settings/ConnectorsSection.tsx
+++ b/src/components/settings/ConnectorsSection.tsx
@@ -569,12 +569,16 @@ export function ConnectorsSection({
     setNotionConnecting(true);
     try {
       await notionConnectorConnect();
-      await connectorsApplyRuntime();
-      await refresh();
+      // OAuth succeeded: tokens are stored. Close the consent dialog now,
+      // before the runtime apply/refresh that can fail independently. A
+      // runtime-apply failure after a successful grant is a transient
+      // infra issue, not a reason to re-prompt for OAuth.
       if (operationId === notionOperationIdRef.current) {
         setNotionConnectOpen(false);
         toast.success("Notion connected");
       }
+      await connectorsApplyRuntime();
+      await refresh();
     } catch (err) {
       if (operationId === notionOperationIdRef.current) toast.error(messageFromError(err));
     } finally {
@@ -1146,6 +1150,7 @@ export function ConnectorsSection({
         }
         description={NOTION_CONNECT_DIALOG_DESCRIPTION}
         disableBackdropClose={notionConnecting}
+        closeDisabled={notionConnecting}
         footer={
           <Fragment>
             <button

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -92,7 +92,7 @@ export function Dialog({
       document.body.style.overflow = previousOverflow;
       previousFocusRef.current?.focus?.();
     };
-  }, [open]);
+  }, [open, closeDisabled]);
 
   useLayoutEffect(() => {
     if (!open || !cardRef.current) return;
@@ -128,9 +128,14 @@ export function Dialog({
           <h2 id={titleId} className="dialog-title">
             {title}
           </h2>
-          <button type="button" className="dialog-close" aria-label="Close" onClick={onClose}>
+          <button
+            type="button"
+            className="dialog-close"
+            aria-label="Close"
+            onClick={onClose}
             disabled={closeDisabled}
             aria-disabled={closeDisabled || undefined}
+          >
             <IconCrossMedium size={14} />
           </button>
         </header>

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -15,6 +15,10 @@ type DialogProps = {
   footer?: ReactNode;
   /** Disable closing on backdrop click (still closes on Esc). */
   disableBackdropClose?: boolean;
+  /** Disable all close affordances (X button, Esc, backdrop) while a
+   * consumer-side operation is in flight. The X button renders disabled;
+   * Esc and backdrop clicks are ignored. */
+  closeDisabled?: boolean;
   /** Disables default focus management when the consumer wants to take over. */
   initialFocusSelector?: string;
   /** Optional width override. Defaults to the comfortable 460px form width. */
@@ -40,6 +44,7 @@ export function Dialog({
   children,
   footer,
   disableBackdropClose = false,
+  closeDisabled = false,
   initialFocusSelector,
   width,
   className,
@@ -63,7 +68,7 @@ export function Dialog({
     function onKey(event: KeyboardEvent) {
       if (event.key === "Escape") {
         event.preventDefault();
-        onCloseRef.current();
+        if (!closeDisabled) onCloseRef.current();
         return;
       }
       if (event.key !== "Tab" || !cardRef.current) return;
@@ -105,6 +110,7 @@ export function Dialog({
       data-open="true"
       onMouseDown={(event) => {
         if (disableBackdropClose) return;
+        if (closeDisabled) return;
         if (event.target === event.currentTarget) onClose();
       }}
     >
@@ -123,6 +129,8 @@ export function Dialog({
             {title}
           </h2>
           <button type="button" className="dialog-close" aria-label="Close" onClick={onClose}>
+            disabled={closeDisabled}
+            aria-disabled={closeDisabled || undefined}
             <IconCrossMedium size={14} />
           </button>
         </header>

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -61,6 +61,16 @@ export function Dialog({
   useEffect(() => {
     onCloseRef.current = onClose;
   }, [onClose]);
+  // Keep closeDisabled live for the keydown effect without making it a
+  // dependency, mirroring the onCloseRef pattern above. Toggling the close
+  // lock (e.g. the Notion consent dialog entering/leaving the "waiting for
+  // browser" state on OAuth failure) would otherwise tear the keydown
+  // effect down and re-run it — churning the listener and refocusing
+  // `previousFocus` unnecessarily while the dialog stays open.
+  const closeDisabledRef = useRef(closeDisabled);
+  useEffect(() => {
+    closeDisabledRef.current = closeDisabled;
+  }, [closeDisabled]);
 
   useEffect(() => {
     if (!open) return;
@@ -68,7 +78,7 @@ export function Dialog({
     function onKey(event: KeyboardEvent) {
       if (event.key === "Escape") {
         event.preventDefault();
-        if (!closeDisabled) onCloseRef.current();
+        if (!closeDisabledRef.current) onCloseRef.current();
         return;
       }
       if (event.key !== "Tab" || !cardRef.current) return;
@@ -92,7 +102,7 @@ export function Dialog({
       document.body.style.overflow = previousOverflow;
       previousFocusRef.current?.focus?.();
     };
-  }, [open, closeDisabled]);
+  }, [open]);
 
   useLayoutEffect(() => {
     if (!open || !cardRef.current) return;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6160,6 +6160,18 @@ button.agent-user-attachment:hover {
   border: 0;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .agent-follow-up-actions {
   display: flex;
   align-items: center;
@@ -26983,14 +26995,23 @@ button.memory-project:hover {
   line-height: 1.4;
 }
 
-.connector-disclosure {
+.connector-title-line {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.connectors-notion-disclosures {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.connectors-notion-disclosure {
   margin: 0;
-  overflow: hidden;
   color: var(--muted-foreground);
-  font-size: var(--fs-xs);
-  line-height: 1.35;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  font-size: var(--fs-sm);
+  line-height: 1.4;
 }
 
 .connector-actions {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -22064,6 +22064,11 @@ button.memory-project:hover {
   color: var(--foreground);
 }
 
+.dialog-close:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .dialog-description {
   margin: calc(-1 * var(--sp-3)) 0 0;
   color: var(--muted-foreground);

--- a/src/test/connectors-section.test.tsx
+++ b/src/test/connectors-section.test.tsx
@@ -415,10 +415,28 @@ describe("ConnectorsSection", () => {
     expect(
       screen.getByText(/Pages and workspace content for briefs, search, and approved updates/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Access may extend beyond selected pages/i)).toBeInTheDocument();
-    expect(screen.getByText(/Search may include Notion-connected sources/i)).toBeInTheDocument();
+    await userEvent.hover(screen.getByRole("button", { name: "Notion privacy and access scope" }));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      /Access may extend beyond selected pages/i,
+    );
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      /Search may include Notion-connected sources/i,
+    );
 
     await userEvent.click(connect);
+
+    expect(mocks.notionConnectorConnect).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/You'll sign in to Notion and approve June's access/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/Access may extend beyond selected pages/i).length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(
+      screen.getAllByText(/Search may include Notion-connected sources/i).length,
+    ).toBeGreaterThanOrEqual(2);
+
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     await waitFor(() => expect(mocks.notionConnectorConnect).toHaveBeenCalled());
     expect(mocks.connectorsConnect).not.toHaveBeenCalled();
@@ -441,8 +459,13 @@ describe("ConnectorsSection", () => {
 
     expect(await screen.findByText("Connected")).toBeInTheDocument();
     expect(screen.getByText(/Pages, search, and approved updates/i)).toBeInTheDocument();
-    expect(screen.getByText(/Access may extend beyond selected pages/i)).toBeInTheDocument();
-    expect(screen.getByText(/Search may include Notion-connected sources/i)).toBeInTheDocument();
+    await userEvent.hover(screen.getByRole("button", { name: "Notion privacy and access scope" }));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      /Access may extend beyond selected pages/i,
+    );
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      /Search may include Notion-connected sources/i,
+    );
 
     mocks.connectorsList.mockResolvedValue([]);
     await userEvent.click(screen.getByRole("button", { name: "Disconnect Notion" }));
@@ -470,9 +493,26 @@ describe("ConnectorsSection", () => {
     expect(
       screen.getByText(/Reconnect Notion to restore pages, search, and approved updates/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Access may extend beyond selected pages/i)).toBeInTheDocument();
-    expect(screen.getByText(/Search may include Notion-connected sources/i)).toBeInTheDocument();
+    await userEvent.hover(screen.getByRole("button", { name: "Notion privacy and access scope" }));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      /Access may extend beyond selected pages/i,
+    );
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      /Search may include Notion-connected sources/i,
+    );
     await userEvent.click(screen.getByRole("button", { name: "Reconnect Notion" }));
+    expect(mocks.notionConnectorConnect).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/You'll sign in to Notion and approve June's access/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/Access may extend beyond selected pages/i).length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(
+      screen.getAllByText(/Search may include Notion-connected sources/i).length,
+    ).toBeGreaterThanOrEqual(2);
+
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
     await waitFor(() => expect(mocks.notionConnectorConnect).toHaveBeenCalled());
   });
 
@@ -495,7 +535,13 @@ describe("ConnectorsSection", () => {
     expect(
       screen.getByText("June could not confirm the Notion connection. Try again in a moment."),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Access may extend beyond selected pages/i)).toBeInTheDocument();
+    await userEvent.hover(screen.getByRole("button", { name: "Notion privacy and access scope" }));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      /Access may extend beyond selected pages/i,
+    );
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      /Search may include Notion-connected sources/i,
+    );
     expect(screen.queryByRole("button", { name: "Connect Notion" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Reconnect Notion" })).toBeNull();
     await userEvent.click(screen.getByRole("button", { name: "Disconnect Notion" }));
@@ -523,6 +569,8 @@ describe("ConnectorsSection", () => {
 
     await userEvent.click(await screen.findByRole("button", { name: "Reconnect Notion" }));
 
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Reconnect Notion" })).toBeDisabled(),
     );
@@ -546,6 +594,7 @@ describe("ConnectorsSection", () => {
     render(<ConnectorsSection />);
 
     await userEvent.click(await screen.findByRole("button", { name: "Reconnect Notion" }));
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
     await userEvent.click(screen.getByRole("button", { name: "Disconnect Notion" }));
 
     expect(mocks.notionConnectorDisconnect).not.toHaveBeenCalled();

--- a/src/test/connectors-section.test.tsx
+++ b/src/test/connectors-section.test.tsx
@@ -426,6 +426,7 @@ describe("ConnectorsSection", () => {
     await userEvent.click(connect);
 
     expect(mocks.notionConnectorConnect).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog", { name: "Connect Notion" })).toBeInTheDocument();
     expect(
       screen.getByText(/You'll sign in to Notion and approve June's access/i),
     ).toBeInTheDocument();
@@ -436,10 +437,33 @@ describe("ConnectorsSection", () => {
       screen.getAllByText(/Search may include Notion-connected sources/i).length,
     ).toBeGreaterThanOrEqual(2);
 
+    // The (i) button's aria-describedby must resolve to exactly one element
+    // containing both disclosure strings, so screen readers encounter the
+    // caveat when navigating the row.
+    const infoButton = screen.getByRole("button", { name: "Notion privacy and access scope" });
+    const describedById = infoButton.getAttribute("aria-describedby");
+    expect(describedById).toBe("notion-scope-disclosure");
+    const describedByTarget = document.getElementById("notion-scope-disclosure");
+    expect(describedByTarget).not.toBeNull();
+    expect(describedByTarget).toHaveTextContent(/Access may extend beyond selected pages/i);
+    expect(describedByTarget).toHaveTextContent(/Search may include Notion-connected sources/i);
+
     await userEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     await waitFor(() => expect(mocks.notionConnectorConnect).toHaveBeenCalled());
     expect(mocks.connectorsConnect).not.toHaveBeenCalled();
+  });
+
+  it("keeps the Notion dialog open and shows an error when OAuth fails", async () => {
+    mocks.notionConnectorConnect.mockRejectedValue(new Error("OAuth rejected"));
+    render(<ConnectorsSection />);
+
+    await userEvent.click(await findEnabledConnect("Connect Notion"));
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => expect(mocks.notionConnectorConnect).toHaveBeenCalled());
+    // Dialog stays open after an OAuth failure so the user can retry.
+    expect(screen.getByRole("dialog", { name: "Connect Notion" })).toBeInTheDocument();
   });
 
   it("shows connected Notion preview state and disconnects locally", async () => {
@@ -502,6 +526,7 @@ describe("ConnectorsSection", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "Reconnect Notion" }));
     expect(mocks.notionConnectorConnect).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog", { name: "Reconnect Notion" })).toBeInTheDocument();
     expect(
       screen.getByText(/You'll sign in to Notion and approve June's access/i),
     ).toBeInTheDocument();

--- a/src/test/dialog-close-lock.test.tsx
+++ b/src/test/dialog-close-lock.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Dialog } from "../components/ui/Dialog";
+
+describe("Dialog close lock", () => {
+  it("keeps DOM focus inside the dialog when closeDisabled toggles while open", () => {
+    // Regression: adding closeDisabled to the keydown effect deps tore the
+    // effect down (and refocused `previousFocus` in its cleanup) every time
+    // the close lock toggled while the dialog stayed open. With focus back on
+    // the row behind an aria-modal dialog, Tab walked the settings page.
+    const externalButton = document.createElement("button");
+    externalButton.textContent = "Outside trigger";
+    document.body.appendChild(externalButton);
+    externalButton.focus();
+    expect(document.activeElement).toBe(externalButton);
+
+    const onClosed = vi.fn();
+    let closeDisabled = false;
+
+    // Render with closeDisabled=false, then re-render with true and false
+    // again while the dialog stays open, and assert focus never returns to
+    // the external button behind the modal.
+    const { rerender } = render(
+      <Dialog
+        open
+        onClose={onClosed}
+        title="Lock test"
+        closeDisabled={closeDisabled}
+        footer={<button type="button">Footer action</button>}
+      >
+        <p>Body</p>
+      </Dialog>,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Lock test" });
+    // On open, the Dialog focuses the first focusable inside the card.
+    expect(dialog.contains(document.activeElement)).toBe(true);
+
+    // Toggle the close lock on (e.g. OAuth in flight) and back off (e.g.
+    // OAuth failed, dialog stays open). Focus must stay inside the dialog,
+    // not bounce back to the external trigger behind the modal.
+    closeDisabled = true;
+    rerender(
+      <Dialog
+        open
+        onClose={onClosed}
+        title="Lock test"
+        closeDisabled={closeDisabled}
+        footer={<button type="button">Footer action</button>}
+      >
+        <p>Body</p>
+      </Dialog>,
+    );
+    expect(dialog.contains(document.activeElement)).toBe(true);
+
+    closeDisabled = false;
+    rerender(
+      <Dialog
+        open
+        onClose={onClosed}
+        title="Lock test"
+        closeDisabled={closeDisabled}
+        footer={<button type="button">Footer action</button>}
+      >
+        <p>Body</p>
+      </Dialog>,
+    );
+    expect(dialog.contains(document.activeElement)).toBe(true);
+    expect(externalButton.contains(document.activeElement)).toBe(false);
+
+    document.body.removeChild(externalButton);
+  });
+});


### PR DESCRIPTION
## Summary

- The two always-visible Notion disclosure lines on the Plugins row ("Access may extend beyond selected pages." and "Search may include Notion-connected sources.") now render behind an info (i) HoverTip next to the row title, matching the Computer use pattern. The row subtitle becomes just the state blurb (e.g. "Pages and workspace content for briefs, search, and approved updates.").
- A new Notion connect dialog carries both disclosure lines at grant time, so OAuth does not start until the user sees the access-scope and hosted-search caveats and clicks Continue. The Plugins row tooltip is a directory-surface discoverability hint; the connect dialog is the consent surface.
- A visually-hidden copy of the disclosure text is associated with the (i) button via aria-describedby so screen readers encounter the caveat when navigating the row, before the dialog opens.
- Added an optional closeDisabled prop to the shared Dialog component so the X button, Esc, and backdrop are accurately disabled during the browser wait. The Notion connect dialog uses it while notionConnecting is true.
- The consent dialog now closes immediately after notionConnectorConnect() resolves, before connectorsApplyRuntime() — a runtime-apply failure after a successful grant is a transient infra issue, not a reason to re-prompt for OAuth. Genuine OAuth failures still leave the dialog open so the user can retry via Continue.
- PRD addendum (docs/plugins/notion-prd.md) records the supersede of the 2026-07-16 "keep the preview caveat visible" clause for the Plugins row, accurately describing the connect dialog as the consent surface and the aria-describedby association.

## Root cause

N/A — feature change. The two follow-up fixes address review findings from two rounds of code review: (1) the connect dialog not gating OAuth, (2) the (i) button not programmatically associated with disclosure text for screen readers, and (3) the dialog not closing on OAuth success when runtime apply fails.

## Validation

- pnpm typecheck — clean
- pnpm vitest run src/test/connectors-section.test.tsx — 41/41 pass (includes new failure-stays-open test and aria-describedby association assertion)
- pnpm vitest run src/test/computer-use-control.test.tsx — 12/12 pass (HoverTip unaffected)
- pnpm vitest run src/test/dialog-layering.test.ts — 3/3 pass (shared Dialog change unaffected)
- biome check on changed files — no errors
- Manually tested in the running app: the (i) tooltip renders on hover, the connect dialog opens on Connect/Reconnect, Continue starts OAuth, the X button is disabled during the browser wait.

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [x] Needs a June API (backend) deploy before it works end to end. — No. Desktop-only frontend change; no backend contract touched.

Before
<img width="1199" height="752" alt="image" src="https://github.com/user-attachments/assets/a48f2f27-cb8b-426c-b71d-1991e5e1d500" />


After
<img width="1204" height="500" alt="image" src="https://github.com/user-attachments/assets/395363c4-cf5f-4bb7-a06c-5cf90ea0bc9a" />

## Out of scope

- Computer use connector section is unchanged (only read as the reference pattern for the (i) tooltip).
- Other connector rows (Google, Linear, Obsidian, Browser use) are unchanged.
- Notion cancellation-during-browser-wait: wiring a cancel command to the dialog's disabled close affordance is deferred (see Followups).
- The .visually-hidden CSS class is added as a standalone utility; consolidating the existing .agent-follow-up-announcement clip-rect class into it is out of scope.

## Followups

- Wire a Notion cancellation command to the dialog's close affordance so the user can abort an abandoned browser wait before the 300s backend timeout. The current Notion cancellation sender is only installed after discovery/registration and browser launch, so blindly calling it immediately has an early-cancel race — needs a Rust-side change to make cancellation valid for the entire connect operation.
- Optionally tighten the getAllByText(...).length >= 2 test assertions to exact counts if the duplicate disclosure text (visually-hidden span + dialog body) becomes a maintenance concern.

## Security and release checklist

- [x] No secrets, local .env values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. — The Notion access-scope and hosted-search disclosures are a documented privacy boundary; this change moves them from always-visible to a tooltip + consent dialog, with a PRD addendum recording the supersede. The disclosure text itself is unchanged.
- [x] Workflow action references are pinned to full-length commit SHAs. — No workflow changes.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. — None.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. — None.
- [x] User-facing copy follows the repo UI conventions. — Sentence case, no en/em dashes, central-icons only, design tokens used.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787223733&installation_model_id=425925&pr_number=875&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F875&signature=6d79b9a7abec0eb44f4dcdd576979c0e243dc02444e4aa80db329b1e67df9ff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->