### PR TITLE
Keep note-chat recovery keys after accepted retries

### DIFF
--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -272,8 +272,14 @@ export function NoteChatPanel({
     ) {
       return;
     }
-    const accepted = await retryUpstreamFailure().catch(() => false);
-    if (accepted) return;
+    // Keep the one-shot key spent once Hermes accepted the continuation, even
+    // if this panel unmounted or switched notes before the submit resolved.
+    // Only a rejected/failed submit may re-arm "Try again".
+    const result = await retryUpstreamFailure().catch(() => ({
+      accepted: false,
+      current: false,
+    }));
+    if (result.accepted) return;
     upstreamProviderRecoveryStore.release(storedSessionId, recoveryId);
   }
 
@@ -598,8 +604,10 @@ export function NoteChatPanel({
   async function handleSend(text: string) {
     if (working || importing || textActionsDisabledReason) return;
     setComposerError(null);
-    const accepted = await submit(text, attachments);
-    if (accepted) {
+    const result = await submit(text, attachments);
+    // Clear the composer only when this panel still owns the accepted send.
+    // A stale/switched panel must not wipe the draft of the newly selected note.
+    if (result.accepted && result.current) {
       draftRef.current = "";
       setDraftEmpty(true);
       setAttachments([]);

--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -259,6 +259,19 @@ async function reconcileStoredSessionModelMetadata(storedSessionId: string): Pro
   return { appliedHermesModelId, selection };
 }
 
+/** Result of a note-chat prompt attempt.
+ * `accepted` is true once Hermes accepted `prompt.submit`.
+ * `current` is true only while this panel still owns that attempt. */
+export type NoteChatSubmitResult = {
+  accepted: boolean;
+  current: boolean;
+};
+
+export const NOTE_CHAT_SUBMIT_REJECTED: NoteChatSubmitResult = {
+  accepted: false,
+  current: false,
+};
+
 export type NoteChat = {
   /** The rendered conversation: persisted turns + the live streaming tail. */
   turns: AgentChatTurn[];
@@ -274,13 +287,13 @@ export type NoteChat = {
   storedSessionId: string | undefined;
   /** Sends a question about the note, with any imported attachments (images
    * ride the structured attach flow before the prompt; every file's workspace
-   * path rides in the prompt block). Resolves true when the prompt was
-   * accepted (the caller can clear its composer), false on failure (the
-   * caller keeps the draft and chips so the user can retry). */
-  submit: (text: string, attachments?: NoteChatAttachment[]) => Promise<boolean>;
+   * path rides in the prompt block). Resolves `accepted: true` once Hermes
+   * took the prompt. `current` is only true while this panel still owns the
+   * attempt, so a stale unmount can keep drafts/recovery keys correct. */
+  submit: (text: string, attachments?: NoteChatAttachment[]) => Promise<NoteChatSubmitResult>;
   /** Starts one continuation in this chat's existing session without reading
    * or clearing the composer. */
-  retryUpstreamFailure: () => Promise<boolean>;
+  retryUpstreamFailure: () => Promise<NoteChatSubmitResult>;
   /** Interrupts the running agent run. The UI reads stopped immediately; the
    * interrupt RPC follows best-effort, like the workspace's stop. */
   stop: () => void;
@@ -528,12 +541,12 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
       rawText: string,
       attachments: NoteChatAttachment[] = [],
       displayText?: string,
-    ): Promise<boolean> => {
+    ): Promise<NoteChatSubmitResult> => {
       const question = rawText.trim();
-      if ((!question && !attachments.length) || !noteId) return false;
+      if ((!question && !attachments.length) || !noteId) return NOTE_CHAT_SUBMIT_REJECTED;
       // Reject a second send that races the first before setWorking(true)
       // commits — otherwise both could create a session and submit the prompt.
-      if (activeSubmissionRef.current) return false;
+      if (activeSubmissionRef.current) return NOTE_CHAT_SUBMIT_REJECTED;
       const submissionToken = Symbol("note-chat-submit");
       activeSubmissionRef.current = submissionToken;
       setSubmissionPending(true);
@@ -745,7 +758,10 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
           stoppedRuntimeSessionIdRef.current = undefined;
           stoppedRunRef.current = false;
         });
-        return submissionIsCurrent();
+        // Hermes accepted the prompt even if this panel later unmounted or
+        // switched notes. Callers that only care about UI ownership should
+        // check `current`; recovery keys must key off `accepted`.
+        return { accepted: true, current: submissionIsCurrent() };
       } catch (err) {
         dispatchReservation?.cancel();
         if (submissionIsCurrent()) {
@@ -770,7 +786,7 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
             }
           }
         }
-        return false;
+        return { accepted: false, current: submissionIsCurrent() };
       } finally {
         if (activeSubmissionRef.current === submissionToken) {
           activeSubmissionRef.current = undefined;
@@ -787,7 +803,7 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
   );
 
   const retryUpstreamFailure = useCallback(() => {
-    if (!storedSessionIdRef.current) return Promise.resolve(false);
+    if (!storedSessionIdRef.current) return Promise.resolve(NOTE_CHAT_SUBMIT_REJECTED);
     return submitPrompt(UPSTREAM_PROVIDER_FAILURE_RETRY_PROMPT, [], "Try again");
   }, [submitPrompt]);
 

--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -594,6 +594,7 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
       setPendingUserTurns((current) => [...current, optimistic]);
       workingRef.current = true;
       setWorking(true);
+      let promptAccepted = false;
       try {
         const gateway = await connectGateway(true);
         if (!gateway) throw new Error("Hermes gateway is not connected.");
@@ -748,6 +749,9 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
             session_id: runtimeSessionId,
             text: content,
           });
+          // Hermes ownership starts here. Later local bookkeeping failures must
+          // not re-arm recovery keys or look like a rejected submit.
+          promptAccepted = true;
           startAgentRunMonitoring({
             storedSessionId: activeStoredSessionId,
             runtimeSessionId,
@@ -763,17 +767,22 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
         // check `current`; recovery keys must key off `accepted`.
         return { accepted: true, current: submissionIsCurrent() };
       } catch (err) {
-        dispatchReservation?.cancel();
+        if (!promptAccepted) {
+          dispatchReservation?.cancel();
+        }
         if (submissionIsCurrent()) {
-          setPendingUserTurns((current) => current.filter((turn) => turn !== optimistic));
-          workingRef.current = false;
-          setWorking(false);
+          if (!promptAccepted) {
+            setPendingUserTurns((current) => current.filter((turn) => turn !== optimistic));
+            workingRef.current = false;
+            setWorking(false);
+          }
+          // Surface a late bookkeeping failure without undoing Hermes acceptance.
           setError(
             isSessionBusyError(err)
               ? "June is still working on the previous message."
               : messageFromError(err),
           );
-          if (!isSessionBusyError(err)) {
+          if (!promptAccepted && !isSessionBusyError(err)) {
             const currentStoredSessionId = storedSessionIdRef.current;
             if (currentStoredSessionId) {
               cancelAgentRunMonitoring(currentStoredSessionId);
@@ -786,7 +795,7 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
             }
           }
         }
-        return { accepted: false, current: submissionIsCurrent() };
+        return { accepted: promptAccepted, current: submissionIsCurrent() };
       } finally {
         if (activeSubmissionRef.current === submissionToken) {
           activeSubmissionRef.current = undefined;

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -16,7 +16,11 @@ import {
   noteChatSessionIdFor,
   rememberNoteChatSession,
 } from "../components/note-chat/noteChatSessions";
-import { type NoteChat, useNoteChat } from "../components/note-chat/useNoteChat";
+import {
+  type NoteChat,
+  type NoteChatSubmitResult,
+  useNoteChat,
+} from "../components/note-chat/useNoteChat";
 import { reserveHermesSessionDispatch } from "../lib/hermes-session-dispatch-mutex";
 import {
   rememberAppliedSessionModelSelection,
@@ -361,7 +365,10 @@ describe("note chat session map", () => {
     );
 
     const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
-    let submission: Promise<boolean> = Promise.resolve(false);
+    let submission: Promise<NoteChatSubmitResult> = Promise.resolve({
+      accepted: false,
+      current: false,
+    });
     act(() => {
       submission = result.current.submit("Keep the legacy route.");
     });
@@ -672,7 +679,7 @@ describe("note chat session map", () => {
       selectedModel: autoModel.id,
       models: [autoModel, currentModel],
     });
-    const submit = vi.fn(async () => true);
+    const submit = vi.fn(async () => ({ accepted: true, current: true }));
     const chat = noteChat({
       storedSessionId: "stored-note-chat",
       modelSelection: { modelId: autoModel.id, costQuality: 100 },
@@ -838,7 +845,7 @@ describe("note chat session map", () => {
     await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
     act(() => result.current.setSessionModel({ modelId: "kimi-k2-6" }));
 
-    let accepted = false;
+    let accepted: NoteChatSubmitResult = { accepted: false, current: false };
     await act(async () => {
       accepted = await result.current.submit("What remains blocked?");
     });
@@ -1094,7 +1101,10 @@ describe("note chat session map", () => {
           releaseEarlierSend = resolve;
         }),
     );
-    let noteSubmit: Promise<boolean> = Promise.resolve(false);
+    let noteSubmit: Promise<NoteChatSubmitResult> = Promise.resolve({
+      accepted: false,
+      current: false,
+    });
     act(() => {
       noteSubmit = result.current.submit("Run after the workspace message.");
     });

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -291,7 +291,10 @@ describe("note chat session map", () => {
     expect(result.current.modelSelection).toEqual({ modelId: "kimi-k2-6" });
 
     await act(async () => {
-      expect(await result.current.submit("Use the upgraded route.")).toMatchObject({ accepted: true, current: true });
+      expect(await result.current.submit("Use the upgraded route.")).toMatchObject({
+        accepted: true,
+        current: true,
+      });
     });
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("config.set", {
       session_id: "runtime-note-chat",
@@ -324,7 +327,10 @@ describe("note chat session map", () => {
       }),
     );
     await act(async () => {
-      expect(await result.current.submit("Keep this local.")).toMatchObject({ accepted: true, current: true });
+      expect(await result.current.submit("Keep this local.")).toMatchObject({
+        accepted: true,
+        current: true,
+      });
     });
     expect(mocks.gatewayRequest).toHaveBeenCalledWith(
       "config.set",
@@ -396,7 +402,10 @@ describe("note chat session map", () => {
     expect(result.current.appliedHermesModelId).toBe("__june_remote_generation__:kimi-k2-6");
 
     await act(async () => {
-      expect(await result.current.submit("Keep my queued GLM choice.")).toMatchObject({ accepted: true, current: true });
+      expect(await result.current.submit("Keep my queued GLM choice.")).toMatchObject({
+        accepted: true,
+        current: true,
+      });
     });
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("config.set", {
       session_id: "runtime-note-chat",
@@ -419,7 +428,10 @@ describe("note chat session map", () => {
     const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
 
     await act(async () => {
-      expect(await result.current.submit("What changed?")).toMatchObject({ accepted: true, current: true });
+      expect(await result.current.submit("What changed?")).toMatchObject({
+        accepted: true,
+        current: true,
+      });
     });
 
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.create", {
@@ -597,7 +609,6 @@ describe("note chat session map", () => {
     fireEvent.click(retry);
     expect(retryUpstreamFailure).toHaveBeenCalledOnce();
   });
-
 
   it("shows the Auto billing note in the picker while a Venice key is saved", async () => {
     const user = userEvent.setup();
@@ -853,7 +864,10 @@ describe("note chat session map", () => {
     await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
 
     await act(async () => {
-      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({ accepted: true, current: true });
+      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({
+        accepted: true,
+        current: true,
+      });
     });
     expect(result.current.working).toBe(true);
 
@@ -879,7 +893,10 @@ describe("note chat session map", () => {
     mocks.gatewayRequest.mockClear();
 
     await act(async () => {
-      expect(await result.current.submit("What should we do next?")).toMatchObject({ accepted: true, current: true });
+      expect(await result.current.submit("What should we do next?")).toMatchObject({
+        accepted: true,
+        current: true,
+      });
     });
 
     expect(mocks.gatewayRequest.mock.calls).toEqual([
@@ -913,7 +930,10 @@ describe("note chat session map", () => {
     const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
     await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
     await act(async () => {
-      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({ accepted: true, current: true });
+      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({
+        accepted: true,
+        current: true,
+      });
     });
     expect(mocks.startAgentRunMonitoring).toHaveBeenCalledWith({
       storedSessionId: "stored-note-chat",
@@ -942,7 +962,10 @@ describe("note chat session map", () => {
     );
     await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
     await act(async () => {
-      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({ accepted: true, current: true });
+      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({
+        accepted: true,
+        current: true,
+      });
     });
 
     unmount();
@@ -955,7 +978,10 @@ describe("note chat session map", () => {
     const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
     await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
     await act(async () => {
-      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({ accepted: true, current: true });
+      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({
+        accepted: true,
+        current: true,
+      });
     });
 
     act(() => result.current.stop());
@@ -980,7 +1006,10 @@ describe("note chat session map", () => {
     const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
     await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
     await act(async () => {
-      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({ accepted: true, current: true });
+      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({
+        accepted: true,
+        current: true,
+      });
     });
     mocks.markAgentRunSucceeded.mockClear();
     mocks.cancelAgentRunMonitoring.mockClear();
@@ -1010,7 +1039,10 @@ describe("note chat session map", () => {
       const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
       await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
       await act(async () => {
-        expect(await result.current.submit("Summarize the current plan.")).toMatchObject({ accepted: true, current: true });
+        expect(await result.current.submit("Summarize the current plan.")).toMatchObject({
+          accepted: true,
+          current: true,
+        });
       });
 
       act(() => {

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -131,8 +131,8 @@ function noteChat(overrides: Partial<NoteChat> = {}): NoteChat {
     storedSessionId: undefined,
     modelSelection: undefined,
     appliedHermesModelId: undefined,
-    submit: vi.fn(async () => true),
-    retryUpstreamFailure: vi.fn(async () => true),
+    submit: vi.fn(async () => ({ accepted: true, current: true })),
+    retryUpstreamFailure: vi.fn(async () => ({ accepted: true, current: true })),
     stop: vi.fn(),
     setSessionModel: vi.fn(),
     ...overrides,
@@ -236,7 +236,10 @@ describe("note chat session map", () => {
 
     await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
     await act(async () => {
-      expect(await result.current.retryUpstreamFailure()).toBe(true);
+      expect(await result.current.retryUpstreamFailure()).toEqual({
+        accepted: true,
+        current: true,
+      });
     });
 
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.resume", {
@@ -265,7 +268,7 @@ describe("note chat session map", () => {
     expect(result.current.modelSelection).toEqual({ modelId: "kimi-k2-6" });
 
     await act(async () => {
-      expect(await result.current.submit("Use the upgraded route.")).toBe(true);
+      expect(await result.current.submit("Use the upgraded route.")).toMatchObject({ accepted: true, current: true });
     });
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("config.set", {
       session_id: "runtime-note-chat",
@@ -298,7 +301,7 @@ describe("note chat session map", () => {
       }),
     );
     await act(async () => {
-      expect(await result.current.submit("Keep this local.")).toBe(true);
+      expect(await result.current.submit("Keep this local.")).toMatchObject({ accepted: true, current: true });
     });
     expect(mocks.gatewayRequest).toHaveBeenCalledWith(
       "config.set",
@@ -337,7 +340,7 @@ describe("note chat session map", () => {
     resolveSessions([{ id: "stored-note-chat", model: "llama3.1:8b" }]);
 
     await act(async () => {
-      expect(await submission).toBe(true);
+      expect(await submission).toMatchObject({ accepted: true, current: true });
     });
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("config.set", {
       session_id: "runtime-note-chat",
@@ -370,7 +373,7 @@ describe("note chat session map", () => {
     expect(result.current.appliedHermesModelId).toBe("__june_remote_generation__:kimi-k2-6");
 
     await act(async () => {
-      expect(await result.current.submit("Keep my queued GLM choice.")).toBe(true);
+      expect(await result.current.submit("Keep my queued GLM choice.")).toMatchObject({ accepted: true, current: true });
     });
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("config.set", {
       session_id: "runtime-note-chat",
@@ -393,7 +396,7 @@ describe("note chat session map", () => {
     const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
 
     await act(async () => {
-      expect(await result.current.submit("What changed?")).toBe(true);
+      expect(await result.current.submit("What changed?")).toMatchObject({ accepted: true, current: true });
     });
 
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.create", {
@@ -491,7 +494,7 @@ describe("note chat session map", () => {
 
   it("retries an upstream-provider failure once without clearing the note-chat draft", async () => {
     const user = userEvent.setup();
-    const retryUpstreamFailure = vi.fn(async () => true);
+    const retryUpstreamFailure = vi.fn(async () => ({ accepted: true, current: true }));
     render(
       createElement(NoteChatPanel, {
         note: { id: "note-1", title: "Launch planning" },
@@ -529,6 +532,49 @@ describe("note chat session map", () => {
     expect(retry).toBeDisabled();
     expect(composer).toHaveTextContent("Keep this draft");
   });
+
+  it("keeps a spent recovery key after a stale-but-accepted note-chat retry", async () => {
+    const { upstreamProviderRecoveryStore } = await import("../lib/upstream-provider-recovery");
+    // Process-local store can retain keys from earlier panel tests in this file.
+    for (const recoveryId of ["upstream-provider:1", "upstream-provider:2"]) {
+      upstreamProviderRecoveryStore.release("stored-note-chat", recoveryId);
+    }
+    const retryUpstreamFailure = vi.fn(async () => ({ accepted: true, current: false }));
+    render(
+      createElement(NoteChatPanel, {
+        note: { id: "note-1", title: "Launch planning" },
+        chat: noteChat({
+          storedSessionId: "stored-note-chat",
+          retryUpstreamFailure,
+          turns: [
+            {
+              id: "provider-failure-1",
+              role: "assistant",
+              createdAt: "2026-07-21T08:00:00.000Z",
+              status: "complete",
+              parts: [
+                {
+                  type: "notice",
+                  kind: "upstream-provider",
+                  text: "The model service is temporarily unavailable. Your answer is saved.",
+                },
+              ],
+            },
+          ],
+        }),
+        onClose: vi.fn(),
+        onOpenInAgent: vi.fn(),
+      }),
+    );
+
+    const retry = await screen.findByRole("button", { name: "Try again" });
+    fireEvent.click(retry);
+    await waitFor(() => expect(retryUpstreamFailure).toHaveBeenCalledOnce());
+    expect(retry).toBeDisabled();
+    fireEvent.click(retry);
+    expect(retryUpstreamFailure).toHaveBeenCalledOnce();
+  });
+
 
   it("shows the Auto billing note in the picker while a Venice key is saved", async () => {
     const user = userEvent.setup();
@@ -763,7 +809,7 @@ describe("note chat session map", () => {
       accepted = await result.current.submit("What remains blocked?");
     });
 
-    expect(accepted).toBe(true);
+    expect(accepted).toMatchObject({ accepted: true, current: true });
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.resume", {
       session_id: "stored-note-chat",
       cols: 96,
@@ -784,7 +830,7 @@ describe("note chat session map", () => {
     await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
 
     await act(async () => {
-      expect(await result.current.submit("Summarize the current plan.")).toBe(true);
+      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({ accepted: true, current: true });
     });
     expect(result.current.working).toBe(true);
 
@@ -810,7 +856,7 @@ describe("note chat session map", () => {
     mocks.gatewayRequest.mockClear();
 
     await act(async () => {
-      expect(await result.current.submit("What should we do next?")).toBe(true);
+      expect(await result.current.submit("What should we do next?")).toMatchObject({ accepted: true, current: true });
     });
 
     expect(mocks.gatewayRequest.mock.calls).toEqual([
@@ -844,7 +890,7 @@ describe("note chat session map", () => {
     const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
     await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
     await act(async () => {
-      expect(await result.current.submit("Summarize the current plan.")).toBe(true);
+      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({ accepted: true, current: true });
     });
     expect(mocks.startAgentRunMonitoring).toHaveBeenCalledWith({
       storedSessionId: "stored-note-chat",
@@ -873,7 +919,7 @@ describe("note chat session map", () => {
     );
     await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
     await act(async () => {
-      expect(await result.current.submit("Summarize the current plan.")).toBe(true);
+      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({ accepted: true, current: true });
     });
 
     unmount();
@@ -886,7 +932,7 @@ describe("note chat session map", () => {
     const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
     await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
     await act(async () => {
-      expect(await result.current.submit("Summarize the current plan.")).toBe(true);
+      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({ accepted: true, current: true });
     });
 
     act(() => result.current.stop());
@@ -911,7 +957,7 @@ describe("note chat session map", () => {
     const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
     await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
     await act(async () => {
-      expect(await result.current.submit("Summarize the current plan.")).toBe(true);
+      expect(await result.current.submit("Summarize the current plan.")).toMatchObject({ accepted: true, current: true });
     });
     mocks.markAgentRunSucceeded.mockClear();
     mocks.cancelAgentRunMonitoring.mockClear();
@@ -941,7 +987,7 @@ describe("note chat session map", () => {
       const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
       await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
       await act(async () => {
-        expect(await result.current.submit("Summarize the current plan.")).toBe(true);
+        expect(await result.current.submit("Summarize the current plan.")).toMatchObject({ accepted: true, current: true });
       });
 
       act(() => {
@@ -1009,7 +1055,7 @@ describe("note chat session map", () => {
     releaseEarlierSend();
     await earlierSend;
     await act(async () => {
-      expect(await noteSubmit).toBe(true);
+      expect(await noteSubmit).toMatchObject({ accepted: true, current: true });
     });
     expect(mocks.gatewayRequest.mock.calls.slice(-2)).toEqual([
       [
@@ -1067,8 +1113,8 @@ describe("note chat session map", () => {
     const noteBSubmit = result.current.submit("Question for B");
     await act(async () => releaseConnection?.());
 
-    await expect(noteASubmit).resolves.toBe(false);
-    await expect(noteBSubmit).resolves.toBe(true);
+    await expect(noteASubmit).resolves.toMatchObject({ accepted: false, current: false });
+    await expect(noteBSubmit).resolves.toMatchObject({ accepted: true, current: true });
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.resume", {
       session_id: "stored-a",
       cols: 96,

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -229,6 +229,29 @@ describe("note chat session map", () => {
     expect(noteChatSessionIdFor("note-1")).toBe("sess-a");
   });
 
+  it("keeps accepted true when post-submit bookkeeping throws", async () => {
+    rememberNoteChatSession("note-1", "stored-note-chat");
+    mocks.listHermesSessions.mockResolvedValue([{ id: "stored-note-chat" }]);
+    mocks.startAgentRunMonitoring.mockImplementationOnce(() => {
+      throw new Error("monitor failed after accept");
+    });
+    const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
+
+    await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
+    await act(async () => {
+      await expect(result.current.retryUpstreamFailure()).resolves.toMatchObject({
+        accepted: true,
+        current: true,
+      });
+    });
+
+    expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+      session_id: "runtime-note-chat",
+      text: UPSTREAM_PROVIDER_FAILURE_RETRY_PROMPT,
+    });
+    expect(result.current.error).toMatch(/monitor failed after accept/i);
+  });
+
   it("submits an upstream-provider retry in the existing note-chat session", async () => {
     rememberNoteChatSession("note-1", "stored-note-chat");
     mocks.listHermesSessions.mockResolvedValue([{ id: "stored-note-chat" }]);


### PR DESCRIPTION
## Summary
- Residual fix from #872: note-chat submit now returns `{ accepted, current }` so recovery keys key off Hermes acceptance, not panel ownership.
- A stale unmount/note switch after a successful `prompt.submit` no longer re-arms provider-failure Try again.

## Why
The panel previously released the one-shot recovery key whenever the submit resolved with `current=false`, even if Hermes had already accepted the continuation. That allowed a duplicate continuation/charge.

## Validation
- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/test/note-chat-sessions.test.ts` (28 passed)
- Existing upstream recovery unit tests remain green.

## Residual risk
- Process-local recovery store still intentionally resets on full app restart.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787252352&installation_model_id=425925&pr_number=881&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F881&signature=5bfeaf70e04ac59e6e9094234afdcef62eff8fadd52eca8324c60e0fcd03af51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->