### PR TITLE
Fix composer access before Tiptap view mount

### DIFF
--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -78,13 +78,20 @@ export function serializePlainText(doc: ProseMirrorNode): string {
   });
 }
 
+/** Tiptap reports an editor as destroyed both before its view mounts and after
+ * that view unmounts. Treat both lifecycle windows as unavailable so callers
+ * never reach the throwing `editor.view` proxy. */
+function editorHasView(editor: Editor | null): editor is Editor {
+  return editor !== null && !editor.isDestroyed;
+}
+
 /** Focuses the editor with the caret at the end, synchronously. tiptap's
  * `focus` command defers the actual `view.focus()` to a requestAnimationFrame
  * (for scroll handling); that deferral can land after the user has moved on
  * and steal focus back from, say, a menu they just opened. Focusing the view
  * directly keeps it immediate. */
 function focusEnd(editor: Editor | null) {
-  if (!editor || editor.isDestroyed) return;
+  if (!editorHasView(editor)) return;
   editor.commands.setTextSelection(editor.state.doc.content.size);
   editor.view.focus();
 }
@@ -187,7 +194,7 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
 
     function updateScrollFades(nextEditor: Editor | null) {
       const frame = frameRef.current;
-      if (!frame || !nextEditor || nextEditor.isDestroyed) return;
+      if (!frame || !editorHasView(nextEditor)) return;
       const scroller = nextEditor.view.dom;
       // A range selection paints a full-width highlight, and the edge fades
       // shave it — which reads as the selection being clipped, not as content
@@ -282,7 +289,7 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
       onCreate: ({ editor }) => {
         queueMicrotask(() => {
           updateScrollFades(editor);
-          if (!editor.isDestroyed) onReadyRef.current?.(editor);
+          if (editorHasView(editor)) onReadyRef.current?.(editor);
         });
       },
       onUpdate: ({ editor }) => {
@@ -299,22 +306,36 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
 
     useEffect(() => {
       if (!editor) return;
-      const scroller = editor.view.dom;
-      let frame = 0;
-      const schedule = () => {
-        window.cancelAnimationFrame(frame);
-        frame = window.requestAnimationFrame(() => updateScrollFades(editor));
+      let detachScrollTracking: (() => void) | null = null;
+      const attachScrollTracking = () => {
+        if (detachScrollTracking || !editorHasView(editor)) return;
+        const scroller = editor.view.dom;
+        let frame = 0;
+        const schedule = () => {
+          window.cancelAnimationFrame(frame);
+          frame = window.requestAnimationFrame(() => updateScrollFades(editor));
+        };
+        scroller.addEventListener("scroll", schedule, { passive: true });
+        window.addEventListener("resize", schedule);
+        const observer =
+          typeof ResizeObserver === "undefined" ? null : new ResizeObserver(schedule);
+        observer?.observe(scroller);
+        schedule();
+        detachScrollTracking = () => {
+          window.cancelAnimationFrame(frame);
+          scroller.removeEventListener("scroll", schedule);
+          window.removeEventListener("resize", schedule);
+          observer?.disconnect();
+        };
       };
-      scroller.addEventListener("scroll", schedule, { passive: true });
-      window.addEventListener("resize", schedule);
-      const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(schedule);
-      observer?.observe(scroller);
-      schedule();
+
+      // Register first so a view created between the readiness check and the
+      // subscription still gets its scroll tracking attached.
+      editor.on("create", attachScrollTracking);
+      attachScrollTracking();
       return () => {
-        window.cancelAnimationFrame(frame);
-        scroller.removeEventListener("scroll", schedule);
-        window.removeEventListener("resize", schedule);
-        observer?.disconnect();
+        editor.off("create", attachScrollTracking);
+        detachScrollTracking?.();
       };
     }, [editor]);
 
@@ -322,9 +343,11 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
       ref,
       () => ({
         focus: () => focusEnd(editor),
-        clear: () => editor?.commands.clearContent(true),
+        clear: () => {
+          if (editorHasView(editor)) editor.commands.clearContent(true);
+        },
         setContent: (text, category, options) => {
-          if (!editor) return;
+          if (!editorHasView(editor)) return;
           const staged = options?.selectPlaceholder && !category ? stripPlaceholder(text) : null;
           editor.commands.setContent(
             buildDoc(staged?.text ?? text, category, { rehydrateNoteTokens: !staged }),
@@ -346,13 +369,13 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
           }
         },
         insertCategory: (category) => {
-          if (editor) insertReportCategory(editor, category);
+          if (editorHasView(editor)) insertReportCategory(editor, category);
         },
         insertNoteReference: (noteReference) => {
-          if (editor) insertNoteReference(editor, noteReference);
+          if (editorHasView(editor)) insertNoteReference(editor, noteReference);
         },
         insertPlainText: (text) => {
-          if (!editor || editor.isDestroyed) return false;
+          if (!editorHasView(editor)) return false;
           const normalized = text.replace(/\r\n?/g, "\n");
           const content = normalized.split("\n").flatMap((line, index) => {
             const nodes = [];
@@ -367,8 +390,8 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
           editor.view.dispatch(transaction);
           return true;
         },
-        isFocused: () => !!editor?.isFocused && document.hasFocus(),
-        isEmpty: () => editor?.isEmpty ?? true,
+        isFocused: () => editorHasView(editor) && editor.isFocused && document.hasFocus(),
+        isEmpty: () => !editorHasView(editor) || editor.isEmpty,
       }),
       [editor],
     );

--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -23,6 +23,8 @@ import type { ReportCategory } from "./reportCategory";
 import type { HermesSkillInfo } from "../../../lib/tauri";
 import type { BuiltinComposerSlashCommandName } from "../../../lib/agent-composer-slash-commands";
 
+type SetContentOptions = { selectPlaceholder?: boolean; focus?: boolean };
+
 export type ComposerEditorHandle = {
   focus: () => void;
   clear: () => void;
@@ -31,11 +33,7 @@ export type ComposerEditorHandle = {
    * the composer after a failed send. With `selectPlaceholder`, the first
    * `<placeholder>` token's brackets are stripped and the bare phrase left
    * selected so the user can overtype it in place. */
-  setContent: (
-    text: string,
-    category?: ReportCategory | null,
-    options?: { selectPlaceholder?: boolean; focus?: boolean },
-  ) => void;
+  setContent: (text: string, category?: ReportCategory | null, options?: SetContentOptions) => void;
   /** Inserts or swaps the legacy message category tag at the caret. */
   insertCategory: (category: ReportCategory) => void;
   /** Inserts a note reference chip at the caret. Multiple references can
@@ -60,6 +58,18 @@ type ComposerEditorProps = {
    * its DOM element for layout). */
   onReady?: (editor: Editor) => void;
 };
+
+type PendingEditorAction =
+  | { type: "focus" }
+  | { type: "clear" }
+  | {
+      type: "setContent";
+      text: string;
+      category?: ReportCategory | null;
+      options?: SetContentOptions;
+    }
+  | { type: "insertCategory"; category: ReportCategory }
+  | { type: "insertNoteReference"; noteReference: NoteReferenceInput };
 
 /** Serializes the doc to the plain string sent to June: paragraph and
  * hard-break boundaries become newlines, the category chip contributes
@@ -163,12 +173,87 @@ export function buildDoc(
   return { type: "doc", content: paragraphs };
 }
 
+function setEditorContent(
+  editor: Editor,
+  text: string,
+  category?: ReportCategory | null,
+  options?: SetContentOptions,
+) {
+  const staged = options?.selectPlaceholder && !category ? stripPlaceholder(text) : null;
+  editor.commands.setContent(
+    buildDoc(staged?.text ?? text, category, { rehydrateNoteTokens: !staged }),
+    {
+      emitUpdate: true,
+    },
+  );
+  // A hero shortcut authors a "<placeholder>" token; the brackets are
+  // stripped before the text hits the document and the bare phrase left
+  // selected (rather than parking the caret at the end) so typing
+  // overtypes it in place.
+  const range = staged ? { from: staged.from, to: staged.to } : null;
+  const shouldFocus = options?.focus !== false;
+  if (range) {
+    editor.commands.setTextSelection(range);
+    if (shouldFocus) editor.view.focus();
+  } else if (shouldFocus) {
+    focusEnd(editor);
+  }
+}
+
+function applyEditorAction(editor: Editor, action: PendingEditorAction) {
+  switch (action.type) {
+    case "focus":
+      focusEnd(editor);
+      break;
+    case "clear":
+      editor.commands.clearContent(true);
+      break;
+    case "setContent":
+      setEditorContent(editor, action.text, action.category, action.options);
+      break;
+    case "insertCategory":
+      insertReportCategory(editor, action.category);
+      break;
+    case "insertNoteReference":
+      insertNoteReference(editor, action.noteReference);
+      break;
+  }
+}
+
+function queueEditorAction(
+  pendingActions: PendingEditorAction[],
+  action: PendingEditorAction,
+): PendingEditorAction[] {
+  if (action.type === "setContent" || action.type === "clear") {
+    // A replacement supersedes earlier document mutations. Preserve a
+    // standalone focus request, but make content last-write-wins.
+    return [...pendingActions.filter(({ type }) => type === "focus"), action];
+  }
+  if (action.type === "focus" && pendingActions.some(({ type }) => type === "focus")) {
+    return pendingActions;
+  }
+  return [...pendingActions, action];
+}
+
+function flushEditorActions(
+  editor: Editor | null,
+  pendingActionsRef: { current: PendingEditorAction[] },
+) {
+  if (!editorHasView(editor) || pendingActionsRef.current.length === 0) return;
+  const pendingActions = pendingActionsRef.current;
+  pendingActionsRef.current = [];
+  for (const action of pendingActions) {
+    applyEditorAction(editor, action);
+  }
+}
+
 export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorProps>(
   (
     { placeholder, skills, onChange, onSubmit, onFocusChange, onBuiltinSlashCommand, onReady },
     ref,
   ) => {
     const frameRef = useRef<HTMLDivElement | null>(null);
+    const pendingEditorActionsRef = useRef<PendingEditorAction[]>([]);
     const skillsRef = useRef(skills);
     // Latest callbacks behind refs so the editor (created once) never closes
     // over a stale handler.
@@ -329,51 +414,55 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
         };
       };
 
+      const handleViewReady = () => {
+        attachScrollTracking();
+        flushEditorActions(editor, pendingEditorActionsRef);
+      };
+
       // Register first so a view created between the readiness check and the
-      // subscription still gets its scroll tracking attached.
-      editor.on("create", attachScrollTracking);
-      attachScrollTracking();
+      // subscription still gets its scroll tracking and queued updates.
+      editor.on("mount", handleViewReady);
+      editor.on("create", handleViewReady);
+      handleViewReady();
       return () => {
-        editor.off("create", attachScrollTracking);
+        editor.off("mount", handleViewReady);
+        editor.off("create", handleViewReady);
         detachScrollTracking?.();
       };
     }, [editor]);
 
-    useImperativeHandle(
-      ref,
-      () => ({
-        focus: () => focusEnd(editor),
-        clear: () => {
-          if (editorHasView(editor)) editor.commands.clearContent(true);
-        },
-        setContent: (text, category, options) => {
-          if (!editorHasView(editor)) return;
-          const staged = options?.selectPlaceholder && !category ? stripPlaceholder(text) : null;
-          editor.commands.setContent(
-            buildDoc(staged?.text ?? text, category, { rehydrateNoteTokens: !staged }),
-            {
-              emitUpdate: true,
-            },
-          );
-          // A hero shortcut authors a "<placeholder>" token; the brackets are
-          // stripped before the text hits the document and the bare phrase left
-          // selected (rather than parking the caret at the end) so typing
-          // overtypes it in place.
-          const range = staged ? { from: staged.from, to: staged.to } : null;
-          const shouldFocus = options?.focus !== false;
-          if (range) {
-            editor.commands.setTextSelection(range);
-            if (shouldFocus) editor.view.focus();
-          } else if (shouldFocus) {
-            focusEnd(editor);
-          }
-        },
-        insertCategory: (category) => {
-          if (editorHasView(editor)) insertReportCategory(editor, category);
-        },
-        insertNoteReference: (noteReference) => {
-          if (editorHasView(editor)) insertNoteReference(editor, noteReference);
-        },
+    useImperativeHandle(ref, () => {
+      const applyOrQueue = (action: PendingEditorAction) => {
+        if (pendingEditorActionsRef.current.length === 0 && editorHasView(editor)) {
+          applyEditorAction(editor, action);
+          return;
+        }
+        pendingEditorActionsRef.current = queueEditorAction(
+          pendingEditorActionsRef.current,
+          action,
+        );
+        // The view can become available before React runs the readiness
+        // effect. Flush the reconciled queue now so an older request can never
+        // overwrite this newer one when the create event arrives.
+        flushEditorActions(editor, pendingEditorActionsRef);
+      };
+
+      return {
+        focus: () => applyOrQueue({ type: "focus" }),
+        clear: () => applyOrQueue({ type: "clear" }),
+        setContent: (text, category, options) =>
+          applyOrQueue({
+            type: "setContent",
+            text,
+            category,
+            options: options ? { ...options } : undefined,
+          }),
+        insertCategory: (category) => applyOrQueue({ type: "insertCategory", category }),
+        insertNoteReference: (noteReference) =>
+          applyOrQueue({
+            type: "insertNoteReference",
+            noteReference: { ...noteReference },
+          }),
         insertPlainText: (text) => {
           if (!editorHasView(editor)) return false;
           const normalized = text.replace(/\r\n?/g, "\n");
@@ -392,9 +481,8 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
         },
         isFocused: () => editorHasView(editor) && editor.isFocused && document.hasFocus(),
         isEmpty: () => !editorHasView(editor) || editor.isEmpty,
-      }),
-      [editor],
-    );
+      };
+    }, [editor]);
 
     return (
       <div ref={frameRef} className="agent-composer-editor-root scroll-fade">

--- a/src/test/composer-editor-lifecycle.test.tsx
+++ b/src/test/composer-editor-lifecycle.test.tsx
@@ -1,0 +1,62 @@
+import type { Editor } from "@tiptap/react";
+import { createRef } from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const editorMock = vi.hoisted(() => ({ current: null as Editor | null }));
+
+vi.mock("@tiptap/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tiptap/react")>();
+  return {
+    ...actual,
+    EditorContent: () => null,
+    useEditor: () => editorMock.current,
+  };
+});
+
+import {
+  ComposerEditor,
+  type ComposerEditorHandle,
+} from "../components/agent/composer/ComposerEditor";
+
+describe("composer editor lifecycle", () => {
+  it("does not access the editor view or commands before the view mounts", () => {
+    const on = vi.fn();
+    const off = vi.fn();
+    editorMock.current = {
+      isDestroyed: true,
+      on,
+      off,
+      get view(): never {
+        throw new Error("view is not mounted");
+      },
+      get commands(): never {
+        throw new Error("commands require a mounted view");
+      },
+    } as unknown as Editor;
+    const ref = createRef<ComposerEditorHandle>();
+
+    expect(() =>
+      render(
+        <ComposerEditor
+          ref={ref}
+          placeholder="Message June"
+          onChange={vi.fn()}
+          onSubmit={vi.fn()}
+        />,
+      ),
+    ).not.toThrow();
+    expect(on).toHaveBeenCalledWith("create", expect.any(Function));
+
+    expect(() => {
+      ref.current?.focus();
+      ref.current?.clear();
+      ref.current?.setContent("Restored draft");
+      ref.current?.insertCategory("bug");
+      ref.current?.insertNoteReference({ id: "note-1", title: "Note" });
+    }).not.toThrow();
+    expect(ref.current?.insertPlainText("Dictated text")).toBe(false);
+    expect(ref.current?.isFocused()).toBe(false);
+    expect(ref.current?.isEmpty()).toBe(true);
+  });
+});

--- a/src/test/composer-editor-lifecycle.test.tsx
+++ b/src/test/composer-editor-lifecycle.test.tsx
@@ -1,9 +1,13 @@
 import type { Editor } from "@tiptap/react";
 import { createRef } from "react";
-import { render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const editorMock = vi.hoisted(() => ({ current: null as Editor | null }));
+const mutationMocks = vi.hoisted(() => ({
+  insertReportCategory: vi.fn(),
+  insertNoteReference: vi.fn(),
+}));
 
 vi.mock("@tiptap/react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tiptap/react")>();
@@ -14,12 +18,35 @@ vi.mock("@tiptap/react", async (importOriginal) => {
   };
 });
 
+vi.mock("../components/agent/composer/categoryChip", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../components/agent/composer/categoryChip")>();
+  return {
+    ...actual,
+    insertReportCategory: mutationMocks.insertReportCategory,
+  };
+});
+
+vi.mock("../components/agent/composer/noteReference", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../components/agent/composer/noteReference")>();
+  return {
+    ...actual,
+    insertNoteReference: mutationMocks.insertNoteReference,
+  };
+});
+
 import {
+  buildDoc,
   ComposerEditor,
   type ComposerEditorHandle,
 } from "../components/agent/composer/ComposerEditor";
 
 describe("composer editor lifecycle", () => {
+  beforeEach(() => {
+    mutationMocks.insertReportCategory.mockClear();
+    mutationMocks.insertNoteReference.mockClear();
+  });
+
   it("does not access the editor view or commands before the view mounts", () => {
     const on = vi.fn();
     const off = vi.fn();
@@ -58,5 +85,65 @@ describe("composer editor lifecycle", () => {
     expect(ref.current?.insertPlainText("Dictated text")).toBe(false);
     expect(ref.current?.isFocused()).toBe(false);
     expect(ref.current?.isEmpty()).toBe(true);
+  });
+
+  it("applies the latest queued content and later insertions when the view mounts", () => {
+    let mounted = false;
+    const mountHandlers: Array<() => void> = [];
+    const setContent = vi.fn();
+    const scroller = document.createElement("div");
+    const editor = {
+      get isDestroyed() {
+        return !mounted;
+      },
+      on: vi.fn((event: string, handler: () => void) => {
+        if (event === "mount") mountHandlers.push(handler);
+      }),
+      off: vi.fn(),
+      get commands() {
+        if (!mounted) throw new Error("commands require a mounted view");
+        return { setContent };
+      },
+      get view() {
+        if (!mounted) throw new Error("view is not mounted");
+        return { dom: scroller };
+      },
+      state: {
+        selection: { empty: true },
+      },
+    } as unknown as Editor;
+    editorMock.current = editor;
+    const ref = createRef<ComposerEditorHandle>();
+    render(
+      <ComposerEditor ref={ref} placeholder="Message June" onChange={vi.fn()} onSubmit={vi.fn()} />,
+    );
+
+    ref.current?.setContent("Stale draft", "bug", { focus: false });
+    ref.current?.insertCategory("feedback");
+    ref.current?.setContent("Restored draft", null, { focus: false });
+    ref.current?.insertCategory("feature");
+    ref.current?.insertNoteReference({ id: "note-1", title: "Note" });
+
+    expect(setContent).not.toHaveBeenCalled();
+    expect(mutationMocks.insertReportCategory).not.toHaveBeenCalled();
+    expect(mutationMocks.insertNoteReference).not.toHaveBeenCalled();
+    expect(mountHandlers).toHaveLength(1);
+
+    act(() => {
+      mounted = true;
+      mountHandlers[0]();
+    });
+
+    expect(setContent).toHaveBeenCalledOnce();
+    expect(setContent).toHaveBeenCalledWith(buildDoc("Restored draft", null), {
+      emitUpdate: true,
+    });
+    expect(mutationMocks.insertReportCategory).toHaveBeenCalledOnce();
+    expect(mutationMocks.insertReportCategory).toHaveBeenCalledWith(editor, "feature");
+    expect(mutationMocks.insertNoteReference).toHaveBeenCalledOnce();
+    expect(mutationMocks.insertNoteReference).toHaveBeenCalledWith(editor, {
+      id: "note-1",
+      title: "Note",
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Guard every imperative `ComposerEditor` view/command access with Tiptap's mounted-view lifecycle signal.
- Defer scroll tracking until the editor emits `create`, while preserving immediate attachment for already-mounted editors.
- Add a lifecycle regression test whose mock throws if code touches `view` or `commands` before mount.
- Unblocks the `0.0.36-rc.6` desktop release gate.

## Root cause

`ComposerEditor` treated a non-null Tiptap `Editor` as proof that its ProseMirror view was available. During the pre-mount and post-unmount windows, Tiptap 3.27.1 exposes the editor object but reports `isDestroyed` and throws from its `view` proxy; the component's scroll effect dereferenced `editor.view.dom`, and draft restoration invoked `editor.commands.setContent` without checking that lifecycle state. The lazy workspace/error-boundary trees added in #912 made those remount windows more likely, and the macOS release runner consistently exposed the timing race.

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage pnpm vitest run --no-cache src/test/composer-editor-lifecycle.test.tsx src/test/agent-workspace.test.tsx src/test/composer-slash-menu.test.tsx src/test/workspace-lazy.test.tsx` (357 passed, 2 skipped)
- `pnpm check` (passes; existing warning backlog only)
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` (210 files, 3,421 passed, 2 skipped)
- `make local-ci` (pending on this pushed SHA)

- [ ] Tested visually where it matters (not applicable: lifecycle-only fix with no visible UI change).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Changing workspace lazy loading or the error-boundary behavior introduced in #912.
- Changing Tiptap/ProseMirror versions or composer UX.
- Weakening or skipping any release or frontend test.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary (not applicable: no security-sensitive changes).
- [x] Workflow action references are pinned to full-length commit SHAs (not applicable: no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable: no such changes).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable: no backend changes).
- [x] User-facing copy follows the repo UI conventions (not applicable: no user-facing copy changes).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787401492&installation_model_id=425925&pr_number=919&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F919&signature=380a5558f1409a7dec8f51b4a57a11f2b83a1774598f9c7dce22410d77bfd0fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->