### PR TITLE
Document pinned Hermes api_max_retries as three total attempts

### DIFF
--- a/docs/hermes-gateway-gotchas.md
+++ b/docs/hermes-gateway-gotchas.md
@@ -146,11 +146,14 @@ appending so a post-delta replay cannot duplicate it.
 ## Upstream (via june-api)
 
 **Hermes owns agent-chat retries.** June pins `agent.api_max_retries: 3` in
-the per-spawn config. In the pinned runtime that means three total provider
-attempts, with the runtime's jittered waits between them. The desktop forwards
-each attempt once, and June API makes one upstream call for each request. Do not
-add another retry at either layer without moving ownership deliberately: shipped
-clients would multiply the new retry count by Hermes' attempts.
+the per-spawn config. In the pinned Hermes runtime the provider loop is
+`while retry_count < max_retries` and only increments after a failed attempt, so
+`3` is three total provider attempts (with the runtime's jittered waits between
+them). Do not trust generic Hermes docs that count this as four attempts; match
+the pinned runtime loop. The desktop forwards each attempt once, and June API
+makes one upstream call for each request. Do not add another retry at either
+layer without moving ownership deliberately: shipped clients would multiply the
+new retry count by Hermes' attempts.
 
 **One bad tool schema can brick every chat request.** The AI upstream rejects a
 tool parameter schema carrying both `type` and a sibling `allOf` (valid JSON

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -20584,10 +20584,12 @@ mcp_servers:
 
         assert!(config.contains("model:\n  default: \"glm\""));
         assert!(config.contains("  cron: [web, memory]"));
-        // The pinned runtime counts this as three total provider attempts,
-        // with its built-in jittered waits between attempts. June owns the
-        // schedule explicitly so a Hermes default change cannot multiply
-        // agent-chat calls behind shipped clients.
+        // Pinned Hermes conversation_loop uses `while retry_count < max_retries`
+        // and increments only after a failed attempt, so api_max_retries: 3 is
+        // three total provider attempts (not four). Upstream docs that say
+        // "default 3 = four attempts" do not match this runtime loop.
+        // June owns the schedule explicitly so a Hermes default change cannot
+        // multiply agent-chat calls behind shipped clients.
         assert!(config.contains("agent:\n  max_turns: 90\n  api_max_retries: 3\n"));
         assert!(config.contains("approvals:\n  mode: manual\n  cron_mode: deny\n"));
         assert!(config.contains(


### PR DESCRIPTION
## Summary
- Residual clarification from #872: keep `agent.api_max_retries: 3` and document why that is three total provider attempts in the pinned Hermes runtime.
- Update gateway gotchas and config-render test comments so ownership is not confused with generic Hermes docs that claim 3 means four attempts.

## Evidence
Pinned Hermes `conversation_loop` uses `while retry_count < max_retries` and increments only after failed attempts. With `api_max_retries: 3`, that is three total provider attempts.

## Validation
- Docs/comment consistency check across config render and gateway gotchas.
- No runtime behavior change; value remains 3.

## Residual risk
- If a future Hermes pin changes loop semantics, this documentation will need a revisit with the runtime source.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787252355&installation_model_id=425925&pr_number=883&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F883&signature=7a186fba4a54212c2a686c0d1eaedd108c5335773b3b96870b0c89a683ca3329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->