### PR TITLE
perf(frontend): stabilize CSS state and animations

### DIFF
--- a/src/app/app-effects/update-ui.tsx
+++ b/src/app/app-effects/update-ui.tsx
@@ -1,5 +1,6 @@
 import { IconChevronRightSmall } from "central-icons/IconChevronRightSmall";
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
+import type { CSSProperties } from "react";
 import type { AgentSessionStatusDetail } from "../../lib/agent-events";
 import type { JuneUpdate } from "../../lib/updater";
 import { JuneMark } from "../../components/account/AccountGate";
@@ -172,7 +173,14 @@ function UpdateStatusCard({
       {progress ? (
         <div className="update-progress" aria-hidden>
           <div className="update-progress-track">
-            <div className="update-progress-fill" style={{ width: progressWidth }} />
+            <div
+              className="update-progress-fill"
+              style={
+                {
+                  "--update-progress-clip": `calc(100% - max(var(--sp-2), ${progressWidth}))`,
+                } as CSSProperties
+              }
+            />
           </div>
           {percent !== undefined ? (
             <span className="update-progress-percent update-digit-group">

--- a/src/app/app-layout.tsx
+++ b/src/app/app-layout.tsx
@@ -152,10 +152,17 @@ export function renderAppLayout(dependencies: RenderAppLayoutDependencies) {
     updateStatusLeaving,
     workspaceContent,
   } = dependencies;
+  const noteChatVisible = activeView === "meetings" && selectedNote !== undefined && noteChatOpen;
 
   return (
     <main
-      className="app-shell"
+      className={[
+        "app-shell",
+        activeView !== "settings" ? "app-shell-sidebar-default" : "",
+        noteChatVisible ? "app-shell-note-chat-open" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
       data-platform={isWindowsPlatform() ? "windows" : undefined}
       data-sidebar={sidebarCollapsed ? "collapsed" : "expanded"}
       data-sidebar-resizing={sidebarResizing ? "true" : "false"}
@@ -332,7 +339,7 @@ export function renderAppLayout(dependencies: RenderAppLayoutDependencies) {
           layoutFrozen={sidebarResizing}
           onDragRegionPointerDown={handleTitlebarPointerDown}
         />
-        <section className="main-panel">
+        <section className={`main-panel${activeView === "agent" ? " main-panel-agent-view" : ""}`}>
           {accessibilityBlocked && !accessibilityBannerDismissed ? (
             <PermissionBanner
               onDismiss={() => setAccessibilityBannerDismissed(true)}
@@ -393,7 +400,7 @@ export function renderAppLayout(dependencies: RenderAppLayoutDependencies) {
             ) : null}
           </AnimatePresence>
         </section>
-        {activeView === "meetings" && selectedNote && noteChatOpen ? (
+        {noteChatVisible && selectedNote ? (
           <NoteChatPanel
             note={{ id: selectedNote.id, title: selectedNote.title }}
             chat={noteChat}

--- a/src/components/agent/AgentSessionsList.tsx
+++ b/src/components/agent/AgentSessionsList.tsx
@@ -603,7 +603,9 @@ function AgentSessionListRow({
          * render no checkbox (a completed row can't be selected, moved, or
          * bulk-deleted — JUN-203 review). */}
         {completed ? null : (
-          <label className="folder-note-checkbox">
+          <label
+            className={`folder-note-checkbox${checked ? " folder-note-checkbox-checked" : ""}`}
+          >
             <input
               type="checkbox"
               checked={checked}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -907,6 +907,10 @@ export function AgentWorkspace({
   const artifactPanelOpen = artifactPanel !== null;
   useLayoutEffect(() => {
     const shell = document.querySelector(".app-shell");
+    // Safe today because renderAppLayout's shell className is stable while the
+    // agent view owns this workspace: switching views unmounts us, and note
+    // chat cannot open here. If agent-local state ever changes that className,
+    // lift this flag into renderAppLayout instead of keeping the side channel.
     shell?.classList.toggle("app-shell-artifact-panel-open", artifactPanelOpen);
     return () => shell?.classList.remove("app-shell-artifact-panel-open");
   }, [artifactPanelOpen]);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -905,6 +905,12 @@ export function AgentWorkspace({
   // when the panel opens, so the keyboard is the close affordance that never
   // moves; the panel's filter input claims the first Esc to clear itself.
   const artifactPanelOpen = artifactPanel !== null;
+  useLayoutEffect(() => {
+    const shell = document.querySelector(".app-shell");
+    shell?.classList.toggle("app-shell-artifact-panel-open", artifactPanelOpen);
+    return () => shell?.classList.remove("app-shell-artifact-panel-open");
+  }, [artifactPanelOpen]);
+
   useEffect(() => {
     if (!artifactPanelOpen) return;
     const onKey = (event: KeyboardEvent) => {

--- a/src/components/agent/chat-turns/ActionCardPrimitives.tsx
+++ b/src/components/agent/chat-turns/ActionCardPrimitives.tsx
@@ -221,7 +221,10 @@ export function ApproveSplitButton({
   }
 
   return (
-    <div className="agent-approval-split" ref={wrapRef}>
+    <div
+      className={`agent-approval-split${disabled ? " agent-approval-split-disabled" : ""}`}
+      ref={wrapRef}
+    >
       <button
         type="button"
         className="agent-approval-approve"

--- a/src/components/agent/chat-turns/AgentActionCards.tsx
+++ b/src/components/agent/chat-turns/AgentActionCards.tsx
@@ -131,6 +131,12 @@ export type AgentCliAccessCardProps = {
   onEnable: () => void;
 };
 
+type DismissibleAccessCardProps = {
+  /** Controlled by the turn row when its owner needs to mirror card presence. */
+  dismissed?: boolean;
+  onDismiss?: () => void;
+};
+
 /** June asked to enable "Agent CLI access" via the literal token its soul
  * teaches ([REQUEST:AGENT_CLI_ACCESS]). The agent can never flip the setting
  * itself — the flag file sits outside every sandbox write root — so this
@@ -138,8 +144,13 @@ export type AgentCliAccessCardProps = {
  * live setting rather than stored per message: a revisited transcript shows
  * "Enabled" once the grant is on, and re-offers the choice while it is off.
  * Mirrors the approval card chrome. */
-export function AgentCliAccessCard({ cliAccess }: { cliAccess?: AgentCliAccessCardProps }) {
-  const [dismissed, setDismissed] = useState(false);
+export function AgentCliAccessCard({
+  cliAccess,
+  dismissed: controlledDismissed,
+  onDismiss,
+}: { cliAccess?: AgentCliAccessCardProps } & DismissibleAccessCardProps) {
+  const [locallyDismissed, setLocallyDismissed] = useState(false);
+  const dismissed = controlledDismissed ?? locallyDismissed;
   const enabled = cliAccess?.enabled === true;
   const resolved = enabled || dismissed;
   const busy = Boolean(cliAccess?.submitting);
@@ -182,7 +193,10 @@ export function AgentCliAccessCard({ cliAccess }: { cliAccess?: AgentCliAccessCa
             type="button"
             className="btn btn-ghost agent-approval-deny"
             disabled={busy}
-            onClick={() => setDismissed(true)}
+            onClick={() => {
+              if (controlledDismissed === undefined) setLocallyDismissed(true);
+              onDismiss?.();
+            }}
           >
             Not now
           </button>
@@ -260,10 +274,11 @@ export function BrowserApprovalCard({
  * grant is on, and re-offers the choice while it is off. */
 export function AgentBrowserAccessCard({
   browserAccess,
-}: {
-  browserAccess?: AgentBrowserAccessCardProps;
-}) {
-  const [dismissed, setDismissed] = useState(false);
+  dismissed: controlledDismissed,
+  onDismiss,
+}: { browserAccess?: AgentBrowserAccessCardProps } & DismissibleAccessCardProps) {
+  const [locallyDismissed, setLocallyDismissed] = useState(false);
+  const dismissed = controlledDismissed ?? locallyDismissed;
   const enabled = browserAccess?.enabled === true;
   const resolved = enabled || dismissed;
   const busy = Boolean(browserAccess?.submitting);
@@ -306,7 +321,10 @@ export function AgentBrowserAccessCard({
             type="button"
             className="btn btn-ghost agent-approval-deny"
             disabled={busy}
-            onClick={() => setDismissed(true)}
+            onClick={() => {
+              if (controlledDismissed === undefined) setLocallyDismissed(true);
+              onDismiss?.();
+            }}
           >
             Not now
           </button>

--- a/src/components/agent/chat-turns/AgentArtifactPanel.tsx
+++ b/src/components/agent/chat-turns/AgentArtifactPanel.tsx
@@ -79,7 +79,7 @@ function AgentArtifactCard({
   );
 
   return (
-    <article className="agent-artifact-card">
+    <article className={`agent-artifact-card${onOpen ? " agent-artifact-card-interactive" : ""}`}>
       {onOpen ? (
         <button
           type="button"

--- a/src/components/agent/chat-turns/AgentChatTurnRow.tsx
+++ b/src/components/agent/chat-turns/AgentChatTurnRow.tsx
@@ -216,6 +216,15 @@ export const AgentChatTurnRow = memo(function AgentChatTurnRow({
   const nonTextParts = turn.parts.filter((part) => part.type !== "text");
   const concreteResponse = turnIsConcreteResponse(turn);
   const copyText = copyableTextForTurn(turn);
+  const hasActionCard = turn.parts.some(
+    (part) =>
+      part.type === "approval" ||
+      part.type === "clarify" ||
+      part.type === "sudo" ||
+      part.type === "secret" ||
+      (part.type === "text" &&
+        (hasAgentCliAccessRequest(part.text) || hasBrowserAccessRequest(part.text))),
+  );
 
   async function copyTurn() {
     if (!copyText) return;
@@ -346,7 +355,11 @@ export const AgentChatTurnRow = memo(function AgentChatTurnRow({
 
   return (
     <article className="agent-assistant-turn" data-status={turn.status}>
-      <div className="agent-assistant-turn-body">
+      <div
+        className={`agent-assistant-turn-body${
+          hasActionCard ? " agent-assistant-turn-body-action-card" : ""
+        }`}
+      >
         {reasoningParts.length > 0 ? (
           <AgentThinkingGroup
             reasoning={reasoningParts}

--- a/src/components/agent/chat-turns/AgentChatTurnRow.tsx
+++ b/src/components/agent/chat-turns/AgentChatTurnRow.tsx
@@ -172,6 +172,9 @@ export const AgentChatTurnRow = memo(function AgentChatTurnRow({
     thinkingOpen(activeThinkingKey);
   const thinkingIsOpen = thinkingOpen(thinkingKey) || carriedOpen;
   const [copied, setCopied] = useState(false);
+  const [dismissedAccessRequestCards, setDismissedAccessRequestCards] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
   const copyResetTimerRef = useRef<number | undefined>(undefined);
 
   useEffect(() => {
@@ -216,15 +219,35 @@ export const AgentChatTurnRow = memo(function AgentChatTurnRow({
   const nonTextParts = turn.parts.filter((part) => part.type !== "text");
   const concreteResponse = turnIsConcreteResponse(turn);
   const copyText = copyableTextForTurn(turn);
-  const hasActionCard = turn.parts.some(
-    (part) =>
+  const hasActionCard = turn.parts.some((part, index) => {
+    if (
       part.type === "approval" ||
       part.type === "clarify" ||
       part.type === "sudo" ||
-      part.type === "secret" ||
-      (part.type === "text" &&
-        (hasAgentCliAccessRequest(part.text) || hasBrowserAccessRequest(part.text))),
-  );
+      part.type === "secret"
+    ) {
+      return part.status === "pending";
+    }
+    if (part.type !== "text") return false;
+    return (
+      (hasAgentCliAccessRequest(part.text) &&
+        cliAccess?.enabled !== true &&
+        !dismissedAccessRequestCards.has(accessRequestCardKey(turn.id, index, "cli"))) ||
+      (hasBrowserAccessRequest(part.text) &&
+        browserAccess?.enabled !== true &&
+        !dismissedAccessRequestCards.has(accessRequestCardKey(turn.id, index, "browser")))
+    );
+  });
+
+  function dismissAccessRequestCard(index: number, kind: AccessRequestCardKind) {
+    const key = accessRequestCardKey(turn.id, index, kind);
+    setDismissedAccessRequestCards((current) => {
+      if (current.has(key)) return current;
+      const next = new Set(current);
+      next.add(key);
+      return next;
+    });
+  }
 
   async function copyTurn() {
     if (!copyText) return;
@@ -397,10 +420,22 @@ export const AgentChatTurnRow = memo(function AgentChatTurnRow({
                   />
                 ) : null}
                 {hasAgentCliAccessRequest(part.text) ? (
-                  <AgentCliAccessCard cliAccess={cliAccess} />
+                  <AgentCliAccessCard
+                    cliAccess={cliAccess}
+                    dismissed={dismissedAccessRequestCards.has(
+                      accessRequestCardKey(turn.id, index, "cli"),
+                    )}
+                    onDismiss={() => dismissAccessRequestCard(index, "cli")}
+                  />
                 ) : null}
                 {hasBrowserAccessRequest(part.text) ? (
-                  <AgentBrowserAccessCard browserAccess={browserAccess} />
+                  <AgentBrowserAccessCard
+                    browserAccess={browserAccess}
+                    dismissed={dismissedAccessRequestCards.has(
+                      accessRequestCardKey(turn.id, index, "browser"),
+                    )}
+                    onDismiss={() => dismissAccessRequestCard(index, "browser")}
+                  />
                 ) : null}
               </div>
             ) : (
@@ -502,6 +537,12 @@ export const AgentChatTurnRow = memo(function AgentChatTurnRow({
     </article>
   );
 });
+
+type AccessRequestCardKind = "browser" | "cli";
+
+function accessRequestCardKey(turnId: string, partIndex: number, kind: AccessRequestCardKind) {
+  return `${turnId}:${partIndex}:${kind}`;
+}
 
 function AgentUserAttachmentList({
   attachments,

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -202,7 +202,7 @@ function assistantPartNode(
 
 /** The contextual Ask June chat: a fixed side panel next to the meeting note,
  * mirroring the agent artifact panel's attach mechanics (sibling card on the
- * window background; the main card slides left via the :has() margin in
+ * window background; the main card slides left via the shell state class in
  * app.css). The conversation itself is a real Hermes session scoped to the
  * note — see useNoteChat. */
 export function NoteChatPanel({

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -471,7 +471,11 @@ export function NoteEditor({
         {activeTab === "transcription" ? (
           <div className="transcript-view">
             {transcriptText ? (
-              <div className="transcript-toolbar">
+              <div
+                className={`transcript-toolbar${
+                  hasBothSources ? " transcript-toolbar-filtered" : ""
+                }`}
+              >
                 {hasBothSources ? (
                   <SegmentedControl
                     className="transcript-source-filter"
@@ -616,7 +620,7 @@ export function NoteEditor({
                   transition={{ duration: 0.22, ease: "easeOut" }}
                 >
                   <InlineNotice
-                    className="record-consent-note-surface"
+                    className="record-consent-note-surface record-consent-note-surface-actions"
                     aria-label="Recording consent reminder"
                     body="Make sure everyone has agreed to be recorded."
                     actions={

--- a/src/components/notes-list/NotesList.tsx
+++ b/src/components/notes-list/NotesList.tsx
@@ -387,7 +387,7 @@ const AllNoteRow = memo(function AllNoteRow({
         data-has-actions="true"
         data-menu-open={menu !== null}
       >
-        <label className="folder-note-checkbox">
+        <label className={`folder-note-checkbox${checked ? " folder-note-checkbox-checked" : ""}`}>
           <input
             type="checkbox"
             checked={checked}

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -2238,6 +2238,7 @@ export function AppSettings({
                 <div className="settings-rows">
                   <ModelRow
                     mode="transcription"
+                    beforeDivider
                     title="Transcription"
                     description="Speech-to-text for note recordings and dictation."
                     value={modelValueForMode("transcription")}
@@ -2323,6 +2324,7 @@ export function AppSettings({
                 <div className="settings-rows">
                   <ModelRow
                     mode="generation"
+                    beforeDivider={providerSettings.generationModel !== "open-software/auto"}
                     title="Text"
                     description="Used for generated notes and agent responses."
                     value={modelValueForMode("generation")}
@@ -2350,7 +2352,7 @@ export function AppSettings({
                     readOnly={showingActiveProfileModels}
                   />
                   {providerSettings.generationModel === "open-software/auto" ? (
-                    <div className="settings-row">
+                    <div className="settings-row settings-row-before-divider">
                       <div className="settings-row-info">
                         <span className="settings-row-title">Auto preference</span>
                         <span className="settings-row-description">
@@ -2583,6 +2585,7 @@ export function AppSettings({
                     {IMAGE_GENERATION_ENABLED ? (
                       <ModelRow
                         mode="image"
+                        beforeDivider={!VIDEO_GENERATION_ENABLED}
                         title="Image"
                         description="Used when you generate an image from chat."
                         value={modelValueForMode("image")}
@@ -2606,6 +2609,7 @@ export function AppSettings({
                     {VIDEO_GENERATION_ENABLED ? (
                       <ModelRow
                         mode="video"
+                        beforeDivider
                         title="Video"
                         description="Used when you generate a video from chat."
                         value={modelValueForMode("video")}
@@ -3280,6 +3284,7 @@ function numericPayload(value: unknown) {
 
 function ModelRow({
   mode,
+  beforeDivider = false,
   title,
   description,
   value,
@@ -3301,6 +3306,7 @@ function ModelRow({
   summarySuppressed,
 }: {
   mode: ProviderModelMode;
+  beforeDivider?: boolean;
   title: string;
   description: string;
   value: string;
@@ -3324,7 +3330,11 @@ function ModelRow({
   const model = selectedModel(options, value);
   const modelLabel = `${title.toLowerCase()} model`;
   return (
-    <div className="settings-row settings-model-row">
+    <div
+      className={`settings-row settings-model-row${
+        beforeDivider ? " settings-row-before-divider" : ""
+      }`}
+    >
       <div className="settings-row-info">
         <h3 className="settings-row-title">{title}</h3>
         <p className="settings-row-description">{description}</p>

--- a/src/components/settings/McpCatalogSection.tsx
+++ b/src/components/settings/McpCatalogSection.tsx
@@ -10,7 +10,7 @@ import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconPlugin2 } from "central-icons/IconPlugin2";
 import { IconShield } from "central-icons/IconShield";
 import { IconShieldCheck } from "central-icons/IconShieldCheck";
-import { useEffect, useMemo, useState } from "react";
+import { type CSSProperties, useEffect, useMemo, useState } from "react";
 import {
   catalogAuthMeta,
   catalogStatusMeta,
@@ -436,7 +436,11 @@ function InstallControl({
         <span className="skills-hub-install-bar" aria-hidden>
           <span
             className="skills-hub-install-bar-fill"
-            style={pct !== undefined ? { width: `${pct}%` } : undefined}
+            style={
+              pct !== undefined
+                ? ({ "--install-progress-clip": `${100 - pct}%` } as CSSProperties)
+                : undefined
+            }
             data-indeterminate={pct === undefined || undefined}
           />
         </span>

--- a/src/components/settings/SkillsHubSection.tsx
+++ b/src/components/settings/SkillsHubSection.tsx
@@ -10,7 +10,7 @@ import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconPlugin2 } from "central-icons/IconPlugin2";
 import { IconShieldCheck } from "central-icons/IconShieldCheck";
 import { IconWarningSign } from "central-icons/IconWarningSign";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useMemo, useState } from "react";
 import {
   buildSkillInstallReview,
   filterHubResults,
@@ -464,7 +464,11 @@ function InstallControl({
         <span className="skills-hub-install-bar" aria-hidden>
           <span
             className="skills-hub-install-bar-fill"
-            style={pct !== undefined ? { width: `${pct}%` } : undefined}
+            style={
+              pct !== undefined
+                ? ({ "--install-progress-clip": `${100 - pct}%` } as CSSProperties)
+                : undefined
+            }
             data-indeterminate={pct === undefined || undefined}
           />
         </span>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -2253,10 +2253,13 @@ function AgentSessionRow({
   const status = waiting ? "waitingForUser" : working ? "running" : undefined;
   const time = formatSessionTime(sessionTimestamp(session), dateFormat);
   const menuRef = useRef<HTMLButtonElement>(null);
+  const [menuFocused, setMenuFocused] = useState(false);
 
   return (
     <article
-      className="note-row agent-sidebar-row"
+      className={`note-row agent-sidebar-row${
+        menuFocused ? " agent-sidebar-row-menu-focused" : ""
+      }`}
       data-selected={selected}
       data-status={status}
       data-menu-open={menuOpen || undefined}
@@ -2319,6 +2322,8 @@ function AgentSessionRow({
           aria-haspopup="menu"
           aria-expanded={menuOpen}
           disabled={deleting}
+          onFocus={(event) => setMenuFocused(event.currentTarget.matches(":focus-visible"))}
+          onBlur={() => setMenuFocused(false)}
           onClick={(event) => {
             event.preventDefault();
             event.stopPropagation();

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -10,10 +10,14 @@ type CheckboxProps = Omit<ComponentPropsWithoutRef<"input">, "type" | "className
  * the visual — outline when unchecked, brand fill + checkmark when checked.
  * Place inside a <label> next to the option copy.
  */
-export function Checkbox({ checked, ...rest }: CheckboxProps) {
+export function Checkbox({ checked, disabled, ...rest }: CheckboxProps) {
   return (
-    <span className="checkbox-control">
-      <input type="checkbox" checked={checked} {...rest} />
+    <span
+      className={`checkbox-control${checked ? " checkbox-control-checked" : ""}${
+        disabled ? " checkbox-control-disabled" : ""
+      }`}
+    >
+      <input type="checkbox" checked={checked} disabled={disabled} {...rest} />
       <span className="checkbox-box" aria-hidden>
         {checked ? <IconCheckmark2Medium size={10} /> : null}
       </span>

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -34,7 +34,12 @@ export function EmptyState({
   className?: string;
 }) {
   return (
-    <section className={`empty-state${className ? ` ${className}` : ""}`} aria-label={label}>
+    <section
+      className={`empty-state${footer ? " empty-state-with-footer" : ""}${
+        className ? ` ${className}` : ""
+      }`}
+      aria-label={label}
+    >
       <div className="empty-state-content">
         {icon ? (
           <span className="empty-state-icon" aria-hidden>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -357,7 +357,7 @@ input:focus-visible,
    * it stuck on). The dissolve hangs off the fixed composer instead
    * (.agent-composer::before), inside the workspace context where the
    * composer wins. */
-  .main-panel:has(.main-panel-body[data-active-view="agent"])::after {
+  .main-panel.main-panel-agent-view::after {
     animation: none;
   }
   .main-panel-body[data-note-detail-scroller="true"] {
@@ -1982,7 +1982,7 @@ input:focus-visible,
 }
 
 /* Both segments disable together; dim the whole control so it reads inert. */
-.agent-approval-split:has(:disabled) {
+.agent-approval-split-disabled {
   opacity: 0.55;
 }
 
@@ -2368,10 +2368,9 @@ button.agent-user-attachment:hover {
  * at the turn body's floor (inset-block-start: 100%) with only 1px of padding —
  * so under a bordered card the timestamp nearly touches the card's bottom border.
  * Reserve clearance below a card-bearing turn (padding grows the padding box, so
- * the 100%-anchored row drops clear of the border). Scoped via :has() so text
- * turns keep their tight 1px timestamp spacing. */
-.agent-assistant-turn-body:has(.agent-approval-card),
-.agent-assistant-turn-body:has(.agent-clarify-card) {
+ * the 100%-anchored row drops clear of the border). React marks only the turns
+ * that render an action card, so text turns keep their tight 1px spacing. */
+.agent-assistant-turn-body-action-card {
   padding-bottom: var(--sp-2);
 }
 
@@ -3099,7 +3098,7 @@ button.agent-user-attachment:hover {
   text-align: left;
 }
 
-.agent-artifact-card:has(button.agent-artifact-open):hover {
+.agent-artifact-card-interactive:hover {
   border-color: var(--border);
   background: color-mix(in oklch, var(--muted) 35%, transparent);
 }
@@ -3429,7 +3428,7 @@ button.agent-user-attachment:hover {
  * The files panel is its own card on the background surface — a sibling of
  * .main-panel, not a box inside it. It fixes to the window's right edge with
  * the same insets, radius, and shadow as the main card, and the main card
- * slides left (via the :has() margin below) to accept it. Fixed top/bottom
+ * slides left (via the shell's explicit open-state class) to accept it. Fixed top/bottom
  * anchoring also guarantees the panel a bounded height, so its body always
  * scrolls no matter what the chat column is doing.
  *
@@ -3441,7 +3440,7 @@ button.agent-user-attachment:hover {
 
 /* The files panel slides over from the window edge; only the card hands it
  * room so the titlebar tab strip still spans the full window top. */
-.app-shell:has(.agent-workspace[data-artifact-panel="open"]) .main-panel {
+.app-shell.app-shell-artifact-panel-open .main-panel {
   margin-right: calc(var(--agent-files-w) + var(--sp-3));
 }
 
@@ -8490,7 +8489,7 @@ button.agent-user-attachment:hover {
  * falls back to the base rule (titlebar band, 8px from left) — the collapsed
  * sidebar is display:none so the header doesn't exist, and Settings has no
  * sidebar-header. macOS is untouched: no data-platform="windows" attribute. */
-.app-shell[data-platform="windows"][data-sidebar="expanded"]:has(> .sidebar[data-mode="default"])
+.app-shell.app-shell-sidebar-default[data-platform="windows"][data-sidebar="expanded"]
 > .chrome-sidebar-toggle {
   top: var(--sp-3);
   left: max(
@@ -9786,7 +9785,7 @@ button.agent-user-attachment:hover {
 
 .agent-sidebar-row:hover .agent-session-meta,
 .agent-sidebar-row[data-menu-open="true"] .agent-session-meta,
-.agent-sidebar-row:has(.agent-session-row-menu:focus-visible) .agent-session-meta {
+.agent-sidebar-row-menu-focused .agent-session-meta {
   opacity: 0;
 }
 
@@ -10414,9 +10413,9 @@ button.agent-user-attachment:hover {
   background: linear-gradient(to bottom, transparent, var(--card) 78%);
   opacity: 0;
   /* Soften any static opacity flip (e.g. leaving the agent view, where the
-   * :has() rule below holds the dissolve at 0) so the veil never pops in a
+   * agent-view rule below holds the dissolve at 0) so the veil never pops in a
    * single frame over content. Matches the warm wash's 280ms fade. Lives
-   * here, not on the :has() rule, because an exit transition must survive
+   * here, not on the state rule, because an exit transition must survive
    * the rule un-matching; scroll-driven animation values are unaffected, as
    * animations beat transitions. */
   transition: opacity 280ms var(--ease-out);
@@ -10431,7 +10430,7 @@ button.agent-user-attachment:hover {
  * this (animations beat static declarations). In browsers without
  * scroll-timeline support the agent view simply never shows the dissolve —
  * a safe degradation, since it exists to dissolve scrolling content. */
-.main-panel:has(.main-panel-body[data-active-view="agent"])::after {
+.main-panel.main-panel-agent-view::after {
   opacity: 0;
 }
 
@@ -10439,7 +10438,7 @@ button.agent-user-attachment:hover {
  * dissolve sits where the breadcrumb bar normally lives, and in the hero it
  * shows up behind floating popovers as a horizontal wash. Keep it off for the
  * entire agent view. */
-.main-panel:has(.main-panel-body[data-active-view="agent"])::before {
+.main-panel.main-panel-agent-view::before {
   top: var(--detail-bar-h);
   right: var(--scrollbar-w);
   animation: none;
@@ -10957,7 +10956,7 @@ button.agent-user-attachment:hover {
 /* Sits above the first transcript turn and shares its max-width so the
  * filter/Copy align with the turn content (and the editor header). Copy
  * hugs the right by default; the source filter (when present) takes the
- * left, splitting the bar via :has() so we don't need a layout
+ * left, with React marking the two-sided layout so we don't need a
  * placeholder. */
 .transcript-toolbar {
   display: flex;
@@ -10968,7 +10967,7 @@ button.agent-user-attachment:hover {
   margin-bottom: var(--sp-2);
 }
 
-.transcript-toolbar:has(.transcript-source-filter) {
+.transcript-toolbar-filtered {
   justify-content: space-between;
 }
 
@@ -11592,7 +11591,7 @@ button.agent-user-attachment:hover {
  * panel (window inset + panel + card gap + content gutter — the same math as
  * the agent composer's artifact-panel override) so the recorder pill centers
  * on the note card, not the window. */
-.app-shell:has(.note-chat-panel) .editor-footer {
+.app-shell.app-shell-note-chat-open .editor-footer {
   right: calc(2 * var(--sp-3) + var(--note-chat-w) + var(--sp-8));
 }
 
@@ -11691,7 +11690,7 @@ button.agent-user-attachment:hover {
 }
 
 /* The Dismiss button hugs the corner radius like the funding notice's CTA. */
-.record-dock .record-consent-note-surface:has(.inline-notice-actions) {
+.record-dock .record-consent-note-surface-actions {
   padding-right: var(--sp-2);
 }
 
@@ -12150,11 +12149,11 @@ button.agent-user-attachment:hover {
   /* Grows toward the 30px box with a little headroom at the edges. The shared
    * meter drives --level per frame; the 24ms transition smooths sub-frame steps
    * (sharpened from 40ms to match the HUD so the carrier shimmer reads crisp). */
-  height: calc(3px + var(--level, 0) * 24px);
+  height: 100%;
   border-radius: 999px;
   background: var(--foreground);
-  transform: translateY(50%);
-  transition: height 18ms linear;
+  transform: translateY(50%) scaleY(calc(0.1 + var(--level, 0) * 0.8));
+  transition: transform 18ms linear;
 }
 
 .recorder-bar[data-state="paused"] .waveform span {
@@ -13773,7 +13772,7 @@ button.agent-user-attachment:hover {
   background: var(--border-subtle);
 }
 
-.settings-row:has(+ .settings-row-divider) {
+.settings-row-before-divider {
   border-bottom: 0;
 }
 
@@ -21445,7 +21444,7 @@ button.memory-project:hover {
   border-color: color-mix(in oklch, var(--muted-foreground) 35%, var(--border));
 }
 
-.folder-note-checkbox:has(input:checked) .folder-note-select-box {
+.folder-note-checkbox-checked .folder-note-select-box {
   border-color: var(--brand);
   background: var(--brand);
   color: var(--on-solid);
@@ -21645,7 +21644,7 @@ button.memory-project:hover {
 
 .all-notes-row:hover .folder-note-checkbox,
 .all-notes-row:focus-within .folder-note-checkbox,
-.all-notes-row .folder-note-checkbox:has(input:checked),
+.all-notes-row .folder-note-checkbox-checked,
 .all-notes-list[data-selecting="true"] .folder-note-checkbox {
   opacity: 1;
   pointer-events: auto;
@@ -21928,7 +21927,7 @@ button.memory-project:hover {
 }
 
 /* Trim the bottom padding when a footer follows so the two don't double up. */
-.empty-state:has(.empty-state-footer) .empty-state-content {
+.empty-state-with-footer .empty-state-content {
   padding-bottom: var(--sp-10);
 }
 
@@ -23256,12 +23255,13 @@ button.memory-project:hover {
 
 .update-progress-fill {
   height: 100%;
-  min-width: 8px;
+  width: 100%;
   border-radius: inherit;
   /* Lighter than --foreground so the bar reads quiet; --muted-foreground stays
    * clearly ahead of the --surface-subtle track in both themes. */
   background: var(--muted-foreground);
-  transition: width var(--t-fast) var(--ease-out);
+  clip-path: inset(0 var(--update-progress-clip, 100%) 0 0 round var(--r-pill));
+  transition: clip-path var(--t-fast) var(--ease-out);
 }
 
 .update-progress-percent {
@@ -24997,14 +24997,17 @@ button.memory-project:hover {
 .skills-hub-install-bar-fill {
   display: block;
   height: 100%;
-  width: 0;
+  width: 100%;
   border-radius: 999px;
   background: var(--primary);
-  transition: width 0.2s ease;
+  clip-path: inset(0 var(--install-progress-clip, 100%) 0 0 round var(--r-pill));
+  transition: clip-path 0.2s ease;
 }
 
 .skills-hub-install-bar-fill[data-indeterminate] {
   width: 40%;
+  clip-path: none;
+  transition: none;
   animation: skills-hub-indeterminate 1.1s ease-in-out infinite;
 }
 
@@ -26915,13 +26918,13 @@ button.memory-project:hover {
 /* Note chat panel -----------------------------------------------------
  * Ask June beside the open note: the same attach mechanics as the agent
  * files panel — a sibling card fixed to the window's right edge, the main
- * card sliding left via the :has() margin — but holding a conversation
+ * card sliding left via the shell's explicit open-state class — but holding a conversation
  * instead of a document (src/components/note-chat/). */
 .app-shell {
   --note-chat-w: clamp(320px, 32vw, 440px);
 }
 
-.app-shell:has(.note-chat-panel) .main-panel {
+.app-shell.app-shell-note-chat-open .main-panel {
   margin-right: calc(var(--note-chat-w) + var(--sp-3));
 }
 
@@ -27283,17 +27286,17 @@ button.memory-project:hover {
   border-color: color-mix(in oklch, var(--muted-foreground) 35%, var(--border));
 }
 
-.checkbox-control:has(input:checked) .checkbox-box {
+.checkbox-control-checked .checkbox-box {
   border-color: var(--brand);
   background: var(--brand);
 }
 
-.checkbox-control:has(input:focus-visible) .checkbox-box {
+.checkbox-control input:focus-visible + .checkbox-box {
   outline: 2px solid color-mix(in oklch, var(--ring) 55%, transparent);
   outline-offset: 2px;
 }
 
-.checkbox-control:has(input:disabled) {
+.checkbox-control-disabled {
   opacity: 0.55;
 }
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6746,12 +6746,17 @@ describe("AgentWorkspace", () => {
 
     render(<AgentWorkspace initialSession={existingSession} />);
 
+    expect(
+      (await screen.findByText("Browser use requested")).closest(".agent-assistant-turn-body"),
+    ).toHaveClass("agent-assistant-turn-body-action-card");
     await user.click(await screen.findByRole("button", { name: "Not now" }));
 
     // Declining leaves the grant off and the session usable: nothing is sent
     // into the session and the card resolves quietly.
     expect(mocks.setHermesBrowserAccess).not.toHaveBeenCalled();
-    expect(await screen.findByText("Not now")).toBeInTheDocument();
+    expect(
+      (await screen.findByText("Not now")).closest(".agent-assistant-turn-body"),
+    ).not.toHaveClass("agent-assistant-turn-body-action-card");
     expect(screen.queryByRole("button", { name: "Enable Browser use" })).toBeNull();
     expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("prompt.submit", expect.anything());
   });

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6606,7 +6606,9 @@ describe("AgentWorkspace", () => {
 
     // Already granted resolves to the quiet collapsed receipt row — the full
     // "requested" prompt title is not shown, only the enabled outcome.
-    expect(await screen.findByText("Agent CLI access enabled")).toBeInTheDocument();
+    expect(
+      (await screen.findByText("Agent CLI access enabled")).closest(".agent-assistant-turn-body"),
+    ).not.toHaveClass("agent-assistant-turn-body-action-card");
     expect(screen.queryByText("Agent CLI access requested")).toBeNull();
     expect(screen.queryByRole("button", { name: "Enable Agent CLI access" })).toBeNull();
   });
@@ -6728,7 +6730,9 @@ describe("AgentWorkspace", () => {
 
     // Already granted resolves to the quiet collapsed receipt row — the full
     // "requested" prompt title is not shown, only the enabled outcome.
-    expect(await screen.findByText("Browser use enabled")).toBeInTheDocument();
+    expect(
+      (await screen.findByText("Browser use enabled")).closest(".agent-assistant-turn-body"),
+    ).not.toHaveClass("agent-assistant-turn-body-action-card");
     expect(screen.queryByText("Browser use requested")).toBeNull();
     expect(screen.queryByRole("button", { name: "Enable Browser use" })).toBeNull();
   });

--- a/src/test/approval-card-css.test.ts
+++ b/src/test/approval-card-css.test.ts
@@ -118,7 +118,7 @@ describe("pending action card styles", () => {
     expect(split).toContain("padding: 2px;");
     expect(split).toContain("gap: 2px;");
     // Disabled dims the whole control.
-    expect(cssRuleFor(".agent-approval-split:has(:disabled)")).toContain("opacity: 0.55;");
+    expect(cssRuleFor(".agent-approval-split-disabled")).toContain("opacity: 0.55;");
     // Approve carries the solid gray fill (--surface-subtle), firming to --muted
     // on hover — no green, no dark primary fill.
     const approve = cssRuleFor(".agent-approval-approve");
@@ -214,10 +214,9 @@ describe("pending action card styles", () => {
   it("reserves timestamp clearance below a card-bearing turn only", () => {
     // A turn that holds an action card gets padding-bottom so the absolutely
     // positioned timestamp row (anchored at the turn body floor) clears the
-    // card's bottom border. Scoped via :has() so text turns are untouched.
-    const cleared = cssRuleFor(
-      ".agent-assistant-turn-body:has(.agent-approval-card),\n.agent-assistant-turn-body:has(.agent-clarify-card)",
-    );
+    // card's bottom border. React marks only card-bearing turns, so text turns
+    // remain untouched without an ancestor-sensitive selector.
+    const cleared = cssRuleFor(".agent-assistant-turn-body-action-card");
     expect(cleared).toContain("padding-bottom: var(--sp-2);");
     // The base turn body carries no such padding (text turns stay tight).
     expect(cssRuleFor(".agent-turn-actions-inner")).toContain("padding-top: var(--sp-px);");

--- a/src/test/css-stabilization.test.tsx
+++ b/src/test/css-stabilization.test.tsx
@@ -1,0 +1,49 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Checkbox } from "../components/ui/Checkbox";
+import { EmptyState } from "../components/ui/EmptyState";
+import appCss from "../styles/app.css?raw";
+
+describe("CSS stabilization state selectors", () => {
+  it("does not use :has() in the application stylesheet", () => {
+    expect(appCss).not.toContain(":has(");
+  });
+
+  it("uses composited properties for waveform and progress animation", () => {
+    expect(appCss).toContain("transition: transform 18ms linear;");
+    expect(appCss).toContain("transition: clip-path var(--t-fast) var(--ease-out);");
+    expect(appCss).not.toMatch(/transition:[ \t]*(?:height|width)\b/);
+  });
+
+  it("keeps the intrinsic accordion transitions that reflow surrounding content", () => {
+    expect(appCss.match(/transition:\s*grid-template-rows\b/g)).toHaveLength(3);
+  });
+
+  it("marks shared component state explicitly", () => {
+    const { container, rerender } = render(
+      <>
+        <Checkbox checked disabled onChange={() => undefined} />
+        <EmptyState title="Nothing here" footer={<span>Shortcut</span>} />
+      </>,
+    );
+
+    expect(container.querySelector(".checkbox-control")).toHaveClass(
+      "checkbox-control-checked",
+      "checkbox-control-disabled",
+    );
+    expect(container.querySelector(".empty-state")).toHaveClass("empty-state-with-footer");
+
+    rerender(
+      <>
+        <Checkbox checked={false} onChange={() => undefined} />
+        <EmptyState title="Nothing here" />
+      </>,
+    );
+
+    expect(container.querySelector(".checkbox-control")).not.toHaveClass(
+      "checkbox-control-checked",
+      "checkbox-control-disabled",
+    );
+    expect(container.querySelector(".empty-state")).not.toHaveClass("empty-state-with-footer");
+  });
+});

--- a/src/test/hermes-sudo-secret-actions.test.tsx
+++ b/src/test/hermes-sudo-secret-actions.test.tsx
@@ -9,6 +9,10 @@ import {
   SecretPart,
   turnIsConcreteResponse,
 } from "../components/agent/AgentWorkspace";
+import {
+  AgentChatTurnRow,
+  type AgentChatTurnRowProps,
+} from "../components/agent/chat-turns/AgentChatTurnRow";
 import type { AgentChatPart, AgentChatTurn } from "../lib/agent-chat-runtime";
 import { createHermesMethods } from "../lib/hermes-control-plane";
 import secretFixture from "../lib/hermes-control-plane/fixtures/secret-request-response.json";
@@ -256,6 +260,73 @@ function clarifyPart(
 function resolvedRow() {
   return document.querySelector(".agent-resolved-row") as HTMLDetailsElement | null;
 }
+
+function actionTurnRow(part: AgentChatPart, overrides: Partial<AgentChatTurnRowProps> = {}) {
+  return (
+    <AgentChatTurnRow
+      approvalSubmitting={{}}
+      clarifySubmitting={{}}
+      sudoSubmitting={{}}
+      secretSubmitting={{}}
+      thinkingOpen={() => false}
+      onApproval={() => {}}
+      onClarify={() => {}}
+      onSudo={() => {}}
+      onSecret={() => {}}
+      onThinkingOpenChange={() => {}}
+      turn={{
+        id: "action-turn",
+        role: "assistant",
+        createdAt: "2026-07-23T10:00:00Z",
+        status: "complete",
+        parts: [part],
+      }}
+      {...overrides}
+    />
+  );
+}
+
+describe("AgentChatTurnRow action-card clearance", () => {
+  it.each([
+    ["approval", approvalPart(), approvalPart({ status: "resolved", choice: "once" })],
+    ["clarification", clarifyPart(), clarifyPart({ status: "resolved", answer: "Bulleted list" })],
+    ["sudo", sudoPart(), sudoPart({ status: "resolved", approved: true })],
+    ["secret", secretPart(), secretPart({ status: "resolved" })],
+  ])("only marks a %s turn while its actionable card is rendered", (_label, pending, resolved) => {
+    const { rerender } = render(actionTurnRow(pending));
+
+    expect(document.querySelector(".agent-assistant-turn-body")).toHaveClass(
+      "agent-assistant-turn-body-action-card",
+    );
+
+    rerender(actionTurnRow(resolved));
+
+    expect(document.querySelector(".agent-resolved-row")).toBeInTheDocument();
+    expect(document.querySelector(".agent-assistant-turn-body")).not.toHaveClass(
+      "agent-assistant-turn-body-action-card",
+    );
+  });
+
+  it("drops the Agent CLI marker when the access card is dismissed", async () => {
+    render(
+      actionTurnRow(
+        { type: "text", text: "[REQUEST:AGENT_CLI_ACCESS]", status: "complete" },
+        { cliAccess: { enabled: false, submitting: false, onEnable: () => {} } },
+      ),
+    );
+
+    expect(document.querySelector(".agent-assistant-turn-body")).toHaveClass(
+      "agent-assistant-turn-body-action-card",
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Not now" }));
+
+    expect(document.querySelector(".agent-resolved-row")).toBeInTheDocument();
+    expect(document.querySelector(".agent-assistant-turn-body")).not.toHaveClass(
+      "agent-assistant-turn-body-action-card",
+    );
+  });
+});
 
 describe("ApprovalPart", () => {
   it("pending renders a compact card with a split Approve, Deny, and a scope menu", async () => {

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -133,7 +133,7 @@ describe("TabBar", () => {
 
   it("places the Windows sidebar toggle in the sidebar header band when expanded", () => {
     const toggleRule = cssRuleFor(
-      '.app-shell[data-platform="windows"][data-sidebar="expanded"]:has(> .sidebar[data-mode="default"])\n> .chrome-sidebar-toggle',
+      '.app-shell.app-shell-sidebar-default[data-platform="windows"][data-sidebar="expanded"]\n> .chrome-sidebar-toggle',
     );
 
     // Vertically aligned with the sidebar header (flush at the top, --sp-3).
@@ -184,13 +184,11 @@ describe("TabBar", () => {
   });
 
   it("keeps the tab strip full-width when the files panel is open", () => {
-    const panelRule = cssRuleFor(
-      '.app-shell:has(.agent-workspace[data-artifact-panel="open"]) .main-panel',
-    );
+    const panelRule = cssRuleFor(".app-shell.app-shell-artifact-panel-open .main-panel");
 
     expect(panelRule).toContain("margin-right: calc(var(--agent-files-w) + var(--sp-3));");
     expect(appCss).not.toMatch(
-      /\.app-shell:has\(\.agent-workspace\[data-artifact-panel="open"\]\) \.main-column\s*\{[\s\S]*?padding-right:\s*calc\(var\(--agent-files-w\)/,
+      /\.app-shell\.app-shell-artifact-panel-open \.main-column\s*\{[\s\S]*?padding-right:\s*calc\(var\(--agent-files-w\)/,
     );
   });
 


### PR DESCRIPTION
## Summary

- Replace every `:has()` selector in `src/styles/app.css` with explicit state classes set by the React owner.
- Move the waveform meter from animated `height` to `scaleY()`.
- Move update, skill, and MCP install progress from animated `width` to rounded `clip-path` reveals.
- Preserve the existing reduced-motion behavior and add regression coverage for selectors and transition properties.

Refs JUN-399

## Root cause

The stylesheet inferred parent state with relational selectors, so DOM and class changes could trigger subtree selector re-evaluation. Several frequently updated surfaces also transitioned layout properties, forcing layout and paint on every animation frame.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` - 3,408 passed, 2 skipped
- `make local-ci` - `signoff/frontend` passed; `signoff/rust-macos` passed as not applicable
- Faked-bridge Playwright gallery at 1440 x 1100, 2x device scale, with before/after captures for every affected surface group

- [x] Tested visually where it matters (evidence below).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is required.

## Visual evidence

| Surface | Before | After |
| --- | --- | --- |
| Artifact panel shell | ![Artifact panel before](https://app.opensoftware.co/api/v1/files/fil_xlc2Dm5aEkGB/download) | ![Artifact panel after](https://app.opensoftware.co/api/v1/files/fil_8cCnkQ60XrMd/download) |
| Note chat shell | ![Note chat before](https://app.opensoftware.co/api/v1/files/fil_WrYeJsqBJmmf/download) | ![Note chat after](https://app.opensoftware.co/api/v1/files/fil_8AETbbcbFmNi/download) |
| Agent surfaces | ![Agent surfaces before](https://app.opensoftware.co/api/v1/files/fil_qan6KEA2Ovs2/download) | ![Agent surfaces after](https://app.opensoftware.co/api/v1/files/fil_3OrGbHJaK4sj/download) |
| Notes and recording | ![Notes and recording before](https://app.opensoftware.co/api/v1/files/fil_vhYjzKBRhkwt/download) | ![Notes and recording after](https://app.opensoftware.co/api/v1/files/fil_bboMFkTVNw50/download) |
| Shared components and settings | ![Shared and settings before](https://app.opensoftware.co/api/v1/files/fil_hZuLOIuEwDTH/download) | ![Shared and settings after](https://app.opensoftware.co/api/v1/files/fil_VNfteHetFA9k/download) |

The artifact, note-chat, and agent surface pairs are pixel-identical. The remaining pixel deltas are confined to anti-aliased edges produced by `scaleY()` and rounded `clip-path`; their geometry, values, and visual state are unchanged.

## Out of scope

Six layout transitions remain deliberately:

- `.agent-composer` and `.editor-footer` retain `right` because their available width and text wrapping change with the attached side panels; setting the final width immediately and translating would visibly reflow content at the start.
- `.main-panel` retains `margin-right` because it resizes the note/agent card around the attached panel. A transform would move a fixed-width card instead of preserving the responsive layout.
- `.agent-usage-disclosure`, `.funding-chip-reveal`, and `.record-options-panel` retain their existing `grid-template-rows: 0fr` to `1fr` intrinsic disclosure pattern. Transform or clipping substitutes would not reflow surrounding content during expansion.

## Followups

- Run the requested external Opus and Kimi review round before taking the PR out of draft.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. No security-sensitive behavior changed.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow actions changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. None changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. None changed.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787385033&installation_model_id=425925&pr_number=913&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F913&signature=3542d51cc35aa8268955275b07f89ee62a7b2a061ef5fa2c1c2dab2c1fc51e23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->