### PR TITLE
fix(sidebar): anchor toggle to sidebar header on Windows

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -119,7 +119,7 @@ import {
 } from "../lib/tauri";
 import { playRecordingSound, preloadRecordingSounds } from "../lib/recording-sounds";
 import { preloadAgentSounds } from "../lib/agent-sounds";
-import { isMacLikePlatform, isPrimaryShortcut } from "../lib/platform";
+import { isMacLikePlatform, isPrimaryShortcut, isWindowsPlatform } from "../lib/platform";
 import { mergeSourceReadiness } from "../lib/source-readiness";
 import { AGENT_RECORDER_REQUEST_EVENT, MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
 import {
@@ -4135,6 +4135,7 @@ export function App() {
   return (
     <main
       className="app-shell"
+      data-platform={isWindowsPlatform() ? "windows" : undefined}
       data-sidebar={sidebarCollapsed ? "collapsed" : "expanded"}
       data-sidebar-resizing={sidebarResizing ? "true" : "false"}
       data-sidebar-transition={sidebarTransition}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8319,6 +8319,22 @@ button.agent-user-attachment:hover {
   --titlebar-controls-gap: var(--sp-3);
 }
 
+/* Windows-only: let the sidebar toggle ride with the first tab instead of
+ * staying pinned at the left edge. Anchored to the animated sidebar edge
+ * (minus the toggle width and a gap) so it sits immediately to the left of
+ * the first tab in expanded state, and floors at --sp-3 when collapsed.
+ * Because --sidebar-w-current is a registered @property whose transition
+ * lives on .app-shell, the toggle tweens on the same clock as the grid and
+ * the tab strip — no drift mid-snap, and it jumps in sync on button presses
+ * (data-sidebar-transition="none"). macOS is untouched: it keeps the fixed
+ * 80px left from the rule above. */
+.app-shell[data-platform="windows"] .chrome-sidebar-toggle {
+  left: max(
+    var(--sp-3),
+    calc(var(--sidebar-w-current) - var(--control-md) - var(--sp-3))
+  );
+}
+
 .chrome-sidebar-toggle {
   position: fixed;
   /* Vertically centered in the titlebar, then nudged down a hair to sit level

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8321,15 +8321,21 @@ button.agent-user-attachment:hover {
 
 /* Windows has no traffic-light controls, so the titlebar-h (28px) of top
  * padding baked into .sidebar is dead space above the June logo. Reclaim it
- * so the sidebar header sits flush at the top. Raise the sidebar above the
- * fixed titlebar-drag overlay (z-index 100) so the logo link and recording
- * indicator remain interactive — same z-index as .tab-bar (101). position:
- * relative doesn't affect grid layout, just creates a stacking context.
+ * so the sidebar header sits flush at the top. Scoped to default mode only —
+ * Settings keeps the original clearance since it has no sidebar-header and
+ * the toggle falls back to the titlebar band there.
+ *
+ * Instead of raising the sidebar above the drag overlay (which would put it
+ * above session usage overlays at z-index 100), push the drag region's left
+ * edge to the sidebar's right edge so it never covers the sidebar. The drag
+ * region rides --sidebar-w-current so it tracks the sidebar during animation.
  * macOS is untouched: no data-platform="windows" attribute. */
-.app-shell[data-platform="windows"] .sidebar {
+.app-shell[data-platform="windows"] .sidebar[data-mode="default"] {
   padding-top: var(--sp-3);
-  position: relative;
-  z-index: 101;
+}
+
+.app-shell[data-platform="windows"] .titlebar-drag {
+  left: var(--sidebar-w-current);
 }
 
 /* Windows-only: when the sidebar is expanded and in default mode, visually

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8319,20 +8319,33 @@ button.agent-user-attachment:hover {
   --titlebar-controls-gap: var(--sp-3);
 }
 
-/* Windows-only: let the sidebar toggle ride with the first tab instead of
- * staying pinned at the left edge. Anchored to the animated sidebar edge
- * (minus the toggle width and a gap) so it sits immediately to the left of
- * the first tab in expanded state, and floors at --sp-3 when collapsed.
- * Because --sidebar-w-current is a registered @property whose transition
- * lives on .app-shell, the toggle tweens on the same clock as the grid and
- * the tab strip — no drift mid-snap, and it jumps in sync on button presses
- * (data-sidebar-transition="none"). macOS is untouched: it keeps the fixed
- * 80px left from the rule above. */
-.app-shell[data-platform="windows"] .chrome-sidebar-toggle {
+/* Windows-only: when the sidebar is expanded and in default mode, visually
+ * place the toggle in the sidebar header band — in line with the June logo,
+ * floated to the right edge with space between. The toggle stays position:fixed
+ * (owned by App.tsx) so it never unmounts; this is pure visual placement.
+ *
+ * Vertically: drop below the titlebar into the sidebar header band.
+ * Horizontally: right-align with the header's content edge, riding the
+ * animated --sidebar-w-current so the toggle slides with the sidebar on the
+ * same clock as the grid and tab strip.
+ *
+ * When collapsed or in Settings, this selector stops matching and the toggle
+ * falls back to the base rule (titlebar band, 8px from left) — the collapsed
+ * sidebar is display:none so the header doesn't exist, and Settings has no
+ * sidebar-header. macOS is untouched: no data-platform="windows" attribute. */
+.app-shell[data-platform="windows"][data-sidebar="expanded"]:has(> .sidebar[data-mode="default"]) > .chrome-sidebar-toggle {
+  top: calc(var(--titlebar-h) + var(--sp-3));
   left: max(
     var(--sp-3),
-    calc(var(--sidebar-w-current) - var(--control-md) - var(--sp-3))
+    calc(var(--sidebar-w-current) - var(--sp-3) - var(--sp-1) - var(--control-md))
   );
+}
+
+/* Reserve the trailing header slot on Windows so the recording indicator
+ * (or the brand when there's no recording) doesn't sit under the fixed
+ * toggle. The gap between the indicator and the toggle is --sp-2. */
+.app-shell[data-platform="windows"] .sidebar[data-mode="default"] .sidebar-header {
+  padding-right: calc(var(--sp-1) + var(--control-md) + var(--sp-2));
 }
 
 .chrome-sidebar-toggle {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8319,12 +8319,26 @@ button.agent-user-attachment:hover {
   --titlebar-controls-gap: var(--sp-3);
 }
 
+/* Windows has no traffic-light controls, so the titlebar-h (28px) of top
+ * padding baked into .sidebar is dead space above the June logo. Reclaim it
+ * so the sidebar header sits flush at the top. Raise the sidebar above the
+ * fixed titlebar-drag overlay (z-index 100) so the logo link and recording
+ * indicator remain interactive — same z-index as .tab-bar (101). position:
+ * relative doesn't affect grid layout, just creates a stacking context.
+ * macOS is untouched: no data-platform="windows" attribute. */
+.app-shell[data-platform="windows"] .sidebar {
+  padding-top: var(--sp-3);
+  position: relative;
+  z-index: 101;
+}
+
 /* Windows-only: when the sidebar is expanded and in default mode, visually
  * place the toggle in the sidebar header band — in line with the June logo,
  * floated to the right edge with space between. The toggle stays position:fixed
  * (owned by App.tsx) so it never unmounts; this is pure visual placement.
  *
- * Vertically: drop below the titlebar into the sidebar header band.
+ * Vertically: aligned with the sidebar header (now --sp-3 from the top, same
+ * as the horizontal padding).
  * Horizontally: right-align with the header's content edge, riding the
  * animated --sidebar-w-current so the toggle slides with the sidebar on the
  * same clock as the grid and tab strip.
@@ -8334,7 +8348,7 @@ button.agent-user-attachment:hover {
  * sidebar is display:none so the header doesn't exist, and Settings has no
  * sidebar-header. macOS is untouched: no data-platform="windows" attribute. */
 .app-shell[data-platform="windows"][data-sidebar="expanded"]:has(> .sidebar[data-mode="default"]) > .chrome-sidebar-toggle {
-  top: calc(var(--titlebar-h) + var(--sp-3));
+  top: var(--sp-3);
   left: max(
     var(--sp-3),
     calc(var(--sidebar-w-current) - var(--sp-3) - var(--sp-1) - var(--control-md))

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8307,6 +8307,18 @@ button.agent-user-attachment:hover {
   -webkit-app-region: drag;
 }
 
+/* Windows has no traffic-light controls, so the macOS clearance baked into
+ * --titlebar-controls-end (70px for the green button) leaves the sidebar
+ * toggle floating ~86px in with nothing to its left. Override only the two
+ * horizontal geometry tokens on Windows: the toggle's `left` and the tab
+ * strip's `padding-left` both read them, so one override keeps the two
+ * consistent. The vertical nudge token is intentionally untouched — the
+ * defect is horizontal only. */
+.app-shell[data-platform="windows"] {
+  --titlebar-controls-end: 0px;
+  --titlebar-controls-gap: var(--sp-3);
+}
+
 .chrome-sidebar-toggle {
   position: fixed;
   /* Vertically centered in the titlebar, then nudged down a hair to sit level

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8353,7 +8353,8 @@ button.agent-user-attachment:hover {
  * falls back to the base rule (titlebar band, 8px from left) — the collapsed
  * sidebar is display:none so the header doesn't exist, and Settings has no
  * sidebar-header. macOS is untouched: no data-platform="windows" attribute. */
-.app-shell[data-platform="windows"][data-sidebar="expanded"]:has(> .sidebar[data-mode="default"]) > .chrome-sidebar-toggle {
+.app-shell[data-platform="windows"][data-sidebar="expanded"]:has(> .sidebar[data-mode="default"])
+> .chrome-sidebar-toggle {
   top: var(--sp-3);
   left: max(
     var(--sp-3),

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -131,18 +131,33 @@ describe("TabBar", () => {
     expect(rule).not.toContain("--titlebar-controls-nudge");
   });
 
-  it("lets the Windows sidebar toggle ride with the first tab", () => {
-    const rule = cssRuleFor('.app-shell[data-platform="windows"] .chrome-sidebar-toggle');
+  it("places the Windows sidebar toggle in the sidebar header band when expanded", () => {
+    const toggleRule = cssRuleFor(
+      '.app-shell[data-platform="windows"][data-sidebar="expanded"]:has(> .sidebar[data-mode="default"]) > .chrome-sidebar-toggle',
+    );
 
-    // Anchored to the animated sidebar edge so the toggle sits next to the
-    // first tab when expanded and floors at --sp-3 when collapsed. The shared
-    // --sidebar-w-current clock keeps it in lockstep with the grid + tab strip.
-    expect(rule).toContain("var(--sidebar-w-current)");
-    expect(rule).toContain("var(--control-md)");
-    expect(rule).toContain("var(--sp-3)");
+    // Vertically aligned with the sidebar header (below the titlebar band).
+    expect(toggleRule).toContain("calc(var(--titlebar-h) + var(--sp-3))");
+    // Horizontally rides the animated sidebar edge, floored at --sp-3.
+    expect(toggleRule).toContain("var(--sidebar-w-current)");
+    expect(toggleRule).toContain("var(--control-md)");
+    expect(toggleRule).toContain("var(--sp-3)");
+    expect(toggleRule).toContain("var(--sp-1)");
     // macOS keeps the fixed calc(var(--titlebar-controls-end) + …) left; the
     // Windows override must not reintroduce that token on the toggle.
-    expect(rule).not.toContain("--titlebar-controls-end");
+    expect(toggleRule).not.toContain("--titlebar-controls-end");
+  });
+
+  it("reserves a trailing header slot on Windows for the fixed sidebar toggle", () => {
+    const headerRule = cssRuleFor(
+      '.app-shell[data-platform="windows"] .sidebar[data-mode="default"] .sidebar-header',
+    );
+
+    // The reserved padding accounts for the toggle width + a gap so the
+    // recording indicator (or the brand) doesn't sit under the fixed toggle.
+    expect(headerRule).toContain("var(--control-md)");
+    expect(headerRule).toContain("var(--sp-2)");
+    expect(headerRule).toContain("var(--sp-1)");
   });
 
   it("keeps the tab strip full-width when the files panel is open", () => {

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -149,15 +149,26 @@ describe("TabBar", () => {
   });
 
   it("reclaims the titlebar top padding on Windows so the sidebar sits flush", () => {
-    const sidebarRule = cssRuleFor('.app-shell[data-platform="windows"] .sidebar');
+    const sidebarRule = cssRuleFor(
+      '.app-shell[data-platform="windows"] .sidebar[data-mode="default"]',
+    );
 
     // No traffic lights on Windows — the 28px titlebar-h top padding is dead
     // space. Override to --sp-3 so the header sits flush at the top.
     expect(sidebarRule).toContain("padding-top: var(--sp-3)");
-    // Raise above the fixed titlebar-drag overlay (z-index 100) so the logo
-    // link and recording indicator remain interactive.
-    expect(sidebarRule).toContain("position: relative");
-    expect(sidebarRule).toContain("z-index: 101");
+    // Must not create a stacking context — raising the sidebar above
+    // z-index:100 would put it above session usage overlays.
+    expect(sidebarRule).not.toContain("z-index");
+    expect(sidebarRule).not.toContain("position: relative");
+  });
+
+  it("pushes the titlebar drag region past the sidebar on Windows", () => {
+    const dragRule = cssRuleFor('.app-shell[data-platform="windows"] .titlebar-drag');
+
+    // The drag region's left edge rides the animated sidebar width so it never
+    // covers the sidebar (keeping the logo link and recording indicator
+    // interactive) without raising the sidebar's z-index above overlays.
+    expect(dragRule).toContain("left: var(--sidebar-w-current)");
   });
 
   it("reserves a trailing header slot on Windows for the fixed sidebar toggle", () => {

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -131,6 +131,20 @@ describe("TabBar", () => {
     expect(rule).not.toContain("--titlebar-controls-nudge");
   });
 
+  it("lets the Windows sidebar toggle ride with the first tab", () => {
+    const rule = cssRuleFor('.app-shell[data-platform="windows"] .chrome-sidebar-toggle');
+
+    // Anchored to the animated sidebar edge so the toggle sits next to the
+    // first tab when expanded and floors at --sp-3 when collapsed. The shared
+    // --sidebar-w-current clock keeps it in lockstep with the grid + tab strip.
+    expect(rule).toContain("var(--sidebar-w-current)");
+    expect(rule).toContain("var(--control-md)");
+    expect(rule).toContain("var(--sp-3)");
+    // macOS keeps the fixed calc(var(--titlebar-controls-end) + …) left; the
+    // Windows override must not reintroduce that token on the toggle.
+    expect(rule).not.toContain("--titlebar-controls-end");
+  });
+
   it("keeps the tab strip full-width when the files panel is open", () => {
     const panelRule = cssRuleFor(
       '.app-shell:has(.agent-workspace[data-artifact-panel="open"]) .main-panel',

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -136,8 +136,8 @@ describe("TabBar", () => {
       '.app-shell[data-platform="windows"][data-sidebar="expanded"]:has(> .sidebar[data-mode="default"]) > .chrome-sidebar-toggle',
     );
 
-    // Vertically aligned with the sidebar header (below the titlebar band).
-    expect(toggleRule).toContain("calc(var(--titlebar-h) + var(--sp-3))");
+    // Vertically aligned with the sidebar header (flush at the top, --sp-3).
+    expect(toggleRule).toContain("top: var(--sp-3)");
     // Horizontally rides the animated sidebar edge, floored at --sp-3.
     expect(toggleRule).toContain("var(--sidebar-w-current)");
     expect(toggleRule).toContain("var(--control-md)");
@@ -146,6 +146,18 @@ describe("TabBar", () => {
     // macOS keeps the fixed calc(var(--titlebar-controls-end) + …) left; the
     // Windows override must not reintroduce that token on the toggle.
     expect(toggleRule).not.toContain("--titlebar-controls-end");
+  });
+
+  it("reclaims the titlebar top padding on Windows so the sidebar sits flush", () => {
+    const sidebarRule = cssRuleFor('.app-shell[data-platform="windows"] .sidebar');
+
+    // No traffic lights on Windows — the 28px titlebar-h top padding is dead
+    // space. Override to --sp-3 so the header sits flush at the top.
+    expect(sidebarRule).toContain("padding-top: var(--sp-3)");
+    // Raise above the fixed titlebar-drag overlay (z-index 100) so the logo
+    // link and recording indicator remain interactive.
+    expect(sidebarRule).toContain("position: relative");
+    expect(sidebarRule).toContain("z-index: 101");
   });
 
   it("reserves a trailing header slot on Windows for the fixed sidebar toggle", () => {

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -118,6 +118,19 @@ describe("TabBar", () => {
     expect(appCss).not.toContain("var(--control-md) + var(--sp-2) -");
   });
 
+  it("overrides the titlebar control clearance on Windows so the toggle sits at the left edge", () => {
+    const rule = cssRuleFor('.app-shell[data-platform="windows"]');
+
+    // Windows has no traffic lights — the macOS 70px clearance must be zeroed
+    // so the toggle's `left` (and the collapsed tab strip's `padding-left`,
+    // which reads the same tokens) moves to the left edge together.
+    expect(rule).toContain("--titlebar-controls-end: 0px;");
+    expect(rule).toContain("--titlebar-controls-gap: var(--sp-3);");
+    // The vertical nudge is a macOS-specific tweak and must not be overridden
+    // here — the defect is horizontal only.
+    expect(rule).not.toContain("--titlebar-controls-nudge");
+  });
+
   it("keeps the tab strip full-width when the files panel is open", () => {
     const panelRule = cssRuleFor(
       '.app-shell:has(.agent-workspace[data-artifact-panel="open"]) .main-panel',

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -133,7 +133,7 @@ describe("TabBar", () => {
 
   it("places the Windows sidebar toggle in the sidebar header band when expanded", () => {
     const toggleRule = cssRuleFor(
-      '.app-shell[data-platform="windows"][data-sidebar="expanded"]:has(> .sidebar[data-mode="default"]) > .chrome-sidebar-toggle',
+      '.app-shell[data-platform="windows"][data-sidebar="expanded"]:has(> .sidebar[data-mode="default"])\n> .chrome-sidebar-toggle',
     );
 
     // Vertically aligned with the sidebar header (flush at the top, --sp-3).


### PR DESCRIPTION
## Summary

- On Windows, the sidebar toggle was positioned at ~86px from the left edge because `--titlebar-controls-end` (70px) reserves space for macOS traffic lights that do not exist on Windows. The toggle floated in the titlebar with nothing to its left.
- This PR marks the app shell with `data-platform="windows"` on Windows only and overrides the horizontal geometry tokens so the toggle moves to the correct position. The toggle is visually placed in the sidebar header band — in line with the June logo, floated to the right edge with space between.
- The sidebar top padding is reclaimed (the 28px titlebar height is dead space on Windows), so the June logo sits flush at the top. The titlebar drag region is pushed past the sidebar (`left: var(--sidebar-w-current)`) so the logo and recording indicator remain interactive without raising the sidebar z-index above overlays.
- When collapsed or in Settings, the toggle falls back to the titlebar band at 8px from the left. macOS is completely untouched — `data-platform` is `undefined` on non-Windows, so all Windows-scoped rules are inert.

## Root cause

`--titlebar-controls-end: 70px` is baked into `tokens.css` to clear the macOS traffic-light buttons. Windows has no traffic lights, so the sidebar toggle (whose `left` derives from this token) was positioned ~86px in from the left edge with empty space to its left. The sidebar top padding (`calc(var(--sp-3) + var(--titlebar-h))`) also reserved 28px of dead space above the June logo for the same macOS traffic lights.

## Validation

- Manually tested on Windows: toggle sits in the sidebar header band, aligned with the June logo, at the right edge with space between. Collapsed state falls back to top-left. Settings mode unaffected. Recording indicator coexists without overlap.
- Manually tested on macOS: toggle remains at 80px fixed left, sidebar header at original 36px top padding. No visual change.
- `vitest run src/test/tab-bar.test.tsx` — 22/22 pass (including 5 new CSS assertions guarding the Windows override, toggle placement, sidebar padding, drag region, and header slot reservation).
- `pnpm typecheck` — pass.
- `pnpm exec biome check` on changed files — no new warnings.
- Code reviewed via oracle: two high-severity issues found and fixed (Settings back-button overlap, z-index stacking conflict with session usage overlays).

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- no backend changes -->

## Out of scope

- "Ride with first tab" behavior (toggle sliding with the tab strip) — was prototyped in an intermediate commit but superseded by the sidebar-header placement per design feedback.
- "Slide with tabs when collapsed" (Shuta's suggestion from the planning thread) — a separate larger design change that would move the expanded toggle on macOS too; deferred pending a design decision.
- macOS sidebar geometry — intentionally untouched.

## Followups

- Optical gap tuning: the `--sp-2` gap between the recording indicator and the toggle may need adjustment at different sidebar widths (188/240/320px) and font scales.
- The 6px vertical jump when the toggle transitions from header band (8px) to titlebar band (2px) on collapse — polish, not blocking.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787289586&installation_model_id=425925&pr_number=891&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F891&signature=ae4bf6f6b9c4c1535e847e3a59836335f3083ca879e7fa51df4b34a2cdc90b34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->