### PR TITLE
chore(skills): vendor the os-design house design skill

### DIFF
--- a/.agents/skills/os-design/SKILL.md
+++ b/.agents/skills/os-design/SKILL.md
@@ -94,6 +94,12 @@ The full standup and iteration loop lives in
    eyeball, and one potential nudge. UI PRs state that the change was tested
    visually and attach proof.
 
+**The skill stops at handoff.** The deliverable is a clean working-tree diff
+plus visual evidence. Never commit, push, or open a PR unless the user
+explicitly asks — the user eyeballs the dials first, and publishing is their
+call. When they do ask, route PR tending through the repo's review loop
+(shepherd) rather than handling it here.
+
 ## Calling specialist skills
 
 Other design skills are amplifiers, not requirements — check what is

--- a/.agents/skills/os-design/SKILL.md
+++ b/.agents/skills/os-design/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: os-design
+description: Stand up design-featuring work the Open Software way. Use when building, redesigning, or polishing any UI surface in an OS repo (os-june, os-scribe, os-marketing-page, os-platform), when a feature needs visual design decisions before or during implementation, when reviewing interface work for house taste, or when someone asks to "stand up the design", "design this feature", "make it feel like ours", "make it feel better", or wants the Open Software design sensibility applied. Orchestrates specialist design skills (impeccable, emil-design-eng, make-interfaces-feel-better, transitions-dev, mobbin) when installed, but is fully self-sufficient without them. Core commitments it enforces - compose from the repo's existing design-system blocks rather than inventing new ones, and quiet, subtle, elegant over loud.
+---
+
+# Standing up design work at Open Software
+
+This skill carries the house design sensibility so anyone on the team can
+stand up design-featuring work the way Andrew would, whether or not they have
+his reference tools (Mobbin) or his skill set installed. It makes two
+commitments that override any general design instinct or external skill
+advice:
+
+1. **The system is the source of truth.** Every OS repo with UI has design
+   blocks already: tokens, primitives, patterns, documented rules. Compose
+   from those blocks. Inventing a parallel treatment for something the system
+   already answers is the primary failure mode this skill exists to prevent.
+2. **Quiet is the default.** The interface should read sharp, not loud.
+   Structure comes from spacing and hierarchy, not decoration. A surface
+   earns emphasis; it does not get it for free. When in doubt, choose the
+   quieter option.
+
+## Before any pixels: ground in the system
+
+Do this before writing or changing any UI code. Find and read the repo's
+design system:
+
+| Repo | Where the system lives |
+|---|---|
+| os-june | `docs/design/{foundations,components,conventions,taste}.md`, enforceable rules in `spec/` (read every spec in scope), tokens in `src/styles/tokens.css`, live gallery at `styleguide.html` (`pnpm dev`, then `/styleguide.html?section=<id>`) |
+| os-scribe | `src/styles/tokens.css` |
+| os-marketing-page | Tailwind theme + existing component families; per-repo judgment file if present |
+| anything else | Look for `docs/design/`, `DESIGN.md`, a `tokens.css` / theme file, and a components or `ui/` directory |
+
+Then follow these rules without exception:
+
+- **Token before value.** Reach for an existing token (spacing, radius,
+  shadow, type size, duration, easing, color) before hand-coding a number.
+  If a value genuinely needs to exist and no token covers it, extract a new
+  token so the system gains a knob, rather than scattering literals.
+- **Primitive before bespoke.** Check the repo's pattern-to-canonical map
+  (os-june: `docs/design/components.md`) or `ui/` directory before writing
+  new markup for a button, input, toggle, select, tooltip, dialog, chip,
+  empty state, spinner, or menu. If a canonical block exists, use it.
+- **Grep before coining.** In flat-CSS repos (os-june's `app.css`), grep for
+  a class name before creating it, and prefix by feature.
+- **No system yet?** Then the first deliverable of the work is the start of
+  one: mine the existing CSS for de facto tokens and write a short
+  foundations doc, rather than adding a third ad-hoc treatment. (If
+  impeccable is installed, its `document` / `extract` commands do this well.)
+
+## The house taste, distilled
+
+The full sensibility with concrete numbers and verbatim rules lives in
+[references/taste.md](references/taste.md) — read it before making visual
+decisions. The digest:
+
+- **Type:** the default weight is the voice; medium is punctuation, not
+  prose. Never all caps. Sentence case everywhere. Proportional numerals
+  (tabular only for live-ticking values). Sans is the product's voice; serif
+  only at display moments; mono only for code. No typographic dashes in
+  user-facing copy.
+- **Color:** color is spent, not sprayed. Hovers, rows, nav, and menus stay
+  neutral; the brand accent appears only on surfaces that already carry it.
+  Earthy over electric; neutrals stay neutral.
+- **Surfaces:** shadows are soft, multi-layer, and pure elevation; the
+  hairline ring is a separate composed layer, never baked into shadow
+  tokens. Dark mode needs its own shadow tuning. One ambient shadow per
+  popover composite.
+- **Motion:** fast and eased, on the token durations and curves. Hover
+  changes the background only; never animate borders. Nothing bounces for
+  its own sake. Prefer atomic swaps over crossfades when opacity flash is
+  possible.
+- **Spacing:** concentric, even padding; alignment you can verify by eye.
+  Presence without heaviness.
+
+## The workflow
+
+The full standup and iteration loop lives in
+[references/workflow.md](references/workflow.md). The shape:
+
+1. **Study references, then commit to one direction.** Use pattern consensus
+   across best-in-class products, not a single screenshot. Mobbin when
+   available; the fallback canon in the workflow reference when not.
+2. **Build from blocks** (previous section), matching the complexity of the
+   implementation to what the moment earns.
+3. **Park the state and look at it.** Never judge UI from code. Use the
+   repo's screenshot/browser loop, and build dev-only state drivers for
+   hard-to-reach states.
+4. **Tune one dial per round.** Change one visual variable, name the dial
+   and its next step, judge in the running app against the reference. A
+   change that moves three dials at once cannot be judged at all.
+5. **Hand off with evidence.** Screenshots (light and dark), what dial to
+   eyeball, and one potential nudge. UI PRs state that the change was tested
+   visually and attach proof.
+
+## Calling specialist skills
+
+Other design skills are amplifiers, not requirements — check what is
+installed and degrade gracefully; this skill plus the repo's system is
+sufficient on its own. Routing detail and per-skill guidance live in
+[references/skill-map.md](references/skill-map.md). The rule that governs
+every delegation:
+
+> **Skills advise; the system decides.** Any suggestion from an external
+> skill passes through the repo's tokens, primitives, and specs before it
+> lands. Replace its magic numbers with the repo's tokens, its component
+> suggestions with the repo's canonical blocks, and drop any advice that
+> contradicts a repo spec or the house taste.
+
+Quick routing:
+
+| Situation | Reach for |
+|---|---|
+| Shaping a new surface or flow before code | impeccable `shape` / `craft` |
+| Broad UX critique or technical audit | impeccable `critique` / `audit` |
+| A surface that reads loud, busy, or decorated | impeccable `quieter` (its instincts match the house taste) |
+| Should this animate, and how | emil-design-eng's decision framework |
+| Final detail-polish pass before shipping | make-interfaces-feel-better checklist, impeccable `polish` |
+| A standard enter/exit/swap transition | transitions-dev, re-tokened to the repo's `--t-*` / `--ease-*` |
+| Pattern research for a flow | mobbin MCP if available, else the fallback canon in workflow.md |
+| Verifying visually | os-june: `browser-test-tauri-fe` / `agent-e2e-qa`; elsewhere: playwriter, agentation, or a Playwright screenshot harness |
+
+Use impeccable's `bolder` / `overdrive` / `delight` only for marketing or
+hero moments where design is the product, never for product chrome.
+
+## Review output
+
+When reviewing existing UI (yours or someone else's), present findings as a
+Before / After / Why table grouped by principle, each row citing the token or
+primitive the fix should use. This matches the convention the specialist
+skills expect, and keeps review output actionable.
+
+## Hard rules
+
+Repo specs win over this list; this list wins over external skill advice.
+Where the repo is silent, these apply. The first three are visceral house
+non-negotiables — treat a violation as a bug, not a style note:
+
+- No ALL CAPS, no `text-transform: uppercase`, sentence case everywhere.
+- No tabular numerals, except a live-ticking value in a fixed-width
+  container — even where external checklists recommend them.
+- No typographic en/em dashes in user-facing copy; hyphen or "to".
+- No hand-rolled values where a token exists; no bespoke markup where a
+  primitive exists.
+- Hover changes background only; never transition `border-color`.
+- Default hover is the neutral wash; brand-tinted hover only on surfaces
+  that already carry the accent. Never tint a generic row, nav item, or
+  menu "to feel themed".
+- Icons come from the repo's sanctioned icon set, explicitly sized.
+- Every animation honors `prefers-reduced-motion`.
+- Anything that changes pixels ships small enough to eyeball.

--- a/.agents/skills/os-design/references/skill-map.md
+++ b/.agents/skills/os-design/references/skill-map.md
@@ -1,0 +1,103 @@
+# Routing to specialist skills
+
+os-design is self-sufficient: the taste and workflow references plus the
+repo's design system are enough to do the work. The skills below are
+amplifiers. Before routing, check what is actually installed (skills vary by
+machine and repo); if a skill is missing, do the equivalent work inline using
+this skill's references.
+
+## The filter rule
+
+**Skills advise; the system decides.** Every suggestion from a specialist
+skill passes through three gates before it lands in code:
+
+1. **Repo specs win.** If the repo documents a rule (os-june `spec/`,
+   `docs/design/conventions.md`), it overrides the skill's advice. Example:
+   external skills recommend `tabular-nums` for numbers; os-june bans it
+   outside live-ticking values.
+2. **Tokens replace magic numbers.** A skill's duration, easing, radius,
+   shadow, or color suggestion gets mapped to the repo's nearest token. If
+   no token fits and the value is worth keeping, extract a token.
+3. **Canonical blocks replace suggested components.** If a skill proposes
+   building a tooltip/dialog/select/toggle/menu treatment and the repo has a
+   canonical one, use the repo's.
+
+## impeccable (command dispatcher, 25 sub-commands)
+
+The broadest skill; the closest to this one in spirit. It reads
+`PRODUCT.md` / `DESIGN.md` and classifies work as **brand** register (design
+is the product: marketing pages, heroes) or **product** register (design
+serves the product: app chrome). OS product work is almost always product
+register; os-marketing-page hero moments are brand register.
+
+| When | Command |
+|---|---|
+| Shape a feature's UX before code | `shape` |
+| Shape + build end-to-end | `craft` |
+| UX review with scoring/personas | `critique` |
+| Technical audit (a11y, perf, responsive, theming) | `audit` |
+| Final pass before shipping | `polish` |
+| Surface reads loud, busy, decorated | `quieter` — its instincts match the house taste |
+| Strip a surface to its essence | `distill` |
+| Errors, i18n, edge cases, overflow | `harden` |
+| First-run flows, empty states | `onboard` |
+| UX copy, labels, error messages | `clarify` |
+| Responsive/cross-device | `adapt` |
+| UI performance | `optimize` |
+| Generate DESIGN.md from existing code | `document` |
+| Pull tokens/components into a system | `extract` |
+| Live in-browser variant iteration | `live` (needs a dev server) |
+
+Use `bolder`, `delight`, and `overdrive` only where design is the product
+(marketing/hero moments) — never on product chrome; the house answer to
+"bland" product chrome is better hierarchy and spacing, not amplification.
+Note impeccable's absolute bans (gradient text, glassmorphism-by-default,
+identical card grids, modal-first) are compatible with the house taste; its
+"commit boldly to color" guidance is not — the house commits to restraint.
+
+## emil-design-eng
+
+Long-form design-engineering philosophy: when to animate (frequency
+framework — never animate high-frequency/keyboard-driven actions), easing
+choice (ease-out for enter/exit, never ease-in), springs, transform mastery,
+gesture handling. Reach for it when deciding **whether and how** something
+should move, or when building a component whose feel is the point. Its
+review format (Before/After/Why table) is the house review format. Filter
+its specific values through the repo's motion tokens.
+
+## make-interfaces-feel-better
+
+A terse 16-point polish checklist with exact numbers (concentric radii,
+optical alignment, interruptible transitions, icon enter animations, hit
+areas, font smoothing). Run it as the **final detail pass** over finished UI
+work. Two known conflicts with the house taste: its `tabular-nums` rule
+(house: proportional except live-ticking) and any suggestion that adds
+decoration — the filter rule handles both.
+
+## transitions-dev
+
+12 drop-in, framework-agnostic CSS transitions (modal, dropdown, panel,
+icon swap, success check, badge, shake...) with `reveal` / `review` /
+`apply` verbs. Reach for it when a surface needs a standard transition and
+you want a production-ready snippet instead of authoring from scratch.
+Always re-token its `:root` variables onto the repo's `--t-*` / `--ease-*`
+before landing.
+
+## Verification and research
+
+| Need | os-june | Elsewhere |
+|---|---|---|
+| Screenshot/drive the UI | `browser-test-tauri-fe` | playwriter (live Chrome tab), agentation, Playwright harness |
+| Live click-through + video evidence | `agent-e2e-qa` | share-video after manual drive |
+| Pattern research | mobbin MCP | reference canon in workflow.md |
+| Component sourcing (web apps on shadcn) | — | shadcn skill/MCP |
+| A11y + visual review | rams | rams |
+| Charts/data surfaces | dataviz | dataviz |
+| Loading/progress spinners | house `Spinner` primitive | unicode-animations |
+
+## Review loop
+
+Design PRs close out through the same loop as any PR: shepherd (Greptile
+primary, Codex/Octopus advisory) plus the repo's review battery
+(os-june: `repo-review`). Visual evidence attached; Andrew does the final
+merge.

--- a/.agents/skills/os-design/references/taste.md
+++ b/.agents/skills/os-design/references/taste.md
@@ -1,0 +1,165 @@
+# The house taste, in full
+
+Distilled from os-june's `docs/design/taste.md` and several months of design
+sessions across os-june, os-scribe, and os-marketing-page. Where a number is
+given, it is a number that survived iteration in a shipping product; treat it
+as the starting value, not a law. os-june token names are used for
+concreteness — map them to the local repo's equivalents.
+
+## The governing idea
+
+Quiet is the default. Restraint is the house move. The recurring praise words
+in real sessions: subtle, quiet, refined, whisper, hairline, breathing room,
+"presence without heaviness". The recurring rejection words: loud, heavy,
+random, nervous, twee ("a repeating flourish would tip into twee").
+
+Emphasis is a budget. Every weight bump, tint, shadow, and animation spends
+from it. A screen that spends everywhere reads as noise; a screen that spends
+once reads as designed.
+
+## Non-negotiables
+
+These are visceral, zero-tolerance rules, not preferences. Finding one in a
+diff is a bug, not a style note:
+
+- **No ALL CAPS, ever.** No uppercase eyebrows, pre-headers, buttons, tab
+  labels, or metadata; no `text-transform: uppercase` anywhere. Sentence
+  case everywhere; capitals are for proper nouns and acronyms only.
+- **No tabular numerals.** No `tabular-nums` / `font-variant-numeric:
+  tabular-nums`; UI numbers use the typeface's proportional figures. The
+  single exception is a live-ticking value whose digits would jitter the
+  layout, and even then inside a fixed-width container. External polish
+  checklists recommend tabular numbers; here that advice is rejected.
+- **No typographic en/em dashes in user-facing copy.** Hyphens or "to".
+- **No random tinted hovers.** Generic rows, nav items, and menus hover
+  with the neutral wash, never the brand tint.
+- **No animated borders.** Hover changes background only.
+- **No twee.** A decorative flourish that repeats gets cut.
+
+## Type
+
+- **The default weight is the voice.** Body, labels, nav, and chrome sit at
+  regular weight. Medium is punctuation, not prose: headings, row titles,
+  structural emphasis, little else. If a screen feels flat, fix hierarchy or
+  spacing before reaching for weight. In one os-june pass, 205 font-weight
+  declarations were normalized down to exactly two values.
+- **Check the shipped faces before trusting a declared weight.** With
+  `font-synthesis: none` and a limited family (os-june ships 400 + 600
+  only), CSS resolves 500 DOWN to 400 but 700 UP to 600 — declarations can
+  lie. Grep the `@font-face` blocks first.
+- **"Presence without heaviness":** a title can match body size and regular
+  weight and still lead, distinguished only by placement and a single medium
+  accent where structure demands it.
+- **Never all caps.** Not in eyebrows, not pre-headers, not metadata.
+- **Proportional numerals.** Tabular figures read like a spreadsheet; the
+  only place they belong is a live-ticking value whose digits would jitter
+  layout, and even then inside a fixed-width container.
+- **Family roles:** sans is the product's voice; serif appears at display
+  moments (view titles, empty states, welcome) where warmth earns its place;
+  mono is for code and technical identifiers only — it spreads if you let
+  it. Optical trims are fair game (os-june renders its code font at 0.92em).
+- **No typographic dashes in copy.** Hyphens or "to".
+
+## Color
+
+- **Color is spent, not sprayed.** One accent drives the whole app through
+  the token pipeline, so a single deliberate touch goes a long way. Hovers,
+  rows, nav, and menus stay neutral grey; brand tint appears only on
+  surfaces that already carry the accent (send affordances, record controls,
+  onboarding heroes). The recurring failure mode when theming anything new:
+  the "random tinted hover".
+- **Neutrals stay neutral.** Surfaces may take a chroma-capped wash of the
+  accent so vivid and dusty presets tint the greys equally; text never takes
+  the wash.
+- **Earthy over electric.** The preset family (rose, clay, sage, ocean,
+  plum) is dusty and warm. A new accent should feel like it belongs at that
+  table. On glass/marketing surfaces the same instinct holds: dustier
+  presets over saturated ones, because bright glass overpowers the page.
+- **Every color is a token.** When tuning, tune the token so the whole
+  system moves with one knob. When a needed value has no token, extract one
+  rather than scattering `color-mix` percentages.
+- **White-on-solid needs its own token** (os-june: `--on-solid`), because
+  the default foreground token inverts in dark mode and silently breaks on
+  fixed brand/destructive solids.
+
+## Surfaces: shadows, rings, borders
+
+- **Shadows are pure elevation.** Never bake a hairline ring into shared
+  shadow tokens; call sites compose a ring (`--shadow-inset` or a real 1px
+  border) separately, so focus states and overrides can recompose the stack.
+- **Soft and layered over hard and single.** Good shadow tokens are 2-4
+  layer stacks (contact + mid + ambient) that read as physical depth. A
+  hard bottom blur reads as an "underline" — when that appears, step down
+  (e.g. `--shadow-lg` → `--shadow-md`), don't add more layers.
+- **Dark mode has its own shadow overrides.** Light-tuned black shadows
+  vanish on near-black (12% black is invisible). Grep for unthemed
+  `box-shadow` values before touching tokens.
+- **The whisper-shadow recipe** for surfaces that should read as "in the
+  page, not above it": background + hairline transparent border + the
+  smallest shadow token.
+- **Ring recipes that shipped:** unified surface ring
+  `inset 0 0 0 1px rgb(0 0 0 / 8%)`; composer ring at rest = the subtle
+  border color at 60%, focused = focus ring tinted 20% over it. A
+  ring-instead-of-border surface keeps a transparent 1px border for layout
+  so nothing shifts.
+- **One ambient shadow per popover composite.** Stacking shadows on nested
+  layers muddies the edge.
+- **Family treatment:** sibling floating surfaces (tray, queue, notices)
+  share one recipe (same surface token + ring-in-shadow + same radius) so
+  they read as one family.
+
+## Motion
+
+- **Four gates before animating:** does this element change often enough
+  that animation would annoy (frequent/keyboard-driven actions: don't)?
+  what is the purpose? enter/exit ease-out, never ease-in; UI transitions
+  under ~300ms.
+- **Hover changes the background only.** Borders are static chrome;
+  animating them reads as nervous.
+- **Fast and eased, on the tokens** (`--t-fast/med/slow`, `--ease-*`).
+  Nothing bounces for its own sake.
+- **Retargeting transitions, not keyframes, for stateful controls.**
+  Keyframes restart from scratch on each flip and read as buggy under rapid
+  taps; transitions retarget mid-flight. Mash-test every control.
+- **Atomic swaps over crossfades** when a state flips (sprite swap for an
+  eye-state, icon swap): crossfades produce opacity flash.
+- **Single clock:** when two transitions drive one element they drift.
+  Register one animatable `@property` and derive everything from it via
+  `calc()`.
+- **Streaming/progressive text:** batch deltas (~80ms windows) and fade
+  chunks together — a reference-matched two-stage fade (fast to ~0.3 for an
+  instantly readable tail, then a graceful crawl to 1 over ~1.5s) beat
+  per-word animation.
+- **Hover-intent numbers that shipped:** 150ms debounce before hover cards
+  open (so sweeping the pointer doesn't trigger them); ~550ms tooltip delay
+  (so labels don't trail on sweep).
+- **Press feedback:** a subtle scale (0.96-0.97) on press for buttons that
+  earn it.
+- **Hover-revealed actions are absolutely positioned** so hovering never
+  shifts layout.
+- **Everything honors `prefers-reduced-motion`** and degrades to the solid,
+  legible state.
+
+## Spacing and geometry
+
+- **Concentric insets:** outer radius = inner radius + padding, even padding
+  on all sides (a shipped recipe: 4px outer padding → 14px card radius −
+  4px = 10px inner, then 6px content inset — all edges align).
+- **Optical over geometric alignment:** center by eye, pin icons to the
+  visual center of their row.
+- **Chrome doesn't scale, text does.** User font-scale presets are
+  quantized steps; icons and control chrome stay fixed (scaled chrome looks
+  like a rendering bug).
+- **Control sizes come from tokens**, not hand-rolled min/max heights.
+
+## Affordances
+
+- **Subtle over decorated.** The affordance corrections that recur: a "Show
+  more" is muted-foreground text, no weight change, no underline, hover just
+  darkens to foreground. A metadata pill that doesn't need to be a pill gets
+  de-styled to plain text. Secondary buttons are the quiet grey, not a
+  themed tint.
+- **Make the empty state be the UI** where possible: instead of a "nothing
+  here yet" card, show the real directory/list in its ready state.
+- **Stable identity for transient UI:** toasts reuse a stable id so rapid
+  re-fires update one toast in place instead of stacking.

--- a/.agents/skills/os-design/references/workflow.md
+++ b/.agents/skills/os-design/references/workflow.md
@@ -1,0 +1,99 @@
+# Standing up and iterating design work
+
+The loop that design-featuring work follows at Open Software, from first
+reference to handoff. It assumes you have already grounded in the repo's
+design system (SKILL.md, "Before any pixels").
+
+## 1. Study references, then commit
+
+Design decisions start from pattern consensus, not invention.
+
+- **With Mobbin** (MCP tools `search_flows` / `search_screens` /
+  `search_sections`): look for how several best-in-class products solve the
+  same flow, and design to the consensus, not to one screenshot. Real
+  examples of the method: a trial gate designed from Mobbin patterns; an
+  invite entry placed "matching Mobbin's consensus across Gopuff / PayPal /
+  Vivid"; profile-switching split into identity vs workspace switching
+  because "Mobbin shows the split (Confluence, Discord vs Figma, Slack)".
+- **Without Mobbin**, use the house reference canon — the products whose
+  patterns have repeatedly been the target in past work: **Linear** (visual
+  weight, icon weight, density), **Arc** and **Figma** (chrome, switchers),
+  **Claude / ChatGPT** (chat and streaming behaviors), **Codex** (developer
+  surfaces), **Apple HIG** (motion physics, materials), **shadcn**
+  (component anatomy). Open the real product, screenshot the pattern, and
+  design against that. A reference you can screenshot beats a reference you
+  remember: when a streaming-text animation felt wrong, the fix came from
+  watching the reference and matching its actual batching (whole chunks
+  faded together over ~1.5s), not from tweaking blind.
+- Then **commit to one direction** before coding. If the shape of the
+  feature is genuinely open, run a shaping pass first (impeccable `shape`,
+  or a written mini-brief: what the moment is, what register it is in,
+  what it must not become).
+
+## 2. Build from blocks
+
+- Use the canonical primitive for every covered pattern; compose new
+  surfaces from tokens. Match implementation complexity to what the moment
+  earns: product chrome is quiet and conventional; hero/marketing moments
+  may earn more.
+- Prefer adopting a primitive from the system over hand-rolling even
+  mid-build — sessions repeatedly replaced hand-rolled copies with the
+  shared hook/utility and deleted net lines (`useScrollFade` replaced 7
+  copies; `useDismiss` deduped 5 sites).
+- Classify every change as **zero-visual by construction** (renaming a value
+  to the token that already renders it — lands freely) or a **visual dial to
+  eyeball** (anything that changes pixels — ships small and gets looked at).
+  State the classification in the handoff.
+
+## 3. Park the state and look at it
+
+Never judge UI from code. Get the change on screen, in both themes, in the
+real rendering engine.
+
+- **Screenshot loop:** os-june has `browser-test-tauri-fe` (drives the
+  Vite frontend in a real browser, fakes the Tauri IPC bridge) and
+  `agent-e2e-qa` (live click-through with video). Elsewhere use playwriter
+  (the user's live Chrome tab), agentation, or a small Playwright script
+  that captures light + dark snapshots.
+- **State-parking drivers:** for hard-to-reach states (update cards,
+  recording HUDs, empty states, image-gen progress, onboarding), add a
+  dev-only console hook that seeds the state on demand —
+  `window.__updateCard()`, `__seedDemo()`, `__emptyStates()`,
+  `__recordingHud()` are shipped examples. Follow the existing driver
+  pattern in the repo; never bundle drivers into production.
+- **Preview pages** (`*-preview.html`) and the styleguide are legitimate
+  parking lots for component-level work; a disposable bisect page with one
+  strategy per row beats theorizing (this is how the iOS haptics question
+  was settled — on device).
+- Check both themes every time: dark mode shadow/contrast bugs are the most
+  common visual regression.
+- On mobile-reviewed repos (os-marketing-page), the review surface is the
+  deployed preview on a phone: commit, push, wait for the preview check to
+  pass, then ask for eyes. Mash-test interactive controls on the phone —
+  rapid taps expose transition bugs that a single click never will.
+
+## 4. Tune one dial per round
+
+Visual weight (shadows, borders, rings, tints, weights, sizes) converges
+through small iterations:
+
+- Change **one** visual variable per round.
+- **Name the dial and its next step** in the handoff: "shrunk the notch
+  chin from 10px to 6px — one dial; can go to 4px if still too tall."
+- Judge each round in the running app against the reference, not in the
+  diff.
+- A change that moves three dials at once cannot be judged at all; if a
+  round accumulated multiple dials, split them.
+
+## 5. Hand off with evidence
+
+- Screenshots or a short recording, light and dark, attached to the PR (UI
+  PRs state that the change was tested visually — os-june's PR template has
+  a section for it).
+- Say which dials are open to eyeball and what the next notch on each would
+  be; flag "one potential nudge" if you see one.
+- List deliberate deviations from the system (with why) rather than letting
+  a reviewer discover them; if you voiced or learned a new taste rule
+  during the work, fold it into the repo's taste doc (os-june:
+  `docs/design/taste.md`) in the same change.
+- Leave the work as one clean diff that can be eyeballed as a whole.

--- a/.agents/skills/os-design/references/workflow.md
+++ b/.agents/skills/os-design/references/workflow.md
@@ -87,6 +87,12 @@ through small iterations:
 
 ## 5. Hand off with evidence
 
+Handoff is where this skill ends. Do not commit, push, or open a PR unless
+the user explicitly asks — the diff stays in the working tree for the user
+to eyeball first, and publishing is their call. When the user does ask for a
+PR, hand the tending to the repo's review loop (shepherd) and follow the
+repo's PR conventions:
+
 - Screenshots or a short recording, light and dark, attached to the PR (UI
   PRs state that the change was tested visually — os-june's PR template has
   a section for it).

--- a/.claude/skills/os-design
+++ b/.claude/skills/os-design
@@ -1,0 +1,1 @@
+../../.agents/skills/os-design

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ and **every skill is symlinked into `.claude/skills/`**. A skill must never exis
 only under `.claude/`, and a `.claude/skills/<name>` entry must always be a
 symlink to `../../.agents/skills/<name>` — never a real directory. Add a new
 skill under `.agents/skills/<name>/` and create the `.claude/skills/<name>`
-symlink in the same change. Current project skills: `os-platform`,
+symlink in the same change. Current project skills: `os-design`, `os-platform`,
 `os-accounts-integration`, `os-rust-backend`, `os-rust-backend-ci`,
 `os-task-prep`, `repo-build-pr`, `repo-review`, `repo-delegate`,
 `repo-orchestrate`, `repo-retrospect`, `browser-test-tauri-fe`, `agent-e2e-qa`, plus the Spec


### PR DESCRIPTION
## Summary

- Vendors the `os-design` skill under `.agents/skills/os-design/` with the required `.claude/skills/os-design` symlink, and adds it to the AGENTS.md project-skills list.
- The skill is the entry point for design-featuring work in this repo: it grounds agents in the existing design system before any pixels (`docs/design/*`, `spec/*` rules, `tokens.css`, the styleguide), enforces compose-from-canonical-blocks over invention, and carries the house taste (quiet by default, one-dial tuning, the non-negotiables: no all caps, no tabular numerals, no typographic dashes).
- It routes to specialist design skills when they're installed on the driving machine, filtered through the rule "skills advise; the system decides" (repo specs win, tokens replace magic numbers, canonical primitives replace suggested components), and is self-sufficient when they're not.

## Validation

- `SKILL.md` frontmatter validated (name + description); the `.claude/skills` entry is a relative symlink per the repo's skills rule, and the vendored copy is byte-identical to the authored source.
- [ ] Tested visually where it matters (docs/skill only - no UI surface).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- No changes to `docs/design/*` or `spec/*` - the skill references them as the source of truth rather than duplicating or altering them.
- No skills-lock.json entry: this is a local vendored skill (like the repo-* family), not an upstream-tracked one.

## Followups

- Possibly move the skill's source of truth to the shared org skills repo so other repos can pull it via the skills tooling and vendored copies stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787420218&installation_model_id=425925&pr_number=931&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F931&signature=4e8fac7aff1d1e85783ba9af977849d8f11cd80a9d57e41aac9c154b25fdd9e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->