### PR TITLE
fix(notes): preserve generated titles through autosave

### DIFF
--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -2830,22 +2830,26 @@ impl Repositories {
         edited_content: Option<String>,
         active_tab: Option<String>,
     ) -> Result<NotePatchDto, sqlx::error::Error> {
-        let row = query(
-            "UPDATE notes
-             SET title = COALESCE(?, title),
-                 edited_content = COALESCE(?, edited_content),
-                 active_tab = COALESCE(?, active_tab, 'notes'),
-                 updated_at = ?
-             WHERE id = ?
-             RETURNING id, title, generated_content, edited_content, active_tab, updated_at",
-        )
-        .bind(title)
-        .bind(edited_content)
-        .bind(active_tab)
-        .bind(timestamp())
-        .bind(note_id)
-        .fetch_one(&self.pool)
-        .await?;
+        let mut update = QueryBuilder::<Sqlite>::new("UPDATE notes SET ");
+        // An omitted title is a patch omission, not a request to rewrite the
+        // caller's snapshot. Leave the column out so a delayed content
+        // autosave cannot clobber a title committed by note generation.
+        if let Some(title) = title {
+            update.push("title = ").push_bind(title).push(", ");
+        }
+        update
+            .push("edited_content = COALESCE(")
+            .push_bind(edited_content)
+            .push(", edited_content), active_tab = COALESCE(")
+            .push_bind(active_tab)
+            .push(", active_tab, 'notes'), updated_at = ")
+            .push_bind(timestamp())
+            .push(" WHERE id = ")
+            .push_bind(note_id)
+            .push(
+                " RETURNING id, title, generated_content, edited_content, active_tab, updated_at",
+            );
+        let row = update.build().fetch_one(&self.pool).await?;
         let title: String = row.get("title");
         let edited_content = row.try_get::<Option<String>, _>("edited_content")?;
         let generated_content = row.try_get::<Option<String>, _>("generated_content")?;

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -102,6 +102,55 @@ async fn update_note_returns_null_content_and_normalizes_a_null_active_tab() {
 }
 
 #[tokio::test]
+async fn autosave_omits_title_after_generation_commits_a_newer_title() {
+    let repos = repos().await;
+    let note = repos.create_note("default", None).await.expect("note");
+    let autosave_snapshot = repos.get_note(&note.id).await.expect("autosave snapshot");
+    assert_eq!(autosave_snapshot.title, "");
+
+    let generated = repos
+        .set_generated_note(
+            &note.id,
+            Some("Freshly generated title".to_string()),
+            "Generated content".to_string(),
+        )
+        .await
+        .expect("generated note");
+    assert_eq!(generated.title, "Freshly generated title");
+
+    // The debounced autosave is still based on the pre-generation editor
+    // snapshot. Fail deterministically if its content-only patch touches the
+    // title column at all; doing so can rewrite the stale snapshot over the
+    // title that generation committed in the meantime.
+    query(
+        "CREATE TRIGGER reject_stale_autosave_title_write
+         BEFORE UPDATE OF title ON notes
+         BEGIN
+             SELECT RAISE(ABORT, 'content autosave must not write title');
+         END",
+    )
+    .execute(&repos.pool)
+    .await
+    .expect("install title-write guard");
+
+    let updated = repos
+        .update_note(
+            &note.id,
+            None,
+            Some("Content saved from the older editor snapshot".to_string()),
+            None,
+        )
+        .await
+        .expect("content autosave");
+
+    assert_eq!(updated.title, "Freshly generated title");
+    assert_eq!(
+        updated.edited_content.as_deref(),
+        Some("Content saved from the older editor snapshot")
+    );
+}
+
+#[tokio::test]
 async fn deleting_note_removes_it_from_all_note_lists() {
     let repos = repos().await;
     let folder = repos


### PR DESCRIPTION
## Summary

- make note autosave omit the title column when the caller did not supply a title
- add a deterministic reverse-interleave regression proving a generated title survives a delayed content autosave

## Root cause

The autosave path historically treated an omitted title as the title from a previously read note snapshot, so a delayed content save could replay that stale value after note generation committed a newer title. The newer sparse-patch path removed the explicit pre-read, but its SQL still named `title` in every update through `COALESCE`. This change completes the patch semantics: a content-only autosave does not write the title column at all.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --test notes autosave_omits_title_after_generation_commits_a_newer_title`
- `make tauri-fmt-check tauri-lint tauri-test`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test`
- `NODE_OPTIONS=--no-experimental-webstorage make verify`
- in-session diff audit against the live Issue and current autosave callers

- [x] Tested visually where it matters (not applicable: no UI changes; the race is covered deterministically at the repository boundary).
- [ ] Needs a June API (backend) deploy before it works end to end. No: this is a desktop SQLite persistence change.

## Out of scope

- SQLite lock durability and retry behavior, which is already handled on the base branch
- changes to explicit user title edits or note generation's existing compare-and-set guard

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. (Not applicable: this is not security-sensitive.)
- [x] Workflow action references are pinned to full-length commit SHAs. (Not applicable: no workflow changes.)
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. (Not applicable.)
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (Not applicable.)
- [x] User-facing copy follows the repo UI conventions. (Not applicable: no user-facing copy.)

Refs JUN-418

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787422887&installation_model_id=425925&pr_number=933&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F933&signature=959db3018b027039dff74f8e01f893de981ee266bd98495e4af09c32ebb4156e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->