### PR TITLE
Fix Swift runtime linking for macOS release checks

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -18,6 +18,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=JUNE_API_URL");
     if std::env::var("CARGO_CFG_TARGET_OS").ok().as_deref() == Some("macos") {
         println!("cargo:rustc-link-lib=framework=AVFoundation");
+        link_swift_runtime();
     }
     clean_legacy_helper_bundles();
     build_system_audio_helper();
@@ -28,6 +29,43 @@ fn main() {
     ensure_bundled_extension_dir();
     ensure_nm_shim_placeholder();
     tauri_build::build();
+}
+
+/// Swift-backed dependencies emit their runtime search paths from dependency
+/// build scripts, but those linker arguments do not reach this package's final
+/// binaries. Resolve the active toolchain through `xcrun` so both full Xcode
+/// and Command Line Tools layouts work without runner-specific paths.
+fn link_swift_runtime() {
+    println!("cargo:rerun-if-env-changed=DEVELOPER_DIR");
+    println!("cargo:rerun-if-env-changed=TOOLCHAINS");
+    println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
+
+    let Ok(output) = std::process::Command::new("xcrun")
+        .args(["--find", "swiftc"])
+        .output()
+    else {
+        println!("cargo:warning=could not resolve swiftc; Swift runtime rpath is incomplete");
+        return;
+    };
+    if !output.status.success() {
+        println!("cargo:warning=xcrun could not resolve swiftc; Swift runtime rpath is incomplete");
+        return;
+    }
+
+    let swiftc = std::path::PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+    let Some(toolchain_usr) = swiftc.parent().and_then(std::path::Path::parent) else {
+        println!(
+            "cargo:warning=swiftc path has no toolchain root; Swift runtime rpath is incomplete"
+        );
+        return;
+    };
+    for relative in ["lib/swift-5.5/macosx", "lib/swift/macosx"] {
+        let runtime = toolchain_usr.join(relative);
+        if runtime.is_dir() {
+            println!("cargo:rustc-link-search=native={}", runtime.display());
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{}", runtime.display());
+        }
+    }
 }
 
 /// `tauri_build::build()` validates resource source directories during every

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -40,32 +40,37 @@ fn link_swift_runtime() {
     println!("cargo:rerun-if-env-changed=TOOLCHAINS");
     println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
 
-    let Ok(output) = std::process::Command::new("xcrun")
+    let output = std::process::Command::new("xcrun")
         .args(["--find", "swiftc"])
         .output()
-    else {
-        println!("cargo:warning=could not resolve swiftc; Swift runtime rpath is incomplete");
-        return;
-    };
-    if !output.status.success() {
-        println!("cargo:warning=xcrun could not resolve swiftc; Swift runtime rpath is incomplete");
-        return;
-    }
+        .unwrap_or_else(|error| {
+            panic!("failed to run `xcrun --find swiftc`; Swift runtime rpath is required: {error}")
+        });
+    assert!(
+        output.status.success(),
+        "`xcrun --find swiftc` failed; Swift runtime rpath is required: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
 
     let swiftc = std::path::PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
-    let Some(toolchain_usr) = swiftc.parent().and_then(std::path::Path::parent) else {
-        println!(
-            "cargo:warning=swiftc path has no toolchain root; Swift runtime rpath is incomplete"
-        );
-        return;
-    };
+    let toolchain_usr = swiftc
+        .parent()
+        .and_then(std::path::Path::parent)
+        .unwrap_or_else(|| panic!("swiftc path has no toolchain root: {}", swiftc.display()));
+    let mut linked_runtime = false;
     for relative in ["lib/swift-5.5/macosx", "lib/swift/macosx"] {
         let runtime = toolchain_usr.join(relative);
         if runtime.is_dir() {
+            linked_runtime = true;
             println!("cargo:rustc-link-search=native={}", runtime.display());
             println!("cargo:rustc-link-arg=-Wl,-rpath,{}", runtime.display());
         }
     }
+    assert!(
+        linked_runtime,
+        "active Swift toolchain has no supported macOS runtime directory: {}",
+        toolchain_usr.display()
+    );
 }
 
 /// `tauri_build::build()` validates resource source directories during every


### PR DESCRIPTION
## Summary

- Link the Swift runtime search paths into June's final macOS binaries instead of relying on dependency build-script linker arguments that do not propagate.
- Resolve the active Swift toolchain through `xcrun --find swiftc`, supporting both full Xcode and Command Line Tools layouts without a runner-specific path.

## Root cause

The 0.0.36-rc.1 release run failed during `pnpm test:rust` because the `june-computer-use-driver` unit-test binary referenced `@rpath/libswift_Concurrency.dylib` but had no rpath for either `/usr/lib/swift` or the active Xcode Swift runtime. The Swift-backed `screencapturekit`, `apple-cf`, and `apple-metal` dependencies emit their own rpath directives, but dependency-level linker arguments do not reach June's final test binary. On the self-hosted runner, dyld therefore aborted the binary with SIGABRT before its tests could start.

## Validation

- `env -u DEVELOPER_DIR -u RUSTFLAGS cargo test --manifest-path src-tauri/Cargo.toml --bin june-computer-use-driver --locked` (12 passed; proves the fix stands alone)
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer RUSTFLAGS='-C link-arg=-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx' cargo test --manifest-path src-tauri/Cargo.toml --bin june-computer-use-driver --locked` (12 passed)
- `env -u DEVELOPER_DIR -u RUSTFLAGS make tauri-fmt-check tauri-lint tauri-test` (green; 1,301 library tests plus all driver and integration suites)
- `pnpm typecheck` (green)
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` (204 files, 3,374 passed, 2 skipped, 0 failed)
- `actionlint -ignore 'label "blacksmith-[^"]+" is unknown' .github/workflows/rc-desktop-dmg.yml` (green; the repo-wide default run has pre-existing custom-runner-label and unrelated ShellCheck findings)
- Local self-review: minimal build-only diff; no material Standards, Spec, or adversarial findings.

- [x] Tested visually where it matters (not applicable: build-only change with no UI surface).
- [ ] Needs a June API (backend) deploy before it works end to end. No deploy is needed.

## Out of scope

- Changing release-runner Xcode selection or hardcoding a runner filesystem path.
- Editing the Computer use driver protocol or helper sources.
- Re-running or publishing the release candidate.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. (Not applicable: link configuration only.)
- [x] Workflow action references are pinned to full-length commit SHAs. (No workflow action references changed.)
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. (Owner review pending.)
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (Not applicable.)
- [x] User-facing copy follows the repo UI conventions. (No user-facing copy changed.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787305214&installation_model_id=425925&pr_number=899&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F899&signature=3944beea5b64d2d6d19e4a7b3c51d5854f5e41245d3865ebdedd0a5449ad6639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->