### PR TITLE
Fix delayed screen recording settings

### DIFF
--- a/docs/adr/0028-private-stdio-broker-for-computer-use.md
+++ b/docs/adr/0028-private-stdio-broker-for-computer-use.md
@@ -244,3 +244,19 @@ canonical `os-june` binary. The development runner creates that launcher as a
 hard link after every build. A copied or independently built executable with
 an allowed-looking name is rejected. Packaged helper verification remains
 unchanged.
+
+## Addendum - macOS Screen Recording responsible app (2026-07-21)
+
+This addendum corrects the earlier statement that both TCC grants attach to the
+nested helper identity. Accessibility attaches to `June Computer Use Driver`,
+but macOS attributes Screen Recording to the signed outer June app that launches
+the helper. The helper's preflight observes that responsible-app grant, and its
+native request creates the outer June entry in System Settings.
+
+June therefore opens the matching privacy pane before requesting the next
+missing grant. Opening first gives immediate feedback while the helper starts
+and probes TCC in the background. Accessibility setup names and, when needed,
+offers the nested helper as a drag source. Screen Recording setup names the
+outer June app and never tells the user to add the helper to that list. The
+private transport, helper parent authentication, capture execution, and
+app-owned broker policy are unchanged.

--- a/docs/computer-use-support.md
+++ b/docs/computer-use-support.md
@@ -28,8 +28,10 @@ are enabled.
    identifier `co.opensoftware.june.computer-use-driver`. A packaged helper
    also requires the signed outer June app with the same Developer ID team.
 3. In System Settings > Privacy & Security, inspect Accessibility and Screen
-   Recording separately. Removing a macOS grant may require June to be quit and
-   reopened before macOS reports the new state.
+   Recording separately. Accessibility names `June Computer Use Driver`;
+   Screen Recording names the outer `June` app because macOS assigns capture to
+   the responsible launcher. Removing a macOS grant may require June to be quit
+   and reopened before macOS reports the new state.
 4. Return to June. The setup page polls while incomplete and reconfigures the
    runtime when the signed helper becomes capturable.
 5. If the driver crashed, Stop clears its private child and the next eligible

--- a/docs/computer-use-support.md
+++ b/docs/computer-use-support.md
@@ -55,10 +55,11 @@ from System Settings.
 
 Every macOS `make dev` launch gives the debug Computer use helper a stable
 bundle identifier derived from the current worktree path. The launch registers
-that helper with LaunchServices, clears Accessibility and Screen Recording for
-that exact identifier, and removes stale debug staging copies before Tauri
-copies the signed bundle again. This provides a fresh permission walkthrough
-on every dev restart without changing another worktree's TCC state.
+that helper with LaunchServices, clears Accessibility for the helper identifier,
+clears Screen Recording for the outer June development app identifier, and
+removes stale debug staging copies before Tauri copies the signed bundle again.
+This provides a fresh permission walkthrough on every dev restart without
+resetting Screen Recording for the wrong responsible app.
 
 The Tauri dev runner executes a hard-linked product-name alias of Cargo's
 `os-june` binary. The normal alias is `target/**/June`; supported issue

--- a/scripts/computer-use-dev.mjs
+++ b/scripts/computer-use-dev.mjs
@@ -3,7 +3,6 @@ import { createHash } from "node:crypto";
 import { existsSync, readdirSync, rmSync } from "node:fs";
 import path from "node:path";
 
-const TCC_SERVICES = ["Accessibility", "ScreenCapture"];
 const LSREGISTER =
   "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister";
 
@@ -57,9 +56,16 @@ export function stagedComputerUseBundlePaths({ targetDir, bundleName }) {
   return candidates;
 }
 
-export function resetComputerUseGrants(bundleIdentifier, run = spawnSync) {
-  const resetServices = [];
-  for (const service of TCC_SERVICES) {
+export function resetComputerUseDevGrants(
+  { bundlePath, helperBundleIdentifier, appBundleIdentifier },
+  run = spawnSync,
+) {
+  registerComputerUseBundle(bundlePath, run);
+  const grants = [
+    ["Accessibility", helperBundleIdentifier],
+    ["ScreenCapture", appBundleIdentifier],
+  ];
+  for (const [service, bundleIdentifier] of grants) {
     const result = run("/usr/bin/tccutil", ["reset", service, bundleIdentifier], {
       encoding: "utf8",
     });
@@ -69,14 +75,8 @@ export function resetComputerUseGrants(bundleIdentifier, run = spawnSync) {
         `Could not reset ${service} for ${bundleIdentifier}${reason ? `: ${reason}` : ""}`,
       );
     }
-    resetServices.push(service);
   }
-  return resetServices;
-}
-
-export function resetComputerUseDevGrants({ bundlePath, bundleIdentifier }, run = spawnSync) {
-  registerComputerUseBundle(bundlePath, run);
-  return resetComputerUseGrants(bundleIdentifier, run);
+  return grants.map(([service]) => service);
 }
 
 export function registerComputerUseBundle(bundlePath, run = spawnSync) {

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -37,7 +37,7 @@ if (process.platform === "darwin") {
   const pin = JSON.parse(
     readFileSync(resolve(ROOT_DIR, "src-tauri", "cua-driver-pin.json"), "utf8"),
   );
-  const bundleIdentifier = computerUseBundleIdentifier({
+  const helperBundleIdentifier = computerUseBundleIdentifier({
     baseIdentifier: pin.bundleIdentifier,
     profile: "debug",
     worktreeRoot: ROOT_DIR,
@@ -52,10 +52,11 @@ if (process.platform === "darwin") {
   });
   const reset = resetComputerUseDevGrants({
     bundlePath: resolve(ROOT_DIR, ".tauri-helper", pin.bundleName),
-    bundleIdentifier,
+    helperBundleIdentifier,
+    appBundleIdentifier: devAppIdentity.identifier,
   });
   console.error(
-    `Reset Computer use ${reset.join(" and ")} grants for this worktree (${bundleIdentifier}); removed ${removed.length} stale staged bundle${removed.length === 1 ? "" : "s"}.`,
+    `Reset Computer use ${reset[0]} for ${helperBundleIdentifier} and ${reset[1]} for ${devAppIdentity.identifier}; removed ${removed.length} stale staged bundle${removed.length === 1 ? "" : "s"}.`,
   );
 }
 

--- a/src-tauri/src/computer_use.rs
+++ b/src-tauri/src/computer_use.rs
@@ -1125,9 +1125,10 @@ async fn read_permission_probe(
         .unwrap_or(false);
     Ok(PermissionProbe {
         accessibility,
-        // The helper is a fresh LaunchServices-owned process for every probe,
-        // so this preflight belongs to the same app identity that captures.
-        // Keep accepting the live field for compatibility with older helpers.
+        // The helper is fresh for every probe. macOS evaluates Accessibility
+        // against the nested helper and Screen Recording against its signed
+        // outer June responsible app. Keep accepting the live field for
+        // compatibility with older helpers.
         screen_recording: preflight && capturable,
     })
 }

--- a/src-tauri/src/computer_use_driver.rs
+++ b/src-tauri/src/computer_use_driver.rs
@@ -178,9 +178,11 @@ fn permission_result() -> Value {
         "structuredContent": {
             "accessibility": accessibility,
             "screen_recording": screen_recording,
-            // This fresh LaunchServices process owns both the preflight and
-            // every later capture. Avoid upstream's blocking live probe here;
-            // actual captures remain the authoritative runtime check.
+            // Accessibility belongs to this nested helper. macOS attributes
+            // Screen Recording to the signed outer June app that launched it,
+            // and reports that responsible-app grant through this process.
+            // Avoid upstream's blocking live probe here; actual captures remain
+            // the authoritative runtime check.
             "screen_recording_capturable": screen_recording,
             "source": {
                 "attribution": "driver-app",

--- a/src/components/plugins/ComputerUseControl.tsx
+++ b/src/components/plugins/ComputerUseControl.tsx
@@ -59,6 +59,7 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string>();
   const permissionDragRef = useRef<HTMLButtonElement>(null);
+  const permissionRequestRef = useRef<Promise<void> | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -143,8 +144,17 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
         // Give the click immediate visible feedback. Starting the signed helper
         // and probing TCC can take several seconds on a cold launch.
         await openPrivacySettings(pane);
-        const next = await computerUseRequestPermissions();
-        publish(next);
+        if (!permissionRequestRef.current) {
+          const request = computerUseRequestPermissions()
+            .then(publish)
+            .finally(() => {
+              if (permissionRequestRef.current === request) {
+                permissionRequestRef.current = null;
+              }
+            });
+          permissionRequestRef.current = request;
+        }
+        await permissionRequestRef.current;
       } catch (error) {
         setMessage(messageFromError(error));
       }

--- a/src/components/plugins/ComputerUseControl.tsx
+++ b/src/components/plugins/ComputerUseControl.tsx
@@ -45,6 +45,27 @@ function requirementState(ready: boolean, enabled: boolean) {
 
 type MacOSPermission = "accessibility" | "screenRecording";
 
+const pendingPermissionRequests = new Map<MacOSPermission, Promise<ComputerUseStatusDto>>();
+let permissionRequestTail: Promise<unknown> = Promise.resolve();
+
+function requestComputerUsePermission(permission: MacOSPermission) {
+  const pending = pendingPermissionRequests.get(permission);
+  if (pending) return pending;
+
+  const request = permissionRequestTail
+    .catch(() => undefined)
+    .then(() => computerUseRequestPermissions());
+  permissionRequestTail = request;
+  pendingPermissionRequests.set(permission, request);
+  const clear = () => {
+    if (pendingPermissionRequests.get(permission) === request) {
+      pendingPermissionRequests.delete(permission);
+    }
+  };
+  void request.then(clear, clear);
+  return request;
+}
+
 function permissionLabel(permission: MacOSPermission) {
   return permission === "accessibility" ? "Accessibility" : "Screen recording";
 }
@@ -59,7 +80,6 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string>();
   const permissionDragRef = useRef<HTMLButtonElement>(null);
-  const permissionRequestRef = useRef<Promise<void> | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -144,17 +164,7 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
         // Give the click immediate visible feedback. Starting the signed helper
         // and probing TCC can take several seconds on a cold launch.
         await openPrivacySettings(pane);
-        if (!permissionRequestRef.current) {
-          const request = computerUseRequestPermissions()
-            .then(publish)
-            .finally(() => {
-              if (permissionRequestRef.current === request) {
-                permissionRequestRef.current = null;
-              }
-            });
-          permissionRequestRef.current = request;
-        }
-        await permissionRequestRef.current;
+        publish(await requestComputerUsePermission(pane));
       } catch (error) {
         setMessage(messageFromError(error));
       }

--- a/src/components/plugins/ComputerUseControl.tsx
+++ b/src/components/plugins/ComputerUseControl.tsx
@@ -9,6 +9,7 @@ import { messageFromError } from "../../lib/errors";
 import {
   COMPUTER_USE_STATUS_CHANGED_EVENT,
   type ComputerUseStatusDto,
+  computerUseRequestPermissions,
   computerUseStatus,
   computerUseStop,
   openPrivacySettings,
@@ -136,13 +137,20 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
     }
   }, [refresh]);
 
-  const openPermissionSettings = useCallback(async (pane: "accessibility" | "screenRecording") => {
-    try {
-      await openPrivacySettings(pane);
-    } catch (error) {
-      setMessage(messageFromError(error));
-    }
-  }, []);
+  const openPermissionSettings = useCallback(
+    async (pane: "accessibility" | "screenRecording") => {
+      try {
+        // Give the click immediate visible feedback. Starting the signed helper
+        // and probing TCC can take several seconds on a cold launch.
+        await openPrivacySettings(pane);
+        const next = await computerUseRequestPermissions();
+        publish(next);
+      } catch (error) {
+        setMessage(messageFromError(error));
+      }
+    },
+    [publish],
+  );
 
   const enabled = status?.grantEnabled === true;
   const supported = status?.platformSupported !== false;
@@ -160,7 +168,7 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
 
   useEffect(() => {
     const element = permissionDragRef.current;
-    if (!permissionsMissing || !element) {
+    if (!permissionsMissing || nextPermission !== "accessibility" || !element) {
       void setComputerUsePermissionDragBounds(null);
       return;
     }
@@ -187,7 +195,7 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
       window.removeEventListener("scroll", publishBounds, true);
       void setComputerUsePermissionDragBounds(null);
     };
-  }, [permissionsMissing]);
+  }, [nextPermission, permissionsMissing]);
 
   return (
     <li className="connector-row computer-use-control" data-state={status?.state}>
@@ -290,10 +298,18 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
                   <div className="computer-use-permission-assistant-copy">
                     <span className="computer-use-permission-step">Step {permissionStep} of 2</span>
                     <h4 id="add-june-macos">Allow {permissionLabel(nextPermission)}</h4>
-                    <p>
-                      Open System Settings, find <strong>June Computer Use Driver</strong>, and turn
-                      it on. Then return to June. This page updates automatically.
-                    </p>
+                    {nextPermission === "accessibility" ? (
+                      <p>
+                        Open System Settings, find <strong>June Computer Use Driver</strong>, and
+                        turn it on. Then return to June. This page updates automatically.
+                      </p>
+                    ) : (
+                      <p>
+                        Open System Settings, find <strong>June</strong>, and turn it on. macOS
+                        assigns Screen recording to June itself. Then return here. This page updates
+                        automatically.
+                      </p>
+                    )}
                   </div>
                   <button
                     type="button"
@@ -304,29 +320,31 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
                   </button>
                 </div>
 
-                <div className="computer-use-permission-helper">
-                  <div className="computer-use-permission-helper-copy">
-                    <strong>June is not in the list?</strong>
-                    <p>
-                      Drag the helper below into the open System Settings list, then turn it on.
-                    </p>
+                {nextPermission === "accessibility" ? (
+                  <div className="computer-use-permission-helper">
+                    <div className="computer-use-permission-helper-copy">
+                      <strong>June is not in the list?</strong>
+                      <p>
+                        Drag the helper below into the open System Settings list, then turn it on.
+                      </p>
+                    </div>
+                    <button
+                      ref={permissionDragRef}
+                      type="button"
+                      className="computer-use-permission-drag-card"
+                      aria-label="Drag June Computer Use Driver to the open System Settings list"
+                      onClick={() => void openPermissionSettings(nextPermission)}
+                    >
+                      <span className="computer-use-permission-drag-icon" aria-hidden>
+                        <IconTelevision size={20} />
+                      </span>
+                      <span className="computer-use-permission-drag-copy">
+                        <strong>June Computer Use Driver</strong>
+                        <span>Drag into System Settings</span>
+                      </span>
+                    </button>
                   </div>
-                  <button
-                    ref={permissionDragRef}
-                    type="button"
-                    className="computer-use-permission-drag-card"
-                    aria-label="Drag June Computer Use Driver to the open System Settings list"
-                    onClick={() => void openPermissionSettings(nextPermission)}
-                  >
-                    <span className="computer-use-permission-drag-icon" aria-hidden>
-                      <IconTelevision size={20} />
-                    </span>
-                    <span className="computer-use-permission-drag-copy">
-                      <strong>June Computer Use Driver</strong>
-                      <span>Drag into System Settings</span>
-                    </span>
-                  </button>
-                </div>
+                ) : null}
               </section>
             ) : null}
 

--- a/src/test/computer-use-control.test.tsx
+++ b/src/test/computer-use-control.test.tsx
@@ -122,7 +122,7 @@ describe("ComputerUseControl", () => {
     expect(tauriMocks.openPrivacySettings).toHaveBeenCalledWith("screenRecording");
   });
 
-  it("opens Screen recording settings before the permission probe finishes", async () => {
+  it("opens Screen recording settings immediately and coalesces pending permission probes", async () => {
     tauriMocks.computerUseStatus.mockResolvedValue(
       status({ grantEnabled: true, accessibility: true, state: "permission_missing" }),
     );
@@ -135,11 +135,12 @@ describe("ComputerUseControl", () => {
     );
     render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
 
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Open Screen recording settings" }),
-    );
+    const button = await screen.findByRole("button", { name: "Open Screen recording settings" });
+    await userEvent.click(button);
+    await userEvent.click(button);
 
-    expect(tauriMocks.openPrivacySettings).toHaveBeenCalledWith("screenRecording");
+    expect(tauriMocks.openPrivacySettings).toHaveBeenCalledTimes(2);
+    expect(tauriMocks.openPrivacySettings).toHaveBeenLastCalledWith("screenRecording");
     expect(tauriMocks.computerUseRequestPermissions).toHaveBeenCalledTimes(1);
 
     finishPermissionProbe?.(
@@ -151,6 +152,7 @@ describe("ComputerUseControl", () => {
         state: "ready",
       }),
     );
+    await screen.findByText("Ready");
   });
 
   it("keeps Accessibility labeled as step 1 when Screen recording was allowed first", async () => {

--- a/src/test/computer-use-control.test.tsx
+++ b/src/test/computer-use-control.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const tauriMocks = vi.hoisted(() => ({
   computerUseStatus: vi.fn(),
+  computerUseRequestPermissions: vi.fn(),
   setComputerUseGrant: vi.fn(),
   computerUseStop: vi.fn(),
   openPrivacySettings: vi.fn(),
@@ -13,6 +14,7 @@ const tauriMocks = vi.hoisted(() => ({
 vi.mock("../lib/tauri", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../lib/tauri")>()),
   computerUseStatus: tauriMocks.computerUseStatus,
+  computerUseRequestPermissions: tauriMocks.computerUseRequestPermissions,
   setComputerUseGrant: tauriMocks.setComputerUseGrant,
   computerUseStop: tauriMocks.computerUseStop,
   openPrivacySettings: tauriMocks.openPrivacySettings,
@@ -42,6 +44,9 @@ function status(overrides: Partial<ComputerUseStatusDto> = {}): ComputerUseStatu
 
 beforeEach(() => {
   tauriMocks.computerUseStatus.mockResolvedValue(status());
+  tauriMocks.computerUseRequestPermissions.mockResolvedValue(
+    status({ grantEnabled: true, state: "permission_missing" }),
+  );
   tauriMocks.setComputerUseGrant.mockResolvedValue(
     status({ grantEnabled: true, state: "permission_missing" }),
   );
@@ -93,6 +98,7 @@ describe("ComputerUseControl", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent(/Captures are never analytics/);
 
     await userEvent.click(screen.getByRole("button", { name: "Open Accessibility settings" }));
+    expect(tauriMocks.computerUseRequestPermissions).toHaveBeenCalledTimes(1);
     expect(tauriMocks.openPrivacySettings).toHaveBeenCalledWith("accessibility");
     expect(screen.queryByRole("button", { name: "Continue to macOS access" })).toBeNull();
   });
@@ -105,8 +111,46 @@ describe("ComputerUseControl", () => {
 
     expect(await screen.findByText("Step 2 of 2")).toBeInTheDocument();
     expect(screen.getByText("Allow Screen recording")).toBeInTheDocument();
+    expect(screen.getByText(/assigns Screen recording to June itself/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Drag June Computer Use Driver to the open System Settings list",
+      }),
+    ).toBeNull();
     await userEvent.click(screen.getByRole("button", { name: "Open Screen recording settings" }));
+    expect(tauriMocks.computerUseRequestPermissions).toHaveBeenCalledTimes(1);
     expect(tauriMocks.openPrivacySettings).toHaveBeenCalledWith("screenRecording");
+  });
+
+  it("opens Screen recording settings before the permission probe finishes", async () => {
+    tauriMocks.computerUseStatus.mockResolvedValue(
+      status({ grantEnabled: true, accessibility: true, state: "permission_missing" }),
+    );
+    let finishPermissionProbe: ((value: ComputerUseStatusDto) => void) | undefined;
+    tauriMocks.computerUseRequestPermissions.mockImplementationOnce(
+      () =>
+        new Promise<ComputerUseStatusDto>((resolve) => {
+          finishPermissionProbe = resolve;
+        }),
+    );
+    render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Open Screen recording settings" }),
+    );
+
+    expect(tauriMocks.openPrivacySettings).toHaveBeenCalledWith("screenRecording");
+    expect(tauriMocks.computerUseRequestPermissions).toHaveBeenCalledTimes(1);
+
+    finishPermissionProbe?.(
+      status({
+        grantEnabled: true,
+        accessibility: true,
+        screenRecording: true,
+        ready: true,
+        state: "ready",
+      }),
+    );
   });
 
   it("keeps Accessibility labeled as step 1 when Screen recording was allowed first", async () => {

--- a/src/test/computer-use-control.test.tsx
+++ b/src/test/computer-use-control.test.tsx
@@ -155,6 +155,91 @@ describe("ComputerUseControl", () => {
     await screen.findByText("Ready");
   });
 
+  it("coalesces a permission probe across an unmount and remount", async () => {
+    tauriMocks.computerUseStatus.mockResolvedValue(
+      status({ grantEnabled: true, accessibility: true, state: "permission_missing" }),
+    );
+    let finishPermissionProbe: ((value: ComputerUseStatusDto) => void) | undefined;
+    tauriMocks.computerUseRequestPermissions.mockImplementationOnce(
+      () =>
+        new Promise<ComputerUseStatusDto>((resolve) => {
+          finishPermissionProbe = resolve;
+        }),
+    );
+    const first = render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Open Screen recording settings" }),
+    );
+
+    first.unmount();
+    render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Open Screen recording settings" }),
+    );
+
+    expect(tauriMocks.computerUseRequestPermissions).toHaveBeenCalledTimes(1);
+    const readyStatus = status({
+      grantEnabled: true,
+      accessibility: true,
+      screenRecording: true,
+      ready: true,
+      state: "ready",
+    });
+    tauriMocks.computerUseStatus.mockResolvedValue(readyStatus);
+    finishPermissionProbe?.(readyStatus);
+    await screen.findByText("Ready");
+  });
+
+  it("queues a newly reached permission pane behind an active probe", async () => {
+    tauriMocks.computerUseStatus.mockResolvedValue(
+      status({ grantEnabled: true, state: "permission_missing" }),
+    );
+    let finishAccessibilityProbe: ((value: ComputerUseStatusDto) => void) | undefined;
+    let finishScreenRecordingProbe: ((value: ComputerUseStatusDto) => void) | undefined;
+    tauriMocks.computerUseRequestPermissions
+      .mockImplementationOnce(
+        () =>
+          new Promise<ComputerUseStatusDto>((resolve) => {
+            finishAccessibilityProbe = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<ComputerUseStatusDto>((resolve) => {
+            finishScreenRecordingProbe = resolve;
+          }),
+      );
+    const first = render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Open Accessibility settings" }),
+    );
+
+    first.unmount();
+    tauriMocks.computerUseStatus.mockResolvedValue(
+      status({ grantEnabled: true, accessibility: true, state: "permission_missing" }),
+    );
+    render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Open Screen recording settings" }),
+    );
+
+    expect(tauriMocks.computerUseRequestPermissions).toHaveBeenCalledTimes(1);
+    finishAccessibilityProbe?.(
+      status({ grantEnabled: true, accessibility: true, state: "permission_missing" }),
+    );
+    await waitFor(() => expect(tauriMocks.computerUseRequestPermissions).toHaveBeenCalledTimes(2));
+    const readyStatus = status({
+      grantEnabled: true,
+      accessibility: true,
+      screenRecording: true,
+      ready: true,
+      state: "ready",
+    });
+    tauriMocks.computerUseStatus.mockResolvedValue(readyStatus);
+    finishScreenRecordingProbe?.(readyStatus);
+    await screen.findByText("Ready");
+  });
+
   it("keeps Accessibility labeled as step 1 when Screen recording was allowed first", async () => {
     tauriMocks.computerUseStatus.mockResolvedValue(
       status({ grantEnabled: true, screenRecording: true, state: "permission_missing" }),

--- a/src/test/computer-use-dev.test.mjs
+++ b/src/test/computer-use-dev.test.mjs
@@ -101,23 +101,27 @@ describe("Computer use development restart", () => {
     expect(() => writeFileSync(path.join(releaseBundle, "still-present"), "test")).not.toThrow();
   });
 
-  it("registers the helper before resetting both grants for one worktree", () => {
+  it("registers the helper and resets each grant for its responsible app", () => {
     const run = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
-    const bundleIdentifier = "co.opensoftware.june.computer-use-driver.dev.w123456789abc";
+    const helperBundleIdentifier = "co.opensoftware.june.computer-use-driver.dev.w123456789abc";
+    const appBundleIdentifier = "co.opensoftware.june.codex.jun278";
     const bundlePath = "/tmp/june-worktree/.tauri-helper/June Computer Use Driver.app";
 
-    expect(resetComputerUseDevGrants({ bundlePath, bundleIdentifier }, run)).toEqual([
-      "Accessibility",
-      "ScreenCapture",
-    ]);
+    expect(
+      resetComputerUseDevGrants({ bundlePath, helperBundleIdentifier, appBundleIdentifier }, run),
+    ).toEqual(["Accessibility", "ScreenCapture"]);
     expect(run.mock.calls).toEqual([
       [
         "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister",
         ["-f", bundlePath],
         { encoding: "utf8" },
       ],
-      ["/usr/bin/tccutil", ["reset", "Accessibility", bundleIdentifier], { encoding: "utf8" }],
-      ["/usr/bin/tccutil", ["reset", "ScreenCapture", bundleIdentifier], { encoding: "utf8" }],
+      [
+        "/usr/bin/tccutil",
+        ["reset", "Accessibility", helperBundleIdentifier],
+        { encoding: "utf8" },
+      ],
+      ["/usr/bin/tccutil", ["reset", "ScreenCapture", appBundleIdentifier], { encoding: "utf8" }],
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- Open Screen Recording settings before starting the cold Computer use helper permission probe.
- Name the outer June app as the Screen Recording permission owner while keeping Accessibility setup tied to the helper.
- Add regression coverage for the call ordering and document the macOS TCC identity split.

## Root cause

The permission action waited for a helper launch, TCC probe, and runtime reconfiguration before opening System Settings. On a cold launch that made a successful click appear unresponsive. The setup also treated the nested helper as the owner of both permissions even though macOS attributes Screen Recording to the responsible outer June app.

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` - 201 files, 3,249 tests passed, 2 skipped.
- `pnpm exec vitest run src/test/computer-use-control.test.tsx` - 13 tests passed.
- `pnpm typecheck`
- `pnpm check` - passed with the existing warning backlog.
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `git diff --check`

- [ ] Tested visually where it matters. Not exercised against the live macOS System Settings pane in this workspace.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Changes to the macOS privacy deep-link itself or the broader Computer use permission UI.
- Live signed-app permission validation, which remains part of the release-candidate matrix.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such changes are included.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend changes are included.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787260366&installation_model_id=425925&pr_number=886&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F886&signature=534e3c29554729df4741df2ddc22bf6780e3b7891bd470069ab8edee96caca93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->