### PR TITLE
Require promoted RC source commits on main

### DIFF
--- a/.github/workflows/promote-desktop.yml
+++ b/.github/workflows/promote-desktop.yml
@@ -13,6 +13,11 @@ on:
         description: "RC version to promote (e.g. 0.0.25-rc.1). Must match the version the rc release currently holds."
         required: true
         type: string
+      allow-non-main:
+        description: "Emergency override: allow promotion when the RC source commit is not on main"
+        required: true
+        default: false
+        type: boolean
       macos-runner:
         description: "Runner for the signed macOS build"
         required: true
@@ -128,6 +133,45 @@ jobs:
             fi
             node scripts/extension-release.mjs "${args[@]}"
           fi
+
+      - name: Require RC source commit on main
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SOURCE_COMMIT: ${{ steps.rc.outputs.source_commit }}
+          ALLOW_NON_MAIN: ${{ inputs.allow-non-main }}
+          TRIGGERED_BY: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          compare_status="$(gh api \
+            "repos/open-software-network/os-june/compare/${SOURCE_COMMIT}...main" \
+            --jq .status)"
+          if [ "$compare_status" = "ahead" ] || [ "$compare_status" = "identical" ]; then
+            echo "RC source commit $SOURCE_COMMIT is an ancestor of main."
+            exit 0
+          fi
+
+          if [ "$ALLOW_NON_MAIN" = "true" ]; then
+            echo "::warning title=NON-MAIN RC PROMOTION::Emergency override enabled by $TRIGGERED_BY: $SOURCE_COMMIT is not an ancestor of main (compare status: $compare_status)."
+            {
+              echo "## ⚠️ Non-main RC promotion override"
+              echo
+              echo "- Source commit: \`$SOURCE_COMMIT\`"
+              echo "- Compare status against \`main\`: \`$compare_status\`"
+              echo "- Triggered by: \`$TRIGGERED_BY\`"
+              echo "- Promotion is continuing because \`allow-non-main\` was enabled."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::error title=RC source commit is not on main::$SOURCE_COMMIT is not an ancestor of main (compare status: $compare_status). Merge or backport it to main, then retry promotion."
+          {
+            echo "### Promotion blocked: RC source commit is not on main"
+            echo
+            echo "- Source commit: \`$SOURCE_COMMIT\`"
+            echo "- Compare status against \`main\`: \`$compare_status\`"
+            echo "- Merge or backport the RC source commit to \`main\`, then retry promotion."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
 
       # Configuration is required exactly when the RC froze extension work:
       # promoting a correlated submission without store credentials would

--- a/.github/workflows/rc-desktop-dmg.yml
+++ b/.github/workflows/rc-desktop-dmg.yml
@@ -63,6 +63,19 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
 
+      - name: Warn when building rc away from main
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: |
+          set -euo pipefail
+          echo "::warning title=RC BUILD FROM NON-MAIN REF::Building an RC from $GITHUB_REF at $GITHUB_SHA. This is allowed for firefights, but stable promotion will require the source commit on main or an emergency override."
+          {
+            echo "### ⚠️ RC built from a non-main ref"
+            echo
+            echo "- Dispatched ref: \`$GITHUB_REF\`"
+            echo "- Source commit: \`$GITHUB_SHA\`"
+            echo "- This is allowed for firefights. Stable promotion requires this commit on \`main\` unless \`allow-non-main\` is enabled."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm
 


### PR DESCRIPTION
## Summary

- Block stable desktop promotion unless the source commit recorded in `rc-build.json` is an ancestor of live `main`.
- Add a default-off `allow-non-main` emergency override that emits a prominent workflow warning and step summary.
- Warn without blocking when an RC build is dispatched from a ref other than `main`.

## Root cause

Stable promotion trusted the RC's immutable source commit but did not verify that commit had landed on `main`. An RC cut from a firefight branch could therefore be promoted while production contained commits absent from the canonical branch.

## Validation

- `actionlint -ignore 'label ".*" is unknown' .github/workflows/promote-desktop.yml .github/workflows/rc-desktop-dmg.yml`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/test/hermes-macos-bundle.test.ts` (6 passed)
- Exercised the GitHub compare API against live `main`: the current tip returned `identical` and its parent returned `ahead`.
- `make local-ci` (frontend and macOS Rust signoffs posted as not applicable)

- [x] Tested visually where it matters (N/A: workflow-only change with no UI).
- [ ] Needs a June API (backend) deploy before it works end to end. No: this only changes GitHub Actions release workflows.

## Out of scope

- Blocking RC builds from non-main refs; that remains a sanctioned firefight path and now warns only.
- Changing the stable rebuild or release publication flow after the new preflight guard passes.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions (N/A: no app UI copy).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787302681&installation_model_id=425925&pr_number=897&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F897&signature=5b74800d105797bc14a97264b107c411802c254e298113108e4a4824118ad6e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->