### PR TITLE
Include active session context in issue reports

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3271,15 +3271,22 @@ export function App() {
   // It submits through June API without a model turn, so there is nothing to
   // charge; June API creates the team-facing diagnosis.
   function handleReportIssue(category: ReportCategory = "bug") {
+    const reportSession =
+      activeView === "agent" && activeAgentSessionId
+        ? {
+            id: activeAgentSessionId,
+            title: activeAgentSessionSeed?.title,
+          }
+        : undefined;
     pendingSessionProjectRef.current = null;
     setAgentOrigin(undefined);
-    markAgentNewSessionPending(undefined, { category });
+    markAgentNewSessionPending(undefined, { category, reportSession });
     setActiveAgentSession(undefined);
     setActiveView("agent");
     window.setTimeout(() => {
       window.dispatchEvent(
         new CustomEvent<AgentNewSessionDetail>(AGENT_NEW_SESSION_EVENT, {
-          detail: { category },
+          detail: { category, reportSession },
         }),
       );
     }, 0);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -254,7 +254,10 @@ import { SessionUsagePanel } from "./SessionUsagePanel";
 import { useUsagePanelDemo } from "../../lib/usage-panel-demo";
 import { AgentActivityDrawer, AgentArtifactsSection } from "./AgentActivityDrawer";
 import { hermesTraceBuffer } from "../../lib/hermes-trace-buffer";
-import { buildIssueReportSessionContext } from "../../lib/issue-report-session-context";
+import {
+  buildIssueReportSessionContext,
+  issueReportVisibleMessages,
+} from "../../lib/issue-report-session-context";
 import { UnsupportedEventNotice } from "./UnsupportedEventNotice";
 import { HermesTracePanel } from "./HermesTracePanel";
 import { MarkdownContent, highlightText, type HighlightCursor } from "./MarkdownContent";
@@ -9753,12 +9756,24 @@ export function AgentWorkspace({
   async function loadReportDialogSessionContext() {
     const session = reportDialogSession;
     if (!session) return undefined;
-    let messages = hermesSessionMessagesRef.current[session.id] ?? [];
-    try {
-      messages = await listHermesSessionMessages(session.id);
-    } catch {
-      // The already-rendered transcript and sanitized live trace still provide
-      // useful context when Hermes cannot refresh the session on demand.
+    const visibleMessages = () =>
+      issueReportVisibleMessages(
+        hermesSessionMessagesRef.current[session.id] ?? [],
+        pendingHermesMessagesRef.current[session.id] ?? [],
+      );
+    let messages = visibleMessages();
+    if (messages.length === 0) {
+      try {
+        const persistedMessages = await listHermesSessionMessages(session.id);
+        // Prefer anything that became visible while the refresh was in flight,
+        // including an optimistic user turn that Hermes has not persisted yet.
+        const latestVisibleMessages = visibleMessages();
+        messages = latestVisibleMessages.length > 0 ? latestVisibleMessages : persistedMessages;
+      } catch {
+        // The already-rendered transcript and sanitized live trace still provide
+        // useful context when Hermes cannot refresh the session on demand.
+        messages = visibleMessages();
+      }
     }
     return buildIssueReportSessionContext({
       title: session.title,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -254,6 +254,7 @@ import { SessionUsagePanel } from "./SessionUsagePanel";
 import { useUsagePanelDemo } from "../../lib/usage-panel-demo";
 import { AgentActivityDrawer, AgentArtifactsSection } from "./AgentActivityDrawer";
 import { hermesTraceBuffer } from "../../lib/hermes-trace-buffer";
+import { buildIssueReportSessionContext } from "../../lib/issue-report-session-context";
 import { UnsupportedEventNotice } from "./UnsupportedEventNotice";
 import { HermesTracePanel } from "./HermesTracePanel";
 import { MarkdownContent, highlightText, type HighlightCursor } from "./MarkdownContent";
@@ -970,6 +971,9 @@ export type AgentNewSessionDetail = {
   /** Opens the direct issue report dialog with the category preselected. No
    * model runs, so there is nothing to charge. */
   category?: ReportCategory;
+  /** Session that was open when the report flow started. Its visible chat and
+   * sanitized runtime trace can be included with the report. */
+  reportSession?: { id: string; title?: string };
   /** Seeds the composer with a note chip (and skips auto-submit) so the user
    * lands ready to ask about that note instead of starting an ordinary ask. */
   noteRef?: NoteReferenceInput;
@@ -2535,6 +2539,10 @@ export function AgentWorkspace({
   const [reportDialogAttachments, setReportDialogAttachments] = useState<ReportDialogAttachment[]>(
     [],
   );
+  const [reportDialogSession, setReportDialogSession] = useState<{
+    id: string;
+    title?: string;
+  }>();
   // Bumped when a report is sent; see reportDialogAppendForCurrentGeneration.
   const reportDialogGenerationRef = useRef(0);
   const [hermesSessionItems, setHermesSessionItems] = useState<HermesSessionInfo[]>(() => {
@@ -9628,7 +9636,7 @@ export function AgentWorkspace({
     if (seedCategory) {
       pendingSeedNoteRefRef.current = null;
       clearComposerDraft(NEW_SESSION_DRAFT_KEY);
-      openReportDialog(seedCategory);
+      openReportDialog(seedCategory, request?.reportSession);
     } else if (seedNoteRef) {
       clearComposerDraft(NEW_SESSION_DRAFT_KEY);
       seedComposerNoteRef({ defer: options.deferSeed });
@@ -9713,7 +9721,10 @@ export function AgentWorkspace({
     });
   }
 
-  function openReportDialog(categoryToOpen: ReportCategory) {
+  function openReportDialog(
+    categoryToOpen: ReportCategory,
+    explicitSession?: { id: string; title?: string },
+  ) {
     setAttachMenuOpen(false);
     // Every entry-point open is a fresh report intent, so start clean —
     // even when reopening the same category. An abandoned draft (closed
@@ -9727,8 +9738,33 @@ export function AgentWorkspace({
     reportDialogGenerationRef.current += 1;
     setReportDialogDescription("");
     setReportDialogAttachments([]);
+    const selectedSessionId = selectedHermesSessionIdRef.current;
+    const selectedSession = selectedSessionId
+      ? hermesSessionItemsRef.current.find((session) => session.id === selectedSessionId)
+      : undefined;
+    setReportDialogSession(
+      explicitSession ??
+        (selectedSessionId ? { id: selectedSessionId, title: selectedSession?.title } : undefined),
+    );
     setReportDialogCategory(categoryToOpen);
     setReportDialogOpen(true);
+  }
+
+  async function loadReportDialogSessionContext() {
+    const session = reportDialogSession;
+    if (!session) return undefined;
+    let messages = hermesSessionMessagesRef.current[session.id] ?? [];
+    try {
+      messages = await listHermesSessionMessages(session.id);
+    } catch {
+      // The already-rendered transcript and sanitized live trace still provide
+      // useful context when Hermes cannot refresh the session on demand.
+    }
+    return buildIssueReportSessionContext({
+      title: session.title,
+      messages,
+      trace: hermesTraceBuffer.exportSanitizedTrace(session.id),
+    });
   }
 
   /** Drops appends from imports that were still in flight when the report
@@ -11660,6 +11696,9 @@ export function AgentWorkspace({
             onAddFiles={pickReportDialogAttachments}
             onDropFiles={importReportDialogDroppedFiles}
             onRemoveAttachment={removeReportDialogAttachment}
+            sessionContext={reportDialogSession}
+            loadSessionContext={loadReportDialogSessionContext}
+            onRemoveSessionContext={() => setReportDialogSession(undefined)}
             onClose={() => setReportDialogOpen(false)}
             onSent={handleReportDialogSent}
           />
@@ -18278,13 +18317,18 @@ function writeLastOpenSessionId(sessionId: string) {
 
 export function markAgentNewSessionPending(
   prompt?: string,
-  options?: { category?: ReportCategory; noteRef?: NoteReferenceInput },
+  options?: {
+    category?: ReportCategory;
+    noteRef?: NoteReferenceInput;
+    reportSession?: { id: string; title?: string };
+  },
 ) {
   const payload = JSON.stringify({
     createdAt: Date.now(),
     prompt: prompt?.trim() || undefined,
     category: options?.category,
     noteRef: options?.noteRef,
+    reportSession: options?.reportSession,
   });
   try {
     window.sessionStorage.setItem(AGENT_NEW_SESSION_PENDING_KEY, payload);
@@ -18341,6 +18385,16 @@ function parsePendingNoteRef(value: unknown): NoteReferenceInput | undefined {
   };
 }
 
+function parsePendingReportSession(value: unknown): AgentNewSessionDetail["reportSession"] {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as { id?: unknown; title?: unknown };
+  if (typeof record.id !== "string" || record.id.trim().length === 0) return undefined;
+  return {
+    id: record.id,
+    ...(typeof record.title === "string" ? { title: record.title } : {}),
+  };
+}
+
 export function pendingNewSessionRequest(): AgentNewSessionDetail | undefined {
   try {
     const value = readPendingNewSessionPayload();
@@ -18354,6 +18408,7 @@ export function pendingNewSessionRequest(): AgentNewSessionDetail | undefined {
         prompt?: string;
         category?: string;
         noteRef?: unknown;
+        reportSession?: unknown;
       };
       if (
         typeof parsed.createdAt !== "number" ||
@@ -18363,9 +18418,11 @@ export function pendingNewSessionRequest(): AgentNewSessionDetail | undefined {
       }
       const category = isReportCategory(parsed.category) ? parsed.category : undefined;
       const noteRef = category ? undefined : parsePendingNoteRef(parsed.noteRef);
+      const reportSession = category ? parsePendingReportSession(parsed.reportSession) : undefined;
       return {
         ...(typeof parsed.prompt === "string" ? { prompt: parsed.prompt } : {}),
         ...(category ? { category } : {}),
+        ...(reportSession ? { reportSession } : {}),
         ...(noteRef ? { noteRef } : {}),
       };
     } catch {

--- a/src/components/agent/ReportDialog.tsx
+++ b/src/components/agent/ReportDialog.tsx
@@ -28,6 +28,28 @@ export type ReportDialogAttachment = {
 
 const REPORT_DIALOG_DOM_DROP_MAX_BYTES = 50 * 1024 * 1024;
 const REPORT_DIALOG_MAX_ATTACHMENTS = 20;
+const REPORT_SESSION_CONTEXT_LOAD_TIMEOUT_MS = 1_000;
+
+async function loadSessionContextBestEffort(
+  loader: (() => Promise<string | undefined>) | undefined,
+): Promise<string | undefined> {
+  if (!loader) return undefined;
+  let load: Promise<string | undefined>;
+  try {
+    load = Promise.resolve(loader()).catch(() => undefined);
+  } catch {
+    return undefined;
+  }
+  let timeoutId: number | undefined;
+  const timeout = new Promise<undefined>((resolve) => {
+    timeoutId = window.setTimeout(resolve, REPORT_SESSION_CONTEXT_LOAD_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([load, timeout]);
+  } finally {
+    if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+  }
+}
 
 type ReportDialogProps = {
   category: ReportCategory;
@@ -194,7 +216,7 @@ export function ReportDialog({
     setSubmitting(true);
     setError(null);
     try {
-      const relatedSessionContext = await loadSessionContext?.().catch(() => undefined);
+      const relatedSessionContext = await loadSessionContextBestEffort(loadSessionContext);
       const response = await submitIssueReport({
         category,
         description: appendIssueReportSessionContext(

--- a/src/components/agent/ReportDialog.tsx
+++ b/src/components/agent/ReportDialog.tsx
@@ -4,6 +4,7 @@ import { type ClipboardEvent, type DragEvent, useId, useMemo, useRef, useState }
 
 import { clipboardImageFiles } from "../../lib/clipboard-files";
 import { messageFromError } from "../../lib/errors";
+import { appendIssueReportSessionContext } from "../../lib/issue-report-session-context";
 import { recordPositiveFeedbackSent } from "../../lib/referral-nudge";
 import { submitIssueReport } from "../../lib/tauri";
 import { DotSpinner } from "../DotSpinner";
@@ -38,6 +39,9 @@ type ReportDialogProps = {
   onAddFiles: () => unknown;
   onDropFiles: (files: File[]) => unknown;
   onRemoveAttachment: (id: string) => void;
+  sessionContext?: { id: string; title?: string };
+  loadSessionContext?: () => Promise<string | undefined>;
+  onRemoveSessionContext?: () => void;
   onClose: () => void;
   onSent: () => void;
 };
@@ -52,6 +56,9 @@ export function ReportDialog({
   onAddFiles,
   onDropFiles,
   onRemoveAttachment,
+  sessionContext,
+  loadSessionContext,
+  onRemoveSessionContext,
   onClose,
   onSent,
 }: ReportDialogProps) {
@@ -187,11 +194,16 @@ export function ReportDialog({
     setSubmitting(true);
     setError(null);
     try {
+      const relatedSessionContext = await loadSessionContext?.().catch(() => undefined);
       const response = await submitIssueReport({
         category,
-        description: trimmedDescription || ISSUE_REPORT_ATTACHMENTS_ONLY_DESCRIPTION,
+        description: appendIssueReportSessionContext(
+          trimmedDescription || ISSUE_REPORT_ATTACHMENTS_ONLY_DESCRIPTION,
+          relatedSessionContext,
+        ),
         attachmentNames: attachments.map((attachment) => attachment.name),
         attachmentPaths: attachments.map((attachment) => attachment.path),
+        ...(sessionContext ? { sessionId: sessionContext.id } : {}),
       });
       setSubmitting(false);
       setSkippedAttachmentNames(response?.skippedAttachmentNames ?? []);
@@ -289,6 +301,26 @@ export function ReportDialog({
               }}
             />
           </DialogField>
+          {sessionContext ? (
+            <ul className="report-dialog-file-list" aria-label="Included session context">
+              <li className="report-dialog-file">
+                <span className="report-dialog-file-name">
+                  Visible conversation and sanitized diagnostics from{" "}
+                  {sessionContext.title?.trim() || "this session"}
+                </span>
+                {onRemoveSessionContext ? (
+                  <button
+                    type="button"
+                    aria-label="Remove session context"
+                    disabled={busy}
+                    onClick={onRemoveSessionContext}
+                  >
+                    <IconCrossSmall size={12} aria-hidden />
+                  </button>
+                ) : null}
+              </li>
+            </ul>
+          ) : null}
           {attachments.length ? (
             <ul className="report-dialog-file-list" aria-label="Attached files">
               {attachments.map((attachment) => (

--- a/src/lib/issue-report-session-context.ts
+++ b/src/lib/issue-report-session-context.ts
@@ -10,6 +10,13 @@ const TRACE_MAX_CHARS = 8_000;
 // Unicode/counting differences across the TypeScript and Rust boundary.
 const REPORT_DESCRIPTION_SAFE_MAX_CHARS = 19_500;
 
+export function issueReportVisibleMessages(
+  persisted: HermesSessionMessage[],
+  pending: HermesSessionMessage[],
+): HermesSessionMessage[] {
+  return [...persisted, ...pending];
+}
+
 function truncateStart(value: string, maxChars: number): string {
   const characters = Array.from(value);
   if (characters.length <= maxChars) return value;

--- a/src/lib/issue-report-session-context.ts
+++ b/src/lib/issue-report-session-context.ts
@@ -1,0 +1,86 @@
+import { stripProjectContext } from "./agent-project-context";
+import { displayedComposerUserMessageText, textFromHermesContent } from "./agent-chat-runtime";
+import { stripScheduledRunPreamble } from "./hermes-adapter";
+import type { SanitizedTraceBundle } from "./hermes-trace-buffer";
+import type { HermesSessionMessage } from "./tauri";
+
+const TRANSCRIPT_MAX_CHARS = 8_000;
+const TRACE_MAX_CHARS = 8_000;
+// June API accepts 20,000 description characters. Leave a little headroom for
+// Unicode/counting differences across the TypeScript and Rust boundary.
+const REPORT_DESCRIPTION_SAFE_MAX_CHARS = 19_500;
+
+function truncateStart(value: string, maxChars: number): string {
+  const characters = Array.from(value);
+  if (characters.length <= maxChars) return value;
+  return `[Earlier context omitted]\n${characters.slice(-(maxChars - 27)).join("")}`;
+}
+
+function visibleMessageText(message: HermesSessionMessage): string {
+  const text = textFromHermesContent(message.content) ?? textFromHermesContent(message.text) ?? "";
+  const withoutProjectContext = stripProjectContext(text);
+  const withoutWarnings = withoutProjectContext.replace(/\n*--- Context Warnings ---[\s\S]*$/m, "");
+  const attachedContextMarker = withoutWarnings.search(/\n*--- Attached Context ---/m);
+  const visible =
+    attachedContextMarker >= 0 ? withoutWarnings.slice(0, attachedContextMarker) : withoutWarnings;
+  return displayedComposerUserMessageText(stripScheduledRunPreamble(visible.trim())).trim();
+}
+
+function visibleTranscript(messages: HermesSessionMessage[]): string | undefined {
+  const turns = messages.flatMap((message) => {
+    if (message.role !== "user" && message.role !== "assistant") return [];
+    const text = visibleMessageText(message);
+    if (!text) return [];
+    return [`${message.role === "user" ? "User" : "June"}: ${text}`];
+  });
+  if (!turns.length) return undefined;
+  return truncateStart(turns.join("\n\n"), TRANSCRIPT_MAX_CHARS);
+}
+
+function sanitizedTrace(trace: SanitizedTraceBundle): string | undefined {
+  const entries = trace.entries.map((entry) => {
+    const details = [
+      entry.rawType ? `type=${entry.rawType}` : undefined,
+      entry.normalizedKind ? `kind=${entry.normalizedKind}` : undefined,
+      entry.method ? `method=${entry.method}` : undefined,
+      entry.message ? `message=${entry.message}` : undefined,
+      entry.payloadKeys.length ? `keys=${entry.payloadKeys.join(",")}` : undefined,
+      entry.payloadPreview ? `payload=${entry.payloadPreview}` : undefined,
+    ].filter(Boolean);
+    return `${entry.observedAt} ${entry.direction}${details.length ? ` ${details.join(" ")}` : ""}`;
+  });
+  if (!entries.length) return undefined;
+  return truncateStart(entries.join("\n"), TRACE_MAX_CHARS);
+}
+
+export function buildIssueReportSessionContext(input: {
+  title?: string;
+  messages: HermesSessionMessage[];
+  trace: SanitizedTraceBundle;
+}): string | undefined {
+  const transcript = visibleTranscript(input.messages);
+  const trace = sanitizedTrace(input.trace);
+  if (!transcript && !trace) return undefined;
+
+  const sections = [`Session title: ${input.title?.trim() || "Untitled session"}`];
+  if (transcript) sections.push(`Visible conversation:\n\n${transcript}`);
+  if (trace) sections.push(`Sanitized runtime trace:\n\n${trace}`);
+  return sections.join("\n\n");
+}
+
+export function appendIssueReportSessionContext(
+  description: string,
+  sessionContext?: string,
+): string {
+  const trimmedDescription = description.trim();
+  const trimmedContext = sessionContext?.trim();
+  if (!trimmedContext) return trimmedDescription;
+  const separator = "\n\n## Related session context\n\n";
+  const remaining =
+    REPORT_DESCRIPTION_SAFE_MAX_CHARS -
+    Array.from(trimmedDescription).length -
+    Array.from(separator).length;
+  if (remaining <= 0) return trimmedDescription;
+  const boundedContext = Array.from(trimmedContext).slice(0, remaining).join("");
+  return `${trimmedDescription}${separator}${boundedContext}`;
+}

--- a/src/lib/issue-report-session-context.ts
+++ b/src/lib/issue-report-session-context.ts
@@ -13,7 +13,12 @@ const REPORT_DESCRIPTION_SAFE_MAX_CHARS = 19_500;
 function truncateStart(value: string, maxChars: number): string {
   const characters = Array.from(value);
   if (characters.length <= maxChars) return value;
-  return `[Earlier context omitted]\n${characters.slice(-(maxChars - 27)).join("")}`;
+  const marker = "[Earlier context omitted]\n";
+  const markerCharacters = Array.from(marker);
+  if (maxChars <= markerCharacters.length) {
+    return characters.slice(-maxChars).join("");
+  }
+  return `${marker}${characters.slice(-(maxChars - markerCharacters.length)).join("")}`;
 }
 
 function visibleMessageText(message: HermesSessionMessage): string {
@@ -81,6 +86,9 @@ export function appendIssueReportSessionContext(
     Array.from(trimmedDescription).length -
     Array.from(separator).length;
   if (remaining <= 0) return trimmedDescription;
-  const boundedContext = Array.from(trimmedContext).slice(0, remaining).join("");
+  // The trace is the final context section and is itself ordered oldest to
+  // newest. Keep the tail so a long user description cannot discard the
+  // unsupported event that prompted the report.
+  const boundedContext = truncateStart(trimmedContext, remaining);
   return `${trimmedDescription}${separator}${boundedContext}`;
 }

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -812,6 +812,9 @@ describe("App shortcuts", () => {
       await user.click(screen.getByRole("menuitem", { name: menuItem }));
 
       expect(await screen.findByText(chipLabel)).toBeInTheDocument();
+      expect(
+        screen.getByText("Visible conversation and sanitized diagnostics from Existing session"),
+      ).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Start session" })).toBeDisabled();
       expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("session.create", expect.anything());
     }

--- a/src/test/issue-report-session-context.test.ts
+++ b/src/test/issue-report-session-context.test.ts
@@ -3,9 +3,30 @@ import { describe, expect, it } from "vitest";
 import {
   appendIssueReportSessionContext,
   buildIssueReportSessionContext,
+  issueReportVisibleMessages,
 } from "../lib/issue-report-session-context";
 
 describe("issue report session context", () => {
+  it("includes optimistic turns after the persisted conversation", () => {
+    const messages = issueReportVisibleMessages(
+      [{ id: "persisted", role: "assistant", content: "What can I help with?" }],
+      [{ id: "pending", role: "user", content: "This pending prompt failed" }],
+    );
+
+    expect(messages.map((message) => message.id)).toEqual(["persisted", "pending"]);
+    expect(
+      buildIssueReportSessionContext({
+        title: "Pending session",
+        messages,
+        trace: {
+          sessionId: "session-1",
+          exportedAt: "2026-07-22T18:00:00.000Z",
+          entries: [],
+        },
+      }),
+    ).toContain("User: This pending prompt failed");
+  });
+
   it("includes only visible user and assistant conversation plus the sanitized trace", () => {
     const context = buildIssueReportSessionContext({
       title: "Chat greeting",

--- a/src/test/issue-report-session-context.test.ts
+++ b/src/test/issue-report-session-context.test.ts
@@ -56,9 +56,15 @@ describe("issue report session context", () => {
 
   it("bounds added context below the server description limit", () => {
     const description = "d".repeat(10_000);
-    const result = appendIssueReportSessionContext(description, "c".repeat(16_000));
+    const newestDiagnostic = "type=future.event kind=unsupported newest=true";
+    const result = appendIssueReportSessionContext(
+      description,
+      `${"older-context\n".repeat(1_500)}${newestDiagnostic}`,
+    );
 
     expect(Array.from(result)).toHaveLength(19_500);
     expect(result).toContain("## Related session context");
+    expect(result).toContain("[Earlier context omitted]");
+    expect(result.endsWith(newestDiagnostic)).toBe(true);
   });
 });

--- a/src/test/issue-report-session-context.test.ts
+++ b/src/test/issue-report-session-context.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  appendIssueReportSessionContext,
+  buildIssueReportSessionContext,
+} from "../lib/issue-report-session-context";
+
+describe("issue report session context", () => {
+  it("includes only visible user and assistant conversation plus the sanitized trace", () => {
+    const context = buildIssueReportSessionContext({
+      title: "Chat greeting",
+      messages: [
+        { id: "system", role: "system", content: "hidden system prompt" },
+        { id: "user", role: "user", content: "hey june whats up" },
+        { id: "tool", role: "tool", content: "hidden tool output" },
+        {
+          id: "assistant",
+          role: "assistant",
+          content: "Hey! I’m here and ready to help.",
+          reasoning: "hidden chain of thought",
+        },
+      ],
+      trace: {
+        sessionId: "session-1",
+        exportedAt: "2026-07-22T18:00:00.000Z",
+        entries: [
+          {
+            id: 1,
+            direction: "inbound",
+            observedAt: "2026-07-22T18:00:00.000Z",
+            sessionId: "session-1",
+            rawType: "future.event",
+            normalizedKind: "unsupported",
+            payloadKeys: ["token", "status"],
+            payloadPreview: '{"token":"[REDACTED]","status":"waiting"}',
+          },
+        ],
+      },
+    });
+
+    expect(context).toContain("Session title: Chat greeting");
+    expect(context).toContain("User: hey june whats up");
+    expect(context).toContain("June: Hey! I’m here and ready to help.");
+    expect(context).toContain("type=future.event kind=unsupported");
+    expect(context).toContain('payload={"token":"[REDACTED]"');
+    expect(context).not.toContain("hidden system prompt");
+    expect(context).not.toContain("hidden tool output");
+    expect(context).not.toContain("hidden chain of thought");
+  });
+
+  it("appends related context after the user's description", () => {
+    expect(appendIssueReportSessionContext("The session showed an error.", "Session trace")).toBe(
+      "The session showed an error.\n\n## Related session context\n\nSession trace",
+    );
+  });
+
+  it("bounds added context below the server description limit", () => {
+    const description = "d".repeat(10_000);
+    const result = appendIssueReportSessionContext(description, "c".repeat(16_000));
+
+    expect(Array.from(result)).toHaveLength(19_500);
+    expect(result).toContain("## Related session context");
+  });
+});

--- a/src/test/report-dialog.test.tsx
+++ b/src/test/report-dialog.test.tsx
@@ -32,6 +32,9 @@ function Harness({
   onDropFiles = vi.fn(),
   onSent = vi.fn(),
   onClose = vi.fn(),
+  sessionContext,
+  loadSessionContext,
+  onRemoveSessionContext,
 }: {
   initialCategory?: ReportCategory;
   initialDescription?: string;
@@ -39,6 +42,9 @@ function Harness({
   onDropFiles?: (files: File[]) => void;
   onSent?: () => void;
   onClose?: () => void;
+  sessionContext?: { id: string; title?: string };
+  loadSessionContext?: () => Promise<string | undefined>;
+  onRemoveSessionContext?: () => void;
 }) {
   const [category, setCategory] = useState(initialCategory);
   const [description, setDescription] = useState(initialDescription);
@@ -57,6 +63,9 @@ function Harness({
       onRemoveAttachment={(id) =>
         setAttachments((current) => current.filter((attachment) => attachment.id !== id))
       }
+      sessionContext={sessionContext}
+      loadSessionContext={loadSessionContext}
+      onRemoveSessionContext={onRemoveSessionContext}
       onClose={onClose}
       onSent={onSent}
     />
@@ -127,6 +136,40 @@ describe("ReportDialog", () => {
     expect(payload).not.toHaveProperty("sessionId");
     expect(payload).not.toHaveProperty("agentDiagnosis");
     expect(onSent).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes the active session context and identifies the source session", async () => {
+    const user = userEvent.setup();
+    const loadSessionContext = vi
+      .fn()
+      .mockResolvedValue(
+        "Session title: Chat greeting\n\nVisible conversation:\n\nUser: hey june whats up\n\nSanitized runtime trace:\n\ntype=future.event kind=unsupported",
+      );
+    render(
+      <Harness
+        initialDescription="Look at this session and report the bug"
+        sessionContext={{ id: "session-chat-greeting", title: "Chat greeting" }}
+        loadSessionContext={loadSessionContext}
+        onRemoveSessionContext={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("list", { name: "Included session context" })).toHaveTextContent(
+      "Visible conversation and sanitized diagnostics from Chat greeting",
+    );
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+        category: "bug",
+        description:
+          "Look at this session and report the bug\n\n## Related session context\n\nSession title: Chat greeting\n\nVisible conversation:\n\nUser: hey june whats up\n\nSanitized runtime trace:\n\ntype=future.event kind=unsupported",
+        attachmentNames: [],
+        attachmentPaths: [],
+        sessionId: "session-chat-greeting",
+      }),
+    );
+    expect(loadSessionContext).toHaveBeenCalledTimes(1);
   });
 
   it("shows the confirmation in the dialog after sending and closes via Done", async () => {

--- a/src/test/report-dialog.test.tsx
+++ b/src/test/report-dialog.test.tsx
@@ -172,6 +172,32 @@ describe("ReportDialog", () => {
     expect(loadSessionContext).toHaveBeenCalledTimes(1);
   });
 
+  it("sends promptly when active session context cannot finish loading", async () => {
+    const user = userEvent.setup();
+    const loadSessionContext = vi.fn(() => new Promise<string | undefined>(() => undefined));
+    render(
+      <Harness
+        initialDescription="The active session is stuck"
+        sessionContext={{ id: "session-stuck", title: "Stuck session" }}
+        loadSessionContext={loadSessionContext}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    await waitFor(
+      () =>
+        expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+          category: "bug",
+          description: "The active session is stuck",
+          attachmentNames: [],
+          attachmentPaths: [],
+          sessionId: "session-stuck",
+        }),
+      { timeout: 2_000 },
+    );
+  });
+
   it("shows the confirmation in the dialog after sending and closes via Done", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();


### PR DESCRIPTION
## Summary

- carry the active session identity into issue reports opened from a conversation
- include a bounded transcript of visible user and June messages plus the existing secrets-redacted Hermes runtime trace
- disclose the included context in the dialog and let the reporter remove it before sending
- keep the submitted description below the June API character limit

## Why

The direct report dialog submitted only the reporter's description and attachment names. A request such as "look at my Chat greeting session" therefore gave server-side diagnosis no access to that conversation or the unsupported Hermes event that triggered the report, producing an insufficient-detail Issue.

Closes JUN-386

## Validation

- `pnpm test`: 205 files passed, 3,397 tests passed, 2 skipped
- focused regression run: 3 files passed, 65 tests passed
- `pnpm run build`: passed
- scoped Biome check: no errors (repository warnings remain)
- `git diff --check`: passed

## Live QA

- PASS: isolated native debug app opened the account-menu bug report dialog
- PASS: report category controls, description editing, modal layout, and unsent close behavior worked visibly
- BLOCKED: the active-session disclosure row was not exercised in the isolated app because it had no saved sessions and creating one would require a live model-backed call. The account-menu integration and exact submitted payload are covered deterministically.

## Evidence

- Local compressed recording: `.tmp/qa-recordings/20260722-153900-jun-386-report-context.compressed.mp4`

## Known gaps

- Live JUN-386 API details were unavailable because `OS_PLATFORM_API_KEY` was not configured; implementation was grounded in the supplied Issue screenshot and current report-flow code.
