### PR TITLE
Stabilize Computer use permission polling

### DIFF
--- a/docs/computer-use-support.md
+++ b/docs/computer-use-support.md
@@ -34,8 +34,10 @@ are enabled.
    from June into that pane: the helper card for Accessibility, or the outer
    June card for Screen Recording. Removing a macOS grant may require June to
    be quit and reopened before macOS reports the new state.
-4. Return to June. The setup page polls while incomplete and reconfigures the
-   runtime when the signed helper becomes capturable.
+4. Return to June. The visible setup page polls one signed-helper probe at a
+   time while incomplete and reconfigures the runtime when the helper becomes
+   capturable. Polling pauses while the page is hidden and refreshes when it
+   becomes visible again.
 5. If the driver crashed, Stop clears its private child and the next eligible
    task starts a new one. Never start an upstream daemon beside June.
 6. The first access to each target app asks once for access during the current

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3359,6 +3359,7 @@ dependencies = [
  "rand 0.8.6",
  "reqwest 0.12.28",
  "rustfft",
+ "security-framework 3.7.0",
  "semver",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3345,6 +3345,7 @@ dependencies = [
  "base64 0.22.1",
  "block2 0.6.2",
  "chrono",
+ "core-foundation 0.10.1",
  "cpal",
  "cua-driver-core",
  "dotenvy",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -100,6 +100,7 @@ libc = "0.2"
 # screencapturekit supports >=0.6,<0.9, but apple-metal 0.6.1+ references
 # macOS 26 SDK symbols that do not compile on June's macOS 15/Xcode 16 lane.
 apple-metal = { version = "=0.6.0", default-features = false }
+core-foundation = "0.10"
 keyring = { version = "3", features = ["apple-native"] }
 block2 = "0.6"
 cua-driver-core = { git = "https://github.com/trycua/cua", rev = "51582fd2ad8cffb68b2c6c81077d391132d7a0e1" }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -136,6 +136,7 @@ objc2-foundation = { version = "0.3", default-features = false, features = [
 ] }
 window-vibrancy = "0.6"
 platform-macos = { git = "https://github.com/trycua/cua", rev = "51582fd2ad8cffb68b2c6c81077d391132d7a0e1" }
+security-framework = "3.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3", features = ["windows-native"] }

--- a/src-tauri/src/computer_use.rs
+++ b/src-tauri/src/computer_use.rs
@@ -212,6 +212,15 @@ struct PermissionProbe {
     screen_recording: bool,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct PermissionProbeStatus {
+    accessibility: bool,
+    screen_recording: bool,
+    ready: bool,
+    state: &'static str,
+    error: Option<String>,
+}
+
 #[derive(Default)]
 struct PermissionProbeCoordinator {
     active: AsyncMutex<Option<ActivePermissionProbe>>,
@@ -281,12 +290,14 @@ impl PermissionProbeCoordinator {
                     let run_probe = probe.clone();
                     tauri::async_runtime::spawn(async move {
                         let result = run_probe(prompt).await;
+                        // Publish while this flight is still discoverable. A
+                        // caller in this handoff window must share the completed
+                        // result instead of starting an overlapping probe.
+                        let _ = sender.send(Some(result));
                         let mut active = coordinator.active.lock().await;
                         if active.as_ref().is_some_and(|active| active.id == id) {
                             *active = None;
                         }
-                        drop(active);
-                        let _ = sender.send(Some(result));
                     });
                     (receiver, prompt)
                 }
@@ -661,7 +672,7 @@ impl DriverClient {
             self.terminate();
         }
         if !wait_for_process_exit(self.pid, DRIVER_SHUTDOWN_TIMEOUT).await {
-            signal_process_group(self.pid, libc::SIGKILL);
+            force_stop_pid(self.pid);
         }
         if !wait_for_process_exit(self.pid, DRIVER_KILL_TIMEOUT).await {
             tracing::warn!(
@@ -678,7 +689,7 @@ impl DriverClient {
 impl Drop for DriverClient {
     fn drop(&mut self) {
         if self.pid > 0 {
-            signal_process_group(self.pid, libc::SIGKILL);
+            force_stop_pid(self.pid);
             self.pid = 0;
         }
         let _ = std::fs::remove_dir_all(&self.socket_dir);
@@ -1364,6 +1375,14 @@ fn signature_cache_matches(
     fingerprint: &BundleFingerprint,
     force: bool,
 ) -> bool {
+    // SECURITY: This session-local metadata fingerprint is only a cache
+    // invalidation key after a successful `codesign --verify --strict`; it is
+    // not treated as code identity. An attacker able to restore these fields
+    // still cannot inherit the original helper's TCC grant because macOS keys
+    // that grant to its signed code identity/cdhash, or connect to the genuine
+    // helper because every accepted socket is checked live by audit token
+    // against June's identifier and the helper-derived Team OU. Explicit retry
+    // bypasses this cache, and a new June process begins with an empty cache.
     !force && cached.is_some_and(|cached| cached.fingerprint == *fingerprint)
 }
 
@@ -1861,33 +1880,10 @@ async fn status_inner(app: &AppHandle, computer_use: &ComputerUseState) -> Compu
             error: None,
         };
     }
-    let permissions = match probe_permissions(computer_use, &path, false).await {
-        Ok(permissions) => permissions,
-        Err(error) => {
-            return ComputerUseStatus {
-                platform_supported,
-                plan_eligible,
-                grant_enabled,
-                driver_available: true,
-                driver_version: Some(version),
-                accessibility: false,
-                screen_recording: false,
-                model_supports_vision,
-                generation_model,
-                ready: false,
-                state: "error".to_string(),
-                error: Some(error.message),
-            };
-        }
-    };
-    let ready = permissions.accessibility && permissions.screen_recording && model_supports_vision;
-    let state = if !permissions.accessibility || !permissions.screen_recording {
-        "permission_missing"
-    } else if !model_supports_vision {
-        "model_unsupported"
-    } else {
-        "ready"
-    };
+    let permissions = permission_probe_status(
+        probe_permissions(computer_use, &path, false).await,
+        model_supports_vision,
+    );
     ComputerUseStatus {
         platform_supported,
         plan_eligible,
@@ -1898,9 +1894,42 @@ async fn status_inner(app: &AppHandle, computer_use: &ComputerUseState) -> Compu
         screen_recording: permissions.screen_recording,
         model_supports_vision,
         generation_model,
-        ready,
-        state: state.to_string(),
-        error: None,
+        ready: permissions.ready,
+        state: permissions.state.to_string(),
+        error: permissions.error,
+    }
+}
+
+fn permission_probe_status(
+    result: Result<PermissionProbe, AppError>,
+    model_supports_vision: bool,
+) -> PermissionProbeStatus {
+    match result {
+        Ok(permissions) => {
+            let ready =
+                permissions.accessibility && permissions.screen_recording && model_supports_vision;
+            let state = if !permissions.accessibility || !permissions.screen_recording {
+                "permission_missing"
+            } else if !model_supports_vision {
+                "model_unsupported"
+            } else {
+                "ready"
+            };
+            PermissionProbeStatus {
+                accessibility: permissions.accessibility,
+                screen_recording: permissions.screen_recording,
+                ready,
+                state,
+                error: None,
+            }
+        }
+        Err(error) => PermissionProbeStatus {
+            accessibility: false,
+            screen_recording: false,
+            ready: false,
+            state: "error",
+            error: Some(error.message),
+        },
     }
 }
 
@@ -4768,6 +4797,25 @@ mod tests {
         let second = second.await.expect("second poller").expect("second result");
         assert_eq!(first, second);
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn permission_probe_timeout_is_not_reported_as_missing_permissions() {
+        let status = permission_probe_status(
+            Err(AppError::new(
+                "computer_use_driver_timeout",
+                "The Computer use driver did not respond in time.",
+            )),
+            true,
+        );
+
+        assert_eq!(status.state, "error");
+        assert_ne!(
+            (status.accessibility, status.state),
+            (false, "permission_missing")
+        );
+        assert!(!status.ready);
+        assert!(status.error.is_some());
     }
 
     #[test]

--- a/src-tauri/src/computer_use.rs
+++ b/src-tauri/src/computer_use.rs
@@ -25,7 +25,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU32, AtomicU64, Ordering},
-        Mutex, OnceLock,
+        Arc, Mutex, OnceLock,
     },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -35,7 +35,7 @@ use tokio::io::BufReader;
 use tokio::{
     io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt},
     process::Command,
-    sync::{oneshot, Mutex as AsyncMutex},
+    sync::{oneshot, watch, Mutex as AsyncMutex},
 };
 #[cfg(target_os = "macos")]
 use tokio::{
@@ -55,8 +55,12 @@ const APPROVAL_TIMEOUT: Duration = Duration::from_secs(600);
 const DRIVER_CALL_TIMEOUT: Duration = Duration::from_secs(45);
 const DRIVER_START_TIMEOUT: Duration = Duration::from_secs(12);
 const EXTERNAL_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
+const SIGNATURE_VERIFICATION_TIMEOUT: Duration = Duration::from_secs(15);
+const SIGNATURE_TERMINATION_GRACE: Duration = Duration::from_millis(250);
+const SIGNATURE_REAP_TIMEOUT: Duration = Duration::from_secs(1);
 const SHUTDOWN_MUTEX_TIMEOUT: Duration = Duration::from_millis(250);
 const DRIVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(250);
+const DRIVER_KILL_TIMEOUT: Duration = Duration::from_secs(1);
 const DRIVER_MAX_LINE_BYTES: usize = 24 * 1024 * 1024;
 const SCREENSHOT_MAX_BYTES: usize = 12 * 1024 * 1024;
 const DEFAULT_MAX_ELEMENTS: usize = 100;
@@ -85,6 +89,8 @@ fn driver_pin() -> DriverPin {
 pub struct ComputerUseState {
     operation: AsyncMutex<()>,
     driver: AsyncMutex<Option<DriverClient>>,
+    permission_probe: Arc<PermissionProbeCoordinator>,
+    signature_verification: AsyncMutex<Option<CachedBundleSignature>>,
     driver_pid: AtomicU32,
     target: Mutex<Option<TargetContext>>,
     approvals: Mutex<HashMap<String, PendingEntry>>,
@@ -200,10 +206,118 @@ pub struct ComputerUseRunRequest {
     pub session_id: String,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct PermissionProbe {
     accessibility: bool,
     screen_recording: bool,
+}
+
+#[derive(Default)]
+struct PermissionProbeCoordinator {
+    active: AsyncMutex<Option<ActivePermissionProbe>>,
+    next_id: AtomicU64,
+}
+
+struct ActivePermissionProbe {
+    id: u64,
+    prompt: bool,
+    result: watch::Receiver<Option<Result<PermissionProbe, AppError>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileFingerprint {
+    path: PathBuf,
+    length: u64,
+    modified_ns: u128,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BundleFingerprint {
+    outer_executable: FileFingerprint,
+    outer_resources: FileFingerprint,
+    helper_executable: FileFingerprint,
+    helper_resources: FileFingerprint,
+}
+
+struct PackagedDriverBundles {
+    outer: PathBuf,
+    helper: PathBuf,
+    fingerprint: BundleFingerprint,
+}
+
+#[derive(Debug, Clone)]
+struct CachedBundleSignature {
+    fingerprint: BundleFingerprint,
+}
+
+impl PermissionProbeCoordinator {
+    async fn run<F, Fut>(
+        self: &Arc<Self>,
+        prompt: bool,
+        probe: F,
+    ) -> Result<PermissionProbe, AppError>
+    where
+        F: Fn(bool) -> Fut + Clone + Send + Sync + 'static,
+        Fut: Future<Output = Result<PermissionProbe, AppError>> + Send + 'static,
+    {
+        loop {
+            let (receiver, active_prompt) = {
+                let mut active = self.active.lock().await;
+                if let Some(active) = active.as_ref() {
+                    (active.result.clone(), active.prompt)
+                } else {
+                    let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+                    let (sender, receiver) = watch::channel(None);
+                    *active = Some(ActivePermissionProbe {
+                        id,
+                        prompt,
+                        result: receiver.clone(),
+                    });
+                    let coordinator = Arc::clone(self);
+                    let run_probe = probe.clone();
+                    tauri::async_runtime::spawn(async move {
+                        let result = run_probe(prompt).await;
+                        let mut active = coordinator.active.lock().await;
+                        if active.as_ref().is_some_and(|active| active.id == id) {
+                            *active = None;
+                        }
+                        drop(active);
+                        let _ = sender.send(Some(result));
+                    });
+                    (receiver, prompt)
+                }
+            };
+
+            let result = wait_for_permission_probe(receiver).await?;
+            if prompt && !active_prompt && next_permission_prompt(&result).is_some() {
+                // A user request that arrived during a background status
+                // refresh shares that refresh first, then owns the one prompt
+                // it still needs after the background flight has completed.
+                continue;
+            }
+            return Ok(result);
+        }
+    }
+}
+
+async fn wait_for_permission_probe(
+    mut receiver: watch::Receiver<Option<Result<PermissionProbe, AppError>>>,
+) -> Result<PermissionProbe, AppError> {
+    loop {
+        if let Some(result) = receiver.borrow().clone() {
+            return result;
+        }
+        receiver.changed().await.map_err(|_| {
+            AppError::new(
+                "computer_use_driver_stopped",
+                "The Computer use permission probe stopped unexpectedly.",
+            )
+        })?;
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -359,10 +473,6 @@ impl DriverClient {
             .ok()
             .and_then(|credentials| credentials.pid())
             .and_then(|pid| u32::try_from(pid).ok())
-            .filter(|pid| {
-                process_executable_path(*pid as libc::pid_t)
-                    .is_some_and(|actual| same_path(&actual, path))
-            })
             .ok_or_else(|| {
                 let _ = std::fs::remove_dir_all(&socket_dir);
                 AppError::new(
@@ -370,6 +480,17 @@ impl DriverClient {
                     "The private Computer use channel was not owned by June's bundled driver.",
                 )
             })?;
+        if !process_executable_path(pid as libc::pid_t)
+            .is_some_and(|actual| same_path(&actual, path))
+            || !process_group_is_owned(pid)
+        {
+            let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+            let _ = std::fs::remove_dir_all(&socket_dir);
+            return Err(AppError::new(
+                "computer_use_driver_start_failed",
+                "The private Computer use channel did not have the expected isolated driver identity.",
+            ));
+        }
         let (stdout, stdin) = stream.into_split();
         let mut client = Self {
             stdin,
@@ -404,10 +525,7 @@ impl DriverClient {
 
     fn terminate(&mut self) {
         if self.pid > 0 {
-            unsafe {
-                libc::kill(self.pid as libc::pid_t, libc::SIGTERM);
-            }
-            self.pid = 0;
+            signal_process_group(self.pid, libc::SIGTERM);
         }
     }
 
@@ -539,7 +657,19 @@ impl DriverClient {
 
     async fn stop(mut self) {
         let _ = tokio::time::timeout(DRIVER_SHUTDOWN_TIMEOUT, self.stdin.shutdown()).await;
-        self.terminate();
+        if !wait_for_process_exit(self.pid, DRIVER_SHUTDOWN_TIMEOUT).await {
+            self.terminate();
+        }
+        if !wait_for_process_exit(self.pid, DRIVER_SHUTDOWN_TIMEOUT).await {
+            signal_process_group(self.pid, libc::SIGKILL);
+        }
+        if !wait_for_process_exit(self.pid, DRIVER_KILL_TIMEOUT).await {
+            tracing::warn!(
+                pid = self.pid,
+                "Computer use driver process group did not exit"
+            );
+        }
+        self.pid = 0;
         let _ = tokio::fs::remove_dir_all(&self.socket_dir).await;
     }
 }
@@ -547,7 +677,10 @@ impl DriverClient {
 #[cfg(target_os = "macos")]
 impl Drop for DriverClient {
     fn drop(&mut self) {
-        self.terminate();
+        if self.pid > 0 {
+            signal_process_group(self.pid, libc::SIGKILL);
+            self.pid = 0;
+        }
         let _ = std::fs::remove_dir_all(&self.socket_dir);
     }
 }
@@ -894,6 +1027,34 @@ async fn connect_driver_socket(path: &Path) -> io::Result<UnixStream> {
     }
 }
 
+#[cfg(target_os = "macos")]
+fn process_group_is_owned(pid: u32) -> bool {
+    libc::pid_t::try_from(pid)
+        .ok()
+        .is_some_and(|pid| unsafe { libc::getpgid(pid) } == pid)
+}
+
+#[cfg(target_os = "macos")]
+async fn wait_for_process_exit(pid: u32, timeout: Duration) -> bool {
+    if pid == 0 {
+        return true;
+    }
+    let Ok(pid) = libc::pid_t::try_from(pid) else {
+        return true;
+    };
+    let deadline = Instant::now() + timeout;
+    loop {
+        let result = unsafe { libc::kill(pid, 0) };
+        if result == -1 && io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
 fn next_permission_prompt(probe: &PermissionProbe) -> Option<DriverPermissionPrompt> {
     if !probe.accessibility {
         Some(DriverPermissionPrompt::Accessibility)
@@ -1097,6 +1258,213 @@ fn driver_stamp_matches(executable: &Path, pin: &DriverPin) -> bool {
         && value.get("sourceCommit").and_then(Value::as_str) == Some(pin.source_commit.as_str())
 }
 
+fn file_fingerprint(path: &Path) -> io::Result<FileFingerprint> {
+    let metadata = std::fs::metadata(path)?;
+    let modified_ns = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    #[cfg(unix)]
+    use std::os::unix::fs::MetadataExt;
+
+    Ok(FileFingerprint {
+        path: std::fs::canonicalize(path)?,
+        length: metadata.len(),
+        modified_ns,
+        #[cfg(unix)]
+        device: metadata.dev(),
+        #[cfg(unix)]
+        inode: metadata.ino(),
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn packaged_driver_bundles(path: &Path) -> Result<Option<PackagedDriverBundles>, AppError> {
+    let app_ancestors = path
+        .ancestors()
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("app"))
+        })
+        .map(PathBuf::from)
+        .collect::<Vec<_>>();
+    let (Some(helper), Some(outer)) = (app_ancestors.first(), app_ancestors.get(1)) else {
+        return Ok(None);
+    };
+    let expected_outer_executable = outer.join("Contents").join("MacOS").join("os-june");
+    if !std::env::current_exe()
+        .ok()
+        .is_some_and(|current| same_path(&current, &expected_outer_executable))
+    {
+        return Err(AppError::new(
+            "computer_use_driver_signature_failed",
+            "The Computer use driver is not nested under the running June app.",
+        ));
+    }
+
+    let outer_resources = outer
+        .join("Contents")
+        .join("_CodeSignature")
+        .join("CodeResources");
+    let helper_resources = helper
+        .join("Contents")
+        .join("_CodeSignature")
+        .join("CodeResources");
+    let fingerprint_file = |path: &Path| {
+        file_fingerprint(path).map_err(|error| {
+            AppError::new(
+                "computer_use_driver_signature_failed",
+                format!("The Computer use signature fingerprint is unavailable. {error}"),
+            )
+        })
+    };
+    let fingerprint = BundleFingerprint {
+        outer_executable: fingerprint_file(&expected_outer_executable)?,
+        outer_resources: fingerprint_file(&outer_resources)?,
+        helper_executable: fingerprint_file(path)?,
+        helper_resources: fingerprint_file(&helper_resources)?,
+    };
+    Ok(Some(PackagedDriverBundles {
+        outer: outer.clone(),
+        helper: helper.clone(),
+        fingerprint,
+    }))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn packaged_driver_bundles(_path: &Path) -> Result<Option<PackagedDriverBundles>, AppError> {
+    Ok(None)
+}
+
+async fn verify_packaged_driver_signatures(
+    state: &ComputerUseState,
+    path: &Path,
+    force: bool,
+) -> Result<(), AppError> {
+    let Some(bundles) = packaged_driver_bundles(path)? else {
+        return Ok(());
+    };
+    let mut cache = state.signature_verification.lock().await;
+    if signature_cache_matches(cache.as_ref(), &bundles.fingerprint, force) {
+        return Ok(());
+    }
+
+    verify_bundle_signature(bundles.outer.clone()).await?;
+    verify_bundle_signature(bundles.helper.clone()).await?;
+    *cache = Some(CachedBundleSignature {
+        fingerprint: bundles.fingerprint,
+    });
+    Ok(())
+}
+
+fn signature_cache_matches(
+    cached: Option<&CachedBundleSignature>,
+    fingerprint: &BundleFingerprint,
+    force: bool,
+) -> bool {
+    !force && cached.is_some_and(|cached| cached.fingerprint == *fingerprint)
+}
+
+#[cfg(target_os = "macos")]
+async fn verify_bundle_signature(path: PathBuf) -> Result<(), AppError> {
+    tokio::task::spawn_blocking(move || verify_bundle_signature_sync(&path))
+        .await
+        .map_err(|error| {
+            AppError::new(
+                "computer_use_driver_signature_failed",
+                format!("The Computer use signature verifier could not be joined. {error}"),
+            )
+        })?
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn verify_bundle_signature(_path: PathBuf) -> Result<(), AppError> {
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn verify_bundle_signature_sync(path: &Path) -> Result<(), AppError> {
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command as StdCommand, Stdio};
+
+    let mut command = StdCommand::new("/usr/bin/codesign");
+    command
+        .args(["--verify", "--strict"])
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .process_group(0);
+    let mut child = command.spawn().map_err(|error| {
+        AppError::new(
+            "computer_use_driver_signature_failed",
+            format!("The Computer use signature verifier could not start. {error}"),
+        )
+    })?;
+    let pid = child.id();
+    let deadline = Instant::now() + SIGNATURE_VERIFICATION_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => return Ok(()),
+            Ok(Some(_)) => {
+                return Err(AppError::new(
+                    "computer_use_driver_signature_failed",
+                    "The signed Computer use bundle could not be verified.",
+                ));
+            }
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Ok(None) => {
+                terminate_owned_process_group(pid, child);
+                return Err(AppError::new(
+                    "computer_use_driver_signature_timeout",
+                    "The signed Computer use bundle verification timed out.",
+                ));
+            }
+            Err(error) => {
+                terminate_owned_process_group(pid, child);
+                return Err(AppError::new(
+                    "computer_use_driver_signature_failed",
+                    format!("The Computer use signature verifier failed. {error}"),
+                ));
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn terminate_owned_process_group(pid: u32, child: std::process::Child) {
+    signal_process_group(pid, libc::SIGTERM);
+    let outcome = crate::shutdown::terminate_child_with(
+        child,
+        SIGNATURE_TERMINATION_GRACE,
+        SIGNATURE_REAP_TIMEOUT,
+        move |child| {
+            signal_process_group(pid, libc::SIGKILL);
+            let _ = child.kill();
+        },
+    );
+    // The leader can exit before a verifier worker. Sweep the group after the
+    // bounded leader wait so no resource-validation descendant survives.
+    signal_process_group(pid, libc::SIGKILL);
+    if !matches!(
+        outcome,
+        crate::shutdown::ChildTermination::Exited | crate::shutdown::ChildTermination::Killed
+    ) {
+        tracing::warn!(?outcome, pid, "signature verifier could not be reaped");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn signal_process_group(pid: u32, signal: libc::c_int) {
+    if let Ok(pid) = libc::pid_t::try_from(pid) {
+        let _ = unsafe { libc::kill(-pid, signal) };
+    }
+}
+
 fn permission_drag_bundle_path(
     target: crate::computer_use_permission_drag::PermissionDragTarget,
     driver_executable: &Path,
@@ -1173,7 +1541,25 @@ async fn driver_version(path: &Path) -> Result<String, AppError> {
     }
 }
 
-async fn probe_permissions(path: &Path, prompt: bool) -> Result<PermissionProbe, AppError> {
+async fn probe_permissions(
+    state: &ComputerUseState,
+    path: &Path,
+    prompt: bool,
+) -> Result<PermissionProbe, AppError> {
+    let path = path.to_path_buf();
+    state
+        .permission_probe
+        .run(prompt, move |prompt| {
+            let path = path.clone();
+            async move { probe_permissions_uncoordinated(&path, prompt).await }
+        })
+        .await
+}
+
+async fn probe_permissions_uncoordinated(
+    path: &Path,
+    prompt: bool,
+) -> Result<PermissionProbe, AppError> {
     let initial = read_permission_probe(path, None).await?;
     if prompt {
         if let Some(next) = next_permission_prompt(&initial) {
@@ -1339,7 +1725,7 @@ async fn macos_version() -> &'static str {
     MACOS_VERSION.get().map(String::as_str).unwrap_or("unknown")
 }
 
-async fn status_inner(app: &AppHandle) -> ComputerUseStatus {
+async fn status_inner(app: &AppHandle, computer_use: &ComputerUseState) -> ComputerUseStatus {
     let platform_supported = cfg!(target_os = "macos");
     let plan_eligible = plan_eligible().await;
     let grant_enabled = grant_enabled(app).await;
@@ -1424,6 +1810,22 @@ async fn status_inner(app: &AppHandle) -> ComputerUseStatus {
             };
         }
     };
+    if let Err(error) = verify_packaged_driver_signatures(computer_use, &path, false).await {
+        return ComputerUseStatus {
+            platform_supported,
+            plan_eligible,
+            grant_enabled,
+            driver_available: false,
+            driver_version: None,
+            accessibility: false,
+            screen_recording: false,
+            model_supports_vision,
+            generation_model,
+            ready: false,
+            state: "driver_mismatch".to_string(),
+            error: Some(error.message),
+        };
+    }
     let version = match driver_version(&path).await {
         Ok(version) => version,
         Err(error) => {
@@ -1459,7 +1861,7 @@ async fn status_inner(app: &AppHandle) -> ComputerUseStatus {
             error: None,
         };
     }
-    let permissions = match probe_permissions(&path, false).await {
+    let permissions = match probe_permissions(computer_use, &path, false).await {
         Ok(permissions) => permissions,
         Err(error) => {
             return ComputerUseStatus {
@@ -1524,6 +1926,7 @@ fn subscription_plan_eligible(subscribed: bool, plan: Option<&str>) -> bool {
 }
 
 pub(crate) async fn runtime_ready(app: &AppHandle, supports_vision: bool) -> bool {
+    let state = app.state::<ComputerUseState>();
     let ready = if !rollout_gate().await.enabled
         || !supports_vision
         || !plan_eligible().await
@@ -1531,18 +1934,19 @@ pub(crate) async fn runtime_ready(app: &AppHandle, supports_vision: bool) -> boo
     {
         false
     } else if let Ok(path) = bundled_driver_executable(app) {
-        driver_version(&path).await.is_ok()
-            && probe_permissions(&path, false)
+        verify_packaged_driver_signatures(&state, &path, false)
+            .await
+            .is_ok()
+            && driver_version(&path).await.is_ok()
+            && probe_permissions(&state, &path, false)
                 .await
                 .is_ok_and(|probe| probe.accessibility && probe.screen_recording)
     } else {
         false
     };
-    if let Some(state) = app.try_state::<ComputerUseState>() {
-        state
-            .runtime_ready_state
-            .store(ready_state_value(ready), Ordering::SeqCst);
-    }
+    state
+        .runtime_ready_state
+        .store(ready_state_value(ready), Ordering::SeqCst);
     ready
 }
 
@@ -1552,7 +1956,7 @@ pub async fn computer_use_status(
     state: State<'_, ComputerUseState>,
     bridge: State<'_, crate::hermes_bridge::HermesBridge>,
 ) -> Result<ComputerUseStatus, AppError> {
-    let status = status_inner(&app).await;
+    let status = status_inner(&app, &state).await;
     let current = ready_state_value(status.ready);
     let previous = state.runtime_ready_state.swap(current, Ordering::SeqCst);
     if previous != 0 && previous != current {
@@ -1593,7 +1997,7 @@ pub async fn set_computer_use_grant(
         stop_inner(&app, &state).await;
     }
     crate::hermes_bridge::apply_runtime_config_change(&app, &bridge).await?;
-    Ok(status_inner(&app).await)
+    Ok(status_inner(&app, &state).await)
 }
 
 #[tauri::command]
@@ -1622,10 +2026,11 @@ pub async fn computer_use_request_permissions(
     }
     stop_inner(&app, &state).await;
     let path = bundled_driver_executable(&app)?;
+    verify_packaged_driver_signatures(&state, &path, true).await?;
     driver_version(&path).await?;
-    let _ = probe_permissions(&path, true).await?;
+    let _ = probe_permissions(&state, &path, true).await?;
     crate::hermes_bridge::apply_runtime_config_change(&app, &bridge).await?;
-    Ok(status_inner(&app).await)
+    Ok(status_inner(&app, &state).await)
 }
 
 pub(crate) async fn shutdown(app: &AppHandle) {
@@ -1855,7 +2260,11 @@ fn clear_app_authorizations(state: &ComputerUseState) {
 fn force_stop_pid(_pid: u32) {
     #[cfg(target_os = "macos")]
     if _pid > 0 {
-        let _ = unsafe { libc::kill(_pid as libc::pid_t, libc::SIGKILL) };
+        if process_group_is_owned(_pid) {
+            signal_process_group(_pid, libc::SIGKILL);
+        } else {
+            let _ = unsafe { libc::kill(_pid as libc::pid_t, libc::SIGKILL) };
+        }
     }
 }
 
@@ -2042,6 +2451,7 @@ async fn driver_call(
     ensure_attended_run(state)?;
     if driver.is_none() {
         let path = bundled_driver_executable(app)?;
+        verify_packaged_driver_signatures(state, &path, false).await?;
         driver_version(&path).await?;
         let client = DriverClient::start(&path, None).await?;
         state.driver_pid.store(client.pid(), Ordering::SeqCst);
@@ -4314,6 +4724,81 @@ fn now_ms() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn permission_probe_is_single_flight_for_concurrent_pollers() {
+        let coordinator = Arc::new(PermissionProbeCoordinator::default());
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let release = Arc::new(tokio::sync::Notify::new());
+        let probe = {
+            let calls = Arc::clone(&calls);
+            let release = Arc::clone(&release);
+            move |_prompt| {
+                let calls = Arc::clone(&calls);
+                let release = Arc::clone(&release);
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    release.notified().await;
+                    Ok(PermissionProbe {
+                        accessibility: true,
+                        screen_recording: false,
+                    })
+                }
+            }
+        };
+
+        let first = {
+            let coordinator = Arc::clone(&coordinator);
+            let probe = probe.clone();
+            tokio::spawn(async move { coordinator.run(false, probe).await })
+        };
+        while calls.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+        let second = {
+            let coordinator = Arc::clone(&coordinator);
+            let probe = probe.clone();
+            tokio::spawn(async move { coordinator.run(false, probe).await })
+        };
+        tokio::task::yield_now().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        release.notify_waiters();
+        let first = first.await.expect("first poller").expect("first result");
+        let second = second.await.expect("second poller").expect("second result");
+        assert_eq!(first, second);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn signature_cache_invalidates_on_bundle_change_and_explicit_retry() {
+        fn file(name: &str, length: u64) -> FileFingerprint {
+            FileFingerprint {
+                path: PathBuf::from(name),
+                length,
+                modified_ns: 42,
+                #[cfg(unix)]
+                device: 1,
+                #[cfg(unix)]
+                inode: length,
+            }
+        }
+        let fingerprint = BundleFingerprint {
+            outer_executable: file("outer-executable", 100),
+            outer_resources: file("outer-resources", 200),
+            helper_executable: file("helper-executable", 300),
+            helper_resources: file("helper-resources", 400),
+        };
+        let cached = CachedBundleSignature {
+            fingerprint: fingerprint.clone(),
+        };
+        assert!(signature_cache_matches(Some(&cached), &fingerprint, false));
+        assert!(!signature_cache_matches(Some(&cached), &fingerprint, true));
+
+        let mut changed = fingerprint.clone();
+        changed.outer_executable.length += 1;
+        assert!(!signature_cache_matches(Some(&cached), &changed, false));
+    }
 
     #[test]
     fn non_secret_computer_use_grant_never_uses_keychain() {

--- a/src-tauri/src/computer_use_driver.rs
+++ b/src-tauri/src/computer_use_driver.rs
@@ -13,13 +13,20 @@ use cua_driver_core::{
     tool::ToolRegistry,
 };
 #[cfg(target_os = "macos")]
+use security_framework::os::macos::code_signing::{
+    Flags as CodeSigningFlags, GuestAttributes, SecCode, SecRequirement,
+};
+#[cfg(target_os = "macos")]
 use serde_json::{json, Value};
 #[cfg(target_os = "macos")]
 use std::{
     collections::{HashMap, HashSet},
-    io,
+    io::{self, Read},
     path::PathBuf,
+    process::{Child, Command, ExitStatus, Stdio},
     sync::Arc,
+    thread,
+    time::{Duration, Instant},
 };
 #[cfg(target_os = "macos")]
 use tokio::{
@@ -35,6 +42,21 @@ const UPSTREAM_COMMIT: &str = "51582fd2ad8cffb68b2c6c81077d391132d7a0e1";
 const MAX_REQUEST_BYTES: usize = 256 * 1024;
 #[cfg(target_os = "macos")]
 const POINTER_NOTIFICATION_METHOD: &str = "june/pointer";
+#[cfg(target_os = "macos")]
+const SIGNATURE_DETAILS_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(target_os = "macos")]
+const CHILD_TERMINATION_GRACE: Duration = Duration::from_millis(250);
+#[cfg(target_os = "macos")]
+const CHILD_REAP_TIMEOUT: Duration = Duration::from_secs(1);
+#[cfg(target_os = "macos")]
+const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[cfg(target_os = "macos")]
+struct BoundedChildOutput {
+    status: ExitStatus,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
 
 #[cfg(target_os = "macos")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -125,6 +147,7 @@ async fn serve_stdio() -> anyhow::Result<()> {
 
 #[cfg(target_os = "macos")]
 async fn serve_daemon() -> anyhow::Result<()> {
+    isolate_process_group()?;
     let socket_path = std::env::var("JUNE_COMPUTER_USE_SOCKET")
         .map(PathBuf::from)
         .map_err(|_| anyhow::anyhow!("the private June socket is missing"))?;
@@ -344,7 +367,7 @@ fn process_is_june(pid: libc::pid_t) -> bool {
         .collect();
     if let (Some(helper_app), Some(outer_app)) = (app_ancestors.first(), app_ancestors.get(1)) {
         return same_file(&process_path, &packaged_main_executable(outer_app))
-            && packaged_signatures_match(outer_app, helper_app);
+            && packaged_process_signature_matches(pid, helper_app);
     }
 
     // Development builds are not nested yet. Accept only the Cargo binary or
@@ -414,15 +437,27 @@ fn development_launcher_name_is_allowed(name: &std::ffi::OsStr) -> bool {
 }
 
 #[cfg(target_os = "macos")]
-fn packaged_signatures_match(outer_app: &std::path::Path, helper_app: &std::path::Path) -> bool {
-    let Some(outer) = verified_signature(outer_app, "co.opensoftware.june") else {
-        return false;
-    };
-    let Some(helper) = verified_signature(helper_app, "co.opensoftware.june.computer-use-driver")
+fn packaged_process_signature_matches(pid: libc::pid_t, helper_app: &std::path::Path) -> bool {
+    let Some(helper) = signature_details(helper_app, "co.opensoftware.june.computer-use-driver")
     else {
         return false;
     };
-    outer.team_identifier == helper.team_identifier
+    let Some(requirement) = june_process_requirement(&helper.team_identifier) else {
+        return false;
+    };
+    let mut attributes = GuestAttributes::new();
+    attributes.set_pid(pid);
+    let Ok(peer) = SecCode::copy_guest_with_attribues(None, &attributes, CodeSigningFlags::NONE)
+    else {
+        return false;
+    };
+    peer.check_validity(
+        CodeSigningFlags::DO_NOT_VALIDATE_RESOURCES
+            | CodeSigningFlags::STRICT_VALIDATE
+            | CodeSigningFlags::NO_NETWORK_ACCESS,
+        &requirement,
+    )
+    .is_ok()
 }
 
 #[cfg(target_os = "macos")]
@@ -431,24 +466,13 @@ struct VerifiedSignature {
 }
 
 #[cfg(target_os = "macos")]
-fn verified_signature(
+fn signature_details(
     path: &std::path::Path,
     expected_identifier: &str,
 ) -> Option<VerifiedSignature> {
-    let verified = std::process::Command::new("/usr/bin/codesign")
-        .args(["--verify", "--strict"])
-        .arg(path)
-        .status()
-        .ok()?
-        .success();
-    if !verified {
-        return None;
-    }
-    let details = std::process::Command::new("/usr/bin/codesign")
-        .args(["-dv", "--verbose=4"])
-        .arg(path)
-        .output()
-        .ok()?;
+    let mut command = Command::new("/usr/bin/codesign");
+    command.args(["-dv", "--verbose=4"]).arg(path);
+    let details = bounded_child_output(command, SIGNATURE_DETAILS_TIMEOUT).ok()??;
     if !details.status.success() {
         return None;
     }
@@ -468,6 +492,23 @@ fn verified_signature(
 }
 
 #[cfg(target_os = "macos")]
+fn june_process_requirement(team_identifier: &str) -> Option<SecRequirement> {
+    if team_identifier.is_empty()
+        || team_identifier.len() > 64
+        || !team_identifier
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric())
+    {
+        return None;
+    }
+    format!(
+        "anchor apple generic and identifier \"co.opensoftware.june\" and certificate leaf[subject.OU] = \"{team_identifier}\""
+    )
+    .parse()
+    .ok()
+}
+
+#[cfg(target_os = "macos")]
 fn signature_value<'a>(details: &'a str, key: &str) -> Option<&'a str> {
     let prefix = format!("{key}=");
     details
@@ -475,6 +516,94 @@ fn signature_value<'a>(details: &'a str, key: &str) -> Option<&'a str> {
         .find_map(|line| line.trim().strip_prefix(prefix.as_str()))
         .map(str::trim)
         .filter(|value| !value.is_empty())
+}
+
+#[cfg(target_os = "macos")]
+fn isolate_process_group() -> anyhow::Result<()> {
+    let pid = unsafe { libc::getpid() };
+    if unsafe { libc::getpgrp() } == pid || unsafe { libc::setpgid(0, 0) } == 0 {
+        return Ok(());
+    }
+    Err(anyhow::anyhow!(
+        "the private helper could not isolate its process group: {}",
+        io::Error::last_os_error()
+    ))
+}
+
+#[cfg(target_os = "macos")]
+fn bounded_child_output(
+    mut command: Command,
+    timeout: Duration,
+) -> io::Result<Option<BoundedChildOutput>> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command.spawn()?;
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let stdout_reader = thread::spawn(move || read_pipe(stdout));
+    let stderr_reader = thread::spawn(move || read_pipe(stderr));
+
+    let status = match poll_child_exit(&mut child, timeout)? {
+        Some(status) => status,
+        None => {
+            if !terminate_child_and_reap(child) {
+                // The detached reaper and pipe readers retain ownership until
+                // the late exit. Do not block helper authentication on them.
+                return Ok(None);
+            }
+            return Ok(None);
+        }
+    };
+    let stdout = stdout_reader.join().unwrap_or_else(|_| Ok(Vec::new()))?;
+    let stderr = stderr_reader.join().unwrap_or_else(|_| Ok(Vec::new()))?;
+    Ok(Some(BoundedChildOutput {
+        status,
+        stdout,
+        stderr,
+    }))
+}
+
+#[cfg(target_os = "macos")]
+fn read_pipe<R: Read>(pipe: Option<R>) -> io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    if let Some(mut pipe) = pipe {
+        pipe.read_to_end(&mut bytes)?;
+    }
+    Ok(bytes)
+}
+
+#[cfg(target_os = "macos")]
+fn poll_child_exit(child: &mut Child, timeout: Duration) -> io::Result<Option<ExitStatus>> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait()? {
+            Some(status) => return Ok(Some(status)),
+            None if Instant::now() < deadline => thread::sleep(CHILD_POLL_INTERVAL),
+            None => return Ok(None),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn terminate_child_and_reap(mut child: Child) -> bool {
+    if let Ok(pid) = libc::pid_t::try_from(child.id()) {
+        let _ = unsafe { libc::kill(pid, libc::SIGTERM) };
+    }
+    if let Ok(Some(_)) = poll_child_exit(&mut child, CHILD_TERMINATION_GRACE) {
+        return true;
+    }
+
+    let _ = child.kill();
+    match poll_child_exit(&mut child, CHILD_REAP_TIMEOUT) {
+        Ok(Some(_)) => true,
+        Ok(None) | Err(_) => {
+            let _ = thread::Builder::new()
+                .name("june-helper-child-reaper".to_string())
+                .spawn(move || {
+                    let _ = child.wait();
+                });
+            false
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -995,6 +1124,30 @@ mod tests {
             packaged_main_executable(std::path::Path::new("/Applications/June.app")),
             std::path::PathBuf::from("/Applications/June.app/Contents/MacOS/os-june")
         );
+    }
+
+    #[test]
+    fn live_process_requirement_rejects_untrusted_team_syntax() {
+        assert!(june_process_requirement("ABCDE12345").is_some());
+        assert!(june_process_requirement("").is_none());
+        assert!(june_process_requirement("ABCDE12345\" or true").is_none());
+    }
+
+    #[test]
+    fn timed_out_signature_child_is_killed_and_reaped() {
+        let child = Command::new("/bin/sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn stuck signature child");
+        let pid = child.id() as libc::pid_t;
+
+        assert!(terminate_child_and_reap(child));
+        let probe = unsafe { libc::kill(pid, 0) };
+        assert_eq!(probe, -1);
+        assert_eq!(io::Error::last_os_error().raw_os_error(), Some(libc::ESRCH));
     }
 
     #[test]

--- a/src-tauri/src/computer_use_driver.rs
+++ b/src-tauri/src/computer_use_driver.rs
@@ -8,6 +8,8 @@
 //! desktop-control surface.
 
 #[cfg(target_os = "macos")]
+use core_foundation::{base::TCFType, data::CFData};
+#[cfg(target_os = "macos")]
 use cua_driver_core::{
     protocol::{initialize_result, Request, Response},
     tool::ToolRegistry,
@@ -22,6 +24,7 @@ use serde_json::{json, Value};
 use std::{
     collections::{HashMap, HashSet},
     io::{self, Read},
+    os::fd::AsRawFd,
     path::PathBuf,
     process::{Child, Command, ExitStatus, Stdio},
     sync::Arc,
@@ -34,7 +37,7 @@ use tokio::{
         AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt,
         BufReader,
     },
-    net::UnixListener,
+    net::{UnixListener, UnixStream},
 };
 
 const UPSTREAM_VERSION: &str = "0.5.0";
@@ -168,7 +171,8 @@ async fn serve_daemon() -> anyhow::Result<()> {
         .peer_cred()?
         .pid()
         .ok_or_else(|| anyhow::anyhow!("the private June peer has no process identity"))?;
-    if !process_is_june(peer_pid) {
+    let peer_audit_token = socket_peer_audit_token(&stream)?;
+    if !process_is_june(peer_pid, Some(&peer_audit_token)) {
         anyhow::bail!("the private helper accepts only June");
     }
     let (reader, writer) = stream.into_split();
@@ -343,11 +347,11 @@ where
 
 #[cfg(target_os = "macos")]
 fn parent_is_june() -> bool {
-    process_is_june(unsafe { libc::getppid() })
+    process_is_june(unsafe { libc::getppid() }, None)
 }
 
 #[cfg(target_os = "macos")]
-fn process_is_june(pid: libc::pid_t) -> bool {
+fn process_is_june(pid: libc::pid_t, audit_token: Option<&[u8]>) -> bool {
     let Some(process_path) = process_path(pid) else {
         return false;
     };
@@ -366,8 +370,12 @@ fn process_is_june(pid: libc::pid_t) -> bool {
         .map(PathBuf::from)
         .collect();
     if let (Some(helper_app), Some(outer_app)) = (app_ancestors.first(), app_ancestors.get(1)) {
+        // Packaged peers must arrive over the private daemon socket so their
+        // non-reusable audit token is available. Direct stdio remains a
+        // development-only path below.
         return same_file(&process_path, &packaged_main_executable(outer_app))
-            && packaged_process_signature_matches(pid, helper_app);
+            && audit_token
+                .is_some_and(|token| packaged_process_signature_matches(token, helper_app));
     }
 
     // Development builds are not nested yet. Accept only the Cargo binary or
@@ -437,7 +445,33 @@ fn development_launcher_name_is_allowed(name: &std::ffi::OsStr) -> bool {
 }
 
 #[cfg(target_os = "macos")]
-fn packaged_process_signature_matches(pid: libc::pid_t, helper_app: &std::path::Path) -> bool {
+fn socket_peer_audit_token(stream: &UnixStream) -> io::Result<[u8; 32]> {
+    let mut token = [0u8; 32];
+    let mut token_len = libc::socklen_t::try_from(token.len())
+        .map_err(|_| io::Error::other("invalid macOS audit token length"))?;
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_LOCAL,
+            libc::LOCAL_PEERTOKEN,
+            token.as_mut_ptr().cast(),
+            &mut token_len,
+        )
+    };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if usize::try_from(token_len).ok() != Some(token.len()) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "the private June peer returned an invalid audit token",
+        ));
+    }
+    Ok(token)
+}
+
+#[cfg(target_os = "macos")]
+fn packaged_process_signature_matches(audit_token: &[u8], helper_app: &std::path::Path) -> bool {
     let Some(helper) = signature_details(helper_app, "co.opensoftware.june.computer-use-driver")
     else {
         return false;
@@ -445,8 +479,9 @@ fn packaged_process_signature_matches(pid: libc::pid_t, helper_app: &std::path::
     let Some(requirement) = june_process_requirement(&helper.team_identifier) else {
         return false;
     };
+    let audit_token = CFData::from_buffer(audit_token);
     let mut attributes = GuestAttributes::new();
-    attributes.set_pid(pid);
+    attributes.set_audit_token(audit_token.as_concrete_TypeRef());
     let Ok(peer) = SecCode::copy_guest_with_attribues(None, &attributes, CodeSigningFlags::NONE)
     else {
         return false;
@@ -470,6 +505,13 @@ fn signature_details(
     path: &std::path::Path,
     expected_identifier: &str,
 ) -> Option<VerifiedSignature> {
+    let mut verification = Command::new("/usr/bin/codesign");
+    verification.args(["--verify", "--strict"]).arg(path);
+    let verification = bounded_child_output(verification, SIGNATURE_DETAILS_TIMEOUT).ok()??;
+    if !verification.status.success() {
+        return None;
+    }
+
     let mut command = Command::new("/usr/bin/codesign");
     command.args(["-dv", "--verbose=4"]).arg(path);
     let details = bounded_child_output(command, SIGNATURE_DETAILS_TIMEOUT).ok()??;
@@ -1124,6 +1166,22 @@ mod tests {
             packaged_main_executable(std::path::Path::new("/Applications/June.app")),
             std::path::PathBuf::from("/Applications/June.app/Contents/MacOS/os-june")
         );
+    }
+
+    #[tokio::test]
+    async fn accepted_private_socket_exposes_peer_audit_token() {
+        let directory = tempfile::tempdir().expect("private socket directory");
+        let socket_path = directory.path().join("driver.sock");
+        let listener = UnixListener::bind(&socket_path).expect("private socket listener");
+        let client = tokio::spawn(UnixStream::connect(socket_path));
+        let (server, _) = listener.accept().await.expect("accepted private peer");
+        let _client = client
+            .await
+            .expect("private peer task")
+            .expect("connected private peer");
+
+        let token = socket_peer_audit_token(&server).expect("peer audit token");
+        assert_ne!(token, [0; 32]);
     }
 
     #[test]

--- a/src/components/plugins/ComputerUseControl.tsx
+++ b/src/components/plugins/ComputerUseControl.tsx
@@ -45,8 +45,22 @@ function requirementState(ready: boolean, enabled: boolean) {
 
 type MacOSPermission = "accessibility" | "screenRecording";
 
+const STATUS_POLL_INTERVAL_MS = 2000;
+let pendingStatusRefresh: Promise<ComputerUseStatusDto> | undefined;
 const pendingPermissionRequests = new Map<MacOSPermission, Promise<ComputerUseStatusDto>>();
 let permissionRequestTail: Promise<unknown> = Promise.resolve();
+
+function readComputerUseStatus() {
+  if (pendingStatusRefresh) return pendingStatusRefresh;
+
+  const request = computerUseStatus();
+  pendingStatusRefresh = request;
+  const clear = () => {
+    if (pendingStatusRefresh === request) pendingStatusRefresh = undefined;
+  };
+  void request.then(clear, clear);
+  return request;
+}
 
 function requestComputerUsePermission(permission: MacOSPermission) {
   const pending = pendingPermissionRequests.get(permission);
@@ -83,7 +97,7 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
 
   const refresh = useCallback(async () => {
     try {
-      setStatus(await computerUseStatus());
+      setStatus(await readComputerUseStatus());
     } catch (error) {
       setMessage(messageFromError(error));
     }
@@ -93,7 +107,7 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
     let active = true;
     const load = async () => {
       try {
-        const next = await computerUseStatus();
+        const next = await readComputerUseStatus();
         if (active) setStatus(next);
       } catch (error) {
         if (active) setMessage(messageFromError(error));
@@ -113,8 +127,34 @@ export function ComputerUseControl({ onOpenModels, onOpenBilling }: ComputerUseC
 
   useEffect(() => {
     if (!status?.grantEnabled || status.ready) return;
-    const timer = window.setInterval(() => void refresh(), 2000);
-    return () => window.clearInterval(timer);
+    let active = true;
+    let timer: number | undefined;
+    const clearTimer = () => {
+      if (timer !== undefined) window.clearTimeout(timer);
+      timer = undefined;
+    };
+    const schedule = () => {
+      clearTimer();
+      if (!active || document.visibilityState !== "visible") return;
+      timer = window.setTimeout(async () => {
+        await refresh();
+        schedule();
+      }, STATUS_POLL_INTERVAL_MS);
+    };
+    const onVisibilityChange = () => {
+      clearTimer();
+      if (document.visibilityState === "visible") {
+        void refresh().then(schedule);
+      }
+    };
+
+    schedule();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      active = false;
+      clearTimer();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
   }, [refresh, status?.grantEnabled, status?.ready]);
 
   const publish = useCallback((next: ComputerUseStatusDto) => {

--- a/src/test/computer-use-control.test.tsx
+++ b/src/test/computer-use-control.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -155,6 +155,88 @@ describe("ComputerUseControl", () => {
     await waitFor(() => expect(tauriMocks.openPrivacySettings).toHaveBeenCalledTimes(2));
     expect(tauriMocks.openPrivacySettings).toHaveBeenLastCalledWith("screenRecording");
     await screen.findByText("Ready");
+  });
+
+  it("waits for each status poll before scheduling the next one", async () => {
+    vi.useFakeTimers();
+    try {
+      const incomplete = status({ grantEnabled: true, state: "permission_missing" });
+      let finishPoll: ((value: ComputerUseStatusDto) => void) | undefined;
+      tauriMocks.computerUseStatus
+        .mockResolvedValueOnce(incomplete)
+        .mockImplementationOnce(
+          () =>
+            new Promise<ComputerUseStatusDto>((resolve) => {
+              finishPoll = resolve;
+            }),
+        )
+        .mockResolvedValue(incomplete);
+
+      render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(tauriMocks.computerUseStatus).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(tauriMocks.computerUseStatus).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(tauriMocks.computerUseStatus).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        finishPoll?.(incomplete);
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(tauriMocks.computerUseStatus).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("pauses status polling while the settings page is hidden", async () => {
+    vi.useFakeTimers();
+    let visibility: DocumentVisibilityState = "visible";
+    const visibilitySpy = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockImplementation(() => visibility);
+    try {
+      const incomplete = status({ grantEnabled: true, state: "permission_missing" });
+      tauriMocks.computerUseStatus.mockResolvedValue(incomplete);
+      render(<ComputerUseControl onOpenModels={vi.fn()} onOpenBilling={vi.fn()} />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(tauriMocks.computerUseStatus).toHaveBeenCalledTimes(2);
+
+      visibility = "hidden";
+      act(() => document.dispatchEvent(new Event("visibilitychange")));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(tauriMocks.computerUseStatus).toHaveBeenCalledTimes(2);
+
+      visibility = "visible";
+      await act(async () => {
+        document.dispatchEvent(new Event("visibilitychange"));
+        await Promise.resolve();
+      });
+      expect(tauriMocks.computerUseStatus).toHaveBeenCalledTimes(3);
+    } finally {
+      visibilitySpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it("coalesces a permission probe across an unmount and remount", async () => {


### PR DESCRIPTION
## Summary

- Single-flight Computer use permission probes in Rust and share the result across every status/runtime caller, including the completed-flight handoff before coordinator cleanup.
- Cache strict outer-app and helper signature verification by bundle fingerprint for the app session, invalidate it when signed files change, and force a fresh verification on explicit permission retry.
- Authenticate the live June peer by the accepted socket's macOS audit token and expected identifier/Team OU, with a strict helper-signature verification before reading signing metadata.
- Isolate helper/verifier process groups, terminate and reap them with bounded escalation, and gate group kills on ownership before falling back to the recorded PID.
- Replace overlapping 2-second settings polling with awaited polling that pauses while the page is hidden and refreshes when it becomes visible.

## Root cause

The permission setup UI used an unawaited 2-second interval, while both status and runtime-readiness paths could independently launch fresh signed-helper probes. Every helper launch synchronously ran `codesign --verify --strict` over the full outer June bundle. On the rc.5 bundle that verification exceeded the polling interval, so probes overlapped and multiplied under contention. Timeout cleanup signaled only the helper PID; verifier descendants could survive after reparenting. Once enough helpers and verifiers accumulated, later probes hit their timeout and the status path converted the failed probe into both permission booleans being false. A clean probe after process cleanup reported the granted Accessibility permission correctly, confirming the missing-permission report was timeout-driven rather than a TCC state change.

## Validation

- Opus and Kimi review round: both MERGE; core fix and security model verified against security-framework 3.7 and macOS semantics.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer TMPDIR=/private/tmp node scripts/prepare-cua-driver.mjs`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --locked -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked` with full Xcode: 1,342 library tests passed, 5 ignored; all 15 helper tests and every integration suite passed.
- Focused permission single-flight, timeout-state, signature-cache invalidation, child-reaping, and socket audit-token tests passed.
- `pnpm typecheck`
- `pnpm test`: pre-commit frontend state ran 209 files and 3,422 tests with 0 failures and 2 skipped; Vitest exited nonzero only for the documented post-test Tiptap rejection. Fresh `make local-ci` on the pushed SHA passed 3,420 tests and hit two documented load-sensitive ProseMirror cases; both passed in the repository-prescribed isolated rerun.
- Fresh `signoff/frontend` and `signoff/rust-macos` posted on `537dd74ea0822ec4b2429c90b5c4305c713ec05f`.

- [ ] Tested visually where it matters (not run: this needs a signed RC bundle with real TCC grants and a multi-minute permission-page soak).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Changing macOS TCC grants or prompting for access on the development machine.
- Building and soaking a Developer ID-signed RC artifact.
- June API changes.

## Followups

- Complete the fresh Greptile review while this PR remains draft.
- Soak the permission setup page in the next signed RC and confirm one helper flight, one initial full-bundle verification, stable granted state, and no surviving helper or verifier processes.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. Pending final review while the PR remains draft.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend surface changed.
- [x] User-facing copy follows the repo UI conventions.

Refs JUN-411
