### PR TITLE
Switch profiles from the sidebar account menu

### DIFF
--- a/profile-switcher-preview.html
+++ b/profile-switcher-preview.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<!--
+  Dev-only preview for the sidebar profile switcher. Renders the real
+  SidebarIdentity (account menu + profiles group) in a plain browser by faking
+  the Tauri IPC bridge and pre-arming __profileSwitcherDemo(), so the switcher
+  can be designed and screenshotted without the native build or a Hermes
+  runtime. Nothing here ships (vite builds only the configured entries).
+  Usage: pnpm dev, open /profile-switcher-preview.html.
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>June profile switcher preview</title>
+    <script>
+      (function () {
+        const callbacks = new Map();
+        let nextId = 1;
+        const listeners = new Map();
+        window.__TAURI_INTERNALS__ = {
+          transformCallback(cb) {
+            const id = nextId++;
+            callbacks.set(id, cb);
+            return id;
+          },
+          unregisterCallback(id) {
+            callbacks.delete(id);
+          },
+          convertFileSrc(p) {
+            return p;
+          },
+          async invoke(cmd, args = {}) {
+            switch (cmd) {
+              case "plugin:event|listen": {
+                listeners.set(args.event, args.handler);
+                return args.handler;
+              }
+              case "plugin:event|unlisten":
+                return null;
+              default:
+                console.log("[preview] unstubbed invoke:", cmd, args);
+                return null;
+            }
+          },
+        };
+        window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+          unregisterListener() {},
+        };
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/profile-switcher-preview.tsx"></script>
+  </body>
+</html>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -27,6 +27,7 @@ import { IconMoveFolder } from "central-icons/IconMoveFolder";
 import { IconNoteText } from "central-icons/IconNoteText";
 import { IconPencil } from "central-icons/IconPencil";
 import { IconPin } from "central-icons/IconPin";
+import { IconCheckmark2Small } from "central-icons/IconCheckmark2Small";
 import { IconCircleCheck } from "central-icons/IconCircleCheck";
 import { IconArrowUndoUp } from "central-icons/IconArrowUndoUp";
 import { IconPlugin1 } from "central-icons/IconPlugin1";
@@ -80,6 +81,12 @@ import { useDismiss } from "../../lib/use-dismiss";
 import { attachScrollThumbFade } from "../../lib/scroll-thumb-fade";
 import { useScrollFade } from "../../lib/use-scroll-fade";
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
+import { useForcedProfileSwitcherState } from "../../lib/profile-switcher-demo";
+import {
+  canActivateProfile,
+  useProfileManager,
+  type ProfileManagerState,
+} from "../../lib/hermes-admin";
 import { useRecordingPresenceBounds } from "../../lib/recording-presence-bounds";
 import { isPrimaryShortcut, primaryShortcutLabel } from "../../lib/platform";
 import type {
@@ -1462,6 +1469,11 @@ export function Sidebar({
             setIdentityMenuOpen(false);
             onChangeView("settings");
           }}
+          onManageProfiles={() => {
+            setIdentityMenuOpen(false);
+            onSettingsTabChange?.("profile-builder");
+            onChangeView("settings");
+          }}
           onReportIssue={
             onReportIssue
               ? (category) => {
@@ -2110,13 +2122,14 @@ const REPORT_MENU_ITEMS: { category: ReportCategory; label: string }[] = [
   { category: "feedback", label: "Send feedback" },
   { category: "feature", label: "Request a feature" },
 ];
-function SidebarIdentity({
+export function SidebarIdentity({
   account,
   menuOpen,
   onToggleMenu,
   onCloseMenu,
   onInviteFriends,
   onOpenSettings,
+  onManageProfiles,
   onReportIssue,
   onSignOut,
 }: {
@@ -2126,6 +2139,7 @@ function SidebarIdentity({
   onCloseMenu: () => void;
   onInviteFriends?: () => void;
   onOpenSettings: () => void;
+  onManageProfiles: () => void;
   onReportIssue?: (category: ReportCategory) => void;
   onSignOut?: () => void;
 }) {
@@ -2133,6 +2147,18 @@ function SidebarIdentity({
   const name = accountDisplayName(account);
 
   useDismiss(wrapRef, menuOpen, onCloseMenu);
+
+  const realProfileState = useProfileManager("sandboxed");
+  const forcedProfileState = useForcedProfileSwitcherState();
+  const profileState = forcedProfileState ?? realProfileState;
+  // Re-read the list and sticky active pointer whenever the menu opens, so an
+  // out-of-band switch (settings surface, Hermes CLI, dashboard) is reflected
+  // before the user picks a row. refresh is bound once per controller, so
+  // this effect does not refire on snapshot churn.
+  const refreshProfiles = profileState.refresh;
+  useEffect(() => {
+    if (menuOpen) refreshProfiles();
+  }, [menuOpen, refreshProfiles]);
 
   return (
     <div className="sidebar-identity-wrap" ref={wrapRef}>
@@ -2149,6 +2175,11 @@ function SidebarIdentity({
       </button>
       {menuOpen ? (
         <div className="sidebar-identity-menu" role="menu">
+          <SidebarProfileSwitcher
+            state={profileState}
+            onSwitched={onCloseMenu}
+            onManageProfiles={onManageProfiles}
+          />
           {onInviteFriends ? (
             <button
               type="button"
@@ -2191,6 +2222,81 @@ function SidebarIdentity({
         </div>
       ) : null}
     </div>
+  );
+}
+
+// The profiles group at the top of the account menu: one-click switching
+// between profiles (each keeps its own notes, sessions, and settings, per
+// ADR 0031) without a trip through Settings. Hidden until a second profile
+// exists, so the menu stays quiet for everyone who never made one; creating
+// and deleting stay on the Settings -> Profiles surface. The leading check
+// slot mirrors native macOS menus: it carries the active check, or the
+// in-flight spinner while Hermes confirms a switch.
+export function SidebarProfileSwitcher({
+  state,
+  onSwitched,
+  onManageProfiles,
+}: {
+  state: ProfileManagerState;
+  onSwitched: () => void;
+  onManageProfiles: () => void;
+}) {
+  if (state.status !== "ready" || state.profiles.length < 2) return null;
+  const switching = state.pendingAction?.kind === "activate" ? state.pendingAction.name : null;
+
+  return (
+    <>
+      <div className="sidebar-profile-group" role="group" aria-label="Profiles">
+        <span className="sidebar-profile-group-label" aria-hidden>
+          Profiles
+        </span>
+        {state.profiles.map((profile) => {
+          const isActive = profile.name === state.activeName;
+          const guard = canActivateProfile(profile.name, state.activeName, state.activeConfirmed);
+          return (
+            <button
+              key={profile.name}
+              type="button"
+              role="menuitemradio"
+              aria-checked={isActive}
+              className="sidebar-profile-item"
+              disabled={switching !== null || (!isActive && !guard.ok)}
+              title={!isActive && !guard.ok ? guard.reason : undefined}
+              onClick={() => {
+                // Picking the already-active row is a no-op select: close,
+                // like a native menu.
+                if (isActive) {
+                  onSwitched();
+                  return;
+                }
+                void state.activate(profile.name).then((switched) => {
+                  if (switched) onSwitched();
+                });
+              }}
+            >
+              <span className="sidebar-profile-check" aria-hidden>
+                {switching === profile.name ? (
+                  <DotSpinner />
+                ) : isActive ? (
+                  <IconCheckmark2Small size={14} />
+                ) : null}
+              </span>
+              <span className="sidebar-profile-name">{profile.name}</span>
+            </button>
+          );
+        })}
+        {state.error ? (
+          <p className="sidebar-profile-error" role="alert">
+            {state.error}
+          </p>
+        ) : null}
+        <button type="button" role="menuitem" onClick={onManageProfiles}>
+          <IconMagicWand size={14} />
+          Manage profiles
+        </button>
+      </div>
+      <div className="context-menu-separator" role="separator" />
+    </>
   );
 }
 

--- a/src/lib/profile-switcher-demo.ts
+++ b/src/lib/profile-switcher-demo.ts
@@ -1,0 +1,89 @@
+// Dev-only console driver for the sidebar profile switcher:
+// window.__profileSwitcherDemo() forces a fake multi-profile manager state
+// into the identity menu so the switcher renders (and switches, with a
+// simulated in-flight beat) in a plain browser with no Hermes runtime.
+// __profileSwitcherDemo(false) — or calling it again — flips back.
+// __profileSwitcherDemo(["default", "work"]) seeds custom names (the second
+// entry starts active, mirroring a named-profile session).
+//
+// The fake state never touches the app-global active-profile store or any
+// Tauri command, so real session stamping and data scoping are unaffected.
+//
+// The hook is imported unconditionally by the sidebar (the state simply stays
+// null in production); only the console command registration is gated on
+// import.meta.env.DEV, in main.tsx.
+
+import { useSyncExternalStore } from "react";
+import type { ProfileManagerState } from "./hermes-admin";
+
+const PROFILE_SWITCHER_DEMO_EVENT = "june:profile-switcher-demo-changed";
+
+const DEFAULT_DEMO_NAMES = ["default", "work", "research"];
+
+let demoState: ProfileManagerState | null = null;
+
+function emit() {
+  window.dispatchEvent(new Event(PROFILE_SWITCHER_DEMO_EVENT));
+}
+
+function subscribe(onChange: () => void) {
+  window.addEventListener(PROFILE_SWITCHER_DEMO_EVENT, onChange);
+  return () => window.removeEventListener(PROFILE_SWITCHER_DEMO_EVENT, onChange);
+}
+
+function buildDemoState(names: string[]): ProfileManagerState {
+  return {
+    status: "ready",
+    profiles: names.map((name) => ({ name, raw: {} })),
+    activeName: names[1] ?? names[0] ?? "default",
+    activeConfirmed: true,
+    pendingAction: null,
+    pendingRemoval: null,
+    error: null,
+    activate(name: string) {
+      if (!demoState) return Promise.resolve(false);
+      demoState = { ...demoState, pendingAction: { kind: "activate", name } };
+      emit();
+      // A visible in-flight beat, long enough to judge the spinner state.
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          if (!demoState) return resolve(false);
+          demoState = { ...demoState, pendingAction: null, activeName: name };
+          emit();
+          resolve(true);
+        }, 450);
+      });
+    },
+    beginRemove: () => Promise.resolve(false),
+    confirmRemoval: () => Promise.resolve(false),
+    cancelRemoval: () => {},
+    refresh: () => {},
+    dismissError: () => {},
+  };
+}
+
+/** The forced switcher state while __profileSwitcherDemo() is on, else null. */
+export function useForcedProfileSwitcherState(): ProfileManagerState | null {
+  return useSyncExternalStore(
+    subscribe,
+    () => demoState,
+    () => null,
+  );
+}
+
+export function registerProfileSwitcherDemo() {
+  if (typeof window === "undefined") return;
+  (window as unknown as Record<string, unknown>).__profileSwitcherDemo = (
+    input?: boolean | string[],
+  ) => {
+    if (input === false || (demoState && input === undefined)) {
+      demoState = null;
+      emit();
+      return "Back to real profiles.";
+    }
+    const names = Array.isArray(input) && input.length > 0 ? input : DEFAULT_DEMO_NAMES;
+    demoState = buildDemoState(names);
+    emit();
+    return `Sidebar profile switcher forced with ${names.length} profiles. Open the account menu; __profileSwitcherDemo(false) to reset.`;
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -92,6 +92,12 @@ if (import.meta.env.DEV) {
   void import("./lib/project-memory-demo").then(({ registerProjectMemoryDemo }) =>
     registerProjectMemoryDemo(),
   );
+  // __profileSwitcherDemo() forces a fake multi-profile state into the
+  // sidebar account menu so the profile switcher renders without a Hermes
+  // runtime; call again or __profileSwitcherDemo(false) to reset.
+  void import("./lib/profile-switcher-demo").then(({ registerProfileSwitcherDemo }) =>
+    registerProfileSwitcherDemo(),
+  );
 }
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(

--- a/src/profile-switcher-preview.tsx
+++ b/src/profile-switcher-preview.tsx
@@ -1,0 +1,59 @@
+// Dev-only preview entry: renders the real SidebarIdentity (account menu +
+// profile switcher) against the faked Tauri bridge in
+// profile-switcher-preview.html, with __profileSwitcherDemo() pre-armed, so
+// the switcher can be designed and screenshotted in a plain browser (no
+// native build, no Hermes runtime). Nothing here ships: vite builds only the
+// configured entries.
+import { useState } from "react";
+import ReactDOM from "react-dom/client";
+import { SidebarIdentity } from "./components/sidebar/Sidebar";
+import { registerProfileSwitcherDemo } from "./lib/profile-switcher-demo";
+import type { AccountStatus } from "./lib/tauri";
+import { initTheme } from "./lib/theme";
+import "./styles/app.css";
+
+initTheme();
+registerProfileSwitcherDemo();
+(
+  window as unknown as { __profileSwitcherDemo: (input?: boolean | string[]) => string }
+).__profileSwitcherDemo();
+
+const account: AccountStatus = {
+  signedIn: true,
+  configured: true,
+  user: {
+    id: "usr_preview",
+    handle: "andrew",
+    displayName: "Andrew",
+    email: "andrew@example.com",
+  },
+};
+
+function Preview() {
+  const [menuOpen, setMenuOpen] = useState(true);
+  return (
+    <div style={{ display: "flex", height: "100vh" }}>
+      <aside
+        className="sidebar"
+        style={{ display: "flex", flexDirection: "column", width: 260, height: "100%" }}
+      >
+        <div style={{ flex: 1 }} />
+        <footer className="sidebar-footer">
+          <SidebarIdentity
+            account={account}
+            menuOpen={menuOpen}
+            onToggleMenu={() => setMenuOpen((open) => !open)}
+            onCloseMenu={() => setMenuOpen(false)}
+            onInviteFriends={() => console.log("[preview] invite friends")}
+            onOpenSettings={() => console.log("[preview] open settings")}
+            onManageProfiles={() => console.log("[preview] manage profiles")}
+            onReportIssue={(category) => console.log("[preview] report", category)}
+            onSignOut={() => console.log("[preview] sign out")}
+          />
+        </footer>
+      </aside>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(<Preview />);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9359,6 +9359,46 @@ button.agent-user-attachment:hover {
   color: var(--muted-foreground);
 }
 
+/* Profiles group at the top of the account menu — one-click switching once a
+ * second profile exists. Rows inherit the shared menu-button treatment; the
+ * fixed leading slot mirrors native macOS menus, carrying the active check or
+ * the in-flight spinner so names stay aligned either way. */
+.sidebar-profile-group-label {
+  padding: var(--sp-1) var(--sp-3) 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.sidebar-profile-check {
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 14px;
+}
+
+.sidebar-profile-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* While a switch is in flight every row disables; keep them legible but
+ * clearly parked, and suppress the hover wash so nothing invites a click. */
+.sidebar-identity-menu button:disabled {
+  color: var(--muted-foreground);
+}
+
+.sidebar-identity-menu button:disabled:hover {
+  background: transparent;
+}
+
+.sidebar-profile-error {
+  margin: 0;
+  padding: var(--sp-1) var(--sp-3);
+  color: var(--destructive);
+  font-size: var(--fs-sm);
+}
+
 /* Settings nav — replaces the main sidebar list while the settings page is
  * open, with a quiet back affordance to notes at the top. */
 .sidebar-settings-section {

--- a/src/test/sidebar-profile-switcher.test.tsx
+++ b/src/test/sidebar-profile-switcher.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SidebarProfileSwitcher } from "../components/sidebar/Sidebar";
+import type { ProfileManagerState } from "../lib/hermes-admin";
+
+function stubManager(overrides: Partial<ProfileManagerState> = {}): ProfileManagerState {
+  return {
+    status: "ready",
+    profiles: [
+      { name: "default", raw: {} },
+      { name: "research", raw: {} },
+      { name: "writing", raw: {} },
+    ],
+    activeName: "research",
+    activeConfirmed: true,
+    pendingAction: null,
+    pendingRemoval: null,
+    error: null,
+    activate: vi.fn().mockResolvedValue(true),
+    beginRemove: vi.fn().mockResolvedValue(true),
+    confirmRemoval: vi.fn().mockResolvedValue(true),
+    cancelRemoval: vi.fn(),
+    refresh: vi.fn(),
+    dismissError: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderSwitcher(state: ProfileManagerState) {
+  const onSwitched = vi.fn();
+  const onManageProfiles = vi.fn();
+  render(
+    <SidebarProfileSwitcher
+      state={state}
+      onSwitched={onSwitched}
+      onManageProfiles={onManageProfiles}
+    />,
+  );
+  return { onSwitched, onManageProfiles };
+}
+
+describe("SidebarProfileSwitcher", () => {
+  it("stays hidden until a second profile exists", () => {
+    renderSwitcher(stubManager({ profiles: [{ name: "default", raw: {} }] }));
+    expect(screen.queryByRole("group", { name: "Profiles" })).not.toBeInTheDocument();
+  });
+
+  it("stays hidden while the manager is not ready", () => {
+    renderSwitcher(stubManager({ status: "loading", profiles: [] }));
+    expect(screen.queryByRole("group", { name: "Profiles" })).not.toBeInTheDocument();
+  });
+
+  it("lists every profile and checks only the active one", () => {
+    renderSwitcher(stubManager());
+    const rows = screen.getAllByRole("menuitemradio");
+    expect(rows.map((row) => row.textContent)).toEqual(["default", "research", "writing"]);
+    expect(screen.getByRole("menuitemradio", { name: "research" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByRole("menuitemradio", { name: "default" })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+  });
+
+  it("activates the picked profile and closes the menu on success", async () => {
+    const state = stubManager();
+    const { onSwitched } = renderSwitcher(state);
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "writing" }));
+    expect(state.activate).toHaveBeenCalledWith("writing");
+    await waitFor(() => expect(onSwitched).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps the menu open when the switch fails", async () => {
+    const state = stubManager({ activate: vi.fn().mockResolvedValue(false) });
+    const { onSwitched } = renderSwitcher(state);
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "writing" }));
+    expect(state.activate).toHaveBeenCalledWith("writing");
+    await waitFor(() => expect(state.activate).toHaveBeenCalled());
+    expect(onSwitched).not.toHaveBeenCalled();
+  });
+
+  it("treats picking the active profile as a plain close", async () => {
+    const state = stubManager();
+    const { onSwitched } = renderSwitcher(state);
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "research" }));
+    expect(state.activate).not.toHaveBeenCalled();
+    expect(onSwitched).toHaveBeenCalledTimes(1);
+  });
+
+  it("parks every row while a switch is in flight", () => {
+    renderSwitcher(stubManager({ pendingAction: { kind: "activate", name: "writing" } }));
+    for (const row of screen.getAllByRole("menuitemradio")) {
+      expect(row).toBeDisabled();
+    }
+  });
+
+  it("blocks switching while the active profile is unconfirmed", () => {
+    renderSwitcher(stubManager({ activeConfirmed: false }));
+    expect(screen.getByRole("menuitemradio", { name: "writing" })).toBeDisabled();
+  });
+
+  it("surfaces a failed-switch error inline", () => {
+    renderSwitcher(stubManager({ error: "Hermes rejected the switch." }));
+    expect(screen.getByRole("alert")).toHaveTextContent("Hermes rejected the switch.");
+  });
+
+  it("opens profile management from the trailing row", async () => {
+    const { onManageProfiles } = renderSwitcher(stubManager());
+    await userEvent.click(screen.getByRole("menuitem", { name: "Manage profiles" }));
+    expect(onManageProfiles).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- The account menu in the sidebar grows a quiet Profiles group, so switching profiles is one click from persistent chrome instead of a trip through Settings -> Profiles (follow-up to #674, JUN-210).
- Hidden until a second profile exists: everyone who never created a profile keeps today's exact menu. With profiles, each renders as a `menuitemradio` row with a native-style leading check slot (check on the active row, spinner while a switch is in flight), plus a "Manage profiles" row that deep-links to the Settings Profiles tab.
- Switching reuses the existing `ProfileManagerController` pessimistic activate path, so notes, sessions, and settings surfaces re-scope live exactly as they do for a settings-surface switch. The list and sticky active pointer re-read on every menu open, so out-of-band switches (settings surface, Hermes CLI, dashboard) are reflected before the user picks a row.
- `__profileSwitcherDemo()` (dev-only) forces a fake manager state into the menu so the switcher renders in a plain browser; `profile-switcher-preview.html` mounts the real `SidebarIdentity` against it. The fake state never touches the app-global active-profile store or any Tauri command, so real session stamping and data scoping are unaffected.

## Validation

- 10 new vitest cases (`src/test/sidebar-profile-switcher.test.tsx`): hidden below two profiles, check placement, activate-and-close on success, stays open on failure, active-row no-op close, rows parked while switching, unconfirmed-active guard, inline error, manage-profiles deep link.
- Full gate: Biome clean, `tsc` clean, 215 vitest files / 3477 tests green.
- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).

| Light, resting | Switch in flight | Dark |
| --- | --- | --- |
| ![Light, menu open](https://app.opensoftware.co/api/v1/files/fil_LSrvL3hJFMBG/download) | ![Switching, spinner in the check slot](https://app.opensoftware.co/api/v1/files/fil_Pi13YsLXCTHq/download) | ![Dark, menu open](https://app.opensoftware.co/api/v1/files/fil_Rl96BbSFQ4Up/download) |

- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- An ambient active-profile indicator on the sidebar footer itself (the identity row still shows only the account name; worth a separate design pass).
- A shared menu/popover positioning primitive - the group renders inline in the existing hand-rolled identity menu on purpose, per docs/design/components.md ("menus are hand-rolled today").
- Profile creation/deletion from the menu - those stay on the Settings Profiles surface.

## Followups

- The active-profile isolation hardening Jakub filed (JUN-419, JUN-423, JUN-431) makes casual switching safer still; this PR neither depends on nor changes those paths.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. (None.)
- [x] Workflow action references are pinned to full-length commit SHAs. (No workflow changes.)
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. (None.)
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (None.)
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787421426&installation_model_id=425925&pr_number=932&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F932&signature=3c4db22532d7ca1c96aeda38eab773a6ae05d8f1d272c4aa66f024638d559e59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->