### PR TITLE
Hide Computer use under Advanced

### DIFF
--- a/src/components/settings/ConnectorsSection.tsx
+++ b/src/components/settings/ConnectorsSection.tsx
@@ -45,6 +45,7 @@ import { SettingsPageHeader } from "./AppSettings";
 import { useExperimentalFlags } from "../../lib/experimental-flags";
 import { BrowserUseCapabilityRow } from "./BrowserExtensionSettings";
 import { IconCircleInfo } from "central-icons/IconCircleInfo";
+import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
 
 // Read-only by default: Google gets mail read and calendar read, Linear gets
 // workspace read, GitHub gets repository read. Write scopes are opt-in
@@ -429,6 +430,7 @@ export function ConnectorsSection({
   const [notionDisconnecting, setNotionDisconnecting] = useState(false);
   const [notionConnectOpen, setNotionConnectOpen] = useState(false);
   const [notionDialogMode, setNotionDialogMode] = useState<"connect" | "reconnect">("connect");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const notionOperationIdRef = useRef(0);
   // Linear team-selection dialog: the account id it's open for (null =
   // closed). Kept separate from the fetched team list/selection so a fetch
@@ -1093,7 +1095,25 @@ export function ConnectorsSection({
               setNotionConnectOpen(true);
             }}
           />
-          <ComputerUseControl onOpenModels={onOpenModels} onOpenBilling={onOpenBilling} />
+          <li className="connectors-advanced-row">
+            <button
+              type="button"
+              className="connectors-advanced-toggle"
+              aria-expanded={advancedOpen}
+              onClick={() => setAdvancedOpen((open) => !open)}
+            >
+              <span>Advanced</span>
+              <IconChevronDownSmall
+                size={14}
+                aria-hidden
+                className="connectors-advanced-chevron"
+                data-open={advancedOpen || undefined}
+              />
+            </button>
+          </li>
+          {advancedOpen ? (
+            <ComputerUseControl onOpenModels={onOpenModels} onOpenBilling={onOpenBilling} />
+          ) : null}
         </ul>
       </div>
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -27311,6 +27311,37 @@ button.memory-project:hover {
   background: var(--secondary);
 }
 
+.connectors-advanced-row {
+  display: flex;
+  padding: var(--sp-1) var(--sp-3) var(--sp-2);
+}
+
+.connectors-advanced-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: var(--sp-2) 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  font: inherit;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+}
+
+.connectors-advanced-toggle:hover {
+  color: var(--foreground);
+}
+
+.connectors-advanced-chevron {
+  transition: transform var(--t-fast) var(--ease-out);
+}
+
+.connectors-advanced-chevron[data-open="true"] {
+  transform: rotate(180deg);
+}
+
 /* Brand marks are monochrome (central-icons currentColor), so the tile keeps
  * the quiet surface-subtle wash and the mark renders in foreground — no
  * multicolor logo tiles. */

--- a/src/test/connectors-section.test.tsx
+++ b/src/test/connectors-section.test.tsx
@@ -295,12 +295,19 @@ describe("ConnectorsSection", () => {
     expect(within(row).queryByText("Finish setup")).toBeNull();
   });
 
-  it("presents connected services and Computer use together as plugins", async () => {
+  it("hides Computer use under the Advanced toggle", async () => {
     render(<ConnectorsSection />);
 
     expect(screen.getByRole("heading", { name: "Plugins" })).toBeInTheDocument();
-    expect(screen.getByText("Computer use")).toBeInTheDocument();
+    const advanced = screen.getByRole("button", { name: "Advanced" });
+    expect(advanced).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Computer use")).not.toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Connect Google" })).toBeEnabled();
+
+    await userEvent.click(advanced);
+
+    expect(advanced).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Computer use")).toBeInTheDocument();
   });
 
   it("uses plugin terminology for Obsidian status errors", async () => {


### PR DESCRIPTION
## What changed

- Add a collapsed Advanced disclosure at the bottom of the Plugins list.
- Render the existing Computer use control only after the disclosure is expanded.
- Add focused coverage for the default-hidden and expanded states.

## Why

Computer use is not currently reliable enough to remain a prominent top-level plugin option. This keeps it available without presenting it alongside the primary plugin integrations by default.

## Validation

- `pnpm exec vitest run src/test/connectors-section.test.tsx src/test/computer-use-control.test.tsx` (75 tests passed)
- `pnpm exec tsc --noEmit`
- `pnpm check` (passes with existing repository warnings)
- `pnpm build`
- Live browser walkthrough of the real Plugins component with a mocked Tauri bridge: Advanced starts collapsed, Computer use is absent, expanding reveals exactly one Computer use row, and the clean run reported no console errors.

## QA evidence

The browser walkthrough was visually inspected in both collapsed and expanded states. No video was uploaded because public artifact sharing was not explicitly authorized.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787318462&installation_model_id=425925&pr_number=900&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F900&signature=51b0cfb7ee63e8a1d60745e609bd030201cd907f0379b96bd4270f7e33fabc8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->