### PR TITLE
perf(frontend): split heavy workspaces

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,20 +2,17 @@ import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  AGENT_NEW_SESSION_EVENT,
-  AGENT_SESSION_RENAMED_EVENT,
   markAgentNewSessionPending,
-  recordManualAgentSessionTitle,
   type AgentNewSessionDetail,
-  type AgentSessionRenamedDetail,
-} from "../components/agent/AgentWorkspace";
+} from "../components/agent/session-persistence";
+import { recordManualAgentSessionTitle } from "../components/agent/agent-session-continuity";
 import { NoteHeaderActions } from "../components/note-editor/NoteHeaderActions";
 import { toast } from "../components/ui/Toaster";
 import { exportNoteAsPdf } from "../lib/note-pdf";
 import { useNoteChat } from "../components/note-chat/useNoteChat";
 import { noteReadyToShare } from "../lib/share-payload";
-import { SETTINGS_TABS } from "../components/settings/AppSettings";
-import { type TabItem } from "../components/tabs/TabBar";
+import { SETTINGS_TABS } from "../components/settings/settings-config";
+import type { TabItem } from "../components/tabs/TabBar";
 import { reorderTabs } from "./tabs/tabs";
 import { useReferralNudgeTriggers } from "./referral-nudge-triggers";
 import {
@@ -42,8 +39,11 @@ import { preloadRecordingSounds } from "../lib/recording-sounds";
 import { preloadAgentSounds } from "../lib/agent-sounds";
 import {
   AGENT_GALLERY_EVENT,
+  AGENT_NEW_SESSION_EVENT,
+  AGENT_SESSION_RENAMED_EVENT,
   emitAgentSessionsChanged,
   type AgentGalleryDetail,
+  type AgentSessionRenamedDetail,
 } from "../lib/agent-events";
 import { selectSessionProjectContext } from "../lib/agent-project-context";
 import { rememberSessionManuallyTitled } from "../lib/agent-session-titles";
@@ -89,8 +89,8 @@ import {
   shouldBlockOnFunding,
   shouldBlockOnSignIn,
 } from "../lib/account-gate";
-import { type MaxUpgradeTransport } from "../lib/billing-actions";
-import { type MaxGrantWait } from "../lib/max-upgrade";
+import type { MaxUpgradeTransport } from "../lib/billing-actions";
+import type { MaxGrantWait } from "../lib/max-upgrade";
 import { reconcileToStable, relaunchJune, type JuneUpdate } from "../lib/updater";
 import { attachScrollThumbFade } from "../lib/scroll-thumb-fade";
 import {

--- a/src/app/app-domain-actions.ts
+++ b/src/app/app-domain-actions.ts
@@ -1,8 +1,8 @@
 import {
-  AGENT_NEW_SESSION_EVENT,
   markAgentNewSessionPending,
   type AgentNewSessionDetail,
-} from "../components/agent/AgentWorkspace";
+} from "../components/agent/session-persistence";
+import { AGENT_NEW_SESSION_EVENT } from "../lib/agent-events";
 import type { ReportCategory } from "../components/agent/composer/reportCategory";
 import {
   assignNoteToFolder,

--- a/src/app/app-layout-types.ts
+++ b/src/app/app-layout-types.ts
@@ -1,11 +1,11 @@
 import type { AgentSessionsListHandle } from "../components/agent/AgentSessionsList";
 import type { ReportCategory } from "../components/agent/composer/reportCategory";
-import { type NotesListHandle } from "../components/notes-list/NotesList";
-import { type SettingsTab } from "../components/settings/AppSettings";
-import { type SidebarView } from "../components/sidebar/Sidebar";
-import { type TabItem } from "../components/tabs/TabBar";
-import { type TabNav } from "./tabs/tabs";
-import { type ReferralNudgeMoment } from "../components/referral/ReferralNudge";
+import type { NotesListHandle } from "../components/notes-list/NotesList";
+import type { SettingsTab } from "../components/settings/settings-config";
+import type { SidebarView } from "../components/sidebar/Sidebar";
+import type { TabItem } from "../components/tabs/TabBar";
+import type { TabNav } from "./tabs/tabs";
+import type { ReferralNudgeMoment } from "../components/referral/ReferralNudge";
 import type {
   FolderDto,
   NoteDto,
@@ -13,16 +13,16 @@ import type {
   AccountStatus,
   HermesSessionInfo,
 } from "../lib/tauri";
-import { type MaxUpgradeTransport } from "../lib/billing-actions";
+import type { MaxUpgradeTransport } from "../lib/billing-actions";
 import type { MaxGrantWait } from "../lib/max-upgrade";
 import type { NoteChat } from "../components/note-chat/useNoteChat";
-import { type JuneUpdate } from "../lib/updater";
-import {
-  type UpdateInstallProgress,
-  type UpdatePromptPayload,
-  type UpdateStatusDisplayState,
+import type { JuneUpdate } from "../lib/updater";
+import type {
+  UpdateInstallProgress,
+  UpdatePromptPayload,
+  UpdateStatusDisplayState,
 } from "./update-decision";
-import { type RecordingInactivityPrompt } from "./app-shell";
+import type { RecordingInactivityPrompt } from "./app-shell";
 import type { NotesAction, NotesState } from "./state/app-state";
 import type * as React from "react";
 

--- a/src/app/app-workspace-view-types.ts
+++ b/src/app/app-workspace-view-types.ts
@@ -1,14 +1,14 @@
 import type { AgentSessionsListHandle } from "../components/agent/AgentSessionsList";
 import type { ReportCategory } from "../components/agent/composer/reportCategory";
-import { type NotesListHandle } from "../components/notes-list/NotesList";
-import { type SettingsTab } from "../components/settings/AppSettings";
-import { type SidebarView } from "../components/sidebar/Sidebar";
-import { type TabNav } from "./tabs/tabs";
-import { type LiveTranscriptEventDto, type RecoverableRecordingDto } from "../lib/tauri";
+import type { NotesListHandle } from "../components/notes-list/NotesList";
+import type { SettingsTab } from "../components/settings/settings-config";
+import type { SidebarView } from "../components/sidebar/Sidebar";
+import type { TabNav } from "./tabs/tabs";
+import type { LiveTranscriptEventDto, RecoverableRecordingDto } from "../lib/tauri";
 import type { FolderDto, NoteDto, AccountStatus, HermesSessionInfo } from "../lib/tauri";
 import type { RecordingSourceMode, RecordingSourceReadinessDto } from "../lib/tauri";
-import { type JuneUpdate } from "../lib/updater";
-import { type UpdateCheckMode, type UpdatePromptPayload } from "./update-decision";
+import type { JuneUpdate } from "../lib/updater";
+import type { UpdateCheckMode, UpdatePromptPayload } from "./update-decision";
 import type { NotesAction, NotesState } from "./state/app-state";
 import type * as React from "react";
 

--- a/src/app/app-workspace-view.tsx
+++ b/src/app/app-workspace-view.tsx
@@ -1,13 +1,9 @@
 import { FundingNotice, fundingTierOf } from "../components/account/FundingNotice";
-import { AgentWorkspace, markAgentNewSessionPending } from "../components/agent/AgentWorkspace";
+import { markAgentNewSessionPending } from "../components/agent/session-persistence";
 import { AgentSessionsList } from "../components/agent/AgentSessionsList";
 import { DictationHistoryView } from "../components/dictation/DictationHistoryView";
-import { FoldersWorkspace } from "../components/folders/FoldersWorkspace";
-import { RoutinesView } from "../components/routines/RoutinesView";
-import { NoteEditor } from "../components/note-editor/NoteEditor";
 import { ShareLinkCopyAction } from "../components/share/ShareLinkCopyAction";
 import { NotesList } from "../components/notes-list/NotesList";
-import { AppSettings } from "../components/settings/AppSettings";
 import { BreadcrumbBar } from "../components/ui/BreadcrumbBar";
 import { IconProjects } from "central-icons/IconProjects";
 import { retryProcessing, updateNote } from "../lib/tauri";
@@ -21,6 +17,13 @@ import {
   ROUTINE_FUNDING_DISABLED_REASON,
 } from "./app-shell";
 import type { RenderAppWorkspaceDependencies } from "./app-workspace-view-types";
+import {
+  AgentWorkspaceRoute,
+  AppSettingsRoute,
+  FoldersWorkspaceRoute,
+  NoteEditorRoute,
+  RoutinesViewRoute,
+} from "./workspace-lazy";
 
 export function renderAppWorkspace(dependencies: RenderAppWorkspaceDependencies) {
   const {
@@ -128,7 +131,7 @@ export function renderAppWorkspace(dependencies: RenderAppWorkspaceDependencies)
   } = dependencies;
 
   return activeView === "settings" ? (
-    <AppSettings
+    <AppSettingsRoute
       account={account}
       accountLoading={accountLoading}
       sourceMode={sourceMode}
@@ -175,7 +178,7 @@ export function renderAppWorkspace(dependencies: RenderAppWorkspaceDependencies)
       }}
     />
   ) : activeView === "routines" ? (
-    <RoutinesView
+    <RoutinesViewRoute
       creditActionsDisabledReason={fundingRequired ? ROUTINE_FUNDING_DISABLED_REASON : undefined}
       onCreateRoutine={(prompt) => {
         // The agent workspace is unmounted while Routines is shown,
@@ -202,7 +205,7 @@ export function renderAppWorkspace(dependencies: RenderAppWorkspaceDependencies)
   ) : activeView === "agent" ? (
     // The origin crumbs render inside the workspace's own sticky
     // session bar, so they persist while the chat scrolls beneath.
-    <AgentWorkspace
+    <AgentWorkspaceRoute
       initialSession={activeAgentSessionSeed}
       initialSessionId={activeAgentSessionId}
       onSessionSelected={setActiveAgentSession}
@@ -360,7 +363,7 @@ export function renderAppWorkspace(dependencies: RenderAppWorkspaceDependencies)
       onDeleteNotes={(noteIds) => void handleDeleteNotes(noteIds)}
     />
   ) : activeView === "folders" ? (
-    <FoldersWorkspace
+    <FoldersWorkspaceRoute
       folders={state.folders}
       notes={state.notes}
       sessions={agentSessions}
@@ -513,7 +516,7 @@ export function renderAppWorkspace(dependencies: RenderAppWorkspaceDependencies)
         />
       )}
       <div ref={noteDetailScrollRef} className="note-detail-scroll" data-has-detail-bar="true">
-        <NoteEditor
+        <NoteEditorRoute
           note={selectedNote}
           transcriptScrollRef={noteDetailScrollRef}
           folders={state.folders}

--- a/src/app/use-agent-menu-events.ts
+++ b/src/app/use-agent-menu-events.ts
@@ -1,10 +1,10 @@
 import { listen } from "@tauri-apps/api/event";
 import { useEffect } from "react";
 import {
-  AGENT_NEW_SESSION_EVENT,
   markAgentNewSessionPending,
   type AgentNewSessionDetail,
-} from "../components/agent/AgentWorkspace";
+} from "../components/agent/session-persistence";
+import { AGENT_NEW_SESSION_EVENT } from "../lib/agent-events";
 import { listHermesSessions } from "../lib/hermes-adapter";
 import {
   AGENT_MENU_BAR_NEW_SESSION_EVENT,

--- a/src/app/use-agent-session-sync.ts
+++ b/src/app/use-agent-session-sync.ts
@@ -3,7 +3,7 @@ import {
   AGENT_DELETE_SESSION_EVENT,
   AGENT_SESSIONS_CHANGED_EVENT,
   type AgentSessionsChangedDetail,
-} from "../components/agent/AgentWorkspace";
+} from "../lib/agent-events";
 import { assignSessionToFolder } from "../lib/tauri";
 import { AGENT_SESSION_STATUS_EVENT, type AgentSessionStatusDetail } from "../lib/agent-events";
 import { getActiveHermesProfileName } from "../lib/active-hermes-profile";

--- a/src/app/use-app-navigation.ts
+++ b/src/app/use-app-navigation.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
-  AGENT_NEW_SESSION_EVENT,
   markAgentNewSessionPending,
   type AgentNewSessionDetail,
-} from "../components/agent/AgentWorkspace";
+} from "../components/agent/session-persistence";
+import { AGENT_NEW_SESSION_EVENT } from "../lib/agent-events";
 import { defaultNav, makeTabId, navEquals, type TabNav } from "./tabs/tabs";
 import { getNote } from "../lib/tauri";
 import { messageFromError } from "../lib/errors";

--- a/src/app/use-app-state.ts
+++ b/src/app/use-app-state.ts
@@ -1,22 +1,22 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
-import { markAgentNewSessionPending } from "../components/agent/AgentWorkspace";
+import { markAgentNewSessionPending } from "../components/agent/session-persistence";
 import type { AgentSessionsListHandle } from "../components/agent/AgentSessionsList";
-import { type NotesListHandle } from "../components/notes-list/NotesList";
-import { type SettingsTab } from "../components/settings/AppSettings";
-import { type SidebarView } from "../components/sidebar/Sidebar";
+import type { NotesListHandle } from "../components/notes-list/NotesList";
+import type { SettingsTab } from "../components/settings/settings-config";
+import type { SidebarView } from "../components/sidebar/Sidebar";
 import { defaultNav, makeTabId, type Tab, type TabNav } from "./tabs/tabs";
-import { type LiveTranscriptEventDto } from "../lib/tauri";
+import type { LiveTranscriptEventDto } from "../lib/tauri";
 import { isMacLikePlatform, isWindowsPlatform } from "../lib/platform";
-import { type AgentSessionStatusDetail } from "../lib/agent-events";
+import type { AgentSessionStatusDetail } from "../lib/agent-events";
 import { useActiveHermesProfileName } from "../lib/active-hermes-profile";
-import { type SessionProfileMap } from "../lib/session-profile-filter";
-import { type RecordingInactivityTracker } from "../lib/recording-inactivity";
+import type { SessionProfileMap } from "../lib/session-profile-filter";
+import type { RecordingInactivityTracker } from "../lib/recording-inactivity";
 import { getAgentHudEnabled } from "../lib/agent-hud-settings";
 import type { NoteDto, HermesSessionInfo } from "../lib/tauri";
 import type { RecordingSourceMode, RecordingSourceReadinessDto } from "../lib/tauri";
 import { useAccountStatus } from "../lib/account-status";
 import { shouldReplayOnboarding } from "../lib/onboarding";
-import { type JuneUpdate } from "../lib/updater";
+import type { JuneUpdate } from "../lib/updater";
 import { createInitialState, notesReducer } from "./state/app-state";
 import {
   INITIAL_UPDATE_STATUS_DISPLAY,

--- a/src/app/use-dictation-events.ts
+++ b/src/app/use-dictation-events.ts
@@ -1,12 +1,11 @@
 import { listen } from "@tauri-apps/api/event";
 import { useEffect } from "react";
 import {
-  AGENT_NEW_SESSION_EVENT,
   markAgentNewSessionPending,
   type AgentNewSessionDetail,
-} from "../components/agent/AgentWorkspace";
+} from "../components/agent/session-persistence";
 import { recordDictationFinished } from "../lib/referral-nudge";
-import { dispatchAgentSessionStatus } from "../lib/agent-events";
+import { AGENT_NEW_SESSION_EVENT, dispatchAgentSessionStatus } from "../lib/agent-events";
 import { nextDictationWorkflowActive, parseDictationHelperEvent } from "../lib/dictation-events";
 import { titleFromPrompt } from "../lib/hermes-adapter";
 import { stringPayloadValue } from "./app-helpers";

--- a/src/app/workspace-lazy.tsx
+++ b/src/app/workspace-lazy.tsx
@@ -1,0 +1,91 @@
+import { type ComponentProps, type ComponentType, createElement, lazy, Suspense } from "react";
+
+type WorkspaceLoader<Props extends object> = {
+  Component: ComponentType<Props>;
+  preload: () => Promise<void>;
+};
+
+function createWorkspaceLoader<Module, Props extends object>(
+  loadModule: () => Promise<Module>,
+  selectComponent: (module: Module) => ComponentType<Props>,
+): WorkspaceLoader<Props> {
+  let loadedComponent: ComponentType<Props> | undefined;
+  let modulePromise: Promise<Module> | undefined;
+
+  function load() {
+    modulePromise ??= loadModule().then((module) => {
+      loadedComponent = selectComponent(module);
+      return module;
+    });
+    return modulePromise;
+  }
+
+  const LazyComponent = lazy(async () => ({
+    default: selectComponent(await load()),
+  }));
+
+  function CachedWorkspace(props: Props) {
+    const Component = loadedComponent ?? (LazyComponent as unknown as ComponentType<Props>);
+    return <Suspense fallback={<WorkspaceFallback />}>{createElement(Component, props)}</Suspense>;
+  }
+
+  return {
+    Component: CachedWorkspace,
+    preload: async () => {
+      await load();
+    },
+  };
+}
+
+type AgentWorkspaceModule = typeof import("../components/agent/AgentWorkspace");
+type AgentWorkspaceProps = NonNullable<ComponentProps<AgentWorkspaceModule["AgentWorkspace"]>>;
+type FoldersWorkspaceModule = typeof import("../components/folders/FoldersWorkspace");
+type FoldersWorkspaceProps = ComponentProps<FoldersWorkspaceModule["FoldersWorkspace"]>;
+type NoteEditorModule = typeof import("../components/note-editor/NoteEditor");
+type NoteEditorProps = ComponentProps<NoteEditorModule["NoteEditor"]>;
+type RoutinesViewModule = typeof import("../components/routines/RoutinesView");
+type RoutinesViewProps = ComponentProps<RoutinesViewModule["RoutinesView"]>;
+type AppSettingsModule = typeof import("../components/settings/AppSettings");
+type AppSettingsProps = ComponentProps<AppSettingsModule["AppSettings"]>;
+
+const agentWorkspace = createWorkspaceLoader<AgentWorkspaceModule, AgentWorkspaceProps>(
+  () => import("../components/agent/AgentWorkspace"),
+  (module) => module.AgentWorkspace,
+);
+const foldersWorkspace = createWorkspaceLoader<FoldersWorkspaceModule, FoldersWorkspaceProps>(
+  () => import("../components/folders/FoldersWorkspace"),
+  (module) => module.FoldersWorkspace,
+);
+const noteEditor = createWorkspaceLoader<NoteEditorModule, NoteEditorProps>(
+  () => import("../components/note-editor/NoteEditor"),
+  (module) => module.NoteEditor,
+);
+const routinesView = createWorkspaceLoader<RoutinesViewModule, RoutinesViewProps>(
+  () => import("../components/routines/RoutinesView"),
+  (module) => module.RoutinesView,
+);
+const appSettings = createWorkspaceLoader<AppSettingsModule, AppSettingsProps>(
+  () => import("../components/settings/AppSettings"),
+  (module) => module.AppSettings,
+);
+
+export const AgentWorkspaceRoute = agentWorkspace.Component;
+export const FoldersWorkspaceRoute = foldersWorkspace.Component;
+export const NoteEditorRoute = noteEditor.Component;
+export const RoutinesViewRoute = routinesView.Component;
+export const AppSettingsRoute = appSettings.Component;
+
+function WorkspaceFallback() {
+  return (
+    <section className="workspace-fallback" aria-label="Loading view" aria-busy="true">
+      <span className="workspace-fallback-title" />
+      <div className="workspace-fallback-lines" aria-hidden="true">
+        <span />
+        <span />
+        <span />
+      </div>
+    </section>
+  );
+}
+
+export const preloadInitialWorkspace = agentWorkspace.preload;

--- a/src/app/workspace-lazy.tsx
+++ b/src/app/workspace-lazy.tsx
@@ -158,6 +158,7 @@ export function prefetchRemainingWorkspacesAfterPaint() {
 
   const runPrefetch = () => {
     if (cancelled) return;
+    // Failed idle imports reset in load() and remain retryable on navigation.
     void Promise.allSettled(deferredWorkspacePreloads.map((preload) => preload()));
   };
 

--- a/src/app/workspace-lazy.tsx
+++ b/src/app/workspace-lazy.tsx
@@ -1,40 +1,102 @@
-import { type ComponentProps, type ComponentType, createElement, lazy, Suspense } from "react";
+import {
+  Component,
+  type ComponentProps,
+  type ComponentType,
+  createElement,
+  lazy,
+  type ReactNode,
+  Suspense,
+  useMemo,
+  useState,
+} from "react";
 
 type WorkspaceLoader<Props extends object> = {
   Component: ComponentType<Props>;
   preload: () => Promise<void>;
 };
 
-function createWorkspaceLoader<Module, Props extends object>(
+export function createWorkspaceLoader<Module, Props extends object>(
   loadModule: () => Promise<Module>,
   selectComponent: (module: Module) => ComponentType<Props>,
 ): WorkspaceLoader<Props> {
-  let loadedComponent: ComponentType<Props> | undefined;
   let modulePromise: Promise<Module> | undefined;
 
   function load() {
-    modulePromise ??= loadModule().then((module) => {
-      loadedComponent = selectComponent(module);
-      return module;
-    });
+    modulePromise ??= Promise.resolve()
+      .then(loadModule)
+      .catch((error: unknown) => {
+        modulePromise = undefined;
+        throw error;
+      });
     return modulePromise;
   }
 
-  const LazyComponent = lazy(async () => ({
-    default: selectComponent(await load()),
-  }));
+  function createLazyComponent() {
+    return lazy(async () => ({
+      default: selectComponent(await load()),
+    }));
+  }
 
-  function CachedWorkspace(props: Props) {
-    const Component = loadedComponent ?? (LazyComponent as unknown as ComponentType<Props>);
-    return <Suspense fallback={<WorkspaceFallback />}>{createElement(Component, props)}</Suspense>;
+  const InitialLazyComponent = createLazyComponent();
+
+  function WorkspaceRoute(props: Props) {
+    const [attempt, setAttempt] = useState(0);
+    const LazyComponent = useMemo(
+      () => (attempt === 0 ? InitialLazyComponent : createLazyComponent()),
+      [attempt],
+    );
+    const ComponentToRender = LazyComponent as unknown as ComponentType<Props>;
+
+    return (
+      <WorkspaceLoadErrorBoundary key={attempt} onRetry={() => setAttempt((value) => value + 1)}>
+        <Suspense fallback={<WorkspaceFallback />}>
+          {createElement(ComponentToRender, props)}
+        </Suspense>
+      </WorkspaceLoadErrorBoundary>
+    );
   }
 
   return {
-    Component: CachedWorkspace,
+    Component: WorkspaceRoute,
     preload: async () => {
       await load();
     },
   };
+}
+
+type WorkspaceLoadErrorBoundaryProps = {
+  children: ReactNode;
+  onRetry: () => void;
+};
+
+class WorkspaceLoadErrorBoundary extends Component<
+  WorkspaceLoadErrorBoundaryProps,
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  render() {
+    if (this.state.failed) {
+      return <WorkspaceLoadFailure onRetry={this.props.onRetry} />;
+    }
+    return this.props.children;
+  }
+}
+
+function WorkspaceLoadFailure({ onRetry }: { onRetry: () => void }) {
+  return (
+    <section className="workspace-fallback workspace-load-error" role="alert">
+      <h2>Couldn't open this view</h2>
+      <p>June couldn't load this part of the app. Try again.</p>
+      <button type="button" className="primary-action primary-solid" onClick={onRetry}>
+        Try again
+      </button>
+    </section>
+  );
 }
 
 type AgentWorkspaceModule = typeof import("../components/agent/AgentWorkspace");
@@ -74,6 +136,47 @@ export const FoldersWorkspaceRoute = foldersWorkspace.Component;
 export const NoteEditorRoute = noteEditor.Component;
 export const RoutinesViewRoute = routinesView.Component;
 export const AppSettingsRoute = appSettings.Component;
+
+const deferredWorkspacePreloads = [
+  // Meeting-start navigation lands here, so queue the note editor first.
+  noteEditor.preload,
+  appSettings.preload,
+  foldersWorkspace.preload,
+  routinesView.preload,
+];
+
+type IdleCallbackWindow = Window & {
+  requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+export function prefetchRemainingWorkspacesAfterPaint() {
+  const idleWindow = window as IdleCallbackWindow;
+  let cancelled = false;
+  let idleHandle: number | undefined;
+  let timeoutHandle: number | undefined;
+
+  const runPrefetch = () => {
+    if (cancelled) return;
+    void Promise.allSettled(deferredWorkspacePreloads.map((preload) => preload()));
+  };
+
+  const frameHandle = window.requestAnimationFrame(() => {
+    if (cancelled) return;
+    if (idleWindow.requestIdleCallback) {
+      idleHandle = idleWindow.requestIdleCallback(runPrefetch, { timeout: 1_500 });
+      return;
+    }
+    timeoutHandle = window.setTimeout(runPrefetch, 0);
+  });
+
+  return () => {
+    cancelled = true;
+    window.cancelAnimationFrame(frameHandle);
+    if (idleHandle !== undefined) idleWindow.cancelIdleCallback?.(idleHandle);
+    if (timeoutHandle !== undefined) window.clearTimeout(timeoutHandle);
+  };
+}
 
 function WorkspaceFallback() {
   return (

--- a/src/components/agent/agent-workspace-config.tsx
+++ b/src/components/agent/agent-workspace-config.tsx
@@ -14,6 +14,8 @@ import {
   AGENT_NEW_SESSION_EVENT,
   AGENT_NEW_SESSION_PENDING_KEY,
   AGENT_SESSIONS_CHANGED_EVENT,
+  AGENT_SESSION_RENAMED_EVENT,
+  type AgentSessionRenamedDetail,
   type AgentSessionsChangedDetail,
 } from "../../lib/agent-events";
 
@@ -230,19 +232,12 @@ export function shuffleAgentShortcuts(): AgentShortcut[] {
   return pool;
 }
 
-export const AGENT_SESSION_RENAMED_EVENT = "june:agent:session-renamed";
-
-/** stored session id (not the runtime session id). */
-export type AgentSessionRenamedDetail = {
-  sessionId: string;
-  title: string;
-};
-
 export {
   AGENT_DELETE_SESSION_EVENT,
   AGENT_NEW_SESSION_EVENT,
   AGENT_NEW_SESSION_PENDING_KEY,
   AGENT_SESSIONS_CHANGED_EVENT,
+  AGENT_SESSION_RENAMED_EVENT,
 };
 
-export type { AgentSessionsChangedDetail };
+export type { AgentSessionRenamedDetail, AgentSessionsChangedDetail };

--- a/src/components/settings/AgentSettingsSection.tsx
+++ b/src/components/settings/AgentSettingsSection.tsx
@@ -4,8 +4,8 @@ import {
   FilesystemPanel,
   MessagingPanel,
   MessagingPlatformDetail,
-  messagingTrimEdits,
-} from "../agent/AgentWorkspace";
+} from "../agent/management/MessagingFilesystemPanels";
+import { messagingTrimEdits } from "../agent/management/management-helpers";
 import { BreadcrumbBar } from "../ui/BreadcrumbBar";
 import { HoverTip } from "../ui/HoverTip";
 import {

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -148,6 +148,8 @@ import { SetupSnapshotSection } from "./SetupSnapshotSection";
 import { SkillBundlesSection } from "./SkillBundlesSection";
 import { SkillsHubSection } from "./SkillsHubSection";
 import { TeamTapsSection } from "./TeamTapsSection";
+import { SETTINGS_TABS, type SettingsTab } from "./settings-config";
+export { SETTINGS_TABS, type SettingsTab } from "./settings-config";
 import { ToolsetsSection } from "./ToolsetsSection";
 import { DictionarySettingsSection } from "./DictionarySettingsSection";
 import { MemorySettingsSection } from "./MemorySettingsSection";
@@ -347,61 +349,6 @@ async function activeProfileTextModel(profileName: string): Promise<string | und
 }
 
 const MIC_TEST_DURATION_SECONDS = 5;
-
-export type SettingsTab =
-  | "general"
-  | "appearance"
-  | "billing"
-  | "shortcuts"
-  | "dictation"
-  | "audio"
-  | "models"
-  | "agent"
-  | "memory"
-  | "connectors"
-  | "skills"
-  | "external-dirs"
-  | "skill-review"
-  | "mcp"
-  | "mcp-catalog"
-  | "mcp-diagnostics"
-  | "mcp-security"
-  | "skills-hub"
-  | "taps"
-  | "toolsets"
-  | "bundles"
-  | "profile-builder"
-  | "integrations-health"
-  | "import-export"
-  | "about";
-
-export const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
-  { id: "general", label: "General" },
-  { id: "appearance", label: "Appearance" },
-  { id: "billing", label: "Billing" },
-  { id: "shortcuts", label: "Shortcuts" },
-  { id: "dictation", label: "Dictation" },
-  { id: "audio", label: "Audio" },
-  { id: "models", label: "Models" },
-  { id: "agent", label: "Agent" },
-  { id: "memory", label: "Memory" },
-  { id: "connectors", label: "Plugins" },
-  { id: "skills", label: "Installed skills" },
-  { id: "external-dirs", label: "External skill directories" },
-  { id: "skill-review", label: "Pending skill changes" },
-  { id: "mcp", label: "MCP servers" },
-  { id: "mcp-catalog", label: "MCP catalog" },
-  { id: "mcp-diagnostics", label: "MCP diagnostics" },
-  { id: "mcp-security", label: "MCP security" },
-  { id: "skills-hub", label: "Skills hub" },
-  { id: "taps", label: "Team skill taps" },
-  { id: "toolsets", label: "Toolsets" },
-  { id: "bundles", label: "Bundles" },
-  { id: "profile-builder", label: "Profiles" },
-  { id: "integrations-health", label: "Integrations health" },
-  { id: "import-export", label: "Import / export" },
-  { id: "about", label: "About" },
-];
 
 /**
  * The shared settings page header (Codex-app style): a large serif page title

--- a/src/components/settings/settings-config.ts
+++ b/src/components/settings/settings-config.ts
@@ -1,0 +1,54 @@
+export type SettingsTab =
+  | "general"
+  | "appearance"
+  | "billing"
+  | "shortcuts"
+  | "dictation"
+  | "audio"
+  | "models"
+  | "agent"
+  | "memory"
+  | "connectors"
+  | "skills"
+  | "external-dirs"
+  | "skill-review"
+  | "mcp"
+  | "mcp-catalog"
+  | "mcp-diagnostics"
+  | "mcp-security"
+  | "skills-hub"
+  | "taps"
+  | "toolsets"
+  | "bundles"
+  | "profile-builder"
+  | "integrations-health"
+  | "import-export"
+  | "about";
+
+export const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
+  { id: "general", label: "General" },
+  { id: "appearance", label: "Appearance" },
+  { id: "billing", label: "Billing" },
+  { id: "shortcuts", label: "Shortcuts" },
+  { id: "dictation", label: "Dictation" },
+  { id: "audio", label: "Audio" },
+  { id: "models", label: "Models" },
+  { id: "agent", label: "Agent" },
+  { id: "memory", label: "Memory" },
+  { id: "connectors", label: "Plugins" },
+  { id: "skills", label: "Installed skills" },
+  { id: "external-dirs", label: "External skill directories" },
+  { id: "skill-review", label: "Pending skill changes" },
+  { id: "mcp", label: "MCP servers" },
+  { id: "mcp-catalog", label: "MCP catalog" },
+  { id: "mcp-diagnostics", label: "MCP diagnostics" },
+  { id: "mcp-security", label: "MCP security" },
+  { id: "skills-hub", label: "Skills hub" },
+  { id: "taps", label: "Team skill taps" },
+  { id: "toolsets", label: "Toolsets" },
+  { id: "bundles", label: "Bundles" },
+  { id: "profile-builder", label: "Profiles" },
+  { id: "integrations-health", label: "Integrations health" },
+  { id: "import-export", label: "Import / export" },
+  { id: "about", label: "About" },
+];

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -55,12 +55,7 @@ import {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
-import {
-  AGENT_SESSION_RENAMED_EVENT,
-  markAgentNewSessionPending,
-  type AgentSessionRenamedDetail,
-  type AgentSessionsChangedDetail,
-} from "../agent/AgentWorkspace";
+import { markAgentNewSessionPending } from "../agent/session-persistence";
 import { CategoryIcon } from "../agent/composer/CategoryIcon";
 import { JuneWordmark } from "../brand/JuneWordmark";
 import { AccountAvatar, accountDisplayName } from "../account/AccountAvatar";
@@ -69,7 +64,10 @@ import {
   AGENT_DELETE_SESSION_EVENT,
   AGENT_NEW_SESSION_EVENT,
   AGENT_SESSIONS_CHANGED_EVENT,
+  AGENT_SESSION_RENAMED_EVENT,
   emitAgentSessionsChanged,
+  type AgentSessionRenamedDetail,
+  type AgentSessionsChangedDetail,
 } from "../../lib/agent-events";
 import {
   deleteHermesSession,
@@ -100,7 +98,7 @@ import {
 } from "../../lib/session-profile-filter";
 import { JuneMark } from "../account/AccountGate";
 import { OPEN_REFERRAL_DIALOG_EVENT } from "../referral/ReferralNudge";
-import { SETTINGS_TABS, type SettingsTab } from "../settings/AppSettings";
+import { SETTINGS_TABS, type SettingsTab } from "../settings/settings-config";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { CopyLinkField } from "../ui/CopyLinkField";
 import { Dialog } from "../ui/Dialog";

--- a/src/lib/agent-events.ts
+++ b/src/lib/agent-events.ts
@@ -4,6 +4,7 @@ export const AGENT_NEW_SESSION_EVENT = "june:agent:new-session";
 export const AGENT_DELETE_SESSION_EVENT = "june:agent:delete-session";
 export const AGENT_SESSIONS_CHANGED_EVENT = "june:agent:sessions-changed";
 export const AGENT_NEW_SESSION_PENDING_KEY = "june:agent:new-session-pending";
+export const AGENT_SESSION_RENAMED_EVENT = "june:agent:session-renamed";
 export const AGENT_SESSION_STATUS_EVENT = "june:agent:session-status";
 export const AGENT_RUN_SETTLED_EVENT = "june:agent:run-settled";
 export const AGENT_OPEN_EVENT = "june:agent:open";
@@ -12,6 +13,12 @@ export const AGENT_OPEN_EVENT = "june:agent:open";
 export const AGENT_GALLERY_EVENT = "june:agent:gallery";
 
 export type AgentGalleryDetail = { show: boolean; errors?: boolean };
+
+/** Stored session id (not the runtime session id). */
+export type AgentSessionRenamedDetail = {
+  sessionId: string;
+  title: string;
+};
 
 export type AgentSessionStatusKind =
   | "received"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,10 @@ import { initFontScale, installFontScaleShortcuts } from "./lib/font-scale";
 import { installExternalLinkOpener } from "./lib/external-links";
 import { initializeExperimentalFlags } from "./lib/experimental-flags";
 import { isMacLikePlatform, isWindowsPlatform } from "./lib/platform";
-import { preloadInitialWorkspace } from "./app/workspace-lazy";
+import {
+  prefetchRemainingWorkspacesAfterPaint,
+  preloadInitialWorkspace,
+} from "./app/workspace-lazy";
 import "./styles/app.css";
 
 declare global {
@@ -33,9 +36,15 @@ initFontScale();
 installFontScaleShortcuts();
 installExternalLinkOpener();
 installNativeContextMenuGuard();
+// Intentionally await the default Agent workspace before mounting React. This
+// trades some first-paint parsing for a stable launch with no fallback flash;
+// JUN-391 owns the broader paint-first startup work. The remaining workspaces
+// are fetched after first paint below.
 await Promise.all([
   initializeExperimentalFlags(),
-  isMacLikePlatform() || isWindowsPlatform() ? preloadInitialWorkspace() : Promise.resolve(),
+  isMacLikePlatform() || isWindowsPlatform()
+    ? preloadInitialWorkspace().catch(() => undefined)
+    : Promise.resolve(),
 ]);
 
 // Console driver for the agent HUD overlay window: __agentHud("demo") etc.
@@ -97,3 +106,4 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     {import.meta.env.DEV ? <Agentation /> : null}
   </React.StrictMode>,
 );
+prefetchRemainingWorkspacesAfterPaint();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,8 @@ import { initBrand } from "./lib/brand";
 import { initFontScale, installFontScaleShortcuts } from "./lib/font-scale";
 import { installExternalLinkOpener } from "./lib/external-links";
 import { initializeExperimentalFlags } from "./lib/experimental-flags";
+import { isMacLikePlatform, isWindowsPlatform } from "./lib/platform";
+import { preloadInitialWorkspace } from "./app/workspace-lazy";
 import "./styles/app.css";
 
 declare global {
@@ -31,7 +33,10 @@ initFontScale();
 installFontScaleShortcuts();
 installExternalLinkOpener();
 installNativeContextMenuGuard();
-await initializeExperimentalFlags();
+await Promise.all([
+  initializeExperimentalFlags(),
+  isMacLikePlatform() || isWindowsPlatform() ? preloadInitialWorkspace() : Promise.resolve(),
+]);
 
 // Console driver for the agent HUD overlay window: __agentHud("demo") etc.
 // from this window's devtools. Emits on the Tauri bus only, so fake demo

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -10497,6 +10497,46 @@ button.agent-user-attachment:hover {
   height: 100%;
 }
 
+.workspace-fallback {
+  display: flex;
+  flex-direction: column;
+  align-self: start;
+  width: min(100%, var(--content-max));
+  margin: 0 auto;
+  padding: var(--sp-10) 0;
+  gap: var(--sp-8);
+}
+
+.workspace-fallback-title,
+.workspace-fallback-lines span {
+  display: block;
+  border-radius: var(--r-sm);
+  background: var(--surface-subtle);
+}
+
+.workspace-fallback-title {
+  width: 38%;
+  height: var(--sp-6);
+}
+
+.workspace-fallback-lines {
+  display: grid;
+  gap: var(--sp-4);
+}
+
+.workspace-fallback-lines span {
+  width: 100%;
+  height: var(--sp-3);
+}
+
+.workspace-fallback-lines span:nth-child(2) {
+  width: 84%;
+}
+
+.workspace-fallback-lines span:nth-child(3) {
+  width: 62%;
+}
+
 /* Wrapper gives the editor a real viewport-height box inside the card. Long
  * note content contributes to the card scroller while the recorder is fixed
  * to the card bottom. */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -10537,6 +10537,32 @@ button.agent-user-attachment:hover {
   width: 62%;
 }
 
+.workspace-load-error {
+  align-items: flex-start;
+  gap: var(--sp-4);
+}
+
+.workspace-load-error h2,
+.workspace-load-error p {
+  margin: 0;
+}
+
+.workspace-load-error h2 {
+  color: var(--foreground);
+  font-family: var(--font-serif);
+  font-size: var(--fs-xl);
+  font-weight: 400;
+}
+
+.workspace-load-error p {
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+}
+
+.workspace-load-error .primary-action {
+  margin-top: var(--sp-2);
+}
+
 /* Wrapper gives the editor a real viewport-height box inside the card. Long
  * note content contributes to the card scroller while the recorder is fixed
  * to the card bottom. */

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -314,7 +314,7 @@ describe("meeting start transcription event", () => {
     });
     expect(mocks.acknowledgeMeetingStartRequest).toHaveBeenCalledWith("meeting-request-1");
     expect(mocks.playRecordingSound).toHaveBeenCalledWith("start");
-    expect(screen.getByLabelText("Note title")).toHaveValue("New meeting");
+    expect(await screen.findByLabelText("Note title")).toHaveValue("New meeting");
   });
 
   it("keeps calendar enrichment that arrives before native meeting startup resolves", async () => {

--- a/src/test/workspace-lazy.test.tsx
+++ b/src/test/workspace-lazy.test.tsx
@@ -1,0 +1,153 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { type ComponentType, useEffect, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createWorkspaceLoader,
+  prefetchRemainingWorkspacesAfterPaint,
+} from "../app/workspace-lazy";
+
+const deferredImports = vi.hoisted(() => ({
+  noteEditor: vi.fn(),
+  settings: vi.fn(),
+  folders: vi.fn(),
+  routines: vi.fn(),
+}));
+
+vi.mock("../components/note-editor/NoteEditor", () => {
+  deferredImports.noteEditor();
+  return { NoteEditor: () => null };
+});
+
+vi.mock("../components/settings/AppSettings", () => {
+  deferredImports.settings();
+  return { AppSettings: () => null };
+});
+
+vi.mock("../components/folders/FoldersWorkspace", () => {
+  deferredImports.folders();
+  return { FoldersWorkspace: () => null };
+});
+
+vi.mock("../components/routines/RoutinesView", () => {
+  deferredImports.routines();
+  return { RoutinesView: () => null };
+});
+
+type ProbeProps = {
+  label: string;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("lazy workspace routes", () => {
+  it("keeps the resolved workspace mounted across parent renders", async () => {
+    let resolveModule: ((module: { Probe: ComponentType<ProbeProps> }) => void) | undefined;
+    const modulePromise = new Promise<{ Probe: ComponentType<ProbeProps> }>((resolve) => {
+      resolveModule = resolve;
+    });
+    const mounted = vi.fn();
+    const unmounted = vi.fn();
+
+    function Probe({ label }: ProbeProps) {
+      useEffect(() => {
+        mounted();
+        return unmounted;
+      }, []);
+      return <div data-testid="workspace-probe">{label}</div>;
+    }
+
+    const workspace = createWorkspaceLoader(
+      () => modulePromise,
+      (module) => module.Probe,
+    );
+
+    function Parent() {
+      const [label, setLabel] = useState("First");
+      return (
+        <>
+          <button type="button" onClick={() => setLabel("Second")}>
+            Update parent
+          </button>
+          <workspace.Component label={label} />
+        </>
+      );
+    }
+
+    render(<Parent />);
+    expect(screen.getByLabelText("Loading view")).toBeInTheDocument();
+
+    await act(async () => resolveModule?.({ Probe }));
+    const probe = await screen.findByTestId("workspace-probe");
+    expect(mounted).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Update parent" }));
+
+    expect(screen.getByTestId("workspace-probe")).toBe(probe);
+    expect(screen.getByTestId("workspace-probe")).toHaveTextContent("Second");
+    expect(mounted).toHaveBeenCalledTimes(1);
+    expect(unmounted).not.toHaveBeenCalled();
+  });
+
+  it("contains a rejected workspace import and retries it", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    let attempts = 0;
+
+    function Probe({ label }: ProbeProps) {
+      return <div data-testid="workspace-probe">{label}</div>;
+    }
+
+    const workspace = createWorkspaceLoader(
+      async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("Chunk unavailable");
+        return { Probe };
+      },
+      (module) => module.Probe,
+    );
+
+    render(<workspace.Component label="Recovered" />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Couldn't open this view");
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(await screen.findByTestId("workspace-probe")).toHaveTextContent("Recovered");
+    expect(attempts).toBe(2);
+    consoleError.mockRestore();
+  });
+
+  it("prefetches the remaining workspaces after paint during idle time", async () => {
+    deferredImports.noteEditor.mockClear();
+    deferredImports.settings.mockClear();
+    deferredImports.folders.mockClear();
+    deferredImports.routines.mockClear();
+
+    let runIdle: (() => void) | undefined;
+    const requestIdleCallback = vi.fn((callback: () => void) => {
+      runIdle = callback;
+      return 7;
+    });
+    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+    vi.stubGlobal("cancelIdleCallback", vi.fn());
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(0);
+      return 3;
+    });
+
+    prefetchRemainingWorkspacesAfterPaint();
+
+    expect(requestIdleCallback).toHaveBeenCalledOnce();
+    expect(deferredImports.noteEditor).not.toHaveBeenCalled();
+
+    runIdle?.();
+
+    await waitFor(() => {
+      expect(deferredImports.noteEditor).toHaveBeenCalledOnce();
+      expect(deferredImports.settings).toHaveBeenCalledOnce();
+      expect(deferredImports.folders).toHaveBeenCalledOnce();
+      expect(deferredImports.routines).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,20 @@ export default defineConfig({
         "agent-hud": fileURLToPath(new URL("./agent-hud.html", import.meta.url)),
         "meeting-hud": fileURLToPath(new URL("./meeting-hud.html", import.meta.url)),
       },
+      output: {
+        manualChunks(id) {
+          if (!id.includes("/node_modules/")) return;
+
+          if (id.includes("/@tiptap/") || id.includes("/prosemirror-")) {
+            return "vendor-editor";
+          }
+          if (id.includes("/react-dom/server.") || id.includes("/react-dom/cjs/react-dom-server")) {
+            return "vendor-react-server";
+          }
+          if (id.includes("/react-dom/")) return "vendor-react-dom";
+          if (id.includes("/react/")) return "vendor-react";
+        },
+      },
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- Lazy-load Agent, Routines, Settings, Projects, and note editor workspaces behind a shared token-based Suspense fallback.
- Preload the default Agent workspace before the supported-platform app mounts, avoiding an initial fallback flash.
- Split React, React DOM, React DOM server, and TipTap/ProseMirror into a few stable vendor chunks while preserving the four production HTML entry points.

Refs JUN-400

## Root cause

The Vite build declared its HTML inputs but no chunk strategy, and the app shell statically imported every heavy workspace. Small settings metadata and agent event helpers also flowed through the heavy workspace modules, so Rollup kept almost the entire desktop dependency graph in the main entry paid at every launch.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` - 207 files passed, 3,404 tests passed, 2 skipped
- `pnpm build`
- `make local-ci`
- Main JS: 2,479.26 kB raw / 712.31 kB gzip before; 889.00 kB raw / 263.22 kB gzip after
- Lazy chunks: Agent 324.02 kB, Settings 527.71 kB, Routines 58.85 kB, Projects 38.38 kB, note editor 36.34 kB
- Vendor editor chunk: 447.28 kB raw / 142.51 kB gzip
- Verified all four production HTML entries build. HUD preload graphs do not include the editor or client React DOM chunks and remain within about 1.5 kB raw of baseline.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). Not run: this is a loading-boundary refactor; the default workspace is preloaded before mount and the fallback uses existing design tokens.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Feature or navigation behavior changes
- Per-module micro-chunks beyond the workspace and vendor boundaries
- June API, native shell, HUD UI, or release changes

## Followups

- Keep this PR in draft for the planned external Opus and Kimi review round.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. None.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787384739&installation_model_id=425925&pr_number=912&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F912&signature=1f4ae29528abb1ce59df142a5d821e3e081d4aa6714f28a227ce7b63cfdad5c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->