### PR TITLE
Fix updater relaunch freeze

### DIFF
--- a/src-tauri/src/updates.rs
+++ b/src-tauri/src/updates.rs
@@ -270,13 +270,21 @@ pub async fn install_update(
 /// CGEventTap and its stdio — and the relaunched instance then cannot bring up a
 /// clean helper, so every helper-reported permission (dictation mic and
 /// accessibility) reads missing even though the grants are intact (JUN-338).
-/// Tearing down explicitly here guarantees the helper (and the Hermes runtime)
-/// are gone before the new instance starts.
+/// Tearing down explicitly here guarantees the helpers and Hermes runtime are
+/// gone before the new instance starts. The final restart is dispatched to the
+/// main thread so Tauri restarts directly instead of delivering `RunEvent::Exit`
+/// and synchronously repeating the full cleanup on the UI event loop. That
+/// duplicate exit path can leave the window parked in its disabled relaunching
+/// state while a background service is still winding down.
 #[tauri::command]
-pub async fn relaunch_for_update(app: AppHandle) {
+pub async fn relaunch_for_update(app: AppHandle) -> Result<(), AppError> {
     crate::dictation::stop_helper(&app);
+    crate::computer_use::shutdown(&app).await;
     crate::hermes_bridge::shutdown(&app).await;
-    app.restart();
+
+    let restart_app = app.clone();
+    app.run_on_main_thread(move || restart_app.restart())
+        .map_err(|error| AppError::new("update_relaunch_failed", error.to_string()))
 }
 
 #[tauri::command]


### PR DESCRIPTION
## What changed

- Shut down Computer use alongside dictation and Hermes before an update relaunch.
- Dispatch the final Tauri restart on the main thread after cleanup completes.
- Return a structured relaunch error if the main-thread restart cannot be scheduled.

## Why

The updater command previously called `AppHandle::restart()` from its background command thread. Tauri then delivered `RunEvent::Exit` and June synchronously repeated the full cleanup on the UI event loop. That duplicate shutdown could leave the app parked in the disabled relaunching state while background services wound down.

The new sequence performs every owned-service cleanup once, then restarts from the main thread so Tauri does not repeat the blocking exit path.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked updates::tests` (17 passed)
- `pnpm test -- --run src/test/updater.test.ts src/test/update-decision.test.ts` (repo script ran the full suite: 3,380 passed, 2 skipped)

## Live QA

BLOCKED: The local machine had both the installed June app and the development build running under the same macOS app identity. Accessibility control could not safely target the test build without risking interaction with the users real app. No production update was downloaded or installed. The temporary screen recording was deleted because it captured unrelated private desktop content and was not uploaded.

## Known gaps

- A signed production updater package was not installed during local QA.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787326958&installation_model_id=425925&pr_number=904&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F904&signature=c6c4b0834b49704945f26211bcb0498a1bbca6c80ecf6167fe85262610675012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->