### PR TITLE
Fix update relaunch shutdown freeze

### DIFF
--- a/docs/hermes-gateway-gotchas.md
+++ b/docs/hermes-gateway-gotchas.md
@@ -28,6 +28,16 @@ to "reconnect" existing clients.
 with `launchctl bootout gui/$UID/ai.hermes.gateway`. June re-registers it on
 next launch.
 
+**App teardown is ordered and bounded.** Ordinary quit enters the idempotent
+shutdown coordinator from `RunEvent::ExitRequested`; update relaunch enters the
+same coordinator from its command. Cleanup runs off the main event loop and
+Hermes keeps this order: latch and quiesce starts, unload the launchd Gateway
+while the provider proxy is alive, reap interactive runtime process groups,
+then stop the provider proxy. `RunEvent::Exit` performs no cleanup because work
+started there can be dropped before it runs. Every leaf has its own deadline,
+and a five-second aggregate deadline schedules the final exit or restart even
+if a leaf remains stuck.
+
 ## Config
 
 **`config.yaml` has two writers — June must merge, never overwrite.** June

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -226,7 +226,12 @@ For the first updater-to-updater validation, install an older updater-capable
 build, run **June -> Check for updates…**, confirm the prompt shows the
 new version and release notes, install, and verify the app relaunches without
 Gatekeeper warnings. Also confirm microphone and Accessibility permissions are
-still granted after relaunch.
+still granted after relaunch. During the relaunch, confirm the app remains
+responsive after the command is accepted: the main event loop must return in
+under one second while bounded child cleanup continues off-thread. For the
+forced-leaf check, stop one tracked Hermes child with `kill -STOP <pid>` before
+accepting the update and confirm June still relaunches after kill escalation or
+the five-second aggregate deadline instead of showing a permanent beachball.
 
 If any signing, notarization, updater signature, Gatekeeper, or relaunch check
 fails, do not promote the release. Keep the fallback build path until the CI

--- a/src-tauri/src/browser/launcher.rs
+++ b/src-tauri/src/browser/launcher.rs
@@ -15,6 +15,7 @@ use std::fs::File;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::Duration;
 
 /// A supported Chromium-family browser. The variant order is the detection
 /// priority order fixed by the PRD (Chrome, then Edge, then Brave, then stock
@@ -210,9 +211,15 @@ impl LaunchedBrowser {
         if self.killed {
             return;
         }
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-        self.killed = true;
+        let outcome = crate::shutdown::terminate_child(
+            &mut self.child,
+            Duration::ZERO,
+            Duration::from_millis(250),
+        );
+        self.killed = matches!(
+            outcome,
+            crate::shutdown::ChildTermination::Exited | crate::shutdown::ChildTermination::Killed
+        );
     }
 
     /// The process id while the child has not been reaped, for diagnostics and

--- a/src-tauri/src/browser/launcher.rs
+++ b/src-tauri/src/browser/launcher.rs
@@ -193,7 +193,7 @@ impl Drop for EphemeralProfile {
 /// [`EphemeralProfile`] guard is the sole profile owner, so kill/Drop here must
 /// not delete profile data.
 pub struct LaunchedBrowser {
-    child: std::process::Child,
+    child: Option<std::process::Child>,
     /// `(read from browser, write to browser)`. Taken once by the CDP client.
     cdp_pipes: Option<(File, File)>,
     killed: bool,
@@ -211,15 +211,12 @@ impl LaunchedBrowser {
         if self.killed {
             return;
         }
-        let outcome = crate::shutdown::terminate_child(
-            &mut self.child,
-            Duration::ZERO,
-            Duration::from_millis(250),
-        );
-        self.killed = matches!(
-            outcome,
-            crate::shutdown::ChildTermination::Exited | crate::shutdown::ChildTermination::Killed
-        );
+        if let Some(child) = self.child.take() {
+            let _ =
+                crate::shutdown::terminate_child(child, Duration::ZERO, Duration::from_millis(250));
+        }
+        // The child was either reaped or transferred to the detached reaper.
+        self.killed = true;
     }
 
     /// The process id while the child has not been reaped, for diagnostics and
@@ -228,7 +225,7 @@ impl LaunchedBrowser {
         if self.killed {
             None
         } else {
-            Some(self.child.id())
+            self.child.as_ref().map(std::process::Child::id)
         }
     }
 
@@ -238,7 +235,11 @@ impl LaunchedBrowser {
         if self.killed {
             return true;
         }
-        match self.child.try_wait() {
+        let Some(child) = self.child.as_mut() else {
+            self.killed = true;
+            return true;
+        };
+        match child.try_wait() {
             Ok(Some(_)) => {
                 self.killed = true;
                 true
@@ -399,7 +400,7 @@ pub fn launch(binary: &Path, profile_dir: &Path, proxy_port: u16) -> io::Result<
     let read_from_browser = unsafe { File::from_raw_fd(out_read) };
 
     Ok(LaunchedBrowser {
-        child,
+        child: Some(child),
         cdp_pipes: Some((read_from_browser, write_to_browser)),
         killed: false,
     })
@@ -546,7 +547,7 @@ mod tests {
             .spawn()
             .unwrap();
         let mut launched = LaunchedBrowser {
-            child,
+            child: Some(child),
             cdp_pipes: None,
             killed: false,
         };

--- a/src-tauri/src/browser/managed.rs
+++ b/src-tauri/src/browser/managed.rs
@@ -253,20 +253,14 @@ impl ManagedSessionResources {
         self.profile.delete();
     }
 
-    fn teardown_for_shutdown(self: &Arc<Self>) {
+    fn teardown_for_shutdown(&self, deadline: crate::shutdown::ShutdownDeadline) {
         if self.closed.load(Ordering::SeqCst) {
             return;
         }
-        let Some(mut browser) =
-            crate::shutdown::try_lock_for(&self.browser, Duration::from_millis(250))
-        else {
-            let resources = Arc::clone(self);
-            if let Err(error) = std::thread::Builder::new()
-                .name("june-managed-browser-retry".to_string())
-                .spawn(move || resources.teardown())
-            {
-                tracing::warn!(%error, "could not schedule managed browser teardown retry");
-            }
+        let Some(mut browser) = deadline.try_lock(&self.browser) else {
+            tracing::warn!(
+                "managed browser teardown exhausted the aggregate deadline acquiring the browser lock"
+            );
             return;
         };
         if self.closed.swap(true, Ordering::SeqCst) {
@@ -327,18 +321,18 @@ impl StartingManagedSession {
         }
     }
 
-    fn terminate_for_shutdown(self: &Arc<Self>) {
+    fn terminate_for_shutdown(&self, deadline: crate::shutdown::ShutdownDeadline) {
         self.cancelled.store(true, Ordering::SeqCst);
-        let resources = crate::shutdown::try_lock_for(&self.resources, Duration::from_millis(250));
-        if let Some(resources) = resources.and_then(|resources| resources.as_ref().cloned()) {
-            resources.teardown_for_shutdown();
-        } else {
-            let starting = Arc::clone(self);
-            if let Err(error) = std::thread::Builder::new()
-                .name("june-managed-start-retry".to_string())
-                .spawn(move || starting.terminate())
-            {
-                tracing::warn!(%error, "could not schedule managed browser start teardown retry");
+        match deadline.try_lock(&self.resources) {
+            Some(resources) => {
+                if let Some(resources) = resources.as_ref().cloned() {
+                    resources.teardown_for_shutdown(deadline);
+                }
+            }
+            None => {
+                tracing::warn!(
+                    "managed browser teardown exhausted the aggregate deadline acquiring startup resources"
+                );
             }
         }
         if !self.begun.load(Ordering::SeqCst) {
@@ -1128,39 +1122,32 @@ impl ManagedBrowserTransport {
         }
     }
 
-    fn terminate_session_for_shutdown(&self, session_id: &str) {
-        let Some(starting_sessions) =
-            crate::shutdown::try_lock_for(&self.inner.starting, Duration::from_millis(250))
-        else {
-            self.schedule_termination_retry(session_id);
+    fn terminate_session_for_shutdown(
+        &self,
+        session_id: &str,
+        deadline: crate::shutdown::ShutdownDeadline,
+    ) {
+        let Some(starting_sessions) = deadline.try_lock(&self.inner.starting) else {
+            tracing::warn!(
+                "managed browser teardown exhausted the aggregate deadline acquiring the starting-session map"
+            );
             return;
         };
         let starting = starting_sessions.get(session_id).cloned();
         drop(starting_sessions);
         if let Some(starting) = starting {
-            starting.terminate_for_shutdown();
+            starting.terminate_for_shutdown(deadline);
         }
-        let Some(mut sessions) =
-            crate::shutdown::try_lock_for(&self.inner.sessions, Duration::from_millis(250))
-        else {
-            self.schedule_termination_retry(session_id);
+        let Some(mut sessions) = deadline.try_lock(&self.inner.sessions) else {
+            tracing::warn!(
+                "managed browser teardown exhausted the aggregate deadline acquiring the live-session map"
+            );
             return;
         };
         let session = sessions.remove(session_id);
         drop(sessions);
         if let Some(session) = session {
-            session.resources.teardown_for_shutdown();
-        }
-    }
-
-    fn schedule_termination_retry(&self, session_id: &str) {
-        let transport = self.clone();
-        let session_id = session_id.to_string();
-        if let Err(error) = std::thread::Builder::new()
-            .name("june-managed-session-retry".to_string())
-            .spawn(move || transport.terminate_session(&session_id))
-        {
-            tracing::warn!(%error, "could not schedule managed session teardown retry");
+            session.resources.teardown_for_shutdown(deadline);
         }
     }
 
@@ -1274,8 +1261,12 @@ impl BrowserTransport for ManagedBrowserTransport {
         ManagedBrowserTransport::terminate_session(self, session_id);
     }
 
-    fn terminate_session_for_shutdown(&self, session_id: &str) {
-        ManagedBrowserTransport::terminate_session_for_shutdown(self, session_id);
+    fn terminate_session_for_shutdown(
+        &self,
+        session_id: &str,
+        deadline: crate::shutdown::ShutdownDeadline,
+    ) {
+        ManagedBrowserTransport::terminate_session_for_shutdown(self, session_id, deadline);
     }
 }
 
@@ -1679,6 +1670,47 @@ mod tests {
         assert!(error.message.contains("session-456"));
         assert!(!error.message.contains("private.example"));
         assert!(!error.message.contains("field-value-456"));
+    }
+
+    #[tokio::test]
+    async fn shutdown_waits_for_a_contended_managed_session_map() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let transport =
+            ManagedBrowserTransport::new(ManagedSessionConfig::production(temp.path().into()));
+        transport
+            .reserve_session("contended-session")
+            .expect("reserve managed session");
+        let starting = transport
+            .starting()
+            .get("contended-session")
+            .cloned()
+            .expect("starting session");
+
+        let starting_guard = transport
+            .inner
+            .starting
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+        let shutdown_transport = transport.clone();
+        let shutdown = std::thread::spawn(move || {
+            shutdown_transport.terminate_session_for_shutdown(
+                "contended-session",
+                crate::shutdown::ShutdownDeadline::after(Duration::from_secs(2)),
+            );
+            let _ = done_tx.send(());
+        });
+
+        assert!(
+            done_rx.recv_timeout(Duration::from_millis(300)).is_err(),
+            "managed teardown must remain supervised past the old 250 ms lock attempt"
+        );
+        drop(starting_guard);
+        done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("managed teardown completes after the session map is released");
+        shutdown.join().expect("shutdown thread");
+        assert!(starting.is_cancelled());
     }
 }
 

--- a/src-tauri/src/browser/managed.rs
+++ b/src-tauri/src/browser/managed.rs
@@ -253,13 +253,20 @@ impl ManagedSessionResources {
         self.profile.delete();
     }
 
-    fn teardown_for_shutdown(&self) {
+    fn teardown_for_shutdown(self: &Arc<Self>) {
         if self.closed.load(Ordering::SeqCst) {
             return;
         }
         let Some(mut browser) =
             crate::shutdown::try_lock_for(&self.browser, Duration::from_millis(250))
         else {
+            let resources = Arc::clone(self);
+            if let Err(error) = std::thread::Builder::new()
+                .name("june-managed-browser-retry".to_string())
+                .spawn(move || resources.teardown())
+            {
+                tracing::warn!(%error, "could not schedule managed browser teardown retry");
+            }
             return;
         };
         if self.closed.swap(true, Ordering::SeqCst) {
@@ -320,13 +327,19 @@ impl StartingManagedSession {
         }
     }
 
-    fn terminate_for_shutdown(&self) {
+    fn terminate_for_shutdown(self: &Arc<Self>) {
         self.cancelled.store(true, Ordering::SeqCst);
-        if let Some(resources) =
-            crate::shutdown::try_lock_for(&self.resources, Duration::from_millis(250))
-                .and_then(|resources| resources.as_ref().cloned())
-        {
+        let resources = crate::shutdown::try_lock_for(&self.resources, Duration::from_millis(250));
+        if let Some(resources) = resources.and_then(|resources| resources.as_ref().cloned()) {
             resources.teardown_for_shutdown();
+        } else {
+            let starting = Arc::clone(self);
+            if let Err(error) = std::thread::Builder::new()
+                .name("june-managed-start-retry".to_string())
+                .spawn(move || starting.terminate())
+            {
+                tracing::warn!(%error, "could not schedule managed browser start teardown retry");
+            }
         }
         if !self.begun.load(Ordering::SeqCst) {
             self.finish();
@@ -991,6 +1004,7 @@ pub struct ManagedScreenshot {
 
 /// JUN-291 transport adapter. It owns managed-session lifecycle while the
 /// broker owns authorization, transport selection, and artifact persistence.
+#[derive(Clone)]
 pub(crate) struct ManagedBrowserTransport {
     inner: Arc<ManagedTransportInner>,
 }
@@ -1115,17 +1129,38 @@ impl ManagedBrowserTransport {
     }
 
     fn terminate_session_for_shutdown(&self, session_id: &str) {
-        let starting =
+        let Some(starting_sessions) =
             crate::shutdown::try_lock_for(&self.inner.starting, Duration::from_millis(250))
-                .and_then(|starting| starting.get(session_id).cloned());
+        else {
+            self.schedule_termination_retry(session_id);
+            return;
+        };
+        let starting = starting_sessions.get(session_id).cloned();
+        drop(starting_sessions);
         if let Some(starting) = starting {
             starting.terminate_for_shutdown();
         }
-        let session =
+        let Some(mut sessions) =
             crate::shutdown::try_lock_for(&self.inner.sessions, Duration::from_millis(250))
-                .and_then(|mut sessions| sessions.remove(session_id));
+        else {
+            self.schedule_termination_retry(session_id);
+            return;
+        };
+        let session = sessions.remove(session_id);
+        drop(sessions);
         if let Some(session) = session {
             session.resources.teardown_for_shutdown();
+        }
+    }
+
+    fn schedule_termination_retry(&self, session_id: &str) {
+        let transport = self.clone();
+        let session_id = session_id.to_string();
+        if let Err(error) = std::thread::Builder::new()
+            .name("june-managed-session-retry".to_string())
+            .spawn(move || transport.terminate_session(&session_id))
+        {
+            tracing::warn!(%error, "could not schedule managed session teardown retry");
         }
     }
 

--- a/src-tauri/src/browser/managed.rs
+++ b/src-tauri/src/browser/managed.rs
@@ -244,9 +244,28 @@ impl ManagedSessionResources {
         if self.closed.swap(true, Ordering::SeqCst) {
             return;
         }
-        if let Ok(mut browser) = self.browser.lock() {
-            browser.kill();
+        let mut browser = self
+            .browser
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        browser.kill();
+        self.proxy.shutdown();
+        self.profile.delete();
+    }
+
+    fn teardown_for_shutdown(&self) {
+        if self.closed.load(Ordering::SeqCst) {
+            return;
         }
+        let Some(mut browser) =
+            crate::shutdown::try_lock_for(&self.browser, Duration::from_millis(250))
+        else {
+            return;
+        };
+        if self.closed.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        browser.kill();
         self.proxy.shutdown();
         self.profile.delete();
     }
@@ -295,6 +314,19 @@ impl StartingManagedSession {
             .cloned()
         {
             resources.teardown();
+        }
+        if !self.begun.load(Ordering::SeqCst) {
+            self.finish();
+        }
+    }
+
+    fn terminate_for_shutdown(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+        if let Some(resources) =
+            crate::shutdown::try_lock_for(&self.resources, Duration::from_millis(250))
+                .and_then(|resources| resources.as_ref().cloned())
+        {
+            resources.teardown_for_shutdown();
         }
         if !self.begun.load(Ordering::SeqCst) {
             self.finish();
@@ -1082,6 +1114,21 @@ impl ManagedBrowserTransport {
         }
     }
 
+    fn terminate_session_for_shutdown(&self, session_id: &str) {
+        let starting =
+            crate::shutdown::try_lock_for(&self.inner.starting, Duration::from_millis(250))
+                .and_then(|starting| starting.get(session_id).cloned());
+        if let Some(starting) = starting {
+            starting.terminate_for_shutdown();
+        }
+        let session =
+            crate::shutdown::try_lock_for(&self.inner.sessions, Duration::from_millis(250))
+                .and_then(|mut sessions| sessions.remove(session_id));
+        if let Some(session) = session {
+            session.resources.teardown_for_shutdown();
+        }
+    }
+
     async fn close_session(&self, session_id: &str) {
         let starting = self.starting().get(session_id).cloned();
         self.terminate_session(session_id);
@@ -1190,6 +1237,10 @@ impl BrowserTransport for ManagedBrowserTransport {
 
     fn terminate_session(&self, session_id: &str) {
         ManagedBrowserTransport::terminate_session(self, session_id);
+    }
+
+    fn terminate_session_for_shutdown(&self, session_id: &str) {
+        ManagedBrowserTransport::terminate_session_for_shutdown(self, session_id);
     }
 }
 

--- a/src-tauri/src/browser_broker.rs
+++ b/src-tauri/src/browser_broker.rs
@@ -284,6 +284,12 @@ struct BrowserBrokerState {
     routine_entitlement_override: Option<bool>,
 }
 
+struct BrowserShutdownPlan {
+    transports: HashMap<BrowserTransportKind, Arc<dyn BrowserTransport>>,
+    sessions: Vec<(String, BrowserTransportKind)>,
+    approvals_changed: bool,
+}
+
 struct BrowserSession {
     transport_kind: BrowserTransportKind,
     routine_id: Option<String>,
@@ -680,32 +686,59 @@ impl BrowserBroker {
 
     /// App-exit backstop. Managed transports terminate synchronously so no
     /// in-flight request can keep Chromium or its ephemeral profile alive.
-    pub(crate) fn terminate_sessions(&self) {
-        let (transports, sessions, approvals_changed) = {
-            let Some(mut state) =
-                crate::shutdown::try_lock_for(&self.state, Duration::from_millis(250))
-            else {
-                tracing::warn!("browser shutdown timed out acquiring the broker state lock");
-                return;
-            };
-            state.transition_blocked = true;
-            let approvals_changed = !state.pending_approvals.is_empty();
-            state.pending_approvals.clear();
-            state.pending_by_action.clear();
-            state.resolved_actions.clear();
-            let transports = state.transports.clone();
-            let sessions = state
-                .sessions
-                .drain()
-                .map(|(id, session)| (id, session.transport_kind))
-                .collect::<Vec<_>>();
-            (transports, sessions, approvals_changed)
+    pub(crate) fn terminate_sessions(self: &Arc<Self>) {
+        let Some(mut state) =
+            crate::shutdown::try_lock_for(&self.state, Duration::from_millis(250))
+        else {
+            tracing::warn!(
+                "browser shutdown timed out acquiring the broker state lock; scheduling retry"
+            );
+            let broker = Arc::clone(self);
+            if let Err(error) = std::thread::Builder::new()
+                .name("june-browser-shutdown-retry".to_string())
+                .spawn(move || broker.terminate_sessions_blocking())
+            {
+                tracing::warn!(%error, "could not schedule browser shutdown retry");
+            }
+            return;
         };
-        if approvals_changed {
+        let shutdown = Self::drain_sessions_for_shutdown(&mut state);
+        drop(state);
+        self.finish_session_termination(shutdown);
+    }
+
+    fn terminate_sessions_blocking(&self) {
+        let mut state = self.lock();
+        let shutdown = Self::drain_sessions_for_shutdown(&mut state);
+        drop(state);
+        self.finish_session_termination(shutdown);
+    }
+
+    fn drain_sessions_for_shutdown(state: &mut BrowserBrokerState) -> BrowserShutdownPlan {
+        state.transition_blocked = true;
+        let approvals_changed = !state.pending_approvals.is_empty();
+        state.pending_approvals.clear();
+        state.pending_by_action.clear();
+        state.resolved_actions.clear();
+        let transports = state.transports.clone();
+        let sessions = state
+            .sessions
+            .drain()
+            .map(|(id, session)| (id, session.transport_kind))
+            .collect::<Vec<_>>();
+        BrowserShutdownPlan {
+            transports,
+            sessions,
+            approvals_changed,
+        }
+    }
+
+    fn finish_session_termination(&self, plan: BrowserShutdownPlan) {
+        if plan.approvals_changed {
             self.notify_approvals_changed();
         }
-        for (session_id, kind) in sessions {
-            if let Some(transport) = transports.get(&kind) {
+        for (session_id, kind) in plan.sessions {
+            if let Some(transport) = plan.transports.get(&kind) {
                 transport.terminate_session_for_shutdown(&session_id);
             }
         }
@@ -2294,14 +2327,14 @@ mod tests {
             state
                 .terminated
                 .store(true, std::sync::atomic::Ordering::SeqCst);
-            if let Some(mut child) = state
+            if let Some(child) = state
                 .child
                 .try_lock()
                 .ok()
                 .and_then(|mut child| child.take())
             {
                 let _ = crate::shutdown::terminate_child(
-                    &mut child,
+                    child,
                     Duration::ZERO,
                     Duration::from_millis(250),
                 );

--- a/src-tauri/src/browser_broker.rs
+++ b/src-tauri/src/browser_broker.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
     pin::Pin,
     sync::{Arc, Mutex},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use serde::{Deserialize, Serialize};
@@ -50,6 +50,12 @@ pub(crate) trait BrowserTransport: Send + Sync {
     /// override this so revoke and app exit kill Chromium even when another
     /// request still holds the session and is awaiting CDP.
     fn terminate_session(&self, _session_id: &str) {}
+
+    /// App-shutdown variant. Managed transports override this to keep mutex
+    /// acquisition bounded; other transports retain their existing teardown.
+    fn terminate_session_for_shutdown(&self, session_id: &str) {
+        self.terminate_session(session_id);
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -676,7 +682,12 @@ impl BrowserBroker {
     /// in-flight request can keep Chromium or its ephemeral profile alive.
     pub(crate) fn terminate_sessions(&self) {
         let (transports, sessions, approvals_changed) = {
-            let mut state = self.lock();
+            let Some(mut state) =
+                crate::shutdown::try_lock_for(&self.state, Duration::from_millis(250))
+            else {
+                tracing::warn!("browser shutdown timed out acquiring the broker state lock");
+                return;
+            };
             state.transition_blocked = true;
             let approvals_changed = !state.pending_approvals.is_empty();
             state.pending_approvals.clear();
@@ -695,7 +706,7 @@ impl BrowserBroker {
         }
         for (session_id, kind) in sessions {
             if let Some(transport) = transports.get(&kind) {
-                transport.terminate_session(&session_id);
+                transport.terminate_session_for_shutdown(&session_id);
             }
         }
     }
@@ -2285,12 +2296,15 @@ mod tests {
                 .store(true, std::sync::atomic::Ordering::SeqCst);
             if let Some(mut child) = state
                 .child
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .take()
+                .try_lock()
+                .ok()
+                .and_then(|mut child| child.take())
             {
-                let _ = child.kill();
-                let _ = child.wait();
+                let _ = crate::shutdown::terminate_child(
+                    &mut child,
+                    Duration::ZERO,
+                    Duration::from_millis(250),
+                );
             }
             let _ = std::fs::remove_dir_all(&state.profile);
             state.release.notify_waiters();

--- a/src-tauri/src/browser_broker.rs
+++ b/src-tauri/src/browser_broker.rs
@@ -4,8 +4,11 @@ use std::{
     path::{Path, PathBuf},
     pin::Pin,
     sync::{Arc, Mutex},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH},
 };
+
+#[cfg(test)]
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -52,8 +55,13 @@ pub(crate) trait BrowserTransport: Send + Sync {
     fn terminate_session(&self, _session_id: &str) {}
 
     /// App-shutdown variant. Managed transports override this to keep mutex
-    /// acquisition bounded; other transports retain their existing teardown.
-    fn terminate_session_for_shutdown(&self, session_id: &str) {
+    /// acquisition inside the supervised aggregate deadline; other transports
+    /// retain their existing teardown.
+    fn terminate_session_for_shutdown(
+        &self,
+        session_id: &str,
+        _deadline: crate::shutdown::ShutdownDeadline,
+    ) {
         self.terminate_session(session_id);
     }
 }
@@ -287,7 +295,7 @@ struct BrowserBrokerState {
 struct BrowserShutdownPlan {
     transports: HashMap<BrowserTransportKind, Arc<dyn BrowserTransport>>,
     sessions: Vec<(String, BrowserTransportKind)>,
-    approvals_changed: bool,
+    approvals_changed: Option<Arc<dyn Fn() + Send + Sync>>,
 }
 
 struct BrowserSession {
@@ -686,37 +694,23 @@ impl BrowserBroker {
 
     /// App-exit backstop. Managed transports terminate synchronously so no
     /// in-flight request can keep Chromium or its ephemeral profile alive.
-    pub(crate) fn terminate_sessions(self: &Arc<Self>) {
-        let Some(mut state) =
-            crate::shutdown::try_lock_for(&self.state, Duration::from_millis(250))
-        else {
+    pub(crate) fn terminate_sessions(&self, deadline: crate::shutdown::ShutdownDeadline) {
+        let Some(mut state) = deadline.try_lock(&self.state) else {
             tracing::warn!(
-                "browser shutdown timed out acquiring the broker state lock; scheduling retry"
+                "browser shutdown exhausted the aggregate deadline acquiring the broker state lock"
             );
-            let broker = Arc::clone(self);
-            if let Err(error) = std::thread::Builder::new()
-                .name("june-browser-shutdown-retry".to_string())
-                .spawn(move || broker.terminate_sessions_blocking())
-            {
-                tracing::warn!(%error, "could not schedule browser shutdown retry");
-            }
             return;
         };
         let shutdown = Self::drain_sessions_for_shutdown(&mut state);
         drop(state);
-        self.finish_session_termination(shutdown);
-    }
-
-    fn terminate_sessions_blocking(&self) {
-        let mut state = self.lock();
-        let shutdown = Self::drain_sessions_for_shutdown(&mut state);
-        drop(state);
-        self.finish_session_termination(shutdown);
+        self.finish_session_termination(shutdown, deadline);
     }
 
     fn drain_sessions_for_shutdown(state: &mut BrowserBrokerState) -> BrowserShutdownPlan {
         state.transition_blocked = true;
-        let approvals_changed = !state.pending_approvals.is_empty();
+        let approvals_changed = (!state.pending_approvals.is_empty())
+            .then(|| state.approvals_changed.clone())
+            .flatten();
         state.pending_approvals.clear();
         state.pending_by_action.clear();
         state.resolved_actions.clear();
@@ -733,13 +727,17 @@ impl BrowserBroker {
         }
     }
 
-    fn finish_session_termination(&self, plan: BrowserShutdownPlan) {
-        if plan.approvals_changed {
-            self.notify_approvals_changed();
+    fn finish_session_termination(
+        &self,
+        plan: BrowserShutdownPlan,
+        deadline: crate::shutdown::ShutdownDeadline,
+    ) {
+        if let Some(notify) = plan.approvals_changed {
+            notify();
         }
         for (session_id, kind) in plan.sessions {
             if let Some(transport) = plan.transports.get(&kind) {
-                transport.terminate_session_for_shutdown(&session_id);
+                transport.terminate_session_for_shutdown(&session_id, deadline);
             }
         }
     }
@@ -3329,6 +3327,58 @@ mod tests {
             self.terminated
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         }
+    }
+
+    #[test]
+    fn shutdown_waits_for_contended_broker_state_before_terminating_sessions() {
+        let broker = Arc::new(BrowserBroker::default());
+        let transport = Arc::new(TeardownTrackingTransport::default());
+        {
+            let mut state = broker.lock();
+            state
+                .transports
+                .insert(BrowserTransportKind::Managed, transport.clone());
+            state.sessions.insert(
+                "contended-session".to_string(),
+                BrowserSession {
+                    transport_kind: BrowserTransportKind::Managed,
+                    ..BrowserSession::default()
+                },
+            );
+        }
+
+        let state_guard = broker
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+        let shutdown_broker = Arc::clone(&broker);
+        let shutdown = std::thread::spawn(move || {
+            shutdown_broker.terminate_sessions(crate::shutdown::ShutdownDeadline::after(
+                Duration::from_secs(2),
+            ));
+            let _ = done_tx.send(());
+        });
+
+        assert!(
+            done_rx.recv_timeout(Duration::from_millis(300)).is_err(),
+            "supervised browser teardown must retain ownership past the old 250 ms lock attempt"
+        );
+        drop(state_guard);
+        done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("shutdown completes after broker state is released");
+        shutdown.join().expect("shutdown thread");
+
+        let state = broker.lock();
+        assert!(state.transition_blocked);
+        assert!(state.sessions.is_empty());
+        assert_eq!(
+            transport
+                .terminated
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/computer_use.rs
+++ b/src-tauri/src/computer_use.rs
@@ -54,6 +54,9 @@ const GRANT_FILE_NAME: &str = "computer-use-grant-v1";
 const APPROVAL_TIMEOUT: Duration = Duration::from_secs(600);
 const DRIVER_CALL_TIMEOUT: Duration = Duration::from_secs(45);
 const DRIVER_START_TIMEOUT: Duration = Duration::from_secs(12);
+const EXTERNAL_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
+const SHUTDOWN_MUTEX_TIMEOUT: Duration = Duration::from_millis(250);
+const DRIVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(250);
 const DRIVER_MAX_LINE_BYTES: usize = 24 * 1024 * 1024;
 const SCREENSHOT_MAX_BYTES: usize = 12 * 1024 * 1024;
 const DEFAULT_MAX_ELEMENTS: usize = 100;
@@ -324,16 +327,15 @@ impl DriverClient {
         }
         let socket_path = socket_dir.join("driver.sock");
         let launch = driver_launch_spec(path, &socket_path, &capability, permission_prompt)?;
-        let output = driver_command(&launch.program)
-            .args(&launch.args)
-            .output()
-            .await
-            .map_err(|error| {
-                AppError::new(
-                    "computer_use_driver_start_failed",
-                    format!("Could not launch the bundled Computer use driver. {error}"),
-                )
-            })?;
+        let mut command = driver_command(&launch.program);
+        command.args(&launch.args);
+        let output = bounded_command_output(
+            command,
+            EXTERNAL_COMMAND_TIMEOUT,
+            "computer_use_driver_start_failed",
+            "Could not launch the bundled Computer use driver.",
+        )
+        .await?;
         if !output.status.success() {
             let _ = std::fs::remove_dir_all(&socket_dir);
             return Err(AppError::new(
@@ -536,7 +538,7 @@ impl DriverClient {
     }
 
     async fn stop(mut self) {
-        let _ = self.stdin.shutdown().await;
+        let _ = tokio::time::timeout(DRIVER_SHUTDOWN_TIMEOUT, self.stdin.shutdown()).await;
         self.terminate();
         let _ = tokio::fs::remove_dir_all(&self.socket_dir).await;
     }
@@ -912,6 +914,19 @@ fn driver_command(path: &Path) -> Command {
     command
 }
 
+async fn bounded_command_output(
+    mut command: Command,
+    timeout: Duration,
+    code: &'static str,
+    message: &'static str,
+) -> Result<std::process::Output, AppError> {
+    command.kill_on_drop(true);
+    tokio::time::timeout(timeout, command.output())
+        .await
+        .map_err(|_| AppError::new(code, format!("{message} The command timed out.")))?
+        .map_err(|error| AppError::new(code, format!("{message} {error}")))
+}
+
 fn should_scrub_driver_env(name: &OsStr) -> bool {
     let name = name.to_string_lossy();
     name.starts_with("CUA_DRIVER_RS_")
@@ -1118,11 +1133,15 @@ pub(crate) unsafe fn begin_permission_drag(
 }
 
 async fn driver_version(path: &Path) -> Result<String, AppError> {
-    let output = driver_command(path)
-        .arg("--version")
-        .output()
-        .await
-        .map_err(|error| AppError::new("computer_use_driver_version_failed", error.to_string()))?;
+    let mut command = driver_command(path);
+    command.arg("--version");
+    let output = bounded_command_output(
+        command,
+        EXTERNAL_COMMAND_TIMEOUT,
+        "computer_use_driver_version_failed",
+        "The bundled Computer use driver version check failed.",
+    )
+    .await?;
     if !output.status.success() {
         return Err(AppError::new(
             "computer_use_driver_version_failed",
@@ -1209,8 +1228,8 @@ async fn read_permission_probe(
 async fn rollout_gate() -> RolloutGate {
     let cache = ROLLOUT_GATE.get_or_init(|| Mutex::new(None));
     let refresh = ROLLOUT_REFRESH.get_or_init(|| AsyncMutex::new(()));
-    rollout_gate_with_fetch(cache, refresh, || {
-        crate::june_api::computer_use_rollout(macos_version())
+    rollout_gate_with_fetch(cache, refresh, || async {
+        crate::june_api::computer_use_rollout(macos_version().await).await
     })
     .await
 }
@@ -1284,33 +1303,40 @@ where
     gate
 }
 
-fn macos_version() -> &'static str {
-    MACOS_VERSION
-        .get_or_init(|| {
-            #[cfg(target_os = "macos")]
-            {
-                std::process::Command::new("/usr/bin/sw_vers")
-                    .arg("-productVersion")
-                    .output()
-                    .ok()
-                    .filter(|output| output.status.success())
-                    .and_then(|output| String::from_utf8(output.stdout).ok())
-                    .map(|version| version.trim().to_string())
-                    .filter(|version| {
-                        !version.is_empty()
-                            && version.len() <= 64
-                            && version
-                                .chars()
-                                .all(|character| character.is_ascii_digit() || character == '.')
-                    })
-                    .unwrap_or_else(|| "unknown".to_string())
-            }
-            #[cfg(not(target_os = "macos"))]
-            {
-                "unsupported".to_string()
-            }
+async fn macos_version() -> &'static str {
+    if let Some(version) = MACOS_VERSION.get() {
+        return version.as_str();
+    }
+
+    #[cfg(target_os = "macos")]
+    let version = {
+        let mut command = Command::new("/usr/bin/sw_vers");
+        command.arg("-productVersion");
+        bounded_command_output(
+            command,
+            EXTERNAL_COMMAND_TIMEOUT,
+            "computer_use_macos_version_failed",
+            "The macOS version check failed.",
+        )
+        .await
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|version| version.trim().to_string())
+        .filter(|version| {
+            !version.is_empty()
+                && version.len() <= 64
+                && version
+                    .chars()
+                    .all(|character| character.is_ascii_digit() || character == '.')
         })
-        .as_str()
+        .unwrap_or_else(|| "unknown".to_string())
+    };
+    #[cfg(not(target_os = "macos"))]
+    let version = "unsupported".to_string();
+
+    let _ = MACOS_VERSION.set(version);
+    MACOS_VERSION.get().map(String::as_str).unwrap_or("unknown")
 }
 
 async fn status_inner(app: &AppHandle) -> ComputerUseStatus {
@@ -1604,7 +1630,7 @@ pub async fn computer_use_request_permissions(
 
 pub(crate) async fn shutdown(app: &AppHandle) {
     let state = app.state::<ComputerUseState>();
-    stop_inner(app, &state).await;
+    stop_for_shutdown(app, &state).await;
 }
 
 #[tauri::command]
@@ -1745,7 +1771,53 @@ async fn stop_inner(app: &AppHandle, state: &ComputerUseState) {
     }
     clear_app_authorizations(state);
     clear_capture_dir(app);
-    let _ = set_june_stage_companion(app, false);
+    let _ = set_june_stage_companion(app, false).await;
+}
+
+async fn stop_for_shutdown(app: &AppHandle, state: &ComputerUseState) {
+    let _cleanup = CleanupInProgress::begin(&state.cleanup_in_progress);
+    if let Some(mut runs) =
+        crate::shutdown::try_lock_for(&state.attended_runs, SHUTDOWN_MUTEX_TIMEOUT)
+    {
+        runs.clear();
+    } else {
+        tracing::warn!("computer use shutdown timed out acquiring the run lock");
+    }
+    state.epoch.fetch_add(1, Ordering::SeqCst);
+    crate::computer_use_cursor::hide(app);
+
+    let entries = crate::shutdown::try_lock_for(&state.approvals, SHUTDOWN_MUTEX_TIMEOUT)
+        .map(|mut approvals| {
+            approvals
+                .drain()
+                .map(|(_, entry)| entry)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    for entry in entries {
+        let _ = entry.responder.send(false);
+    }
+
+    force_stop_pid(state.driver_pid.swap(0, Ordering::SeqCst));
+    if let Some(mut driver) =
+        crate::shutdown::lock_async_for(&state.driver, SHUTDOWN_MUTEX_TIMEOUT).await
+    {
+        if let Some(driver) = driver.take() {
+            let _ = tokio::time::timeout(DRIVER_SHUTDOWN_TIMEOUT, driver.stop()).await;
+        }
+    } else {
+        tracing::warn!("computer use shutdown timed out acquiring the driver lock");
+    }
+    if let Some(mut target) = crate::shutdown::try_lock_for(&state.target, SHUTDOWN_MUTEX_TIMEOUT) {
+        *target = None;
+    }
+    if let Some(mut authorized_apps) =
+        crate::shutdown::try_lock_for(&state.authorized_apps, SHUTDOWN_MUTEX_TIMEOUT)
+    {
+        authorized_apps.clear();
+    }
+    clear_capture_dir(app);
+    let _ = set_june_stage_companion(app, false).await;
 }
 
 /// Ends resources for a completed attended run without erasing a newer run
@@ -1771,7 +1843,7 @@ async fn stop_if_idle(app: &AppHandle, state: &ComputerUseState, generation: u64
     }
     clear_app_authorizations(state);
     clear_capture_dir(app);
-    let _ = set_june_stage_companion(app, false);
+    let _ = set_june_stage_companion(app, false).await;
 }
 
 fn clear_app_authorizations(state: &ComputerUseState) {
@@ -1783,10 +1855,7 @@ fn clear_app_authorizations(state: &ComputerUseState) {
 fn force_stop_pid(_pid: u32) {
     #[cfg(target_os = "macos")]
     if _pid > 0 {
-        let _ = std::process::Command::new("/bin/kill")
-            .arg("-KILL")
-            .arg(_pid.to_string())
-            .status();
+        let _ = unsafe { libc::kill(_pid as libc::pid_t, libc::SIGKILL) };
     }
 }
 
@@ -2227,7 +2296,7 @@ fn native_stage_join_verified(result: &Value) -> bool {
 }
 
 #[cfg(target_os = "macos")]
-fn set_june_stage_companion(app: &AppHandle, enabled: bool) -> Result<(), AppError> {
+async fn set_june_stage_companion(app: &AppHandle, enabled: bool) -> Result<(), AppError> {
     use objc2_app_kit::{NSWindow, NSWindowCollectionBehavior};
 
     let main = app.get_webview_window("main").ok_or_else(|| {
@@ -2250,7 +2319,7 @@ fn set_june_stage_companion(app: &AppHandle, enabled: bool) -> Result<(), AppErr
     }
 
     let window = handle as usize;
-    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+    let (sender, receiver) = oneshot::channel();
     app.run_on_main_thread(move || {
         let window = unsafe { &*(window as *const NSWindow) };
         if enabled {
@@ -2277,17 +2346,25 @@ fn set_june_stage_companion(app: &AppHandle, enabled: bool) -> Result<(), AppErr
             format!("June could not prepare its window for Computer use. {error}"),
         )
     })?;
-    receiver.recv_timeout(Duration::from_secs(1)).map_err(|_| {
-        AppError::new(
-            "computer_use_window_restore_failed",
-            "June could not prepare its window for Computer use.",
-        )
-    })?;
+    tokio::time::timeout(Duration::from_secs(1), receiver)
+        .await
+        .map_err(|_| {
+            AppError::new(
+                "computer_use_window_restore_failed",
+                "June could not prepare its window for Computer use.",
+            )
+        })?
+        .map_err(|_| {
+            AppError::new(
+                "computer_use_window_restore_failed",
+                "June could not prepare its window for Computer use.",
+            )
+        })?;
     Ok(())
 }
 
 #[cfg(not(target_os = "macos"))]
-fn set_june_stage_companion(_app: &AppHandle, _enabled: bool) -> Result<(), AppError> {
+async fn set_june_stage_companion(_app: &AppHandle, _enabled: bool) -> Result<(), AppError> {
     Ok(())
 }
 
@@ -2304,7 +2381,7 @@ async fn join_target_to_june_stage(
         let _ = main.unminimize();
         let _ = main.set_focus();
     }
-    set_june_stage_companion(app, true)?;
+    set_june_stage_companion(app, true).await?;
     tokio::time::sleep(Duration::from_millis(250)).await;
     ensure_task_generation_current(state, task_generation)?;
     let stage_join_result = driver_call(

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1590,9 +1590,20 @@ pub fn stop_helper(app: &AppHandle) {
     // (woken by the resulting stdout EOF) skips respawning instead of fighting
     // app quit.
     state.shutting_down.store(true, Ordering::SeqCst);
-    // Take the helper out from under the lock, then kill outside it so the
-    // blocking wait() cannot stall a concurrent command thread.
-    let helper = state.process.lock().ok().and_then(|mut guard| guard.take());
+    // Take the helper out under a bounded lock, then stop it outside the
+    // critical section. A command thread stuck while writing to the helper
+    // must not hold app shutdown forever.
+    let helper = match crate::shutdown::try_lock_for(&state.process, HELPER_SHUTDOWN_MUTEX_TIMEOUT)
+    {
+        Some(mut guard) => guard.take(),
+        None => {
+            tracing::warn!(
+                timeout_ms = HELPER_SHUTDOWN_MUTEX_TIMEOUT.as_millis(),
+                "dictation helper shutdown timed out acquiring the process lock"
+            );
+            None
+        }
+    };
     if let Some(helper) = helper {
         abandon_helper(helper);
     }
@@ -2898,8 +2909,11 @@ fn spawn_helper(app: &AppHandle) -> Result<HelperProcess, AppError> {
             error = %error.message,
             "dictation: could not record helper ownership; killing untracked helper"
         );
-        let _ = child.kill();
-        let _ = child.wait();
+        let _ = crate::shutdown::terminate_child(
+            &mut child,
+            Duration::ZERO,
+            HELPER_FORCED_REAP_TIMEOUT,
+        );
         return Err(error);
     }
 
@@ -3156,7 +3170,11 @@ fn decide_and_record_respawn(
 fn reap_exited_helper(state: &HelperState) -> bool {
     if let Ok(mut guard) = state.process.lock() {
         if let Some(mut process) = guard.take() {
-            let _ = process.child.wait();
+            let _ = crate::shutdown::terminate_child(
+                &mut process.child,
+                Duration::from_millis(100),
+                HELPER_FORCED_REAP_TIMEOUT,
+            );
             return true;
         }
     }
@@ -3194,36 +3212,60 @@ fn store_respawned_helper(state: &HelperState, mut helper: HelperProcess) -> Sto
 }
 
 const HELPER_SHUTDOWN_GRACE: Duration = Duration::from_millis(750);
-const HELPER_SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(25);
+const HELPER_FORCED_REAP_TIMEOUT: Duration = Duration::from_millis(250);
+const HELPER_SHUTDOWN_MUTEX_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// Stops a helper we spawned but will not install (shutdown raced the respawn).
 /// Dropping a [`Child`] only detaches it, so we kill explicitly to avoid an
 /// orphaned helper holding the global hotkey tap. Give a cooperative shutdown a
 /// short grace period first so the helper can restore clipboard state and remove
 /// temporary recordings before the forced-kill fallback.
-fn abandon_helper(mut helper: HelperProcess) {
-    let _ = helper.stdin.write_all(b"{\"type\":\"shutdown\"}\n");
-    let _ = helper.stdin.flush();
-    if wait_for_helper_exit(&mut helper.child, HELPER_SHUTDOWN_GRACE) {
-        return;
+fn abandon_helper(helper: HelperProcess) {
+    let HelperProcess { mut child, stdin } = helper;
+    send_helper_shutdown_nonblocking(stdin);
+    let outcome = crate::shutdown::terminate_child(
+        &mut child,
+        HELPER_SHUTDOWN_GRACE,
+        HELPER_FORCED_REAP_TIMEOUT,
+    );
+    if matches!(
+        outcome,
+        crate::shutdown::ChildTermination::TimedOut | crate::shutdown::ChildTermination::WaitFailed
+    ) {
+        tracing::warn!(
+            ?outcome,
+            helper_pid = child.id(),
+            "dictation helper could not be reaped before shutdown continued"
+        );
     }
-    let _ = helper.child.kill();
-    let _ = helper.child.wait();
 }
 
-fn wait_for_helper_exit(child: &mut Child, grace: Duration) -> bool {
-    let deadline = Instant::now() + grace;
-    loop {
-        match child.try_wait() {
-            Ok(Some(_)) => return true,
-            Ok(None) => {}
-            Err(_) => return true,
-        }
-        if Instant::now() >= deadline {
-            return false;
-        }
-        thread::sleep(HELPER_SHUTDOWN_POLL_INTERVAL);
+/// The helper normally needs one final command to restore clipboard and
+/// recording state. Mark the pipe nonblocking before the single small write so
+/// a wedged helper with a full stdin pipe cannot wedge app shutdown too.
+#[cfg(unix)]
+fn send_helper_shutdown_nonblocking(mut stdin: ChildStdin) {
+    use std::os::fd::AsRawFd;
+
+    let fd = stdin.as_raw_fd();
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        tracing::warn!("dictation helper shutdown could not make stdin nonblocking");
+        return;
     }
+    let _ = stdin.write(b"{\"type\":\"shutdown\"}\n");
+}
+
+#[cfg(not(unix))]
+fn send_helper_shutdown_nonblocking(mut stdin: ChildStdin) {
+    // Windows anonymous pipes do not expose a portable nonblocking flag. Move
+    // the best-effort write onto its own detached thread; the bounded child
+    // reaper below remains independent of whether this write ever returns.
+    let _ = thread::Builder::new()
+        .name("dictation-shutdown-pipe".to_string())
+        .spawn(move || {
+            let _ = stdin.write_all(b"{\"type\":\"shutdown\"}\n");
+        });
 }
 
 /// Re-applies the persisted microphone and shortcut settings to a just-respawned

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -2909,11 +2909,7 @@ fn spawn_helper(app: &AppHandle) -> Result<HelperProcess, AppError> {
             error = %error.message,
             "dictation: could not record helper ownership; killing untracked helper"
         );
-        let _ = crate::shutdown::terminate_child(
-            &mut child,
-            Duration::ZERO,
-            HELPER_FORCED_REAP_TIMEOUT,
-        );
+        let _ = crate::shutdown::terminate_child(child, Duration::ZERO, HELPER_FORCED_REAP_TIMEOUT);
         return Err(error);
     }
 
@@ -3169,9 +3165,9 @@ fn decide_and_record_respawn(
 
 fn reap_exited_helper(state: &HelperState) -> bool {
     if let Ok(mut guard) = state.process.lock() {
-        if let Some(mut process) = guard.take() {
+        if let Some(process) = guard.take() {
             let _ = crate::shutdown::terminate_child(
-                &mut process.child,
+                process.child,
                 Duration::from_millis(100),
                 HELPER_FORCED_REAP_TIMEOUT,
             );
@@ -3218,23 +3214,23 @@ const HELPER_SHUTDOWN_MUTEX_TIMEOUT: Duration = Duration::from_millis(250);
 /// Stops a helper we spawned but will not install (shutdown raced the respawn).
 /// Dropping a [`Child`] only detaches it, so we kill explicitly to avoid an
 /// orphaned helper holding the global hotkey tap. Give a cooperative shutdown a
-/// short grace period first so the helper can restore clipboard state and remove
-/// temporary recordings before the forced-kill fallback.
+/// short grace period first so the helper can restore clipboard state and
+/// finalize an in-flight WAV before the forced-kill fallback. The aggregate app
+/// deadline may still cut off a wedged finalize; that trades the incomplete
+/// current artifact for a relaunch that cannot be held hostage by the helper.
 fn abandon_helper(helper: HelperProcess) {
-    let HelperProcess { mut child, stdin } = helper;
+    let HelperProcess { child, stdin } = helper;
+    let helper_pid = child.id();
     send_helper_shutdown_nonblocking(stdin);
-    let outcome = crate::shutdown::terminate_child(
-        &mut child,
-        HELPER_SHUTDOWN_GRACE,
-        HELPER_FORCED_REAP_TIMEOUT,
-    );
+    let outcome =
+        crate::shutdown::terminate_child(child, HELPER_SHUTDOWN_GRACE, HELPER_FORCED_REAP_TIMEOUT);
     if matches!(
         outcome,
         crate::shutdown::ChildTermination::TimedOut | crate::shutdown::ChildTermination::WaitFailed
     ) {
         tracing::warn!(
             ?outcome,
-            helper_pid = child.id(),
+            helper_pid,
             "dictation helper could not be reaped before shutdown continued"
         );
     }

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -5031,12 +5031,18 @@ pub async fn shutdown(app: &tauri::AppHandle) {
     }
 
     bridge.browser_broker.terminate_sessions();
-    let _ = stop_hermes_bridge_inner(&bridge);
-    let proxy = bridge
-        .provider_proxy
-        .lock()
-        .ok()
-        .and_then(|mut guard| guard.take());
+    stop_hermes_bridge_for_shutdown(&bridge);
+    let proxy = match crate::shutdown::try_lock_for(&bridge.provider_proxy, SHUTDOWN_MUTEX_TIMEOUT)
+    {
+        Some(mut guard) => guard.take(),
+        None => {
+            tracing::warn!(
+                timeout_ms = SHUTDOWN_MUTEX_TIMEOUT.as_millis(),
+                "timed out acquiring the provider proxy lock during app shutdown"
+            );
+            None
+        }
+    };
     if let Some(mut proxy) = proxy {
         if let Some(shutdown) = proxy.shutdown.take() {
             let _ = shutdown.send(());
@@ -5069,16 +5075,7 @@ async fn shutdown_hermes_gateway(
             None
         }
     };
-    let gateway_connection = bridge
-        .routine_gateway_connection
-        .lock()
-        .ok()
-        .and_then(|mut connection| connection.take())
-        .or_else(|| {
-            live_connections(bridge)
-                .ok()
-                .and_then(|connections| connections.into_iter().next())
-        });
+    let gateway_connection = shutdown_gateway_connection(bridge);
     // Remove persistence before the bounded async unload work. Even if the
     // aggregate shutdown deadline expires, a later login cannot reload the
     // stale service definition while June's provider proxy is absent.
@@ -5118,6 +5115,8 @@ async fn shutdown_hermes_gateway(
 /// child before draining. The window it guards (spawn -> register) is short, so
 /// this is only a safety bound; teardown proceeds regardless once it elapses.
 const SHUTDOWN_START_QUIESCE_TIMEOUT: Duration = Duration::from_secs(2);
+const SHUTDOWN_MUTEX_TIMEOUT: Duration = Duration::from_millis(250);
+const SHUTDOWN_CHILD_REAP_TIMEOUT: Duration = Duration::from_millis(250);
 /// Gateway lifecycle commands are serialized with shutdown, so every command
 /// needs a deadline: a stuck start/restart must not keep app teardown waiting
 /// on the lifecycle lock indefinitely. Fifteen seconds leaves room for the
@@ -5165,6 +5164,40 @@ fn await_starts_quiesced(bridge: &HermesBridge, timeout: Duration) {
         }
         std::thread::sleep(Duration::from_millis(5));
     }
+}
+
+fn shutdown_gateway_connection(bridge: &HermesBridge) -> Option<HermesBridgeConnection> {
+    if let Some(mut connection) =
+        crate::shutdown::try_lock_for(&bridge.routine_gateway_connection, SHUTDOWN_MUTEX_TIMEOUT)
+    {
+        if let Some(connection) = connection.take() {
+            return Some(connection);
+        }
+    } else {
+        tracing::warn!(
+            timeout_ms = SHUTDOWN_MUTEX_TIMEOUT.as_millis(),
+            "timed out acquiring the routine gateway connection lock during app shutdown"
+        );
+    }
+
+    let Some(mut processes) =
+        crate::shutdown::try_lock_for(&bridge.processes, SHUTDOWN_MUTEX_TIMEOUT)
+    else {
+        tracing::warn!(
+            timeout_ms = SHUTDOWN_MUTEX_TIMEOUT.as_millis(),
+            "timed out acquiring the Hermes process lock for gateway shutdown"
+        );
+        return None;
+    };
+    for full_mode in [false, true] {
+        let Some(process) = processes.get_mut(&full_mode) else {
+            continue;
+        };
+        if matches!(process.child.try_wait(), Ok(None)) {
+            return Some(process.connection.clone());
+        }
+    }
+    None
 }
 
 pub(crate) fn release_shared_browser_tab(app: &tauri::AppHandle, tab_id: i64) {
@@ -6785,8 +6818,11 @@ fn wait_with_timeout(mut child: Child, timeout: Duration) -> Result<BoundedOutpu
             }
             Ok(None) => {
                 if Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
+                    let _ = crate::shutdown::terminate_child(
+                        &mut child,
+                        Duration::ZERO,
+                        SHUTDOWN_CHILD_REAP_TIMEOUT,
+                    );
                     timed_out = true;
                     exit_success = false;
                     break;
@@ -8061,6 +8097,23 @@ fn stop_hermes_bridge_inner(bridge: &HermesBridge) -> Result<(), AppError> {
     Ok(())
 }
 
+fn stop_hermes_bridge_for_shutdown(bridge: &HermesBridge) {
+    let processes: Vec<HermesProcess> =
+        match crate::shutdown::try_lock_for(&bridge.processes, SHUTDOWN_MUTEX_TIMEOUT) {
+            Some(mut guard) => guard.drain().map(|(_, process)| process).collect(),
+            None => {
+                tracing::warn!(
+                    timeout_ms = SHUTDOWN_MUTEX_TIMEOUT.as_millis(),
+                    "timed out acquiring the Hermes process lock during app shutdown"
+                );
+                return;
+            }
+        };
+    for process in processes {
+        shutdown_hermes_process(Some(process));
+    }
+}
+
 /// Stops only the process spawned by the start attempt identified by
 /// `generation`, whichever mode slot it sits in. A stop (or stop+restart)
 /// that raced with that start leaves a different process in the slot, which
@@ -8088,9 +8141,13 @@ fn shutdown_hermes_process(process: Option<HermesProcess>) {
         // reap the tracked child itself.
         #[cfg(unix)]
         kill_process_group(process.child.id());
-        let _ = process.child.kill();
-        match process.child.wait() {
-            Ok(_) => {
+        match crate::shutdown::terminate_child(
+            &mut process.child,
+            Duration::ZERO,
+            SHUTDOWN_CHILD_REAP_TIMEOUT,
+        ) {
+            crate::shutdown::ChildTermination::Exited
+            | crate::shutdown::ChildTermination::Killed => {
                 if let Err(error) =
                     remove_hermes_ownership_record(process.ownership_record.as_deref())
                 {
@@ -8100,11 +8157,11 @@ fn shutdown_hermes_process(process: Option<HermesProcess>) {
                     );
                 }
             }
-            Err(error) => {
+            outcome => {
                 // Retain the record when the leader was not confirmed reaped;
                 // the next startup must make the fail-closed recovery decision.
                 tracing::warn!(
-                    %error,
+                    ?outcome,
                     pid = process.child.id(),
                     "Hermes runtime leader could not be reaped; retaining ownership record"
                 );
@@ -8121,8 +8178,10 @@ fn shutdown_hermes_process(process: Option<HermesProcess>) {
 fn reap_unregistered_child(child: &mut Child, ownership_record: Option<&Path>) {
     #[cfg(unix)]
     kill_process_group(child.id());
-    let _ = child.kill();
-    if child.wait().is_ok() {
+    if matches!(
+        crate::shutdown::terminate_child(child, Duration::ZERO, SHUTDOWN_CHILD_REAP_TIMEOUT,),
+        crate::shutdown::ChildTermination::Exited | crate::shutdown::ChildTermination::Killed
+    ) {
         if let Err(error) = remove_hermes_ownership_record(ownership_record) {
             tracing::warn!(
                 %error,
@@ -8620,13 +8679,9 @@ fn wait_for_recorded_hermes_runtime_exit(
 /// group id.
 #[cfg(unix)]
 fn kill_process_group(pid: u32) {
-    let _ = Command::new("/bin/kill")
-        .arg("-KILL")
-        .arg(format!("-{pid}"))
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
+    if let Ok(pid) = libc::pid_t::try_from(pid) {
+        let _ = unsafe { libc::kill(-pid, libc::SIGKILL) };
+    }
 }
 
 async fn resolve_hermes_command(

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -4999,7 +4999,7 @@ fn hermes_file_mime_type(path: &Path) -> Option<&'static str> {
     image_mime_type(path).or_else(|| video_mime_type(path))
 }
 
-pub async fn shutdown(app: &tauri::AppHandle) {
+pub(crate) async fn shutdown(app: &tauri::AppHandle, deadline: crate::shutdown::ShutdownDeadline) {
     let bridge = app.state::<HermesBridge>();
     // Latch teardown *before* draining so an in-flight `start_hermes_bridge_inner`
     // cannot register a runtime after the drain and re-orphan the tree we are
@@ -5030,7 +5030,7 @@ pub async fn shutdown(app: &tauri::AppHandle) {
         ),
     }
 
-    bridge.browser_broker.terminate_sessions();
+    bridge.browser_broker.terminate_sessions(deadline);
     stop_hermes_bridge_for_shutdown(&bridge);
     let proxy = match crate::shutdown::try_lock_for(&bridge.provider_proxy, SHUTDOWN_MUTEX_TIMEOUT)
     {

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -5114,9 +5114,12 @@ async fn shutdown_hermes_gateway(
 /// How long `shutdown` waits for in-flight starts to register/reap their spawned
 /// child before draining. The window it guards (spawn -> register) is short, so
 /// this is only a safety bound; teardown proceeds regardless once it elapses.
-const SHUTDOWN_START_QUIESCE_TIMEOUT: Duration = Duration::from_secs(2);
+pub(crate) const SHUTDOWN_START_QUIESCE_TIMEOUT_MS: u64 = 2_000;
+const SHUTDOWN_START_QUIESCE_TIMEOUT: Duration =
+    Duration::from_millis(SHUTDOWN_START_QUIESCE_TIMEOUT_MS);
 const SHUTDOWN_MUTEX_TIMEOUT: Duration = Duration::from_millis(250);
 const SHUTDOWN_CHILD_REAP_TIMEOUT: Duration = Duration::from_millis(250);
+const HERMES_PROCESS_SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
 /// Gateway lifecycle commands are serialized with shutdown, so every command
 /// needs a deadline: a stuck start/restart must not keep app teardown waiting
 /// on the lifecycle lock indefinitely. Fifteen seconds leaves room for the
@@ -5130,7 +5133,9 @@ const GATEWAY_LIFECYCLE_COMMAND_TIMEOUT: Duration = Duration::from_secs(15);
 const GATEWAY_SHUTDOWN_LOCK_TIMEOUT: Duration = Duration::from_secs(1);
 /// One aggregate deadline prevents individually bounded launchctl/CLI steps
 /// from stacking into an unacceptably long main-thread quit or update relaunch.
-const GATEWAY_SHUTDOWN_TOTAL_TIMEOUT: Duration = Duration::from_secs(6);
+pub(crate) const GATEWAY_SHUTDOWN_TOTAL_TIMEOUT_MS: u64 = 6_000;
+const GATEWAY_SHUTDOWN_TOTAL_TIMEOUT: Duration =
+    Duration::from_millis(GATEWAY_SHUTDOWN_TOTAL_TIMEOUT_MS);
 /// Leave the non-macOS CLI stop below the aggregate deadline so its own timeout
 /// path can terminate the whole lifecycle process group before the outer future
 /// is dropped.
@@ -6818,7 +6823,7 @@ fn wait_with_timeout(mut child: Child, timeout: Duration) -> Result<BoundedOutpu
             }
             Ok(None) => {
                 if Instant::now() >= deadline {
-                    let _ = crate::shutdown::terminate_child(
+                    let _ = crate::shutdown::terminate_child_in_place(
                         &mut child,
                         Duration::ZERO,
                         SHUTDOWN_CHILD_REAP_TIMEOUT,
@@ -8134,23 +8139,43 @@ fn stop_hermes_bridge_generation(bridge: &HermesBridge, generation: u64) -> Resu
 }
 
 fn shutdown_hermes_process(process: Option<HermesProcess>) {
-    if let Some(mut process) = process {
-        // Sweep the runtime's process group first so any worker subprocess it
-        // forked dies with it rather than detaching and outliving the app (the
-        // child spawns into its own group; see the spawn site). Then kill and
-        // reap the tracked child itself.
+    if let Some(process) = process {
+        let pid = process.child.id();
+        let ownership_record = process.ownership_record;
+        // Ask the whole runtime process group to stop before escalating. This
+        // short grace gives SQLite WAL writes a chance to commit; if the hard
+        // deadline still requires SIGKILL, WAL mode limits loss to the
+        // uncommitted transaction while preserving committed state.
         #[cfg(unix)]
-        kill_process_group(process.child.id());
-        match crate::shutdown::terminate_child(
-            &mut process.child,
-            Duration::ZERO,
+        terminate_process_group(pid);
+        #[cfg(unix)]
+        let graceful_started = Instant::now();
+        let outcome = crate::shutdown::terminate_child_with(
+            process.child,
+            HERMES_PROCESS_SHUTDOWN_GRACE,
             SHUTDOWN_CHILD_REAP_TIMEOUT,
-        ) {
+            move |child| {
+                #[cfg(unix)]
+                kill_process_group(pid);
+                let _ = child.kill();
+            },
+        );
+        #[cfg(unix)]
+        {
+            // The leader can exit before a worker that shared its process
+            // group. Give every worker the same grace, then sweep the group so
+            // an ignored SIGTERM cannot survive the relaunch.
+            if matches!(outcome, crate::shutdown::ChildTermination::Exited) {
+                std::thread::sleep(
+                    HERMES_PROCESS_SHUTDOWN_GRACE.saturating_sub(graceful_started.elapsed()),
+                );
+            }
+            kill_process_group(pid);
+        }
+        match outcome {
             crate::shutdown::ChildTermination::Exited
             | crate::shutdown::ChildTermination::Killed => {
-                if let Err(error) =
-                    remove_hermes_ownership_record(process.ownership_record.as_deref())
-                {
+                if let Err(error) = remove_hermes_ownership_record(ownership_record.as_deref()) {
                     tracing::warn!(
                         %error,
                         "Hermes runtime was reaped but its ownership record could not be removed"
@@ -8162,7 +8187,7 @@ fn shutdown_hermes_process(process: Option<HermesProcess>) {
                 // the next startup must make the fail-closed recovery decision.
                 tracing::warn!(
                     ?outcome,
-                    pid = process.child.id(),
+                    pid,
                     "Hermes runtime leader could not be reaped; retaining ownership record"
                 );
             }
@@ -8179,7 +8204,11 @@ fn reap_unregistered_child(child: &mut Child, ownership_record: Option<&Path>) {
     #[cfg(unix)]
     kill_process_group(child.id());
     if matches!(
-        crate::shutdown::terminate_child(child, Duration::ZERO, SHUTDOWN_CHILD_REAP_TIMEOUT,),
+        crate::shutdown::terminate_child_in_place(
+            child,
+            Duration::ZERO,
+            SHUTDOWN_CHILD_REAP_TIMEOUT,
+        ),
         crate::shutdown::ChildTermination::Exited | crate::shutdown::ChildTermination::Killed
     ) {
         if let Err(error) = remove_hermes_ownership_record(ownership_record) {
@@ -8681,6 +8710,15 @@ fn wait_for_recorded_hermes_runtime_exit(
 fn kill_process_group(pid: u32) {
     if let Ok(pid) = libc::pid_t::try_from(pid) {
         let _ = unsafe { libc::kill(-pid, libc::SIGKILL) };
+    }
+}
+
+/// Best-effort cooperative stop for a runtime process group. Shutdown follows
+/// this with bounded polling and SIGKILL escalation.
+#[cfg(unix)]
+fn terminate_process_group(pid: u32) {
+    if let Ok(pid) = libc::pid_t::try_from(pid) {
+        let _ = unsafe { libc::kill(-pid, libc::SIGTERM) };
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ pub mod obsidian;
 pub mod os_accounts;
 pub mod p3a;
 pub mod providers;
+mod shutdown;
 pub mod theme_icon;
 pub mod updates;
 pub mod video_download_url;
@@ -409,6 +410,7 @@ pub fn run() {
         .manage(RecordingPresenceBoundsState::default())
         .manage(hermes_bridge::HermesBridge::default())
         .manage(computer_use::ComputerUseState::default())
+        .manage(shutdown::ShutdownCoordinator::default())
         .manage(os_accounts::LoginFlow::default())
         .manage(extension_host::ExtensionHost::default())
         .manage(connectors::ConnectFlow::default())
@@ -443,11 +445,12 @@ pub fn run() {
         .build(context)
         .expect("failed to build June")
         .run(|app, event| match event {
-            tauri::RunEvent::Exit => {
-                dictation::stop_helper(app);
-                tauri::async_runtime::block_on(computer_use::shutdown(app));
-                tauri::async_runtime::block_on(hermes_bridge::shutdown(app));
+            tauri::RunEvent::ExitRequested { code, api, .. } => {
+                shutdown::handle_exit_requested(app, code, &api);
             }
+            // Teardown must never start here. Tauri is already exiting, so
+            // fire-and-forget work can be dropped before it runs.
+            tauri::RunEvent::Exit => {}
             #[cfg(target_os = "macos")]
             tauri::RunEvent::Reopen { .. } => show_main_window(app),
             _ => {}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -448,9 +448,10 @@ pub fn run() {
             tauri::RunEvent::ExitRequested { code, api, .. } => {
                 shutdown::handle_exit_requested(app, code, &api);
             }
-            // Teardown must never start here. Tauri is already exiting, so
-            // fire-and-forget work can be dropped before it runs.
-            tauri::RunEvent::Exit => {}
+            // Tao emits only Exit for macOS logout/application termination.
+            // This is a bounded synchronous backstop when ExitRequested never
+            // had a chance to latch the coordinator.
+            tauri::RunEvent::Exit => shutdown::handle_exit(app),
             #[cfg(target_os = "macos")]
             tauri::RunEvent::Reopen { .. } => show_main_window(app),
             _ => {}

--- a/src-tauri/src/shutdown.rs
+++ b/src-tauri/src/shutdown.rs
@@ -1,7 +1,7 @@
 use crate::domain::types::AppError;
 use std::process::Child;
 use std::sync::mpsc::{self, Receiver};
-use std::sync::{Mutex, MutexGuard, TryLockError};
+use std::sync::{Condvar, Mutex, MutexGuard, TryLockError};
 use std::thread;
 use std::time::{Duration, Instant};
 use tauri::Manager;
@@ -9,9 +9,23 @@ use tauri::Manager;
 /// App teardown gets this long in total, regardless of which individual leaf
 /// is slow or stuck. The supervisor is separate from the cleanup worker, so a
 /// blocking syscall in one leaf cannot postpone the final exit/restart.
-const SHUTDOWN_AGGREGATE_DEADLINE: Duration = Duration::from_secs(5);
+///
+/// The dictation (1.25 s) and Computer use (2.5 s) branches run concurrently
+/// with Hermes, so neither can consume Hermes' ordered budget: start quiescence
+/// (2 s) + Gateway unload (6 s) + process/browser/proxy finalization (2 s).
+const SHUTDOWN_AGGREGATE_DEADLINE_MS: u64 = 10_000;
+const SHUTDOWN_AGGREGATE_DEADLINE: Duration = Duration::from_millis(SHUTDOWN_AGGREGATE_DEADLINE_MS);
+const HERMES_FINALIZATION_BUDGET_MS: u64 = 2_000;
+const EXIT_FALLBACK_DEADLINE: Duration = Duration::from_secs(3);
 const MUTEX_POLL_INTERVAL: Duration = Duration::from_millis(5);
 const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+const _: () = assert!(
+    SHUTDOWN_AGGREGATE_DEADLINE_MS
+        >= crate::hermes_bridge::SHUTDOWN_START_QUIESCE_TIMEOUT_MS
+            + crate::hermes_bridge::GATEWAY_SHUTDOWN_TOTAL_TIMEOUT_MS
+            + HERMES_FINALIZATION_BUDGET_MS
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ShutdownTarget {
@@ -34,12 +48,14 @@ enum BeginShutdown {
 
 pub(crate) struct ShutdownCoordinator {
     phase: Mutex<ShutdownPhase>,
+    phase_changed: Condvar,
 }
 
 impl Default for ShutdownCoordinator {
     fn default() -> Self {
         Self {
             phase: Mutex::new(ShutdownPhase::Idle),
+            phase_changed: Condvar::new(),
         }
     }
 }
@@ -68,10 +84,30 @@ impl ShutdownCoordinator {
 
     fn mark_finalizing(&self, target: ShutdownTarget) {
         *self.lock_phase() = ShutdownPhase::Finalizing(target);
+        self.phase_changed.notify_all();
     }
 
     fn final_exit_is_allowed(&self) -> bool {
         matches!(*self.lock_phase(), ShutdownPhase::Finalizing(_))
+    }
+
+    fn is_idle(&self) -> bool {
+        matches!(*self.lock_phase(), ShutdownPhase::Idle)
+    }
+
+    #[cfg(windows)]
+    fn wait_until_finalizing(&self, timeout: Duration) -> bool {
+        let phase = self.lock_phase();
+        if matches!(*phase, ShutdownPhase::Finalizing(_)) {
+            return true;
+        }
+        let (phase, _) = self
+            .phase_changed
+            .wait_timeout_while(phase, timeout, |phase| {
+                !matches!(phase, ShutdownPhase::Finalizing(_))
+            })
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        matches!(*phase, ShutdownPhase::Finalizing(_))
     }
 }
 
@@ -92,6 +128,17 @@ pub(crate) fn handle_exit_requested(
     // remain alive while the coordinator owns teardown. June's updater avoids
     // the restart exception by latching Restart directly through its command.
     api.prevent_exit();
+    if code == Some(tauri::RESTART_EXIT_CODE) && coordinator.is_idle() {
+        // A direct `app.restart()`/`request_restart()` caller can bypass
+        // `prevent_exit` (and a main-thread restart skips ExitRequested
+        // entirely). All restart callers except this coordinator's finalizer
+        // must use `shutdown::request_restart`, which latches Running first.
+        tracing::error!("restart reached ExitRequested without the shutdown coordinator");
+        debug_assert!(
+            !coordinator.is_idle(),
+            "restart callers must use shutdown::request_restart, not Tauri restart directly"
+        );
+    }
     let target = if code == Some(tauri::RESTART_EXIT_CODE) {
         ShutdownTarget::Restart
     } else {
@@ -108,8 +155,56 @@ pub(crate) fn handle_exit_requested(
     }
 }
 
+/// Last-chance cleanup for termination paths that Tao delivers only as
+/// `RunEvent::Exit` (including macOS logout/application termination). Normal
+/// quits and update relaunches have already latched Running or Finalizing and
+/// remain no-ops here.
+pub(crate) fn handle_exit(app: &tauri::AppHandle) {
+    let coordinator = app.state::<ShutdownCoordinator>();
+    let cleanup_app = app.clone();
+    if matches!(
+        run_bounded_cleanup_if_idle(
+            &coordinator,
+            ShutdownTarget::Exit(0),
+            EXIT_FALLBACK_DEADLINE,
+            move || tauri::async_runtime::block_on(run_cleanup(&cleanup_app)),
+        ),
+        Some(true)
+    ) {
+        tracing::info!("completed last-chance cleanup from RunEvent::Exit");
+    }
+}
+
 pub(crate) fn request_restart(app: &tauri::AppHandle) -> Result<(), AppError> {
     request(app, ShutdownTarget::Restart)
+}
+
+/// Windows' updater exits the process from `Update::install_inner` after this
+/// hook and never emits ExitRequested. Run the same idempotent cleanup
+/// synchronously, then perform Tauri's own cleanup as the final API call before
+/// the plugin invokes `std::process::exit`.
+#[cfg(windows)]
+pub(crate) fn cleanup_before_updater_exit(app: &tauri::AppHandle) {
+    let coordinator = app.state::<ShutdownCoordinator>();
+    let cleanup_app = app.clone();
+    match coordinator.begin(ShutdownTarget::Restart) {
+        BeginShutdown::Started(target) => {
+            let completed = run_bounded_cleanup(SHUTDOWN_AGGREGATE_DEADLINE, move || {
+                tauri::async_runtime::block_on(run_cleanup(&cleanup_app));
+            });
+            if !completed {
+                tracing::warn!(
+                    timeout_ms = SHUTDOWN_AGGREGATE_DEADLINE.as_millis(),
+                    "Windows updater cleanup hit its aggregate deadline"
+                );
+            }
+            coordinator.mark_finalizing(target);
+        }
+        BeginShutdown::AlreadyRunning(_) => {
+            let _ = coordinator.wait_until_finalizing(SHUTDOWN_AGGREGATE_DEADLINE);
+        }
+    }
+    app.cleanup_before_exit();
 }
 
 fn request(app: &tauri::AppHandle, requested: ShutdownTarget) -> Result<(), AppError> {
@@ -168,16 +263,61 @@ where
 }
 
 async fn run_cleanup(app: &tauri::AppHandle) {
-    crate::dictation::stop_helper(app);
-    crate::computer_use::shutdown(app).await;
+    let dictation_app = app.clone();
+    let dictation =
+        tauri::async_runtime::spawn_blocking(move || crate::dictation::stop_helper(&dictation_app));
+    let computer_use = crate::computer_use::shutdown(app);
     // This call preserves the load-bearing order inside the Hermes subsystem:
     // quiesce starts -> unload the Gateway -> reap runtimes -> stop the
     // provider proxy.
-    crate::hermes_bridge::shutdown(app).await;
+    let hermes = crate::hermes_bridge::shutdown(app);
+    let (dictation_result, (), ()) = tokio::join!(dictation, computer_use, hermes);
+    if let Err(error) = dictation_result {
+        tracing::warn!(%error, "dictation shutdown worker could not be joined");
+    }
 }
 
 fn wait_for_cleanup(receiver: &Receiver<()>, timeout: Duration) -> bool {
     receiver.recv_timeout(timeout).is_ok()
+}
+
+fn run_bounded_cleanup<C>(deadline: Duration, cleanup: C) -> bool
+where
+    C: FnOnce() + Send + 'static,
+{
+    let (done_tx, done_rx) = mpsc::sync_channel(1);
+    let spawned = thread::Builder::new()
+        .name("june-shutdown-cleanup".to_string())
+        .spawn(move || {
+            cleanup();
+            let _ = done_tx.send(());
+        })
+        .is_ok();
+    spawned && wait_for_cleanup(&done_rx, deadline)
+}
+
+fn run_bounded_cleanup_if_idle<C>(
+    coordinator: &ShutdownCoordinator,
+    target: ShutdownTarget,
+    deadline: Duration,
+    cleanup: C,
+) -> Option<bool>
+where
+    C: FnOnce() + Send + 'static,
+{
+    let BeginShutdown::Started(target) = coordinator.begin(target) else {
+        return None;
+    };
+    let completed = run_bounded_cleanup(deadline, cleanup);
+    if !completed {
+        tracing::warn!(
+            ?target,
+            timeout_ms = deadline.as_millis(),
+            "last-chance app cleanup hit its deadline"
+        );
+    }
+    coordinator.mark_finalizing(target);
+    Some(completed)
 }
 
 fn finalize(app: tauri::AppHandle, target: ShutdownTarget) {
@@ -228,9 +368,46 @@ pub(crate) enum ChildTermination {
 }
 
 /// Polls a child with `try_wait`, then escalates to the platform kill primitive
-/// and polls again. It never calls `Child::wait`, so even an uninterruptible or
-/// stopped child cannot hold the shutdown worker indefinitely.
+/// and polls again. If the bounded poll expires after SIGKILL, ownership moves
+/// to a detached reaper so a late exit is still waited and cannot become a
+/// zombie without holding shutdown open.
 pub(crate) fn terminate_child(
+    child: Child,
+    graceful_timeout: Duration,
+    kill_timeout: Duration,
+) -> ChildTermination {
+    terminate_child_with(child, graceful_timeout, kill_timeout, |child| {
+        let _ = child.kill();
+    })
+}
+
+pub(crate) fn terminate_child_with(
+    mut child: Child,
+    graceful_timeout: Duration,
+    kill_timeout: Duration,
+    escalate: impl FnOnce(&mut Child),
+) -> ChildTermination {
+    match poll_child_exit(&mut child, graceful_timeout) {
+        Ok(true) => return ChildTermination::Exited,
+        Err(()) => return ChildTermination::WaitFailed,
+        Ok(false) => {}
+    }
+
+    escalate(&mut child);
+    match poll_child_exit(&mut child, kill_timeout) {
+        Ok(true) => ChildTermination::Killed,
+        Ok(false) => {
+            spawn_detached_child_reaper(child);
+            ChildTermination::TimedOut
+        }
+        Err(()) => ChildTermination::WaitFailed,
+    }
+}
+
+/// Compatibility helper for pre-registration error paths that still need to
+/// retain the `Child` on success. App-shutdown ownership paths use
+/// [`terminate_child`] so a timed-out child is handed to a detached reaper.
+pub(crate) fn terminate_child_in_place(
     child: &mut Child,
     graceful_timeout: Duration,
     kill_timeout: Duration,
@@ -240,12 +417,22 @@ pub(crate) fn terminate_child(
         Err(()) => return ChildTermination::WaitFailed,
         Ok(false) => {}
     }
-
     let _ = child.kill();
     match poll_child_exit(child, kill_timeout) {
         Ok(true) => ChildTermination::Killed,
         Ok(false) => ChildTermination::TimedOut,
         Err(()) => ChildTermination::WaitFailed,
+    }
+}
+
+fn spawn_detached_child_reaper(mut child: Child) {
+    if let Err(error) = thread::Builder::new()
+        .name("june-child-reaper".to_string())
+        .spawn(move || {
+            let _ = child.wait();
+        })
+    {
+        tracing::warn!(%error, "could not start detached child reaper");
     }
 }
 
@@ -264,6 +451,12 @@ fn poll_child_exit(child: &mut Child, timeout: Duration) -> Result<bool, ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    fn deadline_covers_ordered_leaves(aggregate_ms: u64, leaves_ms: &[u64]) -> bool {
+        aggregate_ms >= leaves_ms.iter().sum()
+    }
 
     #[test]
     fn duplicate_requests_share_one_shutdown() {
@@ -311,6 +504,69 @@ mod tests {
     }
 
     #[test]
+    fn aggregate_deadline_covers_the_ordered_hermes_leaf_budgets() {
+        assert!(deadline_covers_ordered_leaves(
+            SHUTDOWN_AGGREGATE_DEADLINE_MS,
+            &[
+                crate::hermes_bridge::SHUTDOWN_START_QUIESCE_TIMEOUT_MS,
+                crate::hermes_bridge::GATEWAY_SHUTDOWN_TOTAL_TIMEOUT_MS,
+                HERMES_FINALIZATION_BUDGET_MS,
+            ],
+        ));
+    }
+
+    #[test]
+    fn exit_fallback_runs_only_while_the_coordinator_is_idle() {
+        let coordinator = ShutdownCoordinator::default();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let first_calls = Arc::clone(&calls);
+        assert_eq!(
+            run_bounded_cleanup_if_idle(
+                &coordinator,
+                ShutdownTarget::Exit(0),
+                Duration::from_secs(1),
+                move || {
+                    first_calls.fetch_add(1, Ordering::SeqCst);
+                },
+            ),
+            Some(true)
+        );
+        assert!(matches!(
+            *coordinator.lock_phase(),
+            ShutdownPhase::Finalizing(ShutdownTarget::Exit(0))
+        ));
+
+        let duplicate_calls = Arc::clone(&calls);
+        assert_eq!(
+            run_bounded_cleanup_if_idle(
+                &coordinator,
+                ShutdownTarget::Restart,
+                Duration::from_secs(1),
+                move || {
+                    duplicate_calls.fetch_add(1, Ordering::SeqCst);
+                },
+            ),
+            None
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let running = ShutdownCoordinator::default();
+        assert_eq!(
+            running.begin(ShutdownTarget::Restart),
+            BeginShutdown::Started(ShutdownTarget::Restart)
+        );
+        assert_eq!(
+            run_bounded_cleanup_if_idle(
+                &running,
+                ShutdownTarget::Exit(0),
+                Duration::from_secs(1),
+                || panic!("running cleanup must remain owned by its first caller"),
+            ),
+            None
+        );
+    }
+
+    #[test]
     fn supervised_request_returns_before_blocked_cleanup() {
         let (release_tx, release_rx) = mpsc::sync_channel(1);
         let (final_tx, final_rx) = mpsc::sync_channel(1);
@@ -352,7 +608,7 @@ mod tests {
     fn stopped_child_is_killed_and_reaped_without_blocking_wait() {
         use std::process::{Command, Stdio};
 
-        let mut child = Command::new("/bin/sleep")
+        let child = Command::new("/bin/sleep")
             .arg("30")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
@@ -364,13 +620,41 @@ mod tests {
 
         let started = Instant::now();
         assert_eq!(
-            terminate_child(
-                &mut child,
-                Duration::from_millis(20),
-                Duration::from_secs(1)
-            ),
+            terminate_child(child, Duration::from_millis(20), Duration::from_secs(1)),
             ChildTermination::Killed
         );
         assert!(started.elapsed() < Duration::from_secs(2));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn timed_out_kill_is_eventually_reaped_by_a_detached_thread() {
+        use std::process::{Command, Stdio};
+
+        let child = Command::new("/bin/sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn child");
+        let pid = child.id() as libc::pid_t;
+        assert_eq!(
+            terminate_child(child, Duration::ZERO, Duration::ZERO),
+            ChildTermination::TimedOut
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let result = unsafe { libc::kill(pid, 0) };
+            if result == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "detached reaper left the killed child as a zombie"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
     }
 }

--- a/src-tauri/src/shutdown.rs
+++ b/src-tauri/src/shutdown.rs
@@ -27,6 +27,33 @@ const _: () = assert!(
             + HERMES_FINALIZATION_BUDGET_MS
 );
 
+/// One absolute deadline shared by every leaf in a supervised cleanup run.
+///
+/// A leaf that has to wait for ownership stays on the cleanup worker's call
+/// stack until this deadline. That makes the supervisor account for the wait:
+/// successful cleanup delays finalization, while an expired deadline produces
+/// an explicit leaf fallback instead of an untracked retry thread.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ShutdownDeadline {
+    expires_at: Instant,
+}
+
+impl ShutdownDeadline {
+    pub(crate) fn after(timeout: Duration) -> Self {
+        Self {
+            expires_at: Instant::now() + timeout,
+        }
+    }
+
+    fn remaining(self) -> Duration {
+        self.expires_at.saturating_duration_since(Instant::now())
+    }
+
+    pub(crate) fn try_lock<'a, T>(self, mutex: &'a Mutex<T>) -> Option<MutexGuard<'a, T>> {
+        try_lock_for(mutex, self.remaining())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ShutdownTarget {
     Exit(i32),
@@ -162,12 +189,13 @@ pub(crate) fn handle_exit_requested(
 pub(crate) fn handle_exit(app: &tauri::AppHandle) {
     let coordinator = app.state::<ShutdownCoordinator>();
     let cleanup_app = app.clone();
+    let cleanup_deadline = ShutdownDeadline::after(EXIT_FALLBACK_DEADLINE);
     if matches!(
         run_bounded_cleanup_if_idle(
             &coordinator,
             ShutdownTarget::Exit(0),
             EXIT_FALLBACK_DEADLINE,
-            move || tauri::async_runtime::block_on(run_cleanup(&cleanup_app)),
+            move || { tauri::async_runtime::block_on(run_cleanup(&cleanup_app, cleanup_deadline)) },
         ),
         Some(true)
     ) {
@@ -189,8 +217,9 @@ pub(crate) fn cleanup_before_updater_exit(app: &tauri::AppHandle) {
     let cleanup_app = app.clone();
     match coordinator.begin(ShutdownTarget::Restart) {
         BeginShutdown::Started(target) => {
+            let cleanup_deadline = ShutdownDeadline::after(SHUTDOWN_AGGREGATE_DEADLINE);
             let completed = run_bounded_cleanup(SHUTDOWN_AGGREGATE_DEADLINE, move || {
-                tauri::async_runtime::block_on(run_cleanup(&cleanup_app));
+                tauri::async_runtime::block_on(run_cleanup(&cleanup_app, cleanup_deadline));
             });
             if !completed {
                 tracing::warn!(
@@ -215,9 +244,10 @@ fn request(app: &tauri::AppHandle, requested: ShutdownTarget) -> Result<(), AppE
 
     let cleanup_app = app.clone();
     let final_app = app.clone();
+    let cleanup_deadline = ShutdownDeadline::after(SHUTDOWN_AGGREGATE_DEADLINE);
     spawn_supervised_shutdown(
         SHUTDOWN_AGGREGATE_DEADLINE,
-        move || tauri::async_runtime::block_on(run_cleanup(&cleanup_app)),
+        move || tauri::async_runtime::block_on(run_cleanup(&cleanup_app, cleanup_deadline)),
         move |completed| {
             if completed {
                 tracing::info!(?target, "app shutdown cleanup completed");
@@ -262,7 +292,7 @@ where
         .map(|_| ())
 }
 
-async fn run_cleanup(app: &tauri::AppHandle) {
+async fn run_cleanup(app: &tauri::AppHandle, deadline: ShutdownDeadline) {
     let dictation_app = app.clone();
     let dictation =
         tauri::async_runtime::spawn_blocking(move || crate::dictation::stop_helper(&dictation_app));
@@ -270,7 +300,7 @@ async fn run_cleanup(app: &tauri::AppHandle) {
     // This call preserves the load-bearing order inside the Hermes subsystem:
     // quiesce starts -> unload the Gateway -> reap runtimes -> stop the
     // provider proxy.
-    let hermes = crate::hermes_bridge::shutdown(app);
+    let hermes = crate::hermes_bridge::shutdown(app, deadline);
     let (dictation_result, (), ()) = tokio::join!(dictation, computer_use, hermes);
     if let Err(error) = dictation_result {
         tracing::warn!(%error, "dictation shutdown worker could not be joined");

--- a/src-tauri/src/shutdown.rs
+++ b/src-tauri/src/shutdown.rs
@@ -1,0 +1,376 @@
+use crate::domain::types::AppError;
+use std::process::Child;
+use std::sync::mpsc::{self, Receiver};
+use std::sync::{Mutex, MutexGuard, TryLockError};
+use std::thread;
+use std::time::{Duration, Instant};
+use tauri::Manager;
+
+/// App teardown gets this long in total, regardless of which individual leaf
+/// is slow or stuck. The supervisor is separate from the cleanup worker, so a
+/// blocking syscall in one leaf cannot postpone the final exit/restart.
+const SHUTDOWN_AGGREGATE_DEADLINE: Duration = Duration::from_secs(5);
+const MUTEX_POLL_INTERVAL: Duration = Duration::from_millis(5);
+const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShutdownTarget {
+    Exit(i32),
+    Restart,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShutdownPhase {
+    Idle,
+    Running(ShutdownTarget),
+    Finalizing(ShutdownTarget),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BeginShutdown {
+    Started(ShutdownTarget),
+    AlreadyRunning(ShutdownTarget),
+}
+
+pub(crate) struct ShutdownCoordinator {
+    phase: Mutex<ShutdownPhase>,
+}
+
+impl Default for ShutdownCoordinator {
+    fn default() -> Self {
+        Self {
+            phase: Mutex::new(ShutdownPhase::Idle),
+        }
+    }
+}
+
+impl ShutdownCoordinator {
+    fn lock_phase(&self) -> MutexGuard<'_, ShutdownPhase> {
+        self.phase
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// The first request decides whether this process exits or restarts. Later
+    /// requests share the in-flight cleanup and cannot change its final action.
+    fn begin(&self, requested: ShutdownTarget) -> BeginShutdown {
+        let mut phase = self.lock_phase();
+        match *phase {
+            ShutdownPhase::Idle => {
+                *phase = ShutdownPhase::Running(requested);
+                BeginShutdown::Started(requested)
+            }
+            ShutdownPhase::Running(target) | ShutdownPhase::Finalizing(target) => {
+                BeginShutdown::AlreadyRunning(target)
+            }
+        }
+    }
+
+    fn mark_finalizing(&self, target: ShutdownTarget) {
+        *self.lock_phase() = ShutdownPhase::Finalizing(target);
+    }
+
+    fn final_exit_is_allowed(&self) -> bool {
+        matches!(*self.lock_phase(), ShutdownPhase::Finalizing(_))
+    }
+}
+
+/// Intercepts ordinary Tauri exit requests while the main event loop can still
+/// be kept alive. `RunEvent::Exit` is too late: Tauri is already tearing down
+/// the runtime and cannot reliably run asynchronous cleanup from there.
+pub(crate) fn handle_exit_requested(
+    app: &tauri::AppHandle,
+    code: Option<i32>,
+    api: &tauri::ExitRequestApi,
+) {
+    let coordinator = app.state::<ShutdownCoordinator>();
+    if coordinator.final_exit_is_allowed() {
+        return;
+    }
+
+    // Tauri ignores this for its built-in restart code, but ordinary exit must
+    // remain alive while the coordinator owns teardown. June's updater avoids
+    // the restart exception by latching Restart directly through its command.
+    api.prevent_exit();
+    let target = if code == Some(tauri::RESTART_EXIT_CODE) {
+        ShutdownTarget::Restart
+    } else {
+        ShutdownTarget::Exit(code.unwrap_or(0))
+    };
+
+    if let Err(error) = request(app, target) {
+        tracing::error!(
+            code = %error.code,
+            "could not start the shutdown coordinator; allowing a fail-safe exit"
+        );
+        coordinator.mark_finalizing(target);
+        finalize(app.clone(), target);
+    }
+}
+
+pub(crate) fn request_restart(app: &tauri::AppHandle) -> Result<(), AppError> {
+    request(app, ShutdownTarget::Restart)
+}
+
+fn request(app: &tauri::AppHandle, requested: ShutdownTarget) -> Result<(), AppError> {
+    let coordinator = app.state::<ShutdownCoordinator>();
+    let BeginShutdown::Started(target) = coordinator.begin(requested) else {
+        return Ok(());
+    };
+
+    let cleanup_app = app.clone();
+    let final_app = app.clone();
+    spawn_supervised_shutdown(
+        SHUTDOWN_AGGREGATE_DEADLINE,
+        move || tauri::async_runtime::block_on(run_cleanup(&cleanup_app)),
+        move |completed| {
+            if completed {
+                tracing::info!(?target, "app shutdown cleanup completed");
+            } else {
+                tracing::warn!(
+                    ?target,
+                    timeout_ms = SHUTDOWN_AGGREGATE_DEADLINE.as_millis(),
+                    "app shutdown cleanup hit its aggregate deadline"
+                );
+            }
+            final_app
+                .state::<ShutdownCoordinator>()
+                .mark_finalizing(target);
+            finalize(final_app, target);
+        },
+    )
+    .map_err(|error| AppError::new("shutdown_start_failed", error.to_string()))
+}
+
+fn spawn_supervised_shutdown<C, F>(
+    deadline: Duration,
+    cleanup: C,
+    finalize: F,
+) -> std::io::Result<()>
+where
+    C: FnOnce() + Send + 'static,
+    F: FnOnce(bool) + Send + 'static,
+{
+    thread::Builder::new()
+        .name("june-shutdown-supervisor".to_string())
+        .spawn(move || {
+            let (done_tx, done_rx) = mpsc::sync_channel(1);
+            let cleanup_spawn = thread::Builder::new()
+                .name("june-shutdown-cleanup".to_string())
+                .spawn(move || {
+                    cleanup();
+                    let _ = done_tx.send(());
+                });
+            let completed = cleanup_spawn.is_ok() && wait_for_cleanup(&done_rx, deadline);
+            finalize(completed);
+        })
+        .map(|_| ())
+}
+
+async fn run_cleanup(app: &tauri::AppHandle) {
+    crate::dictation::stop_helper(app);
+    crate::computer_use::shutdown(app).await;
+    // This call preserves the load-bearing order inside the Hermes subsystem:
+    // quiesce starts -> unload the Gateway -> reap runtimes -> stop the
+    // provider proxy.
+    crate::hermes_bridge::shutdown(app).await;
+}
+
+fn wait_for_cleanup(receiver: &Receiver<()>, timeout: Duration) -> bool {
+    receiver.recv_timeout(timeout).is_ok()
+}
+
+fn finalize(app: tauri::AppHandle, target: ShutdownTarget) {
+    let final_app = app.clone();
+    let scheduled = app.run_on_main_thread(move || match target {
+        ShutdownTarget::Exit(code) => final_app.exit(code),
+        ShutdownTarget::Restart => final_app.restart(),
+    });
+    if let Err(error) = scheduled {
+        tracing::error!(%error, ?target, "could not schedule final shutdown action on the main thread");
+        match target {
+            ShutdownTarget::Exit(code) => app.exit(code),
+            ShutdownTarget::Restart => app.request_restart(),
+        }
+    }
+}
+
+/// Acquires a synchronous mutex without allowing shutdown to wait forever on a
+/// thread that may itself need the main event loop to make progress.
+pub(crate) fn try_lock_for<T>(mutex: &Mutex<T>, timeout: Duration) -> Option<MutexGuard<'_, T>> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match mutex.try_lock() {
+            Ok(guard) => return Some(guard),
+            Err(TryLockError::Poisoned(error)) => return Some(error.into_inner()),
+            Err(TryLockError::WouldBlock) if Instant::now() < deadline => {
+                thread::sleep(MUTEX_POLL_INTERVAL);
+            }
+            Err(TryLockError::WouldBlock) => return None,
+        }
+    }
+}
+
+/// Acquires an async mutex with a shutdown-only deadline.
+pub(crate) async fn lock_async_for<T>(
+    mutex: &tokio::sync::Mutex<T>,
+    timeout: Duration,
+) -> Option<tokio::sync::MutexGuard<'_, T>> {
+    tokio::time::timeout(timeout, mutex.lock()).await.ok()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChildTermination {
+    Exited,
+    Killed,
+    TimedOut,
+    WaitFailed,
+}
+
+/// Polls a child with `try_wait`, then escalates to the platform kill primitive
+/// and polls again. It never calls `Child::wait`, so even an uninterruptible or
+/// stopped child cannot hold the shutdown worker indefinitely.
+pub(crate) fn terminate_child(
+    child: &mut Child,
+    graceful_timeout: Duration,
+    kill_timeout: Duration,
+) -> ChildTermination {
+    match poll_child_exit(child, graceful_timeout) {
+        Ok(true) => return ChildTermination::Exited,
+        Err(()) => return ChildTermination::WaitFailed,
+        Ok(false) => {}
+    }
+
+    let _ = child.kill();
+    match poll_child_exit(child, kill_timeout) {
+        Ok(true) => ChildTermination::Killed,
+        Ok(false) => ChildTermination::TimedOut,
+        Err(()) => ChildTermination::WaitFailed,
+    }
+}
+
+fn poll_child_exit(child: &mut Child, timeout: Duration) -> Result<bool, ()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return Ok(true),
+            Ok(None) if Instant::now() < deadline => thread::sleep(CHILD_POLL_INTERVAL),
+            Ok(None) => return Ok(false),
+            Err(_) => return Err(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duplicate_requests_share_one_shutdown() {
+        let coordinator = ShutdownCoordinator::default();
+        assert_eq!(
+            coordinator.begin(ShutdownTarget::Exit(0)),
+            BeginShutdown::Started(ShutdownTarget::Exit(0))
+        );
+        assert_eq!(
+            coordinator.begin(ShutdownTarget::Exit(0)),
+            BeginShutdown::AlreadyRunning(ShutdownTarget::Exit(0))
+        );
+    }
+
+    #[test]
+    fn first_request_latches_exit_vs_restart() {
+        let restart_first = ShutdownCoordinator::default();
+        assert_eq!(
+            restart_first.begin(ShutdownTarget::Restart),
+            BeginShutdown::Started(ShutdownTarget::Restart)
+        );
+        assert_eq!(
+            restart_first.begin(ShutdownTarget::Exit(7)),
+            BeginShutdown::AlreadyRunning(ShutdownTarget::Restart)
+        );
+
+        let exit_first = ShutdownCoordinator::default();
+        assert_eq!(
+            exit_first.begin(ShutdownTarget::Exit(7)),
+            BeginShutdown::Started(ShutdownTarget::Exit(7))
+        );
+        assert_eq!(
+            exit_first.begin(ShutdownTarget::Restart),
+            BeginShutdown::AlreadyRunning(ShutdownTarget::Exit(7))
+        );
+    }
+
+    #[test]
+    fn cleanup_wait_obeys_the_aggregate_deadline() {
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let started = Instant::now();
+        assert!(!wait_for_cleanup(&receiver, Duration::from_millis(20)));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        drop(sender);
+    }
+
+    #[test]
+    fn supervised_request_returns_before_blocked_cleanup() {
+        let (release_tx, release_rx) = mpsc::sync_channel(1);
+        let (final_tx, final_rx) = mpsc::sync_channel(1);
+        let started = Instant::now();
+        spawn_supervised_shutdown(
+            Duration::from_millis(20),
+            move || {
+                let _ = release_rx.recv();
+            },
+            move |completed| {
+                let _ = final_tx.send(completed);
+            },
+        )
+        .expect("spawn supervisor");
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "request path must return control to the main event loop"
+        );
+        assert!(
+            !final_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("deadline finalizer"),
+            "deadline must finalize while cleanup remains blocked"
+        );
+        let _ = release_tx.send(());
+    }
+
+    #[test]
+    fn mutex_acquisition_obeys_its_deadline() {
+        let mutex = Mutex::new(());
+        let _guard = mutex.lock().expect("test lock");
+        let started = Instant::now();
+        assert!(try_lock_for(&mutex, Duration::from_millis(20)).is_none());
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stopped_child_is_killed_and_reaped_without_blocking_wait() {
+        use std::process::{Command, Stdio};
+
+        let mut child = Command::new("/bin/sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn stuck child");
+        let result = unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGSTOP) };
+        assert_eq!(result, 0, "stop child");
+
+        let started = Instant::now();
+        assert_eq!(
+            terminate_child(
+                &mut child,
+                Duration::from_millis(20),
+                Duration::from_secs(1)
+            ),
+            ChildTermination::Killed
+        );
+        assert!(started.elapsed() < Duration::from_secs(2));
+    }
+}

--- a/src-tauri/src/updates.rs
+++ b/src-tauri/src/updates.rs
@@ -260,8 +260,8 @@ pub async fn install_update(
     Ok(())
 }
 
-/// Relaunches June after an in-app update has been staged, running the same
-/// child-process teardown app quit does *before* the process restarts.
+/// Relaunches June after an in-app update has been staged through the same
+/// idempotent shutdown coordinator used by ordinary app quit.
 ///
 /// The plugin `relaunch()` (and `AppHandle::restart()` on the main thread)
 /// restarts without a guaranteed pass through the `RunEvent::Exit` cleanup that
@@ -270,21 +270,13 @@ pub async fn install_update(
 /// CGEventTap and its stdio — and the relaunched instance then cannot bring up a
 /// clean helper, so every helper-reported permission (dictation mic and
 /// accessibility) reads missing even though the grants are intact (JUN-338).
-/// Tearing down explicitly here guarantees the helpers and Hermes runtime are
-/// gone before the new instance starts. The final restart is dispatched to the
-/// main thread so Tauri restarts directly instead of delivering `RunEvent::Exit`
-/// and synchronously repeating the full cleanup on the UI event loop. That
-/// duplicate exit path can leave the window parked in its disabled relaunching
-/// state while a background service is still winding down.
+/// The coordinator latches Restart, performs teardown off the main event loop,
+/// and schedules the final restart on the main thread after cleanup or its hard
+/// aggregate deadline. A concurrent quit request shares the same cleanup and
+/// cannot replace the already-latched restart.
 #[tauri::command]
 pub async fn relaunch_for_update(app: AppHandle) -> Result<(), AppError> {
-    crate::dictation::stop_helper(&app);
-    crate::computer_use::shutdown(&app).await;
-    crate::hermes_bridge::shutdown(&app).await;
-
-    let restart_app = app.clone();
-    app.run_on_main_thread(move || restart_app.restart())
-        .map_err(|error| AppError::new("update_relaunch_failed", error.to_string()))
+    crate::shutdown::request_restart(&app)
 }
 
 #[tauri::command]

--- a/src-tauri/src/updates.rs
+++ b/src-tauri/src/updates.rs
@@ -191,10 +191,22 @@ pub async fn fetch_update(
     let channel = current_channel(&app);
     let endpoint = tauri::Url::parse(channel.endpoint())
         .map_err(|error| AppError::new("update_check_failed", error.to_string()))?;
-    let update = app
+    let updater = app
         .updater_builder()
         .endpoints(vec![endpoint])
-        .map_err(|error| AppError::new("update_check_failed", error.to_string()))?
+        .map_err(|error| AppError::new("update_check_failed", error.to_string()))?;
+    // On Windows the updater invokes this hook and then calls
+    // `std::process::exit(0)` from `Update::install_inner`; no ExitRequested
+    // event follows. Override Tauri's default hook with June's bounded cleanup,
+    // which calls `cleanup_before_exit` itself as its final step.
+    #[cfg(windows)]
+    let updater = {
+        let exit_app = app.clone();
+        updater.on_before_exit(move || {
+            crate::shutdown::cleanup_before_updater_exit(&exit_app);
+        })
+    };
+    let update = updater
         // The comparator is the sole downgrade gate; routing the default path
         // through `should_update` too keeps all install-decision logic in one
         // tested place. With reconcile=false this is exactly `remote > current`.


### PR DESCRIPTION
## Summary

- Route ordinary quit and in-app update relaunch through one first-request-wins shutdown coordinator.
- Intercept `RunEvent::ExitRequested`, prevent ordinary exit, perform cleanup off the main event loop, and schedule the final exit or restart on the main thread after cleanup or a ten-second aggregate deadline.
- Cover lifecycle paths that bypass `ExitRequested`: the Windows updater runs the same bounded cleanup from `on_before_exit`, while macOS logout/application termination gets a short synchronous `RunEvent::Exit` fallback only when cleanup is still idle.
- Start dictation, Computer use, and Hermes teardown concurrently so the ordered Hermes path always retains its 2 s quiesce + 6 s Gateway + 2 s finalization budget.
- Keep Hermes teardown ordered as quiesce, Gateway unload, runtime reap, then provider proxy shutdown while bounding mutexes, child reaping, external commands, the dictation pipe, and Computer use window coordination.
- Transfer killed children that outlive the bounded poll to detached reapers, give Hermes 500 ms of SIGTERM grace before process-group SIGKILL, and retain bounded browser teardown retries after lock contention.
- Extend the bounded Gateway work from #896 and the dictation reap from #780 without changing the recovery behavior covered by #872.

Refs JUN-410

## Root cause

Update relaunch had competing teardown paths. The updater command synchronously completed its own teardown before requesting restart, and Tauri then entered `RunEvent::Exit`, where June synchronously repeated dictation, Computer use, and Hermes teardown on the main event loop. Several leaves could wait forever: `Child::wait`, mutex acquisition, external `open`/`kill`/version commands, dictation stdin writes, and a synchronous main-thread response wait. Once any duplicate leaf stalled, the relaunch UI was already disabled and the main thread could no longer service macOS, producing the permanent beachball.

Starting cleanup from `RunEvent::Exit` was also too late for a fire-and-forget alternative because Tauri was already tearing down the runtime. Moving the normal path to preventable `ExitRequested` fixed that ordering, but two terminal paths bypass it: `tauri-plugin-updater` calls its Windows `on_before_exit` hook and then `std::process::exit(0)`, while Tao maps macOS logout/application termination directly to `RunEvent::Exit`. Without dedicated coordinator entry points those paths performed no June teardown.

The initial five-second aggregate deadline was shorter than the six-second Gateway budget and followed earlier sequential leaves, so it could force restart before Gateway teardown had a chance to finish. Killed children that missed the final `try_wait` poll were also dropped without a later blocking reap, leaving a zombie until process exit. Browser mutex timeouts could similarly discard the last tracked cleanup attempt.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --locked -- -D warnings`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer cargo test --manifest-path src-tauri/Cargo.toml --all-targets`
  - 1,317 library tests passed, 5 ignored; all driver and integration suites passed.
  - All 18 shutdown-matching and 14 Gateway-matching tests passed.
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test`
  - 207 test files passed; 3,404 tests passed, 2 skipped.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer NODE_OPTIONS=--no-experimental-webstorage make local-ci`
  - Posted `signoff/frontend` and `signoff/rust-macos` on `c9a547f551ea89abe88d580df1b256dbb81b971e`.
- Update-relaunch smoke: `supervised_request_returns_before_blocked_cleanup` deliberately holds the cleanup worker forever, verifies the request path returns control in under one second, and observes the deadline finalizer while cleanup is still blocked. `stopped_child_is_killed_and_reaped_without_blocking_wait` SIGSTOPs a child and verifies SIGKILL escalation within the bound; `timed_out_kill_is_eventually_reaped_by_a_detached_thread` verifies the late-reap path. This reproduces the hang conditions without requiring a signed updater artifact.

- [x] Tested visually where it matters (not applicable: native teardown only; no UI changes).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Building, signing, notarizing, or promoting a release artifact.
- Changing Hermes Gateway ownership, provider proxy contracts, updater metadata, or update-channel behavior.
- Reworking process-management paths that are not reachable from app shutdown.

## Followups

- Run the requested Opus and Kimi verification round on the latest SHA while this PR remains draft.
- Before release promotion, complete the signed updater-to-updater smoke in `docs/release-macos.md`, including the stopped-child case and confirmation that the main event loop returns in under one second.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. Process termination remains scoped to child PIDs and process groups already owned and tracked by June.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. Pending verification of the review fixes while the PR remains draft.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend changes.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.
