### PR TITLE
Detect stalled Hermes gateway connections

### DIFF
--- a/docs/hermes-architecture.md
+++ b/docs/hermes-architecture.md
@@ -104,9 +104,11 @@ classified events into `AgentChatTurn` / `AgentChatPart[]` for rendering.
   is fetched for a working session only after a bounded streak of unreachable
   polls, consecutive reachable snapshots that omit it, or an unexpected stream
   disconnect; the current bridge has no message-revision or delta contract.
-  Gateway events render message deltas but are not a lifecycle heartbeat.
-  JUN-414 tracks detecting a silently stalled OPEN socket and forcing
-  reconnect.
+  The same existing `session.active_list` traffic is also the Gateway
+  heartbeat: three consecutive request timeouts invalidate every open client
+  for that runtime mode, converting a silently stalled OPEN socket into the
+  established unexpected-close and reconnect path without adding another
+  periodic request.
 - **Browser approvals are event-led.** The browser-approval change event
   refreshes pending approvals promptly. Snapshot reads are limited to initial
   subscription, listener reattachment, and focus, visibility, or online

--- a/docs/hermes-gateway-gotchas.md
+++ b/docs/hermes-gateway-gotchas.md
@@ -28,6 +28,14 @@ to "reconnect" existing clients.
 with `launchctl bootout gui/$UID/ai.hermes.gateway`. June re-registers it on
 next launch.
 
+**The pinned chat gateway has no application ping.** Its JSON-RPC registry
+does not expose ping, pong, or tick, and WKWebView's browser `WebSocket` cannot
+send protocol-level ping frames. June therefore treats the existing
+`session.active_list` cycle as its liveness signal. Three consecutive request
+timeouts force-disconnect all clients for that runtime mode so the ordinary
+close/reconnect recovery path runs. Do not add a second always-on heartbeat
+request.
+
 **App teardown is ordered and bounded.** Ordinary quit enters the idempotent
 shutdown coordinator from `RunEvent::ExitRequested`; update relaunch enters the
 same coordinator from its command. Cleanup runs off the main event loop and

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2355,6 +2355,7 @@ export function AgentWorkspace({
     recordHermesActivityAndDeriveStatus,
     refreshHermesSession,
     selectedHermesSessionIdRef,
+    sessionGatewayUnlistenRef,
     setBridge,
     setBridgeStarting,
     setError,

--- a/src/components/agent/gateway-recovery-actions-types.ts
+++ b/src/components/agent/gateway-recovery-actions-types.ts
@@ -43,6 +43,7 @@ export type createGatewayRecoveryActionsDependencies = {
   ) => AgentSessionStatusKind | undefined;
   refreshHermesSession: (sessionId: string) => Promise<HermesSessionMessage[] | undefined>;
   selectedHermesSessionIdRef: React.MutableRefObject<string | undefined>;
+  sessionGatewayUnlistenRef: React.MutableRefObject<Map<string, () => void>>;
   setBridge: React.Dispatch<React.SetStateAction<HermesBridgeStatus>>;
   setBridgeStarting: React.Dispatch<React.SetStateAction<boolean>>;
   setError: (message: string | null, options?: AgentWorkspaceErrorOptions) => void;

--- a/src/components/agent/gateway-recovery-actions.ts
+++ b/src/components/agent/gateway-recovery-actions.ts
@@ -32,6 +32,7 @@ export function createGatewayRecoveryActions(
     recordHermesActivityAndDeriveStatus,
     refreshHermesSession,
     selectedHermesSessionIdRef,
+    sessionGatewayUnlistenRef,
     setBridge,
     setBridgeStarting,
     setError,
@@ -120,6 +121,12 @@ export function createGatewayRecoveryActions(
       ),
     );
     if (!activeSessionIds.size) return;
+    // A listener owns the exact attended Computer use lease opened with its
+    // prompt. Tear listeners down before reconnect work so a stalled socket
+    // cannot retain that authority through the reconnect timeout or failure.
+    for (const sessionId of activeSessionIds) {
+      sessionGatewayUnlistenRef.current.get(sessionId)?.();
+    }
     gatewayRecoveringRef.current.add(fullMode);
     // The patched Hermes gateway denies and drains unresolved MCP approvals
     // when its notification socket disconnects. Mirror that fail-closed

--- a/src/components/agent/session-event-listener.ts
+++ b/src/components/agent/session-event-listener.ts
@@ -223,9 +223,7 @@ export function createSessionEventListener(dependencies: createSessionEventListe
         });
       }
       if (isTerminalHermesEvent(classified)) {
-        if (computerUseRunLeaseId) {
-          void releaseComputerUseRun(storedSessionId, computerUseRunLeaseId);
-        } else {
+        if (!computerUseRunLeaseId) {
           void releaseAllComputerUseRuns(storedSessionId);
         }
         unlisten();
@@ -256,8 +254,17 @@ export function createSessionEventListener(dependencies: createSessionEventListe
         }
       }
     });
+    let listening = true;
     unlisten = () => {
+      if (!listening) return;
+      listening = false;
       removeListener();
+      // This listener owns exactly the lease opened with its prompt. A
+      // terminal event, explicit teardown, or gateway-stall recovery all
+      // release that lease through the same boundary.
+      if (computerUseRunLeaseId) {
+        void releaseComputerUseRun(storedSessionId, computerUseRunLeaseId);
+      }
       // Stop, cancellation, listener replacement, and normal teardown all
       // converge here. Publish any trailing delta before cancelling its timer
       // so React never remains behind the authoritative event ref.

--- a/src/components/agent/use-agent-gateway-actions.ts
+++ b/src/components/agent/use-agent-gateway-actions.ts
@@ -35,7 +35,7 @@ export function useAgentGatewayActions(dependencies: UseAgentGatewayActionsDepen
     if (!wsUrl) throw new Error("Hermes bridge did not return a gateway URL.");
     let gateway = gatewaysRef.current.get(fullMode);
     if (!gateway) {
-      gateway = new HermesGatewayClient();
+      gateway = new HermesGatewayClient(fullMode);
       gatewaysRef.current.set(fullMode, gateway);
       // Fires only on unexpected drops — the unmount close() detaches the
       // socket first, and a superseded socket never notifies.

--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -138,7 +138,7 @@ async function connectGateway(startIfNeeded: boolean): Promise<HermesGatewayClie
     const wsUrl = connection?.wsUrl;
     if (!wsUrl) throw new Error("Hermes bridge did not return a gateway URL.");
     if (!sharedGateway) {
-      const gateway = new HermesGatewayClient();
+      const gateway = new HermesGatewayClient(false);
       gateway.onEvent((raw) => {
         const event = classifyHermesEvent(raw);
         for (const subscriber of [...eventSubscribers]) subscriber(event);

--- a/src/lib/hermes-active-session-snapshots.ts
+++ b/src/lib/hermes-active-session-snapshots.ts
@@ -1,5 +1,9 @@
 import { hermesConnectionForMode } from "./hermes-connection";
-import { HermesGatewayClient } from "./hermes-gateway";
+import {
+  forceDisconnectHermesGatewayClients,
+  HermesGatewayClient,
+  HermesGatewayRequestTimeoutError,
+} from "./hermes-gateway";
 import { hermesBridgeStatus } from "./tauri";
 
 export type HermesActiveSessionRow = {
@@ -25,11 +29,13 @@ type ModeObserver = {
 
 const SNAPSHOT_INTERVAL_MS = 500;
 const SNAPSHOT_REQUEST_TIMEOUT_MS = SNAPSHOT_INTERVAL_MS;
+export const HERMES_GATEWAY_HEARTBEAT_MISS_THRESHOLD = 3;
 const listenersByMode = new Map<boolean, Set<SnapshotListener>>();
 const observersByMode = new Map<boolean, ModeObserver>();
 const cycleInFlightByMode = new Set<boolean>();
 const cycleTimersByMode = new Map<boolean, ReturnType<typeof setTimeout>>();
 const immediateCyclesByMode = new Set<boolean>();
+const heartbeatMissesByMode = new Map<boolean, number>();
 
 function modeHasListeners(fullMode: boolean) {
   return Boolean(listenersByMode.get(fullMode)?.size);
@@ -39,6 +45,7 @@ function closeObserver(fullMode: boolean) {
   const observer = observersByMode.get(fullMode);
   if (!observer) return;
   observersByMode.delete(fullMode);
+  heartbeatMissesByMode.delete(fullMode);
   observer.gateway.close();
 }
 
@@ -63,7 +70,7 @@ function scheduleCycle(fullMode: boolean, delayMs: number) {
 }
 
 function createObserver(fullMode: boolean) {
-  const gateway = new HermesGatewayClient();
+  const gateway = new HermesGatewayClient(fullMode);
   const observer: ModeObserver = { connected: false, gateway };
   gateway.onClose(() => {
     if (observersByMode.get(fullMode) === observer) {
@@ -135,8 +142,20 @@ async function pollMode(fullMode: boolean) {
     const response = await observer.gateway.request<{
       sessions?: HermesActiveSessionRow[];
     }>("session.active_list", {}, SNAPSHOT_REQUEST_TIMEOUT_MS);
+    heartbeatMissesByMode.delete(fullMode);
     publishSnapshot(fullMode, true, Array.isArray(response?.sessions) ? response.sessions : []);
-  } catch {
+  } catch (error) {
+    if (error instanceof HermesGatewayRequestTimeoutError) {
+      const misses = (heartbeatMissesByMode.get(fullMode) ?? 0) + 1;
+      if (misses >= HERMES_GATEWAY_HEARTBEAT_MISS_THRESHOLD) {
+        heartbeatMissesByMode.delete(fullMode);
+        forceDisconnectHermesGatewayClients(fullMode);
+      } else {
+        heartbeatMissesByMode.set(fullMode, misses);
+      }
+    } else {
+      heartbeatMissesByMode.delete(fullMode);
+    }
     // Unreachable is an observation, not an empty active-session list. It
     // engages bounded native-persistence fallbacks while preserving
     // locally-known activity.
@@ -182,6 +201,7 @@ export function subscribeHermesActiveSessionSnapshots(
     current?.delete(listener);
     if (current?.size) return;
     listenersByMode.delete(fullMode);
+    heartbeatMissesByMode.delete(fullMode);
     const timer = cycleTimersByMode.get(fullMode);
     if (timer !== undefined) clearTimeout(timer);
     cycleTimersByMode.delete(fullMode);
@@ -197,6 +217,7 @@ export function resetHermesActiveSessionSnapshotsForTests() {
   cycleTimersByMode.clear();
   cycleInFlightByMode.clear();
   immediateCyclesByMode.clear();
+  heartbeatMissesByMode.clear();
   listenersByMode.clear();
   for (const fullMode of [...observersByMode.keys()]) closeObserver(fullMode);
 }

--- a/src/lib/hermes-gateway.ts
+++ b/src/lib/hermes-gateway.ts
@@ -117,14 +117,24 @@ export class HermesGatewayClient {
       this.handleUnexpectedClose(socket);
     });
     const connectPromise = new Promise<void>((resolve, reject) => {
+      let opened = false;
+      const failInitialConnection = (error: Error) => {
+        if (opened) return;
+        if (this.socket === socket) {
+          this.socket = undefined;
+          this.unregisterFromMode();
+        }
+        reject(error);
+      };
       const timer = window.setTimeout(() => {
-        reject(new Error("Hermes gateway connection timed out."));
+        failInitialConnection(new Error("Hermes gateway connection timed out."));
         socket.close();
       }, 15000);
       socket.addEventListener(
         "open",
         () => {
           window.clearTimeout(timer);
+          opened = true;
           resolve();
         },
         { once: true },
@@ -133,7 +143,7 @@ export class HermesGatewayClient {
         "error",
         () => {
           window.clearTimeout(timer);
-          reject(new Error("Could not connect to Hermes gateway."));
+          failInitialConnection(new Error("Could not connect to Hermes gateway."));
         },
         { once: true },
       );

--- a/src/lib/hermes-gateway.ts
+++ b/src/lib/hermes-gateway.ts
@@ -44,6 +44,8 @@ type Frame = {
   error?: { code?: number; message?: string };
 };
 
+const clientsByMode = new Map<boolean, Set<HermesGatewayClient>>();
+
 /** RPC rejection from the gateway, keeping the JSON-RPC error code so callers
  * can branch on well-known conditions instead of matching message strings. */
 export class HermesGatewayError extends Error {
@@ -53,6 +55,28 @@ export class HermesGatewayError extends Error {
     super(message);
     this.name = "HermesGatewayError";
     this.code = code;
+  }
+}
+
+/** A request received no response before its caller-owned deadline. Keeping
+ * this distinct from ordinary gateway failures lets the existing active-list
+ * poll count silent stalls without treating explicit disconnects as misses. */
+export class HermesGatewayRequestTimeoutError extends Error {
+  readonly method: string;
+
+  constructor(method: string) {
+    super(`Hermes request timed out: ${method}`);
+    this.name = "HermesGatewayRequestTimeoutError";
+    this.method = method;
+  }
+}
+
+/** Converts a mode-wide liveness failure into the same unexpected-close signal
+ * used for ordinary transport drops. Each client immediately detaches its
+ * silent socket, so reconnect does not wait for the browser's TCP close timer. */
+export function forceDisconnectHermesGatewayClients(fullMode: boolean) {
+  for (const client of [...(clientsByMode.get(fullMode) ?? [])]) {
+    client.forceDisconnect();
   }
 }
 
@@ -72,6 +96,10 @@ export class HermesGatewayClient {
   private handlers = new Set<(event: HermesGatewayEvent) => void>();
   private closeHandlers = new Set<() => void>();
 
+  constructor(private readonly fullMode?: boolean) {
+    this.registerForMode();
+  }
+
   async connect(wsUrl: string) {
     if (this.socket?.readyState === WebSocket.OPEN) return;
     // Coalesce concurrent connects: a second caller arriving while the
@@ -79,16 +107,14 @@ export class HermesGatewayClient {
     // just awaits the same connection attempt.
     if (this.connectPromise) return this.connectPromise;
     this.close();
+    this.registerForMode();
     const socket = new WebSocket(wsUrl);
     this.socket = socket;
     socket.addEventListener("message", (event) => this.handleMessage(event.data));
     socket.addEventListener("close", () => {
       // A stale socket's close event must not reject requests pending on
       // the socket that replaced it, nor notify close listeners.
-      if (this.socket !== socket) return;
-      this.socket = undefined;
-      this.rejectAll(new Error("Hermes gateway connection closed."));
-      for (const handler of [...this.closeHandlers]) handler();
+      this.handleUnexpectedClose(socket);
     });
     const connectPromise = new Promise<void>((resolve, reject) => {
       const timer = window.setTimeout(() => {
@@ -125,7 +151,19 @@ export class HermesGatewayClient {
     // identity guard in the close handler then skips rejectAll/onClose.
     const socket = this.socket;
     this.socket = undefined;
+    this.unregisterFromMode();
     socket?.close();
+  }
+
+  /** Declares the current OPEN socket unhealthy and synchronously runs the
+   * unexpected-close path. Browser WebSocket.close() can itself wait on a
+   * wedged TCP peer, so detach and notify before asking the old socket to
+   * close. */
+  forceDisconnect() {
+    const socket = this.socket;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return;
+    this.handleUnexpectedClose(socket);
+    socket.close();
   }
 
   onEvent(handler: (event: HermesGatewayEvent) => void) {
@@ -155,7 +193,7 @@ export class HermesGatewayClient {
       };
       pending.timer = window.setTimeout(() => {
         if (this.pending.delete(id)) {
-          reject(new Error(`Hermes request timed out: ${method}`));
+          reject(new HermesGatewayRequestTimeoutError(method));
         }
       }, timeoutMs);
       this.pending.set(id, pending);
@@ -195,6 +233,28 @@ export class HermesGatewayClient {
       pending.reject(error);
       this.pending.delete(id);
     }
+  }
+
+  private handleUnexpectedClose(socket: WebSocket) {
+    if (this.socket !== socket) return;
+    this.socket = undefined;
+    this.unregisterFromMode();
+    this.rejectAll(new Error("Hermes gateway connection closed."));
+    for (const handler of [...this.closeHandlers]) handler();
+  }
+
+  private registerForMode() {
+    if (this.fullMode === undefined) return;
+    const clients = clientsByMode.get(this.fullMode) ?? new Set<HermesGatewayClient>();
+    clients.add(this);
+    clientsByMode.set(this.fullMode, clients);
+  }
+
+  private unregisterFromMode() {
+    if (this.fullMode === undefined) return;
+    const clients = clientsByMode.get(this.fullMode);
+    clients?.delete(this);
+    if (clients?.size === 0) clientsByMode.delete(this.fullMode);
   }
 }
 

--- a/src/test/agent-run-monitor.test.ts
+++ b/src/test/agent-run-monitor.test.ts
@@ -424,6 +424,23 @@ describe("agent run monitor", () => {
     expect(monitorMocks.forceDisconnect).toHaveBeenCalledWith(false);
   });
 
+  it("resets heartbeat misses after a successful active-list response", async () => {
+    let activeListCalls = 0;
+    monitorMocks.request.mockImplementation((method: string) => {
+      if (method !== "session.active_list") return Promise.resolve({});
+      activeListCalls += 1;
+      if (activeListCalls === 3) return Promise.resolve({ sessions: [] });
+      return new Promise(() => undefined);
+    });
+    startRun();
+
+    await flush();
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    expect(activeListCalls).toBe(5);
+    expect(monitorMocks.forceDisconnect).not.toHaveBeenCalled();
+  });
+
   it("distributes one active-session request per cycle to runs in the same mode", async () => {
     activeRuntime();
     startRun();

--- a/src/test/agent-run-monitor.test.ts
+++ b/src/test/agent-run-monitor.test.ts
@@ -16,8 +16,11 @@ const monitorMocks = vi.hoisted(() => {
   const sessionMessages = vi.fn();
   const dispatchSettled = vi.fn();
   const dispatchStatus = vi.fn();
+  const forceDisconnect = vi.fn();
   const instances: MockGateway[] = [];
   const requestContexts: MockGateway[] = [];
+
+  class MockGatewayRequestTimeoutError extends Error {}
 
   class MockGateway {
     readonly eventHandlers = new Set<EventHandler>();
@@ -44,7 +47,7 @@ const monitorMocks = vi.hoisted(() => {
       const response = request.call(this, method, params) as Promise<T>;
       return new Promise<T>((resolve, reject) => {
         const timer = setTimeout(
-          () => reject(new Error(`Hermes request timed out: ${method}`)),
+          () => reject(new MockGatewayRequestTimeoutError(`Hermes request timed out: ${method}`)),
           timeoutMs,
         );
         void Promise.resolve(response).then(
@@ -70,7 +73,9 @@ const monitorMocks = vi.hoisted(() => {
     bridgeStatus,
     dispatchSettled,
     dispatchStatus,
+    forceDisconnect,
     instances,
+    MockGatewayRequestTimeoutError,
     request,
     requestContexts,
     sessions,
@@ -79,7 +84,9 @@ const monitorMocks = vi.hoisted(() => {
 });
 
 vi.mock("../lib/hermes-gateway", () => ({
+  forceDisconnectHermesGatewayClients: monitorMocks.forceDisconnect,
   HermesGatewayClient: monitorMocks.MockGateway,
+  HermesGatewayRequestTimeoutError: monitorMocks.MockGatewayRequestTimeoutError,
 }));
 
 vi.mock("../lib/tauri", () => ({
@@ -181,6 +188,7 @@ describe("agent run monitor", () => {
     monitorMocks.sessionMessages.mockReset().mockResolvedValue({ messages: [] });
     monitorMocks.dispatchSettled.mockReset();
     monitorMocks.dispatchStatus.mockReset();
+    monitorMocks.forceDisconnect.mockReset();
   });
 
   afterEach(() => {
@@ -413,7 +421,7 @@ describe("agent run monitor", () => {
 
     expect(monitorMocks.sessions).toHaveBeenCalled();
     expect(monitorMocks.dispatchSettled).toHaveBeenCalledOnce();
-    expect(monitorMocks.instances[0]?.close).not.toHaveBeenCalled();
+    expect(monitorMocks.forceDisconnect).toHaveBeenCalledWith(false);
   });
 
   it("distributes one active-session request per cycle to runs in the same mode", async () => {

--- a/src/test/agent-run-monitor.test.ts
+++ b/src/test/agent-run-monitor.test.ts
@@ -425,6 +425,7 @@ describe("agent run monitor", () => {
   });
 
   it("resets heartbeat misses after a successful active-list response", async () => {
+    // timeout, timeout, success, timeout, timeout must not disconnect.
     let activeListCalls = 0;
     monitorMocks.request.mockImplementation((method: string) => {
       if (method !== "session.active_list") return Promise.resolve({});

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -140,6 +140,7 @@ const mocks = vi.hoisted(() => ({
   listHermesSessions: vi.fn(),
   listSessionProfiles: vi.fn(),
   gatewayRequest: vi.fn(),
+  forceDisconnectGatewayClients: vi.fn(),
   markAgentRunSucceeded: vi.fn(),
   releaseAgentRunSettlement: vi.fn(),
   startAgentRunMonitoring: vi.fn(),
@@ -266,45 +267,49 @@ vi.mock("../lib/hermes-adapter", async (importOriginal) => ({
   titleFromPrompt: mocks.titleFromPrompt,
 }));
 
-vi.mock("../lib/hermes-gateway", async (importOriginal) => ({
-  // Real HermesGatewayError / isSessionBusyError — only the client is faked.
-  ...(await importOriginal<typeof import("../lib/hermes-gateway")>()),
-  HermesGatewayClient: class {
-    constructor() {
-      mocks.gatewayInstances.push(this as unknown as (typeof mocks.gatewayInstances)[number]);
-    }
-    connect = vi.fn();
-    close = vi.fn();
-    onEvent = vi.fn((handler: (event: Record<string, unknown>) => void) => {
-      mocks.gatewayEventHandlers.add(handler);
-      return () => mocks.gatewayEventHandlers.delete(handler);
-    });
-    onClose = vi.fn((handler: () => void) => {
-      mocks.gatewayCloseHandlers.add(handler);
-      return () => mocks.gatewayCloseHandlers.delete(handler);
-    });
-    request<T>(method: string, params: Record<string, unknown>, timeoutMs?: number) {
-      const response = mocks.gatewayRequest(method, params) as Promise<T>;
-      if (timeoutMs === undefined) return response;
-      return new Promise<T>((resolve, reject) => {
-        const timer = window.setTimeout(
-          () => reject(new Error(`Hermes request timed out: ${method}`)),
-          timeoutMs,
-        );
-        void Promise.resolve(response).then(
-          (value) => {
-            window.clearTimeout(timer);
-            resolve(value);
-          },
-          (error) => {
-            window.clearTimeout(timer);
-            reject(error);
-          },
-        );
+vi.mock("../lib/hermes-gateway", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../lib/hermes-gateway")>();
+  return {
+    // Real error types and helpers — only the client and mode invalidation are faked.
+    ...original,
+    forceDisconnectHermesGatewayClients: mocks.forceDisconnectGatewayClients,
+    HermesGatewayClient: class {
+      constructor() {
+        mocks.gatewayInstances.push(this as unknown as (typeof mocks.gatewayInstances)[number]);
+      }
+      connect = vi.fn();
+      close = vi.fn();
+      onEvent = vi.fn((handler: (event: Record<string, unknown>) => void) => {
+        mocks.gatewayEventHandlers.add(handler);
+        return () => mocks.gatewayEventHandlers.delete(handler);
       });
-    }
-  },
-}));
+      onClose = vi.fn((handler: () => void) => {
+        mocks.gatewayCloseHandlers.add(handler);
+        return () => mocks.gatewayCloseHandlers.delete(handler);
+      });
+      request<T>(method: string, params: Record<string, unknown>, timeoutMs?: number) {
+        const response = mocks.gatewayRequest(method, params) as Promise<T>;
+        if (timeoutMs === undefined) return response;
+        return new Promise<T>((resolve, reject) => {
+          const timer = window.setTimeout(
+            () => reject(new original.HermesGatewayRequestTimeoutError(method)),
+            timeoutMs,
+          );
+          void Promise.resolve(response).then(
+            (value) => {
+              window.clearTimeout(timer);
+              resolve(value);
+            },
+            (error) => {
+              window.clearTimeout(timer);
+              reject(error);
+            },
+          );
+        });
+      }
+    },
+  };
+});
 
 const existingTask = {
   id: "task-1",
@@ -595,6 +600,9 @@ describe("AgentWorkspace", () => {
     mocks.gatewayEventHandlers.clear();
     mocks.gatewayCloseHandlers.clear();
     mocks.gatewayInstances.length = 0;
+    mocks.forceDisconnectGatewayClients.mockImplementation(() => {
+      for (const handler of [...mocks.gatewayCloseHandlers]) handler();
+    });
     resetHermesActiveSessionSnapshotsForTests();
     // Auto-cleanup unmounts the workspace after each test, which snapshots
     // any still-working session for the next mount — across tests that would
@@ -9753,16 +9761,37 @@ describe("AgentWorkspace", () => {
       replyPersisted ? [...userOnly, reply] : userOnly,
     );
     mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        return Promise.resolve({
+          session_id: "runtime-session-2",
+          stored_session_id: "session-2",
+        });
+      }
       if (method === "session.active_list") {
         return new Promise(() => undefined);
       }
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-recovered" });
+      }
       return Promise.resolve({});
     });
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "finish after wake" }),
+    );
 
     vi.useFakeTimers();
     try {
       render(<AgentWorkspace />);
-      await settleUnderFakeTimers(() => expect(screen.getByText("Thinking…")).toBeInTheDocument());
+      await settleUnderFakeTimers(
+        () => {
+          expect(mocks.computerUseBeginRun).toHaveBeenCalled();
+          expect(screen.getByText("Thinking…")).toBeInTheDocument();
+        },
+        { maxMs: 2_000 },
+      );
+      const computerUseRunLeaseId = mocks.computerUseBeginRun.mock.calls.at(-1)?.[0];
+      expect(computerUseRunLeaseId).toMatch(/^session-2:/);
       const historyCallsBeforeStallRecovery = mocks.listHermesSessionMessages.mock.calls.length;
 
       // No gateway close is emitted. The socket stays logically OPEN while
@@ -9772,6 +9801,12 @@ describe("AgentWorkspace", () => {
         await vi.advanceTimersByTimeAsync(3_000);
       });
 
+      expect(mocks.forceDisconnectGatewayClients).toHaveBeenCalledWith(false);
+      expect(mocks.computerUseEndRun).toHaveBeenCalledWith(computerUseRunLeaseId);
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.resume", {
+        session_id: "session-2",
+        cols: 96,
+      });
       expect(mocks.listHermesSessionMessages.mock.calls.length).toBeGreaterThan(
         historyCallsBeforeStallRecovery,
       );
@@ -9789,7 +9824,7 @@ describe("AgentWorkspace", () => {
       );
       expect(screen.getByText("Recovered from native history.")).toBeInTheDocument();
       expect(screen.queryByText("Thinking…")).toBeNull();
-      expect(mocks.markAgentRunSucceeded).toHaveBeenCalledWith("session-1");
+      expect(mocks.markAgentRunSucceeded).toHaveBeenCalledWith("session-2");
     } finally {
       vi.useRealTimers();
     }

--- a/src/test/hermes-gateway.test.ts
+++ b/src/test/hermes-gateway.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { HermesGatewayClient, HermesGatewayError, isSessionBusyError } from "../lib/hermes-gateway";
+import {
+  forceDisconnectHermesGatewayClients,
+  HermesGatewayClient,
+  HermesGatewayError,
+  isSessionBusyError,
+} from "../lib/hermes-gateway";
 
 type Listener = (event: unknown) => void;
 
@@ -180,5 +185,30 @@ describe("HermesGatewayClient", () => {
     // Intentional teardown → listeners stay quiet.
     client.close();
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("force-disconnects a stalled mode and allows its existing client to reconnect", async () => {
+    const client = new HermesGatewayClient(false);
+    const onClose = vi.fn();
+    client.onClose(onClose);
+
+    const first = client.connect("ws://gateway");
+    const stalled = FakeWebSocket.instances[0];
+    stalled.open();
+    await first;
+
+    forceDisconnectHermesGatewayClients(false);
+
+    expect(stalled.readyState).toBe(FakeWebSocket.CLOSED);
+    expect(onClose).toHaveBeenCalledOnce();
+
+    const recovering = client.connect("ws://gateway");
+    const recovered = FakeWebSocket.instances[1];
+    recovered.open();
+    await recovering;
+
+    expect(recovered.readyState).toBe(FakeWebSocket.OPEN);
+    expect(onClose).toHaveBeenCalledOnce();
+    client.close();
   });
 });

--- a/src/test/hermes-gateway.test.ts
+++ b/src/test/hermes-gateway.test.ts
@@ -104,6 +104,32 @@ describe("HermesGatewayClient", () => {
     expect(FakeWebSocket.instances).toHaveLength(1);
   });
 
+  it("unregisters a mode client when its initial connection times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new HermesGatewayClient(false);
+      const onClose = vi.fn();
+      client.onClose(onClose);
+      const connecting = client.connect("ws://gateway");
+      const socket = FakeWebSocket.instances[0];
+      socket.close = vi.fn();
+      const timedOut = expect(connecting).rejects.toThrow(
+        "Hermes gateway connection timed out.",
+      );
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      await timedOut;
+
+      // A delayed open event from the failed socket must not resurrect the
+      // client in the mode registry or participate in future disconnects.
+      socket.open();
+      forceDisconnectHermesGatewayClients(false);
+      expect(onClose).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("ignores a stale socket's close event for requests pending on the new socket", async () => {
     const client = new HermesGatewayClient();
     const first = client.connect("ws://gateway");

--- a/src/test/hermes-gateway.test.ts
+++ b/src/test/hermes-gateway.test.ts
@@ -113,9 +113,7 @@ describe("HermesGatewayClient", () => {
       const connecting = client.connect("ws://gateway");
       const socket = FakeWebSocket.instances[0];
       socket.close = vi.fn();
-      const timedOut = expect(connecting).rejects.toThrow(
-        "Hermes gateway connection timed out.",
-      );
+      const timedOut = expect(connecting).rejects.toThrow("Hermes gateway connection timed out.");
 
       await vi.advanceTimersByTimeAsync(15_000);
       await timedOut;


### PR DESCRIPTION
## Summary

- Reuses the existing per-mode `session.active_list` cycle as the Hermes Gateway heartbeat, without adding always-on traffic.
- Counts three consecutive request timeouts, then force-disconnects every open Gateway client for that runtime mode so the established unexpected-close, reconnect, resume, and native-persistence recovery path runs.
- Releases the exact attended Computer use run lease before reconnect work begins, building on the listener-owned lease semantics from #923 so a lost terminal frame cannot strand authority.
- The exact pinned Hermes source (`3ef6bbd201263d354fd83ec55b3c306ded2eb72a`) has no ping, pong, or tick JSON-RPC method; its loopback server disables WebSocket ping intervals, and the WKWebView browser WebSocket API cannot emit protocol ping frames. Application-level liveness is therefore the supported mechanism.

## Root cause

The browser Gateway client treated an OPEN WebSocket as healthy indefinitely. After sleep/wake, a network transition, or an idle proxy stall, requests and event frames could stop without a close event. Stream consumers then never entered the existing recovery path, and an attended Computer use listener could retain its run lease if the terminal frame was among the lost frames.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage CI=true pnpm test` - 211 files, 3,453 passed, 2 skipped
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer pnpm test:rust` - 1,344 library tests passed plus all integration suites
- `NODE_OPTIONS=--no-experimental-webstorage CI=true make local-ci` - `signoff/frontend` and `signoff/rust-macos` posted on `f94ddff7e3ab20565d8384824e0ef976d8428082`
- Deterministic stalled-frame coverage verifies forced close, reconnect/resume, native-history recovery, and exact lease release within the heartbeat threshold.
- `pnpm test:hermes-smoke` was attempted, but this machine's user install is Hermes v0.18.2 rather than the pinned v0.19.0 and fails the launchd-status preflight. Protocol capability was verified against the downloaded pinned archive after confirming its documented SHA-256.

- [ ] Tested visually where it matters (no rendered UI change; behavior is covered at the WebSocket/recovery boundary).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend change is required.

## Out of scope

- Adding a second periodic request, a new Hermes wire method, or a Rust WebSocket proxy.
- Adding a separate wall-clock lease TTL; this change uses the requested heartbeat-stall release and #923's exact listener-owned lease.

## Followups

- Run the requested dual review before marking the PR ready.
- The idle-stall first-submit hang is tracked separately as issue 433.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs (no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable).
- [x] User-facing copy follows the repo UI conventions (no UI copy changes).

Refs JUN-414
