### PR TITLE
Add composer thinking level control (Instant, Medium, Hard)

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -305,6 +305,17 @@ import {
 } from "../../lib/local-generation";
 import { autoPillDesignation, preferredVisionFallbackModel } from "../../lib/suggested-models";
 import {
+  forgetSessionThinkingLevel,
+  loadThinkingLevel,
+  loadSessionThinkingLevels,
+  rememberSessionThinkingLevel,
+  saveThinkingLevel,
+  thinkingEffortForLevel,
+  thinkingLevelForEffort,
+  thinkingOptionForLevel,
+  type ThinkingLevel,
+} from "../../lib/thinking-level";
+import {
   AUTO_MODEL_ID,
   modelOptions,
   selectedModel as selectedModelOption,
@@ -2841,6 +2852,32 @@ export function AgentWorkspace({
   const composerModelTriggerRef = useRef<HTMLButtonElement>(null);
   const composerModelPopoverRef = useRef<HTMLDivElement>(null);
   const composerModelSearchRef = useRef<HTMLInputElement>(null);
+  // Thinking level: how much June reasons before answering. The stored draft
+  // seeds new sessions (session.create's reasoning_effort). The efforts map
+  // records each session's OWN level — its creation pin, a pick made while
+  // the session was open, or the effort its live runtime last reported via
+  // session.info — persisted in localStorage so it survives relaunch; the
+  // composer shows a session's own level, never the machine-wide draft of
+  // whatever chat was retuned last. The applied map remembers which effort
+  // the session's CURRENT runtime is known to be at (acked config.set, the
+  // create pin, or a session.info report) so a turn only re-asserts when
+  // the runtime or the level actually changed (config.set writes the profile
+  // config each call, so it is not something to fire blindly on every send).
+  const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(() => loadThinkingLevel());
+  const thinkingLevelRef = useRef(thinkingLevel);
+  const sessionThinkingEffortsRef = useRef<Record<string, ThinkingLevel> | null>(null);
+  // Lazy one-time load of the persisted per-session efforts (a ref, not
+  // state: async send/pick closures must read the latest map, not a render
+  // snapshot).
+  function sessionThinkingEfforts(): Record<string, ThinkingLevel> {
+    if (!sessionThinkingEffortsRef.current) {
+      sessionThinkingEffortsRef.current = loadSessionThinkingLevels();
+    }
+    return sessionThinkingEffortsRef.current;
+  }
+  const sessionThinkingAppliedRef = useRef<Record<string, { runtimeId: string; effort: string }>>(
+    {},
+  );
   // Attestation walkthrough URL served by the backend (same page as Settings
   // → About → Verify server); the privacy badge links to it when known.
   const [capabilityQuery, setCapabilityQuery] = useState("");
@@ -3367,6 +3404,14 @@ export function AgentWorkspace({
           selectedModelOption(generationModelOptions, activeGenerationModelId));
   }, [activeGenerationModelId, generationModelOptions]);
   const generationPrivacyBadge = generationModel ? modelPrivacyBadge(generationModel) : undefined;
+  // The control shows the open session's OWN level (its creation pin, a pick
+  // made while it was open, or what its runtime last reported) — never the
+  // draft, which would label every chat with whatever level was picked last
+  // anywhere. The draft only shows for a new session, where it applies.
+  const composerThinkingLevel: ThinkingLevel =
+    selectedHermesSessionId && !newSessionMode
+      ? (sessionThinkingEfforts()[selectedHermesSessionId] ?? thinkingLevel)
+      : thinkingLevel;
   // The model the image-attach banner offers to switch to: a vision + tool
   // capable model, preferring a known private vision pick (Kimi K2.6) over the
   // alphabetically-first vision model. See preferredVisionFallbackModel.
@@ -3773,7 +3818,7 @@ export function AgentWorkspace({
         }
         // Escape peels one layer at a time: the all-models panel first,
         // then the popover itself.
-        if (composerModelFlyout?.kind === "all") {
+        if (composerModelFlyout?.kind === "all" || composerModelFlyout?.kind === "effort") {
           setComposerModelFlyout(null);
           setModelSearch("");
         } else {
@@ -5008,6 +5053,63 @@ export function AgentWorkspace({
     return assistantTurnId.endsWith(":assistant")
       ? assistantTurnId.slice(0, -":assistant".length)
       : assistantTurnId;
+  }
+
+  // Picking a thinking level always updates the stored draft (the next new
+  // session opens with it). With a session open it ALSO retunes that session:
+  // the level is recorded per chat (persisted, so a relaunch still shows the
+  // session's own level), applied to the live runtime through config.set
+  // (setSessionReasoningEffort), and re-asserted on the next turn if the
+  // runtime is not up right now — see submitHermesSession, which only
+  // re-sends when the current runtime is not already known to be at it.
+  async function handleSelectThinkingLevel(level: ThinkingLevel) {
+    thinkingLevelRef.current = level;
+    setThinkingLevel(level);
+    saveThinkingLevel(level);
+    const sessionId = newSessionModeRef.current ? undefined : selectedHermesSessionIdRef.current;
+    if (!sessionId || isProvisionalHermesSessionId(sessionId)) return;
+    sessionThinkingEffortsRef.current = {
+      ...sessionThinkingEfforts(),
+      [sessionId]: level,
+    };
+    rememberSessionThinkingLevel(sessionId, level);
+    await applyThinkingLevelToSession(sessionId, level);
+  }
+
+  // Best-effort live retune of one session's reasoning effort. Skips the RPC
+  // entirely when the session's CURRENT runtime is already known to be at
+  // this effort — known via an acked config.set, the creation pin, or the
+  // runtime's own session.info report. Keying the skip on the runtime id (not
+  // just the session) keeps a replacement runtime honest: a resumed session
+  // gets re-asserted on its new runtime instead of trusting the old one's ack.
+  async function applyThinkingLevelToSession(
+    sessionId: string,
+    level: ThinkingLevel,
+    explicitRuntimeSessionId?: string,
+  ) {
+    const effort = thinkingEffortForLevel(level);
+    const runtimeSessionId = explicitRuntimeSessionId ?? runtimeSessionIdsRef.current[sessionId];
+    if (!runtimeSessionId) return;
+    const applied = sessionThinkingAppliedRef.current[sessionId];
+    if (applied?.runtimeId === runtimeSessionId && applied.effort === effort) {
+      return;
+    }
+    try {
+      const gateway = await ensureHermesGateway(sessionUnrestricted(sessionId));
+      await createHermesMethods(gateway).setSessionReasoningEffort({
+        sessionId: runtimeSessionId,
+        effort,
+      });
+      sessionThinkingAppliedRef.current = {
+        ...sessionThinkingAppliedRef.current,
+        [sessionId]: { runtimeId: runtimeSessionId, effort },
+      };
+      setError(null);
+    } catch {
+      // The level is still recorded, so the next turn re-asserts it once
+      // the runtime is reachable; no banner for something the send flow
+      // quietly heals.
+    }
   }
 
   async function finishImageSlashGeneration(input: {
@@ -7022,6 +7124,33 @@ export function AgentWorkspace({
       // trace panel can reconstruct the session. recordInbound re-classifies and
       // sanitizes internally; nothing raw is retained.
       hermesTraceBuffer.recordInbound(liveEvent, { storedSessionId });
+      // The runtime's session.info is the source of truth for the effort a
+      // session ACTUALLY runs at (emitted after every build and on every
+      // live retune): hydrate the per-session record from it so the composer
+      // labels this chat with its own level after a relaunch or a change made
+      // outside June, and mark the reporting runtime as known-at that effort
+      // so the send flow never fires a redundant config.set against it.
+      if (event.type === "session.info") {
+        const reportedEffort = (event.payload as { reasoning_effort?: unknown } | undefined)
+          ?.reasoning_effort;
+        const reportedLevel = thinkingLevelForEffort(
+          typeof reportedEffort === "string" ? reportedEffort : undefined,
+        );
+        if (reportedLevel) {
+          sessionThinkingEffortsRef.current = {
+            ...sessionThinkingEfforts(),
+            [storedSessionId]: reportedLevel,
+          };
+          rememberSessionThinkingLevel(storedSessionId, reportedLevel);
+          sessionThinkingAppliedRef.current = {
+            ...sessionThinkingAppliedRef.current,
+            [storedSessionId]: {
+              runtimeId: runtimeSessionId,
+              effort: thinkingEffortForLevel(reportedLevel),
+            },
+          };
+        }
+      }
       if (storedClassified.kind === "unsupported") {
         // Feed the bounded per-session store so the user gets a recoverable
         // notice (when this is the active session) and developers get a
@@ -7376,8 +7505,12 @@ export function AgentWorkspace({
               // session.create treats `model` as a per-session override.
               // Under a named profile the override would silently bypass the
               // profile's own configured text model - the point of profiles -
-              // so it is omitted and the profile's model applies.
+              // so it is omitted and the profile's model applies. The
+              // thinking level's reasoning_effort follows the same rule.
               ...(targetSessionModelId && !underProfile ? { model: targetSessionModelId } : {}),
+              ...(!underProfile
+                ? { reasoning_effort: thinkingEffortForLevel(thinkingLevelRef.current) }
+                : {}),
               ...(underProfile ? { profile: nextUnderProfileName } : {}),
             });
         const nextStoredSessionId =
@@ -7410,6 +7543,26 @@ export function AgentWorkspace({
     // message as an Up next item on the durable session.
     if (!modelTarget.targetStoredSessionId) {
       modelTarget.targetStoredSessionId = storedSessionId;
+    }
+    if (created && !createdUnderProfile) {
+      // Record the new session's level as its own (persisted, so a relaunch
+      // still shows this chat at its level), and mark its runtime as already
+      // at it: the create pinned this effort, so the re-assert path must not
+      // fire a redundant config.set on the session's first turns. Skipped
+      // under a named profile, where the profile's own config applies.
+      const createdLevel = thinkingLevelRef.current;
+      sessionThinkingEffortsRef.current = {
+        ...sessionThinkingEfforts(),
+        [storedSessionId]: createdLevel,
+      };
+      rememberSessionThinkingLevel(storedSessionId, createdLevel);
+      sessionThinkingAppliedRef.current = {
+        ...sessionThinkingAppliedRef.current,
+        [storedSessionId]: {
+          runtimeId: created.session_id ?? "",
+          effort: thinkingEffortForLevel(createdLevel),
+        },
+      };
     }
     const queuedIssueReport = options?.issueReport;
     if (queuedIssueReport && targetStoredSessionId) {
@@ -7512,6 +7665,14 @@ export function AgentWorkspace({
     if (!runtimeSessionId) {
       clearQueuedIssueReport();
       rollbackOptimisticBeforePrompt(new Error("Hermes did not resume the session."));
+    }
+    // A thinking level picked while this session's runtime was down (or a
+    // live retune that failed) re-asserts here, before the prompt, so the
+    // turn runs at the level the control shows. No-op when the current
+    // runtime is already known to be at it (see applyThinkingLevelToSession).
+    const thinkingSessionLevel = sessionThinkingEfforts()[storedSessionId];
+    if (thinkingSessionLevel) {
+      await applyThinkingLevelToSession(storedSessionId, thinkingSessionLevel, runtimeSessionId);
     }
     const dispatchPreparedSession = async (): Promise<string | undefined> => {
       // Re-read after acquiring the cross-surface lock. NoteChat may have sent
@@ -9910,6 +10071,8 @@ export function AgentWorkspace({
     // id.
     forgetSessionMode(sessionId);
     commitSessionModelSelections(forgetSessionModelSelection(sessionId));
+    // Same for the session's thinking-level record.
+    forgetSessionThinkingLevel(sessionId);
   }
 
   async function deleteSelectedHermesSession(sessionId: string) {
@@ -11114,6 +11277,7 @@ export function AgentWorkspace({
                     ? autoPillDesignation(activeGenerationCostQuality)
                     : undefined
                 }
+                effort={thinkingOptionForLevel(composerThinkingLevel).label}
                 triggerRef={composerModelTriggerRef}
                 onToggleOpen={() => {
                   if (composerModelOpen) {
@@ -11321,6 +11485,12 @@ export function AgentWorkspace({
                 void handleSelectGenerationModel(modelId, costQuality, options)
               }
               onCostQualityChange={handleCostQualityChange}
+              thinkingLevel={composerThinkingLevel}
+              onSelectThinking={(level) => {
+                setComposerModelFlyout(null);
+                setComposerModelOpen(false);
+                void handleSelectThinkingLevel(level);
+              }}
             />
           )
         ) : null}

--- a/src/components/agent/composer/ModelPicker.tsx
+++ b/src/components/agent/composer/ModelPicker.tsx
@@ -31,6 +31,7 @@ export function ComposerModelPicker({
   open,
   model,
   detail,
+  effort,
   readOnly = false,
   triggerRef,
   onToggleOpen,
@@ -40,6 +41,11 @@ export function ComposerModelPicker({
   /** Ghosted designation beside the name — the Auto routing preference
    * ("Auto Higher"), quieter than the model name. */
   detail?: string;
+  /** Ghosted thinking level beside the name ("Medium"), visual only: kept
+   * out of the trigger's aria-label so existing "Model: <name>" queries and
+   * announcements are unchanged; the Effort row in the popover carries the
+   * accessible value. */
+  effort?: string;
   readOnly?: boolean;
   triggerRef: RefObject<HTMLButtonElement>;
   onToggleOpen: () => void;
@@ -51,6 +57,11 @@ export function ComposerModelPicker({
         <span className="agent-composer-model-label">
           <span>{model.name}</span>
           {detail ? <span className="agent-composer-model-trigger-detail">{detail}</span> : null}
+          {effort ? (
+            <span className="agent-composer-model-trigger-level" aria-hidden>
+              {effort}
+            </span>
+          ) : null}
         </span>
       </div>
     );
@@ -68,6 +79,11 @@ export function ComposerModelPicker({
       >
         <span>{model.name}</span>
         {detail ? <span className="agent-composer-model-trigger-detail">{detail}</span> : null}
+        {effort ? (
+          <span className="agent-composer-model-trigger-level" aria-hidden>
+            {effort}
+          </span>
+        ) : null}
         <IconChevronDownSmall size={12} aria-hidden />
       </button>
     </div>
@@ -84,6 +100,7 @@ export type ComposerModelFlyout =
   | { kind: "model"; id: string }
   | { kind: "all" }
   | { kind: "auto" }
+  | { kind: "effort" }
   | null;
 
 // Row hovers should feel quick while moving through models, but still keep a

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -18,6 +18,11 @@ import {
   suggestedModelsForMode,
 } from "../../lib/suggested-models";
 import type { ProviderModelMode, VeniceModelDto } from "../../lib/tauri";
+import {
+  thinkingOptionForLevel,
+  THINKING_LEVELS,
+  type ThinkingLevel,
+} from "../../lib/thinking-level";
 import { useScrollFade } from "../../lib/use-scroll-fade";
 import { rectFromElement, type HoverBridgeRect } from "../ui/hoverBridge";
 import { useCatalogHoverBridge, useModelDetailHoverBridge } from "../ui/useModelHoverBridge";
@@ -30,6 +35,7 @@ export type ModelPickerFlyout =
   | { kind: "model"; id: string }
   | { kind: "all" }
   | { kind: "auto" }
+  | { kind: "effort" }
   | null;
 
 // The automatic router's cost-to-quality preference, shared by this popover's
@@ -103,6 +109,8 @@ export function ModelPickerPopover({
   onSearchChange,
   onSelect,
   onCostQualityChange,
+  thinkingLevel,
+  onSelectThinking,
 }: {
   mode: ProviderModelMode;
   flyout: ModelPickerFlyout;
@@ -131,6 +139,11 @@ export function ModelPickerPopover({
    * swaps the selection to/from the Auto router, plus the Preference
    * drill-in writing through this callback while Auto is on. */
   onCostQualityChange?: (value: number) => void;
+  /** Enables the Effort drill-in row (agent surfaces): shows the session's
+   * thinking level and opens the three-level submenu. Omitted on surfaces
+   * without reasoning effort control (image/video pickers). */
+  thinkingLevel?: ThinkingLevel;
+  onSelectThinking?: (level: ThinkingLevel) => void;
 }) {
   const flyoutRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -660,6 +673,45 @@ export function ModelPickerPopover({
         <span className="agent-composer-model-row-name">All models</span>
         <IconChevronRightSmall size={16} aria-hidden className="agent-composer-model-row-chevron" />
       </button>
+      {thinkingLevel && onSelectThinking ? (
+        <button
+          type="button"
+          className="agent-composer-model-row"
+          aria-haspopup="true"
+          aria-expanded={flyout?.kind === "effort"}
+          data-active={flyout?.kind === "effort" || undefined}
+          onMouseEnter={() => {
+            if (modelBridge.isActive()) {
+              return;
+            }
+            const open = () => onFlyoutChange({ kind: "effort" });
+            if (flyout) {
+              cancelHoverIntent();
+              open();
+            } else {
+              hoverIntent(open);
+            }
+          }}
+          onFocus={() => {
+            cancelHoverIntent();
+            onFlyoutChange({ kind: "effort" });
+          }}
+          onClick={() => {
+            cancelHoverIntent();
+            onFlyoutChange({ kind: "effort" });
+          }}
+        >
+          <span className="agent-composer-model-row-name">Effort</span>
+          <span className="agent-composer-model-row-value">
+            {thinkingOptionForLevel(thinkingLevel).label}
+          </span>
+          <IconChevronRightSmall
+            size={16}
+            aria-hidden
+            className="agent-composer-model-row-chevron"
+          />
+        </button>
+      ) : null}
       {detail && portalTarget
         ? createPortal(
             // Portaled to the body and fixed-positioned so no scroll container
@@ -739,6 +791,44 @@ export function ModelPickerPopover({
                 ) : null}
               </button>
             ))}
+          </div>
+        </div>
+      ) : null}
+      {thinkingLevel && onSelectThinking && flyout?.kind === "effort" ? (
+        <div
+          ref={flyoutRef}
+          className="agent-composer-model-flyout agent-composer-model-effort-panel"
+          role="group"
+          aria-label="Thinking level"
+          onPointerLeave={() => {
+            cancelHoverIntent();
+            setBridging(false);
+          }}
+        >
+          <div className="agent-composer-model-surface">
+            <p className="agent-composer-model-title">Effort</p>
+            <div className="agent-composer-model-menu" role="listbox" aria-label="Thinking level">
+              {THINKING_LEVELS.map((option) => (
+                <button
+                  key={option.id}
+                  type="button"
+                  className="agent-composer-model-row"
+                  role="option"
+                  aria-selected={option.id === thinkingLevel}
+                  onClick={() => onSelectThinking(option.id)}
+                >
+                  <span className="agent-composer-model-row-name">{option.label}</span>
+                  {option.id === thinkingLevel ? (
+                    <IconCheckmark2Small
+                      size={14}
+                      aria-hidden
+                      className="agent-composer-model-row-check"
+                    />
+                  ) : null}
+                </button>
+              ))}
+            </div>
+            <p className="agent-composer-model-note">Higher effort consumes usage limits faster.</p>
           </div>
         </div>
       ) : null}

--- a/src/components/ui/useModelHoverBridge.ts
+++ b/src/components/ui/useModelHoverBridge.ts
@@ -12,12 +12,14 @@ import {
 // The picker flyout state, shared verbatim by the composer and settings pickers
 // (both declare a structurally identical alias). A row's detail card is open
 // when `kind === "model"`; the searchable catalog when `kind === "all"`; the
-// Auto preference panel when `kind === "auto"` (the bridge itself only ever
-// traverses to "model" cards, so it ignores that kind).
+// Auto preference panel when `kind === "auto"`; the Effort submenu when
+// `kind === "effort"` (the bridge itself only ever traverses to "model"
+// cards, so it ignores those kinds).
 export type ModelHoverFlyout =
   | { kind: "model"; id: string }
   | { kind: "all" }
   | { kind: "auto" }
+  | { kind: "effort" }
   | null;
 
 // Reports whether a safe-polygon traversal is currently anchored, so the rows

--- a/src/lib/hermes-control-plane/compatibility/matrix.ts
+++ b/src/lib/hermes-control-plane/compatibility/matrix.ts
@@ -149,8 +149,8 @@ const methods: HermesCompatibilitySection = {
   "config.set": {
     status: "supported",
     rationale:
-      "Before the next user message, AgentWorkspace applies a queued session model with session-scoped config.set; Hermes rejects the mutation with 4009 while the agent run is active.",
-    since: PIN,
+      "Session-scoped config.set applies a queued session model before the next user message and retunes a live session's reasoning effort from the composer model menu's Effort submenu (setSessionReasoningEffort); covered by hermes-control-plane-methods and agent-workspace tests.",
+    since: CURRENT_PIN,
   },
   "command.dispatch": {
     status: "planned",
@@ -359,9 +359,9 @@ const features: HermesCompatibilitySection = {
     since: CURRENT_PIN,
   },
   reasoningEffortControls: {
-    status: "planned",
+    status: "supported",
     rationale:
-      "Hermes 0.19 adds max and ultra reasoning effort plus per-model overrides, but June's model picker does not expose those tiers.",
+      "The composer model menu's Effort submenu exposes three reasoning levels (Instant, Medium, Hard) mapped onto Hermes effort tiers: new sessions pin reasoning_effort on session.create and a live session retunes via config.set (setSessionReasoningEffort); max/ultra tiers and per-model overrides stay unexposed.",
     since: CURRENT_PIN,
   },
 };

--- a/src/lib/hermes-control-plane/methods.ts
+++ b/src/lib/hermes-control-plane/methods.ts
@@ -68,6 +68,15 @@ export type InterruptSubagentParams = {
   sessionId: string;
   subagentId: string;
 };
+export type SetSessionReasoningEffortParams = {
+  /** The session's RUNTIME id (not the stored id): config.set looks the
+   * session up in the gateway's live-session map. */
+  sessionId: string;
+  /** A Hermes reasoning-effort string: none, minimal, low, medium, high, or
+   * xhigh. Callers map June's thinking levels onto these in
+   * `thinking-level.ts`; this seam passes the wire value through untouched. */
+  effort: string;
+};
 export type AttachImageParams = {
   sessionId: string;
   mimeType: string;
@@ -91,6 +100,12 @@ export type HermesMethods = {
   respondToSudo(params: RespondToSudoParams): Promise<unknown>;
   respondToSecret(params: RespondToSecretParams): Promise<unknown>;
   interruptSubagent(params: InterruptSubagentParams): Promise<unknown>;
+  /** Changes how much a LIVE session reasons before answering by setting the
+   * gateway's `reasoning` config key (the same surface the TUI's /reasoning
+   * command uses). The gateway applies the new effort to the session's agent
+   * immediately, persists it into the session's stored runtime config (so
+   * resume keeps it), and emits a fresh session.info. */
+  setSessionReasoningEffort(params: SetSessionReasoningEffortParams): Promise<unknown>;
   attachImage(params: AttachImageParams): Promise<unknown>;
 };
 
@@ -156,6 +171,13 @@ export function createHermesMethods(client: HermesRequestLike): HermesMethods {
       return request("subagent.interrupt", {
         session_id: sessionId,
         subagent_id: subagentId,
+      });
+    },
+    setSessionReasoningEffort({ sessionId, effort }) {
+      return request("config.set", {
+        session_id: sessionId,
+        key: "reasoning",
+        value: effort,
       });
     },
     attachImage({ sessionId, mimeType, dataBase64, fileName }) {

--- a/src/lib/hermes-control-plane/raw-types.ts
+++ b/src/lib/hermes-control-plane/raw-types.ts
@@ -97,6 +97,7 @@ export type RawHermesMethodName =
   | "sudo.respond"
   | "secret.respond"
   | "subagent.interrupt"
+  | "config.set"
   | "image.attach"
   | "image.attach_bytes"
   | (string & {});

--- a/src/lib/thinking-level.ts
+++ b/src/lib/thinking-level.ts
@@ -1,0 +1,176 @@
+/**
+ * The composer's thinking level control: how much June reasons before
+ * answering. It lives in the model menu as an "Effort" row with a submenu of
+ * three levels, mirroring the upstream desktop's model menu.
+ *
+ * Three user-facing stops map onto Hermes' reasoning-effort levels
+ * (`parse_reasoning_effort` in hermes_constants.py: none, minimal, low,
+ * medium, high, xhigh). June deliberately exposes only three of them so the
+ * choice stays a simple speed/depth tradeoff:
+ *
+ * - Instant -> "minimal": the model barely deliberates, so first tokens
+ *   arrive almost immediately.
+ * - Medium -> "medium": Hermes' own default; a balance of speed and depth.
+ * - Hard -> "high": substantially more reasoning for harder problems.
+ *
+ * The choice rides to Hermes as a PER-SESSION override (`reasoning_effort`
+ * on session.create, `config.set` key "reasoning" for a live session), so
+ * June never has to rely on the profile config default. The user's last pick
+ * is kept in localStorage as the draft for the next new session, mirroring
+ * how agent-session-modes.ts records the Unrestricted opt-in (machine-local
+ * state, readable synchronously on render).
+ */
+
+export type ThinkingLevel = "instant" | "medium" | "hard";
+
+export type ThinkingLevelOption = {
+  id: ThinkingLevel;
+  /** Sentence-case label rendered on the submenu row. */
+  label: string;
+  /** One-line description of the tradeoff, no dashes (project copy rule). */
+  blurb: string;
+  /** The Hermes reasoning-effort string sent on the wire. */
+  effort: string;
+};
+
+/** Slider stops in track order (left to right: fastest to deepest). */
+export const THINKING_LEVELS: readonly ThinkingLevelOption[] = Object.freeze([
+  {
+    id: "instant",
+    label: "Instant",
+    blurb: "Answers right away, with very little deliberation.",
+    effort: "minimal",
+  },
+  {
+    id: "medium",
+    label: "Medium",
+    blurb: "Balances speed and depth for most tasks.",
+    effort: "medium",
+  },
+  {
+    id: "hard",
+    label: "Hard",
+    blurb: "Spends more time reasoning through hard problems.",
+    effort: "high",
+  },
+]);
+
+/** The control lands here when the user has never picked a level. Matches
+ * Hermes' own default effort, so a fresh install behaves like upstream. */
+export const DEFAULT_THINKING_LEVEL: ThinkingLevel = "medium";
+
+const STORAGE_KEY = "june.agent.thinkingLevel";
+
+export function isThinkingLevel(value: unknown): value is ThinkingLevel {
+  return value === "instant" || value === "medium" || value === "hard";
+}
+
+export function thinkingOptionForLevel(level: ThinkingLevel): ThinkingLevelOption {
+  const option = THINKING_LEVELS.find((entry) => entry.id === level);
+  // The union has exactly one option per level; the find cannot miss. The
+  // fallback keeps a corrupt future edit from crashing the composer.
+  return option ?? THINKING_LEVELS[1];
+}
+
+/** The wire value Hermes expects for this level (`reasoning_effort`). */
+export function thinkingEffortForLevel(level: ThinkingLevel): string {
+  return thinkingOptionForLevel(level).effort;
+}
+
+/** Best-effort reverse mapping from a Hermes effort string (e.g. one reported
+ * by session.info) back onto a level. Low collapses into Instant and
+ * xhigh into Hard; unknown/empty values return undefined so callers can keep
+ * their current draft instead of snapping to a stop. */
+export function thinkingLevelForEffort(effort: string | undefined): ThinkingLevel | undefined {
+  switch ((effort ?? "").trim().toLowerCase()) {
+    case "none":
+    case "minimal":
+    case "low":
+      return "instant";
+    case "medium":
+      return "medium";
+    case "high":
+    case "xhigh":
+      return "hard";
+    default:
+      return undefined;
+  }
+}
+
+/** The stored draft level for the next new session; the default when nothing
+ * (or something unreadable) was stored. */
+export function loadThinkingLevel(): ThinkingLevel {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return isThinkingLevel(raw) ? raw : DEFAULT_THINKING_LEVEL;
+  } catch {
+    return DEFAULT_THINKING_LEVEL;
+  }
+}
+
+export function saveThinkingLevel(level: ThinkingLevel) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, level);
+  } catch {
+    // Ignore; worst case the next launch drafts the default again.
+  }
+}
+
+/**
+ * Per-session record of each chat's reasoning effort, mirroring
+ * agent-session-modes.ts: machine-local (like the runtime's own session
+ * store) and readable synchronously on render. This is what lets the
+ * composer show the level a session actually runs at — its creation pin, a
+ * pick made while it was open, or the effort its live runtime last reported
+ * via session.info — instead of guessing from the machine-wide draft.
+ */
+
+const SESSION_LEVELS_STORAGE_KEY = "june.agent.sessionThinkingLevels";
+
+function readSessionLevelsStore(): Record<string, ThinkingLevel> {
+  try {
+    const raw = window.localStorage.getItem(SESSION_LEVELS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const store: Record<string, ThinkingLevel> = {};
+    for (const [sessionId, level] of Object.entries(parsed)) {
+      if (isThinkingLevel(level)) store[sessionId] = level;
+    }
+    return store;
+  } catch {
+    return {};
+  }
+}
+
+function writeSessionLevelsStore(store: Record<string, ThinkingLevel>) {
+  try {
+    if (Object.keys(store).length === 0) {
+      window.localStorage.removeItem(SESSION_LEVELS_STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(SESSION_LEVELS_STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // Ignore; worst case a session shows the draft until its runtime reports.
+  }
+}
+
+/** Every session's best-known effort, keyed by stored session id. */
+export function loadSessionThinkingLevels(): Record<string, ThinkingLevel> {
+  return readSessionLevelsStore();
+}
+
+export function rememberSessionThinkingLevel(sessionId: string, level: ThinkingLevel) {
+  const store = readSessionLevelsStore();
+  store[sessionId] = level;
+  writeSessionLevelsStore(store);
+}
+
+export function forgetSessionThinkingLevel(sessionId: string) {
+  const store = readSessionLevelsStore();
+  if (!(sessionId in store)) return;
+  delete store[sessionId];
+  writeSessionLevelsStore(store);
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6981,6 +6981,42 @@ button.agent-user-attachment:hover {
   font-size: var(--fs-sm);
 }
 
+/* The composer model pill also carries the current thinking level, dimmed
+ * like a secondary value next to the model name. */
+.agent-composer-model-trigger-level {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+}
+
+/* The Effort submenu row inside the model popover: label on the left,
+ * current level + chevron on the right, like the upstream desktop's model
+ * menu. */
+.agent-composer-model-row-value {
+  flex: 0 0 auto;
+  margin-left: auto;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+/* The effort submenu itself: a compact flyout with plain level rows and a
+ * muted cost note under them. */
+.agent-composer-model-effort-panel {
+  width: 180px;
+}
+
+.agent-composer-model-effort-panel .agent-composer-model-surface {
+  gap: var(--sp-1);
+  max-height: inherit;
+  padding: var(--sp-1);
+}
+
+.agent-composer-model-note {
+  margin: 0;
+  padding: var(--sp-1) var(--sp-2) var(--sp-2);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
 /* Attach (+) and dictation (mic) are both quiet ghost buttons that round to a
  * squircle on hover, matching the send button. */
 .agent-composer-attach {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -4085,6 +4085,218 @@ describe("AgentWorkspace", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows the current thinking level on the model menu's Effort row", async () => {
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Choose text model",
+    });
+    await user.click(within(dialog).getByRole("button", { name: "Effort Medium" }));
+
+    const submenu = await screen.findByRole("group", {
+      name: "Thinking level",
+    });
+    expect(within(submenu).getByRole("option", { name: "Instant" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    expect(within(submenu).getByRole("option", { name: "Medium" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(within(submenu).getByRole("option", { name: "Hard" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    expect(
+      within(submenu).getByText("Higher effort consumes usage limits faster."),
+    ).toBeInTheDocument();
+  });
+
+  it("retunes the open session live when the thinking level changes", async () => {
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    // Send once so the session has a live runtime the retune can target.
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+    await user.type(composer, "first message");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "first message",
+      }),
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Choose text model",
+    });
+    await user.click(within(dialog).getByRole("button", { name: "Effort Medium" }));
+    const submenu = await screen.findByRole("group", {
+      name: "Thinking level",
+    });
+    await user.click(within(submenu).getByRole("option", { name: "Hard" }));
+
+    // The live runtime retunes through config.set (the same surface as the
+    // TUI's /reasoning), keyed by the runtime session id.
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("config.set", {
+        session_id: "runtime-session-1",
+        key: "reasoning",
+        value: "high",
+      }),
+    );
+  });
+
+  it("pins the picked thinking level on the next new session", async () => {
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Choose text model",
+    });
+    await user.click(within(dialog).getByRole("button", { name: "Effort Medium" }));
+    const submenu = await screen.findByRole("group", {
+      name: "Thinking level",
+    });
+    await user.click(within(submenu).getByRole("option", { name: "Instant" }));
+
+    window.dispatchEvent(
+      new CustomEvent(AGENT_NEW_SESSION_EVENT, {
+        detail: { prompt: "write a project update" },
+      }),
+    );
+
+    // New sessions pin the chosen level as a per-session override on
+    // session.create, never a profile config write.
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.create", {
+        title: "Summarize Current Page",
+        cols: 96,
+        model: "__june_remote_generation__:zai-org-glm-5-2",
+        reasoning_effort: "minimal",
+      }),
+    );
+  });
+
+  it("labels a chat with the effort its runtime reports, not the draft", async () => {
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    // Send once so the session's listener is attached to its runtime.
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+    await user.type(composer, "first message");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "first message",
+      }),
+    );
+
+    // No local pick was ever made; the runtime reports this session's own
+    // effort (e.g. it was retuned before a relaunch, and the in-memory record
+    // is gone). The composer must show the session's actual level.
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "session.info",
+          session_id: "runtime-session-1",
+          payload: { reasoning_effort: "high" },
+        });
+      }
+    });
+
+    await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Choose text model",
+    });
+    expect(within(dialog).getByRole("button", { name: "Effort Hard" })).toBeInTheDocument();
+  });
+
+  it("keeps another chat on its own level after retuning the current chat", async () => {
+    const secondSession = {
+      ...existingSession,
+      id: "session-2",
+      title: "Second session",
+      preview: "Second preview",
+      last_active: "2026-06-04T12:05:00Z",
+    };
+    mocks.listHermesSessions.mockResolvedValue([existingSession, secondSession]);
+    // session-2 runs at Medium (its creation pin, persisted). Retuning
+    // session-1 must not relabel it with the new global draft.
+    window.localStorage.setItem(
+      "june.agent.sessionThinkingLevels",
+      JSON.stringify({ "session-2": "medium" }),
+    );
+    const user = userEvent.setup();
+
+    const view = render(<AgentWorkspace initialSession={existingSession} />);
+
+    await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Choose text model",
+    });
+    await user.click(within(dialog).getByRole("button", { name: "Effort Medium" }));
+    const submenu = await screen.findByRole("group", {
+      name: "Thinking level",
+    });
+    await user.click(within(submenu).getByRole("option", { name: "Hard" }));
+
+    view.rerender(<AgentWorkspace initialSession={secondSession} />);
+
+    await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
+    const dialog2 = await screen.findByRole("dialog", {
+      name: "Choose text model",
+    });
+    expect(within(dialog2).getByRole("button", { name: "Effort Medium" })).toBeInTheDocument();
+    expect(within(dialog2).queryByRole("button", { name: "Effort Hard" })).not.toBeInTheDocument();
+  });
+
+  it("re-asserts a persisted session level on the first send after a reload", async () => {
+    // The session was retuned to Hard before the app restarted: its record
+    // survived (localStorage) but the in-memory ack cache did not, so the
+    // fresh runtime must be retuned before the next prompt runs.
+    window.localStorage.setItem(
+      "june.agent.sessionThinkingLevels",
+      JSON.stringify({ "session-1": "hard" }),
+    );
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await user.click(await screen.findByRole("button", { name: "Model: GLM 5.2" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Choose text model",
+    });
+    expect(within(dialog).getByRole("button", { name: "Effort Hard" })).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+    await user.type(composer, "hello again");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("config.set", {
+        session_id: "runtime-session-1",
+        key: "reasoning",
+        value: "high",
+      }),
+    );
+    expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+      session_id: "runtime-session-1",
+      text: "hello again",
+    });
+  });
+
   it("stages /model from the slash menu, then opens the model palette on Enter", async () => {
     const user = userEvent.setup();
 
@@ -7583,6 +7795,7 @@ describe("AgentWorkspace", () => {
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.create", {
       title: "Summarize Current Page",
       cols: 96,
+      reasoning_effort: "medium",
     });
     expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
       sessionId: "session-2",
@@ -9533,6 +9746,7 @@ describe("AgentWorkspace", () => {
         title: "Summarize Current Page",
         cols: 96,
         model: "__june_remote_generation__:zai-org-glm-5-2",
+        reasoning_effort: "medium",
       }),
     );
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {

--- a/src/test/hermes-control-plane-methods.test.ts
+++ b/src/test/hermes-control-plane-methods.test.ts
@@ -73,6 +73,21 @@ describe("createHermesMethods — typed command wrappers", () => {
     });
   });
 
+  it("setSessionReasoningEffort sets the reasoning key through config.set", async () => {
+    const { request, methods } = setup();
+    await methods.setSessionReasoningEffort({
+      sessionId: "runtime-1",
+      effort: "high",
+    });
+    // The session id is the RUNTIME id (the gateway's live-session map key),
+    // and the effort passes through untouched: callers own the level mapping.
+    expect(request).toHaveBeenCalledWith("config.set", {
+      session_id: "runtime-1",
+      key: "reasoning",
+      value: "high",
+    });
+  });
+
   it("respondToSudo forwards approval + mode to sudo.respond", async () => {
     const { request, methods } = setup();
     await methods.respondToSudo({

--- a/src/test/thinking-level.test.ts
+++ b/src/test/thinking-level.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_THINKING_LEVEL,
+  forgetSessionThinkingLevel,
+  isThinkingLevel,
+  loadSessionThinkingLevels,
+  loadThinkingLevel,
+  rememberSessionThinkingLevel,
+  saveThinkingLevel,
+  thinkingEffortForLevel,
+  thinkingLevelForEffort,
+  thinkingOptionForLevel,
+  THINKING_LEVELS,
+} from "../lib/thinking-level";
+
+const STORAGE_KEY = "june.agent.thinkingLevel";
+
+describe("thinking levels", () => {
+  it("exposes exactly three stops in track order", () => {
+    expect(THINKING_LEVELS.map((option) => option.id)).toEqual(["instant", "medium", "hard"]);
+  });
+
+  it("maps each level onto a Hermes reasoning effort", () => {
+    // Instant barely deliberates (near-instant responses), Medium is Hermes'
+    // own default, Hard reasons substantially more.
+    expect(thinkingEffortForLevel("instant")).toBe("minimal");
+    expect(thinkingEffortForLevel("medium")).toBe("medium");
+    expect(thinkingEffortForLevel("hard")).toBe("high");
+  });
+
+  it("uses sentence-case labels and dash-free blurbs (project copy rule)", () => {
+    for (const option of THINKING_LEVELS) {
+      expect(option.label).toMatch(/^[A-Z][a-z]/);
+      expect(option.blurb).not.toMatch(/[–—]/);
+    }
+  });
+
+  it("resolves every level to an option, defaulting safely", () => {
+    for (const option of THINKING_LEVELS) {
+      expect(thinkingOptionForLevel(option.id)).toBe(option);
+    }
+  });
+
+  it("maps Hermes effort strings back onto the nearest stop", () => {
+    expect(thinkingLevelForEffort("minimal")).toBe("instant");
+    expect(thinkingLevelForEffort("low")).toBe("instant");
+    expect(thinkingLevelForEffort("medium")).toBe("medium");
+    expect(thinkingLevelForEffort("high")).toBe("hard");
+    expect(thinkingLevelForEffort("xhigh")).toBe("hard");
+    expect(thinkingLevelForEffort("")).toBeUndefined();
+    expect(thinkingLevelForEffort(undefined)).toBeUndefined();
+    expect(thinkingLevelForEffort("turbo")).toBeUndefined();
+  });
+});
+
+describe("thinking level persistence", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("drafts Medium when nothing was stored", () => {
+    expect(loadThinkingLevel()).toBe(DEFAULT_THINKING_LEVEL);
+    expect(DEFAULT_THINKING_LEVEL).toBe("medium");
+  });
+
+  it("round-trips a saved level", () => {
+    saveThinkingLevel("hard");
+    expect(loadThinkingLevel()).toBe("hard");
+    saveThinkingLevel("instant");
+    expect(loadThinkingLevel()).toBe("instant");
+  });
+
+  it("falls back to the default for unreadable stored values", () => {
+    window.localStorage.setItem(STORAGE_KEY, "ultra");
+    expect(loadThinkingLevel()).toBe(DEFAULT_THINKING_LEVEL);
+    window.localStorage.setItem(STORAGE_KEY, "");
+    expect(loadThinkingLevel()).toBe(DEFAULT_THINKING_LEVEL);
+  });
+
+  it("guards the level union", () => {
+    expect(isThinkingLevel("instant")).toBe(true);
+    expect(isThinkingLevel("medium")).toBe(true);
+    expect(isThinkingLevel("hard")).toBe(true);
+    expect(isThinkingLevel("xhigh")).toBe(false);
+    expect(isThinkingLevel(null)).toBe(false);
+  });
+});
+
+describe("per-session thinking levels", () => {
+  const SESSIONS_KEY = "june.agent.sessionThinkingLevels";
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("starts empty and round-trips per-session records", () => {
+    expect(loadSessionThinkingLevels()).toEqual({});
+    rememberSessionThinkingLevel("s1", "hard");
+    rememberSessionThinkingLevel("s2", "instant");
+    expect(loadSessionThinkingLevels()).toEqual({
+      s1: "hard",
+      s2: "instant",
+    });
+  });
+
+  it("overwrites a session's level without touching others", () => {
+    rememberSessionThinkingLevel("s1", "hard");
+    rememberSessionThinkingLevel("s2", "medium");
+    rememberSessionThinkingLevel("s1", "instant");
+    expect(loadSessionThinkingLevels()).toEqual({
+      s1: "instant",
+      s2: "medium",
+    });
+  });
+
+  it("forgets a deleted session and drops the key when the map empties", () => {
+    rememberSessionThinkingLevel("s1", "hard");
+    forgetSessionThinkingLevel("s1");
+    expect(loadSessionThinkingLevels()).toEqual({});
+    expect(window.localStorage.getItem(SESSIONS_KEY)).toBeNull();
+    // Forgetting an unknown session is a no-op.
+    rememberSessionThinkingLevel("s2", "medium");
+    forgetSessionThinkingLevel("s3");
+    expect(loadSessionThinkingLevels()).toEqual({ s2: "medium" });
+  });
+
+  it("ignores corrupt stored values", () => {
+    window.localStorage.setItem(SESSIONS_KEY, "not json");
+    expect(loadSessionThinkingLevels()).toEqual({});
+    window.localStorage.setItem(SESSIONS_KEY, JSON.stringify({ s1: "ultra", s2: "hard" }));
+    expect(loadSessionThinkingLevels()).toEqual({ s2: "hard" });
+  });
+});


### PR DESCRIPTION
Backport of #879 and its review fixes onto current main. (The original PR landed on `agent/hermes-019-source`, which is a stale June-era branch; main already has the Hermes 0.19 runtime via #867, so this re-lands just the feature on current main.)

## What changed

The composer model menu gains an **Effort** row with a submenu of three thinking levels — **Instant**, **Medium**, **Hard** — so users can adjust how much June reasons before answering in agent sessions. The composer model pill shows the current level beside the model name (visual-only span; the trigger's aria-label is unchanged), matching the upstream desktop's model menu pattern.

- New `src/lib/thinking-level.ts`: the three levels, their mapping onto Hermes reasoning efforts (`minimal` / `medium` / `high`), the localStorage draft (default Medium), and a persisted per-session effort record.
- The Effort drill-in lives in the shared `ModelPickerPopover`, mirroring the Auto Preference row/panel (flyout kind `effort`, plain level rows, "Higher effort consumes usage limits faster." note); enabled via new optional `thinkingLevel` / `onSelectThinking` props, so image/video pickers are unaffected.
- **New sessions** pin the level as a per-session `reasoning_effort` override on `session.create`, omitted under a named profile for the same reason the model override is omitted there.
- **Live sessions** retune immediately through a typed `setSessionReasoningEffort` control-plane seam (`config.set` key `reasoning`); a pick made while the runtime is down re-asserts just before the next turn, keyed on `{runtimeId, effort}` so a replacement runtime gets re-asserted while a known-good runtime never sees a redundant call.
- Each session's own level is shown (creation pin, user pick, or the runtime's `session.info` report) — never the machine-wide draft — so retuning one chat can't relabel another, and a chat retuned before an app reload still shows its actual level.
- Compatibility matrix flips `reasoningEffortControls` to `supported`; the `config.set` entry now covers both session-scoped model application and reasoning retune. Max/ultra tiers and per-model overrides remain deliberately unexposed.

## Validation (in a worktree on current main)

- `tsc --noEmit` clean; `biome check` clean (0 errors) on all 12 changed files.
- Full frontend suite: 202 files, 3268 tests passed — including new coverage: level mapping/persistence unit tests, the `config.set` seam test, and workspace tests for the Effort submenu, live retune, `reasoning_effort` pinning (and its profile omission), runtime-reported levels, per-chat separation, and post-reload re-assertion.

Note: one follow-up worth checking upstream — whether `config.set`'s reasoning key accepts the `--session` suffix (like model) to skip the profile-config write; kept the verified wire format for now.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787258788&installation_model_id=425925&pr_number=885&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F885&signature=888b9335021e944cfa00d324957e6bd71fd41a6785e63265126b8ac7dbedae06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->