### PR TITLE
Fix duplicate updater failure wording

### DIFF
--- a/src/app/update-decision.ts
+++ b/src/app/update-decision.ts
@@ -209,5 +209,5 @@ function normalizeNotes(notes?: string) {
 function messageFromUnknown(error: unknown) {
   if (error instanceof Error) return error.message;
   if (typeof error === "string") return error;
-  return "Update failed.";
+  return "An unknown error occurred.";
 }

--- a/src/test/update-decision.test.ts
+++ b/src/test/update-decision.test.ts
@@ -155,6 +155,24 @@ describe("checkForJuneUpdate", () => {
     expect(prompt).not.toHaveBeenCalled();
     expect(reportFailure).toHaveBeenCalledWith("signature mismatch");
   });
+
+  it("uses neutral detail for an unstructured failure", async () => {
+    const reportFailure = vi.fn();
+
+    await checkForJuneUpdate(
+      {
+        check: async () => {
+          throw {};
+        },
+        prompt: vi.fn(),
+        reportNoUpdate: vi.fn(),
+        reportFailure,
+      },
+      "manual",
+    );
+
+    expect(reportFailure).toHaveBeenCalledWith("An unknown error occurred.");
+  });
 });
 
 describe("startPeriodicJuneUpdateChecks", () => {
@@ -238,5 +256,23 @@ describe("prepareJuneUpdate", () => {
       version: "0.2.0",
       notes: "Ready after relaunch.",
     });
+  });
+
+  it("uses neutral detail for an unstructured install failure", async () => {
+    const reportFailure = vi.fn();
+
+    await prepareJuneUpdate({
+      update: {
+        ...update(),
+        downloadAndInstall: async () => {
+          throw {};
+        },
+      },
+      reportProgress: vi.fn(),
+      reportReady: vi.fn(),
+      reportFailure,
+    });
+
+    expect(reportFailure).toHaveBeenCalledWith("An unknown error occurred.");
   });
 });


### PR DESCRIPTION
## What changed

- use neutral fallback detail when the updater rejects with an unstructured value
- cover both update checks and update preparation with regression tests

## Why

The UI adds an operation-specific prefix to updater errors. The old generic fallback already said "Update failed.", producing "Update failed: Update failed." in the sidebar banner.

## Validation

- pnpm exec vitest run src/test/update-decision.test.ts (13 passed)
- pnpm test -- src/test/update-decision.test.ts (full frontend suite: 3,382 passed, 2 skipped)
- pnpm exec biome check src/app/update-decision.ts src/test/update-decision.test.ts
- pnpm check (passes with existing baseline warnings outside changed files)
- pnpm build

## Live walkthrough

BLOCKED: the updater failure depends on native updater behavior. The isolated browser preview reached unrelated native bootstrap contracts before the dev update-card driver could park the state. No real update, relaunch, accounts, or permissions were exercised. The exact unstructured error paths are covered deterministically for both checking and preparation.

## Known gaps

- No native updater failure was forced because doing so would require an unreliable external updater failure or a broader fake backend.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787326834&installation_model_id=425925&pr_number=903&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F903&signature=73f3f849681e330485afd6620cbf55bc43200b5a458378fb1bb1b9bc7d6179fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->