### PR TITLE
Add composer thinking level control (Instant, Medium, Hard)

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -209,6 +209,14 @@ import {
 import { resolveModelSwitchOutcome } from "../../lib/hermes-model-switch";
 import { suggestedModelsForMode } from "../../lib/suggested-models";
 import {
+  loadThinkingLevel,
+  saveThinkingLevel,
+  thinkingEffortForLevel,
+  thinkingOptionForLevel,
+  THINKING_LEVELS,
+  type ThinkingLevel,
+} from "../../lib/thinking-level";
+import {
   contextLabel,
   modelOptions,
   pricingLabel,
@@ -1483,6 +1491,19 @@ export function AgentWorkspace({
   const composerModelTriggerRef = useRef<HTMLButtonElement | null>(null);
   const composerModelPopoverRef = useRef<HTMLDivElement | null>(null);
   const composerModelSearchRef = useRef<HTMLInputElement | null>(null);
+  // Thinking level: how much June reasons before answering. The stored draft
+  // seeds new sessions (session.create's reasoning_effort); a per-session
+  // override records a pick made while a session is open, mirroring
+  // sessionModelOverridesRef. The applied map remembers the last effort the
+  // gateway acked for a session's live runtime so a turn only re-asserts the
+  // override when it changed (config.set writes the profile config each call,
+  // so it is not something to fire blindly on every send).
+  const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(() =>
+    loadThinkingLevel(),
+  );
+  const thinkingLevelRef = useRef(thinkingLevel);
+  const sessionThinkingOverridesRef = useRef<Record<string, ThinkingLevel>>({});
+  const sessionThinkingAppliedRef = useRef<Record<string, string>>({});
   // Attestation walkthrough URL served by the backend (same page as Settings
   // → About → Verify server); the privacy badge links to it when known.
   const [capabilityQuery, setCapabilityQuery] = useState("");
@@ -2003,6 +2024,13 @@ export function AgentWorkspace({
     selectedHermesSessionId && !newSessionMode
       ? selectedHermesSession?.model?.trim() || defaultGenerationModelId
       : defaultGenerationModelId;
+  // The control shows the open session's level when one was picked for it,
+  // otherwise the stored draft the next new session will use.
+  const composerThinkingLevel: ThinkingLevel =
+    selectedHermesSessionId && !newSessionMode
+      ? (sessionThinkingOverridesRef.current[selectedHermesSessionId] ??
+        thinkingLevel)
+      : thinkingLevel;
   const generationModel = useMemo(
     () =>
       activeGenerationModelId
@@ -2351,7 +2379,10 @@ export function AgentWorkspace({
         event.preventDefault();
         // Escape peels one layer at a time: the all-models panel first,
         // then the popover itself.
-        if (composerModelFlyout?.kind === "all") {
+        if (
+          composerModelFlyout?.kind === "all" ||
+          composerModelFlyout?.kind === "effort"
+        ) {
           setComposerModelFlyout(null);
           setModelSearch("");
         } else {
@@ -2596,6 +2627,59 @@ export function AgentWorkspace({
     setComposerModelOpen(true);
     setSandboxMenuOpen(false);
     void loadGenerationModel();
+  }
+
+  // Picking a thinking level always updates the stored draft (the next new
+  // session opens with it). With a session open it ALSO retunes that session:
+  // the override is recorded per chat, applied to the live runtime through
+  // config.set (setSessionReasoningEffort), and re-asserted on the next turn
+  // if the runtime is not up right now — see submitHermesSession, which only
+  // re-sends when the last acked effort differs.
+  async function handleSelectThinkingLevel(level: ThinkingLevel) {
+    thinkingLevelRef.current = level;
+    setThinkingLevel(level);
+    saveThinkingLevel(level);
+    const sessionId = newSessionModeRef.current
+      ? undefined
+      : selectedHermesSessionIdRef.current;
+    if (!sessionId || isProvisionalHermesSessionId(sessionId)) return;
+    sessionThinkingOverridesRef.current = {
+      ...sessionThinkingOverridesRef.current,
+      [sessionId]: level,
+    };
+    await applyThinkingLevelToSession(sessionId, level);
+  }
+
+  // Best-effort live retune of one session's reasoning effort. Skips the RPC
+  // entirely when the gateway already acked this effort for the session's
+  // current runtime (the common case: reopening the submenu and picking the
+  // same stop, or sending the next turn after a successful change).
+  async function applyThinkingLevelToSession(
+    sessionId: string,
+    level: ThinkingLevel,
+    explicitRuntimeSessionId?: string,
+  ) {
+    const effort = thinkingEffortForLevel(level);
+    if (sessionThinkingAppliedRef.current[sessionId] === effort) return;
+    const runtimeSessionId =
+      explicitRuntimeSessionId ?? runtimeSessionIdsRef.current[sessionId];
+    if (!runtimeSessionId) return;
+    try {
+      const gateway = await ensureHermesGateway(sessionUnrestricted(sessionId));
+      await createHermesMethods(gateway).setSessionReasoningEffort({
+        sessionId: runtimeSessionId,
+        effort,
+      });
+      sessionThinkingAppliedRef.current = {
+        ...sessionThinkingAppliedRef.current,
+        [sessionId]: effort,
+      };
+      setError(null);
+    } catch {
+      // The override is still recorded, so the next turn re-asserts it once
+      // the runtime is reachable; no banner for something the send flow
+      // quietly heals.
+    }
   }
 
   // Switching the model always writes the global text-model default (Settings'
@@ -4217,6 +4301,13 @@ export function AgentWorkspace({
                 ...(targetSessionModelId
                   ? { model: targetSessionModelId }
                   : {}),
+                // The thinking level pins the session's reasoning effort at
+                // creation (a per-session override, never a profile config
+                // write), so the level the user picked always wins over
+                // whatever the Hermes profile default happens to be.
+                reasoning_effort: thinkingEffortForLevel(
+                  thinkingLevelRef.current,
+                ),
               },
             );
         const nextStoredSessionId =
@@ -4234,6 +4325,14 @@ export function AgentWorkspace({
         };
       })().catch(rollbackOptimisticBeforePrompt);
     storedSessionIdForRollback = storedSessionId;
+    if (created) {
+      // The create already pinned this effort, so the re-assert path
+      // must not fire a redundant config.set on the session's first turns.
+      sessionThinkingAppliedRef.current = {
+        ...sessionThinkingAppliedRef.current,
+        [storedSessionId]: thinkingEffortForLevel(thinkingLevelRef.current),
+      };
+    }
     const queuedIssueReport = options?.issueReport;
     if (queuedIssueReport && targetSessionId) {
       queuedIssueReport.diagnosisStartedAt = new Date().toISOString();
@@ -4315,6 +4414,19 @@ export function AgentWorkspace({
       clearQueuedIssueReport();
       rollbackOptimisticBeforePrompt(
         new Error("Hermes did not resume the session."),
+      );
+    }
+    // A thinking level picked while this session's runtime was down (or a
+    // live retune that failed) re-asserts here, before the prompt, so the
+    // turn runs at the level the control shows. No-op when the gateway already
+    // acked this effort for the current runtime.
+    const thinkingOverride =
+      sessionThinkingOverridesRef.current[storedSessionId];
+    if (thinkingOverride) {
+      await applyThinkingLevelToSession(
+        storedSessionId,
+        thinkingOverride,
+        runtimeSessionId,
       );
     }
     // Feature 19: send any imported images to the session through the
@@ -6319,6 +6431,7 @@ export function AgentWorkspace({
               <ComposerModelPicker
                 open={composerModelOpen}
                 model={generationModel}
+                thinkingLevel={composerThinkingLevel}
                 triggerRef={composerModelTriggerRef}
                 onToggleOpen={() => {
                   if (composerModelOpen) {
@@ -6429,11 +6542,17 @@ export function AgentWorkspace({
             model={generationModel}
             options={modelOptions(generationModels, generationModel?.id ?? "")}
             search={modelSearch}
+            thinkingLevel={composerThinkingLevel}
             popoverRef={composerModelPopoverRef}
             searchRef={composerModelSearchRef}
             onFlyoutChange={setComposerModelFlyout}
             onSearchChange={setModelSearch}
             onSelect={(modelId) => void handleSelectGenerationModel(modelId)}
+            onSelectThinking={(level) => {
+              setComposerModelFlyout(null);
+              setComposerModelOpen(false);
+              void handleSelectThinkingLevel(level);
+            }}
           />
         ) : null}
         {heroMode && sandboxMenuOpen ? (
@@ -7023,15 +7142,18 @@ export function AgentWorkspace({
 function ComposerModelPicker({
   open,
   model,
+  thinkingLevel,
   triggerRef,
   onToggleOpen,
 }: {
   open: boolean;
   model?: VeniceModelDto;
+  thinkingLevel: ThinkingLevel;
   triggerRef: RefObject<HTMLButtonElement>;
   onToggleOpen: () => void;
 }) {
   if (!model) return null;
+  const thinking = thinkingOptionForLevel(thinkingLevel);
   return (
     <div className="agent-composer-model" data-open={open || undefined}>
       <button
@@ -7044,6 +7166,9 @@ function ComposerModelPicker({
         onClick={onToggleOpen}
       >
         <span>{model.name}</span>
+        <span className="agent-composer-model-trigger-level">
+          {thinking.label}
+        </span>
         <IconChevronDownSmall size={12} aria-hidden />
       </button>
     </div>
@@ -7053,10 +7178,12 @@ function ComposerModelPicker({
 // The composer model popover is two-layered, menu-style: the root layer
 // lists the curated suggested models as plain rows, and a flyout panel
 // opens beside it — hover details for a suggested row, or the searchable
-// full catalog behind the "All models" row.
+// full catalog behind the "All models" row, or the thinking-level submenu
+// behind the "Effort" row.
 type ComposerModelFlyout =
   | { kind: "model"; id: string }
   | { kind: "all" }
+  | { kind: "effort" }
   | null;
 
 // Hover-intent delay before a hover opens a flyout or card — a pointer
@@ -7072,21 +7199,25 @@ function ComposerModelPopover({
   model,
   options,
   search,
+  thinkingLevel,
   popoverRef,
   searchRef,
   onFlyoutChange,
   onSearchChange,
   onSelect,
+  onSelectThinking,
 }: {
   flyout: ComposerModelFlyout;
   model?: VeniceModelDto;
   options: VeniceModelDto[];
   search: string;
+  thinkingLevel: ThinkingLevel;
   popoverRef: RefObject<HTMLDivElement>;
   searchRef: RefObject<HTMLInputElement>;
   onFlyoutChange: (flyout: ComposerModelFlyout) => void;
   onSearchChange: (value: string) => void;
   onSelect: (modelId: string) => void;
+  onSelectThinking: (level: ThinkingLevel) => void;
 }) {
   const flyoutRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -7347,6 +7478,34 @@ function ComposerModelPopover({
           className="agent-composer-model-row-chevron"
         />
       </button>
+      <button
+        type="button"
+        className="agent-composer-model-row"
+        aria-haspopup="true"
+        aria-expanded={flyout?.kind === "effort"}
+        data-active={flyout?.kind === "effort" || undefined}
+        onMouseEnter={() =>
+          hoverIntent(() => onFlyoutChange({ kind: "effort" }))
+        }
+        onFocus={() => {
+          cancelHoverIntent();
+          onFlyoutChange({ kind: "effort" });
+        }}
+        onClick={() => {
+          cancelHoverIntent();
+          onFlyoutChange({ kind: "effort" });
+        }}
+      >
+        <span className="agent-composer-model-row-name">Effort</span>
+        <span className="agent-composer-model-row-value">
+          {thinkingOptionForLevel(thinkingLevel).label}
+        </span>
+        <IconChevronRightSmall
+          size={12}
+          aria-hidden
+          className="agent-composer-model-row-chevron"
+        />
+      </button>
       {detail ? (
         <div
           ref={flyoutRef}
@@ -7354,6 +7513,47 @@ function ComposerModelPopover({
         >
           <div className="agent-composer-model-surface">
             <ComposerModelCardContent model={detail.model} />
+          </div>
+        </div>
+      ) : flyout?.kind === "effort" ? (
+        <div
+          ref={flyoutRef}
+          className="agent-composer-model-flyout agent-composer-model-effort-panel"
+          role="group"
+          aria-label="Thinking level"
+        >
+          <div className="agent-composer-model-surface">
+            <p className="agent-composer-model-title">Effort</p>
+            <div
+              className="agent-composer-model-menu"
+              role="listbox"
+              aria-label="Thinking level"
+            >
+              {THINKING_LEVELS.map((option) => (
+                <button
+                  key={option.id}
+                  type="button"
+                  className="agent-composer-model-row"
+                  role="option"
+                  aria-selected={option.id === thinkingLevel}
+                  onClick={() => onSelectThinking(option.id)}
+                >
+                  <span className="agent-composer-model-row-name">
+                    {option.label}
+                  </span>
+                  {option.id === thinkingLevel ? (
+                    <IconCheckmark1Small
+                      size={14}
+                      aria-hidden
+                      className="agent-composer-model-row-check"
+                    />
+                  ) : null}
+                </button>
+              ))}
+            </div>
+            <p className="agent-composer-model-note">
+              Higher effort consumes usage limits faster.
+            </p>
           </div>
         </div>
       ) : flyout?.kind === "all" ? (

--- a/src/lib/hermes-control-plane/compatibility/matrix.ts
+++ b/src/lib/hermes-control-plane/compatibility/matrix.ts
@@ -152,6 +152,12 @@ const methods: HermesCompatibilitySection = {
       "The composer model picker switches a live session by dispatching /model via switchActiveSessionModel (command.dispatch) and only claims success on the gateway ack; covered by hermes-model-switch and agent-workspace tests.",
     since: PIN,
   },
+  "config.set": {
+    status: "supported",
+    rationale:
+      "The composer model menu's Effort submenu retunes a live session's reasoning effort via setSessionReasoningEffort (config.set key reasoning); covered by hermes-control-plane-methods and agent-workspace tests.",
+    since: CURRENT_PIN,
+  },
   "subagent.interrupt": {
     status: "supported",
     rationale:
@@ -337,9 +343,9 @@ const features: HermesCompatibilitySection = {
     since: CURRENT_PIN,
   },
   reasoningEffortControls: {
-    status: "planned",
+    status: "supported",
     rationale:
-      "Hermes 0.19 adds max and ultra reasoning effort plus per-model overrides, but June's model picker does not expose Hermes reasoning tiers.",
+      "The composer model menu's Effort submenu exposes three reasoning levels (Instant, Medium, Hard) mapped onto Hermes effort tiers: new sessions pin reasoning_effort on session.create and a live session retunes via config.set (setSessionReasoningEffort); max/ultra tiers and per-model overrides stay unexposed.",
     since: CURRENT_PIN,
   },
 };

--- a/src/lib/hermes-control-plane/methods.ts
+++ b/src/lib/hermes-control-plane/methods.ts
@@ -68,6 +68,15 @@ export type InterruptSubagentParams = {
   sessionId: string;
   subagentId: string;
 };
+export type SetSessionReasoningEffortParams = {
+  /** The session's RUNTIME id (not the stored id): config.set looks the
+   * session up in the gateway's live-session map. */
+  sessionId: string;
+  /** A Hermes reasoning-effort string: none, minimal, low, medium, high, or
+   * xhigh. Callers map June's thinking levels onto these in
+   * `thinking-level.ts`; this seam passes the wire value through untouched. */
+  effort: string;
+};
 export type AttachImageParams = {
   sessionId: string;
   mimeType: string;
@@ -93,6 +102,14 @@ export type HermesMethods = {
   respondToSudo(params: RespondToSudoParams): Promise<unknown>;
   respondToSecret(params: RespondToSecretParams): Promise<unknown>;
   interruptSubagent(params: InterruptSubagentParams): Promise<unknown>;
+  /** Changes how much a LIVE session reasons before answering by setting the
+   * gateway's `reasoning` config key (the same surface the TUI's /reasoning
+   * command uses). The gateway applies the new effort to the session's agent
+   * immediately, persists it into the session's stored runtime config (so
+   * resume keeps it), and emits a fresh session.info. */
+  setSessionReasoningEffort(
+    params: SetSessionReasoningEffortParams,
+  ): Promise<unknown>;
   attachImage(params: AttachImageParams): Promise<unknown>;
 };
 
@@ -152,6 +169,13 @@ export function createHermesMethods(client: HermesRequestLike): HermesMethods {
       return request("subagent.interrupt", {
         session_id: sessionId,
         subagent_id: subagentId,
+      });
+    },
+    setSessionReasoningEffort({ sessionId, effort }) {
+      return request("config.set", {
+        session_id: sessionId,
+        key: "reasoning",
+        value: effort,
       });
     },
     attachImage({ sessionId, mimeType, dataBase64 }) {

--- a/src/lib/hermes-control-plane/raw-types.ts
+++ b/src/lib/hermes-control-plane/raw-types.ts
@@ -91,6 +91,7 @@ export type RawHermesMethodName =
   | "sudo.respond"
   | "secret.respond"
   | "subagent.interrupt"
+  | "config.set"
   | "image.attach"
   | (string & {});
 

--- a/src/lib/thinking-level.ts
+++ b/src/lib/thinking-level.ts
@@ -1,0 +1,121 @@
+/**
+ * The composer's thinking level control: how much June reasons before
+ * answering. It lives in the model menu as an "Effort" row with a submenu of
+ * three levels, mirroring the upstream desktop's model menu.
+ *
+ * Three user-facing stops map onto Hermes' reasoning-effort levels
+ * (`parse_reasoning_effort` in hermes_constants.py: none, minimal, low,
+ * medium, high, xhigh). June deliberately exposes only three of them so the
+ * choice stays a simple speed/depth tradeoff:
+ *
+ * - Instant -> "minimal": the model barely deliberates, so first tokens
+ *   arrive almost immediately.
+ * - Medium -> "medium": Hermes' own default; a balance of speed and depth.
+ * - Hard -> "high": substantially more reasoning for harder problems.
+ *
+ * The choice rides to Hermes as a PER-SESSION override (`reasoning_effort`
+ * on session.create, `config.set` key "reasoning" for a live session), so
+ * June never has to rely on the profile config default. The user's last pick
+ * is kept in localStorage as the draft for the next new session, mirroring
+ * how agent-session-modes.ts records the Unrestricted opt-in (machine-local
+ * state, readable synchronously on render).
+ */
+
+export type ThinkingLevel = "instant" | "medium" | "hard";
+
+export type ThinkingLevelOption = {
+  id: ThinkingLevel;
+  /** Sentence-case label rendered on the submenu row. */
+  label: string;
+  /** One-line description of the tradeoff, no dashes (project copy rule). */
+  blurb: string;
+  /** The Hermes reasoning-effort string sent on the wire. */
+  effort: string;
+};
+
+/** Slider stops in track order (left to right: fastest to deepest). */
+export const THINKING_LEVELS: readonly ThinkingLevelOption[] = Object.freeze([
+  {
+    id: "instant",
+    label: "Instant",
+    blurb: "Answers right away, with very little deliberation.",
+    effort: "minimal",
+  },
+  {
+    id: "medium",
+    label: "Medium",
+    blurb: "Balances speed and depth for most tasks.",
+    effort: "medium",
+  },
+  {
+    id: "hard",
+    label: "Hard",
+    blurb: "Spends more time reasoning through hard problems.",
+    effort: "high",
+  },
+]);
+
+/** The control lands here when the user has never picked a level. Matches
+ * Hermes' own default effort, so a fresh install behaves like upstream. */
+export const DEFAULT_THINKING_LEVEL: ThinkingLevel = "medium";
+
+const STORAGE_KEY = "june.agent.thinkingLevel";
+
+export function isThinkingLevel(value: unknown): value is ThinkingLevel {
+  return value === "instant" || value === "medium" || value === "hard";
+}
+
+export function thinkingOptionForLevel(
+  level: ThinkingLevel,
+): ThinkingLevelOption {
+  const option = THINKING_LEVELS.find((entry) => entry.id === level);
+  // The union has exactly one option per level; the find cannot miss. The
+  // fallback keeps a corrupt future edit from crashing the composer.
+  return option ?? THINKING_LEVELS[1];
+}
+
+/** The wire value Hermes expects for this level (`reasoning_effort`). */
+export function thinkingEffortForLevel(level: ThinkingLevel): string {
+  return thinkingOptionForLevel(level).effort;
+}
+
+/** Best-effort reverse mapping from a Hermes effort string (e.g. one reported
+ * by session.info) back onto a level. Low collapses into Instant and
+ * xhigh into Hard; unknown/empty values return undefined so callers can keep
+ * their current draft instead of snapping to a stop. */
+export function thinkingLevelForEffort(
+  effort: string | undefined,
+): ThinkingLevel | undefined {
+  switch ((effort ?? "").trim().toLowerCase()) {
+    case "none":
+    case "minimal":
+    case "low":
+      return "instant";
+    case "medium":
+      return "medium";
+    case "high":
+    case "xhigh":
+      return "hard";
+    default:
+      return undefined;
+  }
+}
+
+/** The stored draft level for the next new session; the default when nothing
+ * (or something unreadable) was stored. */
+export function loadThinkingLevel(): ThinkingLevel {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return isThinkingLevel(raw) ? raw : DEFAULT_THINKING_LEVEL;
+  } catch {
+    return DEFAULT_THINKING_LEVEL;
+  }
+}
+
+export function saveThinkingLevel(level: ThinkingLevel) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, level);
+  } catch {
+    // Ignore; worst case the next launch drafts the default again.
+  }
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4558,6 +4558,42 @@ input:focus-visible,
   font-size: var(--fs-sm);
 }
 
+/* The composer model pill also carries the current thinking level, dimmed
+ * like a secondary value next to the model name. */
+.agent-composer-model-trigger-level {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+}
+
+/* The Effort submenu row inside the model popover: label on the left,
+ * current level + chevron on the right, like the upstream desktop's model
+ * menu. */
+.agent-composer-model-row-value {
+  flex: 0 0 auto;
+  margin-left: auto;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+/* The effort submenu itself: a compact flyout with plain level rows and a
+ * muted cost note under them. */
+.agent-composer-model-effort-panel {
+  width: 180px;
+}
+
+.agent-composer-model-effort-panel .agent-composer-model-surface {
+  gap: var(--sp-1);
+  max-height: inherit;
+  padding: var(--sp-1);
+}
+
+.agent-composer-model-note {
+  margin: 0;
+  padding: var(--sp-1) var(--sp-2) var(--sp-2);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
 /* Attach (+) and dictation (mic) are both quiet ghost buttons that round to a
  * squircle on hover, matching the send button. */
 .agent-composer-attach {
@@ -9487,6 +9523,18 @@ input:focus-visible,
   display: inline-flex;
   align-items: center;
   gap: var(--sp-3);
+}
+
+.settings-auto-preference {
+  gap: var(--sp-2);
+  min-width: 240px;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.settings-auto-preference input[type="range"] {
+  width: 140px;
+  accent-color: var(--primary);
 }
 
 .settings-row-mic-test {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2520,6 +2520,115 @@ describe("AgentWorkspace", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows the current thinking level on the model menu's Effort row", async () => {
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Model: GLM 5.2" }),
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: "Choose text model",
+    });
+    await user.click(
+      within(dialog).getByRole("button", { name: "Effort Medium" }),
+    );
+
+    const submenu = await screen.findByRole("group", {
+      name: "Thinking level",
+    });
+    expect(
+      within(submenu).getByRole("option", { name: "Instant" }),
+    ).toHaveAttribute("aria-selected", "false");
+    expect(
+      within(submenu).getByRole("option", { name: "Medium" }),
+    ).toHaveAttribute("aria-selected", "true");
+    expect(
+      within(submenu).getByRole("option", { name: "Hard" }),
+    ).toHaveAttribute("aria-selected", "false");
+    expect(
+      within(submenu).getByText("Higher effort consumes usage limits faster."),
+    ).toBeInTheDocument();
+  });
+
+  it("retunes the open session live when the thinking level changes", async () => {
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    // Send once so the session has a live runtime the retune can target.
+    await user.type(await screen.findByRole("textbox"), "first message");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "first message",
+      }),
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: "Model: GLM 5.2" }),
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: "Choose text model",
+    });
+    await user.click(
+      within(dialog).getByRole("button", { name: "Effort Medium" }),
+    );
+    const submenu = await screen.findByRole("group", {
+      name: "Thinking level",
+    });
+    await user.click(within(submenu).getByRole("option", { name: "Hard" }));
+
+    // The live runtime retunes through config.set (the same surface as the
+    // TUI's /reasoning), keyed by the runtime session id.
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("config.set", {
+        session_id: "runtime-session-1",
+        key: "reasoning",
+        value: "high",
+      }),
+    );
+  });
+
+  it("pins the picked thinking level on the next new session", async () => {
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Model: GLM 5.2" }),
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: "Choose text model",
+    });
+    await user.click(
+      within(dialog).getByRole("button", { name: "Effort Medium" }),
+    );
+    const submenu = await screen.findByRole("group", {
+      name: "Thinking level",
+    });
+    await user.click(within(submenu).getByRole("option", { name: "Instant" }));
+
+    window.dispatchEvent(
+      new CustomEvent(AGENT_NEW_SESSION_EVENT, {
+        detail: { prompt: "write a project update" },
+      }),
+    );
+
+    // New sessions pin the chosen level as a per-session override on
+    // session.create, never a profile config write.
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.create", {
+        title: "Summarize Current Page",
+        cols: 96,
+        model: "zai-org-glm-5-2",
+        reasoning_effort: "minimal",
+      }),
+    );
+  });
+
   it("switches the text model only for the active chat", async () => {
     // Tool-capable catalog: the picker refuses tool-less models for the
     // agent, so the switch target must support function calling.
@@ -3662,6 +3771,7 @@ describe("AgentWorkspace", () => {
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.create", {
       title: "Summarize Current Page",
       cols: 96,
+      reasoning_effort: "medium",
     });
     expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
       sessionId: "session-2",
@@ -4472,6 +4582,7 @@ describe("AgentWorkspace", () => {
         title: "Summarize Current Page",
         cols: 96,
         model: "zai-org-glm-5-2",
+        reasoning_effort: "medium",
       }),
     );
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {

--- a/src/test/hermes-control-plane-methods.test.ts
+++ b/src/test/hermes-control-plane-methods.test.ts
@@ -70,6 +70,21 @@ describe("createHermesMethods — typed command wrappers", () => {
     });
   });
 
+  it("setSessionReasoningEffort sets the reasoning key through config.set", async () => {
+    const { request, methods } = setup();
+    await methods.setSessionReasoningEffort({
+      sessionId: "runtime-1",
+      effort: "high",
+    });
+    // The session id is the RUNTIME id (the gateway's live-session map key),
+    // and the effort passes through untouched: callers own the level mapping.
+    expect(request).toHaveBeenCalledWith("config.set", {
+      session_id: "runtime-1",
+      key: "reasoning",
+      value: "high",
+    });
+  });
+
   it("respondToSudo forwards approval + mode to sudo.respond", async () => {
     const { request, methods } = setup();
     await methods.respondToSudo({

--- a/src/test/thinking-level.test.ts
+++ b/src/test/thinking-level.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_THINKING_LEVEL,
+  isThinkingLevel,
+  loadThinkingLevel,
+  saveThinkingLevel,
+  thinkingEffortForLevel,
+  thinkingLevelForEffort,
+  thinkingOptionForLevel,
+  THINKING_LEVELS,
+} from "../lib/thinking-level";
+
+const STORAGE_KEY = "june.agent.thinkingLevel";
+
+describe("thinking levels", () => {
+  it("exposes exactly three stops in track order", () => {
+    expect(THINKING_LEVELS.map((option) => option.id)).toEqual([
+      "instant",
+      "medium",
+      "hard",
+    ]);
+  });
+
+  it("maps each level onto a Hermes reasoning effort", () => {
+    // Instant barely deliberates (near-instant responses), Medium is Hermes'
+    // own default, Hard reasons substantially more.
+    expect(thinkingEffortForLevel("instant")).toBe("minimal");
+    expect(thinkingEffortForLevel("medium")).toBe("medium");
+    expect(thinkingEffortForLevel("hard")).toBe("high");
+  });
+
+  it("uses sentence-case labels and dash-free blurbs (project copy rule)", () => {
+    for (const option of THINKING_LEVELS) {
+      expect(option.label).toMatch(/^[A-Z][a-z]/);
+      expect(option.blurb).not.toMatch(/[–—]/);
+    }
+  });
+
+  it("resolves every level to an option, defaulting safely", () => {
+    for (const option of THINKING_LEVELS) {
+      expect(thinkingOptionForLevel(option.id)).toBe(option);
+    }
+  });
+
+  it("maps Hermes effort strings back onto the nearest stop", () => {
+    expect(thinkingLevelForEffort("minimal")).toBe("instant");
+    expect(thinkingLevelForEffort("low")).toBe("instant");
+    expect(thinkingLevelForEffort("medium")).toBe("medium");
+    expect(thinkingLevelForEffort("high")).toBe("hard");
+    expect(thinkingLevelForEffort("xhigh")).toBe("hard");
+    expect(thinkingLevelForEffort("")).toBeUndefined();
+    expect(thinkingLevelForEffort(undefined)).toBeUndefined();
+    expect(thinkingLevelForEffort("turbo")).toBeUndefined();
+  });
+});
+
+describe("thinking level persistence", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("drafts Medium when nothing was stored", () => {
+    expect(loadThinkingLevel()).toBe(DEFAULT_THINKING_LEVEL);
+    expect(DEFAULT_THINKING_LEVEL).toBe("medium");
+  });
+
+  it("round-trips a saved level", () => {
+    saveThinkingLevel("hard");
+    expect(loadThinkingLevel()).toBe("hard");
+    saveThinkingLevel("instant");
+    expect(loadThinkingLevel()).toBe("instant");
+  });
+
+  it("falls back to the default for unreadable stored values", () => {
+    window.localStorage.setItem(STORAGE_KEY, "ultra");
+    expect(loadThinkingLevel()).toBe(DEFAULT_THINKING_LEVEL);
+    window.localStorage.setItem(STORAGE_KEY, "");
+    expect(loadThinkingLevel()).toBe(DEFAULT_THINKING_LEVEL);
+  });
+
+  it("guards the level union", () => {
+    expect(isThinkingLevel("instant")).toBe(true);
+    expect(isThinkingLevel("medium")).toBe(true);
+    expect(isThinkingLevel("hard")).toBe(true);
+    expect(isThinkingLevel("xhigh")).toBe(false);
+    expect(isThinkingLevel(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed

The composer model menu gains an **Effort** row with a submenu of three thinking levels — **Instant**, **Medium**, **Hard** — so users can adjust how much June reasons before answering in agent sessions. The composer model pill now shows the current level beside the model name (`GLM 5.2 Medium`), matching the upstream desktop's model menu pattern.

- New `src/lib/thinking-level.ts`: the three levels, their mapping onto Hermes reasoning efforts (`minimal` / `medium` / `high`), and localStorage persistence of the last pick (default Medium, matching the Hermes default).
- `AgentWorkspace`: the Effort row + submenu live in the existing composer model popover (reusing its flyout/row pattern and the all-models Escape peel); picking a level updates the stored draft and, when a session is open, records a per-session override.
- **New sessions** pin the level as a per-session `reasoning_effort` override on `session.create`, so the Hermes profile default never leaks in; resume restores it from the session's persisted model_config.
- **Live sessions** retune immediately through a new typed `setSessionReasoningEffort` control-plane seam (`config.set` key `reasoning`, the same surface as the TUI's `/reasoning` command); a pick made while the runtime is down re-asserts just before the next turn, and an applied-effort cache prevents redundant RPCs.
- Compatibility matrix flips `reasoningEffortControls` to `supported` and gains a `config.set` methods entry, per the matrix's honesty rules. Max/ultra tiers and per-model overrides remain deliberately unexposed.

## Why

Users had no way to trade response speed against reasoning depth per session; Hermes 0.19 exposes reasoning effort tiers and this surfaces the three most useful ones in June's composer.

## Validation

- `npx tsc --noEmit` clean; prettier clean.
- Full frontend suite: 97 files, 1273 tests passed (new unit tests for the level mapping/persistence, a `config.set` seam test, and workspace tests covering the Effort submenu, live retune via `config.set`, and the `reasoning_effort` pin on `session.create`).
- Rendered the menu in both light and dark themes against the upstream reference for visual parity.

Note: stacked on `agent/hermes-019-source` (Hermes 0.19 pin), which this branch builds on; retarget to `main` after that lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787250866&installation_model_id=425925&pr_number=879&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F879&signature=3ad52ad7c2d35b412f456fad965311f00672dd2ee3118bf1695da0dd3ae28f16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->