### PR TITLE
fix(storage): configure SQLite timeouts

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -73,12 +73,25 @@ use tokio::{sync::OnceCell, time::sleep};
 
 const MEMORY_CONTENT_MAX_CHARS: usize = 4_000;
 const FOLDER_INSTRUCTIONS_MAX_CHARS: usize = 4_000;
+const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+const SQLITE_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(10);
 static MEMORY_SETTINGS_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 // React StrictMode and renderer reloads may call `bootstrap_app` more than once
 // while native processing tasks keep running. Startup repair must run exactly
 // once per native process or a second bootstrap could reset a genuinely live
 // job from running back to pending.
 static TRANSCRIPTION_STARTUP_REPAIR: OnceCell<()> = OnceCell::const_new();
+
+fn sqlite_connect_options(path: &Path) -> Result<SqliteConnectOptions, sqlx::Error> {
+    SqliteConnectOptions::from_str(&format!("sqlite://{}", path.display()))
+        .map(|options| options.busy_timeout(SQLITE_BUSY_TIMEOUT))
+}
+
+fn sqlite_pool_options(max_connections: u32) -> SqlitePoolOptions {
+    SqlitePoolOptions::new()
+        .max_connections(max_connections)
+        .acquire_timeout(SQLITE_ACQUIRE_TIMEOUT)
+}
 
 /// Owns a newly published capture until every required database row exists.
 /// If startup returns early or its future is cancelled, dropping this guard
@@ -3531,11 +3544,10 @@ async fn hermes_state_pool(path: &Path) -> Result<SqlitePool, AppError> {
             return Ok(pool.clone());
         }
     }
-    let options = SqliteConnectOptions::from_str(&format!("sqlite://{}", path.display()))
+    let options = sqlite_connect_options(path)
         .map_err(|error| AppError::new("hermes_state_unavailable", error.to_string()))?
         .create_if_missing(false);
-    let pool = SqlitePoolOptions::new()
-        .max_connections(1)
+    let pool = sqlite_pool_options(1)
         .connect_with(options)
         .await
         .map_err(|error| AppError::new("hermes_state_unavailable", error.to_string()))?;
@@ -3689,18 +3701,14 @@ pub(crate) async fn repositories(app: &AppHandle) -> Result<Repositories, AppErr
     let paths = app_paths(app)?;
     REPOSITORIES
         .get_or_try_init(|| async {
-            let options = SqliteConnectOptions::from_str(&format!(
-                "sqlite://{}",
-                paths.database_path.display()
-            ))
-            .map_err(|error| AppError::new("storage_unavailable", error.to_string()))?
-            .create_if_missing(true)
-            // Recording finalization, transcript persistence, and UI polling
-            // legitimately overlap. WAL lets readers observe progress without
-            // blocking the durable job transaction (or vice versa).
-            .journal_mode(SqliteJournalMode::Wal);
-            let pool = SqlitePoolOptions::new()
-                .max_connections(5)
+            let options = sqlite_connect_options(&paths.database_path)
+                .map_err(|error| AppError::new("storage_unavailable", error.to_string()))?
+                .create_if_missing(true)
+                // Recording finalization, transcript persistence, and UI polling
+                // legitimately overlap. WAL lets readers observe progress without
+                // blocking the durable job transaction (or vice versa).
+                .journal_mode(SqliteJournalMode::Wal);
+            let pool = sqlite_pool_options(5)
                 .connect_with(options)
                 .await
                 .map_err(|error| AppError::new("storage_unavailable", error.to_string()))?;
@@ -3812,6 +3820,70 @@ mod retry_audio_source_tests {
 
 #[cfg(test)]
 mod note_transcription_timing_tests;
+
+#[cfg(test)]
+mod sqlite_pool_configuration_tests {
+    use super::{sqlite_connect_options, sqlite_pool_options, SQLITE_ACQUIRE_TIMEOUT};
+    use sqlx::query::query;
+    use sqlx_sqlite::SqliteJournalMode;
+    use std::time::Duration;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn contending_writer_waits_for_the_lock_and_succeeds() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let database_path = temp.path().join("contention.sqlite3");
+        let options = sqlite_connect_options(&database_path)
+            .expect("SQLite options")
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal);
+        let pool_options = sqlite_pool_options(2);
+        assert_eq!(pool_options.get_acquire_timeout(), SQLITE_ACQUIRE_TIMEOUT);
+        let pool = pool_options
+            .connect_with(options)
+            .await
+            .expect("contention database");
+
+        query("CREATE TABLE writes (value TEXT NOT NULL)")
+            .execute(&pool)
+            .await
+            .expect("create writes table");
+        let mut first_writer = pool.acquire().await.expect("first writer connection");
+        let mut second_writer = pool.acquire().await.expect("second writer connection");
+
+        query("BEGIN IMMEDIATE")
+            .execute(&mut *first_writer)
+            .await
+            .expect("begin first write transaction");
+        query("INSERT INTO writes (value) VALUES ('first')")
+            .execute(&mut *first_writer)
+            .await
+            .expect("first write");
+
+        let (attempted_tx, attempted_rx) = tokio::sync::oneshot::channel();
+        let waiting_writer = tokio::spawn(async move {
+            let _ = attempted_tx.send(());
+            query("INSERT INTO writes (value) VALUES ('second')")
+                .execute(&mut *second_writer)
+                .await
+        });
+        attempted_rx.await.expect("second writer should start");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !waiting_writer.is_finished(),
+            "the second writer should wait while the first holds the SQLite write lock"
+        );
+
+        query("COMMIT")
+            .execute(&mut *first_writer)
+            .await
+            .expect("commit first write transaction");
+        tokio::time::timeout(Duration::from_secs(1), waiting_writer)
+            .await
+            .expect("second writer should finish within the busy timeout")
+            .expect("second writer task")
+            .expect("second write should succeed after the lock is released");
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/commands/note_transcription_benchmark.rs
+++ b/src-tauri/src/commands/note_transcription_benchmark.rs
@@ -1,4 +1,4 @@
-use super::finish_recording_session;
+use super::{finish_recording_session, sqlite_connect_options, sqlite_pool_options};
 use crate::{
     audio::capture::{FinishedRecording, FinishedSource},
     db::{migrations::run_migrations, repositories::Repositories},
@@ -9,12 +9,11 @@ use crate::{
 };
 use serde::Serialize;
 use sqlx::row::Row;
-use sqlx_sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+use sqlx_sqlite::SqliteJournalMode;
 use std::{
     collections::HashMap,
     net::SocketAddr,
     path::{Path, PathBuf},
-    str::FromStr,
     sync::{Arc, LazyLock, Mutex, OnceLock},
     time::{Duration, Instant},
 };
@@ -186,12 +185,11 @@ fn remove_benchmark_observer(recording_session_id: &str) {
 
 pub(super) async fn benchmark_repositories(dir: &tempfile::TempDir) -> Repositories {
     let database_path = dir.path().join("june-benchmark.sqlite3");
-    let options = SqliteConnectOptions::from_str(&format!("sqlite://{}", database_path.display()))
+    let options = sqlite_connect_options(&database_path)
         .expect("SQLite options")
         .create_if_missing(true)
         .journal_mode(SqliteJournalMode::Wal);
-    let pool = SqlitePoolOptions::new()
-        .max_connections(5)
+    let pool = sqlite_pool_options(5)
         .connect_with(options)
         .await
         .expect("benchmark database");


### PR DESCRIPTION
## Summary

- Make June's SQLite lock policy explicit with a 5-second busy timeout and a 10-second pool acquire timeout.
- Apply the shared policy to the June repository pool, the cached Hermes state database pool, and the file-backed note-transcription benchmark.
- Add a file-backed contention regression test where one writer holds an immediate transaction and a second writer waits, then succeeds after the lock is released.
- This closes the durability half identified in JUN-418's analysis by making the losing-writer wait behavior explicit and regression-tested.

Refs JUN-407

## Root cause

June's runtime SQLite pools did not own an explicit timeout policy. The main pool configured WAL and five connections, but its lock-wait behavior came from the SQLx dependency default and its acquire behavior came from the generic pool default. That left concurrency behavior implicit at the boundary where autosave, generation compare-and-swap writes, and processing persistence overlap.

SQLx 0.8.6 currently defaults SQLite busy waiting to five seconds. This change makes that behavior a stable June-owned contract, shortens the pool acquire window to the requested ten seconds, and covers actual writer contention.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `make tauri-lint`
- `make tauri-test`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` - 214 files passed; 3,467 tests passed; 2 skipped
- `make local-ci` on `a83cf52496c99c03824e48df7b51521f818a1aed` - `signoff/frontend` not applicable; `signoff/rust-macos` passed
- Small in-session Standards, Spec, and adversarial review pass - no material findings; dual review remains intentionally after the draft PR

- [ ] Tested visually where it matters (not applicable: this changes SQLite pool behavior only; the file-backed contention test exercises the affected path).
- [ ] Needs a June API (backend) deploy before it works end to end. No June API deploy is needed.

## Out of scope

- Changing the existing WAL mode or connection counts.
- Adding application-level write retries or changing write error propagation.
- Changing the compare-and-swap or patch semantics tracked separately from this pool-level durability work.
- Reconfiguring isolated single-connection in-memory test fixtures.

## Followups

- Run the requested dual review while the PR remains draft.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] This is not a security-sensitive change.
- [x] No workflow action references changed.
- [x] No desktop signing, updater, entitlement, capability, or release behavior changed.
- [x] No backend auth, billing, metering, CORS, rate limit, or logging behavior changed.
- [x] No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787414371&installation_model_id=425925&pr_number=929&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F929&signature=d3f69b6c64197a6b6e24061e2674491f3e036c28f605029c06eec1a032a633da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->