### PR TITLE
perf(agent): consolidate Hermes lifecycle polling

### DIFF
--- a/docs/hermes-architecture.md
+++ b/docs/hermes-architecture.md
@@ -96,6 +96,18 @@ classified events into `AgentChatTurn` / `AgentChatPart[]` for rendering.
   works from classified `JuneHermesEvent`s, never from raw frames. Every
   normalized event carries `receivedAt`; first-party local kinds (`steering`)
   are minted by June and never come out of `classifyHermesEvent`.
+- **Lifecycle reconciliation uses one shared snapshot cycle.**
+  `hermes-active-session-snapshots.ts` requests `session.active_list` once per
+  active runtime mode every cycle and distributes the same result to run
+  settlement and the mounted workspace. The gateway event stream remains the
+  primary message path. Complete persisted history is fetched for a working
+  session only after consecutive missing lifecycle heartbeats or an unexpected
+  stream disconnect; the current bridge has no message-revision or delta
+  contract.
+- **Browser approvals are event-led.** The browser-approval change event
+  refreshes pending approvals promptly. Snapshot reads are limited to initial
+  subscription, listener reattachment, and focus, visibility, or online
+  recovery rather than a permanent timer.
 - **Identity override.** June rewrites the runtime's persona at prompt-build time
   via an injected `SOUL.md`; June presents as June, never as Hermes.
 

--- a/docs/hermes-architecture.md
+++ b/docs/hermes-architecture.md
@@ -96,14 +96,17 @@ classified events into `AgentChatTurn` / `AgentChatPart[]` for rendering.
   works from classified `JuneHermesEvent`s, never from raw frames. Every
   normalized event carries `receivedAt`; first-party local kinds (`steering`)
   are minted by June and never come out of `classifyHermesEvent`.
-- **Lifecycle reconciliation uses one shared snapshot cycle.**
+- **Lifecycle reconciliation uses one shared polling cycle.**
   `hermes-active-session-snapshots.ts` requests `session.active_list` once per
-  active runtime mode every cycle and distributes the same result to run
-  settlement and the mounted workspace. The gateway event stream remains the
-  primary message path. Complete persisted history is fetched for a working
-  session only after consecutive missing lifecycle heartbeats or an unexpected
-  stream disconnect; the current bridge has no message-revision or delta
-  contract.
+  active runtime mode every 500 ms cycle and distributes the same result to run
+  settlement and the mounted workspace. Runtime modes schedule independently
+  so a stalled mode cannot throttle a healthy one. Complete persisted history
+  is fetched for a working session only after a bounded streak of unreachable
+  polls, consecutive reachable snapshots that omit it, or an unexpected stream
+  disconnect; the current bridge has no message-revision or delta contract.
+  Gateway events render message deltas but are not a lifecycle heartbeat.
+  JUN-414 tracks detecting a silently stalled OPEN socket and forcing
+  reconnect.
 - **Browser approvals are event-led.** The browser-approval change event
   refreshes pending approvals promptly. Snapshot reads are limited to initial
   subscription, listener reattachment, and focus, visibility, or online

--- a/docs/hermes-architecture.md
+++ b/docs/hermes-architecture.md
@@ -110,7 +110,10 @@ classified events into `AgentChatTurn` / `AgentChatPart[]` for rendering.
 - **Browser approvals are event-led.** The browser-approval change event
   refreshes pending approvals promptly. Snapshot reads are limited to initial
   subscription, listener reattachment, and focus, visibility, or online
-  recovery rather than a permanent timer.
+  recovery. Rejected listener registrations retry with capped exponential
+  backoff and emit a diagnostic after repeated failures. While agent work is
+  active, a 30-second safety snapshot recovers a missed backend event without
+  restoring the old permanent five-second idle poll.
 - **Identity override.** June rewrites the runtime's persona at prompt-build time
   via an injected `SOUL.md`; June presents as June, never as Hermes.
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -467,7 +467,7 @@ export function AgentWorkspace({
     runtimeSessionIds,
     setRuntimeSessionIds,
     runtimeSessionIdsRef,
-    workingReconcileMissesRef,
+    workingReconcileStreaksRef,
     stoppingSessionIds,
     setStoppingSessionIds,
     skills,
@@ -1457,7 +1457,7 @@ export function AgentWorkspace({
     refreshHermesSession,
     runtimeSessionIdsRef,
     setError,
-    workingReconcileMissesRef,
+    workingReconcileStreaksRef,
     workingSessionIdsRef,
   });
 
@@ -1726,14 +1726,14 @@ export function AgentWorkspace({
     return () => window.clearInterval(interval);
   }, [selectedTask?.id, selectedTask?.status, upsertTask]);
 
-  // One process-wide lifecycle snapshot is shared with run settlement. The
-  // healthy gateway stream remains the message source of truth; only a missed
-  // active-session heartbeat window triggers a persisted-history fallback.
+  // One process-wide active-list poll per mode is shared with run settlement.
+  // Gateway events render live message deltas, while bounded missing-row and
+  // unreachable-snapshot streaks trigger native persisted-history recovery.
   // biome-ignore lint/correctness/useExhaustiveDependencies: subscription ownership follows mode membership; the render-local reconciler reads current refs, and resubscribing every render would force extra immediate snapshots.
   useEffect(() => {
-    for (const sessionId of workingReconcileMissesRef.current.keys()) {
+    for (const sessionId of workingReconcileStreaksRef.current.keys()) {
       if (!workingSessionIds.has(sessionId)) {
-        workingReconcileMissesRef.current.delete(sessionId);
+        workingReconcileStreaksRef.current.delete(sessionId);
       }
     }
     if (!bridge.running || workingSessionIds.size === 0) return;

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -28,7 +28,8 @@ import { parseDictationHelperEvent } from "../../lib/dictation-events";
 import { isWindowsPlatform } from "../../lib/platform";
 import { listHermesSessionMessages } from "../../lib/hermes-adapter";
 import { dispatchAgentSessionStatus } from "../../lib/agent-events";
-import { HermesGatewayClient } from "../../lib/hermes-gateway";
+import type { HermesGatewayClient } from "../../lib/hermes-gateway";
+import { subscribeHermesActiveSessionSnapshots } from "../../lib/hermes-active-session-snapshots";
 import {
   createHermesMethods,
   hermesModeFor,
@@ -1429,18 +1430,15 @@ export function AgentWorkspace({
   // working from a trailing user message — would otherwise stay "working"
   // forever, leaving the menu bar stuck on "Working…". The gateway's
   // session.active_list is ground truth for what is actually running, so any
-  // locally-working session absent from it (or sitting idle) for two
-  // consecutive polls gets its activity cleared. Two misses, not one: a
-  // just-submitted prompt can race the runtime session registering.
+  // locally-working session absent from it (or sitting idle) for the original
+  // five-second tolerance gets its activity cleared. The tolerance covers a
+  // just-submitted prompt racing runtime-session registration.
   const {
-    liveRuntimeSessionsForModes,
-    runtimeSnapshotHasSession,
     cancelAgentRunSettlement,
     hasAutomaticContinuation,
     watchCompletedAgentRunSettle,
     reconcileWorkingSessionsAgainstRuntime,
   } = createRuntimeReconciliation({
-    ensureHermesGateway,
     hermesSessionItems,
     pendingAttachmentPreparationsRef,
     pendingSteerBySessionIdRef,
@@ -1718,19 +1716,28 @@ export function AgentWorkspace({
     return () => window.clearInterval(interval);
   }, [selectedTask?.id, selectedTask?.status, upsertTask]);
 
-  // Poll every working session — not just the selected one — so a run whose
-  // live gateway stream died (disconnect, navigation) still reconciles from
-  // persisted messages instead of staying "working" forever.
+  // One process-wide lifecycle snapshot is shared with run settlement. The
+  // healthy gateway stream remains the message source of truth; only a missed
+  // active-session heartbeat window triggers a persisted-history fallback.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: subscription ownership follows mode membership; the render-local reconciler reads current refs, and resubscribing every render would force extra immediate snapshots.
   useEffect(() => {
-    if (!bridge.running || workingSessionIds.size === 0) return;
-    const sessionIds = Array.from(workingSessionIds);
-    const interval = window.setInterval(() => {
-      for (const sessionId of sessionIds) {
-        void refreshHermesSession(sessionId);
+    for (const sessionId of workingReconcileMissesRef.current.keys()) {
+      if (!workingSessionIds.has(sessionId)) {
+        workingReconcileMissesRef.current.delete(sessionId);
       }
-      void reconcileWorkingSessionsAgainstRuntime();
-    }, 2500);
-    return () => window.clearInterval(interval);
+    }
+    if (!bridge.running || workingSessionIds.size === 0) return;
+    const modes = new Set(
+      Array.from(workingSessionIds, (sessionId) => sessionUnrestricted(sessionId)),
+    );
+    const unsubscribe = [...modes].map((fullMode) =>
+      subscribeHermesActiveSessionSnapshots(fullMode, (snapshot) => {
+        void reconcileWorkingSessionsAgainstRuntime(snapshot);
+      }),
+    );
+    return () => {
+      for (const remove of unsubscribe) remove();
+    };
   }, [bridge.running, workingSessionIds]);
 
   useEffect(() => {

--- a/src/components/agent/runtime-reconciliation-types.ts
+++ b/src/components/agent/runtime-reconciliation-types.ts
@@ -1,15 +1,13 @@
-import { type HermesSessionInfo, type HermesSessionMessage } from "../../lib/tauri";
-import { HermesGatewayClient } from "../../lib/hermes-gateway";
-import { type AgentWorkspaceErrorOptions } from "./agent-workspace-errors";
-import {
-  type PendingAttachmentPreparation,
-  type PendingSteer,
-  type QueuedAttachmentFollowUp,
+import type { HermesSessionInfo, HermesSessionMessage } from "../../lib/tauri";
+import type { AgentWorkspaceErrorOptions } from "./agent-workspace-errors";
+import type {
+  PendingAttachmentPreparation,
+  PendingSteer,
+  QueuedAttachmentFollowUp,
 } from "./composer/follow-up-queue";
 import type * as React from "react";
 
 export type createRuntimeReconciliationDependencies = {
-  ensureHermesGateway: (fullMode?: boolean) => Promise<HermesGatewayClient>;
   hermesSessionItems: HermesSessionInfo[];
   pendingAttachmentPreparationsRef: React.MutableRefObject<
     Record<string, Map<number, PendingAttachmentPreparation>>

--- a/src/components/agent/runtime-reconciliation-types.ts
+++ b/src/components/agent/runtime-reconciliation-types.ts
@@ -18,6 +18,8 @@ export type createRuntimeReconciliationDependencies = {
   refreshHermesSession: (sessionId: string) => Promise<HermesSessionMessage[] | undefined>;
   runtimeSessionIdsRef: React.MutableRefObject<Record<string, string>>;
   setError: (message: string | null, options?: AgentWorkspaceErrorOptions) => void;
-  workingReconcileMissesRef: React.MutableRefObject<Map<string, number>>;
+  workingReconcileStreaksRef: React.MutableRefObject<
+    Map<string, { missing: number; unreachable: number }>
+  >;
   workingSessionIdsRef: React.MutableRefObject<Set<string>>;
 };

--- a/src/components/agent/runtime-reconciliation.ts
+++ b/src/components/agent/runtime-reconciliation.ts
@@ -1,5 +1,6 @@
 import { dispatchAgentSessionStatus } from "../../lib/agent-events";
 import { cancelAgentRunMonitoring, releaseAgentRunSettlement } from "../../lib/agent-run-monitor";
+import type { HermesActiveSessionSnapshot } from "../../lib/hermes-active-session-snapshots";
 import { sessionUnrestricted } from "../../lib/agent-session-modes";
 import {
   agentActivityCountsFromStore,
@@ -7,9 +8,13 @@ import {
 } from "./session-state-helpers";
 import type { createRuntimeReconciliationDependencies } from "./runtime-reconciliation-types";
 
+// The shared scheduler runs every 500ms so settlement stays prompt. Preserve
+// the workspace's pre-consolidation five-second registration-race tolerance
+// before treating an absent active row as a missed lifecycle heartbeat.
+const REQUIRED_MISSING_LIFECYCLE_SNAPSHOTS = 11;
+
 export function createRuntimeReconciliation(dependencies: createRuntimeReconciliationDependencies) {
   const {
-    ensureHermesGateway,
     hermesSessionItems,
     pendingAttachmentPreparationsRef,
     pendingSteerBySessionIdRef,
@@ -22,41 +27,11 @@ export function createRuntimeReconciliation(dependencies: createRuntimeReconcili
     workingSessionIdsRef,
   } = dependencies;
 
-  async function liveRuntimeSessionsForModes(modes: boolean[]) {
-    let rows: Array<{ id?: string; session_key?: string; status?: string }> = [];
-    const reachableModes = new Set<boolean>();
-    for (const mode of modes) {
-      try {
-        const gateway = await ensureHermesGateway(mode);
-        const response = await gateway.request<{
-          sessions?: Array<{
-            id?: string;
-            session_key?: string;
-            status?: string;
-          }>;
-        }>("session.active_list", {});
-        rows = rows.concat(Array.isArray(response?.sessions) ? response.sessions : []);
-        reachableModes.add(mode);
-      } catch {
-        // Can't reach this runtime — keep ITS sessions' current state rather
-        // than guess, while the reachable mode still reconciles below.
-      }
-    }
-    const live = new Set<string>();
-    for (const row of rows) {
-      // "idle" means the runtime session exists but isn't processing a turn.
-      if (!row || row.status === "idle") continue;
-      if (row.session_key) live.add(String(row.session_key));
-      if (row.id) live.add(String(row.id));
-    }
-    return { live, reachableModes };
-  }
-
-  function runtimeSnapshotHasSession(snapshot: { live: Set<string> }, sessionId: string) {
+  function runtimeSnapshotHasSession(snapshot: HermesActiveSessionSnapshot, sessionId: string) {
     const runtimeSessionId = runtimeSessionIdsRef.current[sessionId];
     return (
-      snapshot.live.has(sessionId) ||
-      Boolean(runtimeSessionId && snapshot.live.has(runtimeSessionId))
+      snapshot.liveSessionIds.has(sessionId) ||
+      Boolean(runtimeSessionId && snapshot.liveSessionIds.has(runtimeSessionId))
     );
   }
 
@@ -78,30 +53,24 @@ export function createRuntimeReconciliation(dependencies: createRuntimeReconcili
     releaseAgentRunSettlement(storedSessionId);
   }
 
-  async function reconcileWorkingSessionsAgainstRuntime() {
-    const working = Array.from(workingSessionIdsRef.current);
+  async function reconcileWorkingSessionsAgainstRuntime(snapshot: HermesActiveSessionSnapshot) {
+    const allWorking = Array.from(workingSessionIdsRef.current);
     const misses = workingReconcileMissesRef.current;
     for (const sessionId of misses.keys()) {
-      if (!working.includes(sessionId)) misses.delete(sessionId);
+      if (!allWorking.includes(sessionId)) misses.delete(sessionId);
     }
+    if (!snapshot.reachable) return;
+    const working = allWorking.filter(
+      (sessionId) => sessionUnrestricted(sessionId) === snapshot.fullMode,
+    );
     if (working.length === 0) return;
-    // Working sessions may span both runtime processes; ask each mode that
-    // has one and union the answers. A mode we can't reach keeps its
-    // sessions' current state rather than guessing — so a one-gateway
-    // failure must not mark the other mode's sessions dead either.
-    const modes = Array.from(new Set(working.map((sessionId) => sessionUnrestricted(sessionId))));
-    const snapshot = await liveRuntimeSessionsForModes(modes);
-    if (snapshot.reachableModes.size === 0) return;
     for (const sessionId of working) {
-      // Sessions of an unreachable mode were not in any answer we got;
-      // counting them as misses would mark live work dead.
-      if (!snapshot.reachableModes.has(sessionUnrestricted(sessionId))) continue;
       if (runtimeSnapshotHasSession(snapshot, sessionId)) {
         misses.delete(sessionId);
         continue;
       }
       const seen = (misses.get(sessionId) ?? 0) + 1;
-      if (seen < 2) {
+      if (seen < REQUIRED_MISSING_LIFECYCLE_SNAPSHOTS) {
         misses.set(sessionId, seen);
         continue;
       }
@@ -131,8 +100,6 @@ export function createRuntimeReconciliation(dependencies: createRuntimeReconcili
   }
 
   return {
-    liveRuntimeSessionsForModes,
-    runtimeSnapshotHasSession,
     cancelAgentRunSettlement,
     hasAutomaticContinuation,
     watchCompletedAgentRunSettle,

--- a/src/components/agent/runtime-reconciliation.ts
+++ b/src/components/agent/runtime-reconciliation.ts
@@ -10,8 +10,9 @@ import type { createRuntimeReconciliationDependencies } from "./runtime-reconcil
 
 // The shared scheduler runs every 500ms so settlement stays prompt. Preserve
 // the workspace's pre-consolidation five-second registration-race tolerance
-// before treating an absent active row as a missed lifecycle heartbeat.
+// before native history decides that an absent active row is terminal.
 const REQUIRED_MISSING_LIFECYCLE_SNAPSHOTS = 11;
+const REQUIRED_UNREACHABLE_LIFECYCLE_SNAPSHOTS = 3;
 
 export function createRuntimeReconciliation(dependencies: createRuntimeReconciliationDependencies) {
   const {
@@ -23,7 +24,7 @@ export function createRuntimeReconciliation(dependencies: createRuntimeReconcili
     refreshHermesSession,
     runtimeSessionIdsRef,
     setError,
-    workingReconcileMissesRef,
+    workingReconcileStreaksRef,
     workingSessionIdsRef,
   } = dependencies;
 
@@ -55,26 +56,39 @@ export function createRuntimeReconciliation(dependencies: createRuntimeReconcili
 
   async function reconcileWorkingSessionsAgainstRuntime(snapshot: HermesActiveSessionSnapshot) {
     const allWorking = Array.from(workingSessionIdsRef.current);
-    const misses = workingReconcileMissesRef.current;
-    for (const sessionId of misses.keys()) {
-      if (!allWorking.includes(sessionId)) misses.delete(sessionId);
+    const streaks = workingReconcileStreaksRef.current;
+    for (const sessionId of streaks.keys()) {
+      if (!allWorking.includes(sessionId)) streaks.delete(sessionId);
     }
-    if (!snapshot.reachable) return;
     const working = allWorking.filter(
       (sessionId) => sessionUnrestricted(sessionId) === snapshot.fullMode,
     );
     if (working.length === 0) return;
     for (const sessionId of working) {
+      const streak = streaks.get(sessionId) ?? { missing: 0, unreachable: 0 };
+      if (!snapshot.reachable) {
+        const unreachable = streak.unreachable + 1;
+        if (unreachable < REQUIRED_UNREACHABLE_LIFECYCLE_SNAPSHOTS) {
+          streaks.set(sessionId, { missing: 0, unreachable });
+          continue;
+        }
+        streaks.delete(sessionId);
+        // A socket can remain OPEN while frames stop after sleep or a network
+        // transition. Native persistence is socket-independent, so recover
+        // history without interpreting transport failure as a stopped run.
+        await refreshHermesSession(sessionId);
+        continue;
+      }
       if (runtimeSnapshotHasSession(snapshot, sessionId)) {
-        misses.delete(sessionId);
+        streaks.delete(sessionId);
         continue;
       }
-      const seen = (misses.get(sessionId) ?? 0) + 1;
+      const seen = streak.missing + 1;
       if (seen < REQUIRED_MISSING_LIFECYCLE_SNAPSHOTS) {
-        misses.set(sessionId, seen);
+        streaks.set(sessionId, { missing: seen, unreachable: 0 });
         continue;
       }
-      misses.delete(sessionId);
+      streaks.delete(sessionId);
       const freshMessages = await refreshHermesSession(sessionId);
       if (!freshMessages) continue;
       if (sessionHasAssistantAfterLatestUser(freshMessages)) {

--- a/src/components/agent/use-agent-core-state.ts
+++ b/src/components/agent/use-agent-core-state.ts
@@ -1,5 +1,5 @@
 import { listen } from "@tauri-apps/api/event";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import {
   osAccountsUpgrade,
   type AgentTaskDto,
@@ -14,10 +14,11 @@ import {
   useActiveHermesProfile,
 } from "../../lib/active-hermes-profile";
 import { isTopUpRequiresMaxError, messageFromError } from "../../lib/errors";
-import { type ReportCategory } from "./composer/reportCategory";
-import { type ReportDialogAttachment } from "./ReportDialog";
+import { hermesActivityStore } from "../../lib/hermes-activity-store";
+import type { ReportCategory } from "./composer/reportCategory";
+import type { ReportDialogAttachment } from "./ReportDialog";
 import type { AgentAttachment } from "./agent-workspace-models";
-import { type AgentPanel } from "./agent-workspace-config";
+import type { AgentPanel } from "./agent-workspace-config";
 import type { ImageSafeModeConsentRequest } from "./agent-workspace-models";
 import {
   agentWorkspaceErrorStateForMessage,
@@ -28,9 +29,14 @@ import {
   readAgentSessionContinuity,
   shouldOpenNewSessionOnMount,
 } from "./agent-session-continuity";
-import { type ComposerInputSizeWarning } from "./composer/composer-input-helpers";
+import type { ComposerInputSizeWarning } from "./composer/composer-input-helpers";
 import { readLastOpenSessionId } from "./session-persistence";
 import type { UseAgentCoreStateDependencies } from "./use-agent-core-state-types";
+
+const BROWSER_APPROVAL_SAFETY_NET_INTERVAL_MS = 30_000;
+const BROWSER_APPROVAL_LISTENER_RETRY_BASE_MS = 1_000;
+const BROWSER_APPROVAL_LISTENER_RETRY_MAX_MS = 30_000;
+const BROWSER_APPROVAL_LISTENER_DIAGNOSTIC_FAILURES = 3;
 
 export function useAgentCoreState(dependencies: UseAgentCoreStateDependencies) {
   const { BROWSER_APPROVALS_CHANGED_EVENT, initialSession, initialSessionIdProp, onTopUp } =
@@ -38,6 +44,11 @@ export function useAgentCoreState(dependencies: UseAgentCoreStateDependencies) {
 
   const initialSessionId = initialSession?.id ?? initialSessionIdProp;
   const activeHermesProfile = useActiveHermesProfile();
+  const hasActiveAgentWork = useSyncExternalStore(
+    hermesActivityStore.subscribe,
+    () => hermesActivityStore.activeCount() > 0,
+    () => false,
+  );
   // Read once per mount (lazy initializer): the continuity snapshot the
   // previous mount captured on unmount, if any session was still mid-run.
   const [continuity] = useState(readAgentSessionContinuity);
@@ -185,35 +196,75 @@ export function useAgentCoreState(dependencies: UseAgentCoreStateDependencies) {
 
   useEffect(() => {
     let unlisten: (() => void) | undefined;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let listenerFailures = 0;
+    let diagnosticEmitted = false;
     let disposed = false;
     const refreshWhenVisible = () => {
       if (document.visibilityState !== "hidden") void refreshBrowserApprovals();
     };
+    const registerListener = () => {
+      if (disposed) return;
+      void listen(BROWSER_APPROVALS_CHANGED_EVENT, () => void refreshBrowserApprovals()).then(
+        (cleanup) => {
+          if (disposed) {
+            cleanup();
+            return;
+          }
+          unlisten = cleanup;
+          listenerFailures = 0;
+          diagnosticEmitted = false;
+          // Close the race between the initial snapshot and event-subscription
+          // readiness. A successful retry gets the same closing snapshot.
+          void refreshBrowserApprovals();
+        },
+        () => {
+          if (disposed) return;
+          listenerFailures += 1;
+          if (
+            listenerFailures >= BROWSER_APPROVAL_LISTENER_DIAGNOSTIC_FAILURES &&
+            !diagnosticEmitted
+          ) {
+            diagnosticEmitted = true;
+            // biome-ignore lint/suspicious/noConsole: repeated listener failures need a developer diagnostic
+            console.warn(
+              "[agent] Browser approval event listener keeps failing; retrying with backoff while safety snapshots remain available.",
+            );
+          }
+          const delayMs = Math.min(
+            BROWSER_APPROVAL_LISTENER_RETRY_BASE_MS * 2 ** Math.min(listenerFailures - 1, 5),
+            BROWSER_APPROVAL_LISTENER_RETRY_MAX_MS,
+          );
+          retryTimer = setTimeout(registerListener, delayMs);
+        },
+      );
+    };
     void refreshBrowserApprovals();
-    void listen(BROWSER_APPROVALS_CHANGED_EVENT, () => void refreshBrowserApprovals()).then(
-      (cleanup) => {
-        if (disposed) {
-          cleanup();
-          return;
-        }
-        unlisten = cleanup;
-        // Close the race between the initial snapshot and event-subscription
-        // readiness. Re-registering this listener after a remount is also the
-        // approval path's reconnect fallback.
-        void refreshBrowserApprovals();
-      },
-    );
+    registerListener();
     window.addEventListener("focus", refreshWhenVisible);
     window.addEventListener("online", refreshWhenVisible);
     document.addEventListener("visibilitychange", refreshWhenVisible);
     return () => {
       disposed = true;
+      if (retryTimer !== undefined) clearTimeout(retryTimer);
       window.removeEventListener("focus", refreshWhenVisible);
       window.removeEventListener("online", refreshWhenVisible);
       document.removeEventListener("visibilitychange", refreshWhenVisible);
       unlisten?.();
     };
   }, [BROWSER_APPROVALS_CHANGED_EVENT, refreshBrowserApprovals]);
+
+  useEffect(() => {
+    if (!hasActiveAgentWork) return;
+    // Events remain the prompt path. This low-frequency snapshot exists only
+    // while agent work is live, so an idle focused window cannot hide an
+    // approval forever after a missed event or listener failure.
+    const interval = setInterval(
+      () => void refreshBrowserApprovals(),
+      BROWSER_APPROVAL_SAFETY_NET_INTERVAL_MS,
+    );
+    return () => clearInterval(interval);
+  }, [hasActiveAgentWork, refreshBrowserApprovals]);
 
   const respondToBrowserApproval = useCallback(
     async (approvalId: string, approve: boolean, allowSite = false) => {

--- a/src/components/agent/use-agent-core-state.ts
+++ b/src/components/agent/use-agent-core-state.ts
@@ -186,20 +186,34 @@ export function useAgentCoreState(dependencies: UseAgentCoreStateDependencies) {
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     let disposed = false;
+    const refreshWhenVisible = () => {
+      if (document.visibilityState !== "hidden") void refreshBrowserApprovals();
+    };
     void refreshBrowserApprovals();
-    const interval = window.setInterval(() => void refreshBrowserApprovals(), 5_000);
     void listen(BROWSER_APPROVALS_CHANGED_EVENT, () => void refreshBrowserApprovals()).then(
       (cleanup) => {
-        if (disposed) cleanup();
-        else unlisten = cleanup;
+        if (disposed) {
+          cleanup();
+          return;
+        }
+        unlisten = cleanup;
+        // Close the race between the initial snapshot and event-subscription
+        // readiness. Re-registering this listener after a remount is also the
+        // approval path's reconnect fallback.
+        void refreshBrowserApprovals();
       },
     );
+    window.addEventListener("focus", refreshWhenVisible);
+    window.addEventListener("online", refreshWhenVisible);
+    document.addEventListener("visibilitychange", refreshWhenVisible);
     return () => {
       disposed = true;
-      window.clearInterval(interval);
+      window.removeEventListener("focus", refreshWhenVisible);
+      window.removeEventListener("online", refreshWhenVisible);
+      document.removeEventListener("visibilitychange", refreshWhenVisible);
       unlisten?.();
     };
-  }, [refreshBrowserApprovals]);
+  }, [BROWSER_APPROVALS_CHANGED_EVENT, refreshBrowserApprovals]);
 
   const respondToBrowserApproval = useCallback(
     async (approvalId: string, approve: boolean, allowSite = false) => {

--- a/src/components/agent/use-agent-runtime-state.ts
+++ b/src/components/agent/use-agent-runtime-state.ts
@@ -166,8 +166,12 @@ export function useAgentRuntimeState(dependencies: UseAgentRuntimeStateDependenc
   );
   const runtimeSessionIdsRef = useRef(runtimeSessionIds);
   // Consecutive runtime-reconcile polls in which a locally-working session was
-  // absent from the gateway's live list. Cleared the moment it's seen live.
-  const workingReconcileMissesRef = useRef(new Map<string, number>());
+  // absent from a reachable snapshot or the mode itself was unreachable.
+  // Separate streaks preserve the registration-race tolerance while allowing
+  // faster native recovery from a silently stalled gateway.
+  const workingReconcileStreaksRef = useRef(
+    new Map<string, { missing: number; unreachable: number }>(),
+  );
   const [stoppingSessionIds, setStoppingSessionIds] = useState<ReadonlySet<string>>(new Set());
   const [skills, setSkills] = useState<HermesSkillInfo[] | null>(null);
   const skillCommandsLoadRef = useRef<Promise<HermesSkillInfo[]> | null>(null);
@@ -399,7 +403,7 @@ export function useAgentRuntimeState(dependencies: UseAgentRuntimeStateDependenc
     runtimeSessionIds,
     setRuntimeSessionIds,
     runtimeSessionIdsRef,
-    workingReconcileMissesRef,
+    workingReconcileStreaksRef,
     stoppingSessionIds,
     setStoppingSessionIds,
     skills,

--- a/src/lib/agent-run-monitor.ts
+++ b/src/lib/agent-run-monitor.ts
@@ -1,11 +1,12 @@
 import { dispatchAgentRunSettled, dispatchAgentSessionStatus } from "./agent-events";
-import { hermesConnectionForMode } from "./hermes-connection";
-import { HermesGatewayClient } from "./hermes-gateway";
+import {
+  subscribeHermesActiveSessionSnapshots,
+  type HermesActiveSessionRow,
+} from "./hermes-active-session-snapshots";
 import { watchHermesRunSettlement, type HermesRunSettlementHandle } from "./hermes-run-settlement";
 import {
   hermesBridgeSessionMessages,
   hermesBridgeSessions,
-  hermesBridgeStatus,
   type HermesSessionMessage,
   type HermesSessionInfo,
 } from "./tauri";
@@ -27,23 +28,13 @@ type AgentRunMonitor = StartAgentRunMonitoringInput & {
   settlementCleanupTimer?: ReturnType<typeof setTimeout>;
 };
 
-type ModeObserver = {
-  connected: boolean;
-  connecting?: Promise<void>;
-  gateway: HermesGatewayClient;
-  reconnectTimer?: ReturnType<typeof setTimeout>;
-};
-
 type TerminalOutcome =
   | { kind: "succeeded" }
   | { kind: "failed"; summary: string }
   | { kind: "cancelled" };
 
-const OBSERVER_RECONNECT_MS = 1_000;
-const MONITOR_POLL_INTERVAL_MS = 500;
 const MONITOR_TIMEOUT_MS = 6 * 60 * 60 * 1_000;
 const runs = new Map<string, AgentRunMonitor>();
-const observers = new Map<boolean, ModeObserver>();
 let nextGeneration = 0;
 
 /**
@@ -65,10 +56,6 @@ export function startAgentRunMonitoring(input: StartAgentRunMonitoringInput) {
   };
   runs.set(input.storedSessionId, run);
 
-  if (previous && previous.fullMode !== run.fullMode) {
-    closeObserverWhenUnused(previous.fullMode);
-  }
-  void ensureObserver(run.fullMode).catch(() => scheduleObserverReconnect(run.fullMode));
   startSettlementIfReady(run);
   return run.generation;
 }
@@ -129,53 +116,8 @@ function startSettlementIfReady(run: AgentRunMonitor) {
   run.settlement = watchHermesRunSettlement({
     storedSessionId: run.storedSessionId,
     runtimeSessionId: run.runtimeSessionId,
-    pollIntervalMs: MONITOR_POLL_INTERVAL_MS,
     timeoutMs: MONITOR_TIMEOUT_MS,
-    listActiveSessions: async () => {
-      const observer = await ensureObserver(run.fullMode);
-      const response = await observer.gateway.request<{
-        sessions?: Array<{ id?: string; session_key?: string; status?: string }>;
-      }>("session.active_list", {});
-      const rows = Array.isArray(response?.sessions) ? response.sessions : [];
-      const matchingRows = rows.filter(
-        (row) =>
-          row.id === run.runtimeSessionId ||
-          row.id === run.storedSessionId ||
-          row.session_key === run.runtimeSessionId ||
-          row.session_key === run.storedSessionId,
-      );
-      if (matchingRows.some((row) => row.status !== "idle")) run.observedActive = true;
-
-      // Hermes routes session events only to the transport that created or
-      // resumed that session. The submitting UI can report success as a fast
-      // path, but persisted session state is the correctness path after that
-      // UI disappears.
-      if (
-        !run.succeeded &&
-        (run.observedActive || (run.canProbeBeforeObservedActive && matchingRows.length === 0)) &&
-        matchingRows.every((row) => row.status === "idle")
-      ) {
-        const outcome = await persistedTerminalOutcome(run.storedSessionId);
-        if (outcome?.kind === "succeeded") {
-          run.succeeded = true;
-        } else if (outcome) {
-          finishRun(run);
-          if (outcome.kind === "failed") {
-            dispatchAgentSessionStatus({
-              sessionId: run.storedSessionId,
-              title: run.title,
-              status: "failed",
-              summary: outcome.summary,
-            });
-          }
-        }
-      }
-
-      if (!isCurrent(run) || !run.succeeded || run.settlementHeld) {
-        return [{ id: run.runtimeSessionId ?? run.storedSessionId, status: "working" }];
-      }
-      return rows;
-    },
+    observeActiveSessions: (observer) => observeRunSnapshots(run, observer),
     onSettled: () => {
       if (!isCurrent(run) || run.generation !== generation) return;
       dispatchAgentRunSettled({
@@ -195,6 +137,73 @@ function startSettlementIfReady(run: AgentRunMonitor) {
   run.settlementCleanupTimer = setTimeout(() => {
     if (isCurrent(run) && run.generation === generation) finishRun(run);
   }, MONITOR_TIMEOUT_MS + 1);
+}
+
+function observeRunSnapshots(
+  run: AgentRunMonitor,
+  observer: (rows: readonly HermesActiveSessionRow[] | undefined) => void,
+) {
+  let cancelled = false;
+  let processing = Promise.resolve();
+  const unsubscribe = subscribeHermesActiveSessionSnapshots(run.fullMode, (snapshot) => {
+    processing = processing
+      .then(async () => {
+        if (cancelled || !isCurrent(run)) return;
+        if (!snapshot.reachable) {
+          observer(undefined);
+          return;
+        }
+        const rows = snapshot.rows;
+        const matchingRows = rows.filter(
+          (row) =>
+            row.id === run.runtimeSessionId ||
+            row.id === run.storedSessionId ||
+            row.session_key === run.runtimeSessionId ||
+            row.session_key === run.storedSessionId,
+        );
+        if (matchingRows.some((row) => row.status !== "idle")) run.observedActive = true;
+
+        // Hermes routes session events only to the transport that created or
+        // resumed that session. The submitting UI can report success as a fast
+        // path, but persisted session state is the degraded correctness path
+        // after that UI or its stream disappears.
+        if (
+          !run.succeeded &&
+          (run.observedActive || (run.canProbeBeforeObservedActive && matchingRows.length === 0)) &&
+          matchingRows.every((row) => row.status === "idle")
+        ) {
+          const outcome = await persistedTerminalOutcome(run.storedSessionId);
+          if (cancelled || !isCurrent(run)) return;
+          if (outcome?.kind === "succeeded") {
+            run.succeeded = true;
+          } else if (outcome) {
+            finishRun(run);
+            if (outcome.kind === "failed") {
+              dispatchAgentSessionStatus({
+                sessionId: run.storedSessionId,
+                title: run.title,
+                status: "failed",
+                summary: outcome.summary,
+              });
+            }
+            return;
+          }
+        }
+
+        if (!isCurrent(run) || !run.succeeded || run.settlementHeld) {
+          observer([{ id: run.runtimeSessionId ?? run.storedSessionId, status: "working" }]);
+          return;
+        }
+        observer(rows);
+      })
+      .catch(() => {
+        if (!cancelled && isCurrent(run)) observer(undefined);
+      });
+  });
+  return () => {
+    cancelled = true;
+    unsubscribe();
+  };
 }
 
 async function persistedTerminalOutcome(
@@ -251,56 +260,10 @@ function terminalOutcomeFromSession(session: HermesSessionInfo): TerminalOutcome
   return undefined;
 }
 
-function createObserver(fullMode: boolean) {
-  const gateway = new HermesGatewayClient();
-  const observer: ModeObserver = { connected: false, gateway };
-  gateway.onClose(() => {
-    if (observers.get(fullMode) !== observer) return;
-    observer.connected = false;
-    scheduleObserverReconnect(fullMode);
-  });
-  observers.set(fullMode, observer);
-  return observer;
-}
-
-async function ensureObserver(fullMode: boolean) {
-  const observer = observers.get(fullMode) ?? createObserver(fullMode);
-  if (observer.connected) return observer;
-  if (!observer.connecting) {
-    const connectionAttempt = (async () => {
-      const status = await hermesBridgeStatus();
-      const connection = hermesConnectionForMode(status, fullMode);
-      if (!connection?.wsUrl) throw new Error("Hermes gateway is not available.");
-      if (observers.get(fullMode) !== observer) throw new Error("Agent run observer was replaced.");
-      await observer.gateway.connect(connection.wsUrl);
-      if (observers.get(fullMode) !== observer) {
-        observer.gateway.close();
-        throw new Error("Agent run observer was replaced.");
-      }
-      observer.connected = true;
-    })().finally(() => {
-      if (observer.connecting === connectionAttempt) observer.connecting = undefined;
-    });
-    observer.connecting = connectionAttempt;
-  }
-  await observer.connecting;
-  return observer;
-}
-
-function scheduleObserverReconnect(fullMode: boolean) {
-  const observer = observers.get(fullMode);
-  if (!observer || observer.reconnectTimer || !hasRunsForMode(fullMode)) return;
-  observer.reconnectTimer = setTimeout(() => {
-    observer.reconnectTimer = undefined;
-    void ensureObserver(fullMode).catch(() => scheduleObserverReconnect(fullMode));
-  }, OBSERVER_RECONNECT_MS);
-}
-
 function finishRun(run: AgentRunMonitor) {
   if (!isCurrent(run)) return;
   runs.delete(run.storedSessionId);
   cancelSettlement(run);
-  closeObserverWhenUnused(run.fullMode);
 }
 
 function cancelSettlement(run: AgentRunMonitor | undefined) {
@@ -317,27 +280,9 @@ function isCurrent(run: AgentRunMonitor) {
   return runs.get(run.storedSessionId)?.generation === run.generation;
 }
 
-function hasRunsForMode(fullMode: boolean) {
-  return [...runs.values()].some((run) => run.fullMode === fullMode);
-}
-
-function closeObserverWhenUnused(fullMode: boolean) {
-  if (hasRunsForMode(fullMode)) return;
-  const observer = observers.get(fullMode);
-  if (!observer) return;
-  observers.delete(fullMode);
-  if (observer.reconnectTimer !== undefined) clearTimeout(observer.reconnectTimer);
-  observer.gateway.close();
-}
-
 /** Clears singleton state between tests. Production ownership lasts for App. */
 export function resetAgentRunMonitoringForTests() {
   for (const run of runs.values()) cancelSettlement(run);
   runs.clear();
-  for (const observer of observers.values()) {
-    if (observer.reconnectTimer !== undefined) clearTimeout(observer.reconnectTimer);
-    observer.gateway.close();
-  }
-  observers.clear();
   nextGeneration = 0;
 }

--- a/src/lib/agent-run-monitor.ts
+++ b/src/lib/agent-run-monitor.ts
@@ -1,9 +1,10 @@
 import { dispatchAgentRunSettled, dispatchAgentSessionStatus } from "./agent-events";
+import { subscribeHermesActiveSessionSnapshots } from "./hermes-active-session-snapshots";
 import {
-  subscribeHermesActiveSessionSnapshots,
-  type HermesActiveSessionRow,
-} from "./hermes-active-session-snapshots";
-import { watchHermesRunSettlement, type HermesRunSettlementHandle } from "./hermes-run-settlement";
+  watchHermesRunSettlement,
+  type HermesRunSettlementHandle,
+  type HermesRunSettlementObservation,
+} from "./hermes-run-settlement";
 import {
   hermesBridgeSessionMessages,
   hermesBridgeSessions,
@@ -24,6 +25,7 @@ type AgentRunMonitor = StartAgentRunMonitoringInput & {
   generation: number;
   observedActive: boolean;
   succeeded: boolean;
+  unreachableSnapshots: number;
   settlement?: HermesRunSettlementHandle;
   settlementCleanupTimer?: ReturnType<typeof setTimeout>;
 };
@@ -34,6 +36,7 @@ type TerminalOutcome =
   | { kind: "cancelled" };
 
 const MONITOR_TIMEOUT_MS = 6 * 60 * 60 * 1_000;
+const REQUIRED_UNREACHABLE_SNAPSHOTS = 3;
 const runs = new Map<string, AgentRunMonitor>();
 let nextGeneration = 0;
 
@@ -53,6 +56,7 @@ export function startAgentRunMonitoring(input: StartAgentRunMonitoringInput) {
     generation: ++nextGeneration,
     observedActive: false,
     succeeded: false,
+    unreachableSnapshots: 0,
   };
   runs.set(input.storedSessionId, run);
 
@@ -141,7 +145,7 @@ function startSettlementIfReady(run: AgentRunMonitor) {
 
 function observeRunSnapshots(
   run: AgentRunMonitor,
-  observer: (rows: readonly HermesActiveSessionRow[] | undefined) => void,
+  observer: (observation: HermesRunSettlementObservation) => void,
 ) {
   let cancelled = false;
   let processing = Promise.resolve();
@@ -150,9 +154,42 @@ function observeRunSnapshots(
       .then(async () => {
         if (cancelled || !isCurrent(run)) return;
         if (!snapshot.reachable) {
-          observer(undefined);
+          run.unreachableSnapshots += 1;
+          if (run.unreachableSnapshots < REQUIRED_UNREACHABLE_SNAPSHOTS) {
+            observer({ rows: undefined });
+            return;
+          }
+          if (!run.succeeded) {
+            const outcome = await persistedTerminalOutcome(run.storedSessionId);
+            if (cancelled || !isCurrent(run)) return;
+            if (outcome?.kind === "succeeded") {
+              run.succeeded = true;
+            } else if (outcome) {
+              finishRun(run);
+              if (outcome.kind === "failed") {
+                dispatchAgentSessionStatus({
+                  sessionId: run.storedSessionId,
+                  title: run.title,
+                  status: "failed",
+                  summary: outcome.summary,
+                });
+              }
+              return;
+            }
+          }
+          if (!run.succeeded || run.settlementHeld) {
+            observer({
+              rows: [{ id: run.runtimeSessionId ?? run.storedSessionId, status: "working" }],
+            });
+            return;
+          }
+          // Native persisted state confirmed the run is terminal, or the live
+          // stream already did. Let the bounded unreachable streak satisfy
+          // settlement rather than resetting the idle count forever.
+          observer({ countUnreachableAsIdle: true, rows: undefined });
           return;
         }
+        run.unreachableSnapshots = 0;
         const rows = snapshot.rows;
         const matchingRows = rows.filter(
           (row) =>
@@ -191,13 +228,15 @@ function observeRunSnapshots(
         }
 
         if (!isCurrent(run) || !run.succeeded || run.settlementHeld) {
-          observer([{ id: run.runtimeSessionId ?? run.storedSessionId, status: "working" }]);
+          observer({
+            rows: [{ id: run.runtimeSessionId ?? run.storedSessionId, status: "working" }],
+          });
           return;
         }
-        observer(rows);
+        observer({ rows });
       })
       .catch(() => {
-        if (!cancelled && isCurrent(run)) observer(undefined);
+        if (!cancelled && isCurrent(run)) observer({ rows: undefined });
       });
   });
   return () => {

--- a/src/lib/hermes-active-session-snapshots.ts
+++ b/src/lib/hermes-active-session-snapshots.ts
@@ -24,16 +24,15 @@ type ModeObserver = {
 };
 
 const SNAPSHOT_INTERVAL_MS = 500;
+const SNAPSHOT_REQUEST_TIMEOUT_MS = SNAPSHOT_INTERVAL_MS;
 const listenersByMode = new Map<boolean, Set<SnapshotListener>>();
 const observersByMode = new Map<boolean, ModeObserver>();
-let cycleInFlight = false;
-let cycleTimer: ReturnType<typeof setTimeout> | undefined;
-let immediateCycleRequested = false;
+const cycleInFlightByMode = new Set<boolean>();
+const cycleTimersByMode = new Map<boolean, ReturnType<typeof setTimeout>>();
+const immediateCyclesByMode = new Set<boolean>();
 
-function activeModes() {
-  return [...listenersByMode.entries()]
-    .filter(([, listeners]) => listeners.size > 0)
-    .map(([fullMode]) => fullMode);
+function modeHasListeners(fullMode: boolean) {
+  return Boolean(listenersByMode.get(fullMode)?.size);
 }
 
 function closeObserver(fullMode: boolean) {
@@ -43,20 +42,24 @@ function closeObserver(fullMode: boolean) {
   observer.gateway.close();
 }
 
-function scheduleCycle(delayMs: number) {
-  if (activeModes().length === 0) return;
-  if (cycleInFlight) {
-    if (delayMs === 0) immediateCycleRequested = true;
+function scheduleCycle(fullMode: boolean, delayMs: number) {
+  if (!modeHasListeners(fullMode)) return;
+  if (cycleInFlightByMode.has(fullMode)) {
+    if (delayMs === 0) immediateCyclesByMode.add(fullMode);
     return;
   }
-  if (cycleTimer !== undefined) {
+  const currentTimer = cycleTimersByMode.get(fullMode);
+  if (currentTimer !== undefined) {
     if (delayMs !== 0) return;
-    clearTimeout(cycleTimer);
+    clearTimeout(currentTimer);
   }
-  cycleTimer = setTimeout(() => {
-    cycleTimer = undefined;
-    void runCycle();
-  }, delayMs);
+  cycleTimersByMode.set(
+    fullMode,
+    setTimeout(() => {
+      cycleTimersByMode.delete(fullMode);
+      void runCycle(fullMode);
+    }, delayMs),
+  );
 }
 
 function createObserver(fullMode: boolean) {
@@ -131,30 +134,29 @@ async function pollMode(fullMode: boolean) {
     const observer = await ensureObserver(fullMode);
     const response = await observer.gateway.request<{
       sessions?: HermesActiveSessionRow[];
-    }>("session.active_list", {});
+    }>("session.active_list", {}, SNAPSHOT_REQUEST_TIMEOUT_MS);
     publishSnapshot(fullMode, true, Array.isArray(response?.sessions) ? response.sessions : []);
   } catch {
     // Unreachable is an observation, not an empty active-session list. It
-    // breaks settlement idle streaks while preserving locally-known activity.
+    // engages bounded native-persistence fallbacks while preserving
+    // locally-known activity.
     publishSnapshot(fullMode, false, []);
   }
 }
 
-async function runCycle() {
-  if (cycleInFlight) {
-    immediateCycleRequested = true;
+async function runCycle(fullMode: boolean) {
+  if (cycleInFlightByMode.has(fullMode)) {
+    immediateCyclesByMode.add(fullMode);
     return;
   }
-  const modes = activeModes();
-  if (modes.length === 0) return;
-  cycleInFlight = true;
+  if (!modeHasListeners(fullMode)) return;
+  cycleInFlightByMode.add(fullMode);
   try {
-    await Promise.all(modes.map(pollMode));
+    await pollMode(fullMode);
   } finally {
-    cycleInFlight = false;
-    const delayMs = immediateCycleRequested ? 0 : SNAPSHOT_INTERVAL_MS;
-    immediateCycleRequested = false;
-    if (activeModes().length > 0) scheduleCycle(delayMs);
+    cycleInFlightByMode.delete(fullMode);
+    const delayMs = immediateCyclesByMode.delete(fullMode) ? 0 : SNAPSHOT_INTERVAL_MS;
+    if (modeHasListeners(fullMode)) scheduleCycle(fullMode, delayMs);
   }
 }
 
@@ -170,7 +172,7 @@ export function subscribeHermesActiveSessionSnapshots(
   const listeners = listenersByMode.get(fullMode) ?? new Set<SnapshotListener>();
   listeners.add(listener);
   listenersByMode.set(fullMode, listeners);
-  scheduleCycle(0);
+  scheduleCycle(fullMode, 0);
 
   let subscribed = true;
   return () => {
@@ -180,10 +182,10 @@ export function subscribeHermesActiveSessionSnapshots(
     current?.delete(listener);
     if (current?.size) return;
     listenersByMode.delete(fullMode);
-    if (activeModes().length === 0 && cycleTimer !== undefined) {
-      clearTimeout(cycleTimer);
-      cycleTimer = undefined;
-    }
+    const timer = cycleTimersByMode.get(fullMode);
+    if (timer !== undefined) clearTimeout(timer);
+    cycleTimersByMode.delete(fullMode);
+    immediateCyclesByMode.delete(fullMode);
   };
 }
 
@@ -191,10 +193,10 @@ export function subscribeHermesActiveSessionSnapshots(
  * process-wide: polling pauses without consumers, while observer sockets are
  * reused across short subscriber gaps. */
 export function resetHermesActiveSessionSnapshotsForTests() {
-  if (cycleTimer !== undefined) clearTimeout(cycleTimer);
-  cycleTimer = undefined;
-  cycleInFlight = false;
-  immediateCycleRequested = false;
+  for (const timer of cycleTimersByMode.values()) clearTimeout(timer);
+  cycleTimersByMode.clear();
+  cycleInFlightByMode.clear();
+  immediateCyclesByMode.clear();
   listenersByMode.clear();
   for (const fullMode of [...observersByMode.keys()]) closeObserver(fullMode);
 }

--- a/src/lib/hermes-active-session-snapshots.ts
+++ b/src/lib/hermes-active-session-snapshots.ts
@@ -1,0 +1,200 @@
+import { hermesConnectionForMode } from "./hermes-connection";
+import { HermesGatewayClient } from "./hermes-gateway";
+import { hermesBridgeStatus } from "./tauri";
+
+export type HermesActiveSessionRow = {
+  id?: string;
+  session_key?: string;
+  status?: string;
+};
+
+export type HermesActiveSessionSnapshot = {
+  fullMode: boolean;
+  liveSessionIds: ReadonlySet<string>;
+  reachable: boolean;
+  rows: readonly HermesActiveSessionRow[];
+};
+
+type SnapshotListener = (snapshot: HermesActiveSessionSnapshot) => void;
+
+type ModeObserver = {
+  connected: boolean;
+  connecting?: Promise<void>;
+  gateway: HermesGatewayClient;
+};
+
+const SNAPSHOT_INTERVAL_MS = 500;
+const listenersByMode = new Map<boolean, Set<SnapshotListener>>();
+const observersByMode = new Map<boolean, ModeObserver>();
+let cycleInFlight = false;
+let cycleTimer: ReturnType<typeof setTimeout> | undefined;
+let immediateCycleRequested = false;
+
+function activeModes() {
+  return [...listenersByMode.entries()]
+    .filter(([, listeners]) => listeners.size > 0)
+    .map(([fullMode]) => fullMode);
+}
+
+function closeObserver(fullMode: boolean) {
+  const observer = observersByMode.get(fullMode);
+  if (!observer) return;
+  observersByMode.delete(fullMode);
+  observer.gateway.close();
+}
+
+function scheduleCycle(delayMs: number) {
+  if (activeModes().length === 0) return;
+  if (cycleInFlight) {
+    if (delayMs === 0) immediateCycleRequested = true;
+    return;
+  }
+  if (cycleTimer !== undefined) {
+    if (delayMs !== 0) return;
+    clearTimeout(cycleTimer);
+  }
+  cycleTimer = setTimeout(() => {
+    cycleTimer = undefined;
+    void runCycle();
+  }, delayMs);
+}
+
+function createObserver(fullMode: boolean) {
+  const gateway = new HermesGatewayClient();
+  const observer: ModeObserver = { connected: false, gateway };
+  gateway.onClose(() => {
+    if (observersByMode.get(fullMode) === observer) {
+      observer.connected = false;
+    }
+  });
+  observersByMode.set(fullMode, observer);
+  return observer;
+}
+
+async function ensureObserver(fullMode: boolean) {
+  const observer = observersByMode.get(fullMode) ?? createObserver(fullMode);
+  if (observer.connected) return observer;
+  if (!observer.connecting) {
+    const connectionAttempt = (async () => {
+      const status = await hermesBridgeStatus();
+      const connection = hermesConnectionForMode(status, fullMode);
+      if (!connection?.wsUrl) throw new Error("Hermes gateway is not available.");
+      if (observersByMode.get(fullMode) !== observer) {
+        throw new Error("Hermes lifecycle observer was replaced.");
+      }
+      await observer.gateway.connect(connection.wsUrl);
+      if (observersByMode.get(fullMode) !== observer) {
+        observer.gateway.close();
+        throw new Error("Hermes lifecycle observer was replaced.");
+      }
+      observer.connected = true;
+    })().finally(() => {
+      if (observer.connecting === connectionAttempt) observer.connecting = undefined;
+    });
+    observer.connecting = connectionAttempt;
+  }
+  await observer.connecting;
+  return observer;
+}
+
+function publishSnapshot(
+  fullMode: boolean,
+  reachable: boolean,
+  rows: readonly HermesActiveSessionRow[],
+) {
+  const liveSessionIds = new Set<string>();
+  if (reachable) {
+    for (const row of rows) {
+      if (!row || row.status === "idle") continue;
+      if (row.id !== undefined) liveSessionIds.add(String(row.id));
+      if (row.session_key !== undefined) liveSessionIds.add(String(row.session_key));
+    }
+  }
+  const snapshot: HermesActiveSessionSnapshot = {
+    fullMode,
+    liveSessionIds,
+    reachable,
+    rows,
+  };
+  for (const listener of [...(listenersByMode.get(fullMode) ?? [])]) {
+    try {
+      listener(snapshot);
+    } catch {
+      // One lifecycle consumer must not prevent the shared snapshot from
+      // reaching the rest. Async work is owned and reported by each consumer.
+    }
+  }
+}
+
+async function pollMode(fullMode: boolean) {
+  try {
+    const observer = await ensureObserver(fullMode);
+    const response = await observer.gateway.request<{
+      sessions?: HermesActiveSessionRow[];
+    }>("session.active_list", {});
+    publishSnapshot(fullMode, true, Array.isArray(response?.sessions) ? response.sessions : []);
+  } catch {
+    // Unreachable is an observation, not an empty active-session list. It
+    // breaks settlement idle streaks while preserving locally-known activity.
+    publishSnapshot(fullMode, false, []);
+  }
+}
+
+async function runCycle() {
+  if (cycleInFlight) {
+    immediateCycleRequested = true;
+    return;
+  }
+  const modes = activeModes();
+  if (modes.length === 0) return;
+  cycleInFlight = true;
+  try {
+    await Promise.all(modes.map(pollMode));
+  } finally {
+    cycleInFlight = false;
+    const delayMs = immediateCycleRequested ? 0 : SNAPSHOT_INTERVAL_MS;
+    immediateCycleRequested = false;
+    if (activeModes().length > 0) scheduleCycle(delayMs);
+  }
+}
+
+/**
+ * Subscribes to the one process-wide active-session snapshot cycle for a
+ * Hermes runtime mode. Every consumer in that mode receives the same result;
+ * adding consumers never adds another `session.active_list` request.
+ */
+export function subscribeHermesActiveSessionSnapshots(
+  fullMode: boolean,
+  listener: SnapshotListener,
+) {
+  const listeners = listenersByMode.get(fullMode) ?? new Set<SnapshotListener>();
+  listeners.add(listener);
+  listenersByMode.set(fullMode, listeners);
+  scheduleCycle(0);
+
+  let subscribed = true;
+  return () => {
+    if (!subscribed) return;
+    subscribed = false;
+    const current = listenersByMode.get(fullMode);
+    current?.delete(listener);
+    if (current?.size) return;
+    listenersByMode.delete(fullMode);
+    if (activeModes().length === 0 && cycleTimer !== undefined) {
+      clearTimeout(cycleTimer);
+      cycleTimer = undefined;
+    }
+  };
+}
+
+/** Clears singleton scheduler state between tests. Production ownership is
+ * process-wide: polling pauses without consumers, while observer sockets are
+ * reused across short subscriber gaps. */
+export function resetHermesActiveSessionSnapshotsForTests() {
+  if (cycleTimer !== undefined) clearTimeout(cycleTimer);
+  cycleTimer = undefined;
+  cycleInFlight = false;
+  immediateCycleRequested = false;
+  listenersByMode.clear();
+  for (const fullMode of [...observersByMode.keys()]) closeObserver(fullMode);
+}

--- a/src/lib/hermes-control-plane/compatibility/matrix.ts
+++ b/src/lib/hermes-control-plane/compatibility/matrix.ts
@@ -105,7 +105,7 @@ const methods: HermesCompatibilitySection = {
   "session.active_list": {
     status: "supported",
     rationale:
-      "AgentWorkspace polls session.active_list as ground truth for what is actually running.",
+      "The shared Hermes lifecycle scheduler snapshots session.active_list once per runtime mode and distributes it to workspace reconciliation and run settlement.",
     since: PIN,
   },
   "approval.respond": {

--- a/src/lib/hermes-run-settlement.ts
+++ b/src/lib/hermes-run-settlement.ts
@@ -11,13 +11,13 @@ export type HermesRunSettlementHandle = {
 export type WatchHermesRunSettlementOptions = {
   storedSessionId: string;
   runtimeSessionId?: string;
-  listActiveSessions: () => Promise<readonly HermesActiveSessionRow[]>;
+  observeActiveSessions: (
+    observer: (rows: readonly HermesActiveSessionRow[] | undefined) => void,
+  ) => () => void;
   onSettled: () => void;
-  pollIntervalMs?: number;
   timeoutMs?: number;
 };
 
-const DEFAULT_POLL_INTERVAL_MS = 200;
 const DEFAULT_TIMEOUT_MS = 120_000;
 const REQUIRED_IDLE_OBSERVATIONS = 2;
 
@@ -26,7 +26,7 @@ type SettlementWatch = {
   handle: HermesRunSettlementHandle;
   idleObservations: number;
   identifiers: Set<string>;
-  nextPollTimer?: ReturnType<typeof setTimeout>;
+  unsubscribe?: () => void;
   timeoutTimer: ReturnType<typeof setTimeout>;
 };
 
@@ -51,9 +51,10 @@ function matchingSessionIsIdle(
  *
  * One watch is shared per stored session. A call made while that session is
  * already being watched returns the shared handle and adds its optional
- * runtime id to the match set. The first call owns the poll function, timings,
- * and callback; later callbacks are intentionally ignored so one run can emit
- * at most one settlement. Cancelling any shared handle cancels that watch.
+ * runtime id to the match set. The first call owns the snapshot subscription,
+ * timeout, and callback; later callbacks are intentionally ignored so one run
+ * can emit at most one settlement. Cancelling any shared handle cancels that
+ * watch.
  */
 export function watchHermesRunSettlement(
   options: WatchHermesRunSettlementOptions,
@@ -64,7 +65,6 @@ export function watchHermesRunSettlement(
     return existing.handle;
   }
 
-  const pollIntervalMs = Math.max(0, options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
   const timeoutMs = Math.max(0, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   const identifiers = new Set([options.storedSessionId]);
   if (options.runtimeSessionId) identifiers.add(options.runtimeSessionId);
@@ -74,7 +74,8 @@ export function watchHermesRunSettlement(
     if (watch.finished) return;
     watch.finished = true;
     clearTimeout(watch.timeoutTimer);
-    if (watch.nextPollTimer !== undefined) clearTimeout(watch.nextPollTimer);
+    watch.unsubscribe?.();
+    watch.unsubscribe = undefined;
     if (settlementWatches.get(options.storedSessionId) === watch) {
       settlementWatches.delete(options.storedSessionId);
     }
@@ -89,34 +90,23 @@ export function watchHermesRunSettlement(
   };
   settlementWatches.set(options.storedSessionId, watch);
 
-  const scheduleNextPoll = () => {
+  const unsubscribe = options.observeActiveSessions((rows) => {
     if (watch.finished) return;
-    watch.nextPollTimer = setTimeout(() => {
-      watch.nextPollTimer = undefined;
-      void poll();
-    }, pollIntervalMs);
-  };
-  const poll = async () => {
-    try {
-      const rows = await options.listActiveSessions();
-      if (watch.finished) return;
-      if (matchingSessionIsIdle(rows, watch.identifiers)) {
-        watch.idleObservations += 1;
-        if (watch.idleObservations >= REQUIRED_IDLE_OBSERVATIONS) {
-          finish();
-          options.onSettled();
-          return;
-        }
-      } else {
-        watch.idleObservations = 0;
-      }
-    } catch {
-      if (watch.finished) return;
+    if (rows === undefined) {
       watch.idleObservations = 0;
+      return;
     }
-    scheduleNextPoll();
-  };
-
-  void poll();
+    if (matchingSessionIsIdle(rows, watch.identifiers)) {
+      watch.idleObservations += 1;
+      if (watch.idleObservations >= REQUIRED_IDLE_OBSERVATIONS) {
+        finish();
+        options.onSettled();
+      }
+      return;
+    }
+    watch.idleObservations = 0;
+  });
+  if (watch.finished) unsubscribe();
+  else watch.unsubscribe = unsubscribe;
   return handle;
 }

--- a/src/lib/hermes-run-settlement.ts
+++ b/src/lib/hermes-run-settlement.ts
@@ -8,11 +8,16 @@ export type HermesRunSettlementHandle = {
   cancel: () => void;
 };
 
+export type HermesRunSettlementObservation = {
+  countUnreachableAsIdle?: boolean;
+  rows: readonly HermesActiveSessionRow[] | undefined;
+};
+
 export type WatchHermesRunSettlementOptions = {
   storedSessionId: string;
   runtimeSessionId?: string;
   observeActiveSessions: (
-    observer: (rows: readonly HermesActiveSessionRow[] | undefined) => void,
+    observer: (observation: HermesRunSettlementObservation) => void,
   ) => () => void;
   onSettled: () => void;
   timeoutMs?: number;
@@ -47,7 +52,9 @@ function matchingSessionIsIdle(
 /**
  * Confirms that a completed Hermes run has reached true runtime idle before
  * notifying downstream consumers. An empty active-session snapshot is a
- * reachable idle observation; an error is not.
+ * reachable idle observation. An unreachable observation counts only when
+ * the caller has independently confirmed terminal state through the live
+ * stream or native persistence.
  *
  * One watch is shared per stored session. A call made while that session is
  * already being watched returns the shared handle and adds its optional
@@ -90,10 +97,18 @@ export function watchHermesRunSettlement(
   };
   settlementWatches.set(options.storedSessionId, watch);
 
-  const unsubscribe = options.observeActiveSessions((rows) => {
+  const unsubscribe = options.observeActiveSessions(({ countUnreachableAsIdle, rows }) => {
     if (watch.finished) return;
     if (rows === undefined) {
-      watch.idleObservations = 0;
+      if (countUnreachableAsIdle) {
+        watch.idleObservations += 1;
+        if (watch.idleObservations >= REQUIRED_IDLE_OBSERVATIONS) {
+          finish();
+          options.onSettled();
+        }
+      } else {
+        watch.idleObservations = 0;
+      }
       return;
     }
     if (matchingSessionIsIdle(rows, watch.identifiers)) {

--- a/src/test/agent-run-monitor.test.ts
+++ b/src/test/agent-run-monitor.test.ts
@@ -83,6 +83,7 @@ import {
   resetAgentRunMonitoringForTests,
   startAgentRunMonitoring,
 } from "../lib/agent-run-monitor";
+import { resetHermesActiveSessionSnapshotsForTests } from "../lib/hermes-active-session-snapshots";
 
 const SANDBOXED_CONNECTION = {
   baseUrl: "http://127.0.0.1:9000",
@@ -140,6 +141,7 @@ function activeRuntime(runtimeSessionId = "runtime-1") {
 describe("agent run monitor", () => {
   beforeEach(() => {
     resetAgentRunMonitoringForTests();
+    resetHermesActiveSessionSnapshotsForTests();
     vi.useFakeTimers();
     monitorMocks.instances.length = 0;
     monitorMocks.bridgeStatus.mockReset().mockResolvedValue({
@@ -163,6 +165,7 @@ describe("agent run monitor", () => {
 
   afterEach(() => {
     resetAgentRunMonitoringForTests();
+    resetHermesActiveSessionSnapshotsForTests();
     vi.clearAllTimers();
     vi.useRealTimers();
   });
@@ -382,7 +385,20 @@ describe("agent run monitor", () => {
     expect(monitorMocks.dispatchSettled).toHaveBeenCalledOnce();
   });
 
-  it("uses one dedicated observer gateway per runtime mode", async () => {
+  it("distributes one active-session request per cycle to runs in the same mode", async () => {
+    activeRuntime();
+    startRun();
+    startRun({ storedSessionId: "stored-2", runtimeSessionId: "runtime-2" });
+
+    await flush();
+    expect(monitorMocks.request).toHaveBeenCalledTimes(1);
+    expect(monitorMocks.request).toHaveBeenLastCalledWith("session.active_list", {});
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(monitorMocks.request).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses one shared lifecycle observer gateway per runtime mode", async () => {
     startRun();
     startRun({ storedSessionId: "stored-2", runtimeSessionId: "runtime-2" });
     startRun({

--- a/src/test/agent-run-monitor.test.ts
+++ b/src/test/agent-run-monitor.test.ts
@@ -17,6 +17,7 @@ const monitorMocks = vi.hoisted(() => {
   const dispatchSettled = vi.fn();
   const dispatchStatus = vi.fn();
   const instances: MockGateway[] = [];
+  const requestContexts: MockGateway[] = [];
 
   class MockGateway {
     readonly eventHandlers = new Set<EventHandler>();
@@ -38,8 +39,25 @@ const monitorMocks = vi.hoisted(() => {
       return () => this.closeHandlers.delete(handler);
     }
 
-    request<T>(method: string, params: Record<string, unknown>) {
-      return request(method, params) as Promise<T>;
+    request<T>(method: string, params: Record<string, unknown>, timeoutMs = 120_000) {
+      requestContexts.push(this);
+      const response = request.call(this, method, params) as Promise<T>;
+      return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error(`Hermes request timed out: ${method}`)),
+          timeoutMs,
+        );
+        void Promise.resolve(response).then(
+          (value) => {
+            clearTimeout(timer);
+            resolve(value);
+          },
+          (error) => {
+            clearTimeout(timer);
+            reject(error);
+          },
+        );
+      });
     }
 
     emit(event: GatewayFrame) {
@@ -54,6 +72,7 @@ const monitorMocks = vi.hoisted(() => {
     dispatchStatus,
     instances,
     request,
+    requestContexts,
     sessions,
     sessionMessages,
   };
@@ -144,6 +163,7 @@ describe("agent run monitor", () => {
     resetHermesActiveSessionSnapshotsForTests();
     vi.useFakeTimers();
     monitorMocks.instances.length = 0;
+    monitorMocks.requestContexts.length = 0;
     monitorMocks.bridgeStatus.mockReset().mockResolvedValue({
       running: true,
       connections: [SANDBOXED_CONNECTION, UNRESTRICTED_CONNECTION],
@@ -385,6 +405,17 @@ describe("agent run monitor", () => {
     expect(monitorMocks.dispatchSettled).toHaveBeenCalledOnce();
   });
 
+  it("settles from native persistence when active-list frames stop without a close", async () => {
+    monitorMocks.request.mockImplementation(() => new Promise(() => undefined));
+    startRun();
+
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    expect(monitorMocks.sessions).toHaveBeenCalled();
+    expect(monitorMocks.dispatchSettled).toHaveBeenCalledOnce();
+    expect(monitorMocks.instances[0]?.close).not.toHaveBeenCalled();
+  });
+
   it("distributes one active-session request per cycle to runs in the same mode", async () => {
     activeRuntime();
     startRun();
@@ -396,6 +427,37 @@ describe("agent run monitor", () => {
 
     await vi.advanceTimersByTimeAsync(500);
     expect(monitorMocks.request).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a healthy runtime mode polling while the other mode is stalled", async () => {
+    monitorMocks.request.mockImplementation(function (
+      this: InstanceType<typeof monitorMocks.MockGateway>,
+    ) {
+      const wsUrl = this.connect.mock.calls[0]?.[0];
+      if (wsUrl === SANDBOXED_CONNECTION.wsUrl) {
+        return new Promise(() => undefined);
+      }
+      return Promise.resolve({
+        sessions: [{ id: "runtime-full", status: "working" }],
+      });
+    });
+    startRun();
+    startRun({
+      storedSessionId: "stored-full",
+      runtimeSessionId: "runtime-full",
+      fullMode: true,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    const sandboxedRequests = monitorMocks.requestContexts.filter(
+      (gateway) => gateway.connect.mock.calls[0]?.[0] === SANDBOXED_CONNECTION.wsUrl,
+    );
+    const unrestrictedRequests = monitorMocks.requestContexts.filter(
+      (gateway) => gateway.connect.mock.calls[0]?.[0] === UNRESTRICTED_CONNECTION.wsUrl,
+    );
+    expect(sandboxedRequests).toHaveLength(2);
+    expect(unrestrictedRequests).toHaveLength(4);
   });
 
   it("uses one shared lifecycle observer gateway per runtime mode", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -43,6 +43,7 @@ import { pendingActionStore } from "../lib/hermes-pending-actions";
 import { unsupportedEventStore } from "../lib/hermes-unsupported-events";
 import { readSessionModelSelections } from "../lib/hermes-session-model-selection";
 import { reserveHermesSessionDispatch } from "../lib/hermes-session-dispatch-mutex";
+import { resetHermesActiveSessionSnapshotsForTests } from "../lib/hermes-active-session-snapshots";
 
 // The hero greeting cycles per visit, so tests match any entry in the pool.
 const HERO_GREETING = new RegExp(
@@ -75,6 +76,8 @@ function stubNavigatorPlatform(platform: string, userAgent: string) {
 
 const mocks = vi.hoisted(() => ({
   assignSessionToProfile: vi.fn(),
+  browserApprovalRespond: vi.fn(),
+  browserApprovalsPending: vi.fn(),
   invoke: vi.fn(),
   cancelAgentRunMonitoring: vi.fn(),
   cancelAgentTask: vi.fn(),
@@ -175,6 +178,8 @@ vi.mock("../lib/tauri", () => ({
   // The pending skill-writes tray loads through the Rust bridge via this named
   // `invoke`. A quiet stub keeps these workspace tests off that path.
   assignSessionToProfile: mocks.assignSessionToProfile,
+  browserApprovalRespond: mocks.browserApprovalRespond,
+  browserApprovalsPending: mocks.browserApprovalsPending,
   invoke: mocks.invoke,
   cancelAgentTask: mocks.cancelAgentTask,
   computerUseBeginRun: mocks.computerUseBeginRun,
@@ -564,6 +569,7 @@ describe("AgentWorkspace", () => {
     mocks.gatewayEventHandlers.clear();
     mocks.gatewayCloseHandlers.clear();
     mocks.gatewayInstances.length = 0;
+    resetHermesActiveSessionSnapshotsForTests();
     // Auto-cleanup unmounts the workspace after each test, which snapshots
     // any still-working session for the next mount — across tests that would
     // leak one test's mid-run session into the next.
@@ -669,6 +675,8 @@ describe("AgentWorkspace", () => {
     mocks.listHermesSessions.mockResolvedValue([existingSession]);
     mocks.listSessionProfiles.mockResolvedValue([]);
     mocks.listHermesSessionMessages.mockResolvedValue([]);
+    mocks.browserApprovalsPending.mockResolvedValue([]);
+    mocks.browserApprovalRespond.mockResolvedValue(undefined);
     mocks.hermesAgentCliAccess.mockResolvedValue({ enabled: false });
     mocks.hermesBrowserAccess.mockResolvedValue({ enabled: false });
     mocks.registerBrowserExtensionHost.mockResolvedValue({
@@ -757,6 +765,46 @@ describe("AgentWorkspace", () => {
     expect(second.workingSessionIds).toBe(first.workingSessionIds);
     expect(second.waitingSessionIds).toBe(first.waitingSessionIds);
     expect(second.toolCallSessionIds).toBe(first.toolCallSessionIds);
+  });
+
+  it("uses browser approval events with focus fallback instead of permanent polling", async () => {
+    vi.useFakeTimers();
+    try {
+      render(<AgentWorkspace />);
+      await settleUnderFakeTimers(() =>
+        expect(mocks.browserApprovalsPending.mock.calls.length).toBeGreaterThanOrEqual(2),
+      );
+      const callsAfterEventSubscription = mocks.browserApprovalsPending.mock.calls.length;
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15_000);
+      });
+      expect(mocks.browserApprovalsPending).toHaveBeenCalledTimes(callsAfterEventSubscription);
+
+      mocks.browserApprovalsPending.mockResolvedValue([
+        {
+          approvalId: "browser-approval-event",
+          site: "https://shop.example",
+          action: "click",
+          elementLabel: "Purchase now",
+          requestedAtMs: 1,
+        },
+      ]);
+      act(() => {
+        void mocks.eventHandlers.get("june://browser-approvals-changed")?.({});
+      });
+      await settleUnderFakeTimers(() =>
+        expect(screen.getByText("Browser approval required")).toBeInTheDocument(),
+      );
+
+      mocks.browserApprovalsPending.mockResolvedValue([]);
+      act(() => window.dispatchEvent(new Event("focus")));
+      await settleUnderFakeTimers(() =>
+        expect(screen.queryByText("Browser approval required")).toBeNull(),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps a session waiting while any distinct pending action remains", () => {
@@ -5919,7 +5967,7 @@ describe("AgentWorkspace", () => {
     );
 
     await act(async () => {
-      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+      await new Promise((resolve) => window.setTimeout(resolve, 5200));
     });
 
     await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2));
@@ -5941,11 +5989,11 @@ describe("AgentWorkspace", () => {
     );
 
     await act(async () => {
-      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+      await new Promise((resolve) => window.setTimeout(resolve, 5200));
     });
 
     expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2);
-  }, 10_000);
+  }, 15_000);
 
   it("rechecks latest messages when a fresh prompt-only suggestion resolves after the reply loads", async () => {
     const rawTitle = "I want you to summarize latest failures";
@@ -6063,7 +6111,7 @@ describe("AgentWorkspace", () => {
     expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+      await new Promise((resolve) => window.setTimeout(resolve, 5200));
     });
 
     await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2));
@@ -6083,12 +6131,12 @@ describe("AgentWorkspace", () => {
     );
 
     await act(async () => {
-      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+      await new Promise((resolve) => window.setTimeout(resolve, 5200));
     });
 
     await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(3));
     expect(await screen.findByText("Persistence Fix")).toBeInTheDocument();
-  }, 10_000);
+  }, 15_000);
 
   it("keeps a prompt title when the first-exchange suggestion is assistant dialogue", async () => {
     const rawTitle = "I want you to summarize latest failures";
@@ -6157,7 +6205,7 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("Failure summary")).toBeInTheDocument();
 
     await act(async () => {
-      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+      await new Promise((resolve) => window.setTimeout(resolve, 5200));
     });
 
     await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2));
@@ -6193,7 +6241,7 @@ describe("AgentWorkspace", () => {
       "sandboxed",
     );
     await act(async () => {
-      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+      await new Promise((resolve) => window.setTimeout(resolve, 5200));
     });
     expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2);
 
@@ -6215,7 +6263,7 @@ describe("AgentWorkspace", () => {
       "sandboxed",
     );
     await act(async () => {
-      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+      await new Promise((resolve) => window.setTimeout(resolve, 5200));
     });
 
     await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(3));
@@ -6224,7 +6272,7 @@ describe("AgentWorkspace", () => {
       "I fixed the staging persistence race and verified the regression test.",
     );
     expect(await screen.findByText("Staging persistence fix")).toBeInTheDocument();
-  }, 15_000);
+  }, 25_000);
 
   it("keeps a failed fresh title fallback retry to a later natural refresh", async () => {
     const rawTitle = "I want you to summarize latest failures";
@@ -6349,7 +6397,7 @@ describe("AgentWorkspace", () => {
     expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      await new Promise((resolve) => window.setTimeout(resolve, 2600));
+      await new Promise((resolve) => window.setTimeout(resolve, 5200));
     });
 
     await waitFor(() => expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledTimes(2));
@@ -6358,7 +6406,7 @@ describe("AgentWorkspace", () => {
       "I found the failing path and isolated the missing persistence call.",
     );
     expect(await screen.findByText("Persistence Fix")).toBeInTheDocument();
-  }, 10_000);
+  }, 12_000);
 
   it("keeps a sidebar rename from being overwritten by a prompt-title exchange upgrade", async () => {
     const rawTitle = "I want you to summarize latest failures";
@@ -9549,6 +9597,39 @@ describe("AgentWorkspace", () => {
     expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("approval.respond", expect.anything());
   });
 
+  it("refreshes persisted history when the live gateway stream disconnects", async () => {
+    const user = userEvent.setup();
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox", { name: "Message June" }), "keep working");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "keep working",
+      }),
+    );
+    expect(await screen.findByText("Thinking…")).toBeInTheDocument();
+    const historyCallsBeforeDisconnect = mocks.listHermesSessionMessages.mock.calls.length;
+
+    act(() => {
+      for (const handler of [...mocks.gatewayCloseHandlers]) handler();
+    });
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.resume", {
+        session_id: "session-1",
+        cols: 96,
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages.mock.calls.length).toBeGreaterThan(
+        historyCallsBeforeDisconnect,
+      ),
+    );
+  });
+
   it("retires an approval across an unexpected close and does not reopen its replay", async () => {
     const statusDetails: AgentSessionStatusDetail[] = [];
     const handleStatus = (event: Event) => {
@@ -10348,22 +10429,18 @@ describe("AgentWorkspace", () => {
       return Promise.resolve({});
     });
 
-    // The whole flow runs under fake timers so the working-gated poll's
-    // interval is created on the fake clock and can be advanced.
+    // The whole flow runs under fake timers so the shared lifecycle snapshots
+    // are created on the fake clock and can be advanced.
     vi.useFakeTimers();
     try {
       render(<AgentWorkspace />);
       await settleUnderFakeTimers(() => expect(screen.getByText("Thinking…")).toBeInTheDocument());
       expect(mocks.computerUseBeginRun).not.toHaveBeenCalled();
 
-      // Two reconcile polls: the first miss is tolerated (a fresh submit can
-      // race the runtime registering), the second clears the activity.
+      // The immediate snapshot starts the original five-second tolerance.
+      // Its expiry confirms the dead runtime and engages history fallback.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(2500);
-      });
-      expect(screen.getByText("Thinking…")).toBeInTheDocument();
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(2500);
+        await vi.advanceTimersByTimeAsync(5_000);
       });
 
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.active_list", {});
@@ -10430,15 +10507,13 @@ describe("AgentWorkspace", () => {
       await settleUnderFakeTimers(() => expect(screen.getByText("Thinking…")).toBeInTheDocument());
 
       // The run actually finished — the reply is now persisted; the runtime
-      // just forgot the session (active_list []). The next poll's refresh sees
-      // it and dispatches exactly one "completed", never a "June stopped".
+      // just forgot the session (active_list []). The next shared snapshot's
+      // degraded refresh sees it and dispatches exactly one "completed", never
+      // a "June stopped".
       replyPersisted = true;
 
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(2500);
-      });
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(2500);
+        await vi.advanceTimersByTimeAsync(5_000);
       });
 
       expect(screen.getByText("Here is the answer.")).toBeInTheDocument();
@@ -10488,10 +10563,7 @@ describe("AgentWorkspace", () => {
       await settleUnderFakeTimers(() => expect(screen.getByText("Thinking…")).toBeInTheDocument());
 
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(2500);
-      });
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(2500);
+        await vi.advanceTimersByTimeAsync(1_000);
       });
 
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.active_list", {});
@@ -14086,9 +14158,19 @@ describe("AgentWorkspace", () => {
         timestamp: "2026-06-04T12:00:01.000Z",
       },
     ]);
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      if (method === "session.active_list") {
+        return Promise.resolve({
+          sessions: [{ id: "runtime-session-1", session_key: "session-1", status: "working" }],
+        });
+      }
+      return Promise.resolve({});
+    });
 
     render(<AgentWorkspace />);
-
     expect(await screen.findByText("older answer")).toBeInTheDocument();
 
     await user.type(screen.getByRole("textbox"), "continue");
@@ -14104,21 +14186,12 @@ describe("AgentWorkspace", () => {
     expect(screen.getAllByText("continue")).toHaveLength(2);
     expect(screen.getByText("Thinking…")).toBeInTheDocument();
 
-    // Let the working-gated poll (2.5s) refresh against the same old
-    // history: the new pending "continue" must survive and the run must not
-    // be marked finished against the old answer.
+    // Healthy lifecycle snapshots do not refetch complete persisted history.
     const refreshCallsBefore = mocks.listHermesSessionMessages.mock.calls.length;
-    await waitFor(
-      () =>
-        expect(mocks.listHermesSessionMessages.mock.calls.length).toBeGreaterThan(
-          refreshCallsBefore,
-        ),
-      { timeout: 4000 },
-    );
-    // Give the refresh's state updates time to land before asserting.
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      await new Promise((resolve) => setTimeout(resolve, 750));
     });
+    expect(mocks.listHermesSessionMessages).toHaveBeenCalledTimes(refreshCallsBefore);
     expect(screen.getAllByText("continue")).toHaveLength(2);
     expect(screen.getByText("Thinking…")).toBeInTheDocument();
   });
@@ -15389,8 +15462,8 @@ describe("AgentWorkspace", () => {
       }
       return Promise.resolve({});
     });
-    // Hold the submit just before completion so the working poll's interval
-    // is created on the fake clock (a real-clock interval can't be advanced).
+    // Hold the submit just before completion so the shared lifecycle cycle is
+    // created on the fake clock (a real-clock timer can't be advanced).
     let resolveEnsureSession: (value: unknown) => void = () => {};
     mocks.ensureHermesBridgeSession.mockImplementationOnce(
       () =>
@@ -15418,10 +15491,10 @@ describe("AgentWorkspace", () => {
         text: "follow up while racing",
       });
 
-      // The working poll's refresh applies the newer history (follow-up +
+      // The missed-heartbeat fallback applies the newer history (follow-up +
       // reply persisted; the optimistic bubble is dropped against it).
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(2500);
+        await vi.advanceTimersByTimeAsync(5_000);
       });
       expect(screen.getByText("raced reply")).toBeInTheDocument();
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -585,6 +585,13 @@ describe("AgentWorkspace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.suggestAgentSessionTitle.mockReset();
+    mocks.eventHandlers.clear();
+    mocks.listen.mockImplementation(
+      async (eventName: string, handler: (event: { payload?: unknown }) => unknown) => {
+        mocks.eventHandlers.set(eventName, handler);
+        return () => mocks.eventHandlers.delete(eventName);
+      },
+    );
     mocks.gatewayEventHandlers.clear();
     mocks.gatewayCloseHandlers.clear();
     mocks.gatewayInstances.length = 0;
@@ -605,6 +612,7 @@ describe("AgentWorkspace", () => {
     // rows (now keyed by the durable stored id) don't leak into the next.
     for (const id of ["session-1", "session-2", "runtime-session-1", "runtime-session-2"]) {
       pendingActionStore.resolveSession(id);
+      hermesActivityStore.clearSession(id);
     }
     setActiveHermesProfileName("default");
     mocks.invoke.mockResolvedValue({ active: "default", current: "default" });
@@ -822,6 +830,64 @@ describe("AgentWorkspace", () => {
         expect(screen.queryByText("Browser approval required")).toBeNull(),
       );
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("recovers browser approvals when listener registration keeps rejecting", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      mocks.listen.mockImplementation(
+        async (eventName: string, handler: (event: { payload?: unknown }) => unknown) => {
+          if (eventName === "june://browser-approvals-changed") {
+            throw new Error("listener unavailable");
+          }
+          mocks.eventHandlers.set(eventName, handler);
+          return () => mocks.eventHandlers.delete(eventName);
+        },
+      );
+      hermesActivityStore.record(
+        {
+          kind: "lifecycle",
+          sessionId: "session-1",
+          flavor: "running",
+          status: "running",
+          text: "",
+          receivedAt: new Date().toISOString(),
+        },
+        "sandboxed",
+      );
+
+      render(<AgentWorkspace />);
+      await settleUnderFakeTimers(() => expect(mocks.browserApprovalsPending).toHaveBeenCalled());
+      mocks.browserApprovalsPending.mockResolvedValue([
+        {
+          approvalId: "browser-approval-safety-net",
+          site: "https://shop.example",
+          action: "click",
+          elementLabel: "Purchase now",
+          requestedAtMs: 1,
+        },
+      ]);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000);
+      });
+      await settleUnderFakeTimers(() =>
+        expect(screen.getByText("Browser approval required")).toBeInTheDocument(),
+      );
+
+      const browserListenerAttempts = mocks.listen.mock.calls.filter(
+        ([eventName]) => eventName === "june://browser-approvals-changed",
+      );
+      expect(browserListenerAttempts.length).toBeGreaterThanOrEqual(4);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Browser approval event listener keeps failing"),
+      );
+    } finally {
+      hermesActivityStore.clearSession("session-1");
+      warn.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -283,7 +283,26 @@ vi.mock("../lib/hermes-gateway", async (importOriginal) => ({
       mocks.gatewayCloseHandlers.add(handler);
       return () => mocks.gatewayCloseHandlers.delete(handler);
     });
-    request = mocks.gatewayRequest;
+    request<T>(method: string, params: Record<string, unknown>, timeoutMs?: number) {
+      const response = mocks.gatewayRequest(method, params) as Promise<T>;
+      if (timeoutMs === undefined) return response;
+      return new Promise<T>((resolve, reject) => {
+        const timer = window.setTimeout(
+          () => reject(new Error(`Hermes request timed out: ${method}`)),
+          timeoutMs,
+        );
+        void Promise.resolve(response).then(
+          (value) => {
+            window.clearTimeout(timer);
+            resolve(value);
+          },
+          (error) => {
+            window.clearTimeout(timer);
+            reject(error);
+          },
+        );
+      });
+    }
   },
 }));
 
@@ -469,8 +488,8 @@ function mockGlmCapabilities(capabilities: string[]) {
  * short (<=1ms) timers each step, so async session hydration that needs a few
  * extra cycles settles instead of racing a single fixed `advanceTimersByTimeAsync(50)`
  * (the root of this suite's CI-load flakes — the initial "Thinking…" render only
- * lost under the loaded CI runner). Capped at 500ms, well under the 2500ms
- * working-session poll, so it never advances into a reconcile tick.
+ * lost under the loaded CI runner). Capped at 500ms, below the bounded
+ * unreachable-snapshot recovery window.
  */
 async function settleUnderFakeTimers(
   assertion: () => void,
@@ -9639,6 +9658,68 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("refreshes native history when active-list stalls without a close event", async () => {
+    const userOnly = [
+      {
+        id: "m1",
+        role: "user" as const,
+        content: "finish after wake",
+        timestamp: new Date().toISOString(),
+      },
+    ];
+    const reply = {
+      id: "m2",
+      role: "assistant" as const,
+      content: "Recovered from native history.",
+      timestamp: new Date().toISOString(),
+    };
+    let replyPersisted = false;
+    mocks.listHermesSessionMessages.mockImplementation(async () =>
+      replyPersisted ? [...userOnly, reply] : userOnly,
+    );
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.active_list") {
+        return new Promise(() => undefined);
+      }
+      return Promise.resolve({});
+    });
+
+    vi.useFakeTimers();
+    try {
+      render(<AgentWorkspace />);
+      await settleUnderFakeTimers(() => expect(screen.getByText("Thinking…")).toBeInTheDocument());
+      const historyCallsBeforeStallRecovery = mocks.listHermesSessionMessages.mock.calls.length;
+
+      // No gateway close is emitted. The socket stays logically OPEN while
+      // active_list frames stop, as can happen across sleep or a network
+      // transition.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3_000);
+      });
+
+      expect(mocks.listHermesSessionMessages.mock.calls.length).toBeGreaterThan(
+        historyCallsBeforeStallRecovery,
+      );
+      expect(screen.getByText("Thinking…")).toBeInTheDocument();
+      expect(screen.queryByText("June stopped before replying.")).toBeNull();
+
+      const historyCallsBeforePersistedReply = mocks.listHermesSessionMessages.mock.calls.length;
+      replyPersisted = true;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3_000);
+      });
+
+      expect(mocks.listHermesSessionMessages.mock.calls.length).toBeGreaterThan(
+        historyCallsBeforePersistedReply,
+      );
+      expect(screen.getByText("Recovered from native history.")).toBeInTheDocument();
+      expect(screen.queryByText("Thinking…")).toBeNull();
+      expect(mocks.markAgentRunSucceeded).toHaveBeenCalledWith("session-1");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("retires an approval across an unexpected close and does not reopen its replay", async () => {
     const statusDetails: AgentSessionStatusDetail[] = [];
     const handleStatus = (event: Event) => {
@@ -15500,7 +15581,7 @@ describe("AgentWorkspace", () => {
         text: "follow up while racing",
       });
 
-      // The missed-heartbeat fallback applies the newer history (follow-up +
+      // The missing-lifecycle fallback applies the newer history (follow-up +
       // reply persisted; the optimistic bubble is dropped against it).
       await act(async () => {
         await vi.advanceTimersByTimeAsync(5_000);

--- a/src/test/hermes-run-settlement.test.ts
+++ b/src/test/hermes-run-settlement.test.ts
@@ -1,20 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type HermesActiveSessionRow,
+  type HermesRunSettlementObservation,
   watchHermesRunSettlement,
 } from "../lib/hermes-run-settlement";
 
 function snapshotSource() {
-  const observers = new Set<(rows: readonly HermesActiveSessionRow[] | undefined) => void>();
+  const observers = new Set<(observation: HermesRunSettlementObservation) => void>();
   const observeActiveSessions = vi.fn(
-    (observer: (rows: readonly HermesActiveSessionRow[] | undefined) => void) => {
+    (observer: (observation: HermesRunSettlementObservation) => void) => {
       observers.add(observer);
       return () => observers.delete(observer);
     },
   );
   return {
-    emit(rows: readonly HermesActiveSessionRow[] | undefined) {
-      for (const observer of [...observers]) observer(rows);
+    emit(rows: readonly HermesActiveSessionRow[] | undefined, countUnreachableAsIdle = false) {
+      for (const observer of [...observers]) {
+        observer({ countUnreachableAsIdle, rows });
+      }
     },
     observeActiveSessions,
     observers,
@@ -124,6 +127,25 @@ describe("Hermes run settlement", () => {
     source.emit([]);
     expect(onSettled).not.toHaveBeenCalled();
     source.emit([]);
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("counts unreachable observations after native terminal confirmation", () => {
+    const source = snapshotSource();
+    const onSettled = vi.fn();
+
+    watchHermesRunSettlement({
+      storedSessionId: "stored-native-terminal",
+      observeActiveSessions: source.observeActiveSessions,
+      onSettled,
+      timeoutMs: 100,
+    });
+
+    source.emit(undefined);
+    source.emit(undefined, true);
+    expect(onSettled).not.toHaveBeenCalled();
+    source.emit(undefined, true);
+
     expect(onSettled).toHaveBeenCalledOnce();
   });
 

--- a/src/test/hermes-run-settlement.test.ts
+++ b/src/test/hermes-run-settlement.test.ts
@@ -1,5 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { watchHermesRunSettlement } from "../lib/hermes-run-settlement";
+import {
+  type HermesActiveSessionRow,
+  watchHermesRunSettlement,
+} from "../lib/hermes-run-settlement";
+
+function snapshotSource() {
+  const observers = new Set<(rows: readonly HermesActiveSessionRow[] | undefined) => void>();
+  const observeActiveSessions = vi.fn(
+    (observer: (rows: readonly HermesActiveSessionRow[] | undefined) => void) => {
+      observers.add(observer);
+      return () => observers.delete(observer);
+    },
+  );
+  return {
+    emit(rows: readonly HermesActiveSessionRow[] | undefined) {
+      for (const observer of [...observers]) observer(rows);
+    },
+    observeActiveSessions,
+    observers,
+  };
+}
 
 describe("Hermes run settlement", () => {
   beforeEach(() => {
@@ -11,175 +31,149 @@ describe("Hermes run settlement", () => {
     vi.useRealTimers();
   });
 
-  it("settles after two reachable idle observations", async () => {
-    const listActiveSessions = vi.fn(async () => []);
+  it("settles after two reachable idle observations", () => {
+    const source = snapshotSource();
     const onSettled = vi.fn();
 
     watchHermesRunSettlement({
       storedSessionId: "stored-1",
-      listActiveSessions,
+      observeActiveSessions: source.observeActiveSessions,
       onSettled,
-      pollIntervalMs: 20,
       timeoutMs: 100,
     });
 
-    await vi.advanceTimersByTimeAsync(0);
-    expect(listActiveSessions).toHaveBeenCalledOnce();
+    source.emit([]);
     expect(onSettled).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(20);
-    expect(listActiveSessions).toHaveBeenCalledTimes(2);
+    source.emit([]);
     expect(onSettled).toHaveBeenCalledOnce();
-
-    await vi.advanceTimersByTimeAsync(100);
-    expect(onSettled).toHaveBeenCalledOnce();
+    expect(source.observers).toHaveLength(0);
   });
 
-  it("requires consecutive idle observations and ignores unrelated busy sessions", async () => {
-    const snapshots = [
-      [],
-      [{ session_key: "stored-1", status: "working" }],
-      [{ session_key: "someone-else", status: "working" }],
-      [{ session_key: "stored-1", status: "idle" }],
-    ];
-    const listActiveSessions = vi.fn(async () => snapshots.shift() ?? []);
+  it("requires consecutive idle observations and ignores unrelated busy sessions", () => {
+    const source = snapshotSource();
     const onSettled = vi.fn();
 
     watchHermesRunSettlement({
       storedSessionId: "stored-1",
-      listActiveSessions,
+      observeActiveSessions: source.observeActiveSessions,
       onSettled,
-      pollIntervalMs: 10,
       timeoutMs: 100,
     });
 
-    await vi.advanceTimersByTimeAsync(20);
+    source.emit([]);
+    source.emit([{ session_key: "stored-1", status: "working" }]);
+    source.emit([{ session_key: "someone-else", status: "working" }]);
     expect(onSettled).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(10);
+    source.emit([{ session_key: "stored-1", status: "idle" }]);
 
     expect(onSettled).toHaveBeenCalledOnce();
-    expect(listActiveSessions).toHaveBeenCalledTimes(4);
   });
 
-  it("treats a non-idle runtime-id match as busy", async () => {
-    const snapshots = [
-      [{ id: "runtime-1", status: "working" }],
-      [{ id: "runtime-1", status: "idle" }],
-      [{ id: "runtime-1", status: "idle" }],
-    ];
+  it("treats a non-idle runtime-id match as busy", () => {
+    const source = snapshotSource();
     const onSettled = vi.fn();
 
     watchHermesRunSettlement({
       storedSessionId: "stored-1",
       runtimeSessionId: "runtime-1",
-      listActiveSessions: vi.fn(async () => snapshots.shift() ?? []),
+      observeActiveSessions: source.observeActiveSessions,
       onSettled,
-      pollIntervalMs: 10,
       timeoutMs: 100,
     });
 
-    await vi.advanceTimersByTimeAsync(10);
+    source.emit([{ id: "runtime-1", status: "working" }]);
+    source.emit([{ id: "runtime-1", status: "idle" }]);
     expect(onSettled).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(10);
+    source.emit([{ id: "runtime-1", status: "idle" }]);
     expect(onSettled).toHaveBeenCalledOnce();
   });
 
-  it("retries errors without settling and stops at the timeout", async () => {
-    const listActiveSessions = vi.fn(async () => {
-      throw new Error("gateway unavailable");
-    });
+  it("ignores unreachable observations and stops at the timeout", async () => {
+    const source = snapshotSource();
     const onSettled = vi.fn();
 
     watchHermesRunSettlement({
       storedSessionId: "stored-timeout",
-      listActiveSessions,
+      observeActiveSessions: source.observeActiveSessions,
       onSettled,
-      pollIntervalMs: 10,
       timeoutMs: 25,
     });
 
+    source.emit(undefined);
+    source.emit(undefined);
     await vi.advanceTimersByTimeAsync(100);
 
-    expect(listActiveSessions).toHaveBeenCalledTimes(3);
     expect(onSettled).not.toHaveBeenCalled();
+    expect(source.observers).toHaveLength(0);
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it("resets an idle streak when a poll fails", async () => {
-    const listActiveSessions = vi
-      .fn<() => Promise<readonly []>>()
-      .mockResolvedValueOnce([])
-      .mockRejectedValueOnce(new Error("gateway unavailable"))
-      .mockResolvedValue([]);
+  it("resets an idle streak when a snapshot is unreachable", () => {
+    const source = snapshotSource();
     const onSettled = vi.fn();
 
     watchHermesRunSettlement({
       storedSessionId: "stored-retry",
-      listActiveSessions,
+      observeActiveSessions: source.observeActiveSessions,
       onSettled,
-      pollIntervalMs: 10,
       timeoutMs: 100,
     });
 
-    await vi.advanceTimersByTimeAsync(20);
+    source.emit([]);
+    source.emit(undefined);
+    source.emit([]);
     expect(onSettled).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(10);
+    source.emit([]);
     expect(onSettled).toHaveBeenCalledOnce();
   });
 
-  it("coalesces a duplicate watch and keeps the first callback", async () => {
-    const listActiveSessions = vi.fn(async () => [
-      { id: "runtime-from-second-call", status: "working" },
-    ]);
+  it("coalesces a duplicate watch and keeps the first callback", () => {
+    const source = snapshotSource();
+    const secondSource = snapshotSource();
     const firstCallback = vi.fn();
     const secondCallback = vi.fn();
     const firstHandle = watchHermesRunSettlement({
       storedSessionId: "stored-shared",
-      listActiveSessions,
+      observeActiveSessions: source.observeActiveSessions,
       onSettled: firstCallback,
-      pollIntervalMs: 10,
       timeoutMs: 100,
     });
     const secondHandle = watchHermesRunSettlement({
       storedSessionId: "stored-shared",
       runtimeSessionId: "runtime-from-second-call",
-      listActiveSessions: vi.fn(async () => []),
+      observeActiveSessions: secondSource.observeActiveSessions,
       onSettled: secondCallback,
-      pollIntervalMs: 1,
       timeoutMs: 2,
     });
 
     expect(secondHandle).toBe(firstHandle);
-    await vi.advanceTimersByTimeAsync(30);
+    source.emit([{ id: "runtime-from-second-call", status: "working" }]);
+    source.emit([]);
+    source.emit([{ id: "runtime-from-second-call", status: "working" }]);
 
     expect(firstCallback).not.toHaveBeenCalled();
     expect(secondCallback).not.toHaveBeenCalled();
-    expect(listActiveSessions).toHaveBeenCalledTimes(4);
+    expect(source.observeActiveSessions).toHaveBeenCalledOnce();
+    expect(secondSource.observeActiveSessions).not.toHaveBeenCalled();
   });
 
-  it("cancels an active watch, including an in-flight observation", async () => {
-    let resolveList: (rows: readonly []) => void = () => undefined;
-    const listActiveSessions = vi.fn(
-      () =>
-        new Promise<readonly []>((resolve) => {
-          resolveList = resolve;
-        }),
-    );
+  it("cancels an active watch and unsubscribes it", async () => {
+    const source = snapshotSource();
     const onSettled = vi.fn();
     const handle = watchHermesRunSettlement({
       storedSessionId: "stored-cancelled",
-      listActiveSessions,
+      observeActiveSessions: source.observeActiveSessions,
       onSettled,
-      pollIntervalMs: 10,
       timeoutMs: 100,
     });
 
     handle.cancel();
-    resolveList([]);
+    source.emit([]);
+    source.emit([]);
     await vi.advanceTimersByTimeAsync(100);
 
-    expect(listActiveSessions).toHaveBeenCalledOnce();
     expect(onSettled).not.toHaveBeenCalled();
+    expect(source.observers).toHaveLength(0);
     expect(vi.getTimerCount()).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- Consolidates Hermes lifecycle observation into one shared 500 ms `session.active_list` snapshot cycle per active runtime mode, distributing each snapshot to workspace reconciliation and run settlement. Runtime modes schedule independently so a stalled mode cannot throttle a healthy one.
- Uses native persisted history only on bounded degraded paths: after three consecutive unreachable snapshots, after the existing missing-row tolerance, or after a stream disconnect. The current bridge has no revision/delta contract, so this rare fallback remains a full fetch.
- Makes browser approval events primary. Listener registration now retries with capped exponential backoff and surfaces a diagnostic after repeated failures. Initial, listener-reattach, focus, visibility, reconnect, and a 30-second safety snapshot while agent work is active provide recovery without restoring the old permanent 5-second idle poll.
- Adds deterministic coverage for an OPEN socket whose `active_list` frames stop without a close event, native run settlement during that stall, independent runtime-mode cadence, disconnect recovery, listener-rejection approval recovery, approval fallback, and shared-cycle request counts.

## Root cause

Hermes lifecycle consumers owned independent timers: every working workspace refetched its full persisted history every 2.5 seconds, each monitored run polled `session.active_list` every 500 ms, and browser approvals retained a permanent 5-second poll despite an event subscription. Those loops multiplied gateway and persistence work.

The first consolidation also treated an unreachable snapshot as a reason to return from workspace reconciliation and reset run-settlement idle observations. A WebSocket can remain OPEN while frames stop after sleep or a network transition, so a run that completed during that silent stall could remain Working forever. Its single scheduler also awaited both runtime modes together, coupling the healthy mode to the stalled mode's request timeout. Approval recovery was initially one-shot and event-dependent: a rejected listener registration or missed event could hide a pending approval indefinitely in an idle, focused window.

## Validation

- `pnpm check` - passes with the existing ratcheted warning backlog only.
- `pnpm typecheck` - passes.
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` - all 211 test files and 3,442 tests passed, 2 skipped.
- Focused browser-approval tests - event-first recovery and listener-rejection safety-net recovery pass.
- Focused AgentWorkspace lifecycle matrix - stream disconnect, silent OPEN-socket stall, disappeared run failure, persisted assistant recovery, and active-run preservation all pass.
- `make local-ci` - passes on `29b57bf1cd5c5e55ea44245717370e10fdf33125`: typecheck, all 211 test files and 3,442 tests passed (2 skipped), followed by fresh `signoff/frontend` and not-applicable `signoff/rust-macos` contexts.
- GitHub Actions: repository hygiene and desktop workflows pass on `29b57bf1cd5c5e55ea44245717370e10fdf33125`.
- Greptile re-review: 5/5 on `29b57bf1cd5c5e55ea44245717370e10fdf33125`.
- Not tested visually: this changes lifecycle scheduling and fallback behavior without changing rendered UI or copy; deterministic tests cover the behavior.
- [ ] Tested visually where it matters. Evidence attached below.
- [ ] Needs a June API deploy before this works end to end.

## Out of scope

- Adding a gateway heartbeat. Gateway message deltas are not a lifecycle heartbeat, so silent OPEN-socket stalls use the bounded native fallback in this PR; JUN-414 tracks heartbeat-driven stall detection and reconnect.
- Adding a message revision or delta contract to the Hermes bridge. Until that contract exists, the rare degraded recovery path intentionally performs a full history fetch.
- Changing user-visible run settlement or browser approval behavior.

## Followups

- JUN-414: add a real gateway heartbeat so silently stalled OPEN sockets force reconnect.
- Add a bridge message revision/delta contract before replacing the degraded-path full fetch.

## Security and release checklist

- [x] No secrets, tokens, credentials, or private endpoints are included.
- [x] Security-sensitive changes are called out in **Summary** and have explicit owner review. (No security-sensitive changes.)
- [x] Workflow changes use immutable action references and least-privilege permissions. (No workflow changes.)
- [x] Release notes and user-facing copy avoid unnecessary third-party product comparisons.
- [x] CI is green, or any intentional exception is documented above.

Refs JUN-394