### PR TITLE
Harden routine finished notifications

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -155,10 +155,7 @@ import {
   routineRunWatchStep,
   saveRoutineRunWatchState,
 } from "../lib/routine-run-notifications";
-import {
-  isPermissionGranted,
-  requestPermission,
-} from "@tauri-apps/plugin-notification";
+import { isPermissionGranted, requestPermission } from "@tauri-apps/plugin-notification";
 import {
   getActiveHermesProfileName,
   PROFILE_DATA_CHANGED_EVENT,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -149,11 +149,16 @@ import {
   titleFromPrompt,
 } from "../lib/hermes-adapter";
 import {
+  createSingleFlight,
   loadRoutineRunWatchState,
   markRunsNotified,
   routineRunWatchStep,
   saveRoutineRunWatchState,
 } from "../lib/routine-run-notifications";
+import {
+  isPermissionGranted,
+  requestPermission,
+} from "@tauri-apps/plugin-notification";
 import {
   getActiveHermesProfileName,
   PROFILE_DATA_CHANGED_EVENT,
@@ -2093,37 +2098,58 @@ export function App() {
     if (appBlocked || !bootstrapped) return;
     let cancelled = false;
     let state = loadRoutineRunWatchState();
+    const runSingleFlight = createSingleFlight();
+
+    async function notificationPermissionGranted() {
+      let granted = await isPermissionGranted().catch(() => false);
+      if (!granted) {
+        const permission = await requestPermission().catch(() => "denied" as const);
+        granted = permission === "granted";
+      }
+      return granted;
+    }
 
     async function poll() {
-      let sessions: HermesSessionInfo[];
-      try {
-        sessions = await listScheduledRunSessions({ includeActive: true });
-      } catch {
-        // Bridge down (asleep, restarting): try again next tick.
-        return;
-      }
-      if (cancelled) return;
-      const { next, notices } = routineRunWatchStep(state, sessions, Date.now());
-      state = next;
-      // Mark a run seen only after its notification actually went out, so a
-      // transient delivery failure retries on the next tick instead of going
-      // silent forever.
-      const delivered: string[] = [];
-      await Promise.all(
-        notices.map((notice) =>
-          sendAppNotification({
-            title: notice.title,
-            body: notice.body,
-            sound: "Ping",
-            group: notice.jobId ? `june-routine-${notice.jobId}` : "june-routine",
-            sessionId: notice.sessionId,
-          })
-            .then(() => delivered.push(notice.sessionId))
-            .catch(() => {}),
-        ),
-      );
-      state = markRunsNotified(state, delivered);
-      saveRoutineRunWatchState(state);
+      await runSingleFlight(async () => {
+        let sessions: HermesSessionInfo[];
+        try {
+          sessions = await listScheduledRunSessions({ includeActive: true });
+        } catch {
+          // Bridge down (asleep, restarting): try again next tick.
+          return;
+        }
+        if (cancelled) return;
+        const { next, notices } = routineRunWatchStep(state, sessions, Date.now());
+        state = next;
+        if (notices.length === 0) {
+          saveRoutineRunWatchState(state);
+          return;
+        }
+        // Match agent/recording notification paths: ask for permission before
+        // sending, and only mark delivered after a successful send so a denied
+        // or failed delivery can retry while the run is still fresh.
+        if (!(await notificationPermissionGranted())) {
+          saveRoutineRunWatchState(state);
+          return;
+        }
+        if (cancelled) return;
+        const delivered: string[] = [];
+        await Promise.all(
+          notices.map((notice) =>
+            sendAppNotification({
+              title: notice.title,
+              body: notice.body,
+              sound: "Ping",
+              group: notice.jobId ? `june-routine-${notice.jobId}` : "june-routine",
+              sessionId: notice.sessionId,
+            })
+              .then(() => delivered.push(notice.sessionId))
+              .catch(() => {}),
+          ),
+        );
+        state = markRunsNotified(state, delivered);
+        saveRoutineRunWatchState(state);
+      });
     }
 
     void poll();

--- a/src/lib/routine-run-notifications.ts
+++ b/src/lib/routine-run-notifications.ts
@@ -77,9 +77,27 @@ function hasEnded(session: HermesSessionInfo) {
   return session.active !== true && session.is_active !== true && (session.message_count ?? 0) > 0;
 }
 
+/**
+ * Freshness for a finished routine run prefers the end timestamp when the
+ * session has one. `sessionTimestamp` ranks `last_active` first, which can
+ * predate a long-running job's real completion and make a just-ended run look
+ * older than the fresh window.
+ */
+export function routineRunFreshnessTimestamp(session: HermesSessionInfo): number | null {
+  const ended = session.ended_at ?? session.endedAt;
+  if (typeof ended === "string" && ended.trim()) {
+    const endedAt = Date.parse(ended);
+    if (Number.isFinite(endedAt) && endedAt > 0) return endedAt;
+  }
+
+  const fallback = Date.parse(sessionTimestamp(session));
+  if (!Number.isFinite(fallback) || fallback <= 0) return null;
+  return fallback;
+}
+
 function runIsFresh(session: HermesSessionInfo, now: number) {
-  const timestamp = Date.parse(sessionTimestamp(session));
-  if (!Number.isFinite(timestamp) || timestamp <= 0) return false;
+  const timestamp = routineRunFreshnessTimestamp(session);
+  if (timestamp == null) return false;
   return now - timestamp <= FRESH_RUN_WINDOW_MS;
 }
 
@@ -147,5 +165,23 @@ export function markRunsNotified(
   return {
     seen: new Set([...seen].slice(-MAX_TRACKED_RUNS)),
     primed: state.primed,
+  };
+}
+
+/**
+ * Serializes async work so overlapping polls cannot both deliver the same
+ * routine notice. Returns false when a previous call is still running.
+ */
+export function createSingleFlight() {
+  let inFlight = false;
+  return async function runSingleFlight(task: () => Promise<void>): Promise<boolean> {
+    if (inFlight) return false;
+    inFlight = true;
+    try {
+      await task();
+      return true;
+    } finally {
+      inFlight = false;
+    }
   };
 }

--- a/src/test/routine-run-notifications.test.ts
+++ b/src/test/routine-run-notifications.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  createSingleFlight,
   loadRoutineRunWatchState,
   markRunsNotified,
+  routineRunFreshnessTimestamp,
   routineRunWatchStep,
   saveRoutineRunWatchState,
   type RoutineRunWatchState,
@@ -127,6 +129,90 @@ describe("routineRunWatchStep", () => {
     const next = markRunsNotified(stepped.next, ["cron_job1_20260720_115000"]);
     expect(next.seen.has("cron_gone_20260101_000000")).toBe(false);
     expect(next.seen.has("cron_job1_20260720_115000")).toBe(true);
+  });
+});
+
+describe("routineRunFreshnessTimestamp", () => {
+  it("prefers ended_at over an older last_active for long-running routines", () => {
+    const timestamp = routineRunFreshnessTimestamp(
+      run("cron_job1_20260720_100000", {
+        last_active: "2026-07-20T10:05:00Z",
+        ended_at: "2026-07-20T11:55:00Z",
+      }),
+    );
+    expect(timestamp).toBe(Date.parse("2026-07-20T11:55:00Z"));
+  });
+
+  it("accepts endedAt camelCase and falls back to sessionTimestamp when no end time exists", () => {
+    expect(
+      routineRunFreshnessTimestamp(
+        run("cron_job1_20260720_115000", {
+          ended_at: null,
+          endedAt: "2026-07-20T11:50:00Z",
+          last_active: "2026-07-20T11:40:00Z",
+        }),
+      ),
+    ).toBe(Date.parse("2026-07-20T11:50:00Z"));
+
+    expect(
+      routineRunFreshnessTimestamp(
+        run("cron_job1_20260720_115000", {
+          ended_at: null,
+          endedAt: null,
+          last_active: "2026-07-20T11:40:00Z",
+        }),
+      ),
+    ).toBe(Date.parse("2026-07-20T11:40:00Z"));
+  });
+});
+
+describe("routineRunWatchStep freshness", () => {
+  it("notifies a just-ended long-running routine even when last_active is old", () => {
+    const { notices } = routineRunWatchStep(
+      PRIMED,
+      [
+        run("cron_job1_20260720_100000", {
+          last_active: "2026-07-20T10:05:00Z",
+          ended_at: "2026-07-20T11:55:00Z",
+        }),
+      ],
+      NOW,
+    );
+    expect(notices).toHaveLength(1);
+    expect(notices[0]?.sessionId).toBe("cron_job1_20260720_100000");
+  });
+});
+
+describe("createSingleFlight", () => {
+  it("skips overlapping work while one flight is in progress", async () => {
+    const runSingleFlight = createSingleFlight();
+    let resolveFirst!: () => void;
+    const firstDone = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    let firstStarted = 0;
+    let secondStarted = 0;
+
+    const first = runSingleFlight(async () => {
+      firstStarted += 1;
+      await firstDone;
+    });
+    const second = runSingleFlight(async () => {
+      secondStarted += 1;
+    });
+
+    await expect(second).resolves.toBe(false);
+    resolveFirst();
+    await expect(first).resolves.toBe(true);
+    expect(firstStarted).toBe(1);
+    expect(secondStarted).toBe(0);
+
+    await expect(
+      runSingleFlight(async () => {
+        secondStarted += 1;
+      }),
+    ).resolves.toBe(true);
+    expect(secondStarted).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- Residual fix from #857 for finished-routine notifications:
  - prefer `ended_at` for freshness so long-running routines still notify
  - serialize overlapping 15s polls with single-flight
  - request notification permission before sending, matching other notification paths

## Why
Long jobs could finish and look stale, overlapping polls could double-fire, and missing permission could silently suppress alerts while the run aged out.

## Validation
- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/test/routine-run-notifications.test.ts` (15 passed)

## Residual risk
- App-level permission/poll wiring is covered by pure helpers plus focused review; no full live notification walkthrough in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787252353&installation_model_id=425925&pr_number=882&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F882&signature=8b07ed5787a2b00476293fc7955d70cdc4e12b0ca0871928573992efa8001049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->