### PR TITLE
Move WAV writing off the real-time audio callback

### DIFF
--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -28,10 +28,13 @@ preview).
    after successful WAV writes. The first writer I/O error, panic, unexpected
    exit, or sustained stall stops the drain and immediately enters the existing
    microphone warning path; recovery checkpoints persist its diagnostic code.
+   Each queued block also carries its callback generation, so overflow cannot
+   merge surviving live-preview audio across a dropped callback boundary.
 3. **`finish_recording`** stops the input stream, drains and finalizes the
    writer task, then atomically renames
    `*.partial.wav` → `*.wav` (the durability commit), stops the helper, cancels
-   preview.
+   preview. Completed microphone byte metadata is replaced from the writer
+   watermark returned after that final drain.
 4. **`process_saved_source_audio`** (`src-tauri/src/domain/processing.rs`) runs
    the batch pipeline for microphone-only and dual-Source recordings:
    `drop_silent_system_sources` → dual-Source `turns::detect_turns` (or one

--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -13,11 +13,19 @@ preview).
 1. **`start_recording`** → `capture::start_capture` opens `microphone.partial.wav`
    (a CPAL input stream) and, in meeting mode, starts the system-audio helper
    writing `system.partial.wav`.
-2. Per input callback: write 16-bit PCM, update `CaptureStats`, and
-   non-blockingly feed the **live preview** sink (a bounded channel) — a worker
-   transcribes ~8s chunks and emits ephemeral `live-transcript-event`s that are
-   **never persisted**.
-3. **`finish_recording`** finalizes the writer, atomically renames
+2. Per input callback: convert samples to 16-bit PCM, update lock-free level
+   atomics, and publish fixed-size blocks into a preallocated bounded audio
+   ring. The callback allocates nothing, takes no locks, and performs no I/O.
+   A dedicated non-real-time task drains the ring into the WAV writer and
+   non-blockingly feeds the **live preview** sink; its worker transcribes ~8s
+   chunks and emits ephemeral `live-transcript-event`s that are **never
+   persisted**. The ring holds 30 seconds at the configured sample rate and
+   channel count, with a memory cap for unusual high-channel devices. If disk
+   writing ever falls more than that capacity behind, the oldest queued blocks
+   are dropped, exact dropped-sample counts appear in recording status, and
+   recovery/finalization checkpoints persist the count.
+3. **`finish_recording`** stops the input stream, drains and finalizes the
+   writer task, then atomically renames
    `*.partial.wav` → `*.wav` (the durability commit), stops the helper, cancels
    preview.
 4. **`process_saved_source_audio`** (`src-tauri/src/domain/processing.rs`) runs
@@ -37,13 +45,16 @@ and live warnings; both the main renderer and meeting HUD subscribe to that
 single stream. Stable metadata still comes from the recording commands, and
 `get_recording_status` remains available as a read-only compatibility command.
 Recovery durability is independent of telemetry: a recording-scoped worker
-flushes and checkpoints elapsed time every 500 ms after the recording rows are
-created.
+requests a ring watermark flush and checkpoints elapsed time every 500 ms after
+the recording rows are created. The WAV task drains through that watermark and
+flushes the WAV before the recovery row advances.
 
 ## Key files
 
-- `src-tauri/src/audio/capture.rs` — mic capture, `CaptureStats`, the single
+- `src-tauri/src/audio/capture.rs` — mic capture lifecycle and the single
   global `ACTIVE_RECORDING` (one recorder at a time).
+- `src-tauri/src/audio/capture_buffer.rs` — preallocated audio ring, atomic
+  capture telemetry, recovery flush protocol, and non-real-time WAV drain.
 - `src-tauri/src/audio/system_macos.rs` + `native/mac-system-audio-recorder/
   main.swift` — the system-audio helper and its readiness/permission probes.
 - `src-tauri/src/audio/turns.rs` — turn detection, coalescing, WAV extraction,

--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -23,7 +23,11 @@ preview).
    channel count, with a memory cap for unusual high-channel devices. If disk
    writing ever falls more than that capacity behind, the oldest queued blocks
    are dropped, exact dropped-sample counts appear in recording status, and
-   recovery/finalization checkpoints persist the count.
+   recovery/finalization checkpoints persist the count. Writer progress is
+   tracked separately from callback production: `bytesWritten` advances only
+   after successful WAV writes. The first writer I/O error, panic, unexpected
+   exit, or sustained stall stops the drain and immediately enters the existing
+   microphone warning path; recovery checkpoints persist its diagnostic code.
 3. **`finish_recording`** stops the input stream, drains and finalizes the
    writer task, then atomically renames
    `*.partial.wav` → `*.wav` (the durability commit), stops the helper, cancels
@@ -47,7 +51,9 @@ single stream. Stable metadata still comes from the recording commands, and
 Recovery durability is independent of telemetry: a recording-scoped worker
 requests a ring watermark flush and checkpoints elapsed time every 500 ms after
 the recording rows are created. The WAV task drains through that watermark and
-flushes the WAV before the recovery row advances.
+flushes the WAV before the recovery row advances. A dead writer releases the
+flush wait so recovery state and diagnostics continue advancing instead of
+waiting for the full timeout.
 
 ## Key files
 

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -1,7 +1,7 @@
 use crate::{
     app_paths::AppPaths,
     audio::{
-        capture_buffer::{CaptureInput, MicrophoneWriter},
+        capture_buffer::{CaptureInput, MicrophoneWriter, MicrophoneWriterIssue},
         live_preview::{
             start_live_transcript_preview, start_system_live_transcript_preview,
             LivePreviewController, SystemLivePreviewController,
@@ -56,6 +56,8 @@ pub const RECOVERY_SNAPSHOT_INTERVAL: Duration = Duration::from_millis(500);
 const MICROPHONE_STALL_THRESHOLD: Duration = Duration::from_secs(3);
 const MICROPHONE_STREAM_WARNING_MESSAGE: &str =
     "Microphone input stopped unexpectedly. Audio after this point may be missing.";
+const MICROPHONE_WRITER_WARNING_MESSAGE: &str =
+    "June stopped saving microphone audio. Stop the recording now to preserve the audio already written.";
 const MICROPHONE_BUFFER_OVERFLOW_WARNING_MESSAGE: &str =
     "Microphone recording could not keep up. Some audio may be missing.";
 
@@ -111,6 +113,7 @@ pub struct RecordingRecoveryCheckpoint {
     pub state: RecordingState,
     pub elapsed_ms: i64,
     pub dropped_samples: u64,
+    pub capture_issue: Option<MicrophoneStreamIssue>,
 }
 
 struct ActiveRecording {
@@ -560,7 +563,7 @@ pub fn start_capture_with_cancel(
                 bytes_written: 0,
                 dropped_samples: 0,
                 silence_warning: false,
-                stream_issue: None,
+                capture_issue: None,
             },
             system_capture.as_ref(),
         ),
@@ -803,6 +806,8 @@ pub fn finish_capture(session_id: &str) -> Result<FinishedRecording, AppError> {
 
 fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, AppError> {
     let status = recording.status_with_state(RecordingState::Validating);
+    let writer_capture_issue =
+        microphone_writer_issue(status.elapsed_ms, recording.writer.health().issue);
     let recording_dto = RecordingSessionDto {
         id: recording.session_id.clone(),
         note_id: recording.note_id.clone(),
@@ -860,14 +865,17 @@ fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, A
         final_path: final_path.clone(),
         elapsed_ms: recording_dto.elapsed_ms,
         dropped_samples,
-        capture_issue: microphone_stream_issue(
-            recording_dto.elapsed_ms,
-            RecordingState::Validating,
-            &stream_error,
-            &last_callback_at,
-            false,
-        )
-        .or_else(|| stall_latch.lock().ok().and_then(|latch| latch.clone())),
+        capture_issue: writer_capture_issue
+            .or_else(|| {
+                microphone_stream_issue(
+                    recording_dto.elapsed_ms,
+                    RecordingState::Validating,
+                    &stream_error,
+                    &last_callback_at,
+                    false,
+                )
+            })
+            .or_else(|| stall_latch.lock().ok().and_then(|latch| latch.clone())),
         failure: None,
     }];
     if let Some(system_result) = system_stopped {
@@ -989,20 +997,27 @@ impl ActiveRecording {
         let peak = stats.peak;
         let rms = stats.rms;
         let recent_peaks = stats.recent_peaks;
-        let bytes_written = stats.samples.saturating_mul(2).min(i64::MAX as u64) as i64;
+        let writer_health = self.writer.health();
+        let bytes_written = writer_health
+            .written_samples
+            .saturating_mul(2)
+            .min(i64::MAX as u64) as i64;
         let dropped_samples = stats.dropped_samples;
         let elapsed_ms = self.elapsed().as_millis() as i64;
-        let microphone_stream_issue = microphone_stream_issue(
-            elapsed_ms,
-            state,
-            &self.stream_error,
-            &self.last_callback_at,
-            self.writer.has_unobserved_callback(),
-        );
-        latch_stall(&self.stall_latch, microphone_stream_issue.as_ref());
+        let microphone_capture_issue = microphone_writer_issue(elapsed_ms, writer_health.issue)
+            .or_else(|| {
+                microphone_stream_issue(
+                    elapsed_ms,
+                    state,
+                    &self.stream_error,
+                    &self.last_callback_at,
+                    self.writer.has_unobserved_callback(),
+                )
+            });
+        latch_stall(&self.stall_latch, microphone_capture_issue.as_ref());
         // A dead stream must not keep animating the last healthy peaks: the
         // waveform reads level, not silence_warning, so zero it on an issue.
-        let level = if microphone_stream_issue.is_some() {
+        let level = if microphone_capture_issue.is_some() {
             AudioLevelDto {
                 peak: 0.0,
                 rms: 0.0,
@@ -1036,11 +1051,11 @@ impl ActiveRecording {
                     dropped_samples,
                     silence_warning: self.started.elapsed() >= Duration::from_secs(10)
                         && rms < DEFAULT_SILENCE_THRESHOLD,
-                    stream_issue: microphone_stream_issue.clone(),
+                    capture_issue: microphone_capture_issue.clone(),
                 },
                 self.system_capture.as_ref(),
             ),
-            warnings: source_warnings(microphone_stream_issue.as_ref(), dropped_samples),
+            warnings: source_warnings(microphone_capture_issue.as_ref(), dropped_samples),
         }
     }
 
@@ -1070,15 +1085,28 @@ impl ActiveRecording {
         }
         self.last_recovery_snapshot_elapsed_ms = elapsed_ms;
         self.writer.flush_for_recovery();
+        let state = if self.paused {
+            RecordingState::Paused
+        } else {
+            RecordingState::Recording
+        };
+        let capture_issue = microphone_writer_issue(elapsed_ms, self.writer.health().issue)
+            .or_else(|| {
+                microphone_stream_issue(
+                    elapsed_ms,
+                    state,
+                    &self.stream_error,
+                    &self.last_callback_at,
+                    self.writer.has_unobserved_callback(),
+                )
+            });
+        latch_stall(&self.stall_latch, capture_issue.as_ref());
         Some(RecordingRecoveryCheckpoint {
             session_id: self.session_id.clone(),
-            state: if self.paused {
-                RecordingState::Paused
-            } else {
-                RecordingState::Recording
-            },
+            state,
             elapsed_ms,
             dropped_samples: self.writer.stats().dropped_samples,
+            capture_issue,
         })
     }
 }
@@ -1112,7 +1140,7 @@ struct MicrophoneStatusInput {
     bytes_written: i64,
     dropped_samples: u64,
     silence_warning: bool,
-    stream_issue: Option<MicrophoneStreamIssue>,
+    capture_issue: Option<MicrophoneStreamIssue>,
 }
 
 fn source_statuses(
@@ -1137,10 +1165,10 @@ fn source_statuses(
         bytes_written: microphone.bytes_written,
         dropped_samples: microphone.dropped_samples,
         level: microphone.level,
-        silence_warning: microphone.silence_warning || microphone.stream_issue.is_some(),
+        silence_warning: microphone.silence_warning || microphone.capture_issue.is_some(),
         path_finalized: false,
         last_error: microphone
-            .stream_issue
+            .capture_issue
             .map(|issue| issue.message)
             .or_else(|| {
                 (microphone.dropped_samples > 0)
@@ -1177,6 +1205,23 @@ fn latch_stall(
             *latch = Some(issue.clone());
         }
     }
+}
+
+fn microphone_writer_issue(
+    elapsed_ms: i64,
+    issue: Option<MicrophoneWriterIssue>,
+) -> Option<MicrophoneStreamIssue> {
+    let code = match issue? {
+        MicrophoneWriterIssue::Io => "microphone_writer_io_error",
+        MicrophoneWriterIssue::Panicked => "microphone_writer_panicked",
+        MicrophoneWriterIssue::StoppedUnexpectedly => "microphone_writer_stopped",
+        MicrophoneWriterIssue::Stalled => "microphone_writer_stalled",
+    };
+    Some(MicrophoneStreamIssue {
+        code: code.to_string(),
+        message: MICROPHONE_WRITER_WARNING_MESSAGE.to_string(),
+        elapsed_ms,
+    })
 }
 
 fn microphone_stream_issue(
@@ -1218,15 +1263,19 @@ fn microphone_stream_issue(
 }
 
 fn source_warnings(
-    microphone_stream_issue: Option<&MicrophoneStreamIssue>,
+    microphone_capture_issue: Option<&MicrophoneStreamIssue>,
     dropped_samples: u64,
 ) -> Vec<SourceWarningDto> {
     let mut warnings = Vec::new();
-    if let Some(issue) = microphone_stream_issue {
+    if let Some(issue) = microphone_capture_issue {
         warnings.push(SourceWarningDto {
             source: RecordingSource::Microphone,
             code: issue.code.clone(),
-            message: MICROPHONE_STREAM_WARNING_MESSAGE.to_string(),
+            message: if issue.code.starts_with("microphone_writer_") {
+                MICROPHONE_WRITER_WARNING_MESSAGE.to_string()
+            } else {
+                MICROPHONE_STREAM_WARNING_MESSAGE.to_string()
+            },
         });
     }
     if dropped_samples > 0 {
@@ -1433,7 +1482,7 @@ mod tests {
                 bytes_written: 1_024,
                 dropped_samples: 0,
                 silence_warning: false,
-                stream_issue: Some(issue.clone()),
+                capture_issue: Some(issue.clone()),
             },
             None,
         );
@@ -1456,6 +1505,41 @@ mod tests {
     }
 
     #[test]
+    fn microphone_writer_failure_appears_in_status_and_warnings() {
+        let issue = microphone_writer_issue(2_000, Some(MicrophoneWriterIssue::Io))
+            .expect("writer failure becomes a capture issue");
+        let sources = source_statuses(
+            RecordingSourceMode::MicrophoneOnly,
+            RecordingState::Recording,
+            2_000,
+            MicrophoneStatusInput {
+                level: AudioLevelDto::default(),
+                bytes_written: 512,
+                dropped_samples: 0,
+                silence_warning: false,
+                capture_issue: Some(issue.clone()),
+            },
+            None,
+        );
+        let warnings = source_warnings(Some(&issue), 0);
+
+        assert_eq!(sources[0].bytes_written, 512);
+        assert_eq!(
+            sources[0].last_error.as_deref(),
+            Some(MICROPHONE_WRITER_WARNING_MESSAGE)
+        );
+        assert!(sources[0].silence_warning);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].code, "microphone_writer_io_error");
+        assert_eq!(warnings[0].message, MICROPHONE_WRITER_WARNING_MESSAGE);
+
+        let panic_issue = microphone_writer_issue(2_500, Some(MicrophoneWriterIssue::Panicked))
+            .expect("worker panic becomes a capture issue");
+        assert_eq!(panic_issue.code, "microphone_writer_panicked");
+        assert_eq!(panic_issue.message, MICROPHONE_WRITER_WARNING_MESSAGE);
+    }
+
+    #[test]
     fn buffer_overflow_count_appears_in_status_and_warnings() {
         let sources = source_statuses(
             RecordingSourceMode::MicrophoneOnly,
@@ -1466,7 +1550,7 @@ mod tests {
                 bytes_written: 1_024,
                 dropped_samples: 37,
                 silence_warning: false,
-                stream_issue: None,
+                capture_issue: None,
             },
             None,
         );

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -1,9 +1,10 @@
 use crate::{
     app_paths::AppPaths,
     audio::{
+        capture_buffer::{CaptureInput, MicrophoneWriter},
         live_preview::{
             start_live_transcript_preview, start_system_live_transcript_preview,
-            LivePreviewController, LivePreviewSink, SystemLivePreviewController,
+            LivePreviewController, SystemLivePreviewController,
         },
         system_audio::{SystemAudioCapture, SystemAudioFailure, SystemAudioStopResult},
     },
@@ -15,9 +16,6 @@ use crate::{
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use hound::{SampleFormat, WavSpec, WavWriter};
 use std::{
-    collections::VecDeque,
-    fs::File,
-    io::BufWriter,
     path::PathBuf,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -58,6 +56,8 @@ pub const RECOVERY_SNAPSHOT_INTERVAL: Duration = Duration::from_millis(500);
 const MICROPHONE_STALL_THRESHOLD: Duration = Duration::from_secs(3);
 const MICROPHONE_STREAM_WARNING_MESSAGE: &str =
     "Microphone input stopped unexpectedly. Audio after this point may be missing.";
+const MICROPHONE_BUFFER_OVERFLOW_WARNING_MESSAGE: &str =
+    "Microphone recording could not keep up. Some audio may be missing.";
 
 static ACTIVE_RECORDING: LazyLock<Mutex<Option<ActiveRecording>>> =
     LazyLock::new(|| Mutex::new(None));
@@ -93,6 +93,7 @@ pub struct FinishedSource {
     pub source: RecordingSource,
     pub final_path: PathBuf,
     pub elapsed_ms: i64,
+    pub dropped_samples: u64,
     pub capture_issue: Option<MicrophoneStreamIssue>,
     pub failure: Option<SystemAudioFailure>,
 }
@@ -103,12 +104,13 @@ pub struct CaptureRecoverySnapshot {
 }
 
 /// Minimal durable checkpoint data collected independently from UI telemetry.
-/// It deliberately excludes capture levels so recovery never needs the stats
-/// lock merely to advance elapsed time in SQLite.
+/// Capture levels stay on lock-free atomics; recovery carries only the
+/// overflow counter needed for durable diagnostics.
 pub struct RecordingRecoveryCheckpoint {
     pub session_id: String,
     pub state: RecordingState,
     pub elapsed_ms: i64,
+    pub dropped_samples: u64,
 }
 
 struct ActiveRecording {
@@ -129,8 +131,10 @@ struct ActiveRecording {
     /// dictation helper owns it. Independent of pause: the recording keeps
     /// running and both tracks keep growing.
     mic_duck_flag: Arc<AtomicBool>,
-    writer: Arc<Mutex<Option<WavWriter<BufWriter<File>>>>>,
-    stats: Arc<Mutex<CaptureStats>>,
+    // Keep the stream before the writer so implicit field teardown stops the
+    // producer before MicrophoneWriter::drop joins its consumer thread.
+    _stream: cpal::Stream,
+    writer: MicrophoneWriter,
     stream_error: Arc<Mutex<Option<MicrophoneStreamIssue>>>,
     last_callback_at: Arc<Mutex<Option<Instant>>>,
     // First stall ever observed, kept until finish: a transient stall whose
@@ -140,7 +144,6 @@ struct ActiveRecording {
     live_preview: Option<LivePreviewController>,
     system_live_preview: Option<SystemLivePreviewController>,
     live_preview_enabled: bool,
-    _stream: cpal::Stream,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -155,15 +158,6 @@ pub struct MicrophoneStreamIssue {
 // platforms; on macOS it is safe for this usage because commands only hold/drop
 // the stream through this single recorder lifecycle.
 unsafe impl Send for ActiveRecording {}
-
-#[derive(Debug, Default)]
-struct CaptureStats {
-    peak: f32,
-    sum_square: f64,
-    samples: u64,
-    recent_peaks: VecDeque<f32>,
-    bytes_written: i64,
-}
 
 pub fn microphone_permission_state() -> (String, Option<String>) {
     microphone_permission_state_from_authorization(microphone_authorization_status())
@@ -363,18 +357,11 @@ pub fn start_capture_with_cancel(
     )
     .map_err(|error| AppError::new("audio_writer_failed", error.to_string()))?;
 
-    let writer = Arc::new(Mutex::new(Some(writer)));
-    let stats = Arc::new(Mutex::new(CaptureStats::default()));
     let stream_error = Arc::new(Mutex::new(None));
     let last_callback_at = Arc::new(Mutex::new(None));
     let stall_latch = Arc::new(Mutex::new(None));
     let paused_flag = Arc::new(AtomicBool::new(false));
     let mic_duck_flag = Arc::new(AtomicBool::new(false));
-    let writer_for_callback = Arc::clone(&writer);
-    let stats_for_callback = Arc::clone(&stats);
-    let last_callback_for_callback = Arc::clone(&last_callback_at);
-    let paused_for_callback = Arc::clone(&paused_flag);
-    let mic_duck_for_callback = Arc::clone(&mic_duck_flag);
     // The user's Live transcription setting gates both preview lanes at the
     // source: when off, no preview audio leaves the device and nothing is
     // billed (JUN-375).
@@ -394,7 +381,26 @@ pub fn start_capture_with_cancel(
     } else {
         None
     };
-    let preview_for_callback = live_preview.as_ref().map(LivePreviewController::sink);
+    let preview_sink = live_preview.as_ref().map(LivePreviewController::sink);
+    let (capture_input, writer) = match MicrophoneWriter::start(
+        writer,
+        sample_rate,
+        channels,
+        preview_sink,
+        Arc::clone(&last_callback_at),
+    ) {
+        Ok(writer) => writer,
+        Err(error) => {
+            if let Some(live_preview) = live_preview {
+                live_preview.cancel();
+            }
+            let _ = std::fs::remove_file(&partial_path);
+            return Err(AppError::new("audio_writer_failed", error));
+        }
+    };
+    let input_for_callback = capture_input.clone();
+    let paused_for_callback = Arc::clone(&paused_flag);
+    let mic_duck_for_callback = Arc::clone(&mic_duck_flag);
     // Diagnostic anchor only, captured before stream construction so err_fn
     // can attribute early errors. The recording clock (`started`, below) is
     // anchored after stream.play(): it feeds elapsed() and the finish-time
@@ -429,12 +435,9 @@ pub fn start_capture_with_cancel(
             move |data: &[f32], _| {
                 write_input_data(
                     data.iter().copied(),
-                    &writer_for_callback,
-                    &stats_for_callback,
-                    &last_callback_for_callback,
+                    &input_for_callback,
                     &paused_for_callback,
                     &mic_duck_for_callback,
-                    preview_for_callback.as_ref(),
                 )
             },
             err_fn,
@@ -445,12 +448,9 @@ pub fn start_capture_with_cancel(
             move |data: &[i16], _| {
                 write_input_data(
                     data.iter().map(|sample| *sample as f32 / i16::MAX as f32),
-                    &writer_for_callback,
-                    &stats_for_callback,
-                    &last_callback_for_callback,
+                    &input_for_callback,
                     &paused_for_callback,
                     &mic_duck_for_callback,
-                    preview_for_callback.as_ref(),
                 )
             },
             err_fn,
@@ -462,12 +462,9 @@ pub fn start_capture_with_cancel(
                 write_input_data(
                     data.iter()
                         .map(|sample| (*sample as f32 - 32768.0) / 32768.0),
-                    &writer_for_callback,
-                    &stats_for_callback,
-                    &last_callback_for_callback,
+                    &input_for_callback,
                     &paused_for_callback,
                     &mic_duck_for_callback,
-                    preview_for_callback.as_ref(),
                 )
             },
             err_fn,
@@ -503,9 +500,7 @@ pub fn start_capture_with_cancel(
                 Some(capture)
             }
             Err(error) => {
-                if let Ok(mut writer_guard) = writer.lock() {
-                    let _ = writer_guard.take();
-                }
+                drop(writer);
                 let _ = std::fs::remove_file(&partial_path);
                 return Err(error);
             }
@@ -560,11 +555,14 @@ pub fn start_capture_with_cancel(
             source_mode,
             RecordingState::Recording,
             0,
-            AudioLevelDto::default(),
-            0,
+            MicrophoneStatusInput {
+                level: AudioLevelDto::default(),
+                bytes_written: 0,
+                dropped_samples: 0,
+                silence_warning: false,
+                stream_issue: None,
+            },
             system_capture.as_ref(),
-            false,
-            None,
         ),
         warnings: Vec::new(),
     };
@@ -635,7 +633,6 @@ pub fn start_capture_with_cancel(
         paused_flag,
         mic_duck_flag,
         writer,
-        stats,
         stream_error,
         last_callback_at,
         stall_latch,
@@ -673,7 +670,7 @@ fn recording_already_active_error() -> AppError {
 }
 
 fn cleanup_abandoned_capture(
-    writer: Arc<Mutex<Option<WavWriter<BufWriter<File>>>>>,
+    writer: MicrophoneWriter,
     partial_path: PathBuf,
     system_partial_path: Option<PathBuf>,
     live_preview: Option<LivePreviewController>,
@@ -691,9 +688,7 @@ fn cleanup_abandoned_capture(
     if let Some(system_capture) = system_capture {
         let _ = system_capture.stop();
     }
-    if let Ok(mut writer_guard) = writer.lock() {
-        let _ = writer_guard.take();
-    }
+    drop(writer);
     let _ = std::fs::remove_file(partial_path);
     if let Some(system_partial_path) = system_partial_path {
         let _ = std::fs::remove_file(system_partial_path);
@@ -840,26 +835,21 @@ fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, A
         ..
     } = recording;
     paused_flag.store(true, Ordering::Release);
+    drop(_stream);
+    let dropped_samples = writer.stats().dropped_samples;
+    let microphone_finalized = (|| -> Result<(), AppError> {
+        writer
+            .finish()
+            .map_err(|error| AppError::new("audio_finalization_failed", error))?;
+        std::fs::rename(&partial_path, &final_path)
+            .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))
+    })();
     if let Some(live_preview) = live_preview {
         live_preview.cancel();
     }
     if let Some(system_live_preview) = system_live_preview {
         system_live_preview.cancel();
     }
-    drop(_stream);
-    let microphone_finalized = (|| -> Result<(), AppError> {
-        if let Some(writer) = writer
-            .lock()
-            .map_err(|_| AppError::new("audio_finalization_failed", "Audio writer lock failed."))?
-            .take()
-        {
-            writer
-                .finalize()
-                .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))?;
-        }
-        std::fs::rename(&partial_path, &final_path)
-            .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))
-    })();
     // Stop the system-audio backend even when microphone finalization failed:
     // dropping `SystemAudioCapture` without `stop()` could leave capture
     // running in the background.
@@ -869,11 +859,13 @@ fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, A
         source: RecordingSource::Microphone,
         final_path: final_path.clone(),
         elapsed_ms: recording_dto.elapsed_ms,
+        dropped_samples,
         capture_issue: microphone_stream_issue(
             recording_dto.elapsed_ms,
             RecordingState::Validating,
             &stream_error,
             &last_callback_at,
+            false,
         )
         .or_else(|| stall_latch.lock().ok().and_then(|latch| latch.clone())),
         failure: None,
@@ -885,6 +877,7 @@ fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, A
                     source: RecordingSource::System,
                     final_path: system_final_path.unwrap_or(system_path.clone()),
                     elapsed_ms: recording_dto.elapsed_ms,
+                    dropped_samples: 0,
                     capture_issue: None,
                     failure: None,
                 });
@@ -895,6 +888,7 @@ fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, A
                         source: RecordingSource::System,
                         final_path: system_path,
                         elapsed_ms: recording_dto.elapsed_ms,
+                        dropped_samples: 0,
                         capture_issue: None,
                         failure: Some(failure),
                     });
@@ -915,67 +909,17 @@ fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, A
 
 fn write_input_data<I>(
     data: I,
-    writer: &Arc<Mutex<Option<WavWriter<BufWriter<File>>>>>,
-    stats: &Arc<Mutex<CaptureStats>>,
-    last_callback_at: &Arc<Mutex<Option<Instant>>>,
+    input: &CaptureInput,
     paused: &Arc<AtomicBool>,
     mic_ducked: &Arc<AtomicBool>,
-    preview: Option<&LivePreviewSink>,
 ) where
     I: Iterator<Item = f32>,
 {
-    if let Ok(mut last_callback_at) = last_callback_at.try_lock() {
-        *last_callback_at = Some(Instant::now());
-    }
-    if paused.load(Ordering::Acquire) {
-        return;
-    }
-    // Ducked writes SILENCE, never drops frames: pause stops both tracks
-    // together, but a duck runs while system audio keeps rolling, and a
-    // shorter mic track would desync the two sources (turn attribution and
-    // transcript merging align them by time). Zeroed samples keep the WAV
-    // growing in lockstep and flatline the level meter honestly.
-    let ducked = mic_ducked.load(Ordering::Acquire);
-    let Ok(mut writer_guard) = writer.lock() else {
-        return;
-    };
-    let Some(writer) = writer_guard.as_mut() else {
-        return;
-    };
-    let Ok(mut stats) = stats.lock() else {
-        return;
-    };
-    let mut preview_samples = preview.map(|_| Vec::new());
-    {
-        let mut callback_peak = 0.0_f32;
-        let mut saw_sample = false;
-        for sample in data {
-            saw_sample = true;
-            let clamped = if ducked { 0.0 } else { sample.clamp(-1.0, 1.0) };
-            let pcm_sample = (clamped * i16::MAX as f32) as i16;
-            let normalized = clamped.abs();
-            callback_peak = callback_peak.max(normalized);
-            stats.peak = stats.peak.max(normalized);
-            stats.sum_square += (normalized as f64).powi(2);
-            stats.samples += 1;
-            stats.bytes_written += 2;
-            let _ = writer.write_sample(pcm_sample);
-            if let Some(samples) = preview_samples.as_mut() {
-                samples.push(pcm_sample);
-            }
-        }
-        if saw_sample {
-            if stats.recent_peaks.len() == 24 {
-                stats.recent_peaks.pop_front();
-            }
-            stats.recent_peaks.push_back(callback_peak);
-        }
-    }
-    drop(stats);
-    drop(writer_guard);
-    if let (Some(preview), Some(samples)) = (preview, preview_samples) {
-        preview.try_send(samples);
-    }
+    // Ducked input becomes silence rather than disappearing so microphone and
+    // system Sources remain time-aligned. CaptureInput performs only bounded
+    // stack work and atomics; all allocation, preview fan-out, and WAV I/O live
+    // on the writer task.
+    input.write(data, paused, mic_ducked);
 }
 
 fn lock_active() -> Result<std::sync::MutexGuard<'static, Option<ActiveRecording>>, AppError> {
@@ -1041,28 +985,19 @@ impl ActiveRecording {
     }
 
     fn status_with_state(&self, state: RecordingState) -> RecordingStatusDto {
-        let stats = self.stats.lock().ok();
-        let (peak, rms, recent_peaks, bytes_written) = if let Some(stats) = stats.as_ref() {
-            let rms = if stats.samples == 0 {
-                0.0
-            } else {
-                (stats.sum_square / stats.samples as f64).sqrt() as f32
-            };
-            (
-                stats.peak,
-                rms,
-                stats.recent_peaks.iter().copied().collect(),
-                stats.bytes_written,
-            )
-        } else {
-            (0.0, 0.0, Vec::new(), 0)
-        };
+        let stats = self.writer.stats();
+        let peak = stats.peak;
+        let rms = stats.rms;
+        let recent_peaks = stats.recent_peaks;
+        let bytes_written = stats.samples.saturating_mul(2).min(i64::MAX as u64) as i64;
+        let dropped_samples = stats.dropped_samples;
         let elapsed_ms = self.elapsed().as_millis() as i64;
         let microphone_stream_issue = microphone_stream_issue(
             elapsed_ms,
             state,
             &self.stream_error,
             &self.last_callback_at,
+            self.writer.has_unobserved_callback(),
         );
         latch_stall(&self.stall_latch, microphone_stream_issue.as_ref());
         // A dead stream must not keep animating the last healthy peaks: the
@@ -1095,14 +1030,17 @@ impl ActiveRecording {
                 self.source_mode,
                 state,
                 elapsed_ms,
-                level,
-                bytes_written,
+                MicrophoneStatusInput {
+                    level,
+                    bytes_written,
+                    dropped_samples,
+                    silence_warning: self.started.elapsed() >= Duration::from_secs(10)
+                        && rms < DEFAULT_SILENCE_THRESHOLD,
+                    stream_issue: microphone_stream_issue.clone(),
+                },
                 self.system_capture.as_ref(),
-                self.started.elapsed() >= Duration::from_secs(10)
-                    && rms < DEFAULT_SILENCE_THRESHOLD,
-                microphone_stream_issue.clone(),
             ),
-            warnings: source_warnings(microphone_stream_issue.as_ref()),
+            warnings: source_warnings(microphone_stream_issue.as_ref(), dropped_samples),
         }
     }
 
@@ -1131,7 +1069,7 @@ impl ActiveRecording {
             return None;
         }
         self.last_recovery_snapshot_elapsed_ms = elapsed_ms;
-        flush_microphone_writer_for_recovery(&self.writer);
+        self.writer.flush_for_recovery();
         Some(RecordingRecoveryCheckpoint {
             session_id: self.session_id.clone(),
             state: if self.paused {
@@ -1140,6 +1078,7 @@ impl ActiveRecording {
                 RecordingState::Recording
             },
             elapsed_ms,
+            dropped_samples: self.writer.stats().dropped_samples,
         })
     }
 }
@@ -1147,15 +1086,6 @@ impl ActiveRecording {
 enum RecoverySnapshotMode {
     Throttled,
     Force,
-}
-
-fn flush_microphone_writer_for_recovery(writer: &Arc<Mutex<Option<WavWriter<BufWriter<File>>>>>) {
-    let Ok(mut writer_guard) = writer.lock() else {
-        return;
-    };
-    if let Some(writer) = writer_guard.as_mut() {
-        let _ = writer.flush();
-    }
 }
 
 fn started_sources(
@@ -1177,15 +1107,20 @@ fn started_sources(
     sources
 }
 
+struct MicrophoneStatusInput {
+    level: AudioLevelDto,
+    bytes_written: i64,
+    dropped_samples: u64,
+    silence_warning: bool,
+    stream_issue: Option<MicrophoneStreamIssue>,
+}
+
 fn source_statuses(
     source_mode: RecordingSourceMode,
     state: RecordingState,
     elapsed_ms: i64,
-    microphone_level: AudioLevelDto,
-    microphone_bytes: i64,
+    microphone: MicrophoneStatusInput,
     system_capture: Option<&SystemAudioCapture>,
-    microphone_silence_warning: bool,
-    microphone_stream_issue: Option<MicrophoneStreamIssue>,
 ) -> Vec<SourceStatusDto> {
     let source_state = match state {
         RecordingState::Paused => SourceState::Paused,
@@ -1199,11 +1134,18 @@ fn source_statuses(
         source: RecordingSource::Microphone,
         state: source_state,
         elapsed_ms,
-        bytes_written: microphone_bytes,
-        level: microphone_level,
-        silence_warning: microphone_silence_warning || microphone_stream_issue.is_some(),
+        bytes_written: microphone.bytes_written,
+        dropped_samples: microphone.dropped_samples,
+        level: microphone.level,
+        silence_warning: microphone.silence_warning || microphone.stream_issue.is_some(),
         path_finalized: false,
-        last_error: microphone_stream_issue.map(|issue| issue.message),
+        last_error: microphone
+            .stream_issue
+            .map(|issue| issue.message)
+            .or_else(|| {
+                (microphone.dropped_samples > 0)
+                    .then(|| MICROPHONE_BUFFER_OVERFLOW_WARNING_MESSAGE.to_string())
+            }),
     }];
     if source_mode == RecordingSourceMode::MicrophonePlusSystem {
         let (level, bytes_written, last_error) = system_capture
@@ -1215,6 +1157,7 @@ fn source_statuses(
             state: source_state,
             elapsed_ms,
             bytes_written,
+            dropped_samples: 0,
             level,
             silence_warning: system_silence_warning,
             path_finalized: false,
@@ -1241,6 +1184,7 @@ fn microphone_stream_issue(
     state: RecordingState,
     stream_error: &Arc<Mutex<Option<MicrophoneStreamIssue>>>,
     last_callback_at: &Arc<Mutex<Option<Instant>>>,
+    callback_ahead_of_monitor: bool,
 ) -> Option<MicrophoneStreamIssue> {
     if let Ok(issue) = stream_error.lock() {
         if issue.is_some() {
@@ -1248,6 +1192,12 @@ fn microphone_stream_issue(
         }
     }
     if state == RecordingState::Paused {
+        return None;
+    }
+    // The WAV task can be delayed by disk I/O. A newer callback heartbeat is
+    // direct evidence that capture is still healthy even if the writer has not
+    // yet refreshed its non-real-time timestamp.
+    if callback_ahead_of_monitor {
         return None;
     }
     let last_callback_at = last_callback_at.lock().ok().and_then(|instant| *instant);
@@ -1269,15 +1219,24 @@ fn microphone_stream_issue(
 
 fn source_warnings(
     microphone_stream_issue: Option<&MicrophoneStreamIssue>,
+    dropped_samples: u64,
 ) -> Vec<SourceWarningDto> {
-    let Some(issue) = microphone_stream_issue else {
-        return Vec::new();
-    };
-    vec![SourceWarningDto {
-        source: RecordingSource::Microphone,
-        code: issue.code.clone(),
-        message: MICROPHONE_STREAM_WARNING_MESSAGE.to_string(),
-    }]
+    let mut warnings = Vec::new();
+    if let Some(issue) = microphone_stream_issue {
+        warnings.push(SourceWarningDto {
+            source: RecordingSource::Microphone,
+            code: issue.code.clone(),
+            message: MICROPHONE_STREAM_WARNING_MESSAGE.to_string(),
+        });
+    }
+    if dropped_samples > 0 {
+        warnings.push(SourceWarningDto {
+            source: RecordingSource::Microphone,
+            code: "microphone_buffer_overflow".to_string(),
+            message: MICROPHONE_BUFFER_OVERFLOW_WARNING_MESSAGE.to_string(),
+        });
+    }
+    warnings
 }
 
 #[cfg(test)]
@@ -1326,7 +1285,7 @@ mod tests {
         assert!(hint.is_some());
     }
 
-    fn test_writer(dir: &tempfile::TempDir) -> Arc<Mutex<Option<WavWriter<BufWriter<File>>>>> {
+    fn test_writer(dir: &tempfile::TempDir) -> (CaptureInput, MicrophoneWriter) {
         let writer = WavWriter::create(
             dir.path().join("mic.wav"),
             WavSpec {
@@ -1337,7 +1296,8 @@ mod tests {
             },
         )
         .expect("create wav writer");
-        Arc::new(Mutex::new(Some(writer)))
+        MicrophoneWriter::start(writer, 48_000, 1, None, Arc::new(Mutex::new(None)))
+            .expect("start microphone writer")
     }
 
     /// A ducked mic writes SILENCE, never drops frames: the sample count must
@@ -1346,53 +1306,46 @@ mod tests {
     #[test]
     fn ducked_mic_writes_aligned_silence_not_dropped_frames() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let writer = test_writer(&dir);
-        let stats = Arc::new(Mutex::new(CaptureStats::default()));
+        let (input, writer) = test_writer(&dir);
         let paused = Arc::new(AtomicBool::new(false));
         let ducked = Arc::new(AtomicBool::new(true));
 
-        write_input_data(
-            [0.5_f32, -0.25, 0.9].into_iter(),
-            &writer,
-            &stats,
-            &Arc::new(Mutex::new(None)),
-            &paused,
-            &ducked,
-            None,
-        );
+        write_input_data([0.5_f32, -0.25, 0.9].into_iter(), &input, &paused, &ducked);
 
-        let stats = stats.lock().expect("stats lock");
+        let stats = input.stats();
         assert_eq!(
             stats.samples, 3,
             "every input frame is written while ducked"
         );
         // The writer is 16-bit PCM (bits_per_sample: 16), so 2 bytes/sample.
         const BYTES_PER_SAMPLE: i64 = 2;
-        assert_eq!(stats.bytes_written, 3 * BYTES_PER_SAMPLE);
+        assert_eq!(
+            stats.samples as i64 * BYTES_PER_SAMPLE,
+            3 * BYTES_PER_SAMPLE
+        );
         assert_eq!(stats.peak, 0.0, "ducked samples are pure silence");
+        writer.finish().expect("finish WAV writer");
+        let samples = hound::WavReader::open(dir.path().join("mic.wav"))
+            .expect("open ducked WAV")
+            .samples::<i16>()
+            .collect::<Result<Vec<_>, _>>()
+            .expect("read ducked samples");
+        assert_eq!(samples, vec![0, 0, 0]);
     }
 
     #[test]
     fn unducked_mic_records_real_samples() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let writer = test_writer(&dir);
-        let stats = Arc::new(Mutex::new(CaptureStats::default()));
+        let (input, writer) = test_writer(&dir);
         let paused = Arc::new(AtomicBool::new(false));
         let ducked = Arc::new(AtomicBool::new(false));
 
-        write_input_data(
-            [0.5_f32, -0.25].into_iter(),
-            &writer,
-            &stats,
-            &Arc::new(Mutex::new(None)),
-            &paused,
-            &ducked,
-            None,
-        );
+        write_input_data([0.5_f32, -0.25].into_iter(), &input, &paused, &ducked);
 
-        let stats = stats.lock().expect("stats lock");
+        let stats = input.stats();
         assert_eq!(stats.samples, 2);
         assert!(stats.peak > 0.4, "real samples keep their level");
+        writer.finish().expect("finish WAV writer");
     }
 
     /// Pause drops frames outright (both tracks stop together) — the duck
@@ -1400,22 +1353,14 @@ mod tests {
     #[test]
     fn paused_mic_still_drops_frames_even_when_ducked() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let writer = test_writer(&dir);
-        let stats = Arc::new(Mutex::new(CaptureStats::default()));
+        let (input, writer) = test_writer(&dir);
         let paused = Arc::new(AtomicBool::new(true));
         let ducked = Arc::new(AtomicBool::new(true));
 
-        write_input_data(
-            [0.5_f32].into_iter(),
-            &writer,
-            &stats,
-            &Arc::new(Mutex::new(None)),
-            &paused,
-            &ducked,
-            None,
-        );
+        write_input_data([0.5_f32].into_iter(), &input, &paused, &ducked);
 
-        assert_eq!(stats.lock().expect("stats lock").samples, 0);
+        assert_eq!(input.stats().samples, 0);
+        writer.finish().expect("finish WAV writer");
     }
 
     fn issue_state_at(
@@ -1429,6 +1374,7 @@ mod tests {
             state,
             &Arc::new(Mutex::new(issue)),
             &Arc::new(Mutex::new(last_callback_at)),
+            false,
         )
     }
 
@@ -1482,13 +1428,16 @@ mod tests {
             RecordingSourceMode::MicrophoneOnly,
             RecordingState::Recording,
             2_000,
-            AudioLevelDto::default(),
-            1_024,
+            MicrophoneStatusInput {
+                level: AudioLevelDto::default(),
+                bytes_written: 1_024,
+                dropped_samples: 0,
+                silence_warning: false,
+                stream_issue: Some(issue.clone()),
+            },
             None,
-            false,
-            Some(issue.clone()),
         );
-        let warnings = source_warnings(Some(&issue));
+        let warnings = source_warnings(Some(&issue), 0);
 
         let microphone = sources
             .iter()
@@ -1504,6 +1453,32 @@ mod tests {
                 message: MICROPHONE_STREAM_WARNING_MESSAGE.to_string(),
             }]
         );
+    }
+
+    #[test]
+    fn buffer_overflow_count_appears_in_status_and_warnings() {
+        let sources = source_statuses(
+            RecordingSourceMode::MicrophoneOnly,
+            RecordingState::Recording,
+            2_000,
+            MicrophoneStatusInput {
+                level: AudioLevelDto::default(),
+                bytes_written: 1_024,
+                dropped_samples: 37,
+                silence_warning: false,
+                stream_issue: None,
+            },
+            None,
+        );
+        let warnings = source_warnings(None, 37);
+
+        assert_eq!(sources[0].dropped_samples, 37);
+        assert_eq!(
+            sources[0].last_error.as_deref(),
+            Some(MICROPHONE_BUFFER_OVERFLOW_WARNING_MESSAGE)
+        );
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].code, "microphone_buffer_overflow");
     }
 
     #[test]

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -806,9 +806,7 @@ pub fn finish_capture(session_id: &str) -> Result<FinishedRecording, AppError> {
 
 fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, AppError> {
     let status = recording.status_with_state(RecordingState::Validating);
-    let writer_capture_issue =
-        microphone_writer_issue(status.elapsed_ms, recording.writer.health().issue);
-    let recording_dto = RecordingSessionDto {
+    let mut recording_dto = RecordingSessionDto {
         id: recording.session_id.clone(),
         note_id: recording.note_id.clone(),
         source_mode: recording.source_mode,
@@ -842,12 +840,13 @@ fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, A
     paused_flag.store(true, Ordering::Release);
     drop(_stream);
     let dropped_samples = writer.stats().dropped_samples;
-    let microphone_finalized = (|| -> Result<(), AppError> {
-        writer
+    let microphone_finalized = (|| -> Result<_, AppError> {
+        let final_writer_health = writer
             .finish()
             .map_err(|error| AppError::new("audio_finalization_failed", error))?;
         std::fs::rename(&partial_path, &final_path)
-            .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))
+            .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))?;
+        Ok(final_writer_health)
     })();
     if let Some(live_preview) = live_preview {
         live_preview.cancel();
@@ -859,7 +858,13 @@ fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, A
     // dropping `SystemAudioCapture` without `stop()` could leave capture
     // running in the background.
     let system_stopped = system_capture.map(SystemAudioCapture::stop);
-    microphone_finalized?;
+    let final_writer_health = microphone_finalized?;
+    set_final_microphone_bytes(
+        &mut recording_dto.sources,
+        final_writer_health.written_bytes(),
+    );
+    let writer_capture_issue =
+        microphone_writer_issue(recording_dto.elapsed_ms, final_writer_health.issue);
     let mut sources = vec![FinishedSource {
         source: RecordingSource::Microphone,
         final_path: final_path.clone(),
@@ -998,10 +1003,7 @@ impl ActiveRecording {
         let rms = stats.rms;
         let recent_peaks = stats.recent_peaks;
         let writer_health = self.writer.health();
-        let bytes_written = writer_health
-            .written_samples
-            .saturating_mul(2)
-            .min(i64::MAX as u64) as i64;
+        let bytes_written = writer_health.written_bytes();
         let dropped_samples = stats.dropped_samples;
         let elapsed_ms = self.elapsed().as_millis() as i64;
         let microphone_capture_issue = microphone_writer_issue(elapsed_ms, writer_health.issue)
@@ -1193,6 +1195,15 @@ fn source_statuses(
         });
     }
     sources
+}
+
+fn set_final_microphone_bytes(sources: &mut [SourceStatusDto], bytes_written: i64) {
+    if let Some(microphone) = sources
+        .iter_mut()
+        .find(|source| source.source == RecordingSource::Microphone)
+    {
+        microphone.bytes_written = bytes_written;
+    }
 }
 
 fn latch_stall(
@@ -1563,6 +1574,32 @@ mod tests {
         );
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].code, "microphone_buffer_overflow");
+    }
+
+    #[test]
+    fn final_microphone_bytes_replace_the_pre_drain_snapshot_only_for_the_microphone() {
+        let mut sources = source_statuses(
+            RecordingSourceMode::MicrophonePlusSystem,
+            RecordingState::Finalizing,
+            2_000,
+            MicrophoneStatusInput {
+                level: AudioLevelDto::default(),
+                bytes_written: 128,
+                dropped_samples: 0,
+                silence_warning: false,
+                capture_issue: None,
+            },
+            None,
+        );
+        let system_bytes = sources[1].bytes_written;
+
+        set_final_microphone_bytes(&mut sources, 4_096);
+
+        assert_eq!(sources[0].bytes_written, 4_096);
+        assert_eq!(
+            sources[1].bytes_written, system_bytes,
+            "microphone drain progress must not replace system-source metadata"
+        );
     }
 
     #[test]

--- a/src-tauri/src/audio/capture_buffer.rs
+++ b/src-tauri/src/audio/capture_buffer.rs
@@ -3,10 +3,10 @@ use hound::WavWriter;
 use std::{
     cell::UnsafeCell,
     fs::File,
-    io::BufWriter,
+    io::{BufWriter, Seek, Write},
     mem::MaybeUninit,
     sync::{
-        atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering},
         Arc, Condvar, Mutex,
     },
     thread::{self, JoinHandle},
@@ -19,6 +19,7 @@ const MAX_AUDIO_BUFFER_BLOCKS: usize = 16_384;
 const RECENT_PEAK_CAPACITY: usize = 24;
 const WRITER_IDLE_POLL_INTERVAL: Duration = Duration::from_millis(1);
 const RECOVERY_FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
+const WRITER_STALL_THRESHOLD: Duration = Duration::from_secs(3);
 
 #[derive(Debug)]
 struct AudioBlock {
@@ -95,7 +96,10 @@ impl AudioRing {
                     Ordering::Relaxed,
                 );
             }
-        } else {
+        } else if !self.try_push_at(enqueue_position, &mut block) {
+            // The consumer may have released the contested slot after the
+            // discard probe. Retry once before accounting the incoming block
+            // as dropped; never spin on the real-time callback.
             self.dropped_samples.fetch_add(
                 block.as_ref().map_or(0, |block| block.len as u64),
                 Ordering::Relaxed,
@@ -250,6 +254,7 @@ impl AtomicCaptureStats {
             } else {
                 (sum_square / samples as f64).sqrt() as f32
             },
+            #[cfg(test)]
             samples,
             recent_peaks,
             dropped_samples,
@@ -261,6 +266,7 @@ impl AtomicCaptureStats {
 pub struct CaptureStatsSnapshot {
     pub peak: f32,
     pub rms: f32,
+    #[cfg(test)]
     pub samples: u64,
     pub recent_peaks: Vec<f32>,
     pub dropped_samples: u64,
@@ -355,10 +361,113 @@ impl Default for WriterControl {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum StoredWriterFailure {
+    None = 0,
+    Io = 1,
+    Panicked = 2,
+    StoppedUnexpectedly = 3,
+}
+
+impl StoredWriterFailure {
+    fn from_raw(raw: u8) -> Self {
+        match raw {
+            1 => Self::Io,
+            2 => Self::Panicked,
+            3 => Self::StoppedUnexpectedly,
+            _ => Self::None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MicrophoneWriterIssue {
+    Io,
+    Panicked,
+    StoppedUnexpectedly,
+    Stalled,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MicrophoneWriterHealth {
+    pub written_samples: u64,
+    pub issue: Option<MicrophoneWriterIssue>,
+}
+
+struct WriterHealth {
+    started: Instant,
+    heartbeat_ms: AtomicU64,
+    written_samples: AtomicU64,
+    failure: AtomicU8,
+}
+
+impl Default for WriterHealth {
+    fn default() -> Self {
+        Self {
+            started: Instant::now(),
+            heartbeat_ms: AtomicU64::new(0),
+            written_samples: AtomicU64::new(0),
+            failure: AtomicU8::new(StoredWriterFailure::None as u8),
+        }
+    }
+}
+
+impl WriterHealth {
+    fn heartbeat(&self) {
+        self.heartbeat_ms.store(
+            self.started.elapsed().as_millis().min(u64::MAX as u128) as u64,
+            Ordering::Release,
+        );
+    }
+
+    fn record_written(&self, samples: usize) {
+        self.written_samples
+            .fetch_add(samples as u64, Ordering::Release);
+        self.heartbeat();
+    }
+
+    fn fail(&self, failure: StoredWriterFailure) {
+        let _ = self.failure.compare_exchange(
+            StoredWriterFailure::None as u8,
+            failure as u8,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+    }
+
+    fn snapshot(&self, ring: &AudioRing, control: &WriterControl) -> MicrophoneWriterHealth {
+        let stored_failure = StoredWriterFailure::from_raw(self.failure.load(Ordering::Acquire));
+        let issue = match stored_failure {
+            StoredWriterFailure::Io => Some(MicrophoneWriterIssue::Io),
+            StoredWriterFailure::Panicked => Some(MicrophoneWriterIssue::Panicked),
+            StoredWriterFailure::StoppedUnexpectedly => {
+                Some(MicrophoneWriterIssue::StoppedUnexpectedly)
+            }
+            StoredWriterFailure::None => {
+                let now_ms = self.started.elapsed().as_millis().min(u64::MAX as u128) as u64;
+                let heartbeat_age_ms =
+                    now_ms.saturating_sub(self.heartbeat_ms.load(Ordering::Acquire));
+                let has_backlog = ring.read_position() < ring.write_position();
+                (has_backlog
+                    && heartbeat_age_ms
+                        > WRITER_STALL_THRESHOLD.as_millis().min(u64::MAX as u128) as u64
+                    && !control.stop_requested.load(Ordering::Acquire))
+                .then_some(MicrophoneWriterIssue::Stalled)
+            }
+        };
+        MicrophoneWriterHealth {
+            written_samples: self.written_samples.load(Ordering::Acquire),
+            issue,
+        }
+    }
+}
+
 pub struct MicrophoneWriter {
     ring: Arc<AudioRing>,
     stats: Arc<AtomicCaptureStats>,
     control: Arc<WriterControl>,
+    health: Arc<WriterHealth>,
     worker: Option<JoinHandle<Result<(), String>>>,
 }
 
@@ -387,28 +496,25 @@ impl MicrophoneWriter {
         let ring = Arc::new(AudioRing::new(capacity));
         let stats = Arc::new(AtomicCaptureStats::default());
         let control = Arc::new(WriterControl::default());
+        let health = Arc::new(WriterHealth::default());
         let worker_ring = Arc::clone(&ring);
         let worker_stats = Arc::clone(&stats);
         let worker_control = Arc::clone(&control);
+        let worker_health = Arc::clone(&health);
         let worker = thread::Builder::new()
             .name("microphone-wav-writer".to_string())
             .spawn(move || {
-                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                run_drain_worker(&worker_control, &worker_health, || {
                     drain_audio(
                         writer,
                         &worker_ring,
                         &worker_stats,
                         &worker_control,
+                        &worker_health,
                         preview,
                         &last_callback_at,
                     )
-                }))
-                .unwrap_or_else(|_| Err("Microphone WAV writer task panicked.".to_string()));
-                worker_control
-                    .worker_finished
-                    .store(true, Ordering::Release);
-                worker_control.flush_changed.notify_all();
-                result
+                })
             })
             .map_err(|error| error.to_string())?;
         let input = CaptureInput {
@@ -421,6 +527,7 @@ impl MicrophoneWriter {
                 ring,
                 stats,
                 control,
+                health,
                 worker: Some(worker),
             },
         ))
@@ -428,6 +535,10 @@ impl MicrophoneWriter {
 
     pub fn stats(&self) -> CaptureStatsSnapshot {
         self.stats.snapshot(self.ring.dropped_samples())
+    }
+
+    pub fn health(&self) -> MicrophoneWriterHealth {
+        self.health.snapshot(&self.ring, &self.control)
     }
 
     pub fn has_unobserved_callback(&self) -> bool {
@@ -486,18 +597,48 @@ impl Drop for MicrophoneWriter {
     }
 }
 
-fn drain_audio(
-    mut writer: WavWriter<BufWriter<File>>,
+fn run_drain_worker<F>(
+    control: &WriterControl,
+    health: &WriterHealth,
+    drain: F,
+) -> Result<(), String>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    let mut result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(drain)) {
+        Ok(result) => result,
+        Err(_) => {
+            health.fail(StoredWriterFailure::Panicked);
+            Err("Microphone WAV writer task panicked.".to_string())
+        }
+    };
+    if result.is_err() {
+        health.fail(StoredWriterFailure::Io);
+    } else if !control.stop_requested.load(Ordering::Acquire) {
+        health.fail(StoredWriterFailure::StoppedUnexpectedly);
+        result = Err("Microphone WAV writer task stopped unexpectedly.".to_string());
+    }
+    control.worker_finished.store(true, Ordering::Release);
+    control.flush_changed.notify_all();
+    result
+}
+
+fn drain_audio<W>(
+    mut writer: WavWriter<W>,
     ring: &AudioRing,
     stats: &AtomicCaptureStats,
     control: &WriterControl,
+    health: &WriterHealth,
     preview: Option<LivePreviewSink>,
     last_callback_at: &Mutex<Option<Instant>>,
-) -> Result<(), String> {
+) -> Result<(), String>
+where
+    W: Write + Seek,
+{
     let mut preview_samples = Vec::new();
     let mut last_heartbeat = 0;
-    let mut first_error = None;
     loop {
+        health.heartbeat();
         let heartbeat = stats.callback_heartbeat.load(Ordering::Acquire);
         if heartbeat != last_heartbeat {
             last_heartbeat = heartbeat;
@@ -510,11 +651,16 @@ fn drain_audio(
         let mut drained_any = false;
         while let Some(block) = ring.pop() {
             drained_any = true;
+            let mut written_from_block = 0;
             for sample in &block.samples[..block.len] {
                 if let Err(error) = writer.write_sample(*sample) {
-                    first_error.get_or_insert_with(|| error.to_string());
+                    health.record_written(written_from_block);
+                    health.fail(StoredWriterFailure::Io);
+                    return Err(error.to_string());
                 }
+                written_from_block += 1;
             }
+            health.record_written(written_from_block);
             if let Some(preview) = preview.as_ref() {
                 preview_samples.extend_from_slice(&block.samples[..block.len]);
                 if block.ends_callback {
@@ -528,7 +674,8 @@ fn drain_audio(
             && ring.read_position() >= control.flush_target.load(Ordering::Acquire)
         {
             if let Err(error) = writer.flush() {
-                first_error.get_or_insert_with(|| error.to_string());
+                health.fail(StoredWriterFailure::Io);
+                return Err(error.to_string());
             }
             control
                 .flushed_generation
@@ -551,17 +698,20 @@ fn drain_audio(
             preview.try_send(preview_samples);
         }
     }
-    if let Err(error) = writer.finalize() {
-        first_error.get_or_insert_with(|| error.to_string());
-    }
-    first_error.map_or(Ok(()), Err)
+    writer.finalize().map_err(|error| {
+        health.fail(StoredWriterFailure::Io);
+        error.to_string()
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use hound::{SampleFormat, WavReader, WavSpec};
-    use std::path::Path;
+    use std::{
+        io::{Cursor, Error, SeekFrom},
+        path::Path,
+    };
 
     fn block(samples: &[i16]) -> AudioBlock {
         let mut block = AudioBlock::empty();
@@ -571,17 +721,59 @@ mod tests {
         block
     }
 
+    fn wav_spec() -> WavSpec {
+        WavSpec {
+            channels: 1,
+            sample_rate: 48_000,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        }
+    }
+
     fn wav_writer(path: &Path) -> WavWriter<BufWriter<File>> {
-        WavWriter::create(
-            path,
-            WavSpec {
-                channels: 1,
-                sample_rate: 48_000,
-                bits_per_sample: 16,
-                sample_format: SampleFormat::Int,
-            },
-        )
-        .expect("create WAV writer")
+        WavWriter::create(path, wav_spec()).expect("create WAV writer")
+    }
+
+    fn write_direct_wav(path: &Path, samples: &[i16]) {
+        let mut direct = wav_writer(path);
+        for sample in samples {
+            direct.write_sample(*sample).expect("write direct sample");
+        }
+        direct.finalize().expect("finalize direct WAV");
+    }
+
+    struct FailAfter {
+        inner: Cursor<Vec<u8>>,
+        limit: u64,
+    }
+
+    impl FailAfter {
+        fn new(limit: u64) -> Self {
+            Self {
+                inner: Cursor::new(Vec::new()),
+                limit,
+            }
+        }
+    }
+
+    impl Write for FailAfter {
+        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+            let remaining = self.limit.saturating_sub(self.inner.position()) as usize;
+            if remaining == 0 {
+                return Err(Error::other("test disk is full"));
+            }
+            self.inner.write(&buffer[..buffer.len().min(remaining)])
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.inner.flush()
+        }
+    }
+
+    impl Seek for FailAfter {
+        fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+            self.inner.seek(position)
+        }
     }
 
     #[test]
@@ -609,6 +801,42 @@ mod tests {
         assert_eq!(ring.pop().unwrap().samples[..2], [5, 6]);
         assert!(ring.pop().is_none());
         assert_eq!(ring.dropped_samples(), 3);
+    }
+
+    #[test]
+    fn overflow_drain_wav_bytes_match_the_surviving_samples() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let buffered_path = dir.path().join("overflow-buffered.wav");
+        let direct_path = dir.path().join("overflow-direct.wav");
+        let ring = AudioRing::new(2);
+        ring.push_overwrite(block(&[1, 2, 3]));
+        ring.push_overwrite(block(&[4]));
+        ring.push_overwrite(block(&[5, 6]));
+        let stats = AtomicCaptureStats::default();
+        let control = WriterControl::default();
+        control.stop_requested.store(true, Ordering::Release);
+        let health = WriterHealth::default();
+        let last_callback_at = Mutex::new(None);
+
+        drain_audio(
+            wav_writer(&buffered_path),
+            &ring,
+            &stats,
+            &control,
+            &health,
+            None,
+            &last_callback_at,
+        )
+        .expect("drain surviving overflow samples");
+        write_direct_wav(&direct_path, &[4, 5, 6]);
+
+        assert_eq!(ring.dropped_samples(), 3);
+        assert_eq!(health.snapshot(&ring, &control).written_samples, 3);
+        assert_eq!(
+            std::fs::read(buffered_path).expect("read buffered overflow WAV"),
+            std::fs::read(direct_path).expect("read direct overflow WAV"),
+            "overflow must preserve the exact bytes of every surviving sample"
+        );
     }
 
     #[test]
@@ -666,6 +894,128 @@ mod tests {
     }
 
     #[test]
+    fn first_write_error_stops_the_worker_and_publishes_exact_progress() {
+        let ring = AudioRing::new(2);
+        ring.push_overwrite(block(&[10, 20, 30]));
+        ring.push_overwrite(block(&[40, 50]));
+        let stats = AtomicCaptureStats::default();
+        let control = WriterControl::default();
+        let health = WriterHealth::default();
+        let last_callback_at = Mutex::new(None);
+        // A mono 16-bit WAV header is 44 bytes. Permit exactly one sample
+        // after it, then fail the next underlying write.
+        let writer =
+            WavWriter::new(FailAfter::new(46), wav_spec()).expect("create failing WAV writer");
+
+        let error = run_drain_worker(&control, &health, || {
+            drain_audio(
+                writer,
+                &ring,
+                &stats,
+                &control,
+                &health,
+                None,
+                &last_callback_at,
+            )
+        })
+        .expect_err("disk failure stops the writer");
+        let snapshot = health.snapshot(&ring, &control);
+
+        assert!(error.contains("test disk is full"));
+        assert_eq!(snapshot.written_samples, 1);
+        assert_eq!(snapshot.issue, Some(MicrophoneWriterIssue::Io));
+        assert!(control.worker_finished.load(Ordering::Acquire));
+        assert_eq!(
+            ring.read_position(),
+            1,
+            "the failed worker must leave later queued blocks untouched"
+        );
+    }
+
+    #[test]
+    fn worker_panic_is_caught_and_published_as_a_health_issue() {
+        let control = WriterControl::default();
+        let health = WriterHealth::default();
+        let ring = AudioRing::new(1);
+
+        let error = run_drain_worker(&control, &health, || -> Result<(), String> {
+            panic!("injected drain panic");
+        })
+        .expect_err("panic becomes a worker failure");
+
+        assert_eq!(error, "Microphone WAV writer task panicked.");
+        assert_eq!(
+            health.snapshot(&ring, &control).issue,
+            Some(MicrophoneWriterIssue::Panicked)
+        );
+        assert!(control.worker_finished.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn stalled_writer_with_backlog_publishes_an_independent_health_issue() {
+        let ring = AudioRing::new(1);
+        ring.push_overwrite(block(&[1, 2]));
+        let control = WriterControl::default();
+        let health = WriterHealth {
+            started: Instant::now() - WRITER_STALL_THRESHOLD - Duration::from_secs(1),
+            heartbeat_ms: AtomicU64::new(0),
+            written_samples: AtomicU64::new(0),
+            failure: AtomicU8::new(StoredWriterFailure::None as u8),
+        };
+
+        assert_eq!(
+            health.snapshot(&ring, &control).issue,
+            Some(MicrophoneWriterIssue::Stalled)
+        );
+    }
+
+    #[test]
+    fn stop_drains_a_partial_callback_block_byte_exactly() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let buffered_path = dir.path().join("stop-buffered.wav");
+        let direct_path = dir.path().join("stop-direct.wav");
+        let samples = (0..(AUDIO_BLOCK_SAMPLES / 2 + 7))
+            .map(|index| match index % 3 {
+                0 => 0.75_f32,
+                1 => -0.5,
+                _ => 0.125,
+            })
+            .collect::<Vec<_>>();
+        let expected_samples = samples
+            .iter()
+            .map(|sample| (sample.clamp(-1.0, 1.0) * i16::MAX as f32) as i16)
+            .collect::<Vec<_>>();
+        let (input, writer) = MicrophoneWriter::start_with_capacity(
+            wav_writer(&buffered_path),
+            8,
+            None,
+            Arc::new(Mutex::new(None)),
+        )
+        .expect("start buffered writer");
+        let ring = Arc::clone(&writer.ring);
+        let control = Arc::clone(&writer.control);
+        let health = Arc::clone(&writer.health);
+
+        input.write(
+            samples.iter().copied(),
+            &AtomicBool::new(false),
+            &AtomicBool::new(false),
+        );
+        writer.finish().expect("stop and drain partial block");
+        write_direct_wav(&direct_path, &expected_samples);
+
+        assert_eq!(
+            health.snapshot(&ring, &control).written_samples,
+            expected_samples.len() as u64
+        );
+        assert_eq!(
+            std::fs::read(buffered_path).expect("read stop-drained WAV"),
+            std::fs::read(direct_path).expect("read direct stop WAV"),
+            "stop must drain a callback block shorter than the ring block size"
+        );
+    }
+
+    #[test]
     fn writer_drain_matches_direct_wav_bytes_and_recovery_flushes() {
         let dir = tempfile::tempdir().expect("tempdir");
         let buffered_path = dir.path().join("buffered.wav");
@@ -702,6 +1052,11 @@ mod tests {
             0,
             "the writer must drain every sample without overflow"
         );
+        assert_eq!(
+            writer.health().written_samples,
+            expected_samples.len() as u64,
+            "status progress must come from successful writer calls"
+        );
         let flushed_samples = WavReader::open(&buffered_path)
             .expect("recovery-flushed WAV is readable")
             .samples::<i16>()
@@ -710,11 +1065,7 @@ mod tests {
         assert_eq!(flushed_samples, expected_samples);
         writer.finish().expect("finish buffered writer");
 
-        let mut direct = wav_writer(&direct_path);
-        for sample in &expected_samples {
-            direct.write_sample(*sample).expect("write direct sample");
-        }
-        direct.finalize().expect("finalize direct WAV");
+        write_direct_wav(&direct_path, &expected_samples);
 
         assert_eq!(
             std::fs::read(buffered_path).expect("read buffered WAV"),

--- a/src-tauri/src/audio/capture_buffer.rs
+++ b/src-tauri/src/audio/capture_buffer.rs
@@ -25,6 +25,7 @@ const WRITER_STALL_THRESHOLD: Duration = Duration::from_secs(3);
 struct AudioBlock {
     samples: [i16; AUDIO_BLOCK_SAMPLES],
     len: usize,
+    callback_id: u64,
     ends_callback: bool,
 }
 
@@ -33,7 +34,15 @@ impl AudioBlock {
         Self {
             samples: [0; AUDIO_BLOCK_SAMPLES],
             len: 0,
+            callback_id: 0,
             ends_callback: false,
+        }
+    }
+
+    fn for_callback(callback_id: u64) -> Self {
+        Self {
+            callback_id,
+            ..Self::empty()
         }
     }
 }
@@ -298,14 +307,14 @@ impl CaptureInput {
         }
 
         let ducked = mic_ducked.load(Ordering::Acquire);
-        let mut block = AudioBlock::empty();
+        let mut block = AudioBlock::for_callback(callback);
         let mut callback_peak = 0.0_f32;
         let mut callback_sum_square = 0.0_f64;
         let mut callback_samples = 0_u64;
         for sample in data {
             if block.len == AUDIO_BLOCK_SAMPLES {
                 self.ring.push_overwrite(block);
-                block = AudioBlock::empty();
+                block = AudioBlock::for_callback(callback);
             }
             let clamped = if ducked { 0.0 } else { sample.clamp(-1.0, 1.0) };
             let pcm_sample = (clamped * i16::MAX as f32) as i16;
@@ -393,6 +402,14 @@ pub enum MicrophoneWriterIssue {
 pub struct MicrophoneWriterHealth {
     pub written_samples: u64,
     pub issue: Option<MicrophoneWriterIssue>,
+}
+
+impl MicrophoneWriterHealth {
+    pub fn written_bytes(self) -> i64 {
+        self.written_samples
+            .saturating_mul(std::mem::size_of::<i16>() as u64)
+            .min(i64::MAX as u64) as i64
+    }
 }
 
 struct WriterHealth {
@@ -575,9 +592,10 @@ impl MicrophoneWriter {
                 });
     }
 
-    pub fn finish(mut self) -> Result<(), String> {
+    pub fn finish(mut self) -> Result<MicrophoneWriterHealth, String> {
         self.control.stop_requested.store(true, Ordering::Release);
-        self.join_worker()
+        self.join_worker()?;
+        Ok(self.health())
     }
 
     fn join_worker(&mut self) -> Result<(), String> {
@@ -623,6 +641,43 @@ where
     result
 }
 
+#[derive(Default)]
+struct PreviewAccumulator {
+    callback_id: Option<u64>,
+    samples: Vec<i16>,
+}
+
+impl PreviewAccumulator {
+    fn push<F>(&mut self, block: &AudioBlock, send: &mut F)
+    where
+        F: FnMut(Vec<i16>),
+    {
+        if self
+            .callback_id
+            .is_some_and(|callback_id| callback_id != block.callback_id)
+        {
+            self.flush(send);
+        }
+        self.callback_id = Some(block.callback_id);
+        self.samples.extend_from_slice(&block.samples[..block.len]);
+        if block.ends_callback {
+            self.flush(send);
+        }
+    }
+
+    fn flush<F>(&mut self, send: &mut F)
+    where
+        F: FnMut(Vec<i16>),
+    {
+        if self.samples.is_empty() {
+            self.callback_id = None;
+            return;
+        }
+        send(std::mem::take(&mut self.samples));
+        self.callback_id = None;
+    }
+}
+
 fn drain_audio<W>(
     mut writer: WavWriter<W>,
     ring: &AudioRing,
@@ -635,7 +690,7 @@ fn drain_audio<W>(
 where
     W: Write + Seek,
 {
-    let mut preview_samples = Vec::new();
+    let mut preview_accumulator = PreviewAccumulator::default();
     let mut last_heartbeat = 0;
     loop {
         health.heartbeat();
@@ -662,10 +717,9 @@ where
             }
             health.record_written(written_from_block);
             if let Some(preview) = preview.as_ref() {
-                preview_samples.extend_from_slice(&block.samples[..block.len]);
-                if block.ends_callback {
-                    preview.try_send(std::mem::take(&mut preview_samples));
-                }
+                preview_accumulator.push(&block, &mut |samples| {
+                    preview.try_send(samples);
+                });
             }
         }
 
@@ -694,9 +748,9 @@ where
     }
 
     if let Some(preview) = preview {
-        if !preview_samples.is_empty() {
-            preview.try_send(preview_samples);
-        }
+        preview_accumulator.flush(&mut |samples| {
+            preview.try_send(samples);
+        });
     }
     writer.finalize().map_err(|error| {
         health.fail(StoredWriterFailure::Io);
@@ -714,10 +768,15 @@ mod tests {
     };
 
     fn block(samples: &[i16]) -> AudioBlock {
+        callback_block(samples, 0, true)
+    }
+
+    fn callback_block(samples: &[i16], callback_id: u64, ends_callback: bool) -> AudioBlock {
         let mut block = AudioBlock::empty();
         block.samples[..samples.len()].copy_from_slice(samples);
         block.len = samples.len();
-        block.ends_callback = true;
+        block.callback_id = callback_id;
+        block.ends_callback = ends_callback;
         block
     }
 
@@ -813,6 +872,7 @@ mod tests {
         ring.push_overwrite(block(&[4]));
         ring.push_overwrite(block(&[5, 6]));
         let stats = AtomicCaptureStats::default();
+        stats.record_callback(1.0, 6.0, 6);
         let control = WriterControl::default();
         control.stop_requested.store(true, Ordering::Release);
         let health = WriterHealth::default();
@@ -831,11 +891,48 @@ mod tests {
         write_direct_wav(&direct_path, &[4, 5, 6]);
 
         assert_eq!(ring.dropped_samples(), 3);
-        assert_eq!(health.snapshot(&ring, &control).written_samples, 3);
+        assert_eq!(
+            stats.snapshot(ring.dropped_samples()).samples,
+            6,
+            "producer telemetry still counts every callback sample"
+        );
+        let writer_health = health.snapshot(&ring, &control);
+        assert_eq!(writer_health.written_samples, 3);
+        assert_eq!(
+            writer_health.written_bytes(),
+            6,
+            "writer byte progress must exclude the three overflowed samples"
+        );
         assert_eq!(
             std::fs::read(buffered_path).expect("read buffered overflow WAV"),
             std::fs::read(direct_path).expect("read direct overflow WAV"),
             "overflow must preserve the exact bytes of every surviving sample"
+        );
+    }
+
+    #[test]
+    fn overflowed_callback_end_cannot_merge_surviving_preview_callbacks() {
+        let ring = AudioRing::new(2);
+        let mut preview = PreviewAccumulator::default();
+        let mut batches = Vec::new();
+
+        preview.push(&callback_block(&[1], 1, false), &mut |samples| {
+            batches.push(samples)
+        });
+        ring.push_overwrite(callback_block(&[2], 1, true));
+        ring.push_overwrite(callback_block(&[3], 2, false));
+        ring.push_overwrite(callback_block(&[4], 2, true));
+
+        while let Some(block) = ring.pop() {
+            preview.push(&block, &mut |samples| batches.push(samples));
+        }
+        preview.flush(&mut |samples| batches.push(samples));
+
+        assert_eq!(ring.dropped_samples(), 1);
+        assert_eq!(
+            batches,
+            vec![vec![1], vec![3, 4]],
+            "a callback-id transition must restore the boundary whose end block overflowed"
         );
     }
 
@@ -992,21 +1089,24 @@ mod tests {
             Arc::new(Mutex::new(None)),
         )
         .expect("start buffered writer");
-        let ring = Arc::clone(&writer.ring);
-        let control = Arc::clone(&writer.control);
-        let health = Arc::clone(&writer.health);
-
         input.write(
             samples.iter().copied(),
             &AtomicBool::new(false),
             &AtomicBool::new(false),
         );
-        writer.finish().expect("stop and drain partial block");
+        let final_health = writer.finish().expect("stop and drain partial block");
         write_direct_wav(&direct_path, &expected_samples);
 
+        let finalized_sample_count = WavReader::open(&buffered_path)
+            .expect("read finalized stop-drained WAV")
+            .samples::<i16>()
+            .collect::<Result<Vec<_>, _>>()
+            .expect("read finalized stop-drained samples")
+            .len() as u64;
+        assert_eq!(final_health.written_samples, finalized_sample_count);
         assert_eq!(
-            health.snapshot(&ring, &control).written_samples,
-            expected_samples.len() as u64
+            final_health.written_bytes(),
+            finalized_sample_count as i64 * 2
         );
         assert_eq!(
             std::fs::read(buffered_path).expect("read stop-drained WAV"),
@@ -1063,10 +1163,15 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .expect("read recovery-flushed samples");
         assert_eq!(flushed_samples, expected_samples);
-        writer.finish().expect("finish buffered writer");
+        let final_health = writer.finish().expect("finish buffered writer");
 
         write_direct_wav(&direct_path, &expected_samples);
 
+        assert_eq!(
+            final_health.written_samples,
+            expected_samples.len() as u64,
+            "finish must return progress captured after the final ring drain"
+        );
         assert_eq!(
             std::fs::read(buffered_path).expect("read buffered WAV"),
             std::fs::read(direct_path).expect("read direct WAV"),

--- a/src-tauri/src/audio/capture_buffer.rs
+++ b/src-tauri/src/audio/capture_buffer.rs
@@ -1,0 +1,725 @@
+use crate::audio::live_preview::LivePreviewSink;
+use hound::WavWriter;
+use std::{
+    cell::UnsafeCell,
+    fs::File,
+    io::BufWriter,
+    mem::MaybeUninit,
+    sync::{
+        atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
+        Arc, Condvar, Mutex,
+    },
+    thread::{self, JoinHandle},
+    time::{Duration, Instant},
+};
+
+const AUDIO_BLOCK_SAMPLES: usize = 2_048;
+const AUDIO_BUFFER_SECONDS: usize = 30;
+const MAX_AUDIO_BUFFER_BLOCKS: usize = 16_384;
+const RECENT_PEAK_CAPACITY: usize = 24;
+const WRITER_IDLE_POLL_INTERVAL: Duration = Duration::from_millis(1);
+const RECOVERY_FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug)]
+struct AudioBlock {
+    samples: [i16; AUDIO_BLOCK_SAMPLES],
+    len: usize,
+    ends_callback: bool,
+}
+
+impl AudioBlock {
+    fn empty() -> Self {
+        Self {
+            samples: [0; AUDIO_BLOCK_SAMPLES],
+            len: 0,
+            ends_callback: false,
+        }
+    }
+}
+
+struct AudioSlot {
+    sequence: AtomicU64,
+    value: UnsafeCell<MaybeUninit<AudioBlock>>,
+}
+
+// A slot is accessed only after its sequence number transfers ownership
+// between the producer and consumer.
+unsafe impl Sync for AudioSlot {}
+
+/// Preallocated, bounded audio handoff. The CPAL callback is the only producer
+/// and the WAV task is the only ordinary consumer. When full, the producer may
+/// claim and discard the oldest unread block before publishing the newest one.
+struct AudioRing {
+    slots: Box<[AudioSlot]>,
+    capacity: u64,
+    enqueue_position: AtomicU64,
+    dequeue_position: AtomicU64,
+    dropped_samples: AtomicU64,
+}
+
+impl AudioRing {
+    fn new(capacity: usize) -> Self {
+        assert!(capacity > 0, "audio ring capacity must be non-zero");
+        let slots = (0..capacity)
+            .map(|sequence| AudioSlot {
+                sequence: AtomicU64::new(sequence as u64),
+                value: UnsafeCell::new(MaybeUninit::uninit()),
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self {
+            slots,
+            capacity: capacity as u64,
+            enqueue_position: AtomicU64::new(0),
+            dequeue_position: AtomicU64::new(0),
+            dropped_samples: AtomicU64::new(0),
+        }
+    }
+
+    fn push_overwrite(&self, block: AudioBlock) {
+        let enqueue_position = self.enqueue_position.load(Ordering::Relaxed);
+        let mut block = Some(block);
+        if self.try_push_at(enqueue_position, &mut block) {
+            return;
+        }
+
+        // Prefer the oldest queued audio. If the writer has already claimed
+        // that slot, do not spin or discard a second block: drop the incoming
+        // block instead and leave the real-time callback bounded.
+        if let Some(dropped) = self.try_discard_oldest_at(enqueue_position) {
+            self.dropped_samples
+                .fetch_add(dropped as u64, Ordering::Relaxed);
+            if !self.try_push_at(enqueue_position, &mut block) {
+                self.dropped_samples.fetch_add(
+                    block.as_ref().map_or(0, |block| block.len as u64),
+                    Ordering::Relaxed,
+                );
+            }
+        } else {
+            self.dropped_samples.fetch_add(
+                block.as_ref().map_or(0, |block| block.len as u64),
+                Ordering::Relaxed,
+            );
+        }
+    }
+
+    fn try_push_at(&self, position: u64, block: &mut Option<AudioBlock>) -> bool {
+        let slot = &self.slots[(position % self.capacity) as usize];
+        if slot.sequence.load(Ordering::Acquire) != position {
+            return false;
+        }
+        // There is one producer, so publishing the next enqueue position does
+        // not need a compare-exchange.
+        self.enqueue_position
+            .store(position.wrapping_add(1), Ordering::Relaxed);
+        unsafe {
+            (*slot.value.get()).write(block.take().expect("audio block is available"));
+        }
+        slot.sequence
+            .store(position.wrapping_add(1), Ordering::Release);
+        true
+    }
+
+    fn try_discard_oldest_at(&self, blocked_enqueue_position: u64) -> Option<usize> {
+        let expected_dequeue = blocked_enqueue_position.wrapping_sub(self.capacity);
+        if self.dequeue_position.load(Ordering::Acquire) != expected_dequeue {
+            return None;
+        }
+        let slot = &self.slots[(expected_dequeue % self.capacity) as usize];
+        if slot.sequence.load(Ordering::Acquire) != expected_dequeue.wrapping_add(1) {
+            return None;
+        }
+        if self
+            .dequeue_position
+            .compare_exchange(
+                expected_dequeue,
+                expected_dequeue.wrapping_add(1),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return None;
+        }
+        let block = unsafe { (*slot.value.get()).assume_init_read() };
+        slot.sequence.store(
+            expected_dequeue.wrapping_add(self.capacity),
+            Ordering::Release,
+        );
+        Some(block.len)
+    }
+
+    fn pop(&self) -> Option<AudioBlock> {
+        loop {
+            let position = self.dequeue_position.load(Ordering::Relaxed);
+            let slot = &self.slots[(position % self.capacity) as usize];
+            if slot.sequence.load(Ordering::Acquire) != position.wrapping_add(1) {
+                return None;
+            }
+            if self
+                .dequeue_position
+                .compare_exchange(
+                    position,
+                    position.wrapping_add(1),
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_err()
+            {
+                continue;
+            }
+            let block = unsafe { (*slot.value.get()).assume_init_read() };
+            slot.sequence
+                .store(position.wrapping_add(self.capacity), Ordering::Release);
+            return Some(block);
+        }
+    }
+
+    fn write_position(&self) -> u64 {
+        self.enqueue_position.load(Ordering::Acquire)
+    }
+
+    fn read_position(&self) -> u64 {
+        self.dequeue_position.load(Ordering::Acquire)
+    }
+
+    fn dropped_samples(&self) -> u64 {
+        self.dropped_samples.load(Ordering::Acquire)
+    }
+}
+
+struct AtomicCaptureStats {
+    peak_bits: AtomicU32,
+    sum_square_bits: AtomicU64,
+    samples: AtomicU64,
+    callback_heartbeat: AtomicU64,
+    completed_callback: AtomicU64,
+    monitored_callback: AtomicU64,
+    recent_peak_count: AtomicU64,
+    recent_peaks: [AtomicU32; RECENT_PEAK_CAPACITY],
+}
+
+impl Default for AtomicCaptureStats {
+    fn default() -> Self {
+        Self {
+            peak_bits: AtomicU32::new(0),
+            sum_square_bits: AtomicU64::new(0.0_f64.to_bits()),
+            samples: AtomicU64::new(0),
+            callback_heartbeat: AtomicU64::new(0),
+            completed_callback: AtomicU64::new(0),
+            monitored_callback: AtomicU64::new(0),
+            recent_peak_count: AtomicU64::new(0),
+            recent_peaks: std::array::from_fn(|_| AtomicU32::new(0)),
+        }
+    }
+}
+
+impl AtomicCaptureStats {
+    fn record_callback(&self, peak: f32, sum_square: f64, samples: u64) {
+        self.peak_bits.fetch_max(peak.to_bits(), Ordering::Relaxed);
+        let previous_sum = f64::from_bits(self.sum_square_bits.load(Ordering::Relaxed));
+        self.sum_square_bits
+            .store((previous_sum + sum_square).to_bits(), Ordering::Relaxed);
+        self.samples.fetch_add(samples, Ordering::Relaxed);
+
+        let callback_index = self.recent_peak_count.load(Ordering::Relaxed);
+        self.recent_peaks[(callback_index % RECENT_PEAK_CAPACITY as u64) as usize]
+            .store(peak.to_bits(), Ordering::Relaxed);
+        self.recent_peak_count
+            .store(callback_index.wrapping_add(1), Ordering::Release);
+    }
+
+    fn snapshot(&self, dropped_samples: u64) -> CaptureStatsSnapshot {
+        let samples = self.samples.load(Ordering::Acquire);
+        let sum_square = f64::from_bits(self.sum_square_bits.load(Ordering::Acquire));
+        let recent_peak_count = self.recent_peak_count.load(Ordering::Acquire);
+        let recent_len = recent_peak_count.min(RECENT_PEAK_CAPACITY as u64);
+        let recent_start = recent_peak_count.wrapping_sub(recent_len);
+        let recent_peaks = (recent_start..recent_peak_count)
+            .map(|index| {
+                f32::from_bits(
+                    self.recent_peaks[(index % RECENT_PEAK_CAPACITY as u64) as usize]
+                        .load(Ordering::Acquire),
+                )
+            })
+            .collect();
+        CaptureStatsSnapshot {
+            peak: f32::from_bits(self.peak_bits.load(Ordering::Acquire)),
+            rms: if samples == 0 {
+                0.0
+            } else {
+                (sum_square / samples as f64).sqrt() as f32
+            },
+            samples,
+            recent_peaks,
+            dropped_samples,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CaptureStatsSnapshot {
+    pub peak: f32,
+    pub rms: f32,
+    pub samples: u64,
+    pub recent_peaks: Vec<f32>,
+    pub dropped_samples: u64,
+}
+
+#[derive(Clone)]
+pub struct CaptureInput {
+    ring: Arc<AudioRing>,
+    stats: Arc<AtomicCaptureStats>,
+}
+
+impl CaptureInput {
+    /// Converts and publishes one CPAL callback without allocation, locking, or
+    /// I/O. The iterator itself must likewise be allocation-free.
+    pub fn write<I>(&self, data: I, paused: &AtomicBool, mic_ducked: &AtomicBool)
+    where
+        I: Iterator<Item = f32>,
+    {
+        let callback = self
+            .stats
+            .callback_heartbeat
+            .fetch_add(1, Ordering::AcqRel)
+            .wrapping_add(1);
+        if paused.load(Ordering::Acquire) {
+            self.stats
+                .completed_callback
+                .store(callback, Ordering::Release);
+            return;
+        }
+
+        let ducked = mic_ducked.load(Ordering::Acquire);
+        let mut block = AudioBlock::empty();
+        let mut callback_peak = 0.0_f32;
+        let mut callback_sum_square = 0.0_f64;
+        let mut callback_samples = 0_u64;
+        for sample in data {
+            if block.len == AUDIO_BLOCK_SAMPLES {
+                self.ring.push_overwrite(block);
+                block = AudioBlock::empty();
+            }
+            let clamped = if ducked { 0.0 } else { sample.clamp(-1.0, 1.0) };
+            let pcm_sample = (clamped * i16::MAX as f32) as i16;
+            let normalized = clamped.abs();
+            callback_peak = callback_peak.max(normalized);
+            callback_sum_square += (normalized as f64).powi(2);
+            callback_samples = callback_samples.saturating_add(1);
+            block.samples[block.len] = pcm_sample;
+            block.len += 1;
+        }
+        if block.len == 0 {
+            self.stats
+                .completed_callback
+                .store(callback, Ordering::Release);
+            return;
+        }
+        block.ends_callback = true;
+        self.ring.push_overwrite(block);
+        self.stats
+            .record_callback(callback_peak, callback_sum_square, callback_samples);
+        self.stats
+            .completed_callback
+            .store(callback, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub fn stats(&self) -> CaptureStatsSnapshot {
+        self.stats.snapshot(self.ring.dropped_samples())
+    }
+}
+
+struct WriterControl {
+    stop_requested: AtomicBool,
+    flush_generation: AtomicU64,
+    flush_target: AtomicU64,
+    flushed_generation: AtomicU64,
+    worker_finished: AtomicBool,
+    flush_wait: Mutex<()>,
+    flush_changed: Condvar,
+}
+
+impl Default for WriterControl {
+    fn default() -> Self {
+        Self {
+            stop_requested: AtomicBool::new(false),
+            flush_generation: AtomicU64::new(0),
+            flush_target: AtomicU64::new(0),
+            flushed_generation: AtomicU64::new(0),
+            worker_finished: AtomicBool::new(false),
+            flush_wait: Mutex::new(()),
+            flush_changed: Condvar::new(),
+        }
+    }
+}
+
+pub struct MicrophoneWriter {
+    ring: Arc<AudioRing>,
+    stats: Arc<AtomicCaptureStats>,
+    control: Arc<WriterControl>,
+    worker: Option<JoinHandle<Result<(), String>>>,
+}
+
+impl MicrophoneWriter {
+    pub fn start(
+        writer: WavWriter<BufWriter<File>>,
+        sample_rate: u32,
+        channels: u16,
+        preview: Option<LivePreviewSink>,
+        last_callback_at: Arc<Mutex<Option<Instant>>>,
+    ) -> Result<(CaptureInput, Self), String> {
+        let samples_per_second = (sample_rate as usize).saturating_mul(channels as usize);
+        let capacity = samples_per_second
+            .saturating_mul(AUDIO_BUFFER_SECONDS)
+            .div_ceil(AUDIO_BLOCK_SAMPLES)
+            .clamp(8, MAX_AUDIO_BUFFER_BLOCKS);
+        Self::start_with_capacity(writer, capacity, preview, last_callback_at)
+    }
+
+    fn start_with_capacity(
+        writer: WavWriter<BufWriter<File>>,
+        capacity: usize,
+        preview: Option<LivePreviewSink>,
+        last_callback_at: Arc<Mutex<Option<Instant>>>,
+    ) -> Result<(CaptureInput, Self), String> {
+        let ring = Arc::new(AudioRing::new(capacity));
+        let stats = Arc::new(AtomicCaptureStats::default());
+        let control = Arc::new(WriterControl::default());
+        let worker_ring = Arc::clone(&ring);
+        let worker_stats = Arc::clone(&stats);
+        let worker_control = Arc::clone(&control);
+        let worker = thread::Builder::new()
+            .name("microphone-wav-writer".to_string())
+            .spawn(move || {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    drain_audio(
+                        writer,
+                        &worker_ring,
+                        &worker_stats,
+                        &worker_control,
+                        preview,
+                        &last_callback_at,
+                    )
+                }))
+                .unwrap_or_else(|_| Err("Microphone WAV writer task panicked.".to_string()));
+                worker_control
+                    .worker_finished
+                    .store(true, Ordering::Release);
+                worker_control.flush_changed.notify_all();
+                result
+            })
+            .map_err(|error| error.to_string())?;
+        let input = CaptureInput {
+            ring: Arc::clone(&ring),
+            stats: Arc::clone(&stats),
+        };
+        Ok((
+            input,
+            Self {
+                ring,
+                stats,
+                control,
+                worker: Some(worker),
+            },
+        ))
+    }
+
+    pub fn stats(&self) -> CaptureStatsSnapshot {
+        self.stats.snapshot(self.ring.dropped_samples())
+    }
+
+    pub fn has_unobserved_callback(&self) -> bool {
+        self.stats.callback_heartbeat.load(Ordering::Acquire)
+            != self.stats.monitored_callback.load(Ordering::Acquire)
+    }
+
+    /// Flushes every block published before this call. The callback continues
+    /// publishing newer audio while the non-real-time caller waits.
+    pub fn flush_for_recovery(&self) {
+        let callback = self.stats.callback_heartbeat.load(Ordering::Acquire);
+        let wait_started = Instant::now();
+        while self.stats.completed_callback.load(Ordering::Acquire) < callback
+            && wait_started.elapsed() < RECOVERY_FLUSH_TIMEOUT
+        {
+            thread::sleep(WRITER_IDLE_POLL_INTERVAL);
+        }
+        let target = self.ring.write_position();
+        self.control.flush_target.store(target, Ordering::Release);
+        let generation = self
+            .control
+            .flush_generation
+            .fetch_add(1, Ordering::AcqRel)
+            .wrapping_add(1);
+        let Ok(guard) = self.control.flush_wait.lock() else {
+            return;
+        };
+        let _ =
+            self.control
+                .flush_changed
+                .wait_timeout_while(guard, RECOVERY_FLUSH_TIMEOUT, |_| {
+                    self.control.flushed_generation.load(Ordering::Acquire) < generation
+                        && !self.control.worker_finished.load(Ordering::Acquire)
+                });
+    }
+
+    pub fn finish(mut self) -> Result<(), String> {
+        self.control.stop_requested.store(true, Ordering::Release);
+        self.join_worker()
+    }
+
+    fn join_worker(&mut self) -> Result<(), String> {
+        let Some(worker) = self.worker.take() else {
+            return Ok(());
+        };
+        worker
+            .join()
+            .map_err(|_| "Microphone WAV writer task panicked.".to_string())?
+    }
+}
+
+impl Drop for MicrophoneWriter {
+    fn drop(&mut self) {
+        self.control.stop_requested.store(true, Ordering::Release);
+        let _ = self.join_worker();
+    }
+}
+
+fn drain_audio(
+    mut writer: WavWriter<BufWriter<File>>,
+    ring: &AudioRing,
+    stats: &AtomicCaptureStats,
+    control: &WriterControl,
+    preview: Option<LivePreviewSink>,
+    last_callback_at: &Mutex<Option<Instant>>,
+) -> Result<(), String> {
+    let mut preview_samples = Vec::new();
+    let mut last_heartbeat = 0;
+    let mut first_error = None;
+    loop {
+        let heartbeat = stats.callback_heartbeat.load(Ordering::Acquire);
+        if heartbeat != last_heartbeat {
+            last_heartbeat = heartbeat;
+            if let Ok(mut last_callback_at) = last_callback_at.lock() {
+                *last_callback_at = Some(Instant::now());
+            }
+            stats.monitored_callback.store(heartbeat, Ordering::Release);
+        }
+
+        let mut drained_any = false;
+        while let Some(block) = ring.pop() {
+            drained_any = true;
+            for sample in &block.samples[..block.len] {
+                if let Err(error) = writer.write_sample(*sample) {
+                    first_error.get_or_insert_with(|| error.to_string());
+                }
+            }
+            if let Some(preview) = preview.as_ref() {
+                preview_samples.extend_from_slice(&block.samples[..block.len]);
+                if block.ends_callback {
+                    preview.try_send(std::mem::take(&mut preview_samples));
+                }
+            }
+        }
+
+        let flush_generation = control.flush_generation.load(Ordering::Acquire);
+        if flush_generation > control.flushed_generation.load(Ordering::Acquire)
+            && ring.read_position() >= control.flush_target.load(Ordering::Acquire)
+        {
+            if let Err(error) = writer.flush() {
+                first_error.get_or_insert_with(|| error.to_string());
+            }
+            control
+                .flushed_generation
+                .store(flush_generation, Ordering::Release);
+            control.flush_changed.notify_all();
+        }
+
+        if control.stop_requested.load(Ordering::Acquire)
+            && ring.read_position() >= ring.write_position()
+        {
+            break;
+        }
+        if !drained_any {
+            thread::sleep(WRITER_IDLE_POLL_INTERVAL);
+        }
+    }
+
+    if let Some(preview) = preview {
+        if !preview_samples.is_empty() {
+            preview.try_send(preview_samples);
+        }
+    }
+    if let Err(error) = writer.finalize() {
+        first_error.get_or_insert_with(|| error.to_string());
+    }
+    first_error.map_or(Ok(()), Err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hound::{SampleFormat, WavReader, WavSpec};
+    use std::path::Path;
+
+    fn block(samples: &[i16]) -> AudioBlock {
+        let mut block = AudioBlock::empty();
+        block.samples[..samples.len()].copy_from_slice(samples);
+        block.len = samples.len();
+        block.ends_callback = true;
+        block
+    }
+
+    fn wav_writer(path: &Path) -> WavWriter<BufWriter<File>> {
+        WavWriter::create(
+            path,
+            WavSpec {
+                channels: 1,
+                sample_rate: 48_000,
+                bits_per_sample: 16,
+                sample_format: SampleFormat::Int,
+            },
+        )
+        .expect("create WAV writer")
+    }
+
+    #[test]
+    fn ring_preserves_fifo_order_until_capacity() {
+        let ring = AudioRing::new(3);
+        ring.push_overwrite(block(&[1, 2]));
+        ring.push_overwrite(block(&[3]));
+        ring.push_overwrite(block(&[4, 5]));
+
+        assert_eq!(ring.pop().unwrap().samples[..2], [1, 2]);
+        assert_eq!(ring.pop().unwrap().samples[..1], [3]);
+        assert_eq!(ring.pop().unwrap().samples[..2], [4, 5]);
+        assert!(ring.pop().is_none());
+        assert_eq!(ring.dropped_samples(), 0);
+    }
+
+    #[test]
+    fn ring_overflow_drops_oldest_and_counts_exact_samples() {
+        let ring = AudioRing::new(2);
+        ring.push_overwrite(block(&[1, 2, 3]));
+        ring.push_overwrite(block(&[4]));
+        ring.push_overwrite(block(&[5, 6]));
+
+        assert_eq!(ring.pop().unwrap().samples[..1], [4]);
+        assert_eq!(ring.pop().unwrap().samples[..2], [5, 6]);
+        assert!(ring.pop().is_none());
+        assert_eq!(ring.dropped_samples(), 3);
+    }
+
+    #[test]
+    fn ring_preserves_every_block_across_concurrent_wraparound() {
+        const BLOCKS: u64 = 10_000;
+        const CAPACITY: u64 = 8;
+        let ring = Arc::new(AudioRing::new(CAPACITY as usize));
+        let consumed = Arc::new(AtomicU64::new(0));
+        let producer_ring = Arc::clone(&ring);
+        let producer_consumed = Arc::clone(&consumed);
+        let producer = thread::spawn(move || {
+            for value in 0..BLOCKS {
+                while value.saturating_sub(producer_consumed.load(Ordering::Acquire))
+                    >= CAPACITY - 1
+                {
+                    thread::yield_now();
+                }
+                producer_ring.push_overwrite(block(&[(value % i16::MAX as u64) as i16]));
+            }
+        });
+
+        for expected in 0..BLOCKS {
+            let next = loop {
+                if let Some(next) = ring.pop() {
+                    break next;
+                }
+                thread::yield_now();
+            };
+            assert_eq!(next.samples[0], (expected % i16::MAX as u64) as i16);
+            consumed.store(expected + 1, Ordering::Release);
+        }
+
+        producer.join().expect("producer completes");
+        assert!(ring.pop().is_none());
+        assert_eq!(ring.dropped_samples(), 0);
+    }
+
+    #[test]
+    fn callback_stats_publish_peak_rms_and_recent_peaks_through_atomics() {
+        let input = CaptureInput {
+            ring: Arc::new(AudioRing::new(2)),
+            stats: Arc::new(AtomicCaptureStats::default()),
+        };
+        input.write(
+            [0.5_f32, -0.25].into_iter(),
+            &AtomicBool::new(false),
+            &AtomicBool::new(false),
+        );
+
+        let stats = input.stats();
+        let expected_rms = ((0.5_f64.powi(2) + 0.25_f64.powi(2)) / 2.0).sqrt() as f32;
+        assert_eq!(stats.peak, 0.5);
+        assert!((stats.rms - expected_rms).abs() < f32::EPSILON);
+        assert_eq!(stats.recent_peaks, vec![0.5]);
+    }
+
+    #[test]
+    fn writer_drain_matches_direct_wav_bytes_and_recovery_flushes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let buffered_path = dir.path().join("buffered.wav");
+        let direct_path = dir.path().join("direct.wav");
+        let samples = (0..(AUDIO_BLOCK_SAMPLES * 2 + 17))
+            .map(|index| match index % 5 {
+                0 => 0.5_f32,
+                1 => -0.25,
+                2 => 1.5,
+                3 => -2.0,
+                _ => 0.0,
+            })
+            .collect::<Vec<_>>();
+        let expected_samples = samples
+            .iter()
+            .map(|sample| (sample.clamp(-1.0, 1.0) * i16::MAX as f32) as i16)
+            .collect::<Vec<_>>();
+
+        let (input, writer) = MicrophoneWriter::start_with_capacity(
+            wav_writer(&buffered_path),
+            8,
+            None,
+            Arc::new(Mutex::new(None)),
+        )
+        .expect("start buffered writer");
+        input.write(
+            samples.iter().copied(),
+            &AtomicBool::new(false),
+            &AtomicBool::new(false),
+        );
+        writer.flush_for_recovery();
+        assert_eq!(
+            input.stats().dropped_samples,
+            0,
+            "the writer must drain every sample without overflow"
+        );
+        let flushed_samples = WavReader::open(&buffered_path)
+            .expect("recovery-flushed WAV is readable")
+            .samples::<i16>()
+            .collect::<Result<Vec<_>, _>>()
+            .expect("read recovery-flushed samples");
+        assert_eq!(flushed_samples, expected_samples);
+        writer.finish().expect("finish buffered writer");
+
+        let mut direct = wav_writer(&direct_path);
+        for sample in &expected_samples {
+            direct.write_sample(*sample).expect("write direct sample");
+        }
+        direct.finalize().expect("finalize direct WAV");
+
+        assert_eq!(
+            std::fs::read(buffered_path).expect("read buffered WAV"),
+            std::fs::read(direct_path).expect("read direct WAV"),
+            "buffering must not change the finalized WAV bytes"
+        );
+    }
+}

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,4 +1,5 @@
 pub mod capture;
+mod capture_buffer;
 pub mod echo;
 pub mod live_preview;
 pub mod recovery;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2158,6 +2158,7 @@ fn spawn_recording_recovery_checkpoint_worker(repos: Repositories, session_id: S
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(RECOVERY_SNAPSHOT_INTERVAL);
         let mut reported_dropped_samples = 0_u64;
+        let mut reported_capture_issue = None;
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         // Tokio intervals tick immediately. The recording-start rows already
         // hold elapsed=0, so wait for the first real checkpoint interval.
@@ -2194,6 +2195,37 @@ fn spawn_recording_recovery_checkpoint_worker(repos: Repositories, session_id: S
                                     "recording overflow checkpoint failed for {}: {}",
                                     checkpoint.session_id, error
                                 );
+                            }
+                        }
+                    }
+                    if let Some(issue) = checkpoint.capture_issue.as_ref() {
+                        if reported_capture_issue.as_deref() != Some(issue.code.as_str()) {
+                            match repos
+                                .add_source_checkpoint(
+                                    &checkpoint.session_id,
+                                    None,
+                                    Some(RecordingSource::Microphone.as_db()),
+                                    "capture_stream_error",
+                                    Some(
+                                        serde_json::json!({
+                                            "code": issue.code,
+                                            "message": issue.message,
+                                            "elapsedMs": issue.elapsed_ms,
+                                        })
+                                        .to_string(),
+                                    ),
+                                )
+                                .await
+                            {
+                                Ok(()) => {
+                                    reported_capture_issue = Some(issue.code.clone());
+                                }
+                                Err(error) => {
+                                    eprintln!(
+                                        "recording capture issue checkpoint failed for {}: {}",
+                                        checkpoint.session_id, error
+                                    );
+                                }
                             }
                         }
                     }
@@ -2404,6 +2436,7 @@ async fn finish_recording_session_with_timing(
                     "capture_stream_error",
                     Some(
                         serde_json::json!({
+                            "code": issue.code,
                             "message": issue.message,
                             "elapsedMs": issue.elapsed_ms,
                         })

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2157,6 +2157,7 @@ pub async fn get_recording_status(
 fn spawn_recording_recovery_checkpoint_worker(repos: Repositories, session_id: String) {
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(RECOVERY_SNAPSHOT_INTERVAL);
+        let mut reported_dropped_samples = 0_u64;
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         // Tokio intervals tick immediately. The recording-start rows already
         // hold elapsed=0, so wait for the first real checkpoint interval.
@@ -2165,6 +2166,37 @@ fn spawn_recording_recovery_checkpoint_worker(repos: Repositories, session_id: S
             ticker.tick().await;
             match capture_recovery_checkpoint(&session_id) {
                 Ok(Some(checkpoint)) => {
+                    if checkpoint.dropped_samples > reported_dropped_samples {
+                        let dropped_since_last =
+                            checkpoint.dropped_samples - reported_dropped_samples;
+                        match repos
+                            .add_source_checkpoint(
+                                &checkpoint.session_id,
+                                None,
+                                Some(RecordingSource::Microphone.as_db()),
+                                "capture_buffer_overflow",
+                                Some(
+                                    serde_json::json!({
+                                        "droppedSamples": checkpoint.dropped_samples,
+                                        "droppedSinceLastCheckpoint": dropped_since_last,
+                                        "elapsedMs": checkpoint.elapsed_ms,
+                                    })
+                                    .to_string(),
+                                ),
+                            )
+                            .await
+                        {
+                            Ok(()) => {
+                                reported_dropped_samples = checkpoint.dropped_samples;
+                            }
+                            Err(error) => {
+                                eprintln!(
+                                    "recording overflow checkpoint failed for {}: {}",
+                                    checkpoint.session_id, error
+                                );
+                            }
+                        }
+                    }
                     if let Err(error) = persist_recording_recovery_state(
                         &repos,
                         &checkpoint.session_id,
@@ -2338,6 +2370,31 @@ async fn finish_recording_session_with_timing(
         let source_artifact = source_artifacts
             .iter()
             .find(|artifact| artifact.source == source.source.as_db());
+        if source.dropped_samples > 0 {
+            if let Err(error) = repos
+                .add_source_checkpoint(
+                    &finished.session_id,
+                    source_artifact.map(|artifact| artifact.id.as_str()),
+                    Some(source.source.as_db()),
+                    "capture_buffer_overflow",
+                    Some(
+                        serde_json::json!({
+                            "droppedSamples": source.dropped_samples,
+                            "final": true,
+                        })
+                        .to_string(),
+                    ),
+                )
+                .await
+            {
+                eprintln!(
+                    "failed to persist capture_buffer_overflow checkpoint for {} source {}: {}",
+                    finished.session_id,
+                    source.source.as_db(),
+                    error
+                );
+            }
+        }
         if let Some(issue) = source.capture_issue.as_ref() {
             if let Err(error) = repos
                 .add_source_checkpoint(

--- a/src-tauri/src/commands/note_transcription_benchmark.rs
+++ b/src-tauri/src/commands/note_transcription_benchmark.rs
@@ -498,6 +498,7 @@ async fn run_benchmark_iteration(
                 source: *source,
                 final_path: path.clone(),
                 elapsed_ms,
+                dropped_samples: 0,
                 capture_issue: None,
                 failure: None,
             })

--- a/src-tauri/src/commands/note_transcription_timing_tests.rs
+++ b/src-tauri/src/commands/note_transcription_timing_tests.rs
@@ -69,6 +69,7 @@ fn timing_finished_recording(
             source: RecordingSource::Microphone,
             final_path: path,
             elapsed_ms: 1_000,
+            dropped_samples: 0,
             capture_issue: None,
             failure: None,
         }],

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -702,6 +702,8 @@ pub struct SourceStatusDto {
     pub state: SourceState,
     pub elapsed_ms: i64,
     pub bytes_written: i64,
+    #[serde(default)]
+    pub dropped_samples: u64,
     pub level: AudioLevelDto,
     pub silence_warning: bool,
     pub path_finalized: bool,

--- a/src-tauri/src/meeting_hud.rs
+++ b/src-tauri/src/meeting_hud.rs
@@ -879,6 +879,7 @@ mod tests {
                 state: SourceState::Recording,
                 elapsed_ms: 1_250,
                 bytes_written: 8_192,
+                dropped_samples: 0,
                 level,
                 silence_warning: false,
                 path_finalized: false,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -379,6 +379,7 @@ export type SourceStatusDto = {
   state: SourceState;
   elapsedMs: number;
   bytesWritten: number;
+  droppedSamples?: number;
   level: AudioLevelDto;
   silenceWarning: boolean;
   pathFinalized: boolean;


### PR DESCRIPTION
## Summary

- Move microphone PCM handoff into a preallocated lock-free ring so the CPAL data callback performs only bounded stack work and atomic operations.
- Drain the ring from a dedicated non-real-time WAV writer thread, preserving callback-sized live-preview batches and recovery flush watermarks.
- Publish peak/RMS telemetry through atomics, derive `bytesWritten` from successful writer progress, and surface exact overflow and drain-worker failure diagnostics.
- Stop the drain on the first WAV error and publish independent I/O, panic, unexpected-exit, or stall health through the existing recording and recovery warning paths.

Refs JUN-401

## Root cause

The CPAL real-time callback locked the shared WAV writer and capture statistics mutexes, wrote every sample to disk, allocated live-preview batches, and updated wall-clock state. Status and recovery readers contended on those same locks, so ordinary disk or reader latency could block real-time capture and lose microphone frames. The first asynchronous drain also kept consuming after a WAV write error and exposed only callback health, allowing status to appear healthy while the file stopped growing.

## Validation

- `env CI=true NODE_OPTIONS=--no-experimental-webstorage DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make verify`
- `env CI=true NODE_OPTIONS=--no-experimental-webstorage DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make local-ci`
- Focused audio tests cover FIFO behavior, exact oldest-drop accounting, the contested-slot retry, 10,000 concurrent ring wraparounds with zero drops, atomic peak/RMS telemetry, recovery flushing, injected disk failure, caught worker panic, independent stall detection, and byte-for-byte WAV equivalence for normal, overflow, and stop-mid-block drains.
- Full Tauri suite: 1,320 library tests passed, 5 ignored, plus all integration suites.
- Full frontend suite: 3,404 tests passed, 2 skipped.
- Not tested visually: this changes native capture scheduling and diagnostics without changing an existing UI flow.
- No June API deploy is required.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- check if yes; say which change -->

## Out of scope

- System-audio helper capture and WAV format changes.
- Any change to recording, pause, ducking, live-preview, or transcription semantics.
- Tuning the overflow warning presentation beyond the existing recording diagnostics surfaces.

## Followups

- Keep this PR in draft for the next external review round after the consolidated Opus and Kimi findings were addressed.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787387367&installation_model_id=425925&pr_number=914&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F914&signature=5b72079b24e7effe59b23c3c2307460d89555501571339a049483de1b5cc15d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->