### PR TITLE
Add searchable model slash command

### DIFF
--- a/docs/hermes-architecture.md
+++ b/docs/hermes-architecture.md
@@ -106,6 +106,10 @@ Builtin composer slash commands are **`/model`**, **`/file`**, and
 (`src/lib/agent-composer-slash-commands.ts`) — plus **skill** slash commands
 (`skill-slash-commands.ts`). In an existing session, `/model` queues the same
 next-message choice as the picker; it does not mutate the active agent run.
+Choosing Model from the slash menu stages `/model`; pressing Enter opens a
+searchable catalog with suggested models pinned above the remaining models and
+an optional Private-only filter. Typing `/model <name>` selects a matching
+model directly.
 
 ## Key Tauri commands
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -309,7 +309,11 @@ import {
   modelOptions,
   selectedModel as selectedModelOption,
 } from "../settings/ModelPickerDialog";
-import { ModelPickerPopover, type ModelPickerFlyout } from "../settings/ModelPickerPopover";
+import {
+  ModelCommandPalette,
+  ModelPickerPopover,
+  type ModelPickerFlyout,
+} from "../settings/ModelPickerPopover";
 import {
   HERMES_SERVER_ERROR_MESSAGE,
   describeHermesError,
@@ -2825,6 +2829,7 @@ export function AgentWorkspace({
   // endpoint in Settings re-arms the warning. Loopback endpoints never arm it.
   const localEnableConfirmArmedForRef = useRef<string | null>(null);
   const [composerModelOpen, setComposerModelOpen] = useState(false);
+  const [composerModelCommandPalette, setComposerModelCommandPalette] = useState(false);
   const [composerModelFlyout, setComposerModelFlyout] = useState<ModelPickerFlyout>(null);
   const [modelSearch, setModelSearch] = useState("");
   const composerModelTriggerRef = useRef<HTMLButtonElement>(null);
@@ -3350,7 +3355,7 @@ export function AgentWorkspace({
   }, [activeGenerationModelId, generationModelOptions]);
   const generationPrivacyBadge = generationModel ? modelPrivacyBadge(generationModel) : undefined;
   // The model the image-attach banner offers to switch to: a vision + tool
-  // capable model, preferring a curated suggested pick (Kimi K2.6) over the
+  // capable model, preferring a known private vision pick (Kimi K2.6) over the
   // alphabetically-first vision model. See preferredVisionFallbackModel.
   const preferredVisionModel = useMemo(
     () => preferredVisionFallbackModel(generationModels),
@@ -3748,6 +3753,11 @@ export function AgentWorkspace({
     function onKey(event: KeyboardEvent) {
       if (event.key === "Escape") {
         event.preventDefault();
+        if (composerModelCommandPalette) {
+          setComposerModelOpen(false);
+          composerEditorRef.current?.focus();
+          return;
+        }
         // Escape peels one layer at a time: the all-models panel first,
         // then the popover itself.
         if (composerModelFlyout?.kind === "all") {
@@ -3764,13 +3774,13 @@ export function AgentWorkspace({
       window.removeEventListener("mousedown", onPointer);
       window.removeEventListener("keydown", onKey);
     };
-  }, [composerModelOpen, composerModelFlyout]);
+  }, [composerModelCommandPalette, composerModelOpen, composerModelFlyout]);
 
   useLayoutEffect(() => {
-    if (composerModelOpen && composerModelFlyout?.kind === "all") {
+    if (composerModelOpen && (composerModelCommandPalette || composerModelFlyout?.kind === "all")) {
       composerModelSearchRef.current?.focus();
     }
-  }, [composerModelFlyout, composerModelOpen]);
+  }, [composerModelCommandPalette, composerModelFlyout, composerModelOpen]);
 
   // The popover lives outside the composer box (whose overflow:hidden would
   // clip it), so CSS alone can only anchor it to the box, leaving the whole
@@ -3778,15 +3788,34 @@ export function AgentWorkspace({
   // open and pin the menu right above it instead.
   useLayoutEffect(() => {
     if (!composerModelOpen) return;
-    const trigger = composerModelTriggerRef.current;
-    const popover = composerModelPopoverRef.current;
-    const form = popover?.parentElement;
-    if (!trigger || !popover || !form) return;
-    const triggerRect = trigger.getBoundingClientRect();
-    const formRect = form.getBoundingClientRect();
-    popover.style.right = `${formRect.right - triggerRect.right}px`;
-    popover.style.bottom = `${formRect.bottom - triggerRect.top + 4}px`;
-  }, [composerModelOpen]);
+    function positionPopover() {
+      const trigger = composerModelTriggerRef.current;
+      const popover = composerModelPopoverRef.current;
+      const form = popover?.parentElement;
+      if (!trigger || !popover || !form) return;
+      const triggerRect = trigger.getBoundingClientRect();
+      const formRect = form.getBoundingClientRect();
+      if (composerModelCommandPalette) {
+        const composerBox = form.querySelector<HTMLElement>(".agent-composer-box");
+        const composerRect = composerBox?.getBoundingClientRect() ?? formRect;
+        popover.style.left = `${composerRect.left - formRect.left}px`;
+        popover.style.right = `${formRect.right - composerRect.right}px`;
+        popover.style.bottom = `${formRect.bottom - composerRect.top + 4}px`;
+        popover.style.setProperty(
+          "--model-command-available-height",
+          `${Math.max(96, composerRect.top - 12)}px`,
+        );
+        return;
+      }
+      popover.style.left = "";
+      popover.style.removeProperty("--model-command-available-height");
+      popover.style.right = `${formRect.right - triggerRect.right}px`;
+      popover.style.bottom = `${formRect.bottom - triggerRect.top + 4}px`;
+    }
+    positionPopover();
+    window.addEventListener("resize", positionPopover);
+    return () => window.removeEventListener("resize", positionPopover);
+  }, [composerModelCommandPalette, composerModelOpen]);
 
   useLayoutEffect(() => {
     if (sandboxMenuOpen) {
@@ -4185,9 +4214,10 @@ export function AgentWorkspace({
 
   // Stale catalog (the mount fetch can fail while the bridge is starting) is
   // refreshed in the background on every open, like Settings does.
-  function openComposerModelPicker() {
+  function openComposerModelPicker(commandPalette = false) {
     setModelSearch("");
     setComposerModelFlyout(null);
+    setComposerModelCommandPalette(commandPalette);
     setComposerModelOpen(true);
     setSandboxMenuOpen(false);
     void loadGenerationModel();
@@ -5769,7 +5799,7 @@ export function AgentWorkspace({
     const query = argument.trim();
     if (!query) {
       clearComposerCommandDraft(commandText);
-      openComposerModelPicker();
+      openComposerModelPicker(true);
       return;
     }
 
@@ -10725,7 +10755,7 @@ export function AgentWorkspace({
         {textActionsDisabledReason
           ? (renderFundingNotice?.({
               ...textFundingContext,
-              onSelectVeniceModel: openComposerModelPicker,
+              onSelectVeniceModel: () => openComposerModelPicker(),
             }) ?? (
               <p className="agent-composer-notice" role="status">
                 {textActionsDisabledReason}
@@ -11206,23 +11236,38 @@ export function AgentWorkspace({
           />
         ) : null}
         {composerModelOpen ? (
-          <ModelPickerPopover
-            mode="generation"
-            flyout={composerModelFlyout}
-            model={generationModel}
-            options={modelOptions(generationModelOptions, generationModel?.id ?? "")}
-            costQuality={activeGenerationCostQuality}
-            veniceApiKeyConfigured={veniceApiKeyConfigured}
-            search={modelSearch}
-            popoverRef={composerModelPopoverRef}
-            searchRef={composerModelSearchRef}
-            onFlyoutChange={setComposerModelFlyout}
-            onSearchChange={setModelSearch}
-            onSelect={(modelId, costQuality, options) =>
-              void handleSelectGenerationModel(modelId, costQuality, options)
-            }
-            onCostQualityChange={handleCostQualityChange}
-          />
+          composerModelCommandPalette ? (
+            <ModelCommandPalette
+              model={generationModel}
+              options={modelOptions(generationModelOptions, generationModel?.id ?? "")}
+              search={modelSearch}
+              popoverRef={composerModelPopoverRef}
+              searchRef={composerModelSearchRef}
+              onSearchChange={setModelSearch}
+              onSelect={(modelId) => {
+                void handleSelectGenerationModel(modelId);
+                composerEditorRef.current?.focus();
+              }}
+            />
+          ) : (
+            <ModelPickerPopover
+              mode="generation"
+              flyout={composerModelFlyout}
+              model={generationModel}
+              options={modelOptions(generationModelOptions, generationModel?.id ?? "")}
+              costQuality={activeGenerationCostQuality}
+              veniceApiKeyConfigured={veniceApiKeyConfigured}
+              search={modelSearch}
+              popoverRef={composerModelPopoverRef}
+              searchRef={composerModelSearchRef}
+              onFlyoutChange={setComposerModelFlyout}
+              onSearchChange={setModelSearch}
+              onSelect={(modelId, costQuality, options) =>
+                void handleSelectGenerationModel(modelId, costQuality, options)
+              }
+              onCostQualityChange={handleCostQualityChange}
+            />
+          )
         ) : null}
         {heroMode && sandboxMenuOpen ? (
           <div

--- a/src/components/agent/composer/CategorySuggestionList.tsx
+++ b/src/components/agent/composer/CategorySuggestionList.tsx
@@ -7,9 +7,11 @@ import {
   useRef,
   useState,
 } from "react";
+import { Icon3dBoxTop } from "central-icons/Icon3dBoxTop";
 import { IconBuildingBlocks } from "central-icons/IconBuildingBlocks";
-import { IconConsoleSimple } from "central-icons/IconConsoleSimple";
+import { IconCat } from "central-icons/IconCat";
 import { IconFileText } from "central-icons/IconFileText";
+import { IconVideoClip } from "central-icons/IconVideoClip";
 
 import type { HermesSkillInfo } from "../../../lib/tauri";
 import type { BuiltinComposerSlashCommandDef } from "../../../lib/agent-composer-slash-commands";
@@ -308,9 +310,14 @@ function commandItemDetailDescription(item: ComposerSlashCommandItem) {
 }
 
 function commandItemIcon(item: Extract<ComposerSlashCommandItem, { kind: "builtin" }>) {
-  return item.command.name === "file" ? (
-    <IconFileText size={16} aria-hidden />
-  ) : (
-    <IconConsoleSimple size={16} aria-hidden />
-  );
+  switch (item.command.name) {
+    case "model":
+      return <Icon3dBoxTop size={16} aria-hidden />;
+    case "file":
+      return <IconFileText size={16} aria-hidden />;
+    case "image":
+      return <IconCat size={16} aria-hidden />;
+    case "video":
+      return <IconVideoClip size={16} aria-hidden />;
+  }
 }

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -4,6 +4,7 @@ import {
   Fragment,
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -765,6 +766,217 @@ export function ModelPickerPopover({
             portalTarget,
           )
         : null}
+    </div>
+  );
+}
+
+/** Single-panel catalog opened by submitting bare `/model` in the composer.
+ * It keeps the curated picks pinned above the rest of the searchable catalog,
+ * using the same row, provider, privacy, and selection language as the compact
+ * toolbar picker. */
+export function ModelCommandPalette({
+  model,
+  options,
+  search,
+  popoverRef,
+  searchRef,
+  onSearchChange,
+  onSelect,
+}: {
+  model?: VeniceModelDto;
+  options: VeniceModelDto[];
+  search: string;
+  popoverRef: RefObject<HTMLDivElement>;
+  searchRef: RefObject<HTMLInputElement>;
+  onSearchChange: (value: string) => void;
+  onSelect: (modelId: string) => void;
+}) {
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const fade = useScrollFade(listRef);
+  const listId = useId();
+  const [privateOnly, setPrivateOnly] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const query = search.trim().toLowerCase();
+  const selectable = useMemo(
+    () => options.filter((option) => modelAvailableForMode("generation", option)),
+    [options],
+  );
+  const privacyFiltered = useMemo(
+    () => (privateOnly ? selectable.filter(modelIsPrivate) : selectable),
+    [privateOnly, selectable],
+  );
+  const matching = useMemo(
+    () =>
+      query
+        ? privacyFiltered.filter((option) => modelMatchesQuery(option, query))
+        : privacyFiltered,
+    [privacyFiltered, query],
+  );
+  const suggested = useMemo(() => suggestedModelsForMode("generation", selectable), [selectable]);
+  const matchingSuggested = suggested.filter(({ model: option }) =>
+    matching.some((candidate) => candidate.id === option.id),
+  );
+  const suggestedIds = new Set(matchingSuggested.map(({ model: option }) => option.id));
+  const remaining = matching.filter((option) => !suggestedIds.has(option.id));
+  const resultRows = [
+    ...matchingSuggested.map(({ model: option, reason }) => ({ option, description: reason })),
+    ...remaining.map((option) => ({ option, description: option.description })),
+  ];
+  const resolvedActiveIndex = Math.min(activeIndex, Math.max(resultRows.length - 1, 0));
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [privateOnly, query]);
+
+  useLayoutEffect(() => {
+    fade.update();
+  }, [fade.update, matchingSuggested.length, remaining.length]);
+
+  function moveActive(delta: number) {
+    if (!resultRows.length) return;
+    setActiveIndex((current) => {
+      const currentIndex = Math.min(current, resultRows.length - 1);
+      const nextIndex = (currentIndex + delta + resultRows.length) % resultRows.length;
+      window.requestAnimationFrame(() => {
+        document
+          .getElementById(`${listId}-option-${nextIndex}`)
+          ?.scrollIntoView?.({ block: "nearest" });
+      });
+      return nextIndex;
+    });
+  }
+
+  const modelRow = (option: VeniceModelDto, description: string | undefined, index: number) => (
+    <button
+      key={option.id}
+      id={`${listId}-option-${index}`}
+      type="button"
+      className="agent-composer-model-row agent-composer-model-command-row"
+      role="option"
+      tabIndex={-1}
+      aria-selected={option.id === model?.id}
+      data-active={index === resolvedActiveIndex || undefined}
+      onFocus={() => setActiveIndex(index)}
+      onPointerMove={() => setActiveIndex(index)}
+      onClick={() => onSelect(option.id)}
+    >
+      <span className="agent-composer-model-row-logo" aria-hidden>
+        <ProviderLogo provider={option.provider} id={option.id} name={option.name} />
+      </span>
+      <span className="agent-composer-model-row-copy">
+        <span className="agent-composer-model-row-name">{option.name}</span>
+        {description ? (
+          <span className="agent-composer-model-command-description">{description}</span>
+        ) : null}
+      </span>
+      {option.id === model?.id ? (
+        <IconCheckmark2Small size={14} aria-hidden className="agent-composer-model-row-check" />
+      ) : null}
+      <ModelRowPrivacyBadge model={option} />
+    </button>
+  );
+
+  return (
+    <div
+      ref={popoverRef}
+      className="agent-composer-model-popover agent-composer-model-command-palette"
+      role="dialog"
+      aria-label="Choose text model"
+    >
+      <label className="agent-composer-model-search">
+        <input
+          ref={searchRef}
+          value={search}
+          onChange={(event) => onSearchChange(event.currentTarget.value)}
+          placeholder="Search models"
+          aria-label="Search models"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded="true"
+          aria-controls={listId}
+          aria-activedescendant={
+            resultRows.length ? `${listId}-option-${resolvedActiveIndex}` : undefined
+          }
+          onKeyDown={(event) => {
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              moveActive(1);
+              return;
+            }
+            if (event.key === "ArrowUp") {
+              event.preventDefault();
+              moveActive(-1);
+              return;
+            }
+            if (event.key === "Enter" && resultRows.length) {
+              event.preventDefault();
+              event.stopPropagation();
+              onSelect(resultRows[resolvedActiveIndex].option.id);
+            }
+          }}
+        />
+      </label>
+      <div className="agent-composer-model-filter">
+        <span>Private</span>
+        <Switch
+          checked={privateOnly}
+          onCheckedChange={setPrivateOnly}
+          aria-label="Only show private models"
+        />
+      </div>
+      <div className="agent-composer-model-command-list-wrap scroll-fade" {...fade.props}>
+        <div
+          ref={listRef}
+          id={listId}
+          className="agent-composer-model-command-list"
+          role="listbox"
+          aria-label="Text models"
+        >
+          {matchingSuggested.length ? (
+            <div
+              className="agent-composer-model-command-section"
+              role="group"
+              aria-labelledby={`${listId}-suggested-label`}
+            >
+              <p
+                id={`${listId}-suggested-label`}
+                className="agent-composer-model-command-section-label"
+              >
+                Suggested
+              </p>
+              {matchingSuggested.map(({ model: option, reason }, index) =>
+                modelRow(option, reason, index),
+              )}
+            </div>
+          ) : null}
+          {matchingSuggested.length && remaining.length ? (
+            <hr className="agent-composer-model-command-divider" role="presentation" />
+          ) : null}
+          {remaining.length ? (
+            <div
+              className="agent-composer-model-command-section"
+              role="group"
+              aria-labelledby={`${listId}-all-label`}
+            >
+              <p id={`${listId}-all-label`} className="agent-composer-model-command-section-label">
+                All models
+              </p>
+              {remaining.map((option, index) =>
+                modelRow(option, option.description, matchingSuggested.length + index),
+              )}
+            </div>
+          ) : null}
+        </div>
+        {!resultRows.length ? (
+          <p className="agent-composer-model-empty" role="status">
+            {privateOnly
+              ? query
+                ? "No private models match your search."
+                : "No private models available."
+              : "No models match your search."}
+          </p>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -32,22 +32,24 @@ export function autoPillDesignation(costQuality: number | undefined): string | u
 /**
  * Curated picks for the model picker's "Suggested" tab — the handful of
  * models we actually recommend, weighed on benchmark performance, price,
- * tool use, and privacy (June's agent needs tool calling, and June's pitch
- * is zero-retention privacy, so every text pick here is a "private" catalog
- * model that supports tools).
+ * tool use, and privacy. June's agent needs tool calling, so every text pick
+ * supports tools; each model's live catalog privacy badge remains the source
+ * of truth for whether it is private or anonymized.
  *
  * Auto lives in the picker's pinned toggle section, not in these rows: the
  * suggested rows stay concrete models so they double as the landing spots
  * when Auto is switched off (the first pick is the toggle-off fallback).
  *
- * Curation snapshot (June 2026), from the live Venice catalog plus public
+ * Curation snapshot (July 2026), from the live Venice catalog plus public
  * benchmarks (SWE-bench agentic coding, Artificial Analysis intelligence
  * index):
  * - GLM 5.2: latest GLM flagship and June's default text model, with
  *   reasoning effort controls, tool use, 200K context, $1.75/$5.50 per 1M
  *   tokens.
- * - Kimi K2.6: leads the open-weights intelligence rankings, built for long
- *   agentic tool runs, 256K context, $0.85/$4.66.
+ * - Kimi K3: newest Kimi flagship, built for multimodal reasoning and long
+ *   agentic tool runs, 1M context, $3.75/$18.75 in anonymous mode.
+ * - Kimi K2.6: private Kimi alternative with multimodal reasoning, tool use,
+ *   and 256K context, $0.85/$4.66 with zero data retention.
  * - GLM 5.1: previous GLM flagship, top-tier agentic coding and tool use
  *   among open models, 200K context, $1.75/$5.50 per 1M tokens.
  * - Parakeet: fast, accurate everyday dictation at the lowest price tier.
@@ -68,9 +70,14 @@ export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
         "Default pick: latest GLM flagship with strong reasoning, tool use, structured output, and zero data retention.",
     },
     {
+      id: "kimi-k3",
+      reason:
+        "Newest Kimi flagship: multimodal reasoning, tool use, and a 1M-token context window in anonymous mode.",
+    },
+    {
       id: "kimi-k2-6",
       reason:
-        "Best alternate: leads independent intelligence rankings and excels at long tool-driven tasks, with zero data retention.",
+        "Private Kimi option: multimodal reasoning, tool use, and a 256K-token context window with zero data retention.",
     },
     {
       id: "zai-org-glm-5-1",
@@ -153,10 +160,10 @@ export function preferredVisionFallbackModel(models: VeniceModelDto[]): VeniceMo
   const eligible = models.filter(
     (model) => modelSupportsImageInput(model) && modelSupportsTools(model),
   );
-  const suggested = PREFERRED_VISION_FALLBACK_IDS.map((id) =>
+  const preferred = PREFERRED_VISION_FALLBACK_IDS.map((id) =>
     eligible.find((model) => model.id === id),
   ).find((model): model is VeniceModelDto => model !== undefined);
-  return suggested ?? eligible[0];
+  return preferred ?? eligible[0];
 }
 
 /** The curated picks that are actually present in the live catalog, in

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6728,6 +6728,74 @@ button.agent-user-attachment:hover {
   padding: var(--sp-1);
 }
 
+/* Bare `/model` opens one command-result palette rather than the toolbar
+ * picker's two-layer drill-in. It aligns to the composer box, leads with
+ * search, keeps curated suggestions first, and continues into the remaining
+ * catalog below a divider. */
+.agent-composer-model-command-palette {
+  gap: 0;
+  width: auto;
+  max-height: min(50vh, var(--model-command-available-height, 50vh));
+  padding: var(--sp-1);
+  overflow: hidden;
+}
+
+.agent-composer-model-command-list-wrap {
+  min-height: 0;
+  overflow: hidden;
+  contain: paint;
+  --scroll-fade-size: var(--sp-4);
+}
+
+.agent-composer-model-command-list {
+  max-height: calc(
+    min(50vh, var(--model-command-available-height, 50vh)) -
+    (2 * var(--control-md)) -
+    var(--sp-2)
+  );
+  padding: var(--sp-1) 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.agent-composer-model-command-section {
+  display: grid;
+  gap: var(--sp-px);
+}
+
+.agent-composer-model-command-section-label {
+  margin: 0;
+  padding: var(--sp-2) var(--sp-2) var(--sp-1);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.2;
+}
+
+.agent-composer-model-command-divider {
+  height: var(--sp-px);
+  margin: var(--sp-1) var(--sp-2);
+  border: 0;
+  background: color-mix(in oklch, var(--border-subtle) 50%, transparent);
+}
+
+.agent-composer-model-command-row .agent-composer-model-row-copy {
+  grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+  align-items: center;
+  gap: var(--sp-3);
+  width: 100%;
+}
+
+.agent-composer-model-command-description {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.25;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .agent-composer-model-search {
   display: flex;
   align-items: center;

--- a/src/test/agent-composer-slash-commands.test.ts
+++ b/src/test/agent-composer-slash-commands.test.ts
@@ -18,6 +18,10 @@ import {
 
 describe("agent composer built-in slash commands", () => {
   it("parses reserved model and file commands", () => {
+    expect(parseBuiltinComposerSlashCommand("/model")).toEqual({
+      name: "model",
+      argument: "",
+    });
     expect(parseBuiltinComposerSlashCommand("/model kimi")).toEqual({
       name: "model",
       argument: "kimi",

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -4078,7 +4078,64 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace initialSession={existingSession} />);
 
     await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
-    expect(await screen.findByRole("dialog", { name: "Choose text model" })).toBeInTheDocument();
+    const picker = await screen.findByRole("dialog", { name: "Choose text model" });
+    expect(
+      within(picker).queryByRole("textbox", { name: "Search models" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("stages /model from the slash menu, then opens the model palette on Enter", async () => {
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+    await user.type(composer, "/");
+    await user.click(await screen.findByRole("option", { name: "Model" }));
+
+    expect(composer).toHaveTextContent("/model");
+    expect(screen.queryByRole("dialog", { name: "Choose text model" })).not.toBeInTheDocument();
+
+    await user.keyboard("{Enter}");
+
+    const palette = await screen.findByRole("dialog", { name: "Choose text model" });
+    expect(within(palette).getByRole("combobox", { name: "Search models" })).toHaveFocus();
+    expect(within(palette).getByText("Suggested")).toBeInTheDocument();
+    expect(within(palette).getByText("All models")).toBeInTheDocument();
+    expect(composer).toHaveTextContent(/^$/);
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog", { name: "Choose text model" })).not.toBeInTheDocument();
+    await waitFor(() => expect(composer).toHaveFocus());
+  });
+
+  it("searches and keyboard-selects a model when bare /model is submitted", async () => {
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+    await user.type(composer, "/model");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    const palette = await screen.findByRole("dialog", { name: "Choose text model" });
+    const search = within(palette).getByRole("combobox", { name: "Search models" });
+    expect(search).toBeInTheDocument();
+    expect(
+      within(palette).getByRole("switch", { name: "Only show private models" }),
+    ).not.toBeChecked();
+    expect(within(palette).getByText("Suggested")).toBeInTheDocument();
+    expect(within(palette).getByText("All models")).toBeInTheDocument();
+    expect(composer).toHaveTextContent(/^$/);
+
+    await user.type(search, "GLM 5.2");
+    expect(within(palette).getByRole("option", { name: /GLM 5\.2/ })).toBeInTheDocument();
+
+    await user.keyboard("{Enter}");
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Choose text model" })).not.toBeInTheDocument(),
+    );
+    expect(composer).toHaveFocus();
   });
 
   it("queues /model in an existing chat and applies it before the next message", async () => {
@@ -11732,9 +11789,9 @@ describe("AgentWorkspace", () => {
     );
   });
 
-  it("prefers the suggested vision model over the first eligible one (JUN-165)", async () => {
+  it("prefers the private vision fallback over the first eligible one (JUN-165)", async () => {
     // The banner action is a one-tap fix, and with several image-capable models
-    // it prefers a curated suggested pick (Kimi K2.6) rather than the
+    // it prefers a known private vision pick (Kimi K2.6) rather than the
     // alphabetically-first vision model — otherwise it lands on an arbitrary
     // model like Claude Fable 5. Qwen VL is listed first here to prove the
     // preference overrides list order; no non-vision-scoped picker is opened.

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -428,14 +428,28 @@ describe("AppSettings", () => {
                 id: "kimi-k2-6",
                 name: "Kimi K2.6",
                 modelType: "text",
-                description: "Open-weights model built for long tool-driven tasks.",
+                description: "Private multimodal model built for long tool-driven tasks.",
                 privacy: "private",
                 priceUnit: "tokens",
                 inputCreditsPerMillionTokens: 850,
                 outputCreditsPerMillionTokens: 4660,
                 contextTokens: 256000,
                 traits: [],
-                capabilities: ["supportsFunctionCalling"],
+                capabilities: ["supportsFunctionCalling", "supportsVision"],
+              },
+              {
+                provider: "venice",
+                id: "kimi-k3",
+                name: "Kimi K3",
+                modelType: "text",
+                description: "Multimodal reasoning model built for long tool-driven tasks.",
+                privacy: "anonymized",
+                priceUnit: "tokens",
+                inputCreditsPerMillionTokens: 3750,
+                outputCreditsPerMillionTokens: 18750,
+                contextTokens: 1000000,
+                traits: [],
+                capabilities: ["supportsFunctionCalling", "supportsVision"],
               },
               {
                 provider: "venice",
@@ -4053,6 +4067,7 @@ describe("AppSettings", () => {
     // section, not the suggested rows.
     expect(await screen.findByRole("option", { name: /GLM 5\.2/ })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: /GLM 5\.1/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Kimi K3/ })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: /Kimi K2\.6/ })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /Auto/ })).not.toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /Venice Uncensored/ })).not.toBeInTheDocument();

--- a/src/test/model-command-palette.test.tsx
+++ b/src/test/model-command-palette.test.tsx
@@ -1,0 +1,79 @@
+import { createRef } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ModelCommandPalette } from "../components/settings/ModelPickerPopover";
+import type { VeniceModelDto } from "../lib/tauri";
+
+const model = (id: string, name: string, privacy: string): VeniceModelDto => ({
+  provider: "venice",
+  id,
+  name,
+  modelType: "text",
+  privacy,
+  traits: [],
+  capabilities: ["supportsFunctionCalling"],
+});
+
+describe("ModelCommandPalette", () => {
+  it("renders the catalog before a current selection is resolved", () => {
+    render(
+      <ModelCommandPalette
+        options={[model("zai-org-glm-5-2", "GLM 5.2", "private")]}
+        search=""
+        popoverRef={createRef<HTMLDivElement>()}
+        searchRef={createRef<HTMLInputElement>()}
+        onSearchChange={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("dialog", { name: "Choose text model" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /GLM 5\.2/ })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+  });
+
+  it("filters suggested and catalog rows to private models", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <ModelCommandPalette
+        model={model("zai-org-glm-5-2", "GLM 5.2", "private")}
+        options={[
+          model("zai-org-glm-5-2", "GLM 5.2", "private"),
+          model("kimi-k3", "Kimi K3", "anonymized"),
+          model("kimi-k2-6", "Kimi K2.6", "private"),
+          model("private-extra", "Private Extra", "private"),
+          model("anonymous-extra", "Anonymous Extra", "anonymized"),
+        ]}
+        search=""
+        popoverRef={createRef<HTMLDivElement>()}
+        searchRef={createRef<HTMLInputElement>()}
+        onSearchChange={vi.fn()}
+        onSelect={onSelect}
+      />,
+    );
+
+    expect(screen.getByRole("option", { name: /Kimi K3/ })).toBeInTheDocument();
+    expect(screen.getAllByRole("option", { name: /Kimi K3/ })).toHaveLength(1);
+    expect(screen.getByRole("option", { name: /Kimi K2\.6/ })).toBeInTheDocument();
+    expect(screen.getAllByRole("option", { name: /Kimi K2\.6/ })).toHaveLength(1);
+    expect(screen.getByRole("option", { name: /Anonymous Extra/ })).toBeInTheDocument();
+
+    const search = screen.getByRole("combobox", { name: "Search models" });
+    await user.click(search);
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+    expect(onSelect).toHaveBeenCalledWith("kimi-k2-6");
+
+    await user.click(screen.getByRole("switch", { name: "Only show private models" }));
+
+    expect(screen.getByRole("option", { name: /GLM 5\.2/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Kimi K2\.6/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Private Extra/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Kimi K3/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Anonymous Extra/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/test/suggested-models.test.ts
+++ b/src/test/suggested-models.test.ts
@@ -20,17 +20,17 @@ const VISION_TOOLS = ["supportsFunctionCalling", "supportsVision"];
 // ("Claude Fable 5") is what a naive `[0]` fallback would pick — the JUN-165
 // bug. These fixtures put Fable first to prove the preference overrides order.
 const fable = model("claude-fable-5", "Claude Fable 5", VISION_TOOLS);
-const kimi = model("kimi-k2-6", "Kimi K2.6", VISION_TOOLS); // suggested pick
+const kimi = model("kimi-k2-6", "Kimi K2.6", VISION_TOOLS); // private fallback pick
+const kimi3 = model("kimi-k3", "Kimi K3", VISION_TOOLS);
 const glm52 = model("zai-org-glm-5-2", "GLM 5.2", ["supportsFunctionCalling"]);
 
 describe("preferredVisionFallbackModel", () => {
-  it("prefers the suggested vision model (Kimi) over the first vision model", () => {
+  it("prefers the private vision fallback (Kimi) over the first vision model", () => {
     const chosen = preferredVisionFallbackModel([fable, kimi, glm52]);
     expect(chosen?.id).toBe("kimi-k2-6");
   });
 
-  it("never returns a non-vision model, even a suggested one (GLM 5.2)", () => {
-    // GLM 5.2 is the first suggested id but is non-vision; it must be skipped.
+  it("never returns a non-vision model", () => {
     const chosen = preferredVisionFallbackModel([glm52, fable]);
     expect(chosen?.id).toBe("claude-fable-5");
   });
@@ -43,7 +43,7 @@ describe("preferredVisionFallbackModel", () => {
 
   it("requires tool support: a vision model without tools is not eligible", () => {
     // A vision model that can't run tools would brick the agent, so the
-    // suggested Kimi entry here (vision only, no tools) must be skipped.
+    // preferred Kimi entry here (vision only, no tools) must be skipped.
     const kimiNoTools = model("kimi-k2-6", "Kimi K2.6", ["supportsVision"]);
     const chosen = preferredVisionFallbackModel([kimiNoTools, fable]);
     expect(chosen?.id).toBe("claude-fable-5");
@@ -61,10 +61,11 @@ describe("suggestedModelsForMode", () => {
     // Auto is not a suggested row — it lives in the picker's pinned toggle
     // section — so the catalog's Auto entry never surfaces here.
     const auto = model("open-software/auto", "Auto", ["supportsFunctionCalling"]);
-    const suggestions = suggestedModelsForMode("generation", [auto, kimi, glm52]);
+    const suggestions = suggestedModelsForMode("generation", [auto, kimi, kimi3, glm52]);
 
     expect(suggestions.map(({ model: suggestion }) => suggestion.id)).toEqual([
       "zai-org-glm-5-2",
+      "kimi-k3",
       "kimi-k2-6",
     ]);
   });


### PR DESCRIPTION
## Summary

- stage `/model` from the composer slash menu, then open a searchable text-model catalog on Enter
- keep curated suggestions above the remaining catalog and add a Private-only filter
- suggest both the newest Kimi K3 model and private Kimi K2.6, with privacy-specific guidance
- use the requested Central icons for model, image, and video slash commands

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` - 199 files passed, 3208 tests passed, 2 skipped
- focused model palette, settings, suggestion, and composer tests passed after the final Kimi curation update
- `pnpm typecheck`
- `pnpm check` - no errors; the existing warning backlog remains
- `git diff --check origin/main`
- live browser walkthrough: `/model` opens the palette, both Kimi models appear under Suggested, search works, and Private keeps Kimi K2.6 while hiding Kimi K3

https://app.opensoftware.co/api/v1/files/fil_VdOx6bwfUThP/download

- [x] Tested visually where it matters; walkthrough attached above.
- [x] Does not need a June API backend deploy; it consumes the existing live model catalog.

## Out of scope

- changing the default generation model or the existing toolbar picker flow
- changing backend model catalog contracts or privacy classifications

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] No security-sensitive behavior is changed.
- [x] Workflow action references are untouched.
- [x] Desktop signing, updater, entitlement, capability, and release behavior are untouched.
- [x] Backend auth, billing, metering, CORS, rate limit, and logging are untouched.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787246886&installation_model_id=425925&pr_number=878&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F878&signature=af81435a948e6b09f8803e43905068846921692355f71e7a2695e3aacb2a5ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->