### PR TITLE
feat: live transcription becomes a disclosed, optional, billed feature (JUN-375)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -146,7 +146,9 @@ never written to `transcripts`, never the note's source of truth (see
 [ADR-0002](docs/adr/0002-live-transcript-preview-strategy.md)). The Settings
 control for it is labeled **Live transcription** (default on); its disclosure
 copy is the consent surface that makes previews billable extra usage, and
-turning it off stops the preview lanes entirely (JUN-375, ADR-0002 addendum).
+turning it off stops the preview lanes (gated at capture start and re-checked
+per chunk, so it also takes effect mid-recording) (JUN-375, ADR-0002
+addendum).
 _Avoid_: realtime transcription, live captions, streaming.
 
 **Transcript coverage**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -143,7 +143,10 @@ _Avoid_: conversion, resampling (that is one step of it).
 **Live transcript preview**:
 Optional, ephemeral chunked transcription shown while recording. Revisable,
 never written to `transcripts`, never the note's source of truth (see
-[ADR-0002](docs/adr/0002-live-transcript-preview-strategy.md)).
+[ADR-0002](docs/adr/0002-live-transcript-preview-strategy.md)). The Settings
+control for it is labeled **Live transcription** (default on); its disclosure
+copy is the consent surface that makes previews billable extra usage, and
+turning it off stops the preview lanes entirely (JUN-375, ADR-0002 addendum).
 _Avoid_: realtime transcription, live captions, streaming.
 
 **Transcript coverage**:

--- a/docs/adr/0002-live-transcript-preview-strategy.md
+++ b/docs/adr/0002-live-transcript-preview-strategy.md
@@ -15,14 +15,22 @@ and the matching open question). Narrowly superseded:
   advanced setting, default on, whose copy discloses that the preview
   transcribes audio twice and may use extra credits. A preview request from a
   build that carries this setting is consented billable usage and settles at
-  the actual computed price.
-- Turning the setting off stops both preview lanes at the capture source: no
-  preview audio leaves the device and nothing is authorized or billed.
+  the computed price clamped to the granted hold.
+- Turning the setting off gates both preview lanes at the capture source, so
+  a recording started with the setting off runs no preview lanes at all: no
+  preview audio leaves the device and nothing is authorized or billed. The
+  setting is also re-read per preview chunk in both lane workers, so turning
+  it off mid-recording stops new preview dispatch (and its billing) promptly
+  - at most one in-flight chunk completes - and turning it back on
+  mid-recording resumes the preview.
 - Wire compatibility is preserved: the desktop adds an optional
   `previewOptedIn` form field to preview transcription requests. June API
-  settles opted-in previews at actual price; requests without the flag (every
-  shipped client that predates the setting) keep the zero-credit settlement
-  from PR #869. No existing field or endpoint changed shape.
+  settles opted-in previews at the computed price clamped to the granted
+  hold cap (same `clamp_to_cap` as the final path, so a partial grant never
+  hard-fails settlement after a successful transcription); requests without
+  the flag (every shipped client that predates the setting) keep the
+  zero-credit settlement from PR #869. No existing field or endpoint changed
+  shape.
 - Preview charges stay distinguishable in the ledger: the preview path keeps
   its `note_transcribe_preview:*` idempotency-key prefix, separate from the
   final `note_transcribe:*` charge for the same recording.

--- a/docs/adr/0002-live-transcript-preview-strategy.md
+++ b/docs/adr/0002-live-transcript-preview-strategy.md
@@ -4,6 +4,32 @@
 
 accepted - Phase 1 microphone preview implemented
 
+## Addendum - 2026-07-21 (JUN-375: disclosed, optional, billed live transcription)
+
+Resolves the billing question this decision deferred ("Do not bill users for
+both preview and final transcription without an explicit product decision",
+and the matching open question). Narrowly superseded:
+
+- The Phase 1 zero-credit preview settlement was the no-consent-surface
+  default, not a permanent stance. June now ships a **Live transcription**
+  advanced setting, default on, whose copy discloses that the preview
+  transcribes audio twice and may use extra credits. A preview request from a
+  build that carries this setting is consented billable usage and settles at
+  the actual computed price.
+- Turning the setting off stops both preview lanes at the capture source: no
+  preview audio leaves the device and nothing is authorized or billed.
+- Wire compatibility is preserved: the desktop adds an optional
+  `previewOptedIn` form field to preview transcription requests. June API
+  settles opted-in previews at actual price; requests without the flag (every
+  shipped client that predates the setting) keep the zero-credit settlement
+  from PR #869. No existing field or endpoint changed shape.
+- Preview charges stay distinguishable in the ledger: the preview path keeps
+  its `note_transcribe_preview:*` idempotency-key prefix, separate from the
+  final `note_transcribe:*` charge for the same recording.
+
+Preview rate limiting for unconsented legacy clients remains open under
+JUN-372.
+
 ## Context
 
 Users want to see words appear while June is taking meeting notes. The product

--- a/june-api/crates/api/src/handlers/notes.rs
+++ b/june-api/crates/api/src/handlers/notes.rs
@@ -66,6 +66,11 @@ pub(crate) async fn transcribe(
     // live-preview semantics; NoteTranscribeService still probes duration,
     // enforces the preview cap, and gates ASR through OS Accounts.
     let preview = parse_preview_flag(form.optional_text("preview").as_deref());
+    // Sent only by builds whose Live transcription setting discloses preview
+    // cost; absence keeps the legacy zero-credit preview settlement. Not an
+    // authorization decision - billing still flows through OS Accounts.
+    let preview_opted_in =
+        preview && parse_preview_flag(form.optional_text("previewOptedIn").as_deref());
     let note_id = form.required_text("noteId")?;
     validation::validate_text_len("note_id", &note_id, validation::MAX_ID_CHARS)?;
     let filename = form
@@ -82,6 +87,7 @@ pub(crate) async fn transcribe(
             language,
             model_id: ModelId(model_id),
             preview,
+            preview_opted_in,
             provider_credentials,
         })
         .await?;

--- a/june-api/crates/services/src/charge_flow.rs
+++ b/june-api/crates/services/src/charge_flow.rs
@@ -144,6 +144,11 @@ pub(crate) struct ReleaseHoldParams<'a> {
     pub action_token: String,
 }
 
+pub(crate) enum ReleaseHoldOutcome {
+    Settled(Receipt),
+    DeferredToTtl,
+}
+
 /// Best-effort release of a Hold whose metered work failed: settles the grant
 /// at zero credits (os-accounts ADR-0032) so it stops counting against the
 /// user's concurrency cap and available balance. Before the release primitive,
@@ -152,7 +157,7 @@ pub(crate) struct ReleaseHoldParams<'a> {
 /// (the 2026-07-14 lost-transcript incident). Errors are logged, never
 /// propagated: the caller is already returning the provider failure, and an
 /// unreleased hold degrades to the old TTL-expiry behavior.
-pub(crate) async fn release_hold(params: ReleaseHoldParams<'_>) {
+pub(crate) async fn release_hold(params: ReleaseHoldParams<'_>) -> ReleaseHoldOutcome {
     // Grant-scoped key (token digest): a release can never collide with a
     // later charge of the same logical work under a fresh grant, and a
     // replayed release of the same grant settles idempotently.
@@ -169,15 +174,21 @@ pub(crate) async fn release_hold(params: ReleaseHoldParams<'_>) {
     })
     .await
     {
-        Ok(_) => tracing::info!(
-            action = params.action.as_str(),
-            "released unused hold after failed metered work"
-        ),
-        Err(error) => tracing::warn!(
-            %error,
-            action = params.action.as_str(),
-            "failed to release unused hold; it expires via TTL"
-        ),
+        Ok(receipt) => {
+            tracing::info!(
+                action = params.action.as_str(),
+                "released unused hold after failed metered work"
+            );
+            ReleaseHoldOutcome::Settled(receipt)
+        }
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                action = params.action.as_str(),
+                "failed to release unused hold; it expires via TTL"
+            );
+            ReleaseHoldOutcome::DeferredToTtl
+        }
     }
 }
 

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -618,12 +618,57 @@ mod tests {
                 language: None,
                 model_id: ModelId("audio-model".to_string()),
                 preview: false,
+                preview_opted_in: false,
                 provider_credentials: ProviderCredentials::default(),
             })
             .await;
 
         assert!(matches!(result, Err(ServiceError::InvalidInput { .. })));
         assert_eq!(os_accounts.events(), Vec::new());
+    }
+
+    #[tokio::test]
+    async fn note_transcribe_opted_in_preview_settles_actual_credits() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let transcriber = Arc::new(RecordingTranscriber::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: transcriber.clone(),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let output = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "live-preview-opted-1".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "preview.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: true,
+                preview_opted_in: true,
+                provider_credentials: ProviderCredentials::default(),
+            })
+            .await
+            .expect("opted-in preview transcription succeeds");
+
+        // Consented preview bills the computed price instead of zero; the
+        // authorization hold is unchanged.
+        assert_eq!(output.receipt.credits_charged.0, 4);
+        assert!(os_accounts.events().iter().any(|event| matches!(
+            event,
+            RecordedCall::Charge { credits: 4, .. }
+        )));
     }
 
     #[tokio::test]
@@ -654,6 +699,7 @@ mod tests {
             language: Some("en".to_string()),
             model_id: ModelId("audio-model".to_string()),
             preview: true,
+            preview_opted_in: false,
             provider_credentials: ProviderCredentials::default(),
         };
         let preview_output = service
@@ -663,6 +709,7 @@ mod tests {
         let final_output = service
             .transcribe(NoteTranscribeParams {
                 preview: false,
+                preview_opted_in: false,
                 ..params
             })
             .await
@@ -741,6 +788,7 @@ mod tests {
                 language: None,
                 model_id: ModelId("audio-model".to_string()),
                 preview: true,
+                preview_opted_in: false,
                 provider_credentials: ProviderCredentials::default(),
             })
             .await;
@@ -801,6 +849,7 @@ mod tests {
                 language: None,
                 model_id: ModelId("audio-model".to_string()),
                 preview: false,
+                preview_opted_in: false,
                 provider_credentials: ProviderCredentials::default(),
             })
             .await;
@@ -853,6 +902,7 @@ mod tests {
                 language: None,
                 model_id: ModelId("audio-model".to_string()),
                 preview: true,
+                preview_opted_in: false,
                 provider_credentials: ProviderCredentials::default(),
             })
             .await
@@ -899,6 +949,7 @@ mod tests {
                 language: None,
                 model_id: ModelId("audio-model".to_string()),
                 preview: false,
+                preview_opted_in: false,
                 provider_credentials: ProviderCredentials::default(),
             })
             .await
@@ -946,6 +997,7 @@ mod tests {
                     language: None,
                     model_id: ModelId("audio-model".to_string()),
                     preview,
+                    preview_opted_in: false,
                     provider_credentials: user_venice_credentials(),
                 })
                 .await
@@ -985,6 +1037,7 @@ mod tests {
                 language: None,
                 model_id: ModelId("audio-model".to_string()),
                 preview: true,
+                preview_opted_in: false,
                 provider_credentials: ProviderCredentials::default(),
             })
             .await;
@@ -1047,6 +1100,7 @@ mod tests {
                 language: None,
                 model_id: ModelId("audio-model".to_string()),
                 preview: false,
+                preview_opted_in: false,
                 provider_credentials: ProviderCredentials::default(),
             })
             .await;
@@ -1098,6 +1152,7 @@ mod tests {
                     language: None,
                     model_id: ModelId("audio-model".to_string()),
                     preview: true,
+                    preview_opted_in: false,
                     provider_credentials: ProviderCredentials::default(),
                 })
                 .await
@@ -1165,6 +1220,7 @@ mod tests {
                 language: None,
                 model_id: ModelId("audio-model".to_string()),
                 preview: true,
+                preview_opted_in: false,
                 provider_credentials: ProviderCredentials::default(),
             })
             .await;
@@ -1211,6 +1267,7 @@ mod tests {
                 language: None,
                 model_id: ModelId("audio-model".to_string()),
                 preview: true,
+                preview_opted_in: false,
                 provider_credentials: ProviderCredentials::default(),
             })
             .await;

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -780,6 +780,7 @@ mod tests {
                     idempotency_key: concat!(
                         "note_transcribe_preview:usr_123:live-preview-opted-cap:",
                         "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+                        ":opted",
                     )
                     .to_string(),
                 },
@@ -1235,6 +1236,71 @@ mod tests {
                     hold_ttl: 60,
                 },
                 release_charge_event("note_transcribe"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn note_transcribe_preview_idempotency_key_distinguishes_consent_states() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: Arc::new(FixedTranscriber),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        for preview_opted_in in [false, true] {
+            service
+                .transcribe(NoteTranscribeParams {
+                    user_id: UserId("usr_123".to_string()),
+                    note_id: "consent-state-preview".to_string(),
+                    audio: vec![1, 2, 3],
+                    filename: "preview.wav".to_string(),
+                    context: None,
+                    language: None,
+                    model_id: ModelId("audio-model".to_string()),
+                    preview: true,
+                    preview_opted_in,
+                    provider_credentials: ProviderCredentials::default(),
+                })
+                .await
+                .expect("preview transcription succeeds");
+        }
+
+        let charge_keys = os_accounts
+            .events()
+            .into_iter()
+            .filter_map(|event| match event {
+                RecordedCall::Charge {
+                    idempotency_key, ..
+                } => Some(idempotency_key),
+                RecordedCall::Authorize { .. } => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            charge_keys,
+            vec![
+                concat!(
+                    "note_transcribe_preview:usr_123:consent-state-preview:",
+                    "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+                )
+                .to_string(),
+                concat!(
+                    "note_transcribe_preview:usr_123:consent-state-preview:",
+                    "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+                    ":opted",
+                )
+                .to_string(),
             ]
         );
     }

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -627,7 +627,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn note_transcribe_preview_authorizes_dispatches_asr_and_charges_actual_credits() {
+    async fn note_transcribe_preview_settles_zero_and_identical_final_charges_actual_credits() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let transcriber = Arc::new(RecordingTranscriber::default());
         let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
@@ -645,25 +645,49 @@ mod tests {
             preview_max_audio_seconds: 30,
         });
 
-        let output = service
-            .transcribe(NoteTranscribeParams {
-                user_id: UserId("usr_123".to_string()),
-                note_id: "live-preview-session-1".to_string(),
-                audio: vec![1, 2, 3],
-                filename: "preview.wav".to_string(),
-                context: Some("Previous words".to_string()),
-                language: Some("en".to_string()),
-                model_id: ModelId("audio-model".to_string()),
-                preview: true,
-                provider_credentials: ProviderCredentials::default(),
-            })
+        let params = NoteTranscribeParams {
+            user_id: UserId("usr_123".to_string()),
+            note_id: "live-preview-session-1".to_string(),
+            audio: vec![1, 2, 3],
+            filename: "preview.wav".to_string(),
+            context: Some("Previous words".to_string()),
+            language: Some("en".to_string()),
+            model_id: ModelId("audio-model".to_string()),
+            preview: true,
+            provider_credentials: ProviderCredentials::default(),
+        };
+        let preview_output = service
+            .transcribe(params.clone())
             .await
             .expect("preview transcription succeeds");
+        let final_output = service
+            .transcribe(NoteTranscribeParams {
+                preview: false,
+                ..params
+            })
+            .await
+            .expect("final transcription succeeds");
 
-        assert_eq!(output.receipt.credits_charged.0, 4);
+        assert_eq!(preview_output.receipt.credits_charged.0, 0);
+        assert_eq!(final_output.receipt.credits_charged.0, 4);
         assert_eq!(
             os_accounts.events(),
             vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 4,
+                    hold_ttl: 60,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 0,
+                    idempotency_key: concat!(
+                        "note_transcribe_preview:usr_123:live-preview-session-1:",
+                        "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+                    )
+                    .to_string(),
+                },
                 RecordedCall::Authorize {
                     user_id: "usr_123".to_string(),
                     action: "note_transcribe".to_string(),
@@ -673,15 +697,11 @@ mod tests {
                 RecordedCall::Charge {
                     action_token: "agt_test".to_string(),
                     credits: 4,
-                    idempotency_key: concat!(
-                        "note_transcribe_preview:usr_123:live-preview-session-1:",
-                        "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
-                    )
-                    .to_string(),
+                    idempotency_key: "note_transcribe:usr_123:live-preview-session-1".to_string(),
                 },
             ]
         );
-        assert_eq!(transcriber.call_count(), 1);
+        assert_eq!(transcriber.call_count(), 2);
         assert_eq!(
             transcriber.last_context(),
             Some("Previous words".to_string())
@@ -719,7 +739,7 @@ mod tests {
                 context: None,
                 language: None,
                 model_id: ModelId("audio-model".to_string()),
-                preview: true,
+                preview: false,
                 provider_credentials: ProviderCredentials::default(),
             })
             .await
@@ -819,7 +839,7 @@ mod tests {
                 RecordedCall::Authorize {
                     user_id: "usr_123".to_string(),
                     action: "note_transcribe".to_string(),
-                    estimate: 1024,
+                    estimate: 4,
                     hold_ttl: 60,
                 },
                 release_charge_event("note_transcribe"),
@@ -997,7 +1017,7 @@ mod tests {
             vec![RecordedCall::Authorize {
                 user_id: "usr_123".to_string(),
                 action: "note_transcribe".to_string(),
-                estimate: 1024,
+                estimate: 4,
                 hold_ttl: 60,
             }]
         );

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -710,6 +710,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn note_transcribe_preview_zero_duration_keeps_a_positive_hold_gate() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: Arc::new(FixedTranscriber),
+            duration_probe: Arc::new(ZeroDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let output = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "zero-duration-preview".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "preview.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: true,
+                provider_credentials: ProviderCredentials::default(),
+            })
+            .await
+            .expect("zero-duration preview still settles successfully");
+
+        assert_eq!(output.receipt.credits_charged.0, 0);
+        assert!(matches!(
+            os_accounts.events().as_slice(),
+            [
+                RecordedCall::Authorize { estimate: 1, .. },
+                RecordedCall::Charge { credits: 0, .. }
+            ]
+        ));
+    }
+
+    #[tokio::test]
     async fn note_transcribe_hold_covers_actual_price_above_flat_estimate() {
         // Audio priced above the flat estimate must raise the hold to the
         // already-known price — otherwise the charge is clamped to the flat
@@ -1826,6 +1869,14 @@ mod tests {
     impl AudioDurationProbe for FixedDurationProbe {
         fn probe(&self, _audio: &[u8]) -> Result<Duration, DomainError> {
             Ok(Duration::from_millis(1500))
+        }
+    }
+
+    struct ZeroDurationProbe;
+
+    impl AudioDurationProbe for ZeroDurationProbe {
+        fn probe(&self, _audio: &[u8]) -> Result<Duration, DomainError> {
+            Ok(Duration::ZERO)
         }
     }
 

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -710,7 +710,123 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn note_transcribe_preview_zero_duration_keeps_a_positive_hold_gate() {
+    async fn note_transcribe_preview_charge_failure_propagates_after_transcription() {
+        let os_accounts = Arc::new(RecordingOsAccounts {
+            fail_charge: true,
+            ..RecordingOsAccounts::default()
+        });
+        let transcriber = Arc::new(RecordingTranscriber::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: transcriber.clone(),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let result = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "preview-settlement-failure".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "preview.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: true,
+                provider_credentials: ProviderCredentials::default(),
+            })
+            .await;
+
+        assert!(matches!(result, Err(ServiceError::MeteringProvider)));
+        assert_eq!(transcriber.call_count(), 1);
+        assert_eq!(
+            os_accounts.events(),
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 4,
+                    hold_ttl: 60,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 0,
+                    idempotency_key: concat!(
+                        "note_transcribe_preview:usr_123:preview-settlement-failure:",
+                        "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+                    )
+                    .to_string(),
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn note_transcribe_final_charge_failure_propagates_after_transcription() {
+        let os_accounts = Arc::new(RecordingOsAccounts {
+            fail_charge: true,
+            ..RecordingOsAccounts::default()
+        });
+        let transcriber = Arc::new(RecordingTranscriber::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: transcriber.clone(),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let result = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "final-settlement-failure".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "recording.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: false,
+                provider_credentials: ProviderCredentials::default(),
+            })
+            .await;
+
+        assert!(matches!(result, Err(ServiceError::MeteringProvider)));
+        assert_eq!(transcriber.call_count(), 1);
+        assert_eq!(
+            os_accounts.events(),
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 1024,
+                    hold_ttl: 60,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 4,
+                    idempotency_key: "note_transcribe:usr_123:final-settlement-failure".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn note_transcribe_preview_zero_duration_keeps_a_positive_hold() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
             pricing: Arc::new(PricingTable::new(models([(

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -674,6 +674,120 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn note_transcribe_opted_in_preview_failure_releases_hold_without_billing() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: Arc::new(FailingTranscriber),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let result = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "live-preview-opted-fail".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "preview.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: true,
+                preview_opted_in: true,
+                provider_credentials: ProviderCredentials::default(),
+            })
+            .await;
+
+        // Consent never bills failed work: the hold releases at zero exactly
+        // like an unconsented preview failure.
+        assert!(matches!(result, Err(ServiceError::UpstreamProvider)));
+        assert_eq!(
+            os_accounts.events(),
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 4,
+                    hold_ttl: 60,
+                },
+                release_charge_event("note_transcribe"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn note_transcribe_opted_in_preview_settlement_clamps_to_granted_cap() {
+        // OS Accounts may grant a hold below the requested estimate; the
+        // opted-in settlement must clamp to the granted cap exactly like the
+        // final path instead of hard-failing the charge after a successful
+        // transcription.
+        let os_accounts = Arc::new(RecordingOsAccounts::with_cap(Some(3)));
+        let transcriber = Arc::new(RecordingTranscriber::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: transcriber.clone(),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let output = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "live-preview-opted-cap".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "preview.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: true,
+                preview_opted_in: true,
+                provider_credentials: ProviderCredentials::default(),
+            })
+            .await
+            .expect("opted-in preview clamps to the granted cap");
+
+        // Computed price is 4 credits (2s at 2 credits/s); the granted cap
+        // is 3, so settlement clamps to 3.
+        assert_eq!(output.receipt.credits_charged.0, 3);
+        assert_eq!(
+            os_accounts.events(),
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 4,
+                    hold_ttl: 60,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 3,
+                    idempotency_key: concat!(
+                        "note_transcribe_preview:usr_123:live-preview-opted-cap:",
+                        "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+                    )
+                    .to_string(),
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn note_transcribe_preview_settles_zero_and_identical_final_charges_actual_credits() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let transcriber = Arc::new(RecordingTranscriber::default());

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -665,10 +665,12 @@ mod tests {
         // Consented preview bills the computed price instead of zero; the
         // authorization hold is unchanged.
         assert_eq!(output.receipt.credits_charged.0, 4);
-        assert!(os_accounts.events().iter().any(|event| matches!(
-            event,
-            RecordedCall::Charge { credits: 4, .. }
-        )));
+        assert!(
+            os_accounts
+                .events()
+                .iter()
+                .any(|event| matches!(event, RecordedCall::Charge { credits: 4, .. }))
+        );
     }
 
     #[tokio::test]

--- a/june-api/crates/services/src/note_transcribe.rs
+++ b/june-api/crates/services/src/note_transcribe.rs
@@ -81,11 +81,13 @@ impl NoteTranscribeService {
             .pricing
             .price_audio_seconds(&params.model_id.0, seconds)?;
         // Preview is not charged, but its Hold remains an abuse gate sized to
-        // the already-known price. Final note transcription keeps the flat
-        // floor, and raises it when the computed price is higher so settlement
-        // cannot be silently clamped below actual usage.
+        // the already-known price. A valid header-only audio file can probe as
+        // zero seconds, so keep a one-credit minimum that still reserves an OS
+        // Accounts grant. Final note transcription keeps the flat floor, and
+        // raises it when the computed price is higher so settlement cannot be
+        // silently clamped below actual usage.
         let estimate = if params.preview {
-            actual
+            Credits(actual.0.max(1))
         } else {
             Credits(actual.0.max(self.flat_estimate_credits))
         };

--- a/june-api/crates/services/src/note_transcribe.rs
+++ b/june-api/crates/services/src/note_transcribe.rs
@@ -1,7 +1,7 @@
 use crate::{
     charge_flow::{
-        AuthorizeParams, ChargeParams, ReleaseHoldParams, authorize_or_deny, charge, clamp_to_cap,
-        log_settled, release_hold, zero_receipt,
+        AuthorizeParams, ChargeParams, ReleaseHoldOutcome, ReleaseHoldParams, authorize_or_deny,
+        charge, clamp_to_cap, release_hold, zero_receipt,
     },
     error::ServiceError,
     metering::{log_skipped_user_venice_key, uses_user_venice_key_for_model},
@@ -66,6 +66,7 @@ impl NoteTranscribeService {
             user_id = %params.user_id.0,
             note_id = %params.note_id,
             model = %params.model_id.0,
+            preview = params.preview,
             audio_bytes = params.audio.len(),
             audio_format = ?format,
             "note_transcribe: handler entered"
@@ -79,11 +80,15 @@ impl NoteTranscribeService {
         let actual = self
             .pricing
             .price_audio_seconds(&params.model_id.0, seconds)?;
-        // The Hold must cover the already-known price: the charge below is
-        // clamped to the Hold's cap, so a flat-only estimate would silently
-        // underbill any audio priced above it. The flat value remains the
-        // floor, keeping short-audio holds exactly as before.
-        let estimate = Credits(actual.0.max(self.flat_estimate_credits));
+        // Preview is not charged, but its Hold remains an abuse gate sized to
+        // the already-known price. Final note transcription keeps the flat
+        // floor, and raises it when the computed price is higher so settlement
+        // cannot be silently clamped below actual usage.
+        let estimate = if params.preview {
+            actual
+        } else {
+            Credits(actual.0.max(self.flat_estimate_credits))
+        };
         let prepared = PreparedNoteTranscription {
             params,
             format,
@@ -175,7 +180,9 @@ impl NoteTranscribeService {
         tracing::info!(
             note_id = %params.note_id,
             model = %params.model_id.0,
-            seconds,
+            preview = true,
+            probed_seconds = seconds,
+            computed_credits = actual.0,
             estimate_credits = estimate.0,
             "note_transcribe: preview request authorized"
         );
@@ -196,16 +203,29 @@ impl NoteTranscribeService {
             Err(error) => {
                 // Failed previews used to settle at the full audio price just
                 // to avoid stranding the hold; release bills nothing instead.
-                release_hold(ReleaseHoldParams {
+                let release_outcome = release_hold(ReleaseHoldParams {
                     os_accounts: self.os_accounts.as_ref(),
                     action: ActionSlug::NoteTranscribe,
                     action_token: authorization.action_token,
                 })
                 .await;
+                if let ReleaseHoldOutcome::Settled(receipt) = release_outcome {
+                    tracing::info!(
+                        user_id = %params.user_id.0,
+                        action = ActionSlug::NoteTranscribe.as_str(),
+                        note_id = %params.note_id,
+                        model = %params.model_id.0,
+                        preview = true,
+                        probed_seconds = seconds,
+                        computed_credits = actual.0,
+                        settled_credits = receipt.credits_charged.0,
+                        idempotent_replay = receipt.idempotent_replay,
+                        "settled failed note transcription"
+                    );
+                }
                 return Err(error.into());
             }
         };
-        let charge_credits = clamp_to_cap(actual, authorization.cap_credits);
         let idempotency_key = format!(
             "note_transcribe_preview:{}:{}:{}",
             params.user_id.0, params.note_id, audio_digest
@@ -213,14 +233,21 @@ impl NoteTranscribeService {
         let receipt = charge(ChargeParams {
             os_accounts: self.os_accounts.as_ref(),
             action_token: authorization.action_token,
-            credits: charge_credits,
+            credits: Credits(0),
             idempotency_key,
         })
         .await?;
         tracing::info!(
+            user_id = %params.user_id.0,
+            action = ActionSlug::NoteTranscribe.as_str(),
             note_id = %params.note_id,
-            credits_charged = receipt.credits_charged.0,
-            "note_transcribe: preview hold settled"
+            model = %params.model_id.0,
+            preview = true,
+            probed_seconds = seconds,
+            computed_credits = actual.0,
+            settled_credits = receipt.credits_charged.0,
+            idempotent_replay = receipt.idempotent_replay,
+            "settled note transcription"
         );
         Ok(NoteTranscribeOutput {
             transcript,
@@ -296,11 +323,17 @@ impl NoteTranscribeService {
             idempotency_key,
         })
         .await?;
-        log_settled(
-            ActionSlug::NoteTranscribe,
-            &params.user_id,
-            &params.model_id.0,
-            &receipt,
+        tracing::info!(
+            user_id = %params.user_id.0,
+            action = ActionSlug::NoteTranscribe.as_str(),
+            note_id = %params.note_id,
+            model = %params.model_id.0,
+            preview = false,
+            probed_seconds = seconds,
+            computed_credits = actual.0,
+            settled_credits = receipt.credits_charged.0,
+            idempotent_replay = receipt.idempotent_replay,
+            "settled note transcription",
         );
         Ok(NoteTranscribeOutput {
             transcript,

--- a/june-api/crates/services/src/note_transcribe.rs
+++ b/june-api/crates/services/src/note_transcribe.rs
@@ -234,10 +234,17 @@ impl NoteTranscribeService {
             "note_transcribe_preview:{}:{}:{}",
             params.user_id.0, params.note_id, audio_digest
         );
+        // Consented previews (disclosed setting, user left it on) bill the
+        // computed price; everything else settles at zero per ADR-0002.
+        let settled = if params.preview_opted_in {
+            actual
+        } else {
+            Credits(0)
+        };
         let receipt = charge(ChargeParams {
             os_accounts: self.os_accounts.as_ref(),
             action_token: authorization.action_token,
-            credits: Credits(0),
+            credits: settled,
             idempotency_key,
         })
         .await?;
@@ -247,6 +254,7 @@ impl NoteTranscribeService {
             note_id = %params.note_id,
             model = %params.model_id.0,
             preview = true,
+            preview_opted_in = params.preview_opted_in,
             probed_seconds = seconds,
             computed_credits = actual.0,
             settled_credits = receipt.credits_charged.0,
@@ -357,6 +365,12 @@ pub struct NoteTranscribeParams {
     pub language: Option<String>,
     pub model_id: ModelId,
     pub preview: bool,
+    /// True only when the client build carries the disclosed Live
+    /// transcription setting and the user left it enabled: such previews are
+    /// consented billable usage and settle at the computed price. Legacy
+    /// clients never send the flag and keep zero-credit preview settlement
+    /// (JUN-375, ADR-0002 addendum).
+    pub preview_opted_in: bool,
     pub provider_credentials: ProviderCredentials,
 }
 

--- a/june-api/crates/services/src/note_transcribe.rs
+++ b/june-api/crates/services/src/note_transcribe.rs
@@ -228,10 +228,15 @@ impl NoteTranscribeService {
                 return Err(error.into());
             }
         };
-        let idempotency_key = format!(
+        // Keep the legacy zero-credit key byte-identical; only consented,
+        // billable previews get a distinct settlement namespace.
+        let mut idempotency_key = format!(
             "note_transcribe_preview:{}:{}:{}",
             params.user_id.0, params.note_id, audio_digest
         );
+        if params.preview_opted_in {
+            idempotency_key.push_str(":opted");
+        }
         // Consented previews (disclosed setting, user left it on) bill the
         // computed price clamped to the authorized hold cap, exactly like the
         // final path; everything else settles at zero per ADR-0002.

--- a/june-api/crates/services/src/note_transcribe.rs
+++ b/june-api/crates/services/src/note_transcribe.rs
@@ -233,9 +233,10 @@ impl NoteTranscribeService {
             params.user_id.0, params.note_id, audio_digest
         );
         // Consented previews (disclosed setting, user left it on) bill the
-        // computed price; everything else settles at zero per ADR-0002.
+        // computed price clamped to the authorized hold cap, exactly like the
+        // final path; everything else settles at zero per ADR-0002.
         let settled = if params.preview_opted_in {
-            actual
+            clamp_to_cap(actual, authorization.cap_credits)
         } else {
             Credits(0)
         };
@@ -399,9 +400,9 @@ pub struct NoteTranscribeParams {
     pub preview: bool,
     /// True only when the client build carries the disclosed Live
     /// transcription setting and the user left it enabled: such previews are
-    /// consented billable usage and settle at the computed price. Legacy
-    /// clients never send the flag and keep zero-credit preview settlement
-    /// (JUN-375, ADR-0002 addendum).
+    /// consented billable usage and settle at the computed price clamped to
+    /// the granted hold cap. Legacy clients never send the flag and keep
+    /// zero-credit preview settlement (JUN-375, ADR-0002 addendum).
     pub preview_opted_in: bool,
     pub provider_credentials: ProviderCredentials,
 }

--- a/june-api/crates/services/src/note_transcribe.rs
+++ b/june-api/crates/services/src/note_transcribe.rs
@@ -80,12 +80,14 @@ impl NoteTranscribeService {
         let actual = self
             .pricing
             .price_audio_seconds(&params.model_id.0, seconds)?;
-        // Preview is not charged, but its Hold remains an abuse gate sized to
-        // the already-known price. A valid header-only audio file can probe as
-        // zero seconds, so keep a one-credit minimum that still reserves an OS
-        // Accounts grant. Final note transcription keeps the flat floor, and
-        // raises it when the computed price is higher so settlement cannot be
-        // silently clamped below actual usage.
+        // Preview is not charged, but it still takes an OS Accounts Hold sized
+        // to the already-known price. A valid header-only audio file can probe
+        // as zero seconds, so keep a one-credit minimum that reserves a grant.
+        // This preserves balance and generic open-grant checks; dedicated
+        // preview rate and concurrency limits are a separate control. Final
+        // note transcription keeps the flat floor, and raises it when the
+        // computed price is higher so settlement cannot be silently clamped
+        // below actual usage.
         let estimate = if params.preview {
             Credits(actual.0.max(1))
         } else {

--- a/june-api/crates/services/src/note_transcribe.rs
+++ b/june-api/crates/services/src/note_transcribe.rs
@@ -42,6 +42,17 @@ struct PreparedNoteTranscription {
     estimate: Credits,
 }
 
+/// Borrowed identity fields for settling a failed preview, kept separate
+/// because the transcription request takes ownership of the audio fields.
+struct FailedPreviewSettlement<'a> {
+    user_id: &'a UserId,
+    note_id: &'a str,
+    model_id: &'a ModelId,
+    seconds: u64,
+    actual: Credits,
+    action_token: String,
+}
+
 impl NoteTranscribeService {
     pub fn new(deps: NoteTranscribeServiceDeps) -> Self {
         Self {
@@ -205,28 +216,15 @@ impl NoteTranscribeService {
         {
             Ok(transcript) => transcript,
             Err(error) => {
-                // Failed previews used to settle at the full audio price just
-                // to avoid stranding the hold; release bills nothing instead.
-                let release_outcome = release_hold(ReleaseHoldParams {
-                    os_accounts: self.os_accounts.as_ref(),
-                    action: ActionSlug::NoteTranscribe,
+                self.release_failed_preview(FailedPreviewSettlement {
+                    user_id: &params.user_id,
+                    note_id: &params.note_id,
+                    model_id: &params.model_id,
+                    seconds,
+                    actual,
                     action_token: authorization.action_token,
                 })
                 .await;
-                if let ReleaseHoldOutcome::Settled(receipt) = release_outcome {
-                    tracing::info!(
-                        user_id = %params.user_id.0,
-                        action = ActionSlug::NoteTranscribe.as_str(),
-                        note_id = %params.note_id,
-                        model = %params.model_id.0,
-                        preview = true,
-                        probed_seconds = seconds,
-                        computed_credits = actual.0,
-                        settled_credits = receipt.credits_charged.0,
-                        idempotent_replay = receipt.idempotent_replay,
-                        "settled failed note transcription"
-                    );
-                }
                 return Err(error.into());
             }
         };
@@ -265,6 +263,40 @@ impl NoteTranscribeService {
             transcript,
             receipt,
         })
+    }
+
+    /// Settles a failed preview. Failed previews used to settle at the full
+    /// audio price just to avoid stranding the hold; release bills nothing
+    /// instead.
+    async fn release_failed_preview(&self, settlement: FailedPreviewSettlement<'_>) {
+        let FailedPreviewSettlement {
+            user_id,
+            note_id,
+            model_id,
+            seconds,
+            actual,
+            action_token,
+        } = settlement;
+        let release_outcome = release_hold(ReleaseHoldParams {
+            os_accounts: self.os_accounts.as_ref(),
+            action: ActionSlug::NoteTranscribe,
+            action_token,
+        })
+        .await;
+        if let ReleaseHoldOutcome::Settled(receipt) = release_outcome {
+            tracing::info!(
+                user_id = %user_id.0,
+                action = ActionSlug::NoteTranscribe.as_str(),
+                note_id = %note_id,
+                model = %model_id.0,
+                preview = true,
+                probed_seconds = seconds,
+                computed_credits = actual.0,
+                settled_credits = receipt.credits_charged.0,
+                idempotent_replay = receipt.idempotent_replay,
+                "settled failed note transcription"
+            );
+        }
     }
 
     async fn transcribe_charged(

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -366,8 +366,12 @@ pub fn start_capture_with_cancel(
     let last_callback_for_callback = Arc::clone(&last_callback_at);
     let paused_for_callback = Arc::clone(&paused_flag);
     let mic_duck_for_callback = Arc::clone(&mic_duck_flag);
-    let live_preview_available =
-        crate::june_api::configured() && crate::os_accounts::cached_signed_in();
+    // The user's Live transcription setting gates both preview lanes at the
+    // source: when off, no preview audio leaves the device and nothing is
+    // billed (JUN-375).
+    let live_preview_available = crate::june_api::configured()
+        && crate::os_accounts::cached_signed_in()
+        && crate::providers::live_transcription();
     let live_preview = if live_preview_available {
         Some(start_live_transcript_preview(
             app.clone(),

--- a/src-tauri/src/audio/live_preview.rs
+++ b/src-tauri/src/audio/live_preview.rs
@@ -247,6 +247,14 @@ async fn run_live_preview_worker(params: LivePreviewWorkerParams) {
                 segment_index += 1;
                 continue;
             }
+            // The Live transcription setting is re-read per chunk so turning
+            // it off mid-recording stops new preview requests (and their
+            // billing) promptly; turning it back on resumes the stream.
+            // (JUN-375)
+            if !crate::providers::live_transcription() {
+                segment_index += 1;
+                continue;
+            }
             let segment_id = preview_segment_id(source, segment_index);
             if let Some(event) = transcribe_preview_chunk(PreviewChunkRequest {
                 note_id: &note_id,
@@ -325,6 +333,13 @@ async fn run_system_live_preview_worker(
                         continue;
                     }
 
+                    // Same live setting check as the microphone lane: turning
+                    // Live transcription off mid-recording stops new preview
+                    // requests promptly (JUN-375).
+                    if !crate::providers::live_transcription() {
+                        segment_index += 1;
+                        continue;
+                    }
                     let segment_id = preview_segment_id(RecordingSource::System, segment_index);
                     if let Some(event) = transcribe_preview_chunk(PreviewChunkRequest {
                         note_id: &note_id,

--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -334,6 +334,11 @@ pub async fn transcribe_saved_audio(
         .part("audio", audio_part(audio, &filename, &request.audio_path)?);
     if request.preview {
         form = form.text("preview", "true");
+        // Builds that carry the Live transcription setting disclose its cost;
+        // a preview request from such a build is therefore consented billable
+        // usage. Legacy clients never send this field and keep zero-credit
+        // preview settlement (JUN-375, ADR-0002 addendum).
+        form = form.text("previewOptedIn", "true");
     }
     if let Some(context) = request
         .context

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -328,6 +328,7 @@ pub fn run() {
             providers::set_venice_api_key,
             providers::clear_venice_api_key,
             providers::set_image_safe_mode,
+            providers::set_live_transcription,
             providers::set_image_safe_mode_prompt_dismissed,
             image_safety::image_prompt_may_be_explicit,
             providers::generate_image,

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -105,6 +105,12 @@ pub struct ProviderModelSettings {
     /// carry an incidental `false` the user never picked.
     #[serde(default)]
     pub image_safe_mode_set_by_user: bool,
+    /// When true (the default), June streams a live transcript preview while
+    /// recording. On builds that carry this setting the preview is billed as
+    /// extra usage (ADR-0002 addendum, JUN-375); turning it off stops the
+    /// preview lanes entirely, so nothing is sent or billed.
+    #[serde(default = "default_live_transcription")]
+    pub live_transcription: bool,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub profile_overrides: BTreeMap<String, ProfileModelOverrides>,
 }
@@ -149,6 +155,7 @@ pub struct ProviderModelSettingsDto {
     pub local_generation: LocalGenerationSettings,
     pub image_safe_mode: bool,
     pub image_safe_mode_prompt_dismissed: bool,
+    pub live_transcription: bool,
 }
 
 impl From<&ProviderModelSettings> for ProviderModelSettingsDto {
@@ -169,6 +176,7 @@ impl From<&ProviderModelSettings> for ProviderModelSettingsDto {
             local_generation: settings.local_generation.clone(),
             image_safe_mode: settings.image_safe_mode,
             image_safe_mode_prompt_dismissed: settings.image_safe_mode_prompt_dismissed,
+            live_transcription: settings.live_transcription,
         }
     }
 }
@@ -398,6 +406,10 @@ pub fn image_safe_mode() -> bool {
 
 pub fn image_safe_mode_prompt_dismissed() -> bool {
     current_settings().image_safe_mode_prompt_dismissed
+}
+
+pub fn live_transcription() -> bool {
+    current_settings().live_transcription
 }
 
 /// Context window (tokens) of the configured generation model, looked up in
@@ -653,6 +665,22 @@ pub fn set_cost_quality(
 #[serde(rename_all = "camelCase")]
 pub struct SetImageSafeModeRequest {
     pub enabled: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SetLiveTranscriptionRequest {
+    pub enabled: bool,
+}
+
+#[tauri::command]
+pub fn set_live_transcription(
+    state: State<'_, ProviderSettingsState>,
+    request: SetLiveTranscriptionRequest,
+) -> Result<ProviderModelSettingsDto, AppError> {
+    update_settings(&state, |settings| {
+        settings.live_transcription = request.enabled;
+    })
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
@@ -1249,8 +1277,13 @@ fn default_settings() -> ProviderModelSettings {
         image_safe_mode: true,
         image_safe_mode_prompt_dismissed: false,
         image_safe_mode_set_by_user: false,
+        live_transcription: true,
         profile_overrides: BTreeMap::new(),
     }
+}
+
+fn default_live_transcription() -> bool {
+    true
 }
 
 fn default_transcription_provider() -> String {

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -678,7 +678,14 @@ pub fn set_live_transcription(
     state: State<'_, ProviderSettingsState>,
     request: SetLiveTranscriptionRequest,
 ) -> Result<ProviderModelSettingsDto, AppError> {
-    update_settings(&state, |settings| {
+    set_live_transcription_impl(&state, request)
+}
+
+fn set_live_transcription_impl(
+    state: &ProviderSettingsState,
+    request: SetLiveTranscriptionRequest,
+) -> Result<ProviderModelSettingsDto, AppError> {
+    update_settings(state, |settings| {
         settings.live_transcription = request.enabled;
     })
 }
@@ -1414,6 +1421,7 @@ fn sanitize_settings(
         image_safe_mode,
         image_safe_mode_prompt_dismissed: settings.image_safe_mode_prompt_dismissed,
         image_safe_mode_set_by_user: settings.image_safe_mode_set_by_user,
+        live_transcription: settings.live_transcription,
         profile_overrides: sanitize_profile_overrides(settings.profile_overrides),
     }
 }
@@ -2066,6 +2074,47 @@ mod tests {
 
         assert!(!settings.image_safe_mode);
         assert!(settings.image_safe_mode_set_by_user);
+    }
+
+    #[test]
+    fn default_settings_enable_live_transcription() {
+        assert!(default_settings().live_transcription);
+    }
+
+    #[test]
+    fn provider_settings_deserialize_defaults_missing_live_transcription_field() {
+        // Files written by builds before JUN-375 carry no `liveTranscription`
+        // key; the serde default keeps the preview on for them.
+        let settings = serde_json::from_value::<ProviderModelSettings>(serde_json::json!({
+            "transcriptionProvider": "venice",
+            "transcriptionModel": "nvidia/parakeet-tdt-0.6b-v3",
+            "generationModel": "zai-org-glm-5-2",
+            "imageModel": "venice-sd35"
+        }))
+        .unwrap();
+
+        assert!(settings.live_transcription);
+    }
+
+    #[test]
+    fn set_live_transcription_persists_the_toggle() {
+        let state = test_state();
+
+        let updated =
+            set_live_transcription_impl(&state, SetLiveTranscriptionRequest { enabled: false })
+                .unwrap();
+        assert!(!updated.live_transcription);
+        let saved: ProviderModelSettings =
+            serde_json::from_str(&fs::read_to_string(&state.path).unwrap()).unwrap();
+        assert!(!saved.live_transcription);
+
+        let updated =
+            set_live_transcription_impl(&state, SetLiveTranscriptionRequest { enabled: true })
+                .unwrap();
+        assert!(updated.live_transcription);
+        let saved: ProviderModelSettings =
+            serde_json::from_str(&fs::read_to_string(&state.path).unwrap()).unwrap();
+        assert!(saved.live_transcription);
     }
 
     #[test]

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -29,6 +29,7 @@ import {
   setDictationMicrophone,
   setDictationShortcut,
   setImageSafeMode,
+  setLiveTranscription,
   setCostQuality,
   setVeniceApiKey,
   setVeniceModel,
@@ -297,6 +298,7 @@ const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
   // On by default, matching the Rust providers default.
   imageSafeMode: true,
   imageSafeModePromptDismissed: false,
+  liveTranscription: true,
 };
 
 type ProviderModelSettingsSnapshot = {
@@ -1403,6 +1405,20 @@ export function AppSettings({
     }
   }
 
+  async function toggleLiveTranscription(enabled: boolean) {
+    try {
+      const next = await setLiveTranscription(enabled);
+      setProviderSettings(next);
+      setStatus(
+        enabled
+          ? "Live transcription on: the transcript streams while you record."
+          : "Live transcription off: the transcript appears after the recording ends.",
+      );
+    } catch (error) {
+      setStatus(messageFromError(error));
+    }
+  }
+
   async function toggleImageSafeMode(enabled: boolean) {
     try {
       const next = await setImageSafeMode(enabled);
@@ -2199,6 +2215,23 @@ export function AppSettings({
                   </button>
                   {showMoreModelOptions ? (
                     <div id="models-more-options-panel" className="settings-more-options-panel">
+                      <div className="settings-row">
+                        <div className="settings-row-info">
+                          <h3 className="settings-row-title">Live transcription</h3>
+                          <p className="settings-row-description">
+                            Show a live transcript while you record. This transcribes audio twice,
+                            so it may use extra credits; turning it off shows the transcript only
+                            after the recording ends.
+                          </p>
+                        </div>
+                        <div className="settings-row-control">
+                          <Switch
+                            checked={providerSettings.liveTranscription}
+                            aria-label="Show a live transcript while recording"
+                            onCheckedChange={toggleLiveTranscription}
+                          />
+                        </div>
+                      </div>
                       <VeniceApiKeyRow
                         configured={providerSettings.veniceApiKeyConfigured}
                         value={veniceApiKeyDraft}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -256,6 +256,10 @@ export type ProviderModelSettingsDto = {
   imageSafeMode: boolean;
   /** Whether the user chose "don't ask again" on the safe-mode consent dialog. */
   imageSafeModePromptDismissed: boolean;
+  /** Live transcript preview while recording. On by default; billed as extra
+   * usage and disclosed in Settings, so previews from this build are sent as
+   * consented (JUN-375). Off stops the preview lanes entirely. */
+  liveTranscription: boolean;
 };
 
 export type ProfileModelOverridesDto = {
@@ -2030,6 +2034,14 @@ export async function clearVeniceApiKey() {
 // on, Venice blurs adult content.
 export async function setImageSafeMode(enabled: boolean) {
   return invoke<ProviderModelSettingsDto>("set_image_safe_mode", {
+    request: { enabled },
+  });
+}
+
+// Toggles the live transcript preview while recording. On by default; billed
+// as extra usage when on, no preview audio leaves the device when off.
+export async function setLiveTranscription(enabled: boolean) {
+  return invoke<ProviderModelSettingsDto>("set_live_transcription", {
     request: { enabled },
   });
 }

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   setVeniceApiKey: vi.fn(),
   clearVeniceApiKey: vi.fn(),
   setImageSafeMode: vi.fn(),
+  setLiveTranscription: vi.fn(),
   setCostQuality: vi.fn(),
   setImageSafeModePromptDismissed: vi.fn(),
   setProfileModelOverrides: vi.fn(),
@@ -120,6 +121,7 @@ vi.mock("../lib/tauri", () => ({
   setVeniceApiKey: mocks.setVeniceApiKey,
   clearVeniceApiKey: mocks.clearVeniceApiKey,
   setImageSafeMode: mocks.setImageSafeMode,
+  setLiveTranscription: mocks.setLiveTranscription,
   setCostQuality: mocks.setCostQuality,
   setImageSafeModePromptDismissed: mocks.setImageSafeModePromptDismissed,
   setProfileModelOverrides: mocks.setProfileModelOverrides,
@@ -253,6 +255,7 @@ function buildProviderSettings() {
     },
     imageSafeMode: true,
     imageSafeModePromptDismissed: false,
+    liveTranscription: true,
     costQuality: 50,
   };
 }
@@ -511,6 +514,10 @@ describe("AppSettings", () => {
     mocks.setImageSafeMode.mockImplementation(async (enabled: boolean) => ({
       ...buildProviderSettings(),
       imageSafeMode: enabled,
+    }));
+    mocks.setLiveTranscription.mockImplementation(async (enabled: boolean) => ({
+      ...buildProviderSettings(),
+      liveTranscription: enabled,
     }));
     mocks.setCostQuality.mockImplementation(async (costQuality: number) => ({
       ...buildProviderSettings(),
@@ -3306,6 +3313,47 @@ describe("AppSettings", () => {
     expect(screen.getByLabelText("Base URL")).toBeInTheDocument();
     expect(screen.getByLabelText("Model ID")).toBeInTheDocument();
     expect(screen.getByText("Enter a local endpoint and model ID first.")).toBeInTheDocument();
+  });
+
+  it("shows the Live transcription toggle with disclosure copy in More options", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Models" }));
+    await user.click(await screen.findByRole("button", { name: "More options for AI models" }));
+
+    // Default on, with the extra-credits disclosure next to it (JUN-375).
+    const toggle = await screen.findByRole("switch", {
+      name: "Show a live transcript while recording",
+    });
+    expect(toggle).toBeChecked();
+    expect(
+      screen.getByText(
+        "Show a live transcript while you record. This transcribes audio twice, so it may use extra credits; turning it off shows the transcript only after the recording ends.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(toggle);
+
+    expect(mocks.setLiveTranscription).toHaveBeenCalledWith(false);
+    await waitFor(() => expect(toggle).not.toBeChecked());
+    expect(
+      await screen.findByText(
+        "Live transcription off: the transcript appears after the recording ends.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("auto-expands More options when a local model is already enabled", async () => {


### PR DESCRIPTION
## Summary

- Live transcription becomes a disclosed, optional, billed feature (Closes JUN-375). New advanced setting under Models > More options, **default on**, with disclosure copy that the preview transcribes audio twice and may use extra credits.
- Setting off gates both preview lanes at the capture source (`capture.rs`): no preview audio leaves the device and nothing is authorized or billed.
- Setting on: preview transcription requests carry a new optional `previewOptedIn` form field; June API settles opted-in previews at the actual computed price. Requests without the flag (all shipped clients that predate the setting) keep the zero-credit settlement from PR #869 - no existing field or endpoint changed shape.
- ADR-0002 gets a dated addendum resolving the deferred preview-billing question (original decision untouched); CONTEXT.md notes the setting label on the Live transcript preview term.
- Depends on #869 - merge that first; the zero-charge path for flag-less clients must stay intact.

## Validation

- `pnpm check` (exit 0), `pnpm typecheck`, `NODE_OPTIONS=--no-experimental-webstorage pnpm test` (3200 passed, 2 skipped; new AppSettings suite test covers the toggle row, disclosure copy, and the mocked `set_live_transcription` flip).
- `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` for src-tauri and june-api.
- `pnpm test:june-api` (all suites green; service regression test: opted-in preview settles actual credits, legacy preview still settles zero).
- `pnpm test:rust` green; needed the documented `DEVELOPER_DIR`/Swift rpath workaround for the `june-computer-use-driver` bin link.
- New src-tauri tests: defaults have `live_transcription: true`, legacy settings files without the field deserialize to `true`, and the setter persists the toggle to `provider-settings.json`.
- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).

Setting on (default) in Models > More options:

![Live transcription setting on](https://app.opensoftware.co/api/v1/files/fil_BnJ0cJZCevy5/download)

After turning it off:

![Live transcription setting off](https://app.opensoftware.co/api/v1/files/fil_YJBZMb3ybsP9/download)

- [x] Needs a June API (backend) deploy before it works end to end. <!-- check if yes; say which change -->

The June API change (`previewOptedIn` parsing in the transcribe handler + opt-in settlement in `note_transcribe`) must deploy before desktop previews from this build bill at actual price; until then they settle at zero, same as legacy clients.

## Out of scope

- JUN-372 preview rate limiting stays open: unconsented legacy clients keep free preview until they update.

## Followups

- JUN-372 (preview rate limiting for legacy clients).

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

Note: commits on this branch are unsigned (1Password signing agent was unreachable at commit time).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787234797&installation_model_id=425925&pr_number=877&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F877&signature=3eed3e5d236fc186ae36de7f0c3407e80b41a2e070e3def96581fa632bee73ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

Supersedes PR #869 (branch contains its commits). Closes JUN-368. Closes JUN-375.