### PR TITLE
fix(auth): open links in the default Windows browser

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -150,4 +150,6 @@ windows = { version = "0.61", features = [
     "Win32_System_Com_StructuredStorage",
     "Win32_System_IO",
     "Win32_System_Threading",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
 ] }

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -2133,29 +2133,85 @@ fn random_b64url(bytes: usize) -> String {
     URL_SAFE_NO_PAD.encode(&buf)
 }
 
+#[cfg(target_os = "windows")]
+pub(crate) fn open_in_browser(url: &str) -> Result<(), AppError> {
+    open_with_windows_shell(url, |target| {
+        use windows::{
+            core::{w, PCWSTR},
+            Win32::UI::{Shell::ShellExecuteW, WindowsAndMessaging::SW_SHOWNORMAL},
+        };
+
+        // `target` remains alive for the duration of this synchronous call.
+        let result = unsafe {
+            ShellExecuteW(
+                None,
+                w!("open"),
+                PCWSTR(target.as_ptr()),
+                None,
+                None,
+                SW_SHOWNORMAL,
+            )
+        };
+        result.0 as isize
+    })
+}
+
+#[cfg(not(target_os = "windows"))]
 pub(crate) fn open_in_browser(url: &str) -> Result<(), AppError> {
     let mut command = browser_open_command(url);
     let mut child = command
         .spawn()
         .map_err(|e| AppError::new("browser_open_failed", e.to_string()))?;
-    // Reap the short-lived `open` process off-thread so it doesn't linger as
-    // a zombie until the app exits.
+    // Reap the short-lived platform launcher off-thread so it doesn't linger
+    // as a zombie until the app exits.
     std::thread::spawn(move || {
         let _ = child.wait();
     });
     Ok(())
 }
 
+#[cfg(any(target_os = "windows", test))]
+fn open_with_windows_shell(
+    url: &str,
+    execute: impl FnOnce(&[u16]) -> isize,
+) -> Result<(), AppError> {
+    if url.contains('\0') {
+        return Err(AppError::new(
+            "browser_open_failed",
+            "Browser target contains an embedded NUL",
+        ));
+    }
+
+    let mut target: Vec<u16> = url.encode_utf16().collect();
+    target.push(0);
+    let result = execute(&target);
+    if result > 32 {
+        return Ok(());
+    }
+
+    let reason = match result {
+        0 => "system resource failure",
+        2 => "target path not found",
+        3 => "target path not found",
+        5 => "access denied",
+        8 => "insufficient memory",
+        27 => "incomplete association",
+        28 => "DDE timeout",
+        29 => "DDE transaction failure",
+        30 => "DDE busy",
+        31 => "no registered association",
+        32 => "required DLL unavailable",
+        _ => "shell activation failure",
+    };
+    Err(AppError::new(
+        "browser_open_failed",
+        format!("Could not open browser: {reason} (ShellExecuteW code {result})"),
+    ))
+}
+
 #[cfg(target_os = "macos")]
 fn browser_open_command(url: &str) -> std::process::Command {
     let mut command = std::process::Command::new("open");
-    command.arg(url);
-    command
-}
-
-#[cfg(target_os = "windows")]
-fn browser_open_command(url: &str) -> std::process::Command {
-    let mut command = std::process::Command::new("explorer.exe");
     command.arg(url);
     command
 }
@@ -2170,6 +2226,98 @@ fn browser_open_command(url: &str) -> std::process::Command {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn windows_shell_preserves_complex_browser_target() {
+        let url = format!(
+            "https://accounts.example.test/login?redirect=https%3A%2F%2Fapp.example.test%2Fcallback%3Fa%3D1%26b%3Dtwo&state={}&label=Zażółć🚀%20gęślą",
+            "x".repeat(2048)
+        );
+
+        open_with_windows_shell(&url, |target| {
+            assert_eq!(target.last(), Some(&0));
+            assert!(!target[..target.len() - 1].contains(&0));
+            assert_eq!(
+                String::from_utf16(&target[..target.len() - 1]).unwrap(),
+                url
+            );
+            33
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn windows_shell_preserves_long_browser_target() {
+        let query = "pkce%2Fvalue%26with%3Descapes&part=".repeat(256);
+        let url = format!("https://accounts.example.test/authorize?{query}");
+
+        open_with_windows_shell(&url, |target| {
+            let decoded = String::from_utf16(&target[..target.len() - 1]).unwrap();
+            assert_eq!(decoded.len(), url.len());
+            assert_eq!(decoded, url);
+            33
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn windows_shell_preserves_custom_scheme_target() {
+        let target_url = "ms-settings:privacy-microphone";
+
+        open_with_windows_shell(target_url, |target| {
+            assert_eq!(target.last(), Some(&0));
+            assert_eq!(
+                String::from_utf16(&target[..target.len() - 1]).unwrap(),
+                target_url
+            );
+            33
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn windows_shell_rejects_embedded_nul_without_executing() {
+        let error = open_with_windows_shell("https://example.test/\0secret", |_| {
+            panic!("executor must not be called")
+        })
+        .unwrap_err();
+
+        assert_eq!(error.code, "browser_open_failed");
+        assert!(error.message.contains("embedded NUL"));
+    }
+
+    #[test]
+    fn windows_shell_classifies_result_boundaries() {
+        assert!(open_with_windows_shell("https://example.test", |_| 33).is_ok());
+
+        for (code, expected_reason) in [
+            (32, "required DLL unavailable"),
+            (31, "no registered association"),
+            (0, "system resource failure"),
+            (26, "shell activation failure"),
+        ] {
+            let error = open_with_windows_shell("https://example.test", |_| code).unwrap_err();
+            assert_eq!(error.code, "browser_open_failed");
+            assert!(error.message.contains(expected_reason));
+            assert!(error.message.contains(&format!("code {code}")));
+        }
+    }
+
+    #[test]
+    fn windows_shell_failure_does_not_expose_browser_target() {
+        let secret = "oauth-secret-do-not-log";
+        let url = format!("https://example.test/login?token={secret}");
+        let error = open_with_windows_shell(&url, |_| 31).unwrap_err();
+
+        assert_eq!(error.code, "browser_open_failed");
+        assert!(!error.message.contains(&url));
+        assert!(!error.message.contains(secret));
+        assert!(error
+            .details
+            .as_ref()
+            .map(|details| !details.to_string().contains(secret))
+            .unwrap_or(true));
+    }
 
     fn account_status_for_plan(
         plan: Option<&str>,


### PR DESCRIPTION
## Summary

- Open Windows authentication, connector OAuth, billing, and external links through the registered default browser.
- Use `ShellExecuteW` directly so query-heavy URLs and trusted custom schemes remain intact without a command-shell parsing layer.
- Preserve the existing macOS and Linux launcher behavior.

## Root cause

The shared Windows `open_in_browser` helper launched URLs through `explorer.exe`. Windows could route that invocation to File Explorer instead of the registered browser, preventing OS Accounts sign-in and other browser handoffs from opening correctly.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- Warning-strict library Clippy passed after suppressing known unrelated warning classes already present on Windows.
- `node scripts/tauri-build.mjs --debug --no-sign` produced the Windows executable and NSIS bundle.
- High-stakes review battery passed Standards, Spec, and two independent adversarial reviews with no actionable findings.
- Focused Rust test compilation succeeded, but test execution is blocked in this checkout by the existing Windows `STATUS_ENTRYPOINT_NOT_FOUND` runner issue. The full Rust test target also encounters existing Unix-only `libc::kill` and `SIGKILL` usage in `tests/managed_browser.rs`.
- Live packaged-app checks for the default browser, `ms-settings:privacy-microphone`, connector OAuth, and console flashing remain pending.

- [ ] Tested visually where it matters. Live Windows browser handoff verification remains pending.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is required.

## Out of scope

- URL construction, OAuth state and PKCE handling, callback behavior, billing behavior, and connector behavior.
- macOS and Linux launcher behavior.
- Changes to the public external-link scheme policy.
- Existing Windows Rust test-runner failures.

## Followups

- Complete the packaged Windows browser, OS Accounts login, connector OAuth, Settings custom-scheme, and no-console-flash walkthrough before marking the PR ready.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such behavior changed.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend behavior changed.
- [x] User-facing copy follows the repo UI conventions. No UI copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787324926&installation_model_id=425925&pr_number=902&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F902&signature=7459d2ad890f8c3f3d0194699209fd8e4902299688cc00042d4b37af555a491e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->