### PR TITLE
Speed up low-effort session starts

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -728,6 +728,27 @@ type AgentPanel = "chat" | "skills" | "messaging";
 // survives the workspace remounting on view switches.
 const UNRESTRICTED_ACK_KEY = "june.agent.unrestrictedAcknowledged";
 
+type BackgroundSessionTitleGuard = {
+  token: symbol;
+  deleting?: true;
+  title?: string;
+};
+
+// Background title requests can outlive an AgentWorkspace mount. Keep their
+// cancellation state at module scope so a delete or rename after remount still
+// invalidates the old closure before it writes to Hermes.
+const backgroundSessionTitleGuards = new Map<string, BackgroundSessionTitleGuard>();
+
+function supersedeBackgroundSessionTitle(sessionId: string, title: string) {
+  backgroundSessionTitleGuards.set(sessionId, { token: Symbol("session-title"), title });
+}
+
+function markBackgroundSessionTitleDeleting(sessionId: string) {
+  const guard = { token: Symbol("session-delete"), deleting: true as const };
+  backgroundSessionTitleGuards.set(sessionId, guard);
+  return guard;
+}
+
 function unrestrictedAcknowledged(): boolean {
   try {
     return window.sessionStorage.getItem(UNRESTRICTED_ACK_KEY) === "true";
@@ -3067,7 +3088,6 @@ export function AgentWorkspace({
   const sessionTitleSourceRef = useRef<Record<string, AgentSessionTitleSource>>(
     continuity?.titleSources ?? {},
   );
-  const deletedHermesSessionIdsRef = useRef<Set<string>>(new Set());
   const titleSuggestionSessionIdsRef = useRef<Set<string>>(new Set());
   const titleSuggestionInFlightSessionIdsRef = useRef<Set<string>>(new Set());
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -7564,7 +7584,7 @@ export function AgentWorkspace({
       })().catch(rollbackOptimisticBeforePrompt);
     storedSessionIdForRollback = storedSessionId;
     if (created) {
-      deletedHermesSessionIdsRef.current.delete(storedSessionId);
+      backgroundSessionTitleGuards.delete(storedSessionId);
     }
     if (createdUnderProfile) {
       await assignSessionToProfile(storedSessionId, createdUnderProfile).catch(
@@ -10038,6 +10058,7 @@ export function AgentWorkspace({
     const next = title.trim();
     if (!next) return null;
     rememberSessionManuallyTitled(sessionId);
+    supersedeBackgroundSessionTitle(sessionId, next);
     titleSuggestionSessionIdsRef.current.add(sessionId);
     sessionTitleOverridesRef.current = {
       ...sessionTitleOverridesRef.current,
@@ -10073,7 +10094,7 @@ export function AgentWorkspace({
   // clears messages, pending sends, activity-store state, and live events so a
   // running session doesn't linger as phantom "working" work.
   function removeHermesSessionLocally(sessionId: string, selectNext = true) {
-    deletedHermesSessionIdsRef.current.add(sessionId);
+    markBackgroundSessionTitleDeleting(sessionId);
     cancelAgentRunSettlement(sessionId);
     setHermesSessionItems((current) => {
       const next = current.filter((session) => session.id !== sessionId);
@@ -10107,11 +10128,24 @@ export function AgentWorkspace({
   }
 
   async function deleteSelectedHermesSession(sessionId: string) {
+    const previousTitleGuard = backgroundSessionTitleGuards.get(sessionId);
+    const deletionGuard = markBackgroundSessionTitleDeleting(sessionId);
     try {
       await deleteHermesSession(sessionId);
       // Clearing the selection falls the workspace back to empty.
       removeHermesSessionLocally(sessionId, false);
     } catch (err) {
+      if (backgroundSessionTitleGuards.get(sessionId)?.token === deletionGuard.token) {
+        if (previousTitleGuard) {
+          backgroundSessionTitleGuards.set(sessionId, previousTitleGuard);
+        } else {
+          backgroundSessionTitleGuards.delete(sessionId);
+        }
+      }
+      const latestMessages = hermesSessionMessagesRef.current[sessionId];
+      if (latestMessages) {
+        void suggestTitleForUntitledSession(sessionId, latestMessages);
+      }
       setError(messageFromError(err), { sessionId });
     }
   }
@@ -10128,11 +10162,13 @@ export function AgentWorkspace({
     sessionId: string,
     suggestionPromise: ReturnType<typeof agentSessionTitleForPrompt>,
   ) {
+    const titleGuard = { token: Symbol("initial-session-title") };
+    backgroundSessionTitleGuards.set(sessionId, titleGuard);
     titleSuggestionInFlightSessionIdsRef.current.add(sessionId);
     try {
       const suggestion = await suggestionPromise;
       if (
-        deletedHermesSessionIdsRef.current.has(sessionId) ||
+        backgroundSessionTitleGuards.get(sessionId)?.token !== titleGuard.token ||
         !suggestion.fromModel ||
         titleSuggestionSessionIdsRef.current.has(sessionId) ||
         ["manual", "exchange", "rejected-final"].includes(
@@ -10154,28 +10190,29 @@ export function AgentWorkspace({
         sessions.map((item) => (item.id === sessionId ? { ...item, title } : item));
       hermesSessionItemsRef.current = applyTitle(hermesSessionItemsRef.current);
       setHermesSessionItems((current) => applyTitle(current));
-      void ensureHermesBridgeSession({ sessionId, title })
-        .then(() => {
-          if (deletedHermesSessionIdsRef.current.has(sessionId)) {
-            // The title PATCH raced a successful delete. Remove the session
-            // again in case Hermes handled the late write through its legacy
-            // create-or-update endpoint.
-            void deleteHermesSession(sessionId).catch(() => {});
-            return;
-          }
-          // A manual rename or exchange title can overtake this background
-          // PATCH. Re-assert the newer title so the slow initial request never
-          // wins merely because it finished last.
-          if (sessionTitleSourceRef.current[sessionId] === "prompt") return;
-          const newerTitle = sessionTitleOverridesRef.current[sessionId];
-          if (newerTitle && newerTitle !== title) {
-            void ensureHermesBridgeSession({ sessionId, title: newerTitle }).catch(() => {});
-          }
-        })
-        .catch(() => {});
+      await ensureHermesBridgeSession({ sessionId, title }).catch(() => undefined);
+      const latestGuard = backgroundSessionTitleGuards.get(sessionId);
+      if (latestGuard?.token !== titleGuard.token) {
+        if (latestGuard?.deleting) {
+          // The title PATCH raced a successful delete. Remove the session
+          // again in case Hermes handled the late write through its legacy
+          // create-or-update endpoint.
+          await deleteHermesSession(sessionId).catch((err) => {
+            setError(messageFromError(err), { sessionId });
+          });
+        } else if (latestGuard?.title && latestGuard.title !== title) {
+          // A rename or exchange title overtook this request, possibly from a
+          // newer AgentWorkspace mount. Re-assert the shared latest title.
+          await ensureHermesBridgeSession({
+            sessionId,
+            title: latestGuard.title,
+          }).catch(() => undefined);
+        }
+      }
     } finally {
       titleSuggestionInFlightSessionIdsRef.current.delete(sessionId);
-      if (!deletedHermesSessionIdsRef.current.has(sessionId)) {
+      if (backgroundSessionTitleGuards.get(sessionId)?.token === titleGuard.token) {
+        backgroundSessionTitleGuards.delete(sessionId);
         const latestMessages = hermesSessionMessagesRef.current[sessionId];
         if (latestMessages) {
           void suggestTitleForUntitledSession(sessionId, latestMessages);
@@ -10290,6 +10327,7 @@ export function AgentWorkspace({
               ? "rejected-final"
               : "rejected"
             : "prompt";
+      supersedeBackgroundSessionTitle(sessionId, title);
       sessionTitleOverridesRef.current = {
         ...sessionTitleOverridesRef.current,
         [sessionId]: title,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -3067,6 +3067,7 @@ export function AgentWorkspace({
   const sessionTitleSourceRef = useRef<Record<string, AgentSessionTitleSource>>(
     continuity?.titleSources ?? {},
   );
+  const deletedHermesSessionIdsRef = useRef<Set<string>>(new Set());
   const titleSuggestionSessionIdsRef = useRef<Set<string>>(new Set());
   const titleSuggestionInFlightSessionIdsRef = useRef<Set<string>>(new Set());
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -7562,6 +7563,9 @@ export function AgentWorkspace({
         };
       })().catch(rollbackOptimisticBeforePrompt);
     storedSessionIdForRollback = storedSessionId;
+    if (created) {
+      deletedHermesSessionIdsRef.current.delete(storedSessionId);
+    }
     if (createdUnderProfile) {
       await assignSessionToProfile(storedSessionId, createdUnderProfile).catch(
         rollbackOptimisticBeforePrompt,
@@ -10069,6 +10073,7 @@ export function AgentWorkspace({
   // clears messages, pending sends, activity-store state, and live events so a
   // running session doesn't linger as phantom "working" work.
   function removeHermesSessionLocally(sessionId: string, selectNext = true) {
+    deletedHermesSessionIdsRef.current.add(sessionId);
     cancelAgentRunSettlement(sessionId);
     setHermesSessionItems((current) => {
       const next = current.filter((session) => session.id !== sessionId);
@@ -10096,6 +10101,9 @@ export function AgentWorkspace({
     commitSessionModelSelections(forgetSessionModelSelection(sessionId));
     // Same for the session's thinking-level record.
     forgetSessionThinkingLevel(sessionId);
+    sessionTitleOverridesRef.current = omitRecordKey(sessionTitleOverridesRef.current, sessionId);
+    sessionTitleSourceRef.current = omitRecordKey(sessionTitleSourceRef.current, sessionId);
+    titleSuggestionSessionIdsRef.current.delete(sessionId);
   }
 
   async function deleteSelectedHermesSession(sessionId: string) {
@@ -10124,6 +10132,7 @@ export function AgentWorkspace({
     try {
       const suggestion = await suggestionPromise;
       if (
+        deletedHermesSessionIdsRef.current.has(sessionId) ||
         !suggestion.fromModel ||
         titleSuggestionSessionIdsRef.current.has(sessionId) ||
         ["manual", "exchange", "rejected-final"].includes(
@@ -10147,6 +10156,13 @@ export function AgentWorkspace({
       setHermesSessionItems((current) => applyTitle(current));
       void ensureHermesBridgeSession({ sessionId, title })
         .then(() => {
+          if (deletedHermesSessionIdsRef.current.has(sessionId)) {
+            // The title PATCH raced a successful delete. Remove the session
+            // again in case Hermes handled the late write through its legacy
+            // create-or-update endpoint.
+            void deleteHermesSession(sessionId).catch(() => {});
+            return;
+          }
           // A manual rename or exchange title can overtake this background
           // PATCH. Re-assert the newer title so the slow initial request never
           // wins merely because it finished last.
@@ -10159,9 +10175,11 @@ export function AgentWorkspace({
         .catch(() => {});
     } finally {
       titleSuggestionInFlightSessionIdsRef.current.delete(sessionId);
-      const latestMessages = hermesSessionMessagesRef.current[sessionId];
-      if (latestMessages) {
-        void suggestTitleForUntitledSession(sessionId, latestMessages);
+      if (!deletedHermesSessionIdsRef.current.has(sessionId)) {
+        const latestMessages = hermesSessionMessagesRef.current[sessionId];
+        if (latestMessages) {
+          void suggestTitleForUntitledSession(sessionId, latestMessages);
+        }
       }
     }
   }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -6099,9 +6099,9 @@ export function AgentWorkspace({
       imageSlashBlockedByModel
     )
       return;
-    // This is the user-visible Send boundary. Skill expansion, file reads,
-    // title generation, and session resume can all await; a picker change
-    // during any of them belongs to the following run.
+    // This is the user-visible Send boundary. Skill expansion, file reads, and
+    // session resume can all await; a picker change during any of them belongs
+    // to the following run. Title generation starts here but stays backgrounded.
     const sentModelTarget = captureSessionModelTarget();
     const sentDispatchOrder = ++composerDispatchOrderRef.current;
     const sentDispatchReservation = sentModelTarget.targetStoredSessionId
@@ -7466,14 +7466,14 @@ export function AgentWorkspace({
       ),
       heldVideoContexts,
     );
-    // Issue reports skip title suggestion: the content is the wrapped
-    // investigation prompt, which would title the session after the wrapper.
-    const titlePromise =
-      targetStoredSessionId || options?.issueReport
+    // Start the AI title request early, but never put it on the prompt's
+    // critical path. The session starts with the deterministic fallback and
+    // the suggestion patches it in the background once a stored id exists.
+    // Issue reports and attachment-only sessions already have suitable titles.
+    const initialTitleSuggestionPromise =
+      targetStoredSessionId || options?.issueReport || attachmentOnlyTitle
         ? undefined
-        : attachmentOnlyTitle
-          ? Promise.resolve(attachmentOnlyTitle)
-          : agentSessionTitleForPrompt(titleContent).then((suggestion) => suggestion.title);
+        : agentSessionTitleForPrompt(titleContent);
     const listedTargetSession = targetStoredSessionId
       ? hermesSessionItemsRef.current.find((session) => session.id === targetStoredSessionId)
       : undefined;
@@ -7509,13 +7509,12 @@ export function AgentWorkspace({
     // session's follow-ups.
     const { created, createdUnderProfile, gateway, sessionTitle, storedSessionId } =
       await (async () => {
-        const [nextGateway, nextSessionTitle] = await Promise.all([
+        const [nextGateway] = await Promise.all([
           ensureHermesGateway(
             targetStoredSessionId
               ? sessionUnrestricted(targetStoredSessionId)
               : fullModeDraftRef.current,
           ),
-          titlePromise ?? Promise.resolve(undefined),
           // Re-read the sticky active profile for every brand-new session so an
           // out-of-band switch (Hermes CLI, upstream dashboard) is honored
           // without a workspace remount. Runs in parallel with gateway setup
@@ -7536,7 +7535,7 @@ export function AgentWorkspace({
         const nextCreated = targetStoredSessionId
           ? undefined
           : await nextGateway.request<HermesRuntimeSessionResponse>("session.create", {
-              title: nextSessionTitle ?? fallbackSessionTitle,
+              title: fallbackSessionTitle,
               cols: 96,
               // session.create treats `model` as a per-session override.
               // Under a named profile the override would silently bypass the
@@ -7558,7 +7557,7 @@ export function AgentWorkspace({
           created: nextCreated,
           createdUnderProfile: underProfile ? nextUnderProfileName : undefined,
           gateway: nextGateway,
-          sessionTitle: nextSessionTitle,
+          sessionTitle: fallbackSessionTitle,
           storedSessionId: nextStoredSessionId,
         };
       })().catch(rollbackOptimisticBeforePrompt);
@@ -7618,7 +7617,7 @@ export function AgentWorkspace({
     if (!targetStoredSessionId) {
       rememberSessionMode(storedSessionId, fullModeDraftRef.current);
     }
-    const sessionDisplayTitle = sessionTitle || fallbackSessionTitle;
+    const sessionDisplayTitle = sessionTitle;
     const ensureStoredHermesSession = () =>
       ensureHermesBridgeSession({
         sessionId: storedSessionId,
@@ -7636,6 +7635,9 @@ export function AgentWorkspace({
         title: sessionDisplayTitle,
         toSessionId: storedSessionId,
       });
+    }
+    if (initialTitleSuggestionPromise) {
+      void applyInitialSessionTitleSuggestion(storedSessionId, initialTitleSuggestionPromise);
     }
     if (!targetStoredSessionId && !options?.skipPrompt && !createdUnderProfile) {
       const latestDefaultSelection: SessionModelSelection = {
@@ -7660,21 +7662,6 @@ export function AgentWorkspace({
       commitSessionModelSelections(
         rememberAppliedSessionModelSelection(storedSessionId, targetSessionModelSelection),
       );
-    }
-    if (sessionTitle) {
-      sessionTitleOverridesRef.current = {
-        ...sessionTitleOverridesRef.current,
-        [storedSessionId]: sessionTitle,
-      };
-      sessionTitleSourceRef.current = {
-        ...sessionTitleSourceRef.current,
-        [storedSessionId]: "prompt",
-      };
-      // The mount-time session load races this store: when its merge lands
-      // first, the fetched placeholder title is already rendered and nothing
-      // re-reads the override (the post-submit reload can no-op on a stale
-      // bridge closure). Re-map the current list so the order doesn't matter.
-      setHermesSessionItems((current) => applySessionTitleOverrides(current));
     }
     if (!optimisticSession) {
       await withTimeout(ensureStoredHermesSession(), 2500).catch(() => undefined);
@@ -10127,6 +10114,56 @@ export function AgentWorkspace({
       const title = overrides[session.id];
       return title ? { ...session, title } : session;
     });
+  }
+
+  async function applyInitialSessionTitleSuggestion(
+    sessionId: string,
+    suggestionPromise: ReturnType<typeof agentSessionTitleForPrompt>,
+  ) {
+    titleSuggestionInFlightSessionIdsRef.current.add(sessionId);
+    try {
+      const suggestion = await suggestionPromise;
+      if (
+        !suggestion.fromModel ||
+        titleSuggestionSessionIdsRef.current.has(sessionId) ||
+        ["manual", "exchange", "rejected-final"].includes(
+          sessionTitleSourceRef.current[sessionId] ?? "",
+        )
+      ) {
+        return;
+      }
+      const title = suggestion.title;
+      sessionTitleOverridesRef.current = {
+        ...sessionTitleOverridesRef.current,
+        [sessionId]: title,
+      };
+      sessionTitleSourceRef.current = {
+        ...sessionTitleSourceRef.current,
+        [sessionId]: "prompt",
+      };
+      const applyTitle = (sessions: HermesSessionInfo[]) =>
+        sessions.map((item) => (item.id === sessionId ? { ...item, title } : item));
+      hermesSessionItemsRef.current = applyTitle(hermesSessionItemsRef.current);
+      setHermesSessionItems((current) => applyTitle(current));
+      void ensureHermesBridgeSession({ sessionId, title })
+        .then(() => {
+          // A manual rename or exchange title can overtake this background
+          // PATCH. Re-assert the newer title so the slow initial request never
+          // wins merely because it finished last.
+          if (sessionTitleSourceRef.current[sessionId] === "prompt") return;
+          const newerTitle = sessionTitleOverridesRef.current[sessionId];
+          if (newerTitle && newerTitle !== title) {
+            void ensureHermesBridgeSession({ sessionId, title: newerTitle }).catch(() => {});
+          }
+        })
+        .catch(() => {});
+    } finally {
+      titleSuggestionInFlightSessionIdsRef.current.delete(sessionId);
+      const latestMessages = hermesSessionMessagesRef.current[sessionId];
+      if (latestMessages) {
+        void suggestTitleForUntitledSession(sessionId, latestMessages);
+      }
+    }
   }
 
   async function suggestTitleForUntitledSession(

--- a/src/lib/thinking-level.ts
+++ b/src/lib/thinking-level.ts
@@ -8,8 +8,7 @@
  * medium, high, xhigh). June deliberately exposes only three of them so the
  * choice stays a simple speed/depth tradeoff:
  *
- * - Low -> "minimal": the model barely deliberates, so first tokens arrive
- *   quickly.
+ * - Low -> "none": the model answers without a separate reasoning pass.
  * - Medium -> "medium": Hermes' own default; a balance of speed and depth.
  * - High -> "high": substantially more reasoning for harder problems.
  *
@@ -39,7 +38,7 @@ export const THINKING_LEVELS: readonly ThinkingLevelOption[] = Object.freeze([
     id: "instant",
     label: "Low",
     blurb: "Faster responses with lower usage.",
-    effort: "minimal",
+    effort: "none",
   },
   {
     id: "medium",

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -8013,10 +8013,17 @@ describe("AgentWorkspace", () => {
   it("discards a pending AI title when its new session is deleted", async () => {
     const user = userEvent.setup();
     let resolveTitle: ((value: { title: string }) => void) | undefined;
+    let resolveDelete: (() => void) | undefined;
     mocks.suggestAgentSessionTitle.mockImplementationOnce(
       () =>
         new Promise((resolve) => {
           resolveTitle = resolve;
+        }),
+    );
+    mocks.deleteHermesSession.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
         }),
     );
     window.sessionStorage.setItem(
@@ -8036,6 +8043,61 @@ describe("AgentWorkspace", () => {
     await user.click(screen.getByRole("button", { name: "Session actions" }));
     await user.click(screen.getByRole("menuitem", { name: "Delete session" }));
     await waitFor(() => expect(mocks.deleteHermesSession).toHaveBeenCalledWith("session-2"));
+
+    // The title resolves while the remote delete is still pending. The guard
+    // must already be active, rather than waiting for deletion to finish.
+    await act(async () => {
+      resolveTitle?.({ title: "Startup Latency" });
+      await Promise.resolve();
+    });
+    expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
+      sessionId: "session-2",
+      title: "Startup Latency",
+    });
+    await act(async () => {
+      resolveDelete?.();
+      await Promise.resolve();
+    });
+  });
+
+  it("keeps a pending AI title from crossing a remount and overwriting a rename", async () => {
+    let resolveTitle: ((value: { title: string }) => void) | undefined;
+    mocks.suggestAgentSessionTitle.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveTitle = resolve;
+        }),
+    );
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "inspect startup latency" }),
+    );
+
+    const first = render(<AgentWorkspace />);
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "inspect startup latency",
+      }),
+    );
+    first.unmount();
+
+    const createdSession = {
+      id: "session-2",
+      title: "inspect startup latency",
+      preview: "inspect startup latency",
+      last_active: "2026-07-22T12:00:00Z",
+    };
+    mocks.listHermesSessions.mockResolvedValue([createdSession]);
+    render(<AgentWorkspace initialSession={createdSession} />);
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_SESSION_RENAMED_EVENT, {
+          detail: { sessionId: "session-2", title: "My startup investigation" },
+        }),
+      );
+    });
+    expect(await screen.findByText("My startup investigation")).toBeInTheDocument();
 
     await act(async () => {
       resolveTitle?.({ title: "Startup Latency" });

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -4192,10 +4192,10 @@ describe("AgentWorkspace", () => {
     // session.create, never a profile config write.
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.create", {
-        title: "Summarize Current Page",
+        title: "write a project update",
         cols: 96,
         model: "__june_remote_generation__:zai-org-glm-5-2",
-        reasoning_effort: "minimal",
+        reasoning_effort: "none",
       }),
     );
   });
@@ -7958,7 +7958,7 @@ describe("AgentWorkspace", () => {
       }),
     );
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.create", {
-      title: "Summarize Current Page",
+      title: "summarize the current page",
       cols: 96,
       reasoning_effort: "medium",
     });
@@ -7969,6 +7969,45 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("Summarize Current Page")).toBeInTheDocument();
     expect(screen.queryByText("Untitled session")).toBeNull();
     expect(window.sessionStorage.getItem(AGENT_NEW_SESSION_PENDING_KEY)).toBeNull();
+  });
+
+  it("submits a new-session prompt before its AI title resolves", async () => {
+    let resolveTitle: ((value: { title: string }) => void) | undefined;
+    mocks.suggestAgentSessionTitle.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveTitle = resolve;
+        }),
+    );
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "inspect startup latency" }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "inspect startup latency",
+      }),
+    );
+    expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.create", {
+      title: "inspect startup latency",
+      cols: 96,
+      reasoning_effort: "medium",
+    });
+
+    await act(async () => {
+      resolveTitle?.({ title: "Startup Latency" });
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
+        sessionId: "session-2",
+        title: "Startup Latency",
+      }),
+    );
   });
 
   it.each([
@@ -9576,7 +9615,7 @@ describe("AgentWorkspace", () => {
       expect(mocks.startAgentRunMonitoring).toHaveBeenCalledWith({
         storedSessionId: "session-2",
         runtimeSessionId: "runtime-session-2",
-        title: "Summarize Current Page",
+        title: "run the build",
         fullMode: false,
         settlementHeld: true,
       });
@@ -9908,7 +9947,7 @@ describe("AgentWorkspace", () => {
 
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.create", {
-        title: "Summarize Current Page",
+        title: "write a project update",
         cols: 96,
         model: "__june_remote_generation__:zai-org-glm-5-2",
         reasoning_effort: "medium",
@@ -9962,7 +10001,7 @@ describe("AgentWorkspace", () => {
 
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.create", {
-        title: "Summarize Current Page",
+        title: "draft a research brief",
         cols: 96,
         // No `model`: the composer's model is June's GLOBAL generation
         // selection, and sending it as the per-session override would bypass

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -8010,6 +8010,43 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("discards a pending AI title when its new session is deleted", async () => {
+    const user = userEvent.setup();
+    let resolveTitle: ((value: { title: string }) => void) | undefined;
+    mocks.suggestAgentSessionTitle.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveTitle = resolve;
+        }),
+    );
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "inspect startup latency" }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "inspect startup latency",
+      }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([]);
+    await user.click(screen.getByRole("button", { name: "Session actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Delete session" }));
+    await waitFor(() => expect(mocks.deleteHermesSession).toHaveBeenCalledWith("session-2"));
+
+    await act(async () => {
+      resolveTitle?.({ title: "Startup Latency" });
+      await Promise.resolve();
+    });
+    expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
+      sessionId: "session-2",
+      title: "Startup Latency",
+    });
+  });
+
   it.each([
     ["routine description", "Set up a weekday summary of my unread notes"],
     ["bundle chat", "/release-check prepare this repository for release"],

--- a/src/test/thinking-level.test.ts
+++ b/src/test/thinking-level.test.ts
@@ -22,9 +22,9 @@ describe("thinking levels", () => {
   });
 
   it("maps each level onto a Hermes reasoning effort", () => {
-    // Low barely deliberates, Medium is Hermes' own default, and High reasons
-    // substantially more.
-    expect(thinkingEffortForLevel("instant")).toBe("minimal");
+    // Low skips a separate reasoning pass, Medium is Hermes' own default, and
+    // High reasons substantially more.
+    expect(thinkingEffortForLevel("instant")).toBe("none");
     expect(thinkingEffortForLevel("medium")).toBe("medium");
     expect(thinkingEffortForLevel("hard")).toBe("high");
   });


### PR DESCRIPTION
## What changed

- Map the Low effort option to Hermes reasoning effort none.
- Start new sessions with a deterministic prompt-derived title immediately.
- Apply the AI-generated title asynchronously after session creation, with guards so manual or exchange titles win races.
- Add regression coverage proving prompt submission does not wait for title generation.

## Why

Low effort still felt slow because June used minimal reasoning and awaited a separate AI title request before session creation. This removes both delays from the user-visible response path.

## Validation

- pnpm exec vitest run src/test/thinking-level.test.ts src/test/agent-workspace.test.tsx: 359 passed, 2 skipped
- Focused non-blocking and Low effort regressions: passed
- pnpm run typecheck: passed
- pnpm build: passed
- Biome check on touched files: passed with error-level diagnostics

## Live QA

BLOCKED at model completion. The background browser reached session creation, invoked the background title path, and received Hermes lifecycle events. The June dev Hermes config pointed to a stopped loopback provider proxy, while the personal Hermes provider returned a failed assistant run. A local recording and screenshots were captured but not uploaded because the run did not produce a passing completion.

## Gaps

- A completed live model reply was not observed due to unavailable local QA provider configuration.
- No billing, account, audio, permission, or private-data flows were exercised.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787329032&installation_model_id=425925&pr_number=905&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F905&signature=c0aa6213e6d764fbc36cff030b64b6eb619a65146b4e21478f84adca070fa57b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->