### PR TITLE
Follow latest live transcription

### DIFF
--- a/docs/superpowers/plans/2026-07-22-transcription-follow-latest.md
+++ b/docs/superpowers/plans/2026-07-22-transcription-follow-latest.md
@@ -1,0 +1,549 @@
+# Transcription follow-latest implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the Transcription tab following newly rendered live preview and saved-audio Turns while the reader is at the live edge, pause following when they scroll upward, resume when they return to the bottom, and land on the latest Turn when they open the tab during an active recording.
+
+**Architecture:** Keep `.note-detail-scroll` as the single scroll owner. Add a focused React hook that tracks whether that viewport is within 48 px of the bottom, distinguishes downward programmatic smooth scrolling from user interruption, and scrolls only when a stable transcript-content key changes. `App` derives the selected note's preview events and persisted Turns, enables the hook only for the Transcription tab, and forces follow mode when that tab opens on the note currently being recorded.
+
+**Tech Stack:** React 18, TypeScript, Vitest, Testing Library, jsdom, existing Tauri event state. No new dependency, CSS, native code, or June API change.
+
+## Global Constraints
+
+- Use the canonical terms **Transcription**, **Live transcript preview**, **Turn**, and **Source** from `CONTEXT.md`; do not introduce “realtime transcription.”
+- Preserve `.note-detail-scroll` as the scroll viewport and preserve its existing `attachScrollThumbFade` behavior.
+- A viewport is at the live edge when `scrollHeight - scrollTop - clientHeight <= 48`.
+- While follow mode is armed, a preview or persisted-Turn display change scrolls to the latest content.
+- A user scroll upward beyond the threshold disarms follow mode. Scrolling back within the threshold rearms it.
+- Wheel, touch, keyboard, scrollbar, and trackpad interruption must work through native scroll events; wheel and touch events must also cancel an in-flight programmatic glide before the next animation frame.
+- Programmatic downward scroll events must not accidentally disarm follow mode. An upward scroll during a programmatic glide is treated as user interruption.
+- Opening Transcription on the note with the active recording lands at the latest Turn. Opening a historical transcript must not unexpectedly jump to the bottom.
+- Use smooth scrolling unless `prefers-reduced-motion: reduce` matches, in which case use `auto`.
+- Saved-audio Turns remain authoritative. This change must not alter preview coalescing, preview reconciliation, event filtering, persistence, polling, billing, or recording state.
+- Do not add a “Latest” button in this pass.
+- Do not modify `NoteEditor.tsx`, `app.css`, Rust, or `june-api/`; the existing component tree and styles are sufficient.
+- Follow test-driven development: observe each focused test fail for the intended missing behavior before implementing it.
+
+---
+
+## File responsibility map
+
+- Modify `src/lib/live-transcript-preview.ts`: derive a deterministic key from fields that can change the visible or ordered transcription.
+- Create `src/lib/use-follow-latest-scroll.ts`: own the 48 px threshold, follow/pause/resume state, programmatic-scroll guard, reduced-motion behavior, and listener cleanup.
+- Modify `src/app/App.tsx`: derive selected-note transcript inputs, enable the hook only for Transcription, and pass the already-filtered preview list to `NoteEditor`.
+- Modify `src/test/live-transcript-preview.test.ts`: prove equivalent polling objects keep a stable key and visible changes change it.
+- Create `src/test/use-follow-latest-scroll.test.tsx`: prove the hook's threshold, follow, pause, resume, active-recording entry, programmatic-scroll, and reduced-motion behavior.
+- Modify `src/test/app-notes-reliability.test.tsx`: prove the real App wires live preview events to the note-detail viewport and respects user interruption.
+
+---
+
+### Task 1: Define a stable visible-transcript content key
+
+**Files:**
+
+- Modify: `src/test/live-transcript-preview.test.ts`
+- Modify: `src/lib/live-transcript-preview.ts`
+
+- [ ] **Step 1: Add failing content-key tests**
+
+Import `transcriptFollowLatestKey` in `src/test/live-transcript-preview.test.ts` and add tests with these assertions:
+
+```ts
+it("keeps the follow-latest key stable across equivalent polling objects", () => {
+  const preview = [liveEvent()];
+  const persisted = [persistedTurn()];
+
+  expect(transcriptFollowLatestKey(preview, persisted)).toBe(
+    transcriptFollowLatestKey(
+      preview.map((event) => ({ ...event })),
+      persisted.map((turn) => ({ ...turn })),
+    ),
+  );
+});
+
+it("changes the follow-latest key when visible transcript content changes", () => {
+  const initial = transcriptFollowLatestKey([liveEvent()], []);
+  const revisedPreview = transcriptFollowLatestKey(
+    [liveEvent({ text: "Revised preview words", endMs: 9000 })],
+    [],
+  );
+  const persistedReplacement = transcriptFollowLatestKey([], [persistedTurn()]);
+
+  expect(revisedPreview).not.toBe(initial);
+  expect(persistedReplacement).not.toBe(initial);
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm the missing export is the failure**
+
+Run:
+
+```bash
+pnpm exec vitest run src/test/live-transcript-preview.test.ts
+```
+
+Expected: FAIL because `transcriptFollowLatestKey` is not exported.
+
+- [ ] **Step 3: Implement the deterministic key**
+
+Add this exported function after `authoritativeTranscriptCoverageKey` in `src/lib/live-transcript-preview.ts`:
+
+```ts
+/**
+ * Stable dependency key for changes that can alter the visible transcription.
+ * App polling reconstructs DTO objects, so React effects must depend on values,
+ * not array identity.
+ */
+export function transcriptFollowLatestKey(
+  live: LiveTranscriptEventDto[],
+  persisted: TranscriptDto[],
+) {
+  return JSON.stringify({
+    live: live.map((event) => [
+      event.noteId,
+      event.sessionId,
+      event.sourceMode,
+      event.source,
+      event.segmentId,
+      event.startMs,
+      event.endMs,
+      event.text,
+      event.language ?? null,
+      event.stability,
+    ]),
+    persisted: persisted.map((turn) => [
+      turn.id,
+      turn.recordingSessionId ?? null,
+      turn.spanId ?? null,
+      turn.sourceMode ?? null,
+      turn.source ?? null,
+      turn.startMs ?? null,
+      turn.endMs ?? null,
+      turn.turnIndex ?? null,
+      turn.text,
+      turn.language ?? null,
+      turn.status,
+      turn.lastError ?? null,
+      turn.recordedSilence ?? false,
+    ]),
+  });
+}
+```
+
+Keep `authoritativeTranscriptCoverageKey` unchanged: it intentionally tracks only authoritative overlap for cleanup, while this new key tracks display changes for scrolling.
+
+- [ ] **Step 4: Re-run the focused test**
+
+Run:
+
+```bash
+pnpm exec vitest run src/test/live-transcript-preview.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add src/lib/live-transcript-preview.ts src/test/live-transcript-preview.test.ts
+git commit -m "test: track visible transcript changes"
+```
+
+---
+
+### Task 2: Build the follow-latest scroll controller
+
+**Files:**
+
+- Create: `src/test/use-follow-latest-scroll.test.tsx`
+- Create: `src/lib/use-follow-latest-scroll.ts`
+
+**Public interface:**
+
+```ts
+export const FOLLOW_LATEST_BOTTOM_THRESHOLD_PX = 48;
+
+export function isNearScrollBottom(
+  scroller: Pick<HTMLElement, "scrollHeight" | "scrollTop" | "clientHeight">,
+  threshold?: number,
+): boolean;
+
+export function useFollowLatestScroll(options: {
+  scrollRef: RefObject<HTMLElement | null>;
+  active: boolean;
+  contentKey: string;
+  scopeKey: string;
+  followOnActivate: boolean;
+}): void;
+```
+
+- [ ] **Step 1: Create the test harness and failing threshold tests**
+
+Create `src/test/use-follow-latest-scroll.test.tsx`. Use `renderHook`, `act`, `fireEvent`, `createRef`, and a real detached `div`. Define writable `scrollTop`, fixed `scrollHeight`/`clientHeight`, and a `scrollTo` spy that clamps to `scrollHeight - clientHeight` and dispatches `scroll`:
+
+```ts
+function createScroller(scrollTop = 600) {
+  let currentScrollTop = scrollTop;
+  const element = document.createElement("div");
+  Object.defineProperties(element, {
+    scrollHeight: { configurable: true, get: () => 1000 },
+    clientHeight: { configurable: true, get: () => 400 },
+    scrollTop: {
+      configurable: true,
+      get: () => currentScrollTop,
+      set: (value: number) => {
+        currentScrollTop = value;
+      },
+    },
+  });
+  const scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+    currentScrollTop = Math.min(Number(top), 600);
+    element.dispatchEvent(new Event("scroll"));
+  });
+  Object.defineProperty(element, "scrollTo", { configurable: true, value: scrollTo });
+  document.body.append(element);
+  const ref = createRef<HTMLElement>();
+  Object.defineProperty(ref, "current", { configurable: true, value: element });
+  return {
+    element,
+    ref,
+    scrollTo,
+    setScrollTop: (value: number) => {
+      currentScrollTop = value;
+    },
+  };
+}
+```
+
+Assert that distance 49 is not near bottom and distance 48 is near bottom. Then run:
+
+```bash
+pnpm exec vitest run src/test/use-follow-latest-scroll.test.tsx
+```
+
+Expected: FAIL because the hook module does not exist.
+
+- [ ] **Step 2: Add behavior tests before implementation**
+
+Add focused tests that rerender the hook and assert:
+
+1. Changing `contentKey` while initially at the bottom calls `scrollTo({ top: 1000, behavior: "smooth" })`.
+2. After setting `scrollTop` to `100` and dispatching `scroll`, changing `contentKey` does not call `scrollTo`.
+3. After that pause, setting `scrollTop` back to `600` and dispatching `scroll` rearms the next content-key change.
+4. Changing `active` from false to true with `followOnActivate: true` scrolls even when parked at `100`.
+5. Changing `active` from false to true with `followOnActivate: false` does not move a historical transcript parked at `100`.
+6. A programmatic downward `scroll` event does not disarm the following content-key change.
+7. `wheel` followed by an upward `scroll` cancels an in-flight glide and pauses the following content-key change.
+8. A mocked `matchMedia` result with `matches: true` changes `behavior` to `"auto"`.
+
+Use `afterEach` to restore mocks, clear timers, and empty `document.body`.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `src/lib/use-follow-latest-scroll.ts` with:
+
+- `FOLLOW_LATEST_BOTTOM_THRESHOLD_PX = 48`.
+- `PROGRAMMATIC_SCROLL_TIMEOUT_MS = 800`, matching the existing agent transcript glide guard.
+- refs for `shouldFollow`, `lastScrollTop`, `programmaticScroll`, timeout id, pending animation-frame id, previous active state, previous content key, and previous scope key.
+- one listener effect that attaches only while `active` and cleans up `scroll`, `wheel`, `touchmove`, and the timeout.
+- one content effect that detects content changes and activation/scope changes, then performs the scroll.
+
+The listener logic must follow this shape:
+
+```ts
+const updateStickiness = () => {
+  const previousScrollTop = lastScrollTopRef.current;
+  lastScrollTopRef.current = scroller.scrollTop;
+  if (programmaticScrollRef.current) {
+    if (scroller.scrollTop < previousScrollTop) {
+      clearProgrammaticScroll();
+      shouldFollowRef.current = isNearScrollBottom(scroller);
+      return;
+    }
+    shouldFollowRef.current = true;
+    if (isNearScrollBottom(scroller)) clearProgrammaticScroll();
+    return;
+  }
+  shouldFollowRef.current = isNearScrollBottom(scroller);
+};
+```
+
+Wheel and touch handlers must call `clearProgrammaticScroll()` and schedule `updateStickiness` with `requestAnimationFrame`, so direct scroll events remain the common path for mouse, keyboard, scrollbar, and trackpad input. Cancel the pending animation frame during cleanup as well as removing listeners and clearing the timeout.
+
+The content effect must enforce these rules:
+
+```ts
+const scopeChanged = previousScopeKeyRef.current !== scopeKey;
+const justActivated = active && !previousActiveRef.current;
+const contentChanged = !scopeChanged && previousContentKeyRef.current !== contentKey;
+
+// Update all previous-value refs on every effect run.
+
+if (scopeChanged) {
+  shouldFollowRef.current = scroller ? isNearScrollBottom(scroller) : true;
+}
+const mustLandOnLatest = followOnActivate && (justActivated || scopeChanged);
+if (mustLandOnLatest) shouldFollowRef.current = true;
+if (!active || (!contentChanged && !mustLandOnLatest) || !shouldFollowRef.current) return;
+```
+
+Before smooth scrolling, arm the programmatic guard and its 800 ms timeout. For reduced motion, clear the guard and use `auto`. Guard `scrollTo` because jsdom does not provide it by default.
+
+- [ ] **Step 4: Run and refine the focused hook tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/test/use-follow-latest-scroll.test.tsx
+```
+
+Expected: PASS with no unhandled timers or React `act` warnings.
+
+- [ ] **Step 5: Run the related agent scroll regression test**
+
+Run:
+
+```bash
+pnpm exec vitest run src/test/agent-scroll-to-latest.test.tsx
+```
+
+Expected: PASS. The new hook is independent and does not change agent transcript scrolling.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add src/lib/use-follow-latest-scroll.ts src/test/use-follow-latest-scroll.test.tsx
+git commit -m "feat: add follow-latest scroll controller"
+```
+
+---
+
+### Task 3: Wire follow-latest into the note Transcription tab
+
+**Files:**
+
+- Modify: `src/test/app-notes-reliability.test.tsx`
+- Modify: `src/app/App.tsx`
+
+- [ ] **Step 1: Add the failing App integration test**
+
+Add `fireEvent` to the Testing Library import in `src/test/app-notes-reliability.test.tsx`. Add one integration test alongside the existing provisional transcript tests:
+
+```ts
+it("follows live transcription until the reader scrolls upward, then resumes at the bottom", async () => {
+  await startRecordingOnFirstNote();
+  await waitFor(() => expect(mocks.listeners.has("live-transcript-event")).toBe(true));
+
+  const scroller = document.querySelector(".note-detail-scroll");
+  expect(scroller).toBeInstanceOf(HTMLElement);
+  let scrollTop = 100;
+  Object.defineProperties(scroller!, {
+    scrollHeight: { configurable: true, get: () => 1000 },
+    clientHeight: { configurable: true, get: () => 400 },
+    scrollTop: {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    },
+  });
+  const scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+    scrollTop = Math.min(Number(top), 600);
+    scroller!.dispatchEvent(new Event("scroll"));
+  });
+  Object.defineProperty(scroller, "scrollTo", { configurable: true, value: scrollTo });
+
+  await userEvent.click(screen.getByRole("button", { name: "Transcription" }));
+  await waitFor(() => expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: "smooth" }));
+  scrollTo.mockClear();
+
+  const emitPreview = async (segmentId: string, text: string, startMs: number) => {
+    await act(async () => {
+      await mocks.listeners.get("live-transcript-event")?.({
+        payload: {
+          noteId: "note-1",
+          sessionId: "rec-1",
+          sourceMode: "microphonePlusSystem",
+          source: "microphone",
+          segmentId,
+          startMs,
+          endMs: startMs + 4000,
+          text,
+          stability: "final",
+        },
+      });
+    });
+  };
+
+  await emitPreview("microphone-0", "First live words", 0);
+  await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+
+  scrollTo.mockClear();
+  scrollTop = 100;
+  fireEvent.wheel(scroller!);
+  fireEvent.scroll(scroller!);
+  await emitPreview("microphone-1", "Words while reading above", 4000);
+  expect(scrollTo).not.toHaveBeenCalled();
+
+  scrollTop = 600;
+  fireEvent.scroll(scroller!);
+  await emitPreview("microphone-2", "Following resumes", 8000);
+  await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+});
+```
+
+If request-animation-frame scheduling makes the wheel assertion race, wait for one animation frame inside `act` before emitting the second preview. Do not weaken the pause assertion.
+
+Also extend the existing `"polls newly persisted turns while note transcription remains active"` test. Install the same scroll geometry and `scrollTo` spy after the note detail opens, clear any setup calls, then assert that the poll response containing `"The first saved turn is visible."` calls `scrollTo` once. This is the integration proof that authoritative saved-audio Turn replacement uses the same follow state as live preview events.
+
+- [ ] **Step 2: Run the integration test and confirm it fails because App never scrolls**
+
+Run:
+
+```bash
+pnpm exec vitest run src/test/app-notes-reliability.test.tsx -t "follows live transcription"
+```
+
+Expected: FAIL because opening Transcription, new preview events, and newly persisted Turns do not call `scrollTo`.
+
+- [ ] **Step 3: Derive selected-note transcript inputs once in App**
+
+Update the live-preview import in `src/app/App.tsx` to include `transcriptFollowLatestKey`, and import `useFollowLatestScroll` from `../lib/use-follow-latest-scroll`.
+
+After `selectedNoteId`, derive:
+
+```ts
+const selectedNoteLiveTranscript = useMemo(
+  () => liveTranscriptEvents.filter((event) => event.noteId === selectedNoteId),
+  [liveTranscriptEvents, selectedNoteId],
+);
+const selectedNoteTranscriptContentKey = useMemo(
+  () =>
+    transcriptFollowLatestKey(
+      selectedNoteLiveTranscript,
+      selectedNote?.sourceTranscripts ?? [],
+    ),
+  [selectedNote?.sourceTranscripts, selectedNoteLiveTranscript],
+);
+```
+
+Replace the inline `liveTranscriptEvents.filter(...)` passed to `NoteEditor` with `selectedNoteLiveTranscript` so rendering and the scroll key use the same selected-note preview set.
+
+- [ ] **Step 4: Enable the hook only for the active Transcription tab**
+
+Immediately after `noteDetailScrollerActive`, add:
+
+```ts
+const transcriptionFollowLatestActive =
+  noteDetailScrollerActive && selectedNote?.activeTab === "transcription";
+const recordingSelectedNote =
+  selectedNoteId !== undefined &&
+  selectedNoteId === recordingNoteId &&
+  state.recordingStatus !== undefined;
+
+useFollowLatestScroll({
+  scrollRef: noteDetailScrollRef,
+  active: transcriptionFollowLatestActive,
+  contentKey: selectedNoteTranscriptContentKey,
+  scopeKey: selectedNoteId ?? "",
+  followOnActivate: recordingSelectedNote,
+});
+```
+
+Do not merge this with the existing scroll-thumb effect. The hook owns follow-latest state; `attachScrollThumbFade` continues to own scrollbar visibility.
+
+- [ ] **Step 5: Run the focused App test**
+
+Run:
+
+```bash
+pnpm exec vitest run src/test/app-notes-reliability.test.tsx -t "follows live transcription"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the complete note reliability and preview suites**
+
+Run:
+
+```bash
+pnpm exec vitest run src/test/app-notes-reliability.test.tsx src/test/live-transcript-preview.test.ts src/test/use-follow-latest-scroll.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 3**
+
+```bash
+git add src/app/App.tsx src/test/app-notes-reliability.test.tsx
+git commit -m "feat: follow live note transcription"
+```
+
+---
+
+### Task 4: Verify the frontend change and inspect the real interaction
+
+**Files:**
+
+- No source changes expected.
+- If a test or check exposes a defect, fix only the relevant Task 1 to 3 file and rerun its focused test first.
+
+- [ ] **Step 1: Run formatting and lint checks**
+
+Run:
+
+```bash
+pnpm check
+```
+
+Expected: PASS with no new warnings in changed files.
+
+- [ ] **Step 2: Run TypeScript validation**
+
+Run:
+
+```bash
+pnpm typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the complete frontend test suite**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: all Vitest tests pass. If the documented `hud-meeting.test.ts` teardown noise appears with zero actual failures, record the exact output and rerun the focused suites; do not hide a real failure.
+
+- [ ] **Step 4: Test the UI in a real browser or Tauri app**
+
+Use the `browser-test-tauri-fe` skill. Start the appropriate preview with `pnpm dev` or `pnpm tauri:dev`, then verify and record:
+
+1. Start a recording and open Transcription while parked above the bottom: it lands on the latest preview.
+2. Let at least two new preview chunks arrive: the viewport follows them.
+3. Scroll upward beyond 48 px: later chunks appear without moving the viewport.
+4. Scroll to the bottom: following resumes on the next chunk.
+5. Enable reduced motion in the test environment: the latest-content move is immediate rather than smooth.
+6. Open a historical transcript: it does not force a jump to the bottom.
+
+Capture a short recording because this is a motion/interaction change. Do not claim visual verification if live microphone/system capture cannot be exercised; report that limitation explicitly.
+
+- [ ] **Step 5: Inspect the final diff for scope and contract drift**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff HEAD~3 -- src/lib/live-transcript-preview.ts src/lib/use-follow-latest-scroll.ts src/app/App.tsx src/test/live-transcript-preview.test.ts src/test/use-follow-latest-scroll.test.tsx src/test/app-notes-reliability.test.tsx
+```
+
+Expected: no whitespace errors; only the planned frontend logic and tests are present. Confirm no changes to `NoteEditor.tsx`, CSS, Rust, June API, dependencies, or API contracts.
+
+- [ ] **Step 6: Record verification in the handoff**
+
+Report focused tests, full frontend tests, `pnpm check`, `pnpm typecheck`, whether the UI was tested visually, and attach the recording if created. State that no June API deploy is needed.

--- a/docs/superpowers/specs/2026-07-22-transcription-follow-latest-design.md
+++ b/docs/superpowers/specs/2026-07-22-transcription-follow-latest-design.md
@@ -1,0 +1,114 @@
+# Transcription follow-latest design
+
+**Status:** Approved on 2026-07-22
+
+**Target:** Keep the newest live transcript preview visible while the user is
+following the live edge, without interrupting someone who scrolls upward to
+read earlier conversation turns.
+
+## Problem
+
+The meeting-note Transcription tab renders new live preview chunks correctly,
+but it does not update the owning `.note-detail-scroll` position when the
+content grows. Once the transcript is taller than the viewport, the newest
+preview can appear below the visible area and make the surface look stale.
+
+The scroller already has a React ref in `App.tsx`, but that ref is currently
+used only to attach scrollbar-fade behavior. `NoteEditor` appends or coalesces
+preview turns without any follow-latest coordination.
+
+## Selected behavior
+
+Use a sticky follow-latest mode:
+
+- While the Transcription tab is open and the scroller is at or within 48 px of
+  the bottom, new live-preview or persisted transcript content scrolls to the
+  latest visible turn.
+- If the user scrolls farther than 48 px from the bottom, follow mode pauses.
+  Content updates must not move the reader's position while paused.
+- Scrolling back within the threshold resumes follow mode.
+- Opening the Transcription tab during an active recording lands at the latest
+  turn.
+- Programmatic scrolling uses smooth motion by default and instant motion when
+  `prefers-reduced-motion: reduce` is active.
+- The first version adds no floating "Latest" button. A user resumes following
+  by scrolling back to the bottom.
+
+This follows the interaction model already used by the Agent transcript while
+keeping the meeting-note implementation limited to its existing scroller.
+
+## Architecture
+
+The follow state belongs beside `noteDetailScrollRef` in `App.tsx`, because
+that element is the actual scroll owner for both Notes and Transcription.
+`NoteEditor` should remain responsible for transcript presentation, not for
+reaching into a parent scroll container.
+
+Add a small, independently testable helper for the bottom-distance calculation
+and keep mutable follow state in refs so scroll events do not cause application
+rerenders. A short-lived programmatic-scroll guard prevents the smooth scroll's
+own intermediate events from being mistaken for the user scrolling upward. The
+scroll listener updates whether the reader is following only outside that
+guard. A post-render effect reacts to the selected note's displayed transcript
+coverage and live-preview signature only while the Transcription tab is active.
+
+When the effect decides to follow, it schedules the scroll after React has
+committed the new transcript DOM. It scrolls the existing note-detail container
+to its `scrollHeight`; it does not target a particular transcript row, so it
+continues to work when adjacent preview chunks are coalesced into one growing
+turn.
+
+## Data flow
+
+1. A `live-transcript-event` updates `liveTranscriptEvents`, or note polling
+   updates persisted Source turns.
+2. `NoteEditor` rerenders the ordered visible transcript.
+3. The follow effect observes the transcript signature after the commit.
+4. If the Transcription tab is active and follow mode is still armed, the
+   note-detail scroller moves to its new bottom.
+5. Outside a guarded programmatic scroll, a user-originated upward scroll
+   recomputes the bottom distance and disarms follow mode once it crosses the
+   threshold.
+
+## State transitions and edge cases
+
+- Switching notes resets follow mode for the new note. If its Transcription tab
+  is active during a recording, the scroller lands at the latest turn.
+- Switching from Notes to Transcription during an active recording arms follow
+  mode and lands at the latest content.
+- Switching away from Transcription performs no transcript-driven scrolling.
+- Reconciliation that replaces preview spans with authoritative saved-audio
+  rows follows the same rule: it moves only while follow mode is armed.
+- Source filtering does not force follow mode back on after the reader has
+  scrolled upward.
+- Preview failure and empty preview chunks require no special handling because
+  they do not change the displayed transcript signature.
+- The behavior must tolerate test and restricted browser environments where
+  `scrollTo` or `matchMedia` is unavailable.
+
+## Testing
+
+Add focused frontend coverage for:
+
+- bottom-distance threshold calculation;
+- a new preview update scrolling while the reader is at the live edge;
+- an upward user scroll suppressing later automatic movement;
+- smooth programmatic scroll events not disarming follow mode;
+- returning to the bottom rearming follow mode;
+- opening Transcription during an active recording landing at the latest turn;
+- reduced-motion preference selecting instant scrolling; and
+- persisted-turn reconciliation respecting the same follow state.
+
+Existing live-preview ordering, coalescing, and reconciliation tests remain the
+source of truth for transcript contents. The new tests cover only scroll
+coordination and must not duplicate those semantics.
+
+## Out of scope
+
+- Backend, capture, chunking, transcription, persistence, and billing changes.
+- Changes to the eight-second preview cadence.
+- A floating "Latest" control or unread-preview counter.
+- Auto-opening the Transcription tab when recording begins.
+- Promoting preview text into the persisted transcript.
+
+The change is desktop-frontend only and does not require a June API deploy.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -133,8 +133,10 @@ import { listHermesSessions, titleFromPrompt } from "../lib/hermes-adapter";
 import {
   authoritativeTranscriptCoverageKey,
   clearTerminalLiveTranscriptEvents,
+  transcriptFollowLatestKey,
   upsertLiveTranscriptEvent,
 } from "../lib/live-transcript-preview";
+import { useFollowLatestScroll } from "../lib/use-follow-latest-scroll";
 import {
   RECORDING_INACTIVITY_RESPONSE_MS,
   RECORDING_INACTIVITY_SNOOZE_MS,
@@ -1039,10 +1041,22 @@ export function App() {
     });
   }, []);
   const selectedNote = state.selectedNote;
+  const selectedNoteId = selectedNote?.id;
+  const selectedNoteLiveTranscript = useMemo(
+    () => liveTranscriptEvents.filter((event) => event.noteId === selectedNoteId),
+    [liveTranscriptEvents, selectedNoteId],
+  );
   const selectedNoteTranscriptCoverageKey = authoritativeTranscriptCoverageKey(
     selectedNote?.sourceTranscripts ?? [],
   );
-  const selectedNoteId = selectedNote?.id;
+  const selectedNoteTranscriptContentKey = useMemo(
+    () =>
+      transcriptFollowLatestKey(
+        selectedNoteLiveTranscript,
+        selectedNote?.sourceTranscripts ?? [],
+      ),
+    [selectedNote?.sourceTranscripts, selectedNoteLiveTranscript],
+  );
   // The contextual Ask June panel next to the open note. Scoped to one note:
   // it only renders while a note is the active view, and closes whenever the
   // open note changes (below) so it never flies out onto a different or
@@ -1147,6 +1161,19 @@ export function App() {
   const recoverableNoteIds = useMemo(() => new Set(recoveriesByNote.keys()), [recoveriesByNote]);
   const selectedRecovery = selectedNote ? recoveriesByNote.get(selectedNote.id) : undefined;
   const noteDetailScrollerActive = activeView === "meetings" && !!selectedNote;
+  const transcriptionFollowLatestActive =
+    noteDetailScrollerActive && selectedNote?.activeTab === "transcription";
+  const recordingSelectedNote =
+    selectedNoteId !== undefined &&
+    selectedNoteId === recordingNoteId &&
+    state.recordingStatus !== undefined;
+  useFollowLatestScroll({
+    scrollRef: noteDetailScrollRef,
+    active: transcriptionFollowLatestActive,
+    contentKey: selectedNoteTranscriptContentKey,
+    scopeKey: selectedNoteId ?? "",
+    followOnActivate: recordingSelectedNote,
+  });
   const detailScrollerActive = activeView === "folders" && !!state.selectedFolderId;
   // A settings drill-in (e.g. a skill detail) that pins its own frosted
   // breadcrumb bar at the top of the panel and scrolls its content beneath —
@@ -4286,9 +4313,7 @@ export function App() {
                       recoveryBlockedReason={
                         fundingRequired ? RECOVERY_FUNDING_DISABLED_REASON : undefined
                       }
-                      liveTranscript={liveTranscriptEvents.filter(
-                        (event) => event.noteId === selectedNoteId,
-                      )}
+                      liveTranscript={selectedNoteLiveTranscript}
                       sourceMode={sourceMode}
                       sourceReadiness={sourceReadiness}
                       recovery={selectedRecovery}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1051,10 +1051,7 @@ export function App() {
   );
   const selectedNoteTranscriptContentKey = useMemo(
     () =>
-      transcriptFollowLatestKey(
-        selectedNoteLiveTranscript,
-        selectedNote?.sourceTranscripts ?? [],
-      ),
+      transcriptFollowLatestKey(selectedNoteLiveTranscript, selectedNote?.sourceTranscripts ?? []),
     [selectedNote?.sourceTranscripts, selectedNoteLiveTranscript],
   );
   // The contextual Ask June panel next to the open note. Scoped to one note:

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -133,10 +133,8 @@ import { listHermesSessions, titleFromPrompt } from "../lib/hermes-adapter";
 import {
   authoritativeTranscriptCoverageKey,
   clearTerminalLiveTranscriptEvents,
-  transcriptFollowLatestKey,
   upsertLiveTranscriptEvent,
 } from "../lib/live-transcript-preview";
-import { useFollowLatestScroll } from "../lib/use-follow-latest-scroll";
 import {
   RECORDING_INACTIVITY_RESPONSE_MS,
   RECORDING_INACTIVITY_SNOOZE_MS,
@@ -1049,11 +1047,6 @@ export function App() {
   const selectedNoteTranscriptCoverageKey = authoritativeTranscriptCoverageKey(
     selectedNote?.sourceTranscripts ?? [],
   );
-  const selectedNoteTranscriptContentKey = useMemo(
-    () =>
-      transcriptFollowLatestKey(selectedNoteLiveTranscript, selectedNote?.sourceTranscripts ?? []),
-    [selectedNote?.sourceTranscripts, selectedNoteLiveTranscript],
-  );
   // The contextual Ask June panel next to the open note. Scoped to one note:
   // it only renders while a note is the active view, and closes whenever the
   // open note changes (below) so it never flies out onto a different or
@@ -1158,19 +1151,6 @@ export function App() {
   const recoverableNoteIds = useMemo(() => new Set(recoveriesByNote.keys()), [recoveriesByNote]);
   const selectedRecovery = selectedNote ? recoveriesByNote.get(selectedNote.id) : undefined;
   const noteDetailScrollerActive = activeView === "meetings" && !!selectedNote;
-  const transcriptionFollowLatestActive =
-    noteDetailScrollerActive && selectedNote?.activeTab === "transcription";
-  const recordingSelectedNote =
-    selectedNoteId !== undefined &&
-    selectedNoteId === recordingNoteId &&
-    state.recordingStatus !== undefined;
-  useFollowLatestScroll({
-    scrollRef: noteDetailScrollRef,
-    active: transcriptionFollowLatestActive,
-    contentKey: selectedNoteTranscriptContentKey,
-    scopeKey: selectedNoteId ?? "",
-    followOnActivate: recordingSelectedNote,
-  });
   const detailScrollerActive = activeView === "folders" && !!state.selectedFolderId;
   // A settings drill-in (e.g. a skill detail) that pins its own frosted
   // breadcrumb bar at the top of the panel and scrolls its content beneath —
@@ -4285,6 +4265,7 @@ export function App() {
                   >
                     <NoteEditor
                       note={selectedNote}
+                      transcriptScrollRef={noteDetailScrollRef}
                       folders={state.folders}
                       recordingStatus={
                         selectedNoteId === recordingNoteId ? state.recordingStatus : undefined

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -9,7 +9,7 @@ import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconChevronBottom } from "central-icons-filled/IconChevronBottom";
 import { IconMicrophone } from "central-icons-filled/IconMicrophone";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
-import type { ReactNode } from "react";
+import type { ReactNode, RefObject } from "react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { FundingTier } from "../account/FundingNotice";
 import { Switch } from "../ui/Switch";
@@ -36,7 +36,9 @@ import { systemAudioAvailability } from "../../lib/source-readiness";
 import {
   coalesceLiveTranscriptEventsForDisplay,
   reconcileLiveTranscriptEvents,
+  transcriptFollowLatestKey,
 } from "../../lib/live-transcript-preview";
+import { useFollowLatestScroll } from "../../lib/use-follow-latest-scroll";
 import {
   isInvalidJuneResponseMessage,
   NoteFailureBanner,
@@ -46,6 +48,7 @@ import { NotePreview } from "./NotePreview";
 
 type NoteEditorProps = {
   note: NoteDto;
+  transcriptScrollRef?: RefObject<HTMLElement | null>;
   folders: FolderDto[];
   recordingStatus?: RecordingStatusDto;
   recordingDisabled?: boolean;
@@ -137,6 +140,7 @@ function formatTurnTime(startMs?: number, endMs?: number) {
 
 export function NoteEditor({
   note,
+  transcriptScrollRef,
   folders,
   recordingStatus,
   recordingDisabled = false,
@@ -328,6 +332,26 @@ export function NoteEditor({
   const shellState = recordingForNote?.state ?? "idle";
   const processingText = processingMessage(note.processingStatus);
   const transcriptText = transcriptToText(note, liveTranscriptTurns);
+  const fallbackTranscriptScrollRef = useRef<HTMLElement>(null);
+  const transcriptDisplayContentKey = useMemo(
+    () =>
+      JSON.stringify([
+        sourceFilter,
+        transcriptFollowLatestKey(reconciledLiveTranscript, note.sourceTranscripts ?? []),
+        note.transcript?.id ?? null,
+        note.transcript?.text ?? null,
+        note.transcript?.status ?? null,
+        note.transcript?.lastError ?? null,
+      ]),
+    [note.sourceTranscripts, note.transcript, reconciledLiveTranscript, sourceFilter],
+  );
+  useFollowLatestScroll({
+    scrollRef: transcriptScrollRef ?? fallbackTranscriptScrollRef,
+    active: activeTab === "transcription",
+    contentKey: transcriptDisplayContentKey,
+    scopeKey: note.id,
+    followOnActivate: recordingActive,
+  });
   const transcriptCoverageNotice = transcriptCoverageNoticeText(note);
   const silentSourceNotice = silentSourceNoticeText(note);
   const showTranscriptProcessing = processingStatus !== null;

--- a/src/lib/live-transcript-preview.ts
+++ b/src/lib/live-transcript-preview.ts
@@ -92,6 +92,46 @@ export function authoritativeTranscriptCoverageKey(persisted: TranscriptDto[]) {
   return JSON.stringify(spans);
 }
 
+/**
+ * Stable dependency key for changes that can alter the visible transcription.
+ * App polling reconstructs DTO objects, so React effects must depend on values,
+ * not array identity.
+ */
+export function transcriptFollowLatestKey(
+  live: LiveTranscriptEventDto[],
+  persisted: TranscriptDto[],
+) {
+  return JSON.stringify({
+    live: live.map((event) => [
+      event.noteId,
+      event.sessionId,
+      event.sourceMode,
+      event.source,
+      event.segmentId,
+      event.startMs,
+      event.endMs,
+      event.text,
+      event.language ?? null,
+      event.stability,
+    ]),
+    persisted: persisted.map((turn) => [
+      turn.id,
+      turn.recordingSessionId ?? null,
+      turn.spanId ?? null,
+      turn.sourceMode ?? null,
+      turn.source ?? null,
+      turn.startMs ?? null,
+      turn.endMs ?? null,
+      turn.turnIndex ?? null,
+      turn.text,
+      turn.language ?? null,
+      turn.status,
+      turn.lastError ?? null,
+      turn.recordedSilence ?? false,
+    ]),
+  });
+}
+
 function preserveReferenceWhenUnchanged(
   current: LiveTranscriptEventDto[],
   filtered: LiveTranscriptEventDto[],

--- a/src/lib/use-follow-latest-scroll.ts
+++ b/src/lib/use-follow-latest-scroll.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { RefObject } from "react";
+
+export const FOLLOW_LATEST_BOTTOM_THRESHOLD_PX = 48;
+
+const PROGRAMMATIC_SCROLL_TIMEOUT_MS = 800;
+
+type ScrollMetrics = Pick<HTMLElement, "scrollHeight" | "scrollTop" | "clientHeight">;
+
+type UseFollowLatestScrollOptions = {
+  scrollRef: RefObject<HTMLElement | null>;
+  active: boolean;
+  contentKey: string;
+  scopeKey: string;
+  followOnActivate: boolean;
+};
+
+export function isNearScrollBottom(
+  scroller: ScrollMetrics,
+  threshold = FOLLOW_LATEST_BOTTOM_THRESHOLD_PX,
+) {
+  return scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight <= threshold;
+}
+
+export function useFollowLatestScroll({
+  scrollRef,
+  active,
+  contentKey,
+  scopeKey,
+  followOnActivate,
+}: UseFollowLatestScrollOptions) {
+  const shouldFollowRef = useRef(true);
+  const lastScrollTopRef = useRef(0);
+  const programmaticScrollRef = useRef(false);
+  const programmaticScrollTimeoutRef = useRef<number>();
+  const userScrollFrameRef = useRef<number>();
+  const previousActiveRef = useRef(false);
+  const previousContentKeyRef = useRef(contentKey);
+  const previousScopeKeyRef = useRef(scopeKey);
+
+  const clearProgrammaticScroll = useCallback(() => {
+    programmaticScrollRef.current = false;
+    if (programmaticScrollTimeoutRef.current !== undefined) {
+      window.clearTimeout(programmaticScrollTimeoutRef.current);
+      programmaticScrollTimeoutRef.current = undefined;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!active) return;
+    const scroller = scrollRef.current;
+    if (!scroller) return;
+
+    const updateStickiness = () => {
+      const previousScrollTop = lastScrollTopRef.current;
+      lastScrollTopRef.current = scroller.scrollTop;
+      if (programmaticScrollRef.current) {
+        if (scroller.scrollTop < previousScrollTop) {
+          clearProgrammaticScroll();
+          shouldFollowRef.current = isNearScrollBottom(scroller);
+          return;
+        }
+        shouldFollowRef.current = true;
+        if (isNearScrollBottom(scroller)) clearProgrammaticScroll();
+        return;
+      }
+      shouldFollowRef.current = isNearScrollBottom(scroller);
+    };
+
+    const updateFromUserScroll = () => {
+      clearProgrammaticScroll();
+      if (userScrollFrameRef.current !== undefined) {
+        window.cancelAnimationFrame(userScrollFrameRef.current);
+      }
+      if (typeof window.requestAnimationFrame !== "function") {
+        updateStickiness();
+        return;
+      }
+      userScrollFrameRef.current = window.requestAnimationFrame(() => {
+        userScrollFrameRef.current = undefined;
+        updateStickiness();
+      });
+    };
+
+    updateStickiness();
+    scroller.addEventListener("scroll", updateStickiness, { passive: true });
+    scroller.addEventListener("wheel", updateFromUserScroll, { passive: true });
+    scroller.addEventListener("touchmove", updateFromUserScroll, { passive: true });
+    return () => {
+      scroller.removeEventListener("scroll", updateStickiness);
+      scroller.removeEventListener("wheel", updateFromUserScroll);
+      scroller.removeEventListener("touchmove", updateFromUserScroll);
+      if (userScrollFrameRef.current !== undefined) {
+        window.cancelAnimationFrame(userScrollFrameRef.current);
+        userScrollFrameRef.current = undefined;
+      }
+      clearProgrammaticScroll();
+    };
+  }, [active, clearProgrammaticScroll, scopeKey, scrollRef]);
+
+  useEffect(() => {
+    const scroller = scrollRef.current;
+    const scopeChanged = previousScopeKeyRef.current !== scopeKey;
+    const justActivated = active && !previousActiveRef.current;
+    const contentChanged = !scopeChanged && previousContentKeyRef.current !== contentKey;
+
+    previousActiveRef.current = active;
+    previousContentKeyRef.current = contentKey;
+    previousScopeKeyRef.current = scopeKey;
+
+    if (scopeChanged) {
+      shouldFollowRef.current = scroller ? isNearScrollBottom(scroller) : true;
+    }
+    const mustLandOnLatest = followOnActivate && (justActivated || scopeChanged);
+    if (mustLandOnLatest) shouldFollowRef.current = true;
+    if (!active || (!contentChanged && !mustLandOnLatest) || !shouldFollowRef.current) return;
+    if (!scroller || typeof scroller.scrollTo !== "function") return;
+
+    const reduceMotion =
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reduceMotion) {
+      clearProgrammaticScroll();
+    } else {
+      lastScrollTopRef.current = scroller.scrollTop;
+      programmaticScrollRef.current = true;
+      if (programmaticScrollTimeoutRef.current !== undefined) {
+        window.clearTimeout(programmaticScrollTimeoutRef.current);
+      }
+      programmaticScrollTimeoutRef.current = window.setTimeout(() => {
+        programmaticScrollRef.current = false;
+        shouldFollowRef.current = isNearScrollBottom(scroller);
+        programmaticScrollTimeoutRef.current = undefined;
+      }, PROGRAMMATIC_SCROLL_TIMEOUT_MS);
+    }
+
+    scroller.scrollTo({
+      top: scroller.scrollHeight,
+      behavior: reduceMotion ? "auto" : "smooth",
+    });
+    shouldFollowRef.current = true;
+  }, [active, clearProgrammaticScroll, contentKey, followOnActivate, scopeKey, scrollRef]);
+}

--- a/src/lib/use-follow-latest-scroll.ts
+++ b/src/lib/use-follow-latest-scroll.ts
@@ -96,7 +96,7 @@ export function useFollowLatestScroll({
       }
       clearProgrammaticScroll();
     };
-  }, [active, clearProgrammaticScroll, scopeKey, scrollRef]);
+  }, [active, clearProgrammaticScroll, scrollRef]);
 
   useEffect(() => {
     const scroller = scrollRef.current;

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
@@ -235,6 +235,35 @@ function deferred<T>() {
     resolve = resolver;
   });
   return { promise, resolve };
+}
+
+function stubNoteDetailScroller(initialScrollTop: number) {
+  const element = document.querySelector<HTMLElement>(".note-detail-scroll");
+  if (!element) throw new Error("Expected the note detail scroller to be mounted");
+  let scrollTop = initialScrollTop;
+  Object.defineProperties(element, {
+    scrollHeight: { configurable: true, get: () => 1000 },
+    clientHeight: { configurable: true, get: () => 400 },
+    scrollTop: {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    },
+  });
+  const scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+    scrollTop = Math.min(Number(top), 600);
+    element.dispatchEvent(new Event("scroll"));
+  });
+  Object.defineProperty(element, "scrollTo", { configurable: true, value: scrollTo });
+  return {
+    element,
+    scrollTo,
+    setScrollTop(value: number) {
+      scrollTop = value;
+    },
+  };
 }
 
 describe("notes recording reliability", () => {
@@ -631,6 +660,51 @@ describe("notes recording reliability", () => {
     await userEvent.click(screen.getByRole("button", { name: "Done" }));
     await waitFor(() => expect(mocks.finishRecording).toHaveBeenCalledWith("rec-1"));
     expect(screen.getByText("Provisional words survive Stop")).toBeInTheDocument();
+  });
+
+  it("follows live transcription until the reader scrolls upward, then resumes at the bottom", async () => {
+    await startRecordingOnFirstNote();
+    await waitFor(() => expect(mocks.listeners.has("live-transcript-event")).toBe(true));
+    const scroller = stubNoteDetailScroller(100);
+
+    await userEvent.click(screen.getByRole("button", { name: "Transcription" }));
+    await waitFor(() =>
+      expect(scroller.scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: "smooth" }),
+    );
+    scroller.scrollTo.mockClear();
+
+    const emitPreview = async (segmentId: string, text: string, startMs: number) => {
+      await act(async () => {
+        await mocks.listeners.get("live-transcript-event")?.({
+          payload: {
+            noteId: "note-1",
+            sessionId: "rec-1",
+            sourceMode: "microphonePlusSystem",
+            source: "microphone",
+            segmentId,
+            startMs,
+            endMs: startMs + 4000,
+            text,
+            stability: "final",
+          },
+        });
+      });
+    };
+
+    await emitPreview("microphone-0", "First live words", 0);
+    await waitFor(() => expect(scroller.scrollTo).toHaveBeenCalledTimes(1));
+
+    scroller.scrollTo.mockClear();
+    scroller.setScrollTop(100);
+    fireEvent.wheel(scroller.element);
+    fireEvent.scroll(scroller.element);
+    await emitPreview("microphone-1", "Words while reading above", 4000);
+    expect(scroller.scrollTo).not.toHaveBeenCalled();
+
+    scroller.setScrollTop(600);
+    fireEvent.scroll(scroller.element);
+    await emitPreview("microphone-2", "Following resumes", 8000);
+    await waitFor(() => expect(scroller.scrollTo).toHaveBeenCalledTimes(1));
   });
 
   it("does not clear a newer preview when the note still has queued recordings", async () => {
@@ -1108,6 +1182,7 @@ describe("notes recording reliability", () => {
     await userEvent.click(await screen.findByRole("button", { name: "Meeting notes" }));
     await userEvent.click(screen.getByRole("button", { name: /First note Preview/ }));
     await waitFor(() => expect(screen.getByText("Transcribing audio")).toBeInTheDocument());
+    const scroller = stubNoteDetailScroller(600);
 
     expect(screen.queryByText("The first saved turn is visible.")).not.toBeInTheDocument();
     mocks.getNote.mockClear();
@@ -1137,6 +1212,7 @@ describe("notes recording reliability", () => {
       },
       { timeout: 3_000 },
     );
+    expect(scroller.scrollTo).toHaveBeenCalledTimes(1);
     const transcribingStatus = screen.getByText("Transcribing audio");
     expect(transcribingStatus.closest('[role="status"]')).not.toBeNull();
   });

--- a/src/test/live-transcript-preview.test.ts
+++ b/src/test/live-transcript-preview.test.ts
@@ -4,6 +4,7 @@ import {
   clearTerminalLiveTranscriptEvents,
   coalesceLiveTranscriptEventsForDisplay,
   reconcileLiveTranscriptEvents,
+  transcriptFollowLatestKey,
   upsertLiveTranscriptEvent,
 } from "../lib/live-transcript-preview";
 import type { LiveTranscriptEventDto, TranscriptDto } from "../lib/tauri";
@@ -236,5 +237,29 @@ describe("live transcript preview", () => {
         { ...system, recordingSessionId: "session-3" },
       ]),
     ).not.toBe(key);
+  });
+
+  it("keeps the follow-latest key stable across equivalent polling objects", () => {
+    const preview = [liveEvent()];
+    const persisted = [persistedTurn()];
+
+    expect(transcriptFollowLatestKey(preview, persisted)).toBe(
+      transcriptFollowLatestKey(
+        preview.map((event) => ({ ...event })),
+        persisted.map((turn) => ({ ...turn })),
+      ),
+    );
+  });
+
+  it("changes the follow-latest key when visible transcript content changes", () => {
+    const initial = transcriptFollowLatestKey([liveEvent()], []);
+    const revisedPreview = transcriptFollowLatestKey(
+      [liveEvent({ text: "Revised preview words", endMs: 9000 })],
+      [],
+    );
+    const persistedReplacement = transcriptFollowLatestKey([], [persistedTurn()]);
+
+    expect(revisedPreview).not.toBe(initial);
+    expect(persistedReplacement).not.toBe(initial);
   });
 });

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -374,6 +374,53 @@ describe("NoteEditor", () => {
     expect(screen.getByText("Microphone response")).toBeInTheDocument();
   });
 
+  it("keeps following when the source filter reveals additional turns", async () => {
+    const scroller = document.createElement("div");
+    Object.defineProperties(scroller, {
+      scrollHeight: { configurable: true, get: () => 1000 },
+      clientHeight: { configurable: true, get: () => 400 },
+      scrollTop: { configurable: true, get: () => 600 },
+    });
+    const scrollTo = vi.fn();
+    Object.defineProperty(scroller, "scrollTo", { configurable: true, value: scrollTo });
+
+    render(
+      <NoteEditor
+        {...props}
+        transcriptScrollRef={{ current: scroller }}
+        note={note({
+          activeTab: "transcription",
+          sourceTranscripts: [
+            {
+              id: "turn-1",
+              text: "Microphone response",
+              source: "microphone",
+              startMs: 1000,
+              endMs: 2500,
+              turnIndex: 0,
+              status: "succeeded",
+            },
+            {
+              id: "turn-2",
+              text: "System playback text",
+              source: "system",
+              startMs: 3000,
+              endMs: 4500,
+              turnIndex: 1,
+              status: "succeeded",
+            },
+          ],
+        })}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Microphone" }));
+    scrollTo.mockClear();
+    await userEvent.click(screen.getByRole("button", { name: "All" }));
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: "smooth" });
+  });
+
   it("shows live transcript preview turns while recording", () => {
     render(
       <NoteEditor

--- a/src/test/use-follow-latest-scroll.test.tsx
+++ b/src/test/use-follow-latest-scroll.test.tsx
@@ -1,0 +1,209 @@
+import { fireEvent, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  FOLLOW_LATEST_BOTTOM_THRESHOLD_PX,
+  isNearScrollBottom,
+  useFollowLatestScroll,
+} from "../lib/use-follow-latest-scroll";
+
+type HookProps = {
+  active: boolean;
+  contentKey: string;
+  scopeKey: string;
+  followOnActivate: boolean;
+};
+
+const originalMatchMedia = window.matchMedia;
+
+function createScroller(initialScrollTop = 600) {
+  let currentScrollTop = initialScrollTop;
+  let currentScrollHeight = 1000;
+  const element = document.createElement("div");
+  Object.defineProperties(element, {
+    scrollHeight: { configurable: true, get: () => currentScrollHeight },
+    clientHeight: { configurable: true, get: () => 400 },
+    scrollTop: {
+      configurable: true,
+      get: () => currentScrollTop,
+      set: (value: number) => {
+        currentScrollTop = value;
+      },
+    },
+  });
+  const scrollTo = vi.fn<(options: ScrollToOptions) => void>();
+  Object.defineProperty(element, "scrollTo", { configurable: true, value: scrollTo });
+  document.body.append(element);
+  const ref = { current: element as HTMLElement };
+  return {
+    element,
+    ref,
+    scrollTo,
+    setScrollHeight(value: number) {
+      currentScrollHeight = value;
+    },
+    setScrollTop(value: number) {
+      currentScrollTop = value;
+    },
+  };
+}
+
+function renderFollowLatest(
+  scroller: ReturnType<typeof createScroller>,
+  initialProps: HookProps,
+) {
+  return renderHook(
+    (props: HookProps) =>
+      useFollowLatestScroll({
+        scrollRef: scroller.ref,
+        ...props,
+      }),
+    { initialProps },
+  );
+}
+
+afterEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+  vi.clearAllMocks();
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+});
+
+describe("isNearScrollBottom", () => {
+  it("treats a distance of 49 pixels as outside the live edge", () => {
+    expect(
+      isNearScrollBottom({
+        scrollHeight: 1000,
+        clientHeight: 400,
+        scrollTop: 551,
+      }),
+    ).toBe(false);
+  });
+
+  it("includes a distance of 48 pixels in the live edge", () => {
+    expect(FOLLOW_LATEST_BOTTOM_THRESHOLD_PX).toBe(48);
+    expect(
+      isNearScrollBottom({
+        scrollHeight: 1000,
+        clientHeight: 400,
+        scrollTop: 552,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("useFollowLatestScroll", () => {
+  const activeProps: HookProps = {
+    active: true,
+    contentKey: "content-1",
+    scopeKey: "note-1",
+    followOnActivate: false,
+  };
+
+  it("scrolls smoothly when content changes at the live edge", () => {
+    const scroller = createScroller();
+    const { rerender } = renderFollowLatest(scroller, activeProps);
+
+    rerender({ ...activeProps, contentKey: "content-2" });
+
+    expect(scroller.scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: "smooth" });
+  });
+
+  it("pauses when the reader scrolls upward", () => {
+    const scroller = createScroller();
+    const { rerender } = renderFollowLatest(scroller, activeProps);
+
+    scroller.setScrollTop(100);
+    fireEvent.scroll(scroller.element);
+    rerender({ ...activeProps, contentKey: "content-2" });
+
+    expect(scroller.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("resumes after the reader returns to the live edge", () => {
+    const scroller = createScroller();
+    const { rerender } = renderFollowLatest(scroller, activeProps);
+
+    scroller.setScrollTop(100);
+    fireEvent.scroll(scroller.element);
+    rerender({ ...activeProps, contentKey: "content-2" });
+    scroller.setScrollTop(600);
+    fireEvent.scroll(scroller.element);
+    rerender({ ...activeProps, contentKey: "content-3" });
+
+    expect(scroller.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("lands on latest when activated for an active recording", () => {
+    const scroller = createScroller(100);
+    const inactiveProps = { ...activeProps, active: false, followOnActivate: true };
+    const { rerender } = renderFollowLatest(scroller, inactiveProps);
+
+    rerender({ ...inactiveProps, active: true });
+
+    expect(scroller.scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: "smooth" });
+  });
+
+  it("does not move a historical transcript when activated away from the live edge", () => {
+    const scroller = createScroller(100);
+    const inactiveProps = { ...activeProps, active: false };
+    const { rerender } = renderFollowLatest(scroller, inactiveProps);
+
+    rerender({ ...inactiveProps, active: true });
+
+    expect(scroller.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("keeps following through intermediate programmatic downward scroll events", () => {
+    const scroller = createScroller();
+    const { rerender } = renderFollowLatest(scroller, activeProps);
+
+    scroller.setScrollHeight(1200);
+    rerender({ ...activeProps, contentKey: "content-2" });
+    scroller.setScrollTop(700);
+    fireEvent.scroll(scroller.element);
+    rerender({ ...activeProps, contentKey: "content-3" });
+
+    expect(scroller.scrollTo).toHaveBeenCalledTimes(2);
+  });
+
+  it("lets wheel input interrupt an in-flight programmatic glide", () => {
+    const scroller = createScroller();
+    const { rerender } = renderFollowLatest(scroller, activeProps);
+
+    scroller.setScrollHeight(1200);
+    rerender({ ...activeProps, contentKey: "content-2" });
+    scroller.scrollTo.mockClear();
+    fireEvent.wheel(scroller.element);
+    scroller.setScrollTop(100);
+    fireEvent.scroll(scroller.element);
+    rerender({ ...activeProps, contentKey: "content-3" });
+
+    expect(scroller.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("uses instant scrolling when reduced motion is preferred", () => {
+    vi.spyOn(window, "matchMedia").mockImplementation(
+      (query) =>
+        ({
+          matches: query === "(prefers-reduced-motion: reduce)",
+          media: query,
+          onchange: null,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as MediaQueryList,
+    );
+    const scroller = createScroller();
+    const { rerender } = renderFollowLatest(scroller, activeProps);
+
+    rerender({ ...activeProps, contentKey: "content-2" });
+
+    expect(scroller.scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: "auto" });
+  });
+});

--- a/src/test/use-follow-latest-scroll.test.tsx
+++ b/src/test/use-follow-latest-scroll.test.tsx
@@ -47,10 +47,7 @@ function createScroller(initialScrollTop = 600) {
   };
 }
 
-function renderFollowLatest(
-  scroller: ReturnType<typeof createScroller>,
-  initialProps: HookProps,
-) {
+function renderFollowLatest(scroller: ReturnType<typeof createScroller>, initialProps: HookProps) {
   return renderHook(
     (props: HookProps) =>
       useFollowLatestScroll({


### PR DESCRIPTION
## Summary

- Keep the Meeting notes Transcription view following the latest visible Turn while the reader stays near the bottom.
- Pause following when the reader scrolls upward and resume after they return to the live edge.
- Land on the latest Turn when opening Transcription for an active recording, while preserving the position of historical transcripts.
- Use value-based transcript keys so equivalent polling objects do not retrigger scrolling, and respect reduced-motion preferences.

## Root cause

Live and persisted transcript updates re-rendered the Turn list, but the shared note detail scroller had no stateful follow-latest policy. As a result, incoming preview Turns and polled persisted Turns could extend below the viewport without moving the reader to the latest content.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm test` - 185 test files passed; 2,978 tests passed and 2 skipped.
- Browser-driven QA against the real rendered app with a fake Tauri bridge: opening followed latest, live updates followed, upward scrolling paused, and returning to the bottom resumed.
- Visual evidence captured locally as `transcription-follow-latest.png` and `transcription-follow-latest.webm`.

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- No changes to transcription generation, recording capture, Turn reconciliation semantics, note layout, or backend APIs.
- No floating “Jump to latest” control; following resumes automatically when the reader returns near the bottom.

## Followups

- Attach the captured screenshot or recording to this draft before marking it ready for review.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787293182&installation_model_id=425925&pr_number=892&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F892&signature=925f48c6aab9ffa23e75550476ff8054c040a28fdd0189953839e94001940d93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->