### PR TITLE
Pin SQLite busy_timeout and tighten pool acquire_timeout

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3687,9 +3687,18 @@ pub(crate) async fn repositories(app: &AppHandle) -> Result<Repositories, AppErr
             // Recording finalization, transcript persistence, and UI polling
             // legitimately overlap. WAL lets readers observe progress without
             // blocking the durable job transaction (or vice versa).
-            .journal_mode(SqliteJournalMode::Wal);
+            .journal_mode(SqliteJournalMode::Wal)
+            // WAL still allows only one writer at a time; writers wait this
+            // long for the lock before SQLITE_BUSY. Pinned explicitly (sqlx
+            // defaults to the same 5s) so lock-wait behavior can't drift
+            // under an upstream sqlx bump.
+            .busy_timeout(Duration::from_secs(5));
             let pool = SqlitePoolOptions::new()
                 .max_connections(5)
+                // Tightened from sqlx's 30s default so a stuck writer
+                // starving the pool surfaces as an error in bounded time
+                // instead of stalling callers for half a minute.
+                .acquire_timeout(Duration::from_secs(10))
                 .connect_with(options)
                 .await
                 .map_err(|error| AppError::new("storage_unavailable", error.to_string()))?;


### PR DESCRIPTION
## Summary

- Pins `busy_timeout(5s)` explicitly on the app database connect options (sqlx 0.8.6 already defaults to 5s; the pin keeps lock-wait behavior from drifting under an upstream sqlx bump).
- Tightens the pool `acquire_timeout` from sqlx's 30s default to 10s so a stuck writer starving the 5-connection pool surfaces as a bounded error sooner. Recording finalization, transcript persistence, and UI polling all overlap on this pool.

Closes JUN-407.

Note for reviewers: the originating audit finding claimed the pool had **no** busy timeout and unbounded acquisition. Verified against the vendored sqlx 0.8.6 source, both already had defaults (5s / 30s), so this change is explicitness plus a tightened acquire bound, not a behavior rescue. A correcting comment was left on JUN-407.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets`, and full `cargo test` green (1339 lib tests + all integration suites, 0 failures).

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). <!-- no UI change -->
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- desktop-only -->

## Out of scope

- The Hermes state reader pool (`commands.rs`, `max_connections(1)`, read-only path) keeps sqlx defaults; it has no competing writers.
- The 1s UI polling load itself (JUN-390) and versioned migrations (JUN-393).

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787404904&installation_model_id=425925&pr_number=922&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F922&signature=dfbafdd4a155cd1230c425b7255b6827a9a3f0396a920be13e3443e90d0e9223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->