### PR TITLE
Fix Computer use run lease lifecycle

### DIFF
--- a/src-tauri/src/computer_use.rs
+++ b/src-tauri/src/computer_use.rs
@@ -1658,6 +1658,10 @@ pub fn computer_use_begin_run(
         ));
     }
     let session_id = validate_run_session_id(&request.session_id)?;
+    begin_run_lease(&state, session_id)
+}
+
+fn begin_run_lease(state: &ComputerUseState, session_id: String) -> Result<(), AppError> {
     let mut runs = state
         .attended_runs
         .lock()
@@ -1677,10 +1681,19 @@ pub fn computer_use_begin_run(
     if inserted {
         state.attended_generation.fetch_add(1, Ordering::SeqCst);
         if starts_new_task {
-            clear_app_authorizations(&state);
+            clear_app_authorizations(state);
         }
     }
     Ok(())
+}
+
+fn end_run_lease(state: &ComputerUseState, session_id: &str) -> Result<Option<u64>, AppError> {
+    let mut runs = state
+        .attended_runs
+        .lock()
+        .map_err(|_| AppError::new("computer_use_unavailable", "Run lease lock failed."))?;
+    let removed = runs.remove(session_id);
+    Ok((removed && runs.is_empty()).then(|| state.attended_generation.load(Ordering::SeqCst)))
 }
 
 #[tauri::command]
@@ -1690,14 +1703,7 @@ pub async fn computer_use_end_run(
     request: ComputerUseRunRequest,
 ) -> Result<(), AppError> {
     let session_id = validate_run_session_id(&request.session_id)?;
-    let idle_generation = {
-        let mut runs = state
-            .attended_runs
-            .lock()
-            .map_err(|_| AppError::new("computer_use_unavailable", "Run lease lock failed."))?;
-        let removed = runs.remove(&session_id);
-        (removed && runs.is_empty()).then(|| state.attended_generation.load(Ordering::SeqCst))
-    };
+    let idle_generation = end_run_lease(&state, &session_id)?;
     if let Some(generation) = idle_generation {
         stop_if_idle(&app, &state, generation).await;
     }
@@ -1824,10 +1830,7 @@ async fn stop_for_shutdown(app: &AppHandle, state: &ComputerUseState) {
 async fn stop_if_idle(app: &AppHandle, state: &ComputerUseState, generation: u64) {
     let _operation = state.operation.lock().await;
     let _cleanup = CleanupInProgress::begin(&state.cleanup_in_progress);
-    let still_idle = state.attended_runs.lock().is_ok_and(|runs| {
-        runs.is_empty() && state.attended_generation.load(Ordering::SeqCst) == generation
-    });
-    if !still_idle {
+    if !idle_generation_is_current(state, generation) {
         return;
     }
     state.epoch.fetch_add(1, Ordering::SeqCst);
@@ -1843,6 +1846,12 @@ async fn stop_if_idle(app: &AppHandle, state: &ComputerUseState, generation: u64
     clear_app_authorizations(state);
     clear_capture_dir(app);
     let _ = set_june_stage_companion(app, false).await;
+}
+
+fn idle_generation_is_current(state: &ComputerUseState, generation: u64) -> bool {
+    state.attended_runs.lock().is_ok_and(|runs| {
+        runs.is_empty() && state.attended_generation.load(Ordering::SeqCst) == generation
+    })
 }
 
 fn clear_app_authorizations(state: &ComputerUseState) {
@@ -4313,6 +4322,49 @@ fn now_ms() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn duplicate_run_release_is_idempotent() {
+        let state = ComputerUseState::default();
+        begin_run_lease(&state, "run-a".to_string()).expect("begin first run");
+        let generation = state.attended_generation.load(Ordering::SeqCst);
+
+        assert_eq!(
+            end_run_lease(&state, "run-a").expect("end first run"),
+            Some(generation)
+        );
+        assert_eq!(
+            end_run_lease(&state, "run-a").expect("repeat end first run"),
+            None
+        );
+        assert!(idle_generation_is_current(&state, generation));
+    }
+
+    #[test]
+    fn successor_run_blocks_stale_idle_cleanup() {
+        let state = ComputerUseState::default();
+        begin_run_lease(&state, "run-a".to_string()).expect("begin first run");
+        let stale_generation = end_run_lease(&state, "run-a")
+            .expect("end first run")
+            .expect("idle generation");
+
+        begin_run_lease(&state, "run-b".to_string()).expect("begin successor run");
+
+        assert!(!idle_generation_is_current(&state, stale_generation));
+        assert_eq!(
+            end_run_lease(&state, "run-a").expect("repeat end predecessor"),
+            None
+        );
+        assert!(
+            state
+                .attended_runs
+                .lock()
+                .expect("run lease lock")
+                .contains("run-b"),
+            "a duplicate predecessor release must not remove the successor"
+        );
+        assert!(ensure_attended_run(&state).is_ok());
+    }
 
     #[test]
     fn non_secret_computer_use_grant_never_uses_keychain() {

--- a/src-tauri/src/computer_use.rs
+++ b/src-tauri/src/computer_use.rs
@@ -1695,9 +1695,8 @@ pub async fn computer_use_end_run(
             .attended_runs
             .lock()
             .map_err(|_| AppError::new("computer_use_unavailable", "Run lease lock failed."))?;
-        runs.remove(&session_id);
-        runs.is_empty()
-            .then(|| state.attended_generation.load(Ordering::SeqCst))
+        let removed = runs.remove(&session_id);
+        (removed && runs.is_empty()).then(|| state.attended_generation.load(Ordering::SeqCst))
     };
     if let Some(generation) = idle_generation {
         stop_if_idle(&app, &state, generation).await;

--- a/src/components/agent/session-event-listener.ts
+++ b/src/components/agent/session-event-listener.ts
@@ -223,9 +223,7 @@ export function createSessionEventListener(dependencies: createSessionEventListe
         });
       }
       if (isTerminalHermesEvent(classified)) {
-        if (computerUseRunLeaseId) {
-          void releaseComputerUseRun(storedSessionId, computerUseRunLeaseId);
-        } else {
+        if (!computerUseRunLeaseId) {
           void releaseAllComputerUseRuns(storedSessionId);
         }
         unlisten();
@@ -258,6 +256,12 @@ export function createSessionEventListener(dependencies: createSessionEventListe
     });
     unlisten = () => {
       removeListener();
+      // This listener owns exactly the lease opened with its prompt. Replacing
+      // the runtime listener (for example after a gateway reconnect) must fail
+      // that lease closed without revoking a newer listener's lease.
+      if (computerUseRunLeaseId) {
+        void releaseComputerUseRun(storedSessionId, computerUseRunLeaseId);
+      }
       // Stop, cancellation, listener replacement, and normal teardown all
       // converge here. Publish any trailing delta before cancelling its timer
       // so React never remains behind the authoritative event ref.

--- a/src/components/agent/session-state-helpers.ts
+++ b/src/components/agent/session-state-helpers.ts
@@ -219,7 +219,7 @@ export function agentStatusFromHermesEvent(
     return hasOpenPendingAction ? "waitingForUser" : "running";
   }
   if (event.kind === "transcript" && event.complete) {
-    return event.failed ? "failed" : "completed";
+    return event.failed ? "failed" : undefined;
   }
   if (event.kind === "lifecycle" && event.flavor === "terminal") {
     const status = event.status.toLowerCase();

--- a/src/lib/hermes-activity-store.ts
+++ b/src/lib/hermes-activity-store.ts
@@ -351,18 +351,19 @@ function applyEvent(row: InternalRecord, event: JuneHermesEvent): void {
       row.phase = "error";
       return;
     case "lifecycle":
-      // Genuine completions arrive as terminal-flavored frames (lifecycle.complete(d),
-      // session/turn/background completions, plus the workspace's synthetic terminal
-      // write). An info frame's status text must never retire a live row, and info
-      // frames must not flip idle rows to running; this matches main's event-driven
-      // spinner semantics.
+      // Genuine completions arrive as terminal-flavored frames (including the
+      // pinned runtime's session.info { running: false }, explicit completion
+      // aliases, and the workspace's synthetic terminal write). An info frame's
+      // status text must never retire a live row, and info frames must not flip
+      // idle rows to running; this matches main's event-driven spinner semantics.
       if (event.flavor === "terminal") row.phase = "complete";
       if (event.flavor === "running") row.phase = "running";
       return;
     case "transcript":
       if (event.complete) {
         // A successful message.complete seals one transcript segment; Hermes
-        // may execute its tool calls next. Only a failed segment ends the run.
+        // may still execute tools or post-run work. Only a failed segment ends
+        // the run before a terminal lifecycle frame arrives.
         if (event.failed) {
           row.phase = "error";
           row.currentTool = undefined;

--- a/src/lib/hermes-activity-store.ts
+++ b/src/lib/hermes-activity-store.ts
@@ -318,7 +318,7 @@ type InternalRecord = {
  * - `error`                   -> error.
  * - `lifecycle`               -> complete when the flavor is terminal, running when
  *                                the flavor is running, no-op when informational.
- * - `transcript`              -> complete on message completion, else running.
+ * - `transcript`              -> error on failed message completion, else running.
  * - `reasoning`               -> running (the agent is producing output).
  * - `steering`                -> no phase change (local transcript marker).
  * - `unsupported`             -> no phase change (don't let an unknown frame
@@ -361,8 +361,12 @@ function applyEvent(row: InternalRecord, event: JuneHermesEvent): void {
       return;
     case "transcript":
       if (event.complete) {
-        row.phase = "complete";
-        row.currentTool = undefined;
+        // A successful message.complete seals one transcript segment; Hermes
+        // may execute its tool calls next. Only a failed segment ends the run.
+        if (event.failed) {
+          row.phase = "error";
+          row.currentTool = undefined;
+        }
         return;
       }
       // The agent is actively producing output — running, unless it has already

--- a/src/lib/hermes-control-plane/event-classifier.ts
+++ b/src/lib/hermes-control-plane/event-classifier.ts
@@ -131,7 +131,7 @@ export function classifyHermesEvent(raw: HermesGatewayEvent): JuneHermesEvent {
     return {
       kind: "lifecycle",
       sessionId,
-      flavor: lifecycleFlavor(type),
+      flavor: lifecycleFlavor(type, payload),
       status: lifecycleStatus(type, payload),
       text: eventText(payload),
       payload: payload ? sanitizePayload(payload) : undefined,
@@ -560,7 +560,19 @@ function lifecycleStatus(type: string, payload: RawHermesPayload | undefined): s
   return stringValue(payload?.status, true) ?? type;
 }
 
-function lifecycleFlavor(type: string): Extract<JuneHermesEvent, { kind: "lifecycle" }>["flavor"] {
+function lifecycleFlavor(
+  type: string,
+  payload: RawHermesPayload | undefined,
+): Extract<JuneHermesEvent, { kind: "lifecycle" }>["flavor"] {
+  // The pinned v2026.7.20 dashboard gateway closes a plain prose run with
+  // session.info { running: false }; it does not emit lifecycle.complete or
+  // turn.completed. The matching running:true frame opens the same run-level
+  // state edge. Keep session.info without a boolean informational for older
+  // runtimes and connection-time snapshots.
+  if (type === "session.info") {
+    if (payload?.running === false) return "terminal";
+    if (payload?.running === true) return "running";
+  }
   switch (type.toLowerCase()) {
     // Intentional extension beyond main's terminal type list: main never tore
     // down on lifecycle.complete, but June's typed lifecycle union does.

--- a/src/lib/hermes-control-plane/events.ts
+++ b/src/lib/hermes-control-plane/events.ts
@@ -257,13 +257,19 @@ export type JuneHermesEvent =
  * exhaustiveness assertions. */
 export type JuneHermesEventKind = JuneHermesEvent["kind"];
 
-/** True for classified events that end the current workspace turn. */
+/** True for classified events that end the current agent run.
+ *
+ * A successful `message.complete` seals one assistant transcript segment. It
+ * can carry tool calls that Hermes executes before the run-level lifecycle
+ * completion, so it is not a terminal edge. A failed segment is terminal
+ * because Hermes will not continue its tool loop after that error.
+ */
 export function isTerminalHermesEvent(event: JuneHermesEvent): boolean {
   switch (event.kind) {
     case "error":
       return true;
     case "transcript":
-      return event.complete === true;
+      return event.complete === true && event.failed === true;
     case "lifecycle":
       return event.flavor === "terminal";
     default:

--- a/src/lib/hermes-control-plane/events.ts
+++ b/src/lib/hermes-control-plane/events.ts
@@ -260,9 +260,11 @@ export type JuneHermesEventKind = JuneHermesEvent["kind"];
 /** True for classified events that end the current agent run.
  *
  * A successful `message.complete` seals one assistant transcript segment. It
- * can carry tool calls that Hermes executes before the run-level lifecycle
- * completion, so it is not a terminal edge. A failed segment is terminal
- * because Hermes will not continue its tool loop after that error.
+ * can precede tool execution or other post-message work, so it is not a
+ * terminal edge. Pinned Hermes v2026.7.20 reports the real idle edge as
+ * `session.info` with `running: false`, which the classifier normalizes to a
+ * terminal lifecycle event. A failed segment remains terminal because Hermes
+ * will not continue its tool loop after that error.
  */
 export function isTerminalHermesEvent(event: JuneHermesEvent): boolean {
   switch (event.kind) {

--- a/src/lib/hermes-control-plane/fixtures/README.md
+++ b/src/lib/hermes-control-plane/fixtures/README.md
@@ -39,7 +39,7 @@ The `frames` are consumed by `replayFixture` / `replayFixtureFrames` in
 One file per event family (some combine a request with its response, or several
 related bespoke types):
 
-`normal-message`, `tool-call-success`, `tool-call-failure`,
+`normal-message`, `plain-prose-turn`, `tool-call-success`, `tool-call-failure`,
 `approval-request-response`, `clarify-request-response`, `sudo-request-response`,
 `secret-request-response`, `subagent-lifecycle`,
 `subagent-background-completion`, `image-attachment`, `model-switch`,
@@ -49,6 +49,11 @@ related bespoke types):
 `raw-events.sample.json` is the original feature-01 seed (one frame per known
 family); the files above extend it into the full replay corpus. Both are safe to
 commit.
+
+`plain-prose-turn` was captured from the exact v2026.7.20 pinned runtime through
+the dashboard gateway with a token-free local provider. Its final run-level
+edge is `session.info` with `running: false`; the runtime does not emit
+`lifecycle.complete` or `turn.completed` for that no-tool prose turn.
 
 ## Recording and sanitizing a new fixture
 

--- a/src/lib/hermes-control-plane/fixtures/plain-prose-turn.json
+++ b/src/lib/hermes-control-plane/fixtures/plain-prose-turn.json
@@ -1,0 +1,65 @@
+{
+  "name": "plain-prose-turn",
+  "hermesVersion": "v2026.7.20",
+  "recordedFrom": "dashboard-gateway",
+  "sanitized": true,
+  "_note": "Captured from the exact pinned runtime commit 3ef6bbd201263d354fd83ec55b3c306ded2eb72a with patch set june-approval-memory-v14 using a token-free local provider. Pinned Hermes emits message.complete followed by session.info running=false; it does not emit lifecycle.complete or turn.completed. Unrelated session metadata was pruned.",
+  "frames": [
+    {
+      "type": "session.info",
+      "session_id": "sess-plain-prose",
+      "payload": {
+        "model": "smoke-model",
+        "provider": "custom",
+        "running": true,
+        "version": "0.19.0",
+        "release_date": "2026.7.20"
+      }
+    },
+    {
+      "type": "message.start",
+      "session_id": "sess-plain-prose"
+    },
+    {
+      "type": "thinking.delta",
+      "session_id": "sess-plain-prose",
+      "payload": { "text": "ಠ_ಠ analyzing..." }
+    },
+    {
+      "type": "thinking.delta",
+      "session_id": "sess-plain-prose",
+      "payload": { "text": "" }
+    },
+    {
+      "type": "message.delta",
+      "session_id": "sess-plain-prose",
+      "payload": { "text": "ok" }
+    },
+    {
+      "type": "thinking.delta",
+      "session_id": "sess-plain-prose",
+      "payload": { "text": "" }
+    },
+    {
+      "type": "reasoning.available",
+      "session_id": "sess-plain-prose",
+      "payload": { "text": "ok" }
+    },
+    {
+      "type": "message.complete",
+      "session_id": "sess-plain-prose",
+      "payload": { "text": "ok", "status": "complete" }
+    },
+    {
+      "type": "session.info",
+      "session_id": "sess-plain-prose",
+      "payload": {
+        "model": "smoke-model",
+        "provider": "custom",
+        "running": false,
+        "version": "0.19.0",
+        "release_date": "2026.7.20"
+      }
+    }
+  ]
+}

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -8608,9 +8608,9 @@ describe("AgentWorkspace", () => {
     act(() => {
       for (const handler of mocks.gatewayEventHandlers) {
         handler({
-          type: "lifecycle.complete",
+          type: "session.info",
           session_id: "runtime-session-2",
-          payload: { status: "success" },
+          payload: { running: false },
         });
       }
     });
@@ -9834,7 +9834,7 @@ describe("AgentWorkspace", () => {
     window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
   });
 
-  it("keeps the Computer use run lease through tool dispatch until lifecycle.complete", async () => {
+  it("keeps the Computer use run lease through tool dispatch until pinned session info reports idle", async () => {
     const statusDetails: AgentSessionStatusDetail[] = [];
     const handleStatus = (event: Event) => {
       statusDetails.push((event as CustomEvent<AgentSessionStatusDetail>).detail);
@@ -9912,9 +9912,9 @@ describe("AgentWorkspace", () => {
     act(() => {
       for (const handler of mocks.gatewayEventHandlers) {
         handler({
-          type: "lifecycle.complete",
+          type: "session.info",
           session_id: "runtime-session-2",
-          payload: { status: "success" },
+          payload: { running: false },
         });
       }
     });
@@ -15764,9 +15764,9 @@ describe("AgentWorkspace", () => {
             payload: { text: "Current response finished." },
           });
           handler({
-            type: "lifecycle.complete",
+            type: "session.info",
             session_id: "runtime-session-1",
-            payload: { status: "success" },
+            payload: { running: false },
           });
         }
       });

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -8605,6 +8605,16 @@ describe("AgentWorkspace", () => {
     expect(screen.getByText("Thought").closest("summary")).toHaveAttribute("aria-label", "Thought");
     expect(screen.getByText("Thought").closest("details")).toHaveAttribute("open");
 
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "lifecycle.complete",
+          session_id: "runtime-session-2",
+          payload: { status: "success" },
+        });
+      }
+    });
+
     await user.type(screen.getByRole("textbox"), "next request");
     await user.click(screen.getByRole("button", { name: "Send message" }));
     await waitFor(() =>
@@ -9575,6 +9585,9 @@ describe("AgentWorkspace", () => {
         text: "connect Todoist",
       }),
     );
+    const computerUseRunLeaseId = mocks.computerUseBeginRun.mock.calls.at(-1)?.[0];
+    expect(computerUseRunLeaseId).toMatch(/^session-2:/);
+    expect(mocks.computerUseEndRun).not.toHaveBeenCalled();
 
     act(() => {
       for (const handler of mocks.gatewayEventHandlers) {
@@ -9600,6 +9613,9 @@ describe("AgentWorkspace", () => {
         session_id: "session-2",
         cols: 96,
       }),
+    );
+    await waitFor(() =>
+      expect(mocks.computerUseEndRun).toHaveBeenCalledWith(computerUseRunLeaseId),
     );
     expect(await screen.findByText("Approval expired")).toBeInTheDocument();
     expect(hermesActivityStore.getRecord("session-2")?.phase).toBe("running");
@@ -9813,6 +9829,101 @@ describe("AgentWorkspace", () => {
     );
     await waitFor(() =>
       expect(mocks.computerUseEndRun).toHaveBeenCalledWith(computerUseRunLeaseId),
+    );
+    expect(mocks.gatewayEventHandlers.size).toBe(0);
+    window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
+  });
+
+  it("keeps the Computer use run lease through tool dispatch until lifecycle.complete", async () => {
+    const statusDetails: AgentSessionStatusDetail[] = [];
+    const handleStatus = (event: Event) => {
+      statusDetails.push((event as CustomEvent<AgentSessionStatusDetail>).detail);
+    };
+    window.addEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "open Calculator",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "open Calculator",
+      }),
+    );
+    const computerUseRunLeaseId = mocks.computerUseBeginRun.mock.calls.at(-1)?.[0];
+    expect(computerUseRunLeaseId).toMatch(/^session-2:/);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "message.complete",
+          session_id: "runtime-session-2",
+          payload: {
+            message_id: "assistant-tool-call",
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "computer-use-1",
+                name: "mcp__june_computer_use__computer_use",
+              },
+            ],
+          },
+        });
+      }
+    });
+
+    expect(mocks.computerUseEndRun).not.toHaveBeenCalled();
+    expect(mocks.gatewayEventHandlers.size).toBe(1);
+    expect(statusDetails).not.toContainEqual(
+      expect.objectContaining({ sessionId: "session-2", status: "completed" }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: {
+            tool_call_id: "computer-use-1",
+            name: "mcp__june_computer_use__computer_use",
+          },
+        });
+        handler({
+          type: "tool.complete",
+          session_id: "runtime-session-2",
+          payload: {
+            tool_call_id: "computer-use-1",
+            name: "mcp__june_computer_use__computer_use",
+            result: { ok: true },
+          },
+        });
+      }
+    });
+
+    expect(mocks.computerUseEndRun).not.toHaveBeenCalled();
+    expect(mocks.gatewayEventHandlers.size).toBe(1);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "lifecycle.complete",
+          session_id: "runtime-session-2",
+          payload: { status: "success" },
+        });
+      }
+    });
+
+    await waitFor(() =>
+      expect(mocks.computerUseEndRun).toHaveBeenCalledWith(computerUseRunLeaseId),
+    );
+    expect(statusDetails).toContainEqual(
+      expect.objectContaining({ sessionId: "session-2", status: "completed" }),
     );
     expect(mocks.gatewayEventHandlers.size).toBe(0);
     window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
@@ -15651,6 +15762,11 @@ describe("AgentWorkspace", () => {
             type: "message.complete",
             session_id: "runtime-session-1",
             payload: { text: "Current response finished." },
+          });
+          handler({
+            type: "lifecycle.complete",
+            session_id: "runtime-session-1",
+            payload: { status: "success" },
           });
         }
       });

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -1087,7 +1087,9 @@ describe("App shortcuts", () => {
 
     await waitFor(() => expect(mocks.listeners.has(OPEN_SETTINGS_EVENT)).toBe(true));
 
-    mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
+    act(() => {
+      mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
+    });
 
     expect(await screen.findByRole("heading", { name: "General" })).toBeInTheDocument();
   });

--- a/src/test/hermes-activity-store.test.ts
+++ b/src/test/hermes-activity-store.test.ts
@@ -213,7 +213,7 @@ describe("createHermesActivityStore", () => {
     expect(store.activeCount()).toBe(1);
   });
 
-  it("keeps a successful message completion active until lifecycle completion", () => {
+  it("keeps a successful message completion active until pinned session info reports idle", () => {
     const store = createHermesActivityStore();
     store.record(classified("message.start", "s1"), "sandboxed");
     expect(store.getRecord("s1")?.phase).toBe("running");
@@ -223,7 +223,7 @@ describe("createHermesActivityStore", () => {
     expect(store.getRecord("s1")?.phase).toBe("running");
     expect(store.activeCount()).toBe(1);
 
-    store.record(classified("lifecycle.complete", "s1", { status: "success" }), "sandboxed");
+    store.record(classified("session.info", "s1", { running: false }), "sandboxed");
 
     expect(store.getRecord("s1")?.phase).toBe("complete");
     expect(store.activeCount()).toBe(0);

--- a/src/test/hermes-activity-store.test.ts
+++ b/src/test/hermes-activity-store.test.ts
@@ -213,12 +213,17 @@ describe("createHermesActivityStore", () => {
     expect(store.activeCount()).toBe(1);
   });
 
-  it("message completion flips the session to phase 'complete'", () => {
+  it("keeps a successful message completion active until lifecycle completion", () => {
     const store = createHermesActivityStore();
     store.record(classified("message.start", "s1"), "sandboxed");
     expect(store.getRecord("s1")?.phase).toBe("running");
 
     store.record(classified("message.complete", "s1", { text: "Done" }), "sandboxed");
+
+    expect(store.getRecord("s1")?.phase).toBe("running");
+    expect(store.activeCount()).toBe(1);
+
+    store.record(classified("lifecycle.complete", "s1", { status: "success" }), "sandboxed");
 
     expect(store.getRecord("s1")?.phase).toBe("complete");
     expect(store.activeCount()).toBe(0);

--- a/src/test/hermes-control-plane-classifier.test.ts
+++ b/src/test/hermes-control-plane-classifier.test.ts
@@ -187,6 +187,21 @@ describe("classifyHermesEvent — transcript", () => {
       expect(complete.delta).toBe("Summary only");
     }
   });
+
+  it("keeps a successful message.complete non-terminal while a failed one ends the run", () => {
+    const successful = classifyHermesEvent(
+      event("message.complete", {
+        message_id: "assistant-tool-call",
+        tool_calls: [{ id: "computer-use-1" }],
+      }),
+    );
+    const failed = classifyHermesEvent(
+      event("message.complete", { message_id: "failed-message", status: "error" }),
+    );
+
+    expect(isTerminalHermesEvent(successful)).toBe(false);
+    expect(isTerminalHermesEvent(failed)).toBe(true);
+  });
 });
 
 describe("classifyHermesEvent — reasoning", () => {

--- a/src/test/hermes-control-plane-classifier.test.ts
+++ b/src/test/hermes-control-plane-classifier.test.ts
@@ -738,6 +738,19 @@ describe("classifyHermesEvent — lifecycle", () => {
     }
   });
 
+  it("uses pinned-runtime session.info running state as the run lifecycle edge", () => {
+    const running = classifyHermesEvent(event("session.info", { running: true }));
+    const terminal = classifyHermesEvent(event("session.info", { running: false }));
+    const informational = classifyHermesEvent(event("session.info", { status: "ready" }));
+
+    expect(running).toMatchObject({ kind: "lifecycle", flavor: "running" });
+    expect(terminal).toMatchObject({ kind: "lifecycle", flavor: "terminal" });
+    expect(informational).toMatchObject({ kind: "lifecycle", flavor: "info" });
+    expect(isTerminalHermesEvent(running)).toBe(false);
+    expect(isTerminalHermesEvent(terminal)).toBe(true);
+    expect(isTerminalHermesEvent(informational)).toBe(false);
+  });
+
   it("keys terminal lifecycle flavor from raw type rather than payload status", () => {
     const result = classifyHermesEvent(event("turn.complete", { status: "success" }));
     expect(result.kind).toBe("lifecycle");

--- a/src/test/hermes-control-plane-replay.test.ts
+++ b/src/test/hermes-control-plane-replay.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { HermesGatewayError, isSessionBusyError } from "../lib/hermes-gateway";
 import {
   classifyHermesEvent,
+  isTerminalHermesEvent,
   replayFixture,
   replayFixtureFrames,
 } from "../lib/hermes-control-plane";
@@ -18,6 +19,7 @@ import type {
 // (vite.config include: ["src/test/**"]). Each import is type-checked because
 // resolveJsonModule is on, so a malformed fixture fails `tsc`/lint, not just here.
 import normalMessage from "../lib/hermes-control-plane/fixtures/normal-message.json";
+import plainProseTurn from "../lib/hermes-control-plane/fixtures/plain-prose-turn.json";
 import toolCallSuccess from "../lib/hermes-control-plane/fixtures/tool-call-success.json";
 import toolCallFailure from "../lib/hermes-control-plane/fixtures/tool-call-failure.json";
 import approvalRequestResponse from "../lib/hermes-control-plane/fixtures/approval-request-response.json";
@@ -66,6 +68,10 @@ type FrameExpectation = {
 
 type FixtureCase = {
   fixture: HermesReplayFixture;
+  provenance?: {
+    hermesVersion: string;
+    recordedFrom: string;
+  };
   /** Expected classification for each frame, in order. Length must equal the
    * fixture's frame count — a mismatch means the fixture changed under us. */
   expected: FrameExpectation[];
@@ -93,6 +99,26 @@ const CASES: Record<string, FixtureCase> = {
       k("transcript"),
       k("transcript"),
       k("transcript"),
+    ],
+  },
+  "plain-prose-turn": {
+    fixture: plainProseTurn as HermesReplayFixture,
+    provenance: {
+      hermesVersion: "v2026.7.20",
+      recordedFrom: "dashboard-gateway",
+    },
+    // Exact pinned-runtime trace: the message segment completes before the
+    // session.info frame reports that the whole run is idle.
+    expected: [
+      k("lifecycle"),
+      k("transcript"),
+      k("reasoning"),
+      k("reasoning"),
+      k("transcript"),
+      k("reasoning"),
+      k("reasoning"),
+      k("transcript"),
+      k("lifecycle"),
     ],
   },
   "tool-call-success": {
@@ -193,9 +219,13 @@ describe("hermes replay — fixture corpus integrity", () => {
   });
 
   it("records provenance metadata on every fixture (version, source, sanitized)", () => {
-    for (const [name, { fixture }] of ALL_CASES) {
-      expect(fixture.hermesVersion, `${name} missing hermesVersion`).toBe("v2026.6.19");
-      expect(fixture.recordedFrom, `${name} missing recordedFrom`).toBe("tui-gateway");
+    for (const [name, { fixture, provenance }] of ALL_CASES) {
+      expect(fixture.hermesVersion, `${name} missing hermesVersion`).toBe(
+        provenance?.hermesVersion ?? "v2026.6.19",
+      );
+      expect(fixture.recordedFrom, `${name} missing recordedFrom`).toBe(
+        provenance?.recordedFrom ?? "tui-gateway",
+      );
       expect(fixture.sanitized, `${name} not marked sanitized`).toBe(true);
     }
   });
@@ -262,6 +292,23 @@ describe("hermes replay — family-specific expectations", () => {
       "Sure, here is the plan: step one.",
     ]);
     expect(transcripts.at(-1)?.complete).toBe(true);
+  });
+
+  it("captures the pinned runtime's terminal frame on a plain prose turn", () => {
+    const replayed = replayFixtureFrames(plainProseTurn as HermesReplayFixture);
+    const rawTypes = replayed.map(({ raw }) => raw.type);
+    const first = replayed.at(0)?.event;
+    const messageComplete = replayed.find(({ raw }) => raw.type === "message.complete")?.event;
+    const terminal = replayed.at(-1)?.event;
+
+    expect(rawTypes).not.toContain("lifecycle.complete");
+    expect(rawTypes).not.toContain("turn.completed");
+    expect(rawTypes.at(-1)).toBe("session.info");
+    expect(first).toMatchObject({ kind: "lifecycle", flavor: "running" });
+    expect(messageComplete).toMatchObject({ kind: "transcript", complete: true });
+    expect(messageComplete && isTerminalHermesEvent(messageComplete)).toBe(false);
+    expect(terminal).toMatchObject({ kind: "lifecycle", flavor: "terminal" });
+    expect(terminal && isTerminalHermesEvent(terminal)).toBe(true);
   });
 
   it("carries approval metadata and a request id through the approval fixture", () => {


### PR DESCRIPTION
## Summary

- Keep the Computer use attended-run lease active across successful `message.complete` transcript segments so the following tool dispatch remains authorized.
- Release the exact lease when the pinned Hermes runtime reports `session.info` with `running: false`, on failed message completion, or on listener teardown.
- Add a replay fixture captured from the real pinned runtime and regression coverage for its plain no-tool terminal sequence.
- Make duplicate native lease releases idempotent and add Rust lease-core tests for duplicate release and successor-run safety.
- Stabilize the native settings event test exposed by the full local CI run by wrapping its React state update in `act`.
- Security-sensitive scope: this corrects the lifetime of the existing attended-run authorization only. It does not widen who can start a lease or which native actions are permitted.

## Root cause

The frontend classified every successful Hermes `message.complete` event as the end of the agent run. Hermes emits that event when an assistant transcript segment is complete, before a following tool is dispatched. The session listener therefore called `computer_use_end_run` and removed the attended-run lease before the first `tool.start`, causing Computer use to reject the action as outside a June chat turn.

Verification against the exact pinned Hermes runtime confirmed the correct boundary: successful `message.complete` is segment completion, and the run-level terminal frame is `session.info` with `running: false`. The fix keeps the lease through successful message completion and releases the exact lease on that terminal session frame. The stored/runtime session ID distinction was not the fault: the stable lease token is derived from the stored session ID plus a UUID, while the runtime session ID only filters inbound events. The JUN-411 readiness probe race and the #910/#915 telemetry and shutdown changes are independent of this early release.

## Validation

- Real pinned-runtime trace: exercised Hermes v2026.7.20, CLI 0.19.0, commit `3ef6bbd201263d354fd83ec55b3c306ded2eb72a`, patch set `june-approval-memory-v14`, through the existing dashboard-gateway smoke protocol with a token-free local provider and the prompt `Reply with the single word: ok`.
- Captured sequence: `session.info running:true` -> `message.start` -> `thinking.delta` -> `message.delta "ok"` -> `reasoning.available` -> `message.complete status:"complete"` -> `session.info running:false`. No `lifecycle.complete` or `turn.completed` frame was emitted; a subsequent `session.active_list` reported the session as `idle`.
- Added the sanitized capture as `src/lib/hermes-control-plane/fixtures/plain-prose-turn.json`; replay coverage asserts that `message.complete` is nonterminal and the final `session.info running:false` frame is terminal.
- `pnpm test:hermes-smoke` was attempted with the exact runtime override, but its macOS LaunchAgent preflight stopped before the gateway phases because the throwaway `HERMES_HOME` has no installed gateway service. The direct dashboard-gateway portion of the existing smoke harness completed successfully and produced the trace above.
- Added Rust lease-core unit coverage for `begin_run` / `end_run` / `stop_if_idle`, including duplicate release idempotency and protection against stale cleanup stopping a successor run.
- Red/green frontend regression: the lease survives successful `message.complete` and releases on `session.info running:false`.
- `pnpm check`
- `pnpm typecheck`
- `pnpm test`: 209 files passed, 3,426 tests passed, 2 skipped.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make tauri-fmt-check tauri-lint tauri-test`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer NODE_OPTIONS=--no-experimental-webstorage CI=true make verify`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer NODE_OPTIONS=--no-experimental-webstorage CI=true make local-ci`
- `signoff/frontend` and `signoff/rust-macos` recorded on `4d19db640f1bc16e27c7d6a97375f9f893db8332`.
- `prepare-cua-driver.mjs` was not run because the Computer use driver was not changed.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). No rendered UI changed.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- JUN-411 permission-readiness probe stampede work.
- The lease heartbeat/TTL backstop tracked by JUN-414.
- Computer use driver changes or permission setup.
- Changes to #910 telemetry or #915 shutdown behavior.

## Followups

- JUN-411 remains the separate followup for permission-readiness probe coordination.
- JUN-414 tracks the lease heartbeat/TTL backstop; it is deliberately not implemented here.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow action references changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable; none changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable; none changed.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

Refs JUN-413
