### PR TITLE
Fix note list pagination and preview loading

### DIFF
--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -8,16 +8,29 @@ use crate::domain::types::{
     ProfileDataSummaryDto, RecordingSourceMode, RecordingState, SessionFolderDto,
     SessionProfileDto, TranscriptCoverageDto, TranscriptDto,
 };
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use chrono::{DateTime, Duration, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sqlx::query::query;
+use sqlx::query_builder::QueryBuilder;
 use sqlx::row::Row;
-use sqlx_sqlite::SqlitePool;
+use sqlx_sqlite::{Sqlite, SqlitePool};
 use uuid::Uuid;
 
 use crate::note_audio_export::{NoteAudioExportSelection, NoteAudioExportSource};
 
 const DICTATION_HISTORY_RETENTION_DAYS: i64 = 7;
+const NOTE_PREVIEW_CHAR_LIMIT: usize = 140;
+const LIST_NOTES_CURSOR_VERSION: u8 = 1;
+const LIST_NOTES_CURSOR_MAX_ENCODED_LEN: usize = 1_024;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ListNotesCursor {
+    version: u8,
+    created_at: String,
+    rowid: i64,
+}
 
 #[derive(Clone)]
 pub struct Repositories {
@@ -1763,65 +1776,143 @@ impl Repositories {
         profile: &str,
         folder_id: Option<String>,
         limit: i64,
-        _cursor: Option<String>,
+        cursor: Option<String>,
     ) -> Result<ListNotesResponse, sqlx::error::Error> {
-        let rows = if let Some(folder_id) = folder_id {
-            query(
-                "SELECT n.id, n.title, n.generated_content, n.edited_content, n.processing_status, n.created_at, n.updated_at
-                 FROM notes n
-                 INNER JOIN note_folders nf ON nf.note_id = n.id
-                 WHERE nf.folder_id = ? AND n.profile = ?
-                 ORDER BY n.created_at DESC, n.rowid DESC
-                 LIMIT ?",
-            )
-            .bind(folder_id)
-            .bind(profile)
-            .bind(limit)
-            .fetch_all(&self.pool)
-            .await?
-        } else {
-            query(
-                "SELECT id, title, generated_content, edited_content, processing_status, created_at, updated_at
-                 FROM notes
-                 WHERE profile = ?
-                 ORDER BY created_at DESC, rowid DESC
-                 LIMIT ?",
-            )
-            .bind(profile)
-            .bind(limit)
-            .fetch_all(&self.pool)
-            .await?
-        };
+        let cursor = cursor
+            .as_deref()
+            .map(decode_list_notes_cursor)
+            .transpose()?;
+        let page_size = usize::try_from(limit).ok();
+        let fetch_limit = page_size
+            .map(|_| limit.saturating_add(1))
+            // Preserve the existing SQLite `LIMIT -1` behavior for callers
+            // that explicitly request an unbounded list.
+            .unwrap_or(limit);
 
-        let mut items = Vec::with_capacity(rows.len());
+        // `char(...)` is the Unicode White_Space set used by Rust's
+        // `char::is_whitespace`. Keeping the blank-content check in SQL lets
+        // this projection match `preview_for` exactly without selecting either
+        // full note body.
+        let mut list_query = QueryBuilder::<Sqlite>::new(format!(
+            "WITH page AS (
+                 SELECT n.rowid AS note_rowid, n.id, n.title,
+                        substr(
+                            CASE
+                                WHEN trim(
+                                    COALESCE(n.edited_content, n.generated_content, ''),
+                                    char(9, 10, 11, 12, 13, 32, 133, 160, 5760,
+                                         8192, 8193, 8194, 8195, 8196, 8197,
+                                         8198, 8199, 8200, 8201, 8202, 8232,
+                                         8233, 8239, 8287, 12288)
+                                ) = ''
+                                THEN n.title
+                                ELSE COALESCE(n.edited_content, n.generated_content, '')
+                            END,
+                            1,
+                            {NOTE_PREVIEW_CHAR_LIMIT}
+                        ) AS preview,
+                        n.processing_status, n.created_at, n.updated_at
+                 FROM notes n"
+        ));
+        if folder_id.is_some() {
+            list_query.push(
+                "
+                 INNER JOIN note_folders nf_filter ON nf_filter.note_id = n.id",
+            );
+        }
+        list_query.push(
+            "
+                 WHERE n.profile = ",
+        );
+        list_query.push_bind(profile);
+        if let Some(folder_id) = folder_id {
+            list_query.push(" AND nf_filter.folder_id = ");
+            list_query.push_bind(folder_id);
+        }
+        if let Some(cursor) = &cursor {
+            list_query.push(" AND (n.created_at < ");
+            list_query.push_bind(&cursor.created_at);
+            list_query.push(" OR (n.created_at = ");
+            list_query.push_bind(&cursor.created_at);
+            list_query.push(" AND n.rowid < ");
+            list_query.push_bind(cursor.rowid);
+            list_query.push("))");
+        }
+        list_query.push(
+            "
+                 ORDER BY n.created_at DESC, n.rowid DESC
+                 LIMIT ",
+        );
+        list_query.push_bind(fetch_limit);
+        list_query.push(
+            "
+             )
+             SELECT page.note_rowid, page.id, page.title, page.preview,
+                    page.processing_status, page.created_at, page.updated_at,
+                    CASE WHEN f.id IS NOT NULL THEN nf.folder_id END AS folder_id
+             FROM page
+             LEFT JOIN note_folders nf ON nf.note_id = page.id
+             LEFT JOIN folders f
+               ON f.id = nf.folder_id AND f.deleted_at IS NULL
+             ORDER BY page.created_at DESC, page.note_rowid DESC, nf.assigned_at ASC",
+        );
+
+        let rows = list_query.build().fetch_all(&self.pool).await?;
+        let mut items_with_cursors: Vec<(NoteListItemDto, ListNotesCursor)> =
+            Vec::with_capacity(rows.len());
         for row in rows {
             let id: String = row.get("id");
-            let title: String = row.get("title");
-            let content = row
-                .try_get::<Option<String>, _>("edited_content")?
-                .or_else(|| {
-                    row.try_get::<Option<String>, _>("generated_content")
-                        .ok()
-                        .flatten()
-                })
-                .unwrap_or_default();
-            items.push(NoteListItemDto {
-                id: id.clone(),
-                title: title.clone(),
-                preview: preview_for(&title, &content),
-                processing_status: ProcessingStatus::from(
-                    row.get::<String, _>("processing_status").as_str(),
-                ),
-                folder_ids: self.folder_ids(&id).await?,
-                created_at: row.get("created_at"),
-                updated_at: row.get("updated_at"),
-                duration_ms: None,
-            });
+            let folder_id = row.try_get::<Option<String>, _>("folder_id")?;
+            if let Some((item, _)) = items_with_cursors.last_mut() {
+                if item.id == id {
+                    if let Some(folder_id) = folder_id {
+                        item.folder_ids.push(folder_id);
+                    }
+                    continue;
+                }
+            }
+
+            let created_at: String = row.get("created_at");
+            items_with_cursors.push((
+                NoteListItemDto {
+                    id,
+                    title: row.get("title"),
+                    preview: row.get("preview"),
+                    processing_status: ProcessingStatus::from(
+                        row.get::<String, _>("processing_status").as_str(),
+                    ),
+                    folder_ids: folder_id.into_iter().collect(),
+                    created_at: created_at.clone(),
+                    updated_at: row.get("updated_at"),
+                    duration_ms: None,
+                },
+                ListNotesCursor {
+                    version: LIST_NOTES_CURSOR_VERSION,
+                    created_at,
+                    rowid: row.get("note_rowid"),
+                },
+            ));
         }
 
+        let has_more = page_size.is_some_and(|page_size| items_with_cursors.len() > page_size);
+        if let Some(page_size) = page_size {
+            items_with_cursors.truncate(page_size);
+        }
+        let next_cursor = if has_more {
+            items_with_cursors
+                .last()
+                .map(|(_, cursor)| encode_list_notes_cursor(cursor))
+                .transpose()?
+        } else {
+            None
+        };
+
         Ok(ListNotesResponse {
-            items,
-            next_cursor: None,
+            items: items_with_cursors
+                .into_iter()
+                .map(|(item, _)| item)
+                .collect(),
+            next_cursor,
         })
     }
 
@@ -6056,7 +6147,33 @@ fn preview_for(title: &str, content: &str) -> String {
     } else {
         content
     };
-    source.chars().take(140).collect()
+    source.chars().take(NOTE_PREVIEW_CHAR_LIMIT).collect()
+}
+
+fn encode_list_notes_cursor(cursor: &ListNotesCursor) -> Result<String, sqlx::Error> {
+    let bytes = serde_json::to_vec(cursor).map_err(|error| {
+        sqlx::Error::Protocol(format!("could not encode notes cursor: {error}"))
+    })?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn decode_list_notes_cursor(cursor: &str) -> Result<ListNotesCursor, sqlx::Error> {
+    if cursor.len() > LIST_NOTES_CURSOR_MAX_ENCODED_LEN {
+        return Err(sqlx::Error::Protocol(
+            "notes cursor is too large".to_string(),
+        ));
+    }
+    let bytes = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| sqlx::Error::Protocol("notes cursor is not valid base64url".to_string()))?;
+    let cursor: ListNotesCursor = serde_json::from_slice(&bytes)
+        .map_err(|_| sqlx::Error::Protocol("notes cursor is not valid JSON".to_string()))?;
+    if cursor.version != LIST_NOTES_CURSOR_VERSION {
+        return Err(sqlx::Error::Protocol(
+            "notes cursor version is not supported".to_string(),
+        ));
+    }
+    Ok(cursor)
 }
 
 fn validation_summary_recorded_silence(summary: Option<&str>) -> bool {

--- a/src-tauri/tests/storage.rs
+++ b/src-tauri/tests/storage.rs
@@ -24,6 +24,20 @@ async fn count_rows(repos: &Repositories, statement: &str) -> i64 {
         .get("count")
 }
 
+fn legacy_note_preview(
+    title: &str,
+    generated_content: Option<&str>,
+    edited_content: Option<&str>,
+) -> String {
+    let content = edited_content.or(generated_content).unwrap_or_default();
+    let source = if content.trim().is_empty() {
+        title
+    } else {
+        content
+    };
+    source.chars().take(140).collect()
+}
+
 #[tokio::test]
 async fn migrations_create_empty_store() {
     let repos = test_repositories().await;
@@ -877,6 +891,270 @@ async fn creates_notes_in_reverse_chronological_order() {
     assert_eq!(notes.items.len(), 2);
     assert_eq!(notes.items[0].id, second.id);
     assert_eq!(notes.items[1].id, first.id);
+}
+
+#[tokio::test]
+async fn list_notes_sql_previews_match_the_legacy_derivation() {
+    let repos = test_repositories().await;
+    let unicode_content = format!("{}Zażółć gęślą jaźń 你好", "🦀".repeat(145));
+    let cases = vec![
+        (
+            "Markdown title",
+            Some("# Heading\n\n- first\n- **second**".to_string()),
+            None,
+        ),
+        (
+            "Edited content is intentionally empty",
+            Some("Generated content must not win".to_string()),
+            Some(String::new()),
+        ),
+        ("Unicode title", Some(unicode_content), None),
+        (
+            "Unicode whitespace falls back to the title",
+            Some("\u{2003}\u{00a0}\u{3000}".to_string()),
+            None,
+        ),
+        (
+            "Long leading whitespace is still content",
+            Some(format!("{}body", " ".repeat(145))),
+            None,
+        ),
+    ];
+
+    let mut expected = Vec::new();
+    for (title, generated_content, edited_content) in cases {
+        let note = repos
+            .create_note("default", None)
+            .await
+            .expect("create preview note");
+        query(
+            "UPDATE notes
+             SET title = ?, generated_content = ?, edited_content = ?
+             WHERE id = ?",
+        )
+        .bind(title)
+        .bind(generated_content.as_deref())
+        .bind(edited_content.as_deref())
+        .bind(&note.id)
+        .execute(&repos.pool)
+        .await
+        .expect("seed preview content");
+        expected.push((
+            note.id,
+            legacy_note_preview(
+                title,
+                generated_content.as_deref(),
+                edited_content.as_deref(),
+            ),
+        ));
+    }
+
+    let listed = repos
+        .list_notes("default", None, 50, None)
+        .await
+        .expect("list notes with SQL previews");
+    for (note_id, expected_preview) in expected {
+        let item = listed
+            .items
+            .iter()
+            .find(|item| item.id == note_id)
+            .expect("preview note should be listed");
+        assert_eq!(item.preview, expected_preview);
+        assert!(item.preview.chars().count() <= 140);
+    }
+}
+
+#[tokio::test]
+async fn list_notes_cursor_paginates_across_timestamp_and_rowid_boundaries() {
+    let repos = test_repositories().await;
+    let oldest = repos
+        .create_note("default", None)
+        .await
+        .expect("oldest note");
+    let tied_earlier = repos
+        .create_note("default", None)
+        .await
+        .expect("earlier tied note");
+    let tied_later = repos
+        .create_note("default", None)
+        .await
+        .expect("later tied note");
+    let newest = repos
+        .create_note("default", None)
+        .await
+        .expect("newest note");
+    let final_note = repos
+        .create_note("default", None)
+        .await
+        .expect("final note");
+
+    for (note_id, created_at) in [
+        (&oldest.id, "2026-07-23T10:01:00.000Z"),
+        (&tied_earlier.id, "2026-07-23T10:02:00.000Z"),
+        (&tied_later.id, "2026-07-23T10:02:00.000Z"),
+        (&newest.id, "2026-07-23T10:03:00.000Z"),
+        (&final_note.id, "2026-07-23T10:00:00.000Z"),
+    ] {
+        query("UPDATE notes SET created_at = ? WHERE id = ?")
+            .bind(created_at)
+            .bind(note_id)
+            .execute(&repos.pool)
+            .await
+            .expect("set pagination timestamp");
+    }
+
+    let first_page = repos
+        .list_notes("default", None, 2, None)
+        .await
+        .expect("first page");
+    assert_eq!(
+        first_page
+            .items
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![newest.id.as_str(), tied_later.id.as_str()]
+    );
+    let first_cursor = first_page.next_cursor.expect("first page cursor");
+
+    let second_page = repos
+        .list_notes("default", None, 2, Some(first_cursor))
+        .await
+        .expect("second page");
+    assert_eq!(
+        second_page
+            .items
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![tied_earlier.id.as_str(), oldest.id.as_str()]
+    );
+    let second_cursor = second_page.next_cursor.expect("second page cursor");
+
+    let third_page = repos
+        .list_notes("default", None, 2, Some(second_cursor))
+        .await
+        .expect("third page");
+    assert_eq!(
+        third_page
+            .items
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![final_note.id.as_str()]
+    );
+    assert!(third_page.next_cursor.is_none());
+}
+
+#[tokio::test]
+async fn list_notes_groups_all_folder_assignments_in_the_page_query() {
+    let repos = test_repositories().await;
+    let alpha = repos
+        .create_folder("default", "Alpha", None)
+        .await
+        .expect("alpha folder");
+    let beta = repos
+        .create_folder("default", "Beta", None)
+        .await
+        .expect("beta folder");
+    let gamma = repos
+        .create_folder("default", "Gamma", None)
+        .await
+        .expect("gamma folder");
+    let archived = repos
+        .create_folder("default", "Archived", None)
+        .await
+        .expect("archived folder");
+    let first = repos
+        .create_note("default", None)
+        .await
+        .expect("first note");
+    let second = repos
+        .create_note("default", None)
+        .await
+        .expect("second note");
+
+    for (note_id, folder_id, assigned_at) in [
+        (&first.id, &alpha.id, "2026-07-23T10:00:00.000Z"),
+        (&first.id, &archived.id, "2026-07-23T10:00:30.000Z"),
+        (&first.id, &beta.id, "2026-07-23T10:01:00.000Z"),
+        (&second.id, &gamma.id, "2026-07-23T10:00:00.000Z"),
+        (&second.id, &alpha.id, "2026-07-23T10:01:00.000Z"),
+    ] {
+        query(
+            "INSERT INTO note_folders (note_id, folder_id, assigned_at)
+             VALUES (?, ?, ?)",
+        )
+        .bind(note_id)
+        .bind(folder_id)
+        .bind(assigned_at)
+        .execute(&repos.pool)
+        .await
+        .expect("assign note folder");
+    }
+    query("UPDATE folders SET deleted_at = ? WHERE id = ?")
+        .bind("2026-07-23T10:02:00.000Z")
+        .bind(&archived.id)
+        .execute(&repos.pool)
+        .await
+        .expect("soft-delete archived folder");
+
+    let all_notes = repos
+        .list_notes("default", None, 50, None)
+        .await
+        .expect("list all notes");
+    let first_item = all_notes
+        .items
+        .iter()
+        .find(|item| item.id == first.id)
+        .expect("first note should be listed");
+    assert_eq!(first_item.folder_ids, vec![alpha.id.clone(), beta.id]);
+    let second_item = all_notes
+        .items
+        .iter()
+        .find(|item| item.id == second.id)
+        .expect("second note should be listed");
+    assert_eq!(second_item.folder_ids, vec![gamma.id, alpha.id.clone()]);
+
+    let alpha_notes = repos
+        .list_notes("default", Some(alpha.id.clone()), 50, None)
+        .await
+        .expect("list alpha notes");
+    assert_eq!(alpha_notes.items.len(), 2);
+    assert_eq!(
+        alpha_notes
+            .items
+            .iter()
+            .find(|item| item.id == first.id)
+            .expect("first alpha note")
+            .folder_ids,
+        first_item.folder_ids
+    );
+    assert_eq!(
+        alpha_notes
+            .items
+            .iter()
+            .find(|item| item.id == second.id)
+            .expect("second alpha note")
+            .folder_ids,
+        second_item.folder_ids
+    );
+
+    let first_alpha_page = repos
+        .list_notes("default", Some(alpha.id.clone()), 1, None)
+        .await
+        .expect("list first alpha page");
+    let alpha_cursor = first_alpha_page
+        .next_cursor
+        .expect("first alpha page cursor");
+    let second_alpha_page = repos
+        .list_notes("default", Some(alpha.id), 1, Some(alpha_cursor))
+        .await
+        .expect("list second alpha page");
+    assert_eq!(first_alpha_page.items.len(), 1);
+    assert_eq!(second_alpha_page.items.len(), 1);
+    assert_ne!(first_alpha_page.items[0].id, second_alpha_page.items[0].id);
+    assert!(second_alpha_page.next_cursor.is_none());
 }
 
 #[tokio::test]

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1741,8 +1741,8 @@ export async function openHermesTuiDebug(input: { sessionId: string; unrestricte
   return invoke<void>("open_hermes_tui_debug", { request: input });
 }
 
-export async function listNotes(folderId?: string, limit?: number) {
-  return invoke<ListNotesResponse>("list_notes", { request: { folderId, limit } });
+export async function listNotes(folderId?: string, limit?: number, cursor?: string) {
+  return invoke<ListNotesResponse>("list_notes", { request: { folderId, limit, cursor } });
 }
 
 export async function getNote(noteId: string) {


### PR DESCRIPTION
## Summary

- Replace the note-list N+1 path with one paged SQL query that joins folder assignments and groups them in Rust.
- Derive the existing 140-character preview in SQLite without selecting either full note body.
- Add versioned keyset cursors over the existing `created_at DESC, rowid DESC` order and forward the optional cursor through the existing desktop request contract.
- Reduce the default 100-note page from up to 101 SQL statements to exactly 1.

Refs JUN-392

## Root cause

`list_notes` selected `generated_content` and `edited_content` for every listed note only to derive a short preview, then issued one serial folder query per note. Although the wire request and response already exposed cursors, the repository ignored the input cursor and always returned `next_cursor: None`.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --locked -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- `pnpm check`
- `pnpm typecheck`
- `pnpm test` - 211 files passed; 3,450 tests passed and 2 skipped
- `make local-ci` - `signoff/frontend` and `signoff/rust-macos` passed on `5f12a0d31db69d14d5f857dc8022a3b9bf5edcd5`
- Added storage coverage for legacy preview parity with Markdown, empty edited content, Unicode, Unicode whitespace, and long leading whitespace; same-timestamp pagination boundaries; filtered pagination; and complete active-folder grouping.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). Not applicable: this changes the storage query and additive request plumbing without changing UI behavior.
- [ ] Needs a June API (backend) deploy before it works end to end. No June API deploy is needed.

## Out of scope

- JUN-390 processing-event and broader note-index work remains separate.
- No index is added here: the query uses the existing profile/created-time note index, note-folder indexes, and folder primary key.

## Followups

- Keep the PR in draft for the requested dual review. Do not merge or mark ready yet.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787411683&installation_model_id=425925&pr_number=927&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F927&signature=0acac136b7cae9ad434ce7ef8ba99fd4a7cb87e1a118e824ee34ceb7d9d6b31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->