### PR TITLE
Disable inherited gateway after app-start reconciliation fails

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1454,6 +1454,15 @@ pub fn start_on_app_start(app: &tauri::App) {
                     "failed to start Hermes messaging gateway during app startup: {}",
                     error.message
                 );
+                // Bridge is up, but reconciliation failed. An inherited LaunchAgent
+                // may still be pointed at the previous process's dead proxy port.
+                // Disable it rather than leaving scheduled routines failing silently.
+                disable_inherited_gateway_after_failed_app_start(
+                    &app,
+                    &bridge,
+                    "gateway reconciliation failed",
+                )
+                .await;
             }
         }
     });


### PR DESCRIPTION
## Summary
- Residual fix from #863: when the Hermes bridge starts successfully but gateway restart/reconciliation fails, disable any inherited LaunchAgent instead of only logging the error.
- Prevents scheduled routines from continuing against the previous process's dead provider-proxy port after ungraceful exits.

## Why
A failed reconciliation left the inherited gateway live and misconfigured. That is a silent background reliability failure for routines.

## Validation
- Code path review against existing `disable_inherited_gateway_after_failed_app_start` failure handling.
- Full `cargo test` for this branch left to CI (local compile was still running/heavy).

## Residual risk
- No new unit harness for the full app-start AppHandle path; relies on the existing cleanup helper and CI Rust checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787252350&installation_model_id=425925&pr_number=880&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F880&signature=5a6e36db947c8f99fb5aae7b6d00c3ff2c288361885b8f21281d4682858f9ec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->