### PR TITLE
Release Tauri event listeners when a HUD page unloads

### DIFF
--- a/src/agent-hud.ts
+++ b/src/agent-hud.ts
@@ -1,4 +1,4 @@
-import { listen } from "@tauri-apps/api/event";
+import { listenUntilUnload } from "./lib/listen-until-unload";
 import { IconCheckmark2Small } from "central-icons/IconCheckmark2Small";
 import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
 import { IconCircleQuestionmark } from "central-icons/IconCircleQuestionmark";
@@ -1107,27 +1107,27 @@ window.addEventListener("storage", (event) => {
   }
 });
 
-void listen<AgentSessionsChangedDetail>(AGENT_SESSIONS_CHANGED_EVENT, (event) =>
+listenUntilUnload<AgentSessionsChangedDetail>(AGENT_SESSIONS_CHANGED_EVENT, (event) =>
   applySessionsChanged(event.payload),
-).catch(() => {});
+);
 
-void listen<AgentSessionStatusDetail>(AGENT_SESSION_STATUS_EVENT, (event) =>
+listenUntilUnload<AgentSessionStatusDetail>(AGENT_SESSION_STATUS_EVENT, (event) =>
   applyStatus(event.payload),
-).catch(() => {});
+);
 
-void listen<AgentRunSettledDetail>(AGENT_RUN_SETTLED_EVENT, (event) =>
+listenUntilUnload<AgentRunSettledDetail>(AGENT_RUN_SETTLED_EVENT, (event) =>
   applyRunSettled(event.payload),
-).catch(() => {});
+);
 
-void listen<AgentHudVisibilityChangedDetail>(AGENT_HUD_VISIBILITY_CHANGED_EVENT, (event) =>
+listenUntilUnload<AgentHudVisibilityChangedDetail>(AGENT_HUD_VISIBILITY_CHANGED_EVENT, (event) =>
   applyVisibility(event.payload.enabled),
-).catch(() => {});
+);
 
 // The native panel intercepts the right-/ctrl-click and asks us to open the
 // menu. The click never reaches the DOM, so there is no competing
 // pointerdown to close it again (the window pointerdown handler only fires
 // for clicks the webview actually receives).
-void listen(AGENT_HUD_CONTEXT_MENU_EVENT, () => openMenu()).catch(() => {});
+listenUntilUnload(AGENT_HUD_CONTEXT_MENU_EVENT, () => openMenu());
 
 setIcon(pillChevron, IconChevronDownSmall, 14);
 render();

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
+import { listenUntilUnload } from "./lib/listen-until-unload";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconExclamationCircle } from "central-icons/IconExclamationCircle";
@@ -1125,25 +1125,25 @@ meetingDismissButton?.addEventListener("click", (event) => {
   void hideHud();
 });
 
-void listen("dictation-event", async (event) => {
+listenUntilUnload("dictation-event", async (event) => {
   await handleDictationEventPayload(event.payload);
-}).catch(() => {});
+});
 
-void listen("meeting-detection-event", async (event) => {
+listenUntilUnload("meeting-detection-event", async (event) => {
   await handleMeetingDetectionEventPayload(event.payload);
-}).catch(() => {});
+});
 
-void listen<boolean>("hud-stop-hover", (event) => {
+listenUntilUnload<boolean>("hud-stop-hover", (event) => {
   setStopHover(Boolean(event.payload));
-}).catch(() => {});
+});
 
-void listen<boolean>("hud-dismiss-hover", (event) => {
+listenUntilUnload<boolean>("hud-dismiss-hover", (event) => {
   setDismissHover(Boolean(event.payload));
-}).catch(() => {});
+});
 
-void listen<boolean>("hud-record-hover", (event) => {
+listenUntilUnload<boolean>("hud-record-hover", (event) => {
   setRecordHover(Boolean(event.payload));
-}).catch(() => {});
+});
 
 // Cold-start companion to the await in syncWindowToPill: the Diatype load
 // may only BEGIN once the prompt first paints text, after the measurement.

--- a/src/lib/listen-until-unload.ts
+++ b/src/lib/listen-until-unload.ts
@@ -1,0 +1,24 @@
+import { listen, type EventCallback, type UnlistenFn } from "@tauri-apps/api/event";
+
+// `listen()` registers on the native Tauri event bus, which outlives the
+// webview. The HUD windows are destroyed and recreated throughout a session,
+// so a module-scope `void listen(...)` leaves one stale registration behind
+// per recreation - growing per-event fan-out and memory until quit. This
+// wrapper keeps every unlisten handle and releases them all when the page
+// unloads.
+const unlisteners: UnlistenFn[] = [];
+let unloadHookInstalled = false;
+
+export function listenUntilUnload<T>(event: string, handler: EventCallback<T>): void {
+  if (!unloadHookInstalled) {
+    unloadHookInstalled = true;
+    window.addEventListener("beforeunload", () => {
+      for (const unlisten of unlisteners.splice(0)) unlisten();
+    });
+  }
+  void listen<T>(event, handler)
+    .then((unlisten) => {
+      unlisteners.push(unlisten);
+    })
+    .catch(() => {});
+}

--- a/src/meeting-hud.ts
+++ b/src/meeting-hud.ts
@@ -1,4 +1,4 @@
-import { listen } from "@tauri-apps/api/event";
+import { listenUntilUnload } from "./lib/listen-until-unload";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
@@ -155,11 +155,11 @@ document.addEventListener("keydown", (event) => {
   }
 });
 
-void listen<RecordingTelemetryDto>(RECORDING_TELEMETRY_EVENT, (event) => {
+listenUntilUnload<RecordingTelemetryDto>(RECORDING_TELEMETRY_EVENT, (event) => {
   if (event.payload) applyStatus(event.payload);
 });
 
-void listen<{ vertical: boolean; animate: boolean }>("meeting-hud-zone", (event) => {
+listenUntilUnload<{ vertical: boolean; animate: boolean }>("meeting-hud-zone", (event) => {
   if (event.payload) applyZone(event.payload);
 });
 


### PR DESCRIPTION
## Summary

- Adds `src/lib/listen-until-unload.ts`: a small wrapper around Tauri's `listen()` that captures every unlisten handle and releases them all on `beforeunload`.
- Routes all 12 module-scope `void listen(...)` calls in the three HUD entry scripts through it: `agent-hud.ts` (5), `hud.ts` (5), `meeting-hud.ts` (2).

Closes JUN-408.

## Root cause

`listen()` registers on the native Tauri event bus, which outlives the webview. The HUD entry scripts registered handlers at module scope with no unlisten handles, so every HUD page recreation/reload stacked another set of stale registrations - growing per-event fan-out and memory until quit.

## Validation

- Biome clean on the four changed files, `pnpm typecheck` clean.
- All 73 HUD vitest tests pass (`agent-hud.test.ts`, `hud-meeting.test.ts`, `hud-css.test.ts`).
- Behavior note: `meeting-hud.ts`'s two `listen()` calls previously had no `.catch`; the shared helper swallows registration errors the same way the other two files always did.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). <!-- no visual change; listener lifecycle only -->
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- desktop-only -->

## Out of scope

- The `window.addEventListener` handlers in the same files: those die with the document and do not leak across recreation.
- Listener hygiene in other webviews (main app window components manage their own lifecycles).

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787405178&installation_model_id=425925&pr_number=924&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F924&signature=53e6c23fd9341081f53b6c9be269a325b86e8f5b4df2044bb990544e774554cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->