### PR TITLE
Debounce composer document serialization

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1163,7 +1163,7 @@ export function AgentWorkspace({
     composerModelSearchRef,
     composerModelTriggerRef,
     composerSteerDemo,
-    draft,
+    composerHasContent,
     errorState,
     fullModeDraftRef,
     gallerySections,
@@ -2061,6 +2061,7 @@ export function AgentWorkspace({
   }
 
   function clearComposerCommandDraft(commandText: string) {
+    if (!composerEditorRef.current?.flushPendingChange()) return;
     if (draftRef.current.trim() !== commandText.trim()) return;
     if (categoryRef.current) return;
     composerEditorRef.current?.clear();
@@ -2531,9 +2532,9 @@ export function AgentWorkspace({
   // remains read-only; transport state stays out of the visual scan line.
   const { renderSteerCard, renderQueuedAttachmentFollowUp } = createQueuedFollowUpRenderers({
     attachments,
+    composerHasContent,
     composerEditorRef,
     deliverQueuedAttachmentFollowUp,
-    draft,
     draftRef,
     editQueuedAttachmentFollowUp,
     queuedAttachmentFollowUpsRef,
@@ -2732,7 +2733,7 @@ export function AgentWorkspace({
   // hovering the chips, has started typing, or has the window backgrounded;
   // never cycles under reduced motion.
   useAgentHeroRotation({
-    draftRef,
+    composerHasContent,
     heroChipsHoverRef,
     heroMode,
     setHeroChipPhase,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -648,6 +648,7 @@ export function AgentWorkspace({
   const composerEditorRef = useRef<ComposerEditorHandle | null>(null);
   const composerTiptapEditorRef = useRef<TiptapEditor | null>(null);
   const composerBoxRef = useRef<HTMLDivElement | null>(null);
+  const [composerHasContent, setComposerHasContent] = useState(Boolean(draft.trim()));
   const [composerClearance, setComposerClearance] = useState(0);
   // A note reference to seed once the editor is ready, set by startNewTask for
   // note-level "Ask June" entry points.
@@ -1582,6 +1583,7 @@ export function AgentWorkspace({
     setAttachMenuOpen,
     setAttachments,
     setCategory,
+    setComposerHasContent,
     setDraft,
     setError,
     setImportingFiles,
@@ -2077,6 +2079,16 @@ export function AgentWorkspace({
 
   let submitImplementation: (event?: FormEvent) => Promise<void>;
   async function submit(event?: FormEvent) {
+    const liveComposer = composerEditorRef.current;
+    if (
+      liveComposer &&
+      !liveComposer.flushPendingChange({
+        changeKey: composerDraftKeyRef.current,
+      })
+    ) {
+      event?.preventDefault();
+      return;
+    }
     return submitImplementation(event);
   }
 
@@ -2751,17 +2763,14 @@ export function AgentWorkspace({
     beginAttachmentPreparation,
     cancelComposerDispatch,
     captureSessionModelTarget,
-    category,
     categoryRef,
     clearComposerDraft,
     composerDispatchOrderRef,
     composerDispatchWasInvalidated,
     composerDraftKeyRef,
     composerEditorRef,
-    composerInputSignature,
     composerSizeProceedSignatureRef,
     deferredFailedIssueReportDeliverySessionIdsRef,
-    draft,
     draftRef,
     enqueueAttachmentFollowUp,
     enqueueFailedComposerFollowUp,
@@ -2771,7 +2780,6 @@ export function AgentWorkspace({
     generationModels,
     handleBuiltinComposerSlashCommand,
     heroMode,
-    imageSlashBlockedByModel,
     importingFiles,
     newSessionModeRef,
     pendingSteerBySessionIdRef,
@@ -2816,6 +2824,8 @@ export function AgentWorkspace({
     composerBoxRef,
     composerDraftKeyRef,
     composerEditorRef,
+    composerHasContent,
+    setComposerHasContent,
     onComposerFocusChange: handleComposerFocusChange,
     composerInSteerState,
     composerModelFlyout,
@@ -2829,7 +2839,6 @@ export function AgentWorkspace({
     composerTiptapEditorRef,
     confirmUnrestricted,
     creditActionsDisabledReason,
-    draft,
     draftRef,
     dropActive,
     editOversizeComposerInput,
@@ -3008,11 +3017,11 @@ export function AgentWorkspace({
     compactSessionId,
     composer,
     composerClearance,
+    composerHasContent,
     compressSessionContext,
     deleteSelectedHermesSession,
     detailContent,
     downloadArtifact,
-    draft,
     fetchSessionUsage,
     galleryErrors,
     generationModel,

--- a/src/components/agent/AgentWorkspaceLayout-types.ts
+++ b/src/components/agent/AgentWorkspaceLayout-types.ts
@@ -44,11 +44,11 @@ export type RenderAgentWorkspaceLayoutDependencies = {
   compactSessionId: string | null;
   composer: JSX.Element | null;
   composerClearance: number;
+  composerHasContent: boolean;
   compressSessionContext: (sessionId: string) => Promise<CompressSessionResult>;
   deleteSelectedHermesSession: (sessionId: string) => Promise<void>;
   detailContent: JSX.Element | null;
   downloadArtifact: (artifact: AgentArtifact) => void;
-  draft: string;
   fetchSessionUsage: (storedSessionId: string) => Promise<SessionUsage>;
   galleryErrors: boolean;
   generationModel: VeniceModelDto | undefined;

--- a/src/components/agent/AgentWorkspaceLayout.tsx
+++ b/src/components/agent/AgentWorkspaceLayout.tsx
@@ -34,11 +34,11 @@ export function renderAgentWorkspaceLayout(dependencies: RenderAgentWorkspaceLay
     compactSessionId,
     composer,
     composerClearance,
+    composerHasContent,
     compressSessionContext,
     deleteSelectedHermesSession,
     detailContent,
     downloadArtifact,
-    draft,
     fetchSessionUsage,
     galleryErrors,
     generationModel,
@@ -275,7 +275,7 @@ export function renderAgentWorkspaceLayout(dependencies: RenderAgentWorkspaceLay
               <div
                 className="agent-hero-chips"
                 data-phase={heroChipPhase}
-                data-hidden={draft.trim() ? "true" : undefined}
+                data-hidden={composerHasContent ? "true" : undefined}
                 onMouseEnter={() => {
                   heroChipsHoverRef.current = true;
                 }}

--- a/src/components/agent/composer-draft-actions-types.ts
+++ b/src/components/agent/composer-draft-actions-types.ts
@@ -28,6 +28,7 @@ export type createComposerDraftActionsDependencies = {
   setAttachMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setAttachments: React.Dispatch<React.SetStateAction<AgentAttachment[]>>;
   setCategory: React.Dispatch<React.SetStateAction<ReportCategory | null>>;
+  setComposerHasContent: React.Dispatch<React.SetStateAction<boolean>>;
   setDraft: React.Dispatch<React.SetStateAction<string>>;
   setError: (message: string | null, options?: AgentWorkspaceErrorOptions) => void;
   setImportingFiles: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/components/agent/composer-draft-actions.ts
+++ b/src/components/agent/composer-draft-actions.ts
@@ -28,6 +28,7 @@ export function createComposerDraftActions(dependencies: createComposerDraftActi
     setAttachMenuOpen,
     setAttachments,
     setCategory,
+    setComposerHasContent,
     setDraft,
     setError,
     setImportingFiles,
@@ -43,6 +44,7 @@ export function createComposerDraftActions(dependencies: createComposerDraftActi
     attachmentsRef.current = [];
     setDraft("");
     setCategory(null);
+    setComposerHasContent(false);
     setAttachments([]);
     forgetComposerDraft(key);
     composerEditorRef.current?.clear();
@@ -51,6 +53,7 @@ export function createComposerDraftActions(dependencies: createComposerDraftActi
   function restoreComposerDraft(key: string | null) {
     const editor = composerEditorRef.current;
     if (!editor) return;
+    if (!editor.flushPendingChange({ persistWithoutRender: true })) return;
     restoredComposerDraftKeyRef.current = key;
     const snapshot = readComposerDraft(key);
     draftRef.current = snapshot?.text ?? "";
@@ -58,9 +61,11 @@ export function createComposerDraftActions(dependencies: createComposerDraftActi
     attachmentsRef.current = snapshot?.attachments ?? [];
     setDraft(snapshot?.text ?? "");
     setCategory(snapshot?.category ?? null);
+    setComposerHasContent(Boolean(snapshot?.text.trim()));
     setAttachments(snapshot?.attachments ?? []);
     editor.setContent(snapshot?.text ?? "", snapshot?.category ?? null, {
       focus: false,
+      changeKey: key,
     });
   }
 

--- a/src/components/agent/composer/AgentComposer-types.ts
+++ b/src/components/agent/composer/AgentComposer-types.ts
@@ -30,6 +30,8 @@ export type RenderAgentComposerDependencies = {
   composerBoxRef: React.MutableRefObject<HTMLDivElement | null>;
   composerDraftKeyRef: React.MutableRefObject<string | null>;
   composerEditorRef: React.MutableRefObject<ComposerEditorHandle | null>;
+  composerHasContent: boolean;
+  setComposerHasContent: React.Dispatch<React.SetStateAction<boolean>>;
   onComposerFocusChange: (focused: boolean) => void;
   composerInSteerState: boolean;
   composerModelFlyout: ModelPickerFlyout;
@@ -43,7 +45,6 @@ export type RenderAgentComposerDependencies = {
   composerTiptapEditorRef: React.MutableRefObject<TiptapEditor | null>;
   confirmUnrestricted: boolean;
   creditActionsDisabledReason: string | undefined;
-  draft: string;
   draftRef: React.MutableRefObject<string>;
   dropActive: boolean;
   editOversizeComposerInput: () => void;

--- a/src/components/agent/composer/AgentComposer.tsx
+++ b/src/components/agent/composer/AgentComposer.tsx
@@ -23,15 +23,34 @@ import { CategoryIcon } from "./CategoryIcon";
 import { REPORT_CATEGORIES } from "./reportCategory";
 import { ReportDialog } from "../ReportDialog";
 import {
+  PROVISIONAL_HERMES_SESSION_PREFIX,
   SANDBOX_OPTIONS,
   rememberUnrestrictedAcknowledged,
   unrestrictedAcknowledged,
 } from "../agent-workspace-config";
-import { rememberComposerDraft } from "../agent-session-continuity";
+import { NEW_SESSION_DRAFT_KEY, rememberComposerDraft } from "../agent-session-continuity";
 import { AgentScrollToLatestButton } from "../chat-turns/TranscriptViews";
 import { formatComposerTokenCount } from "./composer-input-helpers";
 import { AgentAttachmentTile } from "../agent-workspace-support";
 import type { RenderAgentComposerDependencies } from "./AgentComposer-types";
+
+function resolveChangedDraftKey(
+  changedDraftKey: string | null | undefined,
+  currentDraftKey: string | null,
+) {
+  const targetDraftKey = changedDraftKey === undefined ? currentDraftKey : changedDraftKey;
+  // A failed new-session create rolls its provisional session draft back to
+  // the canonical new-session key while the old composer is being removed.
+  // Its teardown snapshot is still the visible next draft and must follow
+  // that rollback rather than being stranded under the retired key.
+  if (
+    currentDraftKey === NEW_SESSION_DRAFT_KEY &&
+    targetDraftKey?.startsWith(`session:${PROVISIONAL_HERMES_SESSION_PREFIX}`)
+  ) {
+    return currentDraftKey;
+  }
+  return targetDraftKey;
+}
 
 export function renderAgentComposer(dependencies: RenderAgentComposerDependencies) {
   const {
@@ -48,6 +67,8 @@ export function renderAgentComposer(dependencies: RenderAgentComposerDependencie
     composerBoxRef,
     composerDraftKeyRef,
     composerEditorRef,
+    composerHasContent,
+    setComposerHasContent,
     onComposerFocusChange,
     composerInSteerState,
     composerModelFlyout,
@@ -61,7 +82,6 @@ export function renderAgentComposer(dependencies: RenderAgentComposerDependencie
     composerTiptapEditorRef,
     confirmUnrestricted,
     creditActionsDisabledReason,
-    draft,
     draftRef,
     dropActive,
     editOversizeComposerInput,
@@ -222,7 +242,8 @@ export function renderAgentComposer(dependencies: RenderAgentComposerDependencie
               disabled={
                 visibleIssueReportReview.submitting ||
                 visibleIssueReportImportingFiles ||
-                visibleIssueReportHasUnsentContext
+                visibleIssueReportHasUnsentContext ||
+                composerHasContent
               }
               onClick={() => void sendReviewableIssueReport(visibleIssueReportReview.sessionId)}
             >
@@ -233,7 +254,7 @@ export function renderAgentComposer(dependencies: RenderAgentComposerDependencie
                 ? "Sending"
                 : visibleIssueReportImportingFiles
                   ? "Attaching files"
-                  : visibleIssueReportHasUnsentContext
+                  : visibleIssueReportHasUnsentContext || composerHasContent
                     ? "Send message first"
                     : "Send report"}
             </button>
@@ -384,7 +405,9 @@ export function renderAgentComposer(dependencies: RenderAgentComposerDependencie
         ) : null}
         <ComposerEditor
           ref={composerEditorRef}
+          changeKey={composerDraftKeyRef.current}
           onFocusChange={onComposerFocusChange}
+          onContentChange={setComposerHasContent}
           skills={skills}
           placeholder={
             generatingVideo
@@ -403,25 +426,37 @@ export function renderAgentComposer(dependencies: RenderAgentComposerDependencie
                       ? "Ask June anything, run / commands"
                       : "Send a message"
           }
-          onChange={(text, nextCategory) => {
-            draftRef.current = text;
-            categoryRef.current = nextCategory;
-            setDraft(text);
-            setCategory(nextCategory);
-            if (
-              !skills &&
-              !skillCommandLoading &&
-              text.trimStart().startsWith("/") &&
-              !isBuiltinComposerSlashCommand(text)
-            ) {
-              void loadSkillCommands({ silent: true });
-            }
-            rememberComposerDraft(
+          onChange={(text, nextCategory, changedDraftKey) => {
+            const targetDraftKey = resolveChangedDraftKey(
+              changedDraftKey,
               composerDraftKeyRef.current,
-              text,
-              nextCategory,
-              attachmentsRef.current,
             );
+            if (targetDraftKey === composerDraftKeyRef.current) {
+              draftRef.current = text;
+              categoryRef.current = nextCategory;
+              setDraft(text);
+              setCategory(nextCategory);
+              if (
+                !skills &&
+                !skillCommandLoading &&
+                text.trimStart().startsWith("/") &&
+                !isBuiltinComposerSlashCommand(text)
+              ) {
+                void loadSkillCommands({ silent: true });
+              }
+            }
+            rememberComposerDraft(targetDraftKey, text, nextCategory, attachmentsRef.current);
+          }}
+          onPendingChangePersist={(text, nextCategory, changedDraftKey) => {
+            const targetDraftKey = resolveChangedDraftKey(
+              changedDraftKey,
+              composerDraftKeyRef.current,
+            );
+            if (targetDraftKey === composerDraftKeyRef.current) {
+              draftRef.current = text;
+              categoryRef.current = nextCategory;
+            }
+            rememberComposerDraft(targetDraftKey, text, nextCategory, attachmentsRef.current);
           }}
           onSubmit={() => void submit()}
           onBuiltinSlashCommand={(name) => {
@@ -517,7 +552,7 @@ export function renderAgentComposer(dependencies: RenderAgentComposerDependencie
               // redirects the run mid-flight (session.steer) without
               // interrupting it. Stop returns when the draft clears, and
               // Escape interrupts the turn at any time.
-              draft.trim().length > 0 || attachments.length > 0 ? (
+              composerHasContent || attachments.length > 0 ? (
                 // Keyed so the swap remounts (button-for-button in one slot
                 // would be updated in place) and the scale-in trade plays.
                 <button
@@ -566,7 +601,7 @@ export function renderAgentComposer(dependencies: RenderAgentComposerDependencie
                   Boolean(textActionsDisabledReason) ||
                   selectedHermesSessionIsProvisional ||
                   imageSlashBlockedByModel ||
-                  (!draft.trim() && !attachments.length)
+                  (!composerHasContent && !attachments.length)
                 }
                 title={
                   imageSlashBlockedByModel

--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -25,6 +25,13 @@ import type { BuiltinComposerSlashCommandName } from "../../../lib/agent-compose
 
 export type ComposerEditorHandle = {
   focus: () => void;
+  /** Publishes the current serialized document immediately. Returns false
+   * while an IME composition is active, when reading the document would
+   * capture an intermediate composition state. */
+  flushPendingChange: (options?: {
+    changeKey?: string | null;
+    persistWithoutRender?: boolean;
+  }) => boolean;
   clear: () => void;
   /** Replaces the whole document with plain text plus an optional leading
    * category chip. Used to prefill (hero shortcuts, HUD replies) and to restore
@@ -34,9 +41,9 @@ export type ComposerEditorHandle = {
   setContent: (
     text: string,
     category?: ReportCategory | null,
-    options?: { selectPlaceholder?: boolean; focus?: boolean },
+    options?: { selectPlaceholder?: boolean; focus?: boolean; changeKey?: string | null },
   ) => void;
-  /** Inserts or swaps the legacy message category tag at the caret. */
+  /** Inserts or swaps the legacy leading message category tag. */
   insertCategory: (category: ReportCategory) => void;
   /** Inserts a note reference chip at the caret. Multiple references can
    * coexist because they serialize into the prompt text. */
@@ -50,16 +57,39 @@ export type ComposerEditorHandle = {
 type ComposerEditorProps = {
   placeholder: string;
   skills?: HermesSkillInfo[] | null;
-  onChange: (text: string, category: ReportCategory | null) => void;
+  changeKey?: string | null;
+  onChange: (
+    text: string,
+    category: ReportCategory | null,
+    changeKey: string | null | undefined,
+  ) => void;
+  /** Persists a pending snapshot without updating React state. Used during
+   * teardown and lifecycle-driven draft switches so refs/storage stay
+   * authoritative without causing a nested render. */
+  onPendingChangePersist?: (
+    text: string,
+    category: ReportCategory | null,
+    changeKey: string | null | undefined,
+  ) => void;
   onSubmit: () => void;
   onFocusChange?: (focused: boolean) => void;
+  /** Reports cheap document empty/non-empty transitions without serializing
+   * the prompt, so Send can react immediately during the trailing window. */
+  onContentChange?: (hasContent: boolean) => void;
   /** Returns true when the host handles the selected command as an immediate
    * action instead of inserting its slash text into the draft. */
   onBuiltinSlashCommand?: (name: BuiltinComposerSlashCommandName) => boolean;
   /** Hands the live editor up to the parent (e.g. so the composer box can read
    * its DOM element for layout). */
   onReady?: (editor: Editor) => void;
+  /** Test seam for counting full-document serialization without changing the
+   * production serializer. */
+  testOnlySerializePlainText?: (doc: ProseMirrorNode) => string;
+  /** Test seam for keeping the trailing timer pending during menu interaction. */
+  testOnlyChangeDelayMs?: number;
 };
+
+export const COMPOSER_CHANGE_DELAY_MS = 75;
 
 /** Serializes the doc to the plain string sent to June: paragraph and
  * hard-break boundaries become newlines, the category chip contributes
@@ -87,6 +117,21 @@ function focusEnd(editor: Editor | null) {
   if (!editor || editor.isDestroyed) return;
   editor.commands.setTextSelection(editor.state.doc.content.size);
   editor.view.focus();
+}
+
+/** Stops at the first sendable leaf without allocating the serialized prompt.
+ * This is normally constant-time for a non-empty draft, while preserving the
+ * existing rule that whitespace and a report-category chip alone cannot send. */
+function hasSubmittableContent(doc: ProseMirrorNode): boolean {
+  let hasContent = false;
+  doc.descendants((node) => {
+    if (node.type.name === NOTE_REFERENCE_NODE || (node.isText && /\S/u.test(node.text ?? ""))) {
+      hasContent = true;
+      return false;
+    }
+    return !hasContent;
+  });
+  return hasContent;
 }
 
 /** Prepares a prefilled single-paragraph prompt for staging: strips the angle
@@ -158,32 +203,153 @@ export function buildDoc(
 
 export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorProps>(
   (
-    { placeholder, skills, onChange, onSubmit, onFocusChange, onBuiltinSlashCommand, onReady },
+    {
+      placeholder,
+      skills,
+      changeKey,
+      onChange,
+      onPendingChangePersist,
+      onSubmit,
+      onFocusChange,
+      onContentChange,
+      onBuiltinSlashCommand,
+      onReady,
+      testOnlySerializePlainText,
+      testOnlyChangeDelayMs,
+    },
     ref,
   ) => {
     const frameRef = useRef<HTMLDivElement | null>(null);
     const skillsRef = useRef(skills);
+    const pendingChangeTimerRef = useRef<number | null>(null);
+    const pendingChangeEditorRef = useRef<Editor | null>(null);
+    const pendingChangeKeyRef = useRef<string | null | undefined>(changeKey);
+    const changePendingRef = useRef(false);
+    const composingRef = useRef(false);
+    const hasContentRef = useRef(false);
+    const serializePlainTextRef = useRef(testOnlySerializePlainText ?? serializePlainText);
+    const changeDelayMsRef = useRef(testOnlyChangeDelayMs ?? COMPOSER_CHANGE_DELAY_MS);
+    const changeKeyRef = useRef(changeKey);
+    const flushPendingChangeRef = useRef<
+      (options?: { changeKey?: string | null; persistWithoutRender?: boolean }) => boolean
+    >(() => true);
+    serializePlainTextRef.current = testOnlySerializePlainText ?? serializePlainText;
+    changeDelayMsRef.current = testOnlyChangeDelayMs ?? COMPOSER_CHANGE_DELAY_MS;
+    changeKeyRef.current = changeKey;
     // Latest callbacks behind refs so the editor (created once) never closes
     // over a stale handler.
     const onChangeRef = useRef(onChange);
+    const onPendingChangePersistRef = useRef(onPendingChangePersist);
     const onSubmitRef = useRef(onSubmit);
     const onFocusChangeRef = useRef(onFocusChange);
+    const onContentChangeRef = useRef(onContentChange);
     const onBuiltinSlashCommandRef = useRef(onBuiltinSlashCommand);
     const onReadyRef = useRef(onReady);
     useEffect(() => {
       onChangeRef.current = onChange;
+      onPendingChangePersistRef.current = onPendingChangePersist;
       onSubmitRef.current = onSubmit;
       onFocusChangeRef.current = onFocusChange;
+      onContentChangeRef.current = onContentChange;
       onBuiltinSlashCommandRef.current = onBuiltinSlashCommand;
       onReadyRef.current = onReady;
       skillsRef.current = skills;
-    }, [onChange, onSubmit, onFocusChange, onBuiltinSlashCommand, onReady, skills]);
+    }, [
+      onChange,
+      onPendingChangePersist,
+      onSubmit,
+      onFocusChange,
+      onContentChange,
+      onBuiltinSlashCommand,
+      onReady,
+      skills,
+    ]);
 
     useEffect(() => {
       document.querySelectorAll(".agent-category-menu-host").forEach((host) => {
         host.dispatchEvent(new CustomEvent(CATEGORY_SKILLS_CHANGED_EVENT));
       });
     }, [skills]);
+
+    function clearPendingChangeTimer() {
+      if (pendingChangeTimerRef.current === null) return;
+      window.clearTimeout(pendingChangeTimerRef.current);
+      pendingChangeTimerRef.current = null;
+    }
+
+    function armPendingChangeTimer() {
+      clearPendingChangeTimer();
+      if (composingRef.current || !changePendingRef.current) return;
+      pendingChangeTimerRef.current = window.setTimeout(() => {
+        pendingChangeTimerRef.current = null;
+        flushPendingChangeRef.current();
+      }, changeDelayMsRef.current);
+    }
+
+    function scheduleChange(nextEditor: Editor) {
+      pendingChangeEditorRef.current = nextEditor;
+      pendingChangeKeyRef.current = changeKeyRef.current;
+      changePendingRef.current = true;
+      armPendingChangeTimer();
+    }
+
+    function flushPendingChange(options?: {
+      changeKey?: string | null;
+      persistWithoutRender?: boolean;
+    }) {
+      if (!changePendingRef.current) return true;
+      const nextEditor = pendingChangeEditorRef.current;
+      if (!nextEditor || nextEditor.isDestroyed) {
+        clearPendingChangeTimer();
+        changePendingRef.current = false;
+        return true;
+      }
+      // ProseMirror can retain its composing flag briefly after the DOM's
+      // compositionend event. Keep the trailing publish armed until both
+      // layers agree that the document is final.
+      if (composingRef.current || nextEditor.view.composing) {
+        armPendingChangeTimer();
+        return false;
+      }
+      clearPendingChangeTimer();
+      changePendingRef.current = false;
+      const publish = options?.persistWithoutRender
+        ? onPendingChangePersistRef.current
+        : onChangeRef.current;
+      publish?.(
+        serializePlainTextRef.current(nextEditor.state.doc),
+        categoryFromDoc(nextEditor.state.doc),
+        options && "changeKey" in options ? options.changeKey : pendingChangeKeyRef.current,
+      );
+      return true;
+    }
+    flushPendingChangeRef.current = flushPendingChange;
+
+    useEffect(
+      () => () => {
+        const pendingEditor = pendingChangeEditorRef.current;
+        if (
+          changePendingRef.current &&
+          pendingEditor &&
+          !pendingEditor.isDestroyed &&
+          !composingRef.current &&
+          !pendingEditor.view.composing
+        ) {
+          onPendingChangePersistRef.current?.(
+            serializePlainTextRef.current(pendingEditor.state.doc),
+            categoryFromDoc(pendingEditor.state.doc),
+            pendingChangeKeyRef.current,
+          );
+        }
+        if (pendingChangeTimerRef.current !== null) {
+          window.clearTimeout(pendingChangeTimerRef.current);
+          pendingChangeTimerRef.current = null;
+        }
+        pendingChangeEditorRef.current = null;
+        changePendingRef.current = false;
+      },
+      [],
+    );
 
     function updateScrollFades(nextEditor: Editor | null) {
       const frame = frameRef.current;
@@ -214,7 +380,10 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
 
     const editor = useEditor({
       onFocus: () => onFocusChangeRef.current?.(true),
-      onBlur: () => onFocusChangeRef.current?.(false),
+      onBlur: () => {
+        flushPendingChangeRef.current();
+        onFocusChangeRef.current?.(false);
+      },
       extensions: [
         StarterKit.configure({
           // Truly-plain composer: no block structure or inline marks, just text,
@@ -239,7 +408,10 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
         Placeholder.configure({ placeholder }),
         createCategoryChip({
           skills: () => skillsRef.current,
-          onBuiltinCommand: (name) => onBuiltinSlashCommandRef.current?.(name) ?? false,
+          onBuiltinCommand: (name) => {
+            if (!flushPendingChange({ changeKey: changeKeyRef.current })) return false;
+            return onBuiltinSlashCommandRef.current?.(name) ?? false;
+          },
         }),
         createNoteReference(),
       ],
@@ -267,29 +439,55 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
           }
           return true;
         },
-        handleKeyDown: (_view, event) => {
-          if (event.key !== "Enter" || event.shiftKey || event.isComposing) {
+        handleKeyDown: (view, event) => {
+          if (
+            event.key !== "Enter" ||
+            event.shiftKey ||
+            event.isComposing ||
+            composingRef.current ||
+            view.composing
+          ) {
             return false;
           }
           // Suggestion palettes own Enter while open (they commit the
           // highlighted row); only a closed palette submits the message.
           if (document.querySelector(".agent-category-menu-host")) return false;
           event.preventDefault();
+          if (!flushPendingChange({ changeKey: changeKeyRef.current })) return true;
           onSubmitRef.current();
           return true;
         },
+        handleDOMEvents: {
+          compositionstart: () => {
+            composingRef.current = true;
+            clearPendingChangeTimer();
+            return false;
+          },
+          compositionend: () => {
+            composingRef.current = false;
+            // onUpdate during composition marked the snapshot dirty without
+            // reading it. The final input transaction may arrive just after
+            // compositionend; either way this trailing timer is rescheduled
+            // by that transaction and publishes only the final document.
+            armPendingChangeTimer();
+            return false;
+          },
+        },
       },
       onCreate: ({ editor }) => {
+        pendingChangeEditorRef.current = editor;
         queueMicrotask(() => {
           updateScrollFades(editor);
           if (!editor.isDestroyed) onReadyRef.current?.(editor);
         });
       },
       onUpdate: ({ editor }) => {
-        onChangeRef.current(
-          serializePlainText(editor.state.doc),
-          categoryFromDoc(editor.state.doc),
-        );
+        const hasContent = hasSubmittableContent(editor.state.doc);
+        if (hasContentRef.current !== hasContent) {
+          hasContentRef.current = hasContent;
+          onContentChangeRef.current?.(hasContent);
+        }
+        scheduleChange(editor);
         requestAnimationFrame(() => updateScrollFades(editor));
       },
       onSelectionUpdate: ({ editor }) => {
@@ -298,7 +496,7 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
     });
 
     useEffect(() => {
-      if (!editor) return;
+      if (!editor || editor.isDestroyed) return;
       const scroller = editor.view.dom;
       let frame = 0;
       const schedule = () => {
@@ -322,9 +520,14 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
       ref,
       () => ({
         focus: () => focusEnd(editor),
-        clear: () => editor?.commands.clearContent(true),
+        flushPendingChange: (options) => flushPendingChange(options),
+        clear: () => {
+          if (editor && !editor.isDestroyed) {
+            editor.commands.clearContent(true);
+          }
+        },
         setContent: (text, category, options) => {
-          if (!editor) return;
+          if (!editor || editor.isDestroyed) return;
           const staged = options?.selectPlaceholder && !category ? stripPlaceholder(text) : null;
           editor.commands.setContent(
             buildDoc(staged?.text ?? text, category, { rehydrateNoteTokens: !staged }),
@@ -332,6 +535,12 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
               emitUpdate: true,
             },
           );
+          // setContent dispatches synchronously, but it can run just before a
+          // session-switch render updates the prop-backed key. Attribute that
+          // pending publish to the destination draft explicitly.
+          if (options && "changeKey" in options) {
+            pendingChangeKeyRef.current = options.changeKey;
+          }
           // A hero shortcut authors a "<placeholder>" token; the brackets are
           // stripped before the text hits the document and the bare phrase left
           // selected (rather than parking the caret at the end) so typing
@@ -346,10 +555,12 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
           }
         },
         insertCategory: (category) => {
-          if (editor) insertReportCategory(editor, category);
+          if (editor && !editor.isDestroyed) insertReportCategory(editor, category);
         },
         insertNoteReference: (noteReference) => {
-          if (editor) insertNoteReference(editor, noteReference);
+          if (editor && !editor.isDestroyed) {
+            insertNoteReference(editor, noteReference);
+          }
         },
         insertPlainText: (text) => {
           if (!editor || editor.isDestroyed) return false;

--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -327,6 +327,8 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
 
     useEffect(
       () => () => {
+        // useEditor defers destruction by one task so this later effect can
+        // persist the final pending document while the editor is still live.
         const pendingEditor = pendingChangeEditorRef.current;
         if (
           changePendingRef.current &&

--- a/src/components/agent/composer/categoryChip.ts
+++ b/src/components/agent/composer/categoryChip.ts
@@ -32,21 +32,20 @@ const SLASH_MENU_SKILL_LIMIT = Number.MAX_SAFE_INTEGER;
 const CATEGORY_SUGGESTION_PLUGIN_KEY = new PluginKey("agentCategorySuggestion");
 export const CATEGORY_SKILLS_CHANGED_EVENT = "agent-category-skills-changed";
 
-/** Reads the active category from a doc by scanning for the chip node. The
- * single-chip invariant (enforced on insert) means the first hit is the
- * answer. */
+/** Reads the active category from the first paragraph's inline children.
+ * Category drafts are built with a leading chip, but a pointer can still place
+ * the caret before that atom. Scanning sibling nodes preserves that case
+ * without descending through every block or walking any text characters. */
 export function categoryFromDoc(doc: ProseMirrorNode): ReportCategory | null {
-  let category: ReportCategory | null = null;
-  doc.descendants((node) => {
-    if (category) return false;
-    if (node.type.name === CATEGORY_CHIP_NODE) {
-      const value = node.attrs.category;
-      if (typeof value === "string") category = value as ReportCategory;
-      return false;
-    }
-    return true;
-  });
-  return category;
+  const firstBlock = doc.firstChild;
+  if (!firstBlock) return null;
+  for (let index = 0; index < firstBlock.childCount; index += 1) {
+    const inlineNode = firstBlock.child(index);
+    if (inlineNode.type.name !== CATEGORY_CHIP_NODE) continue;
+    const value = inlineNode.attrs.category;
+    return typeof value === "string" ? (value as ReportCategory) : null;
+  }
+  return null;
 }
 
 /** Removes every existing chip from `tr`, deleting from the end so the earlier
@@ -103,11 +102,15 @@ function insertCategoryCommand(category: ReportCategory, range?: { from: number;
   };
 }
 
-/** Inserts (or swaps) the category chip at the current selection. Kept for
- * restored older drafts and focused tests; new report entry points use the
- * direct-submit popover instead. */
+/** Inserts (or swaps) the category chip at the start of the first paragraph.
+ * Kept for restored older drafts and focused tests; new report entry points
+ * use the direct-submit popover instead. */
 export function insertReportCategory(editor: Editor, category: ReportCategory) {
-  editor.chain().focus().command(insertCategoryCommand(category)).run();
+  editor
+    .chain()
+    .focus()
+    .command(insertCategoryCommand(category, { from: 1, to: 1 }))
+    .run();
 }
 
 /** The inline atom chip ("Bug report" / "Feedback" / "Feature request"). Built

--- a/src/components/agent/composer/submit-composer-types.ts
+++ b/src/components/agent/composer/submit-composer-types.ts
@@ -30,7 +30,6 @@ export type SubmitComposerDependencies = {
   ) => PendingAttachmentPreparation;
   cancelComposerDispatch: (reservation: HermesSessionDispatchReservation | undefined) => void;
   captureSessionModelTarget: (explicitSession?: HermesSessionInfo) => CapturedSessionModelTarget;
-  category: ReportCategory | null;
   categoryRef: React.MutableRefObject<ReportCategory | null>;
   clearComposerDraft: (key?: string) => void;
   composerDispatchOrderRef: React.MutableRefObject<number>;
@@ -39,10 +38,8 @@ export type SubmitComposerDependencies = {
   ) => boolean;
   composerDraftKeyRef: React.MutableRefObject<string | null>;
   composerEditorRef: React.MutableRefObject<ComposerEditorHandle | null>;
-  composerInputSignature: string;
   composerSizeProceedSignatureRef: React.MutableRefObject<string | null>;
   deferredFailedIssueReportDeliverySessionIdsRef: React.MutableRefObject<Set<string>>;
-  draft: string;
   draftRef: React.MutableRefObject<string>;
   enqueueAttachmentFollowUp: (
     sessionId: string,
@@ -73,7 +70,6 @@ export type SubmitComposerDependencies = {
     dispatchReservation?: HermesSessionDispatchReservation,
   ) => Promise<boolean>;
   heroMode: boolean;
-  imageSlashBlockedByModel: boolean;
   importingFiles: boolean;
   newSessionModeRef: React.MutableRefObject<boolean>;
   pendingSteerBySessionIdRef: React.MutableRefObject<Record<string, PendingSteer[]>>;

--- a/src/components/agent/composer/submit-composer.ts
+++ b/src/components/agent/composer/submit-composer.ts
@@ -5,9 +5,13 @@ import { messageFromError } from "../../../lib/errors";
 import { categoryPrompt } from "../../../lib/issue-report-prompt";
 import { ISSUE_REPORT_ATTACHMENTS_ONLY_DESCRIPTION } from "./reportCategory";
 import { prepareProjectPrompt } from "../../../lib/agent-project-context";
+import { parseBuiltinComposerSlashCommand } from "../../../lib/agent-composer-slash-commands";
+import { IMAGE_GENERATION_ENABLED } from "../../../lib/feature-flags";
+import { modelSupportsImageInput } from "../../../lib/model-privacy";
 import type { PendingIssueReport } from "../agent-session-continuity";
 import { AttachBlockedError } from "./media-slash-persistence";
 import { type PendingSteer, type PreparedComposerSubmission } from "./follow-up-queue";
+import { composerInputSignatureFor } from "./composer-input-helpers";
 import {
   appendIssueReportFollowUp,
   dispatchIssueReportFollowUpSubmitFailed,
@@ -28,17 +32,14 @@ export function createSubmitComposer(dependencies: SubmitComposerDependencies) {
     beginAttachmentPreparation,
     cancelComposerDispatch,
     captureSessionModelTarget,
-    category,
     categoryRef,
     clearComposerDraft,
     composerDispatchOrderRef,
     composerDispatchWasInvalidated,
     composerDraftKeyRef,
     composerEditorRef,
-    composerInputSignature,
     composerSizeProceedSignatureRef,
     deferredFailedIssueReportDeliverySessionIdsRef,
-    draft,
     draftRef,
     enqueueAttachmentFollowUp,
     enqueueFailedComposerFollowUp,
@@ -48,7 +49,6 @@ export function createSubmitComposer(dependencies: SubmitComposerDependencies) {
     generationModels,
     handleBuiltinComposerSlashCommand,
     heroMode,
-    imageSlashBlockedByModel,
     importingFiles,
     newSessionModeRef,
     pendingSteerBySessionIdRef,
@@ -81,14 +81,30 @@ export function createSubmitComposer(dependencies: SubmitComposerDependencies) {
 
   async function submit(event?: FormEvent) {
     event?.preventDefault();
-    const message = draft.trim();
+    const message = draftRef.current.trim();
+    const reportCategory = categoryRef.current;
+    const submittedComposerInputSignature = composerInputSignatureFor({
+      message,
+      category: reportCategory,
+      attachments,
+      model: generationModel,
+    });
+    const submittedSlashCommand = parseBuiltinComposerSlashCommand(message);
+    const submittedGenerationModel = generationModel
+      ? generationModels.find((model) => model.id === generationModel.id)
+      : undefined;
+    const submittedImageSlashBlockedByModel =
+      IMAGE_GENERATION_ENABLED &&
+      submittedSlashCommand?.name === "image" &&
+      !!submittedGenerationModel &&
+      !modelSupportsImageInput(submittedGenerationModel);
     if (
       (!message && !attachments.length) ||
       submitting ||
       importingFiles ||
       textActionsDisabledReason ||
       selectedHermesSessionIsProvisional ||
-      imageSlashBlockedByModel
+      submittedImageSlashBlockedByModel
     )
       return;
     // This is the user-visible Send boundary. Skill expansion, file reads, and
@@ -134,7 +150,7 @@ export function createSubmitComposer(dependencies: SubmitComposerDependencies) {
     }
     const attachmentQueueSessionId =
       attachments.length > 0 &&
-      !category &&
+      !reportCategory &&
       !newSessionModeRef.current &&
       selectedHermesSessionId &&
       workingSessionIdsRef.current.has(selectedHermesSessionId)
@@ -167,7 +183,7 @@ export function createSubmitComposer(dependencies: SubmitComposerDependencies) {
       }
       const sizeWarning = oversizedComposerInputWarning({
         content: sizeEstimateContent(prepared.runtimeContent, attachmentQueueSessionId),
-        inputSignature: composerInputSignature,
+        inputSignature: submittedComposerInputSignature,
         attachments,
         model: generationModel,
         models: generationModels,
@@ -201,14 +217,14 @@ export function createSubmitComposer(dependencies: SubmitComposerDependencies) {
     if (
       message &&
       !attachments.length &&
-      !category &&
+      !reportCategory &&
       !newSessionModeRef.current &&
       selectedHermesSessionId &&
       workingSessionIdsRef.current.has(selectedHermesSessionId)
     ) {
       const steerSizeWarning = oversizedComposerInputWarning({
         content: message,
-        inputSignature: composerInputSignature,
+        inputSignature: submittedComposerInputSignature,
         attachments: [],
         model: generationModel,
         models: generationModels,
@@ -274,7 +290,6 @@ export function createSubmitComposer(dependencies: SubmitComposerDependencies) {
     // The composer's category chip makes this a report: wrap the prompt to
     // frame it for the team and queue the delivery. Captured before the
     // composer clears so a failed send can restore the chip on retry.
-    const reportCategory = category;
     const reportFollowUpSessionId =
       !reportCategory && !newSessionModeRef.current && selectedHermesSessionId
         ? selectedHermesSessionId
@@ -305,6 +320,10 @@ export function createSubmitComposer(dependencies: SubmitComposerDependencies) {
         }
       | undefined;
     try {
+      // Keep the post-Send typing position at the end while async skill and
+      // attachment preparation runs. A user can immediately continue editing
+      // the still-visible draft without their text jumping to the front.
+      composerEditorRef.current?.focus();
       const prepared = await prepareComposerSubmission(message, attachments);
       if (composerDispatchWasInvalidated(sentDispatchReservation)) return;
       const runtimeContent = reportCategory
@@ -313,7 +332,7 @@ export function createSubmitComposer(dependencies: SubmitComposerDependencies) {
       preparedForRecovery = { ...prepared, runtimeContent };
       const sizeWarning = oversizedComposerInputWarning({
         content: sizeEstimateContent(runtimeContent, selectedHermesSessionId ?? undefined),
-        inputSignature: composerInputSignature,
+        inputSignature: submittedComposerInputSignature,
         attachments,
         model: generationModel,
         models: generationModels,
@@ -341,7 +360,15 @@ export function createSubmitComposer(dependencies: SubmitComposerDependencies) {
               attachments.map((attachment) => attachment.path),
             )
           : undefined;
-      if (draftRef.current.trim() === message && categoryRef.current === reportCategory) {
+      const liveComposerIsFinal =
+        composerEditorRef.current?.flushPendingChange({
+          changeKey: composerDraftKeyRef.current,
+        }) ?? true;
+      if (
+        liveComposerIsFinal &&
+        draftRef.current.trim() === message &&
+        categoryRef.current === reportCategory
+      ) {
         composerEditorRef.current?.clear();
         setDraft("");
         setCategory(null);
@@ -384,6 +411,13 @@ export function createSubmitComposer(dependencies: SubmitComposerDependencies) {
     } catch (err) {
       if (composerDispatchWasInvalidated(sentDispatchReservation)) return;
       const errorMessage = messageFromError(err);
+      // A send can fail inside the trailing publish window while the user is
+      // already typing their next message. Publish that live document before
+      // deciding whether the failed message belongs back in the composer or
+      // in Up next.
+      composerEditorRef.current?.flushPendingChange({
+        changeKey: composerDraftKeyRef.current,
+      });
       const composerHasNewInput = Boolean(
         !(composerEditorRef.current?.isEmpty() ?? true) ||
           draftRef.current.trim() ||

--- a/src/components/agent/follow-up-queue-actions.ts
+++ b/src/components/agent/follow-up-queue-actions.ts
@@ -170,6 +170,7 @@ export function createFollowUpQueueActions(dependencies: createFollowUpQueueActi
     ) {
       return;
     }
+    if (!composerEditorRef.current?.flushPendingChange()) return;
     if (draftRef.current.trim() || attachmentsRef.current.length) return;
     const item = queuedAttachmentFollowUpsRef.current[queueKey]?.find(
       (candidate) => candidate.id === itemId,

--- a/src/components/agent/queued-follow-up-renderers-types.ts
+++ b/src/components/agent/queued-follow-up-renderers-types.ts
@@ -5,13 +5,13 @@ import type * as React from "react";
 
 export type createQueuedFollowUpRenderersDependencies = {
   attachments: AgentAttachment[];
+  composerHasContent: boolean;
   composerEditorRef: React.MutableRefObject<ComposerEditorHandle | null>;
   deliverQueuedAttachmentFollowUp: (
     queueKey: string,
     itemId?: string,
     options?: { afterCompletion?: boolean },
   ) => Promise<boolean>;
-  draft: string;
   draftRef: React.MutableRefObject<string>;
   editQueuedAttachmentFollowUp: (queueKey: string, itemId: string) => void;
   queuedAttachmentFollowUpsRef: React.MutableRefObject<Record<string, QueuedAttachmentFollowUp[]>>;

--- a/src/components/agent/queued-follow-up-renderers.tsx
+++ b/src/components/agent/queued-follow-up-renderers.tsx
@@ -14,9 +14,9 @@ export function createQueuedFollowUpRenderers(
 ) {
   const {
     attachments,
+    composerHasContent,
     composerEditorRef,
     deliverQueuedAttachmentFollowUp,
-    draft,
     draftRef,
     editQueuedAttachmentFollowUp,
     queuedAttachmentFollowUpsRef,
@@ -54,7 +54,7 @@ export function createQueuedFollowUpRenderers(
       (attachment) => attachment.attach.kind === "image" && attachment.attach.status === "attached",
     );
     const locallyEditable = item.status !== "sending" && !hasAttachedImage;
-    const editable = locallyEditable && !draft.trim() && attachments.length === 0;
+    const editable = locallyEditable && !composerHasContent && attachments.length === 0;
     const statusLabel =
       item.status === "sending"
         ? "Sending"

--- a/src/components/agent/task-submission-action.ts
+++ b/src/components/agent/task-submission-action.ts
@@ -35,6 +35,15 @@ export function createTaskSubmissionAction(dependencies: createTaskSubmissionAct
     request?: AgentNewSessionDetail,
     options: { deferSeed?: boolean } = {},
   ) {
+    const liveComposer = composerEditorRef.current;
+    if (
+      liveComposer &&
+      !liveComposer.flushPendingChange({
+        changeKey: composerDraftKeyRef.current,
+      })
+    ) {
+      return;
+    }
     clearPendingNewSessionRequest();
     const seedCategory = request?.category ?? null;
     const seedNoteRef = seedCategory ? null : (request?.noteRef ?? null);

--- a/src/components/agent/use-agent-hero-rotation-types.ts
+++ b/src/components/agent/use-agent-hero-rotation-types.ts
@@ -1,7 +1,7 @@
 import type * as React from "react";
 
 export type useAgentHeroRotationDependencies = {
-  draftRef: React.MutableRefObject<string>;
+  composerHasContent: boolean;
   heroChipsHoverRef: React.MutableRefObject<boolean>;
   heroMode: boolean;
   setHeroChipPhase: React.Dispatch<React.SetStateAction<"in" | "out">>;

--- a/src/components/agent/use-agent-hero-rotation.ts
+++ b/src/components/agent/use-agent-hero-rotation.ts
@@ -8,7 +8,7 @@ import {
 import type { useAgentHeroRotationDependencies } from "./use-agent-hero-rotation-types";
 
 export function useAgentHeroRotation(dependencies: useAgentHeroRotationDependencies) {
-  const { draftRef, heroChipsHoverRef, heroMode, setHeroChipPhase, setHeroDeckStart } =
+  const { composerHasContent, heroChipsHoverRef, heroMode, setHeroChipPhase, setHeroDeckStart } =
     dependencies;
 
   useEffect(() => {
@@ -23,7 +23,7 @@ export function useAgentHeroRotation(dependencies: useAgentHeroRotationDependenc
     let swapTimeout: number | undefined;
     const interval = window.setInterval(() => {
       if (document.hidden || heroChipsHoverRef.current) return;
-      if (draftRef.current.trim()) return;
+      if (composerHasContent) return;
       setHeroChipPhase("out");
       swapTimeout = window.setTimeout(() => {
         setHeroDeckStart((start) => (start + HERO_SHORTCUT_COUNT) % AGENT_SHORTCUTS.length);
@@ -38,5 +38,5 @@ export function useAgentHeroRotation(dependencies: useAgentHeroRotationDependenc
       window.clearInterval(interval);
       if (swapTimeout !== undefined) window.clearTimeout(swapTimeout);
     };
-  }, [heroMode]);
+  }, [composerHasContent, heroMode]);
 }

--- a/src/components/agent/use-agent-view-state-types.ts
+++ b/src/components/agent/use-agent-view-state-types.ts
@@ -33,7 +33,7 @@ export type UseAgentViewStateDependencies = {
   composerModelSearchRef: React.RefObject<HTMLInputElement>;
   composerModelTriggerRef: React.RefObject<HTMLButtonElement>;
   composerSteerDemo: boolean;
-  draft: string;
+  composerHasContent: boolean;
   errorState: AgentWorkspaceError | null;
   fullModeDraftRef: React.MutableRefObject<boolean>;
   gallerySections: AgentChatGallerySection[] | null;

--- a/src/components/agent/use-agent-view-state.ts
+++ b/src/components/agent/use-agent-view-state.ts
@@ -36,7 +36,7 @@ export function useAgentViewState(dependencies: UseAgentViewStateDependencies) {
     composerModelSearchRef,
     composerModelTriggerRef,
     composerSteerDemo,
-    draft,
+    composerHasContent,
     errorState,
     fullModeDraftRef,
     gallerySections,
@@ -231,7 +231,7 @@ export function useAgentViewState(dependencies: UseAgentViewStateDependencies) {
         }
       : undefined;
   const visibleIssueReportHasUnsentContext = Boolean(
-    visibleIssueReportReview && (draft.trim() || attachments.length),
+    visibleIssueReportReview && (composerHasContent || attachments.length),
   );
   const visibleIssueReportImportingFiles = Boolean(visibleIssueReportReview && importingFiles);
   // Holds the prior render's heroMode. Read by both the composer auto-grow

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -539,12 +539,12 @@ export function NoteChatPanel({
         setModelOpen(false);
         return;
       }
-      if (draftRef.current.trim()) return;
+      if (!draftEmpty) return;
       onCloseRef.current();
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [modelOpen]);
+  }, [draftEmpty, modelOpen]);
 
   // Restore the remembered width once per mount; the var lives on .app-shell
   // because the main card's margin and the editor footer consume it too.
@@ -601,13 +601,18 @@ export function NoteChatPanel({
     fade.update();
   }, [turns.length, lastTurnSize, working, fade.update]);
 
-  async function handleSend(text: string) {
+  async function handleSend() {
     if (working || importing || textActionsDisabledReason) return;
+    if (!composerRef.current?.flushPendingChange()) return;
+    const serializedText = draftRef.current;
+    const text = serializedText.trim();
     setComposerError(null);
     const result = await submit(text, attachments);
     // Clear the composer only when this panel still owns the accepted send.
     // A stale/switched panel must not wipe the draft of the newly selected note.
     if (result.accepted && result.current) {
+      if (!composerRef.current?.flushPendingChange()) return;
+      if (draftRef.current !== serializedText) return;
       draftRef.current = "";
       setDraftEmpty(true);
       setAttachments([]);
@@ -791,7 +796,8 @@ export function NoteChatPanel({
                 draftRef.current = text;
                 setDraftEmpty(!text.trim());
               }}
-              onSubmit={() => void handleSend(draftRef.current)}
+              onContentChange={(hasContent) => setDraftEmpty(!hasContent)}
+              onSubmit={() => void handleSend()}
             />
             <div className="agent-composer-toolbar">
               <button
@@ -852,7 +858,7 @@ export function NoteChatPanel({
                       importing ||
                       (draftEmpty && !attachments.length)
                     }
-                    onClick={() => void handleSend(draftRef.current)}
+                    onClick={() => void handleSend()}
                   >
                     <IconArrowUp size={18} />
                   </button>

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1636,7 +1636,16 @@ describe("AgentWorkspace", () => {
     ).toHaveLength(1);
     expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("session.steer", expect.anything());
 
-    await user.click(screen.getByRole("button", { name: "Edit queued message" }));
+    await user.type(composer, "keep my new draft");
+    const editQueuedMessage = screen.getByRole("button", { name: "Edit queued message" });
+    expect(editQueuedMessage).toBeDisabled();
+    expect(editQueuedMessage).toHaveAttribute("title", "Clear the composer before editing");
+    expect(composer).toHaveTextContent("keep my new draft");
+    expect(screen.getByText("review the brief next")).toBeInTheDocument();
+
+    await user.clear(composer);
+    expect(editQueuedMessage).toBeEnabled();
+    await user.click(editQueuedMessage);
     expect(screen.queryByText("Up next")).toBeNull();
     expect(composer).toHaveTextContent("review the brief next");
     expect(screen.getByText("brief.pdf")).toBeInTheDocument();
@@ -12079,6 +12088,58 @@ describe("AgentWorkspace", () => {
     );
     expect(await screen.findByText("Q2 report.pdf")).toBeInTheDocument();
     expect(composer.textContent).toBe("");
+    expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "prompt.submit")).toBe(
+      false,
+    );
+  });
+
+  it("keeps text typed while a slash-command file import is pending", async () => {
+    let resolveImport:
+      | ((file: {
+          name: string;
+          path: string;
+          rootLabel: string;
+          size: number;
+          previewDataUrl: null;
+        }) => void)
+      | undefined;
+    mocks.importHermesBridgeFile.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveImport = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    const composer = screen.getByRole("textbox");
+    const command = '/file "/Users/alex/Desktop/Q2 report.pdf"';
+    await user.type(composer, command);
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.importHermesBridgeFile).toHaveBeenCalledWith(
+        "/Users/alex/Desktop/Q2 report.pdf",
+      ),
+    );
+
+    await user.type(composer, " keep these instructions");
+    const liveText = composer.textContent;
+    await act(async () => {
+      resolveImport?.({
+        name: "Q2 report.pdf",
+        path: "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/workspace/uploads/Q2 report.pdf",
+        rootLabel: "Workspace",
+        size: 1234,
+        previewDataUrl: null,
+      });
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("Q2 report.pdf")).toBeInTheDocument();
+    expect(composer.textContent).toBe(liveText);
+    expect(composer).toHaveTextContent('/file "/Users/alex/Desktop/Q2 report.pdf"');
+    expect(composer).toHaveTextContent("keep these instructions");
     expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "prompt.submit")).toBe(
       false,
     );

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -1089,7 +1089,9 @@ describe("App shortcuts", () => {
 
     mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
 
-    expect(await screen.findByRole("heading", { name: "General" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "General" }, { timeout: 10_000 }),
+    ).toBeInTheDocument();
   });
 
   it("refreshes Accessibility after requesting access without opening settings over the native prompt", async () => {

--- a/src/test/category-chip.test.ts
+++ b/src/test/category-chip.test.ts
@@ -55,6 +55,26 @@ describe("category chip insertion", () => {
     // orphaned separator used to leave behind).
     expect(serializePlainText(editor.state.doc)).toBe(" ");
   });
+
+  it("keeps the chip first when inserting into an existing draft", () => {
+    editor = makeEditor();
+    editor.commands.setContent("Report details");
+    editor.commands.setTextSelection(editor.state.doc.content.size);
+
+    insertReportCategory(editor, "bug");
+
+    expect(categoryFromDoc(editor.state.doc)).toBe("bug");
+    expect(serializePlainText(editor.state.doc)).toBe(" Report details");
+  });
+
+  it("finds the category when text is inserted before the chip", () => {
+    editor = makeEditor();
+    insertReportCategory(editor, "bug");
+    editor.commands.setTextSelection(1);
+    editor.commands.insertContent("Report details");
+
+    expect(categoryFromDoc(editor.state.doc)).toBe("bug");
+  });
 });
 
 describe("hero-shortcut placeholder staging", () => {

--- a/src/test/composer-editor-change-publishing.test.tsx
+++ b/src/test/composer-editor-change-publishing.test.tsx
@@ -1,5 +1,5 @@
 import type { Editor } from "@tiptap/react";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -15,6 +15,7 @@ afterEach(() => {
 
 async function renderComposer(options: {
   onChange?: (text: string) => void;
+  onPendingChangePersist?: (text: string) => void;
   onContentChange?: (hasContent: boolean) => void;
   onSubmit?: () => void;
   onBuiltinSlashCommand?: () => boolean;
@@ -26,6 +27,7 @@ async function renderComposer(options: {
     <ComposerEditor
       placeholder="Message June"
       onChange={(text) => options.onChange?.(text)}
+      onPendingChangePersist={(text) => options.onPendingChangePersist?.(text)}
       onContentChange={options.onContentChange}
       onSubmit={() => options.onSubmit?.()}
       onBuiltinSlashCommand={options.onBuiltinSlashCommand}
@@ -160,5 +162,28 @@ describe("composer change publishing", () => {
 
     expect(serialize).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith("編集中");
+  });
+
+  it("persists a pending document before TipTap destroys the editor on unmount", async () => {
+    const serialize = vi.fn(serializePlainText);
+    const onChange = vi.fn();
+    const onPendingChangePersist = vi.fn();
+    const editor = await renderComposer({
+      onChange,
+      onPendingChangePersist,
+      serialize,
+      changeDelayMs: 10_000,
+    });
+    vi.useFakeTimers();
+
+    act(() => {
+      editor.commands.insertContent("survives teardown");
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    cleanup();
+
+    expect(serialize).toHaveBeenCalledTimes(1);
+    expect(onPendingChangePersist).toHaveBeenCalledWith("survives teardown");
   });
 });

--- a/src/test/composer-editor-change-publishing.test.tsx
+++ b/src/test/composer-editor-change-publishing.test.tsx
@@ -1,0 +1,164 @@
+import type { Editor } from "@tiptap/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  COMPOSER_CHANGE_DELAY_MS,
+  ComposerEditor,
+  serializePlainText,
+} from "../components/agent/composer/ComposerEditor";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function renderComposer(options: {
+  onChange?: (text: string) => void;
+  onContentChange?: (hasContent: boolean) => void;
+  onSubmit?: () => void;
+  onBuiltinSlashCommand?: () => boolean;
+  serialize?: typeof serializePlainText;
+  changeDelayMs?: number;
+}) {
+  let editor: Editor | null = null;
+  render(
+    <ComposerEditor
+      placeholder="Message June"
+      onChange={(text) => options.onChange?.(text)}
+      onContentChange={options.onContentChange}
+      onSubmit={() => options.onSubmit?.()}
+      onBuiltinSlashCommand={options.onBuiltinSlashCommand}
+      onReady={(readyEditor) => {
+        editor = readyEditor;
+      }}
+      testOnlySerializePlainText={options.serialize}
+      testOnlyChangeDelayMs={options.changeDelayMs}
+    />,
+  );
+  await waitFor(() => expect(editor).not.toBeNull());
+  return editor as unknown as Editor;
+}
+
+describe("composer change publishing", () => {
+  it("bounds full-document serialization to one trailing call for a typing burst", async () => {
+    const serialize = vi.fn(serializePlainText);
+    const onChange = vi.fn();
+    const editor = await renderComposer({ onChange, serialize });
+    vi.useFakeTimers();
+
+    act(() => {
+      for (const character of "long prompt") {
+        editor.commands.insertContent(character);
+      }
+    });
+
+    expect(serialize).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(COMPOSER_CHANGE_DELAY_MS);
+    });
+
+    expect(serialize).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("long prompt");
+  });
+
+  it("updates sendability without serializing the document or counting whitespace", async () => {
+    const serialize = vi.fn(serializePlainText);
+    const onContentChange = vi.fn();
+    const editor = await renderComposer({ serialize, onContentChange });
+    vi.useFakeTimers();
+
+    act(() => {
+      editor.commands.insertContent("   ");
+    });
+    expect(onContentChange).not.toHaveBeenCalled();
+    expect(serialize).not.toHaveBeenCalled();
+
+    act(() => {
+      editor.commands.insertContent("x");
+    });
+    expect(onContentChange).toHaveBeenLastCalledWith(true);
+    expect(serialize).not.toHaveBeenCalled();
+  });
+
+  it("flushes the exact final text synchronously before Enter submits", async () => {
+    const serialize = vi.fn(serializePlainText);
+    let latestText = "";
+    let submittedText = "";
+    const editor = await renderComposer({
+      serialize,
+      onChange: (text) => {
+        latestText = text;
+      },
+      onSubmit: () => {
+        submittedText = latestText;
+      },
+    });
+    vi.useFakeTimers();
+
+    act(() => {
+      editor.commands.insertContent("exact final text");
+    });
+    expect(serialize).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "Message June" }), {
+      key: "Enter",
+    });
+
+    expect(serialize).toHaveBeenCalledTimes(1);
+    expect(submittedText).toBe("exact final text");
+  });
+
+  it("flushes pending text before a slash-menu command reads composer state", async () => {
+    const serialize = vi.fn(serializePlainText);
+    let latestText = "";
+    let slashMenuText = "";
+    await renderComposer({
+      serialize,
+      changeDelayMs: 10_000,
+      onChange: (text) => {
+        latestText = text;
+      },
+      onBuiltinSlashCommand: () => {
+        slashMenuText = latestText;
+        return true;
+      },
+    });
+    const user = userEvent.setup();
+
+    await user.type(screen.getByRole("textbox", { name: "Message June" }), "/");
+    expect(serialize).not.toHaveBeenCalled();
+
+    fireEvent.mouseDown(screen.getByRole("option", { name: "Model" }));
+
+    expect(serialize).toHaveBeenCalledTimes(1);
+    expect(slashMenuText).toBe("/");
+  });
+
+  it("does not serialize an intermediate IME composition", async () => {
+    const serialize = vi.fn(serializePlainText);
+    const onChange = vi.fn();
+    const editor = await renderComposer({ onChange, serialize });
+    vi.useFakeTimers();
+    const textbox = screen.getByRole("textbox", { name: "Message June" });
+
+    fireEvent.compositionStart(textbox);
+    act(() => {
+      editor.commands.insertContent("編集中");
+      vi.advanceTimersByTime(COMPOSER_CHANGE_DELAY_MS * 2);
+    });
+
+    expect(serialize).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.compositionEnd(textbox);
+    act(() => {
+      vi.advanceTimersByTime(COMPOSER_CHANGE_DELAY_MS * 2);
+    });
+
+    expect(serialize).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("編集中");
+  });
+});

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -610,6 +610,83 @@ describe("note chat session map", () => {
     expect(composer).toHaveTextContent("Keep this draft");
   });
 
+  it("flushes the exact note-chat text before a send-button submit", async () => {
+    const submit = vi.fn(async () => ({ accepted: false, current: true }));
+    const user = userEvent.setup({ delay: null });
+    render(
+      createElement(NoteChatPanel, {
+        note: { id: "note-1", title: "Launch planning" },
+        chat: noteChat({ submit }),
+        onClose: vi.fn(),
+        onOpenInAgent: vi.fn(),
+      }),
+    );
+
+    const composer = await screen.findByRole("textbox");
+    const send = screen.getByRole("button", { name: "Send message" });
+    await user.type(composer, "Exact note follow-up");
+    expect(send).toBeEnabled();
+    fireEvent.click(send);
+
+    await waitFor(() => expect(submit).toHaveBeenCalledWith("Exact note follow-up", []));
+    expect(composer).toHaveTextContent("Exact note follow-up");
+  });
+
+  it("keeps a fresh note-chat draft when Escape lands before trailing publication", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup({ delay: null });
+    render(
+      createElement(NoteChatPanel, {
+        note: { id: "note-1", title: "Launch planning" },
+        chat: noteChat(),
+        onClose,
+        onOpenInAgent: vi.fn(),
+      }),
+    );
+
+    const composer = await screen.findByRole("textbox");
+    await user.type(composer, "Do not close this draft");
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(composer).toHaveTextContent("Do not close this draft");
+  });
+
+  it("keeps text typed while a note-chat submit is in flight", async () => {
+    let resolveSubmit: ((result: NoteChatSubmitResult) => void) | undefined;
+    const submit = vi.fn(
+      () =>
+        new Promise<NoteChatSubmitResult>((resolve) => {
+          resolveSubmit = resolve;
+        }),
+    );
+    const user = userEvent.setup({ delay: null });
+    render(
+      createElement(NoteChatPanel, {
+        note: { id: "note-1", title: "Launch planning" },
+        chat: noteChat({ submit }),
+        onClose: vi.fn(),
+        onOpenInAgent: vi.fn(),
+      }),
+    );
+
+    const composer = await screen.findByRole("textbox");
+    await user.type(composer, "First note question");
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => expect(submit).toHaveBeenCalledWith("First note question", []));
+
+    await user.type(composer, " plus a newer draft");
+    const liveText = composer.textContent;
+    await act(async () => {
+      resolveSubmit?.({ accepted: true, current: true });
+      await Promise.resolve();
+    });
+
+    expect(composer.textContent).toBe(liveText);
+    expect(composer).toHaveTextContent("First note question");
+    expect(composer).toHaveTextContent("plus a newer draft");
+  });
+
   it("keeps a spent recovery key after a stale-but-accepted note-chat retry", async () => {
     const { upstreamProviderRecoveryStore } = await import("../lib/upstream-provider-recovery");
     // Process-local store can retain keys from earlier panel tests in this file.


### PR DESCRIPTION
## Summary

- Coalesce full TipTap document serialization behind a 75 ms trailing composer notification while updating sendability through a cheap early-exit scan.
- Synchronously flush authoritative editor state before submit, slash-command actions, queued-edit guards, async command cleanup, and note-chat sends; use the live cheap content scan for immediate UI guards.
- Limit report-category discovery to the first paragraph, preserve IME and unmount draft persistence, and reconcile the release-blocker pre-mount action guards from main.

Refs JUN-402

## Root cause

Every TipTap `onUpdate` serialized the entire ProseMirror document and searched it for a report category. Because plain-text serialization walks the full document, each input event incurred work proportional to the current prompt length. After trailing publication was introduced, downstream consumers that still treated debounced draft state as live could replace or clear text entered inside the 75 ms window; those paths now flush or use live editor content.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` - 211 files passed; 3,434 tests passed and 2 skipped
- `make local-ci` - posted `signoff/frontend` and the not-applicable `signoff/rust-macos` status on the pushed SHA

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). Not applicable: this changes internal composer publication timing without changing visible UI.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

Incremental plain-text patching from ProseMirror transaction ranges is deliberately deferred. The trailing publication removes full-document work from the per-keystroke path without introducing transaction-mapping complexity.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787399612&installation_model_id=425925&pr_number=916&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F916&signature=4c8dd6284d5d951ab24c69b2e128dd1321f40e3381598fbeeba2ac86d5654b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
