### PR TITLE
Make MCP setup guided and importable

### DIFF
--- a/src/components/settings/McpServersSection.tsx
+++ b/src/components/settings/McpServersSection.tsx
@@ -1,4 +1,5 @@
 import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
+import { IconArrowInbox } from "central-icons/IconArrowInbox";
 import { IconCircleCheck } from "central-icons/IconCircleCheck";
 import { IconCircleInfo } from "central-icons/IconCircleInfo";
 import { IconCircleX } from "central-icons/IconCircleX";
@@ -28,6 +29,7 @@ import {
   oauthStateFor,
   oauthStatusMeta,
   planServerEdit,
+  parseExternalMcpConfig,
   redactedEnv,
   redactedHeaders,
   securityLabelsFor,
@@ -41,6 +43,7 @@ import {
   usesOauth,
   validateDraft,
   type HermesAdminMode,
+  type HermesAddMcpServerPayload,
   type HermesMcpServerInfo,
   type McpEditWrite,
   type McpFilteringState,
@@ -268,7 +271,8 @@ export function McpServersView({
 }) {
   const [query, setQuery] = useState("");
   const [refreshSpins, setRefreshSpins] = useState(0);
-  const [addOpen, setAddOpen] = useState(false);
+  const [setupOpen, setSetupOpen] = useState(false);
+  const [manualTransport, setManualTransport] = useState<McpServerDraft["transport"]>();
   const [toDelete, setToDelete] = useState<HermesMcpServerInfo | undefined>();
   // The server whose connection-field edit dialog is open, or undefined.
   const [toEdit, setToEdit] = useState<HermesMcpServerInfo | undefined>();
@@ -363,10 +367,10 @@ export function McpServersView({
           type="button"
           className="btn btn-secondary mcp-servers-add"
           disabled={isUnavailable}
-          onClick={() => setAddOpen(true)}
+          onClick={() => setSetupOpen(true)}
         >
           <IconPlusMedium size={14} ariaHidden />
-          Add MCP server
+          Set up MCP
         </button>
       </div>
 
@@ -396,8 +400,17 @@ export function McpServersView({
           ) : !hasServers ? (
             <EmptyState
               className="empty-state-compact"
-              title="No MCP servers"
-              description="Add a server to connect external tools. Local (stdio) servers run as subprocesses; remote servers connect over HTTP."
+              title="Connect your first tool"
+              description="Bring in an existing Claude, Cursor, or Codex configuration, or set up a server with a few guided steps."
+              action={
+                <button
+                  type="button"
+                  className="btn btn-secondary mcp-servers-add"
+                  onClick={() => setSetupOpen(true)}
+                >
+                  Start setup
+                </button>
+              }
             />
           ) : visible.length === 0 ? (
             <EmptyState
@@ -427,14 +440,26 @@ export function McpServersView({
         </div>
       </div>
 
+      <McpSetupDialog
+        open={setupOpen}
+        existingNames={state.servers.map((server) => server.name)}
+        onClose={() => setSetupOpen(false)}
+        onManual={(transport) => {
+          setSetupOpen(false);
+          setManualTransport(transport);
+        }}
+        onAdd={state.add}
+      />
+
       <AddServerDialog
-        open={addOpen}
+        open={manualTransport !== undefined}
+        initialTransport={manualTransport ?? "stdio"}
         adding={state.adding}
         existingNames={state.servers.map((server) => server.name)}
-        onClose={() => setAddOpen(false)}
+        onClose={() => setManualTransport(undefined)}
         onAdd={async (payload) => {
           const ok = await state.add(payload);
-          if (ok) setAddOpen(false);
+          if (ok) setManualTransport(undefined);
           return ok;
         }}
       />
@@ -818,8 +843,269 @@ function formatCommand(command: string | undefined, args: string[]): string {
 }
 
 // ---------------------------------------------------------------------------
-// Add-server dialog
+// Guided setup and add-server dialogs
 // ---------------------------------------------------------------------------
+
+function McpSetupDialog({
+  open,
+  existingNames,
+  onClose,
+  onManual,
+  onAdd,
+}: {
+  open: boolean;
+  existingNames: string[];
+  onClose: () => void;
+  onManual: (transport: McpServerDraft["transport"]) => void;
+  onAdd: (payload: HermesAddMcpServerPayload) => Promise<boolean>;
+}) {
+  const [step, setStep] = useState<"choose" | "import">("choose");
+  const [raw, setRaw] = useState("");
+  const [preview, setPreview] = useState<ReturnType<typeof parseExternalMcpConfig>>();
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [importing, setImporting] = useState(false);
+  const [importError, setImportError] = useState<string>();
+
+  function reset() {
+    setStep("choose");
+    setRaw("");
+    setPreview(undefined);
+    setSelected(new Set());
+    setImportError(undefined);
+  }
+
+  function handleClose() {
+    if (importing) return;
+    reset();
+    onClose();
+  }
+
+  function previewImport() {
+    const result = parseExternalMcpConfig(raw);
+    setPreview(result);
+    setImportError(undefined);
+    setSelected(
+      new Set(
+        result.entries
+          .filter((entry) => entry.payload && !existingNames.includes(entry.name))
+          .map((entry) => entry.name),
+      ),
+    );
+  }
+
+  async function applyImport() {
+    if (!preview || importing) return;
+    const entries = preview.entries.filter(
+      (entry) => selected.has(entry.name) && entry.payload && !existingNames.includes(entry.name),
+    );
+    if (entries.length === 0) return;
+
+    setImporting(true);
+    const failed = new Set<string>();
+    for (const entry of entries) {
+      if (entry.payload && !(await onAdd(entry.payload))) failed.add(entry.name);
+    }
+    setImporting(false);
+    if (failed.size > 0) {
+      setSelected(failed);
+      setImportError(
+        failed.size === 1
+          ? "One server could not be added. Review it and try again."
+          : `${failed.size} servers could not be added. Review them and try again.`,
+      );
+      return;
+    }
+    reset();
+    onClose();
+  }
+
+  const selectedCount = preview?.entries.filter(
+    (entry) => selected.has(entry.name) && entry.payload && !existingNames.includes(entry.name),
+  ).length;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      title={step === "choose" ? "Set up MCP" : "Import MCP configuration"}
+      description={
+        step === "choose"
+          ? "Choose the quickest way to connect tools and data to June."
+          : "Paste a Claude, Cursor, or Codex MCP configuration. You can review every server before anything is added."
+      }
+      width={600}
+      className="mcp-add-dialog mcp-setup-dialog"
+      footer={
+        step === "choose" ? (
+          <button type="button" className="primary-action" onClick={handleClose}>
+            Cancel
+          </button>
+        ) : (
+          <>
+            <button
+              type="button"
+              className="primary-action"
+              disabled={importing}
+              onClick={() => {
+                if (preview) {
+                  setPreview(undefined);
+                  setSelected(new Set());
+                  setImportError(undefined);
+                } else {
+                  setStep("choose");
+                }
+              }}
+            >
+              Back
+            </button>
+            {preview ? (
+              <button
+                type="button"
+                className="primary-action primary-solid"
+                disabled={!selectedCount || importing}
+                onClick={() => void applyImport()}
+              >
+                {importing
+                  ? "Importing"
+                  : `Import ${selectedCount ?? 0} ${selectedCount === 1 ? "server" : "servers"}`}
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="primary-action primary-solid"
+                disabled={!raw.trim()}
+                onClick={previewImport}
+              >
+                Preview servers
+              </button>
+            )}
+          </>
+        )
+      }
+    >
+      {step === "choose" ? (
+        <div className="mcp-setup-choices">
+          <button type="button" className="mcp-setup-choice" onClick={() => setStep("import")}>
+            <span className="mcp-setup-choice-icon">
+              <IconArrowInbox size={18} ariaHidden />
+            </span>
+            <span className="mcp-setup-choice-copy">
+              <span className="mcp-setup-choice-title">
+                Import from another app
+                <span className="mcp-setup-recommended">Recommended</span>
+              </span>
+              <span className="mcp-setup-choice-description">
+                Bring over servers from Claude, Cursor, or Codex in one pass.
+              </span>
+            </span>
+          </button>
+          <button type="button" className="mcp-setup-choice" onClick={() => onManual("http")}>
+            <span className="mcp-setup-choice-icon">
+              <IconCloud size={18} ariaHidden />
+            </span>
+            <span className="mcp-setup-choice-copy">
+              <span className="mcp-setup-choice-title">Connect a remote server</span>
+              <span className="mcp-setup-choice-description">
+                Add a hosted MCP endpoint and sign in if it uses OAuth.
+              </span>
+            </span>
+          </button>
+          <button type="button" className="mcp-setup-choice" onClick={() => onManual("stdio")}>
+            <span className="mcp-setup-choice-icon">
+              <IconSettingsGear4 size={18} ariaHidden />
+            </span>
+            <span className="mcp-setup-choice-copy">
+              <span className="mcp-setup-choice-title">Run a local server</span>
+              <span className="mcp-setup-choice-description">
+                Configure a command, its arguments, and environment values.
+              </span>
+            </span>
+          </button>
+        </div>
+      ) : preview ? (
+        <div className="mcp-import-preview">
+          {preview.error ? <p className="mcp-import-error">{preview.error}</p> : null}
+          {!preview.error ? (
+            <p className="mcp-import-summary">
+              Found {preview.entries.length} {preview.entries.length === 1 ? "server" : "servers"}{" "}
+              in your {preview.source} configuration.
+            </p>
+          ) : null}
+          <div className="mcp-import-list">
+            {preview.entries.map((entry) => {
+              const duplicate = existingNames.includes(entry.name);
+              const unavailable = Boolean(entry.error || duplicate || !entry.payload);
+              return (
+                <label
+                  key={entry.name}
+                  className="mcp-import-entry"
+                  data-unavailable={unavailable || undefined}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.has(entry.name)}
+                    disabled={unavailable || importing}
+                    onChange={(event) => {
+                      const checked = event.currentTarget.checked;
+                      setSelected((current) => {
+                        const next = new Set(current);
+                        if (checked) next.add(entry.name);
+                        else next.delete(entry.name);
+                        return next;
+                      });
+                    }}
+                  />
+                  <span className="mcp-import-entry-copy">
+                    <span className="mcp-import-entry-name">{entry.name}</span>
+                    <span className="mcp-import-entry-detail">
+                      {duplicate
+                        ? "Already connected"
+                        : (entry.error ??
+                          (entry.payload?.command
+                            ? `Local command: ${entry.payload.command}`
+                            : `Remote server: ${entry.payload?.url}`))}
+                    </span>
+                    {entry.warnings.map((warning) => (
+                      <span key={warning} className="mcp-import-entry-warning">
+                        {warning}
+                      </span>
+                    ))}
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+          {importError ? <p className="mcp-import-error">{importError}</p> : null}
+        </div>
+      ) : (
+        <div className="mcp-import-paste">
+          <label className="mcp-add-label" htmlFor="mcp-import-config">
+            Configuration
+          </label>
+          <textarea
+            id="mcp-import-config"
+            className="mcp-import-textarea"
+            rows={12}
+            value={raw}
+            spellCheck={false}
+            placeholder={
+              '{\n  "mcpServers": {\n    "example": { "command": "npx", "args": ["server"] }\n  }\n}'
+            }
+            onChange={(event) => {
+              setRaw(event.currentTarget.value);
+              setImportError(undefined);
+            }}
+          />
+          <p className="mcp-add-note">
+            <IconShield size={13} ariaHidden />
+            June reads only MCP server entries. Other app settings are ignored, and nothing is added
+            until you approve the preview.
+          </p>
+        </div>
+      )}
+    </Dialog>
+  );
+}
 
 /** A stable, monotonic id for an editor row. Rows are added and removed in the
  * middle of a list, so a positional React key would let React reuse a row's
@@ -883,22 +1169,30 @@ function toValidationDraft(draft: EditableDraft): McpServerDraft {
 
 function AddServerDialog({
   open,
+  initialTransport,
   adding,
   existingNames,
   onClose,
   onAdd,
 }: {
   open: boolean;
+  initialTransport: McpServerDraft["transport"];
   adding: boolean;
   existingNames: string[];
   onClose: () => void;
   onAdd: (payload: import("../../lib/hermes-admin").HermesAddMcpServerPayload) => Promise<boolean>;
 }) {
-  const [draft, setDraft] = useState<EditableDraft>(() => emptyEditableDraft());
+  const [draft, setDraft] = useState<EditableDraft>(() => emptyEditableDraft(initialTransport));
   const [errors, setErrors] = useState<Record<string, string>>({});
 
+  useEffect(() => {
+    if (!open) return;
+    setDraft(emptyEditableDraft(initialTransport));
+    setErrors({});
+  }, [open, initialTransport]);
+
   function reset() {
-    setDraft(emptyEditableDraft());
+    setDraft(emptyEditableDraft(initialTransport));
     setErrors({});
   }
 
@@ -1765,10 +2059,12 @@ function EmptyState({
   title,
   description,
   className,
+  action,
 }: {
   title: string;
   description: string;
   className?: string;
+  action?: ReactNode;
 }) {
   return (
     <EmptyStateSurface
@@ -1776,6 +2072,7 @@ function EmptyState({
       title={title}
       description={description}
       className={className}
+      action={action}
     />
   );
 }

--- a/src/lib/hermes-admin/index.ts
+++ b/src/lib/hermes-admin/index.ts
@@ -71,6 +71,7 @@ export * from "./use-mcp-filtering";
 export * from "./mcp-security-view";
 export * from "./use-mcp-security";
 export * from "./mcp-catalog-view";
+export * from "./mcp-config-import";
 export * from "./use-mcp-catalog";
 export * from "./hub-search-view";
 export * from "./skill-install-review";

--- a/src/lib/hermes-admin/mcp-config-import.ts
+++ b/src/lib/hermes-admin/mcp-config-import.ts
@@ -16,6 +16,8 @@ export type McpConfigImportResult = {
   error?: string;
 };
 
+const TOOL_POLICY_MARKER = "__june_import_has_tool_policy";
+
 /**
  * Parses the two MCP configuration families people most often already have:
  * Claude/Cursor JSON (`mcpServers`) and Codex TOML (`mcp_servers`). The TOML
@@ -71,6 +73,12 @@ function parseCodexToml(text: string): McpConfigImportResult {
     if (table) {
       const path = splitTomlPath(table[1]);
       const name = path[0];
+      if (name && path[1] === "tools") {
+        servers[name] ??= {};
+        servers[name][TOOL_POLICY_MARKER] = true;
+        current = undefined;
+        continue;
+      }
       if (!name || path.length > 2 || (path[1] && path[1] !== "env")) {
         current = undefined;
         continue;
@@ -180,6 +188,20 @@ function importEntry(name: string, rawConfig: unknown): McpConfigImportEntry {
       name,
       warnings,
       error: "This entry has both a command and URL, so June cannot choose a transport safely.",
+    };
+  }
+  if (
+    config.enabled_tools !== undefined ||
+    config.disabled_tools !== undefined ||
+    config.default_tools_approval_mode !== undefined ||
+    config.tools !== undefined ||
+    config[TOOL_POLICY_MARKER] === true
+  ) {
+    return {
+      name,
+      warnings,
+      error:
+        "This server limits tool access. Add it manually, then reapply its tool access rules before enabling it.",
     };
   }
   if (config.bearer_token_env_var || config.env_http_headers) {

--- a/src/lib/hermes-admin/mcp-config-import.ts
+++ b/src/lib/hermes-admin/mcp-config-import.ts
@@ -17,6 +17,16 @@ export type McpConfigImportResult = {
 };
 
 const TOOL_POLICY_MARKER = "__june_import_has_tool_policy";
+const UNSUPPORTED_BEHAVIOR_KEYS = [
+  "cwd",
+  "env_vars",
+  "experimental_environment",
+  "startup_timeout_sec",
+  "tool_timeout_sec",
+  "required",
+  "oauth_resource",
+  "scopes",
+] as const;
 
 /**
  * Parses the two MCP configuration families people most often already have:
@@ -212,13 +222,15 @@ function importEntry(name: string, rawConfig: unknown): McpConfigImportEntry {
         "This server references HTTP credentials from environment variables. Add it manually so June can store the credential safely.",
     };
   }
-  if (config.env_vars) {
-    warnings.push(
-      "Forwarded environment variable names are not imported. Add any required values after setup.",
-    );
-  }
-  if (config.enabled === false) {
-    warnings.push("This server was disabled in the source app. June will add it enabled.");
+  const unsupportedBehavior = UNSUPPORTED_BEHAVIOR_KEYS.find((key) => config[key] !== undefined);
+  if (unsupportedBehavior || config.enabled === false) {
+    return {
+      name,
+      warnings,
+      error: unsupportedBehavior
+        ? `This server uses the unsupported ${unsupportedBehavior} option. Add it manually so its behavior is preserved.`
+        : "This server is disabled in the source app. Add it manually if you want to keep it disabled.",
+    };
   }
 
   const validation = validateDraft(draft);

--- a/src/lib/hermes-admin/mcp-config-import.ts
+++ b/src/lib/hermes-admin/mcp-config-import.ts
@@ -1,0 +1,353 @@
+import type { HermesAddMcpServerPayload } from "./client";
+import { emptyDraft, validateDraft, type McpServerDraft } from "./mcp-servers-view";
+
+export type McpConfigImportSource = "Claude or Cursor" | "Codex" | "JSON";
+
+export type McpConfigImportEntry = {
+  name: string;
+  payload?: HermesAddMcpServerPayload;
+  warnings: string[];
+  error?: string;
+};
+
+export type McpConfigImportResult = {
+  source: McpConfigImportSource;
+  entries: McpConfigImportEntry[];
+  error?: string;
+};
+
+/**
+ * Parses the two MCP configuration families people most often already have:
+ * Claude/Cursor JSON (`mcpServers`) and Codex TOML (`mcp_servers`). The TOML
+ * reader is deliberately narrow. It only reads MCP tables and ignores every
+ * unrelated Codex setting rather than trying to be a general TOML parser.
+ */
+export function parseExternalMcpConfig(raw: string): McpConfigImportResult {
+  const text = raw.trim();
+  if (!text) return { source: "JSON", entries: [], error: "Paste an MCP configuration first." };
+
+  if (text.startsWith("{")) {
+    return parseJsonConfig(text);
+  }
+  return parseCodexToml(text);
+}
+
+function parseJsonConfig(text: string): McpConfigImportResult {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return {
+      source: "JSON",
+      entries: [],
+      error: "This is not valid JSON. Paste the complete configuration, including braces.",
+    };
+  }
+
+  const root = recordOf(value);
+  const camel = recordOf(root?.mcpServers);
+  const snake = recordOf(root?.mcp_servers);
+  const servers = camel ?? snake;
+  if (!servers) {
+    return {
+      source: "JSON",
+      entries: [],
+      error: "No MCP servers were found. Expected an mcpServers or mcp_servers object.",
+    };
+  }
+
+  return {
+    source: camel ? "Claude or Cursor" : "JSON",
+    entries: Object.entries(servers).map(([name, config]) => importEntry(name, config)),
+  };
+}
+
+function parseCodexToml(text: string): McpConfigImportResult {
+  const servers: Record<string, Record<string, unknown>> = {};
+  let current: { name: string; child?: "env" } | undefined;
+
+  for (const line of logicalTomlLines(text)) {
+    const table = /^\[\s*mcp_servers\.(.+?)\s*\]$/.exec(line);
+    if (table) {
+      const path = splitTomlPath(table[1]);
+      const name = path[0];
+      if (!name || path.length > 2 || (path[1] && path[1] !== "env")) {
+        current = undefined;
+        continue;
+      }
+      servers[name] ??= {};
+      current = { name, child: path[1] === "env" ? "env" : undefined };
+      continue;
+    }
+
+    if (line.startsWith("[")) {
+      current = undefined;
+      continue;
+    }
+    if (!current) continue;
+
+    const assignment = splitTomlAssignment(line);
+    if (!assignment) continue;
+    const [key, valueText] = assignment;
+    const parsed = parseTomlValue(valueText);
+    if (parsed === undefined) continue;
+    if (current.child === "env") {
+      const env = recordOf(servers[current.name].env) ?? {};
+      env[unquoteToml(key.trim())] = parsed;
+      servers[current.name].env = env;
+    } else {
+      servers[current.name][unquoteToml(key.trim())] = parsed;
+    }
+  }
+
+  const entries = Object.entries(servers).map(([name, config]) => importEntry(name, config));
+  return entries.length > 0
+    ? { source: "Codex", entries }
+    : {
+        source: "Codex",
+        entries: [],
+        error: "No Codex MCP tables were found. Expected a table like [mcp_servers.example].",
+      };
+}
+
+/** Joins multiline arrays and inline tables before the narrow MCP parser sees
+ * them. This covers the common hand-formatted Codex config style without
+ * pulling unrelated TOML settings into the import. */
+function logicalTomlLines(text: string): string[] {
+  const lines: string[] = [];
+  let buffer = "";
+  let depth = 0;
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  for (const sourceLine of text.split(/\r?\n/)) {
+    const line = stripTomlComment(sourceLine).trim();
+    if (!line && !buffer) continue;
+    buffer = buffer ? `${buffer} ${line}` : line;
+
+    for (const char of line) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\" && quote === '"') {
+        escaped = true;
+        continue;
+      }
+      if (char === '"' || char === "'") {
+        quote = quote === char ? undefined : (quote ?? char);
+        continue;
+      }
+      if (quote) continue;
+      if (char === "[" || char === "{") depth += 1;
+      if (char === "]" || char === "}") depth -= 1;
+    }
+
+    if (!quote && depth <= 0) {
+      if (buffer.trim()) lines.push(buffer.trim());
+      buffer = "";
+      depth = 0;
+    }
+  }
+  if (buffer.trim()) lines.push(buffer.trim());
+  return lines;
+}
+
+function importEntry(name: string, rawConfig: unknown): McpConfigImportEntry {
+  const config = recordOf(rawConfig);
+  if (!config) return { name, warnings: [], error: "This server configuration is not an object." };
+
+  const warnings: string[] = [];
+  const command = stringOf(config.command);
+  const url = stringOf(config.url);
+  const transport = command ? "stdio" : "http";
+  const draft: McpServerDraft = {
+    ...emptyDraft(transport),
+    name,
+    command: command ?? "",
+    args: stringArrayOf(config.args),
+    env: pairsOf(config.env),
+    url: url ?? "",
+    headers: pairsOf(config.headers ?? config.http_headers),
+    auth: normalizeAuth(config.auth),
+  };
+
+  if (!command && !url) {
+    return { name, warnings, error: "Add either a command or URL before importing this server." };
+  }
+  if (command && url) {
+    return {
+      name,
+      warnings,
+      error: "This entry has both a command and URL, so June cannot choose a transport safely.",
+    };
+  }
+  if (config.bearer_token_env_var || config.env_http_headers) {
+    return {
+      name,
+      warnings,
+      error:
+        "This server references HTTP credentials from environment variables. Add it manually so June can store the credential safely.",
+    };
+  }
+  if (config.env_vars) {
+    warnings.push(
+      "Forwarded environment variable names are not imported. Add any required values after setup.",
+    );
+  }
+  if (config.enabled === false) {
+    warnings.push("This server was disabled in the source app. June will add it enabled.");
+  }
+
+  const validation = validateDraft(draft);
+  if (!validation.ok) {
+    return {
+      name,
+      warnings,
+      error: Object.values(validation.errors)[0] ?? "This server could not be imported.",
+    };
+  }
+  return { name, payload: validation.payload, warnings };
+}
+
+function normalizeAuth(value: unknown): McpServerDraft["auth"] {
+  return value === "oauth" || value === "bearer" ? value : "none";
+}
+
+function recordOf(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringOf(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function stringArrayOf(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function pairsOf(value: unknown): Array<{ key: string; value: string }> {
+  const record = recordOf(value);
+  if (!record) return [];
+  return Object.entries(record).flatMap(([key, item]) =>
+    typeof item === "string" ? [{ key, value: item }] : [],
+  );
+}
+
+function stripTomlComment(line: string): string {
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && quote === '"') {
+      escaped = true;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = quote === char ? undefined : (quote ?? char);
+      continue;
+    }
+    if (char === "#" && !quote) return line.slice(0, index);
+  }
+  return line;
+}
+
+function splitTomlAssignment(line: string): [string, string] | undefined {
+  let quote: '"' | "'" | undefined;
+  let depth = 0;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === '"' || char === "'") quote = quote === char ? undefined : (quote ?? char);
+    if (quote) continue;
+    if (char === "[" || char === "{") depth += 1;
+    if (char === "]" || char === "}") depth -= 1;
+    if (char === "=" && depth === 0) return [line.slice(0, index), line.slice(index + 1)];
+  }
+  return undefined;
+}
+
+function splitTomlPath(path: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | undefined;
+  for (const char of path) {
+    if (char === '"' || char === "'") {
+      quote = quote === char ? undefined : (quote ?? char);
+      current += char;
+    } else if (char === "." && !quote) {
+      parts.push(unquoteToml(current.trim()));
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  if (current.trim()) parts.push(unquoteToml(current.trim()));
+  return parts;
+}
+
+function unquoteToml(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseTomlValue(value: string): unknown {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return trimmed.slice(1, -1);
+    }
+  }
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) return trimmed.slice(1, -1);
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return splitTomlList(trimmed.slice(1, -1)).map((item) => parseTomlValue(item));
+  }
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+    const result: Record<string, unknown> = {};
+    for (const item of splitTomlList(trimmed.slice(1, -1))) {
+      const assignment = splitTomlAssignment(item);
+      if (!assignment) continue;
+      result[unquoteToml(assignment[0])] = parseTomlValue(assignment[1]);
+    }
+    return result;
+  }
+  const number = Number(trimmed);
+  return Number.isFinite(number) ? number : undefined;
+}
+
+function splitTomlList(value: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | undefined;
+  let depth = 0;
+  for (const char of value) {
+    if (char === '"' || char === "'") quote = quote === char ? undefined : (quote ?? char);
+    if (!quote && (char === "[" || char === "{")) depth += 1;
+    if (!quote && (char === "]" || char === "}")) depth -= 1;
+    if (char === "," && !quote && depth === 0) {
+      if (current.trim()) parts.push(current.trim());
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  if (current.trim()) parts.push(current.trim());
+  return parts;
+}

--- a/src/lib/hermes-admin/mcp-config-import.ts
+++ b/src/lib/hermes-admin/mcp-config-import.ts
@@ -278,7 +278,18 @@ function splitTomlPath(path: string): string[] {
   const parts: string[] = [];
   let current = "";
   let quote: '"' | "'" | undefined;
+  let escaped = false;
   for (const char of path) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && quote === '"') {
+      current += char;
+      escaped = true;
+      continue;
+    }
     if (char === '"' || char === "'") {
       quote = quote === char ? undefined : (quote ?? char);
       current += char;
@@ -337,7 +348,18 @@ function splitTomlList(value: string): string[] {
   let current = "";
   let quote: '"' | "'" | undefined;
   let depth = 0;
+  let escaped = false;
   for (const char of value) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && quote === '"') {
+      current += char;
+      escaped = true;
+      continue;
+    }
     if (char === '"' || char === "'") quote = quote === char ? undefined : (quote ?? char);
     if (!quote && (char === "[" || char === "{")) depth += 1;
     if (!quote && (char === "]" || char === "}")) depth -= 1;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -16861,6 +16861,158 @@ button.agent-user-attachment:hover {
   width: 70%;
 }
 
+/* Guided MCP setup. */
+.mcp-setup-choices {
+  display: grid;
+  gap: var(--sp-3);
+}
+
+.mcp-setup-choice {
+  display: grid;
+  grid-template-columns: var(--control-lg) minmax(0, 1fr);
+  align-items: center;
+  gap: var(--sp-3);
+  width: 100%;
+  padding: var(--sp-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  background: var(--card);
+  color: var(--foreground);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--t-fast) var(--ease-out),
+    background-color var(--t-fast) var(--ease-out);
+}
+
+.mcp-setup-choice:hover {
+  border-color: var(--ring);
+  background: var(--secondary);
+}
+
+.mcp-setup-choice:focus-visible {
+  outline: none;
+  border-color: var(--ring-focus);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.mcp-setup-choice-icon {
+  display: inline-grid;
+  place-items: center;
+  width: var(--control-lg);
+  height: var(--control-lg);
+  border-radius: var(--r-sm);
+  background: var(--surface-subtle);
+  color: var(--muted-foreground);
+}
+
+.mcp-setup-choice-copy,
+.mcp-import-entry-copy {
+  min-width: 0;
+  display: grid;
+  gap: var(--sp-px);
+}
+
+.mcp-setup-choice-title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-medium);
+}
+
+.mcp-setup-choice-description,
+.mcp-import-entry-detail,
+.mcp-import-entry-warning,
+.mcp-import-summary {
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+}
+
+.mcp-setup-recommended {
+  padding: 1px var(--sp-2);
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--ring-focus) 18%, transparent);
+  color: var(--foreground);
+  font-size: var(--fs-xs);
+  font-weight: 400;
+}
+
+.mcp-import-paste,
+.mcp-import-preview {
+  display: grid;
+  gap: var(--sp-3);
+}
+
+.mcp-import-textarea {
+  width: 100%;
+  min-height: 240px;
+  resize: vertical;
+  padding: var(--sp-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--card);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+  outline: none;
+}
+
+.mcp-import-textarea:focus-visible {
+  border-color: var(--ring-focus);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.mcp-import-summary,
+.mcp-import-error {
+  margin: 0;
+}
+
+.mcp-import-list {
+  display: grid;
+  gap: var(--sp-2);
+}
+
+.mcp-import-entry {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: var(--sp-3);
+  padding: var(--sp-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  background: var(--card);
+  cursor: pointer;
+}
+
+.mcp-import-entry[data-unavailable="true"] {
+  background: var(--surface-subtle);
+  cursor: default;
+}
+
+.mcp-import-entry input {
+  margin-top: 3px;
+}
+
+.mcp-import-entry-name {
+  color: var(--foreground);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+}
+
+.mcp-import-entry-warning {
+  color: var(--warm-strong);
+}
+
+.mcp-import-error {
+  color: var(--destructive);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+}
+
 /* Add-server dialog form. */
 .mcp-add-form {
   display: grid;

--- a/src/test/mcp-servers.test.tsx
+++ b/src/test/mcp-servers.test.tsx
@@ -411,6 +411,24 @@ approval_mode = "prompt"
     expect(perTool.entries[0].payload).toBeUndefined();
     expect(perTool.entries[0].error).toMatch(/tool access/i);
   });
+
+  it.each([
+    ['cwd = "/tmp/project"', /cwd/i],
+    ['oauth_resource = "https://example.com"', /oauth_resource/i],
+    ['scopes = ["read", "write"]', /scopes/i],
+    ['env_vars = ["TOKEN"]', /env_vars/i],
+    ["startup_timeout_sec = 30", /startup_timeout_sec/i],
+    ["enabled = false", /disabled in the source app/i],
+  ])("blocks unsupported behavior-changing Codex option %s", (option, message) => {
+    const result = parseExternalMcpConfig(`
+[mcp_servers.behavior]
+command = "example"
+${option}
+`);
+
+    expect(result.entries[0].payload).toBeUndefined();
+    expect(result.entries[0].error).toMatch(message);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/test/mcp-servers.test.tsx
+++ b/src/test/mcp-servers.test.tsx
@@ -20,6 +20,7 @@ import {
   isLocalSubprocess,
   isValidHttpUrl,
   parseMcpServer,
+  parseExternalMcpConfig,
   planServerEdit,
   redactedEnv,
   redactedHeaders,
@@ -295,6 +296,85 @@ describe("mcp servers — add-server validation", () => {
     const result = validateDraft(stdioDraft({ env: [{ key: "", value: "" }] }));
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.payload.env).toBeUndefined();
+  });
+});
+
+describe("mcp servers — configuration import", () => {
+  it("imports Claude and Cursor JSON without changing unrelated settings", () => {
+    const result = parseExternalMcpConfig(
+      JSON.stringify({
+        theme: "dark",
+        mcpServers: {
+          filesystem: {
+            command: "npx",
+            args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            env: { FILESYSTEM_KEY: "secret" },
+          },
+          linear: { url: "https://mcp.linear.app/mcp", auth: "oauth" },
+        },
+      }),
+    );
+
+    expect(result.source).toBe("Claude or Cursor");
+    expect(result.entries.map((entry) => entry.payload)).toEqual([
+      {
+        name: "filesystem",
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+        env: { FILESYSTEM_KEY: "secret" },
+      },
+      { name: "linear", url: "https://mcp.linear.app/mcp", auth: "oauth" },
+    ]);
+  });
+
+  it("imports current Codex MCP TOML tables and nested environment values", () => {
+    const result = parseExternalMcpConfig(`
+model = "gpt-5.6"
+
+[mcp_servers.context7]
+command = "npx"
+args = [
+  "-y",
+  "@upstash/context7-mcp",
+]
+
+[mcp_servers.context7.env]
+CONTEXT7_KEY = "secret"
+
+[mcp_servers.figma]
+url = "https://mcp.figma.com/mcp"
+auth = "oauth"
+http_headers = {
+  "X-Figma-Region" = "us-east-1",
+}
+`);
+
+    expect(result.source).toBe("Codex");
+    expect(result.entries.map((entry) => entry.payload)).toEqual([
+      {
+        name: "context7",
+        command: "npx",
+        args: ["-y", "@upstash/context7-mcp"],
+        env: { CONTEXT7_KEY: "secret" },
+      },
+      {
+        name: "figma",
+        url: "https://mcp.figma.com/mcp",
+        auth: "oauth",
+        headers: { "X-Figma-Region": "us-east-1" },
+      },
+    ]);
+  });
+
+  it("blocks Codex environment-backed HTTP credentials from an unsafe partial import", () => {
+    const result = parseExternalMcpConfig(`
+[mcp_servers.figma]
+url = "https://mcp.figma.com/mcp"
+bearer_token_env_var = "FIGMA_OAUTH_TOKEN"
+`);
+
+    expect(result.entries[0].payload).toBeUndefined();
+    expect(result.entries[0].error).toMatch(/credential/i);
   });
 });
 
@@ -950,7 +1030,8 @@ describe("McpServersView — component", () => {
   it("opens the add-server dialog and validates before sending", async () => {
     const add = vi.fn(() => Promise.resolve(true));
     render(<McpServersView state={stubState({ add })} />);
-    fireEvent.click(screen.getByRole("button", { name: /add mcp server/i }));
+    fireEvent.click(screen.getByRole("button", { name: /set up mcp/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /run a local server/i }));
 
     await waitFor(() =>
       expect(screen.getByRole("dialog", { name: "Add MCP server" })).toBeInTheDocument(),
@@ -962,6 +1043,44 @@ describe("McpServersView — component", () => {
     expect(screen.getByText(/enter a name/i)).toBeInTheDocument();
   });
 
+  it("previews and imports servers from another app through guided setup", async () => {
+    const add = vi.fn(() => Promise.resolve(true));
+    render(<McpServersView state={stubState({ add })} />);
+    fireEvent.click(screen.getAllByRole("button", { name: /set up mcp/i })[0]);
+    fireEvent.click(await screen.findByRole("button", { name: /import from another app/i }));
+
+    fireEvent.change(screen.getByLabelText("Configuration"), {
+      target: {
+        value: JSON.stringify({
+          mcpServers: {
+            filesystem: { command: "npx", args: ["-y", "filesystem-mcp"] },
+            linear: { url: "https://mcp.linear.app/mcp", auth: "oauth" },
+          },
+        }),
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /preview servers/i }));
+
+    expect(screen.getByText(/found 2 servers/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /import 2 servers/i }));
+    await waitFor(() => expect(add).toHaveBeenCalledTimes(2));
+    expect(add).toHaveBeenNthCalledWith(1, {
+      name: "filesystem",
+      command: "npx",
+      args: ["-y", "filesystem-mcp"],
+    });
+    expect(add).toHaveBeenNthCalledWith(2, {
+      name: "linear",
+      url: "https://mcp.linear.app/mcp",
+      auth: "oauth",
+    });
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: /import mcp configuration/i }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
   // Regression: the add-form field handlers must read event.currentTarget.value
   // synchronously, not inside the setDraft updater (React nulls currentTarget
   // after the handler returns, which blanked the whole app). Typing into the
@@ -969,7 +1088,8 @@ describe("McpServersView — component", () => {
   it("accepts a typed stdio server without crashing (currentTarget)", async () => {
     const add = vi.fn(() => Promise.resolve(true));
     render(<McpServersView state={stubState({ add })} />);
-    fireEvent.click(screen.getByRole("button", { name: /add mcp server/i }));
+    fireEvent.click(screen.getByRole("button", { name: /set up mcp/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /run a local server/i }));
     await waitFor(() =>
       expect(screen.getByRole("dialog", { name: "Add MCP server" })).toBeInTheDocument(),
     );
@@ -993,12 +1113,12 @@ describe("McpServersView — component", () => {
   it("accepts a typed http server with an auth header without crashing", async () => {
     const add = vi.fn(() => Promise.resolve(true));
     render(<McpServersView state={stubState({ add })} />);
-    fireEvent.click(screen.getByRole("button", { name: /add mcp server/i }));
+    fireEvent.click(screen.getByRole("button", { name: /set up mcp/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /connect a remote server/i }));
     await waitFor(() =>
       expect(screen.getByRole("dialog", { name: "Add MCP server" })).toBeInTheDocument(),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /streamable http/i }));
     fireEvent.change(screen.getByLabelText("Name"), {
       target: { value: "linear" },
     });
@@ -1037,7 +1157,7 @@ describe("McpServersView — component", () => {
 
   it("shows the no-servers empty state for an empty ready list", () => {
     render(<McpServersView state={stubState({ servers: [] })} />);
-    expect(screen.getByText("No MCP servers")).toBeInTheDocument();
+    expect(screen.getByText("Connect your first tool")).toBeInTheDocument();
   });
 
   it("does not show internal June MCP servers in the section", () => {
@@ -1056,7 +1176,7 @@ describe("McpServersView — component", () => {
       />,
     );
 
-    expect(screen.getByText("No MCP servers")).toBeInTheDocument();
+    expect(screen.getByText("Connect your first tool")).toBeInTheDocument();
     for (const name of INTERNAL_MCP_SERVER_NAMES) {
       expect(screen.queryByText(name)).not.toBeInTheDocument();
     }

--- a/src/test/mcp-servers.test.tsx
+++ b/src/test/mcp-servers.test.tsx
@@ -390,6 +390,27 @@ args = ["say \\"hello, June\\"", "--ok"]
       args: ['say "hello, June"', "--ok"],
     });
   });
+
+  it("blocks imports that would silently broaden Codex tool access", () => {
+    const filtered = parseExternalMcpConfig(`
+[mcp_servers.filtered]
+command = "example"
+enabled_tools = ["read"]
+disabled_tools = ["delete"]
+`);
+    const perTool = parseExternalMcpConfig(`
+[mcp_servers.per_tool]
+url = "https://example.com/mcp"
+
+[mcp_servers.per_tool.tools.delete]
+approval_mode = "prompt"
+`);
+
+    expect(filtered.entries[0].payload).toBeUndefined();
+    expect(filtered.entries[0].error).toMatch(/tool access/i);
+    expect(perTool.entries[0].payload).toBeUndefined();
+    expect(perTool.entries[0].error).toMatch(/tool access/i);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/test/mcp-servers.test.tsx
+++ b/src/test/mcp-servers.test.tsx
@@ -376,6 +376,20 @@ bearer_token_env_var = "FIGMA_OAUTH_TOKEN"
     expect(result.entries[0].payload).toBeUndefined();
     expect(result.entries[0].error).toMatch(/credential/i);
   });
+
+  it("preserves escaped quotes and commas inside Codex TOML strings", () => {
+    const result = parseExternalMcpConfig(`
+[mcp_servers.quoted]
+command = "example"
+args = ["say \\"hello, June\\"", "--ok"]
+`);
+
+    expect(result.entries[0].payload).toEqual({
+      name: "quoted",
+      command: "example",
+      args: ['say "hello, June"', "--ok"],
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed
- replace the blank MCP form entry point with a guided setup chooser
- import Claude and Cursor JSON or Codex TOML with a per-server preview and selection step
- route remote and local manual setup into the correct preselected transport form
- reject unsafe partial imports such as environment-backed HTTP credentials

## Why
MCP setup currently assumes users already know June transport and credential details. This makes the common paths obvious and lets existing MCP users bring their setup across without rebuilding it server by server.

## Validation
- `pnpm exec vitest run src/test/mcp-servers.test.tsx` (60 tests passed)
- `pnpm exec tsc --noEmit`
- `pnpm test` (3,272 passed, 2 skipped)
- `pnpm build`
- live Chromium walkthrough: empty state, setup chooser, Codex TOML preview, two-server import, restart prompt, remote server form
- local no-audio QA video verified at `.tmp/qa-recordings/mcp-setup/mcp-setup-walkthrough.compressed.mp4`

## Known gaps
- QA video upload is blocked because no `OS_PLATFORM_API_KEY` or `JUNE__ISSUE_REPORTS__OS_PLATFORM_API_KEY` is available in this worktree
- environment-backed HTTP credentials are intentionally sent to manual setup because Hermes cannot reproduce those references safely through its current create contract