### PR TITLE
Improve list render hygiene

### DIFF
--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -41,8 +41,11 @@ import { CreateFolderDialog } from "./CreateFolderDialog";
 import { EditFolderDialog } from "./EditFolderDialog";
 import { ProjectSettingsDialog } from "./ProjectSettingsDialog";
 import { ImportClaudeProjectsDialog } from "./ImportClaudeProjectsDialog";
+import { buildFolderItemIndex } from "./folder-item-index";
 
 const NO_FOLDERS: FolderDto[] = [];
+const NO_FOLDER_NOTES: readonly NoteListItemDto[] = [];
+const NO_FOLDER_SESSIONS: readonly HermesSessionInfo[] = [];
 
 type FoldersWorkspaceProps = {
   folders: FolderDto[];
@@ -169,6 +172,10 @@ function FolderList({
       }
     });
   }, [folders, normalizedQuery, sort]);
+  const folderItems = useMemo(
+    () => buildFolderItemIndex(notes, sessions, sessionFolderIds),
+    [notes, sessions, sessionFolderIds],
+  );
 
   const content: ReactNode =
     sortedAndFiltered.length > 0 ? (
@@ -177,9 +184,8 @@ function FolderList({
           <FolderCard
             key={folder.id}
             folder={folder}
-            notes={notes}
-            sessions={sessions}
-            sessionFolderIds={sessionFolderIds}
+            notes={folderItems.notesByFolderId.get(folder.id) ?? NO_FOLDER_NOTES}
+            sessions={folderItems.sessionsByFolderId.get(folder.id) ?? NO_FOLDER_SESSIONS}
             menuOpen={menu?.folderId === folder.id}
             onOpen={() => onSelectFolder(folder.id)}
             onDropNote={(noteId) => {
@@ -384,16 +390,14 @@ function FolderCard({
   folder,
   notes,
   sessions,
-  sessionFolderIds,
   menuOpen,
   onOpen,
   onOpenMenu,
   onDropNote,
 }: {
   folder: FolderDto;
-  notes: NoteListItemDto[];
-  sessions: HermesSessionInfo[];
-  sessionFolderIds: Record<string, string[]>;
+  notes: readonly NoteListItemDto[];
+  sessions: readonly HermesSessionInfo[];
   menuOpen: boolean;
   onOpen: () => void;
   onOpenMenu: (anchor: HTMLElement) => void;
@@ -402,11 +406,7 @@ function FolderCard({
   const menuButtonRef = useRef<HTMLButtonElement | null>(null);
   const dragDepth = useRef(0);
   const [dropActive, setDropActive] = useState(false);
-  const folderNotes = notes.filter((note) => note.folderIds.includes(folder.id));
-  const folderSessions = sessions.filter((session) =>
-    (sessionFolderIds[session.id] ?? []).includes(folder.id),
-  );
-  const lastUpdated = folderNotes[0]?.updatedAt ?? folder.updatedAt;
+  const lastUpdated = notes[0]?.updatedAt ?? folder.updatedAt;
 
   function hasNoteData(event: DragEvent<HTMLElement>) {
     const types = event.dataTransfer.types;
@@ -492,16 +492,16 @@ function FolderCard({
             <span className="folder-card-footer-icon" aria-hidden>
               <IconNoteText size={11} />
             </span>
-            {folderNotes.length} {folderNotes.length === 1 ? "meeting note" : "meeting notes"}
+            {notes.length} {notes.length === 1 ? "meeting note" : "meeting notes"}
           </span>
-          {folderSessions.length > 0 ? (
+          {sessions.length > 0 ? (
             <>
               <span className="metadata-dot" aria-hidden />
               <span className="folder-card-footer-item">
                 <span className="folder-card-footer-icon" aria-hidden>
                   <IconBubble3 size={11} />
                 </span>
-                {folderSessions.length} {folderSessions.length === 1 ? "session" : "sessions"}
+                {sessions.length} {sessions.length === 1 ? "session" : "sessions"}
               </span>
             </>
           ) : null}

--- a/src/components/folders/folder-item-index.ts
+++ b/src/components/folders/folder-item-index.ts
@@ -1,0 +1,38 @@
+import type { HermesSessionInfo, NoteListItemDto } from "../../lib/tauri";
+
+export type FolderItemIndex = {
+  notesByFolderId: ReadonlyMap<string, readonly NoteListItemDto[]>;
+  sessionsByFolderId: ReadonlyMap<string, readonly HermesSessionInfo[]>;
+};
+
+export function buildFolderItemIndex(
+  notes: readonly NoteListItemDto[],
+  sessions: readonly HermesSessionInfo[],
+  sessionFolderIds: Readonly<Record<string, string[]>>,
+): FolderItemIndex {
+  const notesByFolderId = new Map<string, NoteListItemDto[]>();
+  const sessionsByFolderId = new Map<string, HermesSessionInfo[]>();
+
+  for (const note of notes) {
+    for (const folderId of new Set(note.folderIds)) {
+      appendFolderItem(notesByFolderId, folderId, note);
+    }
+  }
+
+  for (const session of sessions) {
+    for (const folderId of new Set(sessionFolderIds[session.id] ?? [])) {
+      appendFolderItem(sessionsByFolderId, folderId, session);
+    }
+  }
+
+  return { notesByFolderId, sessionsByFolderId };
+}
+
+function appendFolderItem<T>(itemsByFolderId: Map<string, T[]>, folderId: string, item: T) {
+  const items = itemsByFolderId.get(folderId);
+  if (items) {
+    items.push(item);
+  } else {
+    itemsByFolderId.set(folderId, [item]);
+  }
+}

--- a/src/components/notes-list/NotesList.tsx
+++ b/src/components/notes-list/NotesList.tsx
@@ -8,6 +8,7 @@ import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconTrashCan } from "central-icons/IconTrashCan";
 import {
   forwardRef,
+  memo,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -21,6 +22,7 @@ import { useForcedEmptyStates } from "../../lib/empty-states-demo";
 import { primaryShiftShortcutLabel } from "../../lib/platform";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { EmptyState } from "../ui/EmptyState";
+import { filterNotesByQuery } from "./notes-list-helpers";
 
 const NO_NOTES: NoteListItemDto[] = [];
 
@@ -89,13 +91,7 @@ export const NotesList = forwardRef<NotesListHandle, NotesListProps>(function No
     () => [...notes].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
     [notes],
   );
-  const filteredNotes = useMemo(() => {
-    const normalized = query.trim().toLowerCase();
-    if (!normalized) return sortedNotes;
-    return sortedNotes.filter((note) => {
-      return `${note.title} ${note.preview}`.toLowerCase().includes(normalized);
-    });
-  }, [sortedNotes, query]);
+  const filteredNotes = useMemo(() => filterNotesByQuery(sortedNotes, query), [sortedNotes, query]);
 
   const selectedNoteIds = useMemo(
     () => sortedNotes.filter((note) => selectedIds.has(note.id)).map((note) => note.id),
@@ -146,14 +142,25 @@ export const NotesList = forwardRef<NotesListHandle, NotesListProps>(function No
     }
   }, [notes]);
 
-  function toggleSelected(noteId: string) {
+  const toggleSelected = useCallback((noteId: string) => {
     setSelectedIds((previous) => {
       const next = new Set(previous);
       if (next.has(noteId)) next.delete(noteId);
       else next.add(noteId);
       return next;
     });
-  }
+  }, []);
+
+  const selectNote = useCallback((noteId: string) => onSelectNote(noteId), [onSelectNote]);
+  const openNoteMenu = useCallback((noteId: string, position: MenuPosition) => {
+    setOpenMenu({ noteId, ...position });
+  }, []);
+  const closeNoteMenu = useCallback(() => setOpenMenu(null), []);
+  const openMoveDialog = useCallback(
+    (noteId: string) => onOpenMoveDialog(noteId),
+    [onOpenMoveDialog],
+  );
+  const deleteNote = useCallback((noteId: string) => onDeleteNote(noteId), [onDeleteNote]);
 
   // A deliberate dismiss — ×, Escape, post-delete — slides the bar out.
   const resetSelection = useCallback(() => {
@@ -256,17 +263,15 @@ export const NotesList = forwardRef<NotesListHandle, NotesListProps>(function No
             <AllNoteRow
               key={note.id}
               note={note}
-              activeRecordingNoteId={activeRecordingNoteId}
-              menu={
-                openMenu?.noteId === note.id ? { right: openMenu.right, top: openMenu.top } : null
-              }
-              onSelect={() => onSelectNote(note.id)}
+              liveRecording={note.id === activeRecordingNoteId}
+              menu={openMenu?.noteId === note.id ? openMenu : null}
+              onSelect={selectNote}
               checked={selectedIds.has(note.id)}
-              onToggleSelected={() => toggleSelected(note.id)}
-              onOpenMenu={(position) => setOpenMenu({ noteId: note.id, ...position })}
-              onCloseMenu={() => setOpenMenu(null)}
-              onOpenMove={() => onOpenMoveDialog(note.id)}
-              onDelete={() => onDeleteNote(note.id)}
+              onToggleSelected={toggleSelected}
+              onOpenMenu={openNoteMenu}
+              onCloseMenu={closeNoteMenu}
+              onOpenMove={openMoveDialog}
+              onDelete={deleteNote}
             />
           ))}
         </ul>
@@ -342,9 +347,9 @@ export const NotesList = forwardRef<NotesListHandle, NotesListProps>(function No
   );
 });
 
-function AllNoteRow({
+const AllNoteRow = memo(function AllNoteRow({
   note,
-  activeRecordingNoteId,
+  liveRecording,
   menu,
   onSelect,
   checked,
@@ -355,18 +360,17 @@ function AllNoteRow({
   onDelete,
 }: {
   note: NoteListItemDto;
-  activeRecordingNoteId?: string;
+  liveRecording: boolean;
   menu: MenuPosition | null;
-  onSelect: () => void;
+  onSelect: (noteId: string) => void;
   checked: boolean;
-  onToggleSelected: () => void;
-  onOpenMenu: (position: MenuPosition) => void;
+  onToggleSelected: (noteId: string) => void;
+  onOpenMenu: (noteId: string, position: MenuPosition) => void;
   onCloseMenu: () => void;
-  onOpenMove: () => void;
-  onDelete: () => void;
+  onOpenMove: (noteId: string) => void;
+  onDelete: (noteId: string) => void;
 }) {
   const title = note.title.trim() || "New note";
-  const liveRecording = note.id === activeRecordingNoteId;
   const effectiveStatus =
     note.processingStatus === "recording" && !liveRecording ? "draft" : note.processingStatus;
   const preview =
@@ -388,13 +392,13 @@ function AllNoteRow({
             type="checkbox"
             checked={checked}
             aria-label={`Select ${title}`}
-            onChange={onToggleSelected}
+            onChange={() => onToggleSelected(note.id)}
           />
           <span className="folder-note-select-box" aria-hidden>
             {checked ? <IconCheckmark2Medium size={10} /> : null}
           </span>
         </label>
-        <button type="button" className="folder-note-main" onClick={onSelect}>
+        <button type="button" className="folder-note-main" onClick={() => onSelect(note.id)}>
           <MeetingRowContent
             title={title}
             preview={preview}
@@ -418,7 +422,7 @@ function AllNoteRow({
                 onCloseMenu();
                 return;
               }
-              onOpenMenu(meetingMenuPosition(event.currentTarget));
+              onOpenMenu(note.id, meetingMenuPosition(event.currentTarget));
             }}
           >
             <IconDotGrid1x3Horizontal size={13} />
@@ -436,7 +440,7 @@ function AllNoteRow({
               role="menuitem"
               onClick={() => {
                 onCloseMenu();
-                onOpenMove();
+                onOpenMove(note.id);
               }}
             >
               <IconMoveFolder size={14} />
@@ -461,7 +465,7 @@ function AllNoteRow({
       <ConfirmDialog
         open={confirmDelete}
         onClose={() => setConfirmDelete(false)}
-        onConfirm={onDelete}
+        onConfirm={() => onDelete(note.id)}
         title={`Delete "${title}"?`}
         description="This cannot be undone."
         confirmLabel="Delete note"
@@ -469,7 +473,7 @@ function AllNoteRow({
       />
     </li>
   );
-}
+});
 
 function MeetingRowContent({
   title,

--- a/src/components/notes-list/notes-list-helpers.ts
+++ b/src/components/notes-list/notes-list-helpers.ts
@@ -1,0 +1,8 @@
+import type { NoteListItemDto } from "../../lib/tauri";
+
+export function filterNotesByQuery(notes: NoteListItemDto[], query: string) {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return notes;
+
+  return notes.filter((note) => `${note.title} ${note.preview}`.toLowerCase().includes(normalized));
+}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -115,6 +115,7 @@ import {
   type DateFormatChangedDetail,
   type DateFormatPreference,
 } from "../../lib/date-format";
+import { buildSidebarSessionLists } from "./sidebar-session-lists";
 
 const NO_AGENT_SESSIONS: HermesSessionInfo[] = [];
 
@@ -542,41 +543,22 @@ export function Sidebar({
       `${session.title ?? ""} ${session.preview ?? ""}`.toLowerCase().includes(normalized),
     );
   }, [agentSessions, query]);
-  const pinnedAgentSessionOrder = useMemo(
-    () => buildPinnedSessionOrderIndex(pinnedAgentSessionIds),
-    [pinnedAgentSessionIds],
-  );
-  const pinnedAgentSessions = useMemo(
+  const sidebarSessionLists = useMemo(
     () =>
-      filteredAgentSessions
-        .filter(
-          (session) => pinnedAgentSessionIds.has(session.id) && !completedSessionIds[session.id],
-        )
-        .sort(
-          (a, b) =>
-            pinnedSessionOrder(pinnedAgentSessionOrder, a.id) -
-            pinnedSessionOrder(pinnedAgentSessionOrder, b.id),
-        ),
-    [filteredAgentSessions, pinnedAgentSessionIds, pinnedAgentSessionOrder, completedSessionIds],
-  );
-  const visibleAgentSessions = useMemo(
-    () =>
-      filteredAgentSessions
-        .filter(
-          (session) => !pinnedAgentSessionIds.has(session.id) && !completedSessionIds[session.id],
-        )
-        .slice(0, AGENT_SIDEBAR_SESSION_LIMIT),
+      buildSidebarSessionLists(
+        filteredAgentSessions,
+        pinnedAgentSessionIds,
+        completedSessionIds,
+        AGENT_SIDEBAR_SESSION_LIMIT,
+      ),
     [filteredAgentSessions, pinnedAgentSessionIds, completedSessionIds],
   );
-  const completedAgentSessions = useMemo(
-    () =>
-      filteredAgentSessions
-        .filter((session) => Boolean(completedSessionIds[session.id]))
-        .sort((a, b) =>
-          (completedSessionIds[b.id] ?? "").localeCompare(completedSessionIds[a.id] ?? ""),
-        ),
-    [filteredAgentSessions, completedSessionIds],
-  );
+  const pinnedAgentSessions = sidebarSessionLists.pinned;
+  const visibleAgentSessions = sidebarSessionLists.visible;
+  const completedAgentSessions = sidebarSessionLists.completed;
+  const hasMorePinnedAgentSessions = sidebarSessionLists.pinnedTotal > pinnedAgentSessions.length;
+  const hasMoreCompletedAgentSessions =
+    sidebarSessionLists.completedTotal > completedAgentSessions.length;
 
   async function loadReferralSummary() {
     if (!account.signedIn || account.localDev) return;
@@ -1306,8 +1288,19 @@ export function Sidebar({
               className="sidebar-section sidebar-pinned-section"
               aria-label="Pinned agent sessions"
             >
-              <div className="section-title">
+              <div
+                className={`section-title${hasMorePinnedAgentSessions ? " section-title-with-action" : ""}`}
+              >
                 <span className="section-title-label">Pinned</span>
+                {hasMorePinnedAgentSessions ? (
+                  <button
+                    type="button"
+                    className="section-view-all"
+                    onClick={() => onChangeView("agent-sessions")}
+                  >
+                    View all
+                  </button>
+                ) : null}
               </div>
               <div className="notes-nav sidebar-pinned-list">
                 {pinnedAgentSessions.map((session) => (
@@ -1409,7 +1402,18 @@ export function Sidebar({
                 >
                   Completed
                 </button>
-                <span className="folders-count">{completedAgentSessions.length}</span>
+                <span className="sidebar-section-title-meta">
+                  <span className="folders-count">{sidebarSessionLists.completedTotal}</span>
+                  {hasMoreCompletedAgentSessions ? (
+                    <button
+                      type="button"
+                      className="section-view-all"
+                      onClick={() => onChangeView("agent-sessions")}
+                    >
+                      View all
+                    </button>
+                  ) : null}
+                </span>
               </div>
               {completedCollapsed ? null : (
                 <div className="notes-nav sidebar-completed-list">
@@ -2214,20 +2218,6 @@ function writePinnedAgentSessionIds(ids: ReadonlySet<string>) {
   } catch {
     // Private browsing / locked-down WebViews may reject storage writes.
   }
-}
-
-function buildPinnedSessionOrderIndex(ids: ReadonlySet<string>) {
-  const indexById = new Map<string, number>();
-  let index = 0;
-  for (const id of ids) {
-    indexById.set(id, index);
-    index += 1;
-  }
-  return indexById;
-}
-
-function pinnedSessionOrder(indexById: ReadonlyMap<string, number>, sessionId: string) {
-  return indexById.get(sessionId) ?? Number.MAX_SAFE_INTEGER;
 }
 
 function AgentSessionRow({

--- a/src/components/sidebar/sidebar-session-lists.ts
+++ b/src/components/sidebar/sidebar-session-lists.ts
@@ -1,0 +1,56 @@
+import type { HermesSessionInfo } from "../../lib/tauri";
+
+export type SidebarSessionLists = {
+  pinned: HermesSessionInfo[];
+  visible: HermesSessionInfo[];
+  completed: HermesSessionInfo[];
+  pinnedTotal: number;
+  visibleTotal: number;
+  completedTotal: number;
+};
+
+export function buildSidebarSessionLists(
+  sessions: readonly HermesSessionInfo[],
+  pinnedSessionIds: ReadonlySet<string>,
+  completedSessionIds: Readonly<Record<string, string>>,
+  limit: number,
+): SidebarSessionLists {
+  const pinned: HermesSessionInfo[] = [];
+  const visible: HermesSessionInfo[] = [];
+  const completed: HermesSessionInfo[] = [];
+
+  for (const session of sessions) {
+    if (completedSessionIds[session.id]) {
+      completed.push(session);
+    } else if (pinnedSessionIds.has(session.id)) {
+      pinned.push(session);
+    } else {
+      visible.push(session);
+    }
+  }
+
+  const pinnedOrder = new Map<string, number>();
+  let pinnedIndex = 0;
+  for (const sessionId of pinnedSessionIds) {
+    pinnedOrder.set(sessionId, pinnedIndex);
+    pinnedIndex += 1;
+  }
+  pinned.sort(
+    (a, b) =>
+      (pinnedOrder.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+      (pinnedOrder.get(b.id) ?? Number.MAX_SAFE_INTEGER),
+  );
+  completed.sort((a, b) =>
+    (completedSessionIds[b.id] ?? "").localeCompare(completedSessionIds[a.id] ?? ""),
+  );
+
+  const boundedLimit = Math.max(0, Math.floor(limit));
+  return {
+    pinned: pinned.slice(0, boundedLimit),
+    visible: visible.slice(0, boundedLimit),
+    completed: completed.slice(0, boundedLimit),
+    pinnedTotal: pinned.length,
+    visibleTotal: visible.length,
+    completedTotal: completed.length,
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9504,6 +9504,12 @@ button.agent-user-attachment:hover {
   font-weight: 400;
 }
 
+.sidebar-section-title-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+}
+
 .sidebar[data-collapsed="true"] .section-title-label,
 .sidebar[data-collapsed="true"] .section-title,
 .sidebar[data-collapsed="true"] .notes-nav-wrap {

--- a/src/test/list-render-hygiene.test.ts
+++ b/src/test/list-render-hygiene.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { buildFolderItemIndex } from "../components/folders/folder-item-index";
+import { filterNotesByQuery } from "../components/notes-list/notes-list-helpers";
+import { buildSidebarSessionLists } from "../components/sidebar/sidebar-session-lists";
+import type { HermesSessionInfo, NoteListItemDto } from "../lib/tauri";
+
+const NOW = "2026-07-22T12:00:00Z";
+
+function note(
+  id: string,
+  title: string,
+  preview: string,
+  folderIds: string[] = [],
+): NoteListItemDto {
+  return {
+    id,
+    title,
+    preview,
+    processingStatus: "ready",
+    folderIds,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function session(id: string): HermesSessionInfo {
+  return { id, title: id };
+}
+
+describe("list render hygiene helpers", () => {
+  it("filters notes by normalized title or preview and reuses the unfiltered list", () => {
+    const notes = [
+      note("roadmap", "Product roadmap", "Q3 priorities"),
+      note("retro", "Weekly retro", "Decisions and follow-ups"),
+    ];
+
+    expect(filterNotesByQuery(notes, "  PRODUCT ")).toEqual([notes[0]]);
+    expect(filterNotesByQuery(notes, "FOLLOW-UP")).toEqual([notes[1]]);
+    expect(filterNotesByQuery(notes, "   ")).toBe(notes);
+  });
+
+  it("categorizes, orders, and bounds every sidebar session group", () => {
+    const sessions = [
+      session("active-1"),
+      session("pinned-2"),
+      session("completed-old"),
+      session("pinned-1"),
+      session("active-2"),
+      session("completed-new"),
+      session("active-3"),
+    ];
+    const lists = buildSidebarSessionLists(
+      sessions,
+      new Set(["pinned-1", "pinned-2", "completed-new"]),
+      {
+        "completed-old": "2026-07-20T12:00:00Z",
+        "completed-new": "2026-07-22T12:00:00Z",
+      },
+      2,
+    );
+
+    expect(lists.pinned.map(({ id }) => id)).toEqual(["pinned-1", "pinned-2"]);
+    expect(lists.visible.map(({ id }) => id)).toEqual(["active-1", "active-2"]);
+    expect(lists.completed.map(({ id }) => id)).toEqual(["completed-new", "completed-old"]);
+    expect(lists).toMatchObject({ pinnedTotal: 2, visibleTotal: 3, completedTotal: 2 });
+  });
+
+  it("indexes folder notes and sessions once while preserving source order", () => {
+    const first = note("first", "First", "", ["project-a", "project-a", "project-b"]);
+    const second = note("second", "Second", "", ["project-a"]);
+    const firstSession = session("session-1");
+    const secondSession = session("session-2");
+
+    const index = buildFolderItemIndex([first, second], [firstSession, secondSession], {
+      "session-1": ["project-a", "project-a"],
+      "session-2": ["project-b"],
+    });
+
+    expect(index.notesByFolderId.get("project-a")).toEqual([first, second]);
+    expect(index.notesByFolderId.get("project-b")).toEqual([first]);
+    expect(index.sessionsByFolderId.get("project-a")).toEqual([firstSession]);
+    expect(index.sessionsByFolderId.get("project-b")).toEqual([secondSession]);
+    expect(index.notesByFolderId.has("missing")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- memoize Meeting notes rows with stable ID-based callbacks and a memoized pure search filter
- cap pinned, active, and completed sidebar session groups at the existing 12-row limit while preserving totals and the existing View all path
- precompute project-to-note and project-to-session indexes once per data change instead of rescanning both collections for every card
- cover the new pure helpers for filtering, ordering, slicing, totals, duplicate membership, and source-order preservation

Refs JUN-397

## Root cause

Three list surfaces performed work proportional to their full data sets during routine renders: Meeting notes recreated every row callback, pinned and completed sessions bypassed the sidebar row cap, and every project card independently rescanned all notes and sessions.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` (205 files, 3,394 passed, 2 skipped)
- `make local-ci` on `abef352145d5a7a6920e1478671ef541937c173b` (`signoff/frontend` success, `signoff/rust-macos` success as not applicable)
- web-preview QA with 48 notes, 39 sessions, and 18 projects: search filtering, 12-row sidebar caps, View all routing, project counts, and console/page errors all passed

- [x] Tested visually where it matters (UI changes: browser preview with oversized fixture lists; no console or page errors).
- [ ] Needs a June API (backend) deploy before it works end to end. No June API changes.

## Out of scope

- list virtualization or a new virtualization dependency
- pagination or fetch-contract changes
- search debouncing; filtering remains immediate

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. Not applicable.
- [x] Workflow action references are pinned to full-length commit SHAs. Not applicable.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787346967&installation_model_id=425925&pr_number=908&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F908&signature=a1d6f90064be52453e0231ea059fd6cbe99e1d46a7a1d6750109aede43914112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->