### PR TITLE
fix(notes): preserve concurrent edits after generation

### DIFF
--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -3119,6 +3119,7 @@ impl Repositories {
         } else {
             append_note_content(current.generated_content.clone(), content.clone())
         };
+        let expected_edited_content = current.edited_content.clone();
         let next_edited_content = current.edited_content.map(|edited_content| {
             if existing_session_block {
                 if edited_content.trim()
@@ -3138,11 +3139,32 @@ impl Repositories {
                 append_note_content(Some(edited_content), content)
             }
         });
+        // Title and edited content are user-owned. Apply generation's changes
+        // only while the exact snapshots it read are still current; a NULL
+        // edited-content snapshot never authorizes a write to that column.
         query(
-            "UPDATE notes SET title = ?, generated_content = ?, edited_content = ?, active_tab = 'notes', processing_status = 'ready', last_error = NULL, updated_at = ? WHERE id = ?",
+            "UPDATE notes
+             SET title = CASE
+                     WHEN title IS ? THEN ?
+                     ELSE title
+                 END,
+                 generated_content = ?,
+                 edited_content = CASE
+                     WHEN ? IS NULL THEN edited_content
+                     WHEN edited_content IS ? THEN ?
+                     ELSE edited_content
+                 END,
+                 active_tab = 'notes',
+                 processing_status = 'ready',
+                 last_error = NULL,
+                 updated_at = ?
+             WHERE id = ?",
         )
+        .bind(current.title.as_str())
         .bind(title)
         .bind(next_generated_content)
+        .bind(expected_edited_content.as_deref())
+        .bind(expected_edited_content.as_deref())
         .bind(next_edited_content)
         .bind(timestamp())
         .bind(note_id)

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -2,6 +2,7 @@ use os_june_lib::{
     db::{migrations::run_migrations, repositories::Repositories},
     domain::types::{ProcessingStatus, RecordingSourceMode},
 };
+use sqlx::query::query;
 use sqlx_sqlite::SqlitePoolOptions;
 
 async fn repos() -> Repositories {
@@ -378,6 +379,96 @@ async fn generated_note_composes_distinct_session_blocks_in_order() {
     assert_eq!(
         updated.generated_content.as_deref(),
         Some("First transcript result\n\nSecond transcript result")
+    );
+}
+
+#[tokio::test]
+async fn generated_note_preserves_user_edit_written_after_its_read() {
+    let repos = repos().await;
+    let note = repos.create_note("default", None).await.expect("note");
+
+    // Generation inserts its session block after reading the note and before
+    // updating it. Use that exact boundary to deterministically model an
+    // autosave that commits while generation is still working from its stale
+    // `edited_content = NULL` snapshot.
+    query(
+        "CREATE TRIGGER simulate_concurrent_note_autosave
+         AFTER INSERT ON note_generation_blocks
+         BEGIN
+             UPDATE notes
+             SET title = 'User title persisted during generation',
+                 edited_content = 'User edit persisted during generation'
+             WHERE id = NEW.note_id;
+         END",
+    )
+    .execute(&repos.pool)
+    .await
+    .expect("install concurrent autosave trigger");
+
+    let updated = repos
+        .set_generated_note_for_session(
+            &note.id,
+            Some("session-1"),
+            None,
+            Some("Generated title".to_string()),
+            "Generated content".to_string(),
+        )
+        .await
+        .expect("generated note");
+
+    assert_eq!(updated.title, "User title persisted during generation");
+    assert_eq!(
+        updated.edited_content.as_deref(),
+        Some("User edit persisted during generation")
+    );
+    assert_eq!(
+        updated.generated_content.as_deref(),
+        Some("Generated content")
+    );
+}
+
+#[tokio::test]
+async fn generated_note_preserves_newer_non_null_user_edit_written_after_its_read() {
+    let repos = repos().await;
+    let note = repos.create_note("default", None).await.expect("note");
+    repos
+        .update_note(&note.id, None, Some("Initial user edit".to_string()), None)
+        .await
+        .expect("initial user edit");
+
+    // The trigger fires after generation has read the existing edit and
+    // changes it before generation's final compare-and-set update.
+    query(
+        "CREATE TRIGGER simulate_concurrent_non_null_note_autosave
+         AFTER INSERT ON note_generation_blocks
+         BEGIN
+             UPDATE notes
+             SET edited_content = 'Newer user edit persisted during generation'
+             WHERE id = NEW.note_id;
+         END",
+    )
+    .execute(&repos.pool)
+    .await
+    .expect("install concurrent autosave trigger");
+
+    let updated = repos
+        .set_generated_note_for_session(
+            &note.id,
+            Some("session-1"),
+            None,
+            Some("Generated title".to_string()),
+            "Generated content".to_string(),
+        )
+        .await
+        .expect("generated note");
+
+    assert_eq!(
+        updated.edited_content.as_deref(),
+        Some("Newer user edit persisted during generation")
+    );
+    assert_eq!(
+        updated.generated_content.as_deref(),
+        Some("Generated content")
     );
 }
 


### PR DESCRIPTION
## Summary

- Preserve user-owned note title and edited content when generation completes from a stale note snapshot.
- Keep the existing generation behavior that appends into unchanged, non-null edited content.
- Add a deterministic SQLite-trigger regression test that persists a user edit between generation's read and final update.
- Add a second trigger regression for a non-null snapshot that diverges before the final update.
- Refs JUN-412.

## Root cause

`set_generated_note_for_session` read the note, derived a complete replacement row, and later wrote the stale `edited_content` value back. If autosave persisted an edit after the read, the generation-complete update could overwrite it, including replacing the concurrent edit with `NULL`. The same stale-row update could also replace a concurrent title edit.

The final update now uses compare-and-set guards for the user-owned columns. A `NULL` edited-content snapshot never authorizes generation to write that column; an existing edited body is updated only if it still exactly matches the snapshot that generation read. The title follows the same snapshot guard.

## Validation

- `env CI=true NODE_OPTIONS=--no-experimental-webstorage DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make verify`
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make tauri-fmt-check tauri-lint tauri-test` after merging current `origin/main` at `3e3890d5f45cfd59c285f3d0a3d1ac98ffca16c7`
- `env CI=true NODE_OPTIONS=--no-experimental-webstorage DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make local-ci`
- Regression test: `generated_note_preserves_user_edit_written_after_its_read`
- Regression test: `generated_note_preserves_newer_non_null_user_edit_written_after_its_read`
- `signoff/frontend` posted as not applicable by path.
- `signoff/rust-macos` passed on `2aae53b605d39633de29c7d378e57c8cb42fcecd`.
- The first `local-ci` attempt hit a transient `WouldBlock`/connection-reset failure in the unrelated loopback redirect test. That test passed immediately in isolation, and the complete `local-ci` rerun passed.

- [x] Tested visually where it matters (not applicable: this is a database concurrency fix with no UI changes).
- [ ] Needs a June API (backend) deploy before it works end to end. No June API deploy is needed.

## Out of scope

- Changing the autosave behavior in #917.
- Changing generated-content composition or session-block replay semantics.
- Adding a schema-level row version; exact-value compare-and-set guards are sufficient for the owned columns in this path.

## Followups

- Run the requested dual review round while this PR remains a draft.
- #917 landed in `origin/main` before this final merge. This fix remains compatible with its continuous-autosave path.
- The reverse-direction autosave-clobbers-generated-title race is tracked in JUN-418; do not fix it here.
- The SQLite busy-timeout durability gap is tracked separately in JUN-407; do not fix it here.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary (not applicable).
- [x] Workflow action references are pinned to full-length commit SHAs (no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable).
- [x] User-facing copy follows the repo UI conventions (no user-facing copy changes).
