### PR TITLE
Restyle the OAuth loopback success page to the current design system

### DIFF
--- a/src-tauri/src/connectors/notion.rs
+++ b/src-tauri/src/connectors/notion.rs
@@ -2478,33 +2478,9 @@ fn classify_tool(name: &str) -> &'static str {
     }
 }
 
-const SUCCESS_BODY: &str = r##"<!doctype html>
-<html lang=en>
-<meta charset=utf-8>
-<meta name=viewport content="width=device-width,initial-scale=1">
-<title>June</title>
-<style>
-  :root{--bg:#f1f0ed;--card:#fff;--fg:#2b2a28;--muted:#8a8884;--border:#e7e4de;--mark-fg:#fff;--ok:#2c6747;--ok-soft:#e7efe9}
-  @media (prefers-color-scheme:dark){:root{--bg:#181817;--card:#252423;--fg:#fafafa;--muted:#b2b0ac;--border:rgba(255,255,255,.10);--mark-fg:#181817;--ok:#6fbf94;--ok-soft:rgba(111,191,148,.16)}}
-  *{box-sizing:border-box}
-  html,body{height:100%}
-  body{margin:0;display:grid;place-items:center;padding:24px;background:var(--bg);color:var(--fg);font-family:system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
-  .card{display:flex;flex-direction:column;align-items:center;gap:16px;width:100%;max-width:340px;padding:36px 32px;text-align:center;background:var(--card);border:1px solid var(--border);border-radius:14px;box-shadow:0 1px 2px rgba(0,0,0,.05)}
-  .mark{display:grid;place-items:center;width:40px;height:40px;border-radius:11px;background:var(--fg);color:var(--mark-fg);font-weight:700;font-size:15px;letter-spacing:.06em}
-  .check{display:inline-flex;align-items:center;gap:7px;padding:4px 11px 4px 9px;border-radius:999px;background:var(--ok-soft);color:var(--ok);font-size:12.5px;font-weight:600}
-  .check svg{width:13px;height:13px}
-  .title{margin:0;font-size:17px;font-weight:600;letter-spacing:-.01em}
-  .sub{margin:0;font-size:14px;line-height:1.5;color:var(--muted)}
-</style>
-<body>
-  <main class=card>
-    <div class=mark>OS</div>
-    <span class=check><svg viewBox="0 0 14 14" fill=none stroke=currentColor stroke-width=1.8 stroke-linecap=round stroke-linejoin=round><path d="M3 7.5 6 10l5-6"/></svg>Connected</span>
-    <h1 class=title>You're connected</h1>
-    <p class=sub>You can close this tab and return to June.</p>
-  </main>
-</body>
-</html>"##;
+// The branded loopback success page is shared across connectors; see
+// connectors/oauth.rs for the markup and the token-baking rationale.
+use super::oauth::SUCCESS_BODY;
 
 async fn await_callback(listener: &TcpListener, expected_state: &str) -> Result<String, AppError> {
     loop {
@@ -2550,7 +2526,7 @@ async fn await_callback(listener: &TcpListener, expected_state: &str) -> Result<
                 ));
             }
             CallbackOutcome::Code(code) => {
-                write_http(&mut stream, "200 OK", SUCCESS_BODY).await;
+                write_http(&mut stream, "200 OK", &SUCCESS_BODY).await;
                 return Ok(code);
             }
         }

--- a/src-tauri/src/connectors/oauth.rs
+++ b/src-tauri/src/connectors/oauth.rs
@@ -18,11 +18,17 @@
 //! errors. Error messages carry stable codes and short human text only.
 
 use crate::domain::types::AppError;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{
+    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+    Engine,
+};
 use rand::RngCore;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
-use std::{sync::OnceLock, time::Duration};
+use std::{
+    sync::{LazyLock, OnceLock},
+    time::Duration,
+};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpListener,
@@ -310,36 +316,69 @@ fn build_auth_url(
     url
 }
 
-// Branded loopback success page. Self-contained (the loopback origin cannot
-// reach the app's bundled assets), matching the June look and following the
-// system light/dark preference.
-const SUCCESS_BODY: &str = r##"<!doctype html>
+// Branded loopback success page, shared by every loopback flow (the connectors
+// here plus the dev-only os_accounts sign-in). Self-contained: the loopback
+// origin cannot reach the app's bundled assets, so the two text faces the page
+// uses are embedded as data: URIs — the listener answers exactly one request,
+// so a follow-up fetch for a font file would find the port already closed —
+// and the design tokens from src/styles/tokens.css are baked at their clay
+// defaults (the page can't read the runtime accent, and clay is the fixed
+// brand identity the app icon and marks use). Mirrors the in-app welcome /
+// sign-in surface: warm gradient field, the JuneGradientMark glyph, ok-tone
+// status pill, serif display title. Follows the system light/dark preference,
+// since the page can't read the app's theme setting either.
+const DIATYPE_REGULAR_WOFF2: &[u8] = include_bytes!("../../../public/ABCDiatype-Regular.woff2");
+const MARTINA_PLANTIJN_WOFF2: &[u8] =
+    include_bytes!("../../../public/martina-plantijn-light.woff2");
+
+const SUCCESS_TEMPLATE: &str = r##"<!doctype html>
 <html lang=en>
 <meta charset=utf-8>
 <meta name=viewport content="width=device-width,initial-scale=1">
 <title>June</title>
 <style>
-  :root{--bg:#f1f0ed;--card:#fff;--fg:#2b2a28;--muted:#8a8884;--border:#e7e4de;--mark-fg:#fff;--ok:#2c6747;--ok-soft:#e7efe9}
-  @media (prefers-color-scheme:dark){:root{--bg:#181817;--card:#252423;--fg:#fafafa;--muted:#b2b0ac;--border:rgba(255,255,255,.10);--mark-fg:#181817;--ok:#6fbf94;--ok-soft:rgba(111,191,148,.16)}}
+  @font-face{font-family:"ABC Diatype";src:url(data:font/woff2;base64,%%DIATYPE%%) format("woff2");font-weight:400;font-style:normal}
+  @font-face{font-family:"Martina Plantijn";src:url(data:font/woff2;base64,%%MARTINA%%) format("woff2");font-weight:300 400;font-style:normal}
+  :root{--brand:#b5551f;--brand-wash:#976851;--background:color-mix(in oklch,oklch(95.13% 0.0015 84.59),var(--brand-wash) 3%);--foreground:oklch(27.24% 0.0015 84.59);--card:color-mix(in oklch,oklch(100% 0 none),var(--brand-wash) 2%);--muted-foreground:oklch(55.8% 0.0015 84.59);--success:oklch(48% 0.12 150);--warm-soft:color-mix(in oklch,var(--brand) 16%,var(--card))}
+  @media (prefers-color-scheme:dark){:root{--background:color-mix(in oklch,oklch(16.5% 0.0015 84.59),var(--brand-wash) 6%);--foreground:oklch(98.5% 0.0015 84.59);--card:color-mix(in oklch,oklch(19.5% 0.0015 84.59),var(--brand-wash) 6%);--muted-foreground:oklch(70.9% 0.0015 84.59);--success:oklch(72% 0.14 150);--warm-soft:color-mix(in oklch,var(--brand) 30%,var(--card))}}
   *{box-sizing:border-box}
   html,body{height:100%}
-  body{margin:0;display:grid;place-items:center;padding:24px;background:var(--bg);color:var(--fg);font-family:system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
-  .card{display:flex;flex-direction:column;align-items:center;gap:16px;width:100%;max-width:340px;padding:36px 32px;text-align:center;background:var(--card);border:1px solid var(--border);border-radius:14px;box-shadow:0 1px 2px rgba(0,0,0,.05)}
-  .mark{display:grid;place-items:center;width:40px;height:40px;border-radius:11px;background:var(--fg);color:var(--mark-fg);font-weight:700;font-size:15px;letter-spacing:.06em}
-  .check{display:inline-flex;align-items:center;gap:7px;padding:4px 11px 4px 9px;border-radius:999px;background:var(--ok-soft);color:var(--ok);font-size:12.5px;font-weight:600}
-  .check svg{width:13px;height:13px}
-  .title{margin:0;font-size:17px;font-weight:600;letter-spacing:-.01em}
-  .sub{margin:0;font-size:14px;line-height:1.5;color:var(--muted)}
+  body{margin:0;display:grid;place-items:center;padding:24px;background:linear-gradient(180deg,color-mix(in oklch,var(--background) 78%,var(--warm-soft)) 0%,var(--background) 52%,color-mix(in oklch,var(--background) 92%,var(--warm-soft)) 100%);color:var(--foreground);font-family:"ABC Diatype",ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;font-size:13px;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
+  .stack{display:flex;flex-direction:column;align-items:center;gap:10px;width:100%;max-width:340px;text-align:center}
+  .mark{margin-bottom:6px}
+  .status-pill{display:inline-flex;align-items:center;padding:1px 6px;border-radius:6px;background:color-mix(in oklch,var(--success) 14%,transparent);color:var(--success);font-size:11px;font-weight:400;line-height:1.4}
+  .title{margin:0;font-family:"Martina Plantijn","Iowan Old Style",Georgia,serif;font-size:30px;font-weight:400;line-height:1.2;letter-spacing:0;text-wrap:balance}
+  .sub{margin:0;font-size:14px;line-height:1.5;color:var(--muted-foreground)}
 </style>
 <body>
-  <main class=card>
-    <div class=mark>OS</div>
-    <span class=check><svg viewBox="0 0 14 14" fill=none stroke=currentColor stroke-width=1.8 stroke-linecap=round stroke-linejoin=round><path d="M3 7.5 6 10l5-6"/></svg>Connected</span>
-    <h1 class=title>You're connected</h1>
-    <p class=sub>You can close this tab and return to June.</p>
+  <main class=stack>
+    <svg class=mark width=40 height=46 viewBox="0 0 12 14" fill=none aria-hidden=true><defs><linearGradient id=mark-gradient x1=6 y1=0 x2=6 y2=14 gradientUnits=userSpaceOnUse><stop style="stop-color:color-mix(in oklch,var(--brand) 55%,white)"/><stop offset=1 style="stop-color:var(--brand)"/></linearGradient></defs><g fill="url(#mark-gradient)"><path d="M11.5 6.5C11.7761 6.5 12 6.72386 12 7V8.5C12 8.77614 11.7761 9 11.5 9H10.4141C10.2815 9.00002 10.1543 9.05273 10.0605 9.14648L9.64648 9.56055C9.55273 9.6543 9.50002 9.78148 9.5 9.91406V11C9.5 11.2761 9.27614 11.5 9 11.5H3.41406C3.28148 11.5 3.1543 11.5527 3.06055 11.6465L2.64648 12.0605C2.55273 12.1543 2.50002 12.2815 2.5 12.4141V13.5C2.5 13.7761 2.27614 14 2 14H0.5C0.223858 14 0 13.7761 0 13.5V12C0 11.7239 0.223858 11.5 0.5 11.5H1.58594C1.71852 11.5 1.8457 11.4473 1.93945 11.3535L2.35352 10.9395C2.44727 10.8457 2.49998 10.7185 2.5 10.5859V9.5C2.5 9.22386 2.72386 9 3 9H8.58594C8.71852 8.99998 8.8457 8.94727 8.93945 8.85352L9.35352 8.43945C9.44727 8.3457 9.49998 8.21852 9.5 8.08594V7C9.5 6.72386 9.72386 6.5 10 6.5H11.5Z"/><path d="M11.5 0C11.7761 0 12 0.223858 12 0.5V2C12 2.27614 11.7761 2.5 11.5 2.5H10.4141C10.2815 2.50002 10.1543 2.55273 10.0605 2.64648L9.64648 3.06055C9.55273 3.1543 9.50002 3.28148 9.5 3.41406V4.5C9.5 4.77614 9.27614 5 9 5H3.41406C3.28148 5.00002 3.1543 5.05273 3.06055 5.14648L2.64648 5.56055C2.55273 5.6543 2.50002 5.78148 2.5 5.91406V7C2.5 7.27614 2.27614 7.5 2 7.5H0.5C0.223858 7.5 0 7.27614 0 7V5.5C0 5.22386 0.223858 5 0.5 5H1.58594C1.71852 4.99998 1.8457 4.94727 1.93945 4.85352L2.35352 4.43945C2.44727 4.3457 2.49998 4.21852 2.5 4.08594V3C2.5 2.72386 2.72386 2.5 3 2.5H8.58594C8.71852 2.49998 8.8457 2.44727 8.93945 2.35352L9.35352 1.93945C9.44727 1.8457 9.49998 1.71852 9.5 1.58594V0.5C9.5 0.223858 9.72386 0 10 0H11.5Z"/></g></svg>
+    <span class=status-pill>%%PILL%%</span>
+    <h1 class=title>%%TITLE%%</h1>
+    <p class=sub>%%SUB%%</p>
   </main>
 </body>
 </html>"##;
+
+/// Render the branded loopback success page with flow-specific copy. The
+/// arguments are trusted string literals from this crate, not user input —
+/// they land in the HTML unescaped.
+pub(crate) fn success_page(pill: &str, title: &str, sub: &str) -> String {
+    SUCCESS_TEMPLATE
+        .replace("%%DIATYPE%%", &STANDARD.encode(DIATYPE_REGULAR_WOFF2))
+        .replace("%%MARTINA%%", &STANDARD.encode(MARTINA_PLANTIJN_WOFF2))
+        .replace("%%PILL%%", pill)
+        .replace("%%TITLE%%", title)
+        .replace("%%SUB%%", sub)
+}
+
+pub(crate) static SUCCESS_BODY: LazyLock<String> = LazyLock::new(|| {
+    success_page(
+        "Connected",
+        "You're connected",
+        "You can close this tab and return to June.",
+    )
+});
 
 /// Accept connections until one hits `/callback` with a matching state.
 /// Every per-socket read is bounded so a slow client on the loopback port
@@ -393,7 +432,7 @@ async fn await_callback(
                 ));
             }
             CallbackOutcome::Code(code) => {
-                write_http(&mut stream, "200 OK", SUCCESS_BODY).await;
+                write_http(&mut stream, "200 OK", &SUCCESS_BODY).await;
                 return Ok(code);
             }
         }

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -1169,38 +1169,19 @@ async fn await_authorization_code(
     }
 }
 
-// Branded loopback success page. Self-contained (the loopback origin can't
-// reach the app's bundled fonts/assets), but mirrors the OS Accounts / June
-// look: warm-grey surface, inset card, OS mark, calm hierarchy — and follows
-// the system light/dark preference.
+// Branded loopback success page for the dev-only sign-in loopback: the shared
+// template from connectors/oauth.rs (embedded fonts, baked clay tokens, the
+// welcome-surface look) with sign-in copy.
 #[cfg(debug_assertions)]
-const SUCCESS_BODY: &str = r##"<!doctype html>
-<html lang=en>
-<meta charset=utf-8>
-<meta name=viewport content="width=device-width,initial-scale=1">
-<title>June</title>
-<style>
-  :root{--bg:#f1f0ed;--card:#fff;--fg:#2b2a28;--muted:#8a8884;--border:#e7e4de;--mark-fg:#fff;--ok:#2c6747;--ok-soft:#e7efe9}
-  @media (prefers-color-scheme:dark){:root{--bg:#181817;--card:#252423;--fg:#fafafa;--muted:#b2b0ac;--border:rgba(255,255,255,.10);--mark-fg:#181817;--ok:#6fbf94;--ok-soft:rgba(111,191,148,.16)}}
-  *{box-sizing:border-box}
-  html,body{height:100%}
-  body{margin:0;display:grid;place-items:center;padding:24px;background:var(--bg);color:var(--fg);font-family:system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
-  .card{display:flex;flex-direction:column;align-items:center;gap:16px;width:100%;max-width:340px;padding:36px 32px;text-align:center;background:var(--card);border:1px solid var(--border);border-radius:14px;box-shadow:0 1px 2px rgba(0,0,0,.05)}
-  .mark{display:grid;place-items:center;width:40px;height:40px;border-radius:11px;background:var(--fg);color:var(--mark-fg);font-weight:700;font-size:15px;letter-spacing:.06em}
-  .check{display:inline-flex;align-items:center;gap:7px;padding:4px 11px 4px 9px;border-radius:999px;background:var(--ok-soft);color:var(--ok);font-size:12.5px;font-weight:600}
-  .check svg{width:13px;height:13px}
-  .title{margin:0;font-size:17px;font-weight:600;letter-spacing:-.01em}
-  .sub{margin:0;font-size:14px;line-height:1.5;color:var(--muted)}
-</style>
-<body>
-  <main class=card>
-    <div class=mark>OS</div>
-    <span class=check><svg viewBox="0 0 14 14" fill=none stroke=currentColor stroke-width=1.8 stroke-linecap=round stroke-linejoin=round><path d="M3 7.5 6 10l5-6"/></svg>Signed in</span>
-    <h1 class=title>Signed in to June</h1>
-    <p class=sub>You can close this tab and return to the app.</p>
-  </main>
-</body>
-</html>"##;
+use std::sync::LazyLock;
+#[cfg(debug_assertions)]
+static SUCCESS_BODY: LazyLock<String> = LazyLock::new(|| {
+    crate::connectors::oauth::success_page(
+        "Signed in",
+        "Signed in to June",
+        "You can close this tab and return to the app.",
+    )
+});
 
 /// Accept connections until one hits `/callback`. Every per-socket read is
 /// bounded so a slow-loris client on the loopback port can't stall the
@@ -1240,7 +1221,7 @@ async fn await_callback(listener: &TcpListener, expected_state: &str) -> Result<
                 return Err(missing_code_error());
             }
             CallbackCode::Code(code) => {
-                write_http(&mut stream, "200 OK", SUCCESS_BODY).await;
+                write_http(&mut stream, "200 OK", &SUCCESS_BODY).await;
                 return Ok(code);
             }
         }


### PR DESCRIPTION
## Summary

- Rebuilds the browser success page served by the OAuth loopback flows (connector connects in `connectors/oauth.rs` / `notion.rs`, dev-only sign-in in `os_accounts.rs`), which predated the design system: stale hex palette, raw 600/700 font weights, off-scale sizes, and the outdated dark "OS" block mark.
- The page now mirrors the in-app welcome / sign-in surface: warm gradient field, the `JuneGradientMark` glyph (the sanctioned lightweight fallback for the 3D glass mark), serif display title, and the house ok-tone `.status-pill` recipe, with design tokens baked at their clay defaults since the loopback origin cannot reach app assets or the runtime accent.
- Embeds ABC Diatype Regular and Martina Plantijn light as base64 `data:` URIs (~126KB page): the one-shot listener answers exactly one request, so the browser could never fetch font files separately.
- Dedupes the three drifted copies into one shared `success_page()` template in `connectors/oauth.rs`.

## Validation

- `cargo check` and `cargo fmt --check` clean.
- [x] Tested visually where it matters (rendered page extracted and reviewed in a browser, light and dark).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- The remaining duplicated loopback plumbing (`write_http`, `await_callback`, callback validation) across `notion.rs` / `oauth.rs` / `os_accounts.rs` — this PR only unifies the branded page.
- Plain-text non-success responses (denied / bad request) keep their unstyled bodies.

## Followups

- Worth a one-time confirmation that the ABC Dinamo / Klim font licenses are comfortable with the faces being served in an HTTP response (localhost-only, already bundled in the binary).

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [ ] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787293728&installation_model_id=425925&pr_number=893&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F893&signature=6dee05625ad84f0ec4c4786bda873d1278f77ec611137de9852d83057923e1e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->