### PR TITLE
Give the share passcode a one-time field, labels, and a reset path

### DIFF
--- a/src/components/share/ShareDialog.tsx
+++ b/src/components/share/ShareDialog.tsx
@@ -285,6 +285,7 @@ export function ShareDialog({
         setInviteId(createdInvite.inviteId);
         setLinkMaterialB64(materialB64);
         setPasswordProtected(Boolean(salt));
+        setRevealPasscode(false);
         try {
           await runClipboardCopy(() =>
             copyExistingLink(

--- a/src/components/share/ShareDialog.tsx
+++ b/src/components/share/ShareDialog.tsx
@@ -335,24 +335,29 @@ export function ShareDialog({
   }, [clearCopyFeedback, passcode, runClipboardCopy, showCopyFeedback]);
 
   const handleStopSharing = useCallback(async () => {
-    if (!shareId) return;
-    await shareDelete(shareId).catch((stopError) => {
+    if (!shareId) return false;
+    try {
+      await shareDelete(shareId);
+    } catch (stopError) {
+      // Swallow the failure so the confirm dialog can close and the error
+      // notice becomes visible in the share dialog, where Stop/Reset remain
+      // available for retry.
       setError(describeShareError(stopError));
-      throw stopError;
-    });
+      return false;
+    }
     setShareId(null);
     setInviteId(null);
     setLinkMaterialB64(null);
     setPasswordProtected(false);
     setLegacyShare(false);
     clearCopyFeedback();
+    return true;
   }, [clearCopyFeedback, shareId]);
 
   // Resetting is stop-sharing plus intent: the owner wants a fresh link with a
   // fresh passcode, so land them on the create form with the toggle already on.
   const handleResetLink = useCallback(async () => {
-    await handleStopSharing();
-    setRequirePasscode(true);
+    if (await handleStopSharing()) setRequirePasscode(true);
   }, [handleStopSharing]);
 
   const handleClose = useCallback(() => {

--- a/src/components/share/ShareDialog.tsx
+++ b/src/components/share/ShareDialog.tsx
@@ -1,5 +1,6 @@
 import { IconCircleInfo } from "central-icons/IconCircleInfo";
 import { IconExclamationCircle } from "central-icons/IconExclamationCircle";
+import { IconExclamationTriangle } from "central-icons/IconExclamationTriangle";
 import { IconEyeOpen } from "central-icons/IconEyeOpen";
 import { IconEyeSlash } from "central-icons/IconEyeSlash";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -31,7 +32,7 @@ import {
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { CopyLinkField } from "../ui/CopyLinkField";
 import { CopyStateIcon } from "../ui/CopyStateIcon";
-import { Dialog } from "../ui/Dialog";
+import { Dialog, DialogField } from "../ui/Dialog";
 import { HoverTip } from "../ui/HoverTip";
 import { InlineNotice } from "../ui/InlineNotice";
 import { Switch } from "../ui/Switch";
@@ -73,7 +74,7 @@ export function ShareDialog({
   const [legacyShare, setLegacyShare] = useState(false);
   const [loadFailed, setLoadFailed] = useState(false);
   const [loadVersion, setLoadVersion] = useState(0);
-  const [confirmStop, setConfirmStop] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<"stop" | "reset" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const busyRef = useRef(false);
   const copyingRef = useRef(false);
@@ -132,7 +133,7 @@ export function ShareDialog({
     clearCopyFeedback();
     setLegacyShare(false);
     setLoadFailed(false);
-    setConfirmStop(false);
+    setConfirmAction(null);
     setError(null);
 
     void (async () => {
@@ -347,6 +348,13 @@ export function ShareDialog({
     clearCopyFeedback();
   }, [clearCopyFeedback, shareId]);
 
+  // Resetting is stop-sharing plus intent: the owner wants a fresh link with a
+  // fresh passcode, so land them on the create form with the toggle already on.
+  const handleResetLink = useCallback(async () => {
+    await handleStopSharing();
+    setRequirePasscode(true);
+  }, [handleStopSharing]);
+
   const handleClose = useCallback(() => {
     if (!busyRef.current) onClose();
   }, [onClose]);
@@ -383,7 +391,7 @@ export function ShareDialog({
               type="button"
               className="primary-action share-unshare"
               disabled={busy}
-              onClick={() => setConfirmStop(true)}
+              onClick={() => setConfirmAction("stop")}
             >
               Stop sharing
             </button>
@@ -462,34 +470,89 @@ export function ShareDialog({
           ) : null}
           {hasLink && shareUrl ? (
             <div className="share-link-block">
-              <CopyLinkField
-                value={shareUrl}
-                label={`Share link for ${item.title || `Untitled ${itemNoun}`}`}
-                copied={copied === "link"}
-                disabled={busy || copying}
-                onCopy={() => void handleCopyLink()}
-              />
+              {passwordProtected ? (
+                <DialogField label="Link" htmlFor="share-link-url">
+                  <CopyLinkField
+                    id="share-link-url"
+                    value={shareUrl}
+                    label={`Share link for ${item.title || `Untitled ${itemNoun}`}`}
+                    copied={copied === "link"}
+                    disabled={busy || copying}
+                    onCopy={() => void handleCopyLink()}
+                  />
+                </DialogField>
+              ) : (
+                <CopyLinkField
+                  value={shareUrl}
+                  label={`Share link for ${item.title || `Untitled ${itemNoun}`}`}
+                  copied={copied === "link"}
+                  disabled={busy || copying}
+                  onCopy={() => void handleCopyLink()}
+                />
+              )}
               {passwordProtected && passcode ? (
-                <HoverTip
-                  compact
-                  width={112}
-                  tip={copied === "passcode" ? "Copied" : "Copy passcode"}
-                  forceOpen={copied === "passcode"}
-                  suppressed={busy || copying}
-                  className="share-link-copy-passcode-tip"
-                >
+                <DialogField label="Passcode" htmlFor="share-passcode-view">
+                  <div className="copy-link-field share-passcode-field">
+                    <input
+                      id="share-passcode-view"
+                      className="copy-link-url share-passcode-value"
+                      type={revealPasscode ? "text" : "password"}
+                      value={passcode}
+                      readOnly
+                      onFocus={(event) => event.currentTarget.select()}
+                    />
+                    <button
+                      type="button"
+                      className="icon-button share-passcode-field-reveal"
+                      aria-label={revealPasscode ? "Hide passcode" : "Show passcode"}
+                      aria-pressed={revealPasscode}
+                      onClick={() => setRevealPasscode((value) => !value)}
+                    >
+                      {revealPasscode ? <IconEyeSlash size={16} /> : <IconEyeOpen size={16} />}
+                    </button>
+                    <HoverTip
+                      compact
+                      width={112}
+                      tip={copied === "passcode" ? "Copied" : "Copy passcode"}
+                      forceOpen={copied === "passcode"}
+                      suppressed={busy || copying}
+                      className="copy-link-action-tip"
+                    >
+                      <button
+                        type="button"
+                        className="copy-link-action"
+                        aria-label={copied === "passcode" ? "Passcode copied" : "Copy passcode"}
+                        data-copied={copied === "passcode" ? "true" : undefined}
+                        disabled={busy || copying}
+                        onClick={() => void handleCopyPasscode()}
+                      >
+                        <CopyStateIcon copied={copied === "passcode"} />
+                      </button>
+                    </HoverTip>
+                  </div>
+                </DialogField>
+              ) : null}
+              {passwordProtected && passcode ? (
+                <InlineNotice
+                  tone="warning"
+                  aria-label="One-time passcode notice"
+                  icon={<IconExclamationTriangle size={14} aria-hidden />}
+                  body="This is the only time the passcode is shown. Copy it now and send it separately from the link."
+                />
+              ) : null}
+              {passwordProtected && !passcode ? (
+                <p className="share-dialog-caption">
+                  The passcode can't be shown again. To set a new one,{" "}
                   <button
                     type="button"
-                    className="share-link-copy-passcode"
-                    aria-label={copied === "passcode" ? "Passcode copied" : "Copy passcode"}
-                    data-copied={copied === "passcode" ? "true" : undefined}
-                    disabled={busy || copying}
-                    onClick={() => void handleCopyPasscode()}
+                    className="share-passcode-reset"
+                    disabled={busy}
+                    onClick={() => setConfirmAction("reset")}
                   >
-                    <CopyStateIcon copied={copied === "passcode"} />
-                    Copy passcode
+                    reset this link
                   </button>
-                </HoverTip>
+                  .
+                </p>
               ) : null}
             </div>
           ) : null}
@@ -505,13 +568,17 @@ export function ShareDialog({
         </div>
       </Dialog>
       <ConfirmDialog
-        open={confirmStop}
-        onClose={() => setConfirmStop(false)}
-        onConfirm={handleStopSharing}
-        title="Stop sharing"
-        description={`This shared ${itemNoun} will stop opening for everyone. This cannot erase content people already viewed or copied.`}
-        confirmLabel="Stop sharing"
-        confirmBusyLabel="Stopping..."
+        open={confirmAction !== null}
+        onClose={() => setConfirmAction(null)}
+        onConfirm={confirmAction === "reset" ? handleResetLink : handleStopSharing}
+        title={confirmAction === "reset" ? "Reset link" : "Stop sharing"}
+        description={
+          confirmAction === "reset"
+            ? "The current link will stop opening for everyone. You can then create a new link with a new passcode."
+            : `This shared ${itemNoun} will stop opening for everyone. This cannot erase content people already viewed or copied.`
+        }
+        confirmLabel={confirmAction === "reset" ? "Reset link" : "Stop sharing"}
+        confirmBusyLabel={confirmAction === "reset" ? "Resetting..." : "Stopping..."}
         destructive
       />
     </>

--- a/src/components/ui/CopyLinkField.tsx
+++ b/src/components/ui/CopyLinkField.tsx
@@ -7,16 +7,19 @@ export function CopyLinkField({
   copied,
   disabled = false,
   onCopy,
+  id,
 }: {
   value: string;
   label: string;
   copied: boolean;
   disabled?: boolean;
   onCopy: () => void;
+  id?: string;
 }) {
   return (
     <div className="copy-link-field">
       <input
+        id={id}
         className="copy-link-url"
         value={value}
         readOnly

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -27770,7 +27770,8 @@ button.connector-approvals-info {
 
 /* ---- Share dialog (JUN-308) -------------------------------------------- */
 /* Owner-side private sharing: a settings-style passcode option before the link
- * exists, then one quiet link field directly in the dialog once it does. */
+ * exists, then the link field (plus a one-time passcode field while the
+ * passcode is still in memory) directly in the dialog once it does. */
 
 .share-dialog-body {
   display: flex;
@@ -27849,28 +27850,35 @@ button.connector-approvals-info {
   gap: var(--sp-3);
 }
 
-.share-link-copy-passcode-tip {
-  align-self: flex-start;
-  display: inline-flex;
+/* One-time passcode field, right after link creation: the same field recipe as
+ * the link above it so the two secrets read as one pair. Masked by default —
+ * the share dialog is often open mid-meeting with the screen visible — with
+ * the same reveal toggle as the passcode input that preceded it. */
+.share-passcode-field .share-passcode-value {
+  font-family: var(--font-mono);
 }
 
-.share-link-copy-passcode {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--sp-1);
-  min-height: var(--control-xs);
-  padding: 0 var(--sp-2);
+.share-passcode-field-reveal {
+  flex: 0 0 auto;
+}
+
+/* Inline action inside the reopened-dialog caption: same quiet underline
+ * recipe as .settings-row-action, flowing with the sentence around it. */
+.share-passcode-reset {
+  padding: 0;
   border: 0;
-  border-radius: var(--r-sm);
   background: transparent;
   color: var(--muted-foreground);
   font: inherit;
-  font-size: var(--fs-md);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklch, var(--muted-foreground) 30%, transparent);
+  text-underline-offset: 3px;
   cursor: pointer;
 }
 
-.share-link-copy-passcode:hover {
-  background: var(--muted);
+.share-passcode-reset:hover:not(:disabled) {
+  color: var(--foreground);
+  text-decoration-color: var(--foreground);
 }
 
 .share-unshare {

--- a/src/test/share-dialog.test.tsx
+++ b/src/test/share-dialog.test.tsx
@@ -236,6 +236,35 @@ describe("ShareDialog", () => {
     expect(screen.getByLabelText("Passcode")).toHaveValue("");
   });
 
+  it("surfaces a reset failure without tearing down the link", async () => {
+    const saltB64 = "AQEBAQEBAQEBAQEBAQEBAQ";
+    mocks.shareKeyGet.mockResolvedValue({ shareId: "shr_1", contentKeyB64: saltB64 });
+    mocks.shareGet.mockResolvedValue({
+      shareId: "shr_1",
+      kind: "note",
+      invites: [{ inviteId: "shi_link", email: "link@share.invalid", state: "pending" }],
+    });
+    mocks.shareInviteKeysGet.mockResolvedValue([{ inviteId: "shi_link", inviteKeyB64: saltB64 }]);
+    mocks.shareDelete.mockRejectedValueOnce(new Error("delete failed"));
+    const user = userEvent.setup();
+    render(<ShareDialog open onClose={vi.fn()} item={noteItem()} />);
+
+    await screen.findByRole("textbox", { name: /Share link for/i });
+
+    await user.click(screen.getByRole("button", { name: "reset this link" }));
+    await user.click(screen.getByRole("button", { name: "Reset link" }));
+
+    // The confirm dialog closes so the error notice underneath is visible.
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Reset link" })).not.toBeInTheDocument(),
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent(/delete failed/i);
+    // The share was not torn down locally, so the link stays available for retry
+    // and the create form (with its passcode toggle) never appears.
+    expect(screen.getByRole("textbox", { name: /Share link for/i })).toBeInTheDocument();
+    expect(screen.queryByRole("switch", { name: "Require a passcode" })).not.toBeInTheDocument();
+  });
+
   it("keeps a created link available when automatic copy fails", async () => {
     mocks.shareCreate.mockResolvedValue({
       shareId: "shr_1",

--- a/src/test/share-dialog.test.tsx
+++ b/src/test/share-dialog.test.tsx
@@ -151,6 +151,7 @@ describe("ShareDialog", () => {
 
     await user.click(await screen.findByRole("switch", { name: "Require a passcode" }));
     await user.type(screen.getByLabelText("Passcode"), "correct horse battery staple");
+    await user.click(screen.getByRole("button", { name: "Show passcode" }));
     await user.click(screen.getByRole("button", { name: "Create link" }));
 
     const linkField = (await screen.findByRole("textbox", {

--- a/src/test/share-dialog.test.tsx
+++ b/src/test/share-dialog.test.tsx
@@ -162,6 +162,19 @@ describe("ShareDialog", () => {
     expect(mocks.shareInviteKeySave.mock.calls[0][0].inviteKeyB64).toBe(fragment[3]);
     await waitFor(() => expect(clipboard).toHaveBeenCalledWith(linkField.value));
     expect(screen.getByText(/June never stores the passcode/i)).toBeInTheDocument();
+    expect(screen.getByText(/only time the passcode is shown/i)).toBeInTheDocument();
+
+    expect(screen.getByText("Link")).toBeInTheDocument();
+    const passcodeField = screen.getByLabelText("Passcode") as HTMLInputElement;
+    expect(passcodeField).toHaveAttribute("readonly");
+    expect(passcodeField).toHaveAttribute("type", "password");
+    expect(passcodeField.value).toBe("correct horse battery staple");
+    expect(passcodeField.closest(".copy-link-field")).not.toBeNull();
+    expect(passcodeField.closest(".dialog-field")).not.toBeNull();
+    await user.click(screen.getByRole("button", { name: "Show passcode" }));
+    expect(passcodeField).toHaveAttribute("type", "text");
+    await user.click(screen.getByRole("button", { name: "Hide passcode" }));
+    expect(passcodeField).toHaveAttribute("type", "password");
 
     let finishPasscodeCopy: () => void = () => {};
     clipboard.mockImplementationOnce(
@@ -179,10 +192,48 @@ describe("ShareDialog", () => {
     await waitFor(() => expect(clipboard).toHaveBeenLastCalledWith("correct horse battery staple"));
     const copiedPasscodeButton = screen.getByRole("button", { name: "Passcode copied" });
     expect(copiedPasscodeButton).toBeEnabled();
-    expect(copiedPasscodeButton).toHaveTextContent("Copy passcode");
+    expect(copiedPasscodeButton).toHaveTextContent("");
     expect(copiedPasscodeButton.querySelector(".t-icon-swap")).toHaveAttribute("data-state", "b");
     fireEvent.focus(copiedPasscodeButton);
     expect(screen.getByRole("tooltip")).toHaveTextContent("Copied");
+  });
+
+  it("explains a reopened passcode link without pretending to have the passcode", async () => {
+    // A 16-byte stored material marks the link as passcode-protected; the
+    // passcode itself was never stored, so the dialog can only explain that.
+    const saltB64 = "AQEBAQEBAQEBAQEBAQEBAQ";
+    mocks.shareKeyGet.mockResolvedValue({ shareId: "shr_1", contentKeyB64: saltB64 });
+    mocks.shareGet.mockResolvedValue({
+      shareId: "shr_1",
+      kind: "note",
+      invites: [{ inviteId: "shi_link", email: "link@share.invalid", state: "pending" }],
+    });
+    mocks.shareInviteKeysGet.mockResolvedValue([{ inviteId: "shi_link", inviteKeyB64: saltB64 }]);
+    const user = userEvent.setup();
+    render(<ShareDialog open onClose={vi.fn()} item={noteItem()} />);
+
+    const linkField = (await screen.findByRole("textbox", {
+      name: /Share link for/i,
+    })) as HTMLInputElement;
+    expect(linkField.value).toContain("#link.shi_link.pass.");
+    expect(screen.getByText("Link")).toBeInTheDocument();
+    expect(screen.getByText(/link and passcode/i)).toBeInTheDocument();
+    expect(screen.getByText(/The passcode can't be shown again/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Passcode")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy passcode" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/only time the passcode is shown/i)).not.toBeInTheDocument();
+
+    // The caption's inline action resets the link: confirm, stop the old
+    // share, and land on the create form with the passcode toggle pre-armed.
+    await user.click(screen.getByRole("button", { name: "reset this link" }));
+    expect(
+      screen.getByText(/You can then create a new link with a new passcode/i),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Reset link" }));
+    await waitFor(() => expect(mocks.shareDelete).toHaveBeenCalledWith("shr_1"));
+    expect(await screen.findByRole("button", { name: "Create link" })).toBeEnabled();
+    expect(screen.getByRole("switch", { name: "Require a passcode" })).toBeChecked();
+    expect(screen.getByLabelText("Passcode")).toHaveValue("");
   });
 
   it("keeps a created link available when automatic copy fails", async () => {


### PR DESCRIPTION
## Summary

- After creating a passcode-protected share link, the passcode gets a first-class field directly under the link field: masked by default with the same reveal toggle as the passcode input, mono value, and its own copy button - replacing the small "Copy passcode" text button.
- A warning-tone notice under the pair states this is the only time the passcode is shown and to send it separately from the link (June never stores the passcode, so it is unrecoverable once the dialog closes).
- Both fields get "Link" / "Passcode" labels (via the existing `DialogField` primitive) so the two identically-styled rows are distinguishable; plain non-passcode shares keep the original single unlabeled field.
- Reopening the dialog on a passcode-protected link now explains the absence instead of silently dropping the button: "The passcode can't be shown again. To set a new one, reset this link." - where "reset this link" is an inline action that opens a reset-specific confirm dialog, stops the old share, and lands on the create form with the passcode toggle pre-armed.
- `CopyLinkField` gains an optional `id` prop for label association; the stop-sharing confirm state generalizes to `confirmAction: "stop" | "reset"` driving both confirm variants.

## Validation

- `share-dialog.test.tsx`: 13/13 green, including new coverage for the one-time field (masked default, reveal toggle, labels), the reopen caption, and the full reset flow (confirm → `shareDelete` → create form with toggle armed).
- `pnpm typecheck` and `pnpm check` clean.

- [x] Tested visually where it matters (both dialog states walked through in the browser during design review; screenshots reviewed in-session).
- [ ] Needs a June API (backend) deploy before it works end to end. (Frontend-only; uses existing share endpoints.)

## Out of scope

- Changing a passcode in place (re-wrapping the stored content key under a new passcode-derived key without stopping the share). The crypto supports it since the content key is stored locally; the reset path covers the need for now.
- A combined "copy link + passcode" action - deliberately rejected because it undermines the "send it separately" guidance the dialog itself gives.

## Followups

- None planned. If in-place passcode change becomes worth it, the reset confirm flow is the natural place to swap it in.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs. (No workflow changes.)
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. (None.)
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (None.)
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787294069&installation_model_id=425925&pr_number=894&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F894&signature=fde524ef5bbac51ae22d2f0fd18fc13a974a4677d507855fa5c4987b915a3603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<img width="2360" height="1560" alt="CleanShot 2026-07-22 at 00 48 29@2x" src="https://github.com/user-attachments/assets/036ac73b-6d85-4119-925b-6cf8118226f9" />


<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->