### PR TITLE
fix(hud): release listeners when windows unload

### DIFF
--- a/src/agent-hud.ts
+++ b/src/agent-hud.ts
@@ -26,14 +26,17 @@ import {
 import { isAgentSessionTitleCandidate, sessionSettledTitleKind } from "./lib/agent-session-titles";
 import { JUNE_SPINNER_COLS, juneSpinnerGrid } from "./lib/june-spinner-grid";
 import { titleFromPrompt } from "./lib/hermes-adapter";
+import { createHudLifecycle } from "./lib/hud-lifecycle";
 import { agentHudHide, agentHudOpenAgent, agentHudSetLayout, agentHudShow } from "./lib/tauri";
 import { installNativeContextMenuGuard } from "./lib/native-context-menu";
 import type { HermesSessionInfo } from "./lib/tauri";
 import { subscribeBrand } from "./lib/brand";
 import "./styles/agent-hud.css";
 
+const lifecycle = createHudLifecycle();
+
 // Recolor this HUD window to the selected accent and keep it live-synced.
-subscribeBrand();
+lifecycle.trackUnlisten(subscribeBrand());
 
 type HudSessionStatus = AgentSessionStatusKind | "idle";
 
@@ -78,7 +81,7 @@ const stack = document.querySelector<HTMLElement>("#agent-hud-stack");
 const menu = document.querySelector<HTMLElement>("#agent-hud-menu");
 const hideHud = document.querySelector<HTMLButtonElement>("#agent-hud-hide");
 
-installNativeContextMenuGuard();
+lifecycle.addCleanup(installNativeContextMenuGuard());
 
 const state = {
   enabled: getAgentHudEnabled(),
@@ -112,6 +115,13 @@ let hideTimer: number | undefined;
 let resizeTimer: number | undefined;
 let widthFlipTimer: number | undefined;
 let windowShown = false;
+
+lifecycle.addCleanup(() => {
+  window.clearTimeout(pruneTimer);
+  window.clearTimeout(hideTimer);
+  window.clearTimeout(resizeTimer);
+  window.clearTimeout(widthFlipTimer);
+});
 
 function applySessionsChanged(detail?: AgentSessionsChangedDetail) {
   if (!detail) return;
@@ -1057,11 +1067,15 @@ pill?.addEventListener("keydown", (event) => {
 // ctrl-clicks before WKWebView sees them (see the Tauri listener below);
 // this DOM listener is the fallback for the standalone browser/demo page,
 // where there is no native panel to intercept.
-window.addEventListener("contextmenu", (event) => {
-  event.preventDefault();
-  event.stopPropagation();
-  openMenu();
-});
+window.addEventListener(
+  "contextmenu",
+  (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    openMenu();
+  },
+  { signal: lifecycle.signal },
+);
 
 menu?.addEventListener("pointerdown", (event) => {
   event.stopPropagation();
@@ -1073,61 +1087,95 @@ hideHud?.addEventListener("click", (event) => {
   hideFromMenu();
 });
 
-window.addEventListener("pointerdown", (event) => {
-  if (!state.menuOpen) return;
-  const target = event.target;
-  if (target instanceof Node && menu?.contains(target)) return;
-  closeMenu();
-});
+window.addEventListener(
+  "pointerdown",
+  (event) => {
+    if (!state.menuOpen) return;
+    const target = event.target;
+    if (target instanceof Node && menu?.contains(target)) return;
+    closeMenu();
+  },
+  { signal: lifecycle.signal },
+);
 
-window.addEventListener("keydown", (event) => {
-  if (event.key === "Escape") closeMenu();
-});
+window.addEventListener(
+  "keydown",
+  (event) => {
+    if (event.key === "Escape") closeMenu();
+  },
+  { signal: lifecycle.signal },
+);
 
-window.addEventListener(AGENT_HUD_VISIBILITY_CHANGED_EVENT, (event) => {
-  const detail = (event as CustomEvent<AgentHudVisibilityChangedDetail>).detail;
-  if (detail) applyVisibility(detail.enabled);
-});
+window.addEventListener(
+  AGENT_HUD_VISIBILITY_CHANGED_EVENT,
+  (event) => {
+    const detail = (event as CustomEvent<AgentHudVisibilityChangedDetail>).detail;
+    if (detail) applyVisibility(detail.enabled);
+  },
+  { signal: lifecycle.signal },
+);
 
-window.addEventListener(AGENT_SESSIONS_CHANGED_EVENT, (event) => {
-  applySessionsChanged((event as CustomEvent<AgentSessionsChangedDetail>).detail);
-});
+window.addEventListener(
+  AGENT_SESSIONS_CHANGED_EVENT,
+  (event) => {
+    applySessionsChanged((event as CustomEvent<AgentSessionsChangedDetail>).detail);
+  },
+  { signal: lifecycle.signal },
+);
 
-window.addEventListener(AGENT_SESSION_STATUS_EVENT, (event) => {
-  applyStatus((event as CustomEvent<AgentSessionStatusDetail>).detail);
-});
+window.addEventListener(
+  AGENT_SESSION_STATUS_EVENT,
+  (event) => {
+    applyStatus((event as CustomEvent<AgentSessionStatusDetail>).detail);
+  },
+  { signal: lifecycle.signal },
+);
 
-window.addEventListener(AGENT_RUN_SETTLED_EVENT, (event) => {
-  applyRunSettled((event as CustomEvent<AgentRunSettledDetail>).detail);
-});
+window.addEventListener(
+  AGENT_RUN_SETTLED_EVENT,
+  (event) => {
+    applyRunSettled((event as CustomEvent<AgentRunSettledDetail>).detail);
+  },
+  { signal: lifecycle.signal },
+);
 
-window.addEventListener("storage", (event) => {
-  if (event.key === AGENT_HUD_ENABLED_KEY) {
-    applyVisibility(event.newValue !== "false");
-  }
-});
+window.addEventListener(
+  "storage",
+  (event) => {
+    if (event.key === AGENT_HUD_ENABLED_KEY) {
+      applyVisibility(event.newValue !== "false");
+    }
+  },
+  { signal: lifecycle.signal },
+);
 
-void listen<AgentSessionsChangedDetail>(AGENT_SESSIONS_CHANGED_EVENT, (event) =>
-  applySessionsChanged(event.payload),
-).catch(() => {});
+lifecycle.trackUnlisten(
+  listen<AgentSessionsChangedDetail>(AGENT_SESSIONS_CHANGED_EVENT, (event) =>
+    applySessionsChanged(event.payload),
+  ),
+);
 
-void listen<AgentSessionStatusDetail>(AGENT_SESSION_STATUS_EVENT, (event) =>
-  applyStatus(event.payload),
-).catch(() => {});
+lifecycle.trackUnlisten(
+  listen<AgentSessionStatusDetail>(AGENT_SESSION_STATUS_EVENT, (event) =>
+    applyStatus(event.payload),
+  ),
+);
 
-void listen<AgentRunSettledDetail>(AGENT_RUN_SETTLED_EVENT, (event) =>
-  applyRunSettled(event.payload),
-).catch(() => {});
+lifecycle.trackUnlisten(
+  listen<AgentRunSettledDetail>(AGENT_RUN_SETTLED_EVENT, (event) => applyRunSettled(event.payload)),
+);
 
-void listen<AgentHudVisibilityChangedDetail>(AGENT_HUD_VISIBILITY_CHANGED_EVENT, (event) =>
-  applyVisibility(event.payload.enabled),
-).catch(() => {});
+lifecycle.trackUnlisten(
+  listen<AgentHudVisibilityChangedDetail>(AGENT_HUD_VISIBILITY_CHANGED_EVENT, (event) =>
+    applyVisibility(event.payload.enabled),
+  ),
+);
 
 // The native panel intercepts the right-/ctrl-click and asks us to open the
 // menu. The click never reaches the DOM, so there is no competing
 // pointerdown to close it again (the window pointerdown handler only fires
 // for clicks the webview actually receives).
-void listen(AGENT_HUD_CONTEXT_MENU_EVENT, () => openMenu()).catch(() => {});
+lifecycle.trackUnlisten(listen(AGENT_HUD_CONTEXT_MENU_EVENT, () => openMenu()));
 
 setIcon(pillChevron, IconChevronDownSmall, 14);
 render();

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -20,10 +20,13 @@ import {
 import { isOnboardingComplete, subscribeToOnboardingComplete } from "./lib/onboarding";
 import { installNativeContextMenuGuard } from "./lib/native-context-menu";
 import { subscribeBrand } from "./lib/brand";
+import { createHudLifecycle } from "./lib/hud-lifecycle";
 import "./styles/hud.css";
 
+const lifecycle = createHudLifecycle();
+
 // Recolor this HUD window to the selected accent and keep it live-synced.
-subscribeBrand();
+lifecycle.trackUnlisten(subscribeBrand());
 
 type DictationHudEvent = {
   type: string;
@@ -46,7 +49,7 @@ const appWindow = (() => {
   }
 })();
 
-installNativeContextMenuGuard();
+lifecycle.addCleanup(installNativeContextMenuGuard());
 
 const hud = document.querySelector<HTMLDivElement>("#hud");
 const dragHandle = document.querySelector<HTMLElement>("#hud-handle");
@@ -102,6 +105,13 @@ let hideRequestId = 0;
 let showRequestId = 0;
 let showQueue: Promise<void> = Promise.resolve();
 
+lifecycle.addCleanup(() => {
+  window.clearTimeout(hideTimer);
+  window.clearTimeout(meetingPromptTimer);
+  window.clearTimeout(longDictationNoticeTimer);
+  window.clearInterval(brailleTimer);
+});
+
 // waverows shows multiple horizontal rows of dots flowing across — reads as a
 // "thinking/processing" texture rather than a single dot bouncing.
 const brailleWave = spinners.waverows;
@@ -152,6 +162,10 @@ const meter = createBarMeter(
 
 let rafHandle: number | undefined;
 let shimmerTimer: number | undefined;
+
+lifecycle.addCleanup(() => {
+  window.clearTimeout(shimmerTimer);
+});
 let lastAudioLevelAt = 0;
 const IDLE_RAF_TIMEOUT_MS = 260;
 // Once the bars have settled and no fresh audio is arriving, the only thing
@@ -295,16 +309,16 @@ function startBarLoop() {
     const keepShimmering = IDLE_PULSE_AMP > 0 && hud?.dataset.state === "listening";
     if (reactive) {
       // Bars moving or audio recent → paint every frame for responsiveness.
-      rafHandle = window.requestAnimationFrame(tick);
+      rafHandle = lifecycle.requestAnimationFrame(tick);
     } else if (keepShimmering) {
       // Idle but listening → throttle the carrier so the CPU can idle between ticks.
       shimmerTimer = window.setTimeout(() => {
         shimmerTimer = undefined;
-        rafHandle = window.requestAnimationFrame(tick);
+        rafHandle = lifecycle.requestAnimationFrame(tick);
       }, SHIMMER_FRAME_MS);
     }
   };
-  rafHandle = window.requestAnimationFrame(tick);
+  rafHandle = lifecycle.requestAnimationFrame(tick);
 }
 
 function resetBars() {
@@ -363,7 +377,7 @@ let levelFlushHandle: number | undefined;
 function queueAudioLevel(rawLevel: number) {
   pendingRawLevel = pendingRawLevel === null ? rawLevel : Math.max(pendingRawLevel, rawLevel);
   if (levelFlushHandle !== undefined) return;
-  levelFlushHandle = window.requestAnimationFrame(() => {
+  levelFlushHandle = lifecycle.requestAnimationFrame(() => {
     levelFlushHandle = undefined;
     const next = pendingRawLevel;
     pendingRawLevel = null;
@@ -373,7 +387,7 @@ function queueAudioLevel(rawLevel: number) {
 
 function cancelPendingAudioLevel() {
   if (levelFlushHandle !== undefined) {
-    window.cancelAnimationFrame(levelFlushHandle);
+    lifecycle.cancelAnimationFrame(levelFlushHandle);
     levelFlushHandle = undefined;
   }
   pendingRawLevel = null;
@@ -537,8 +551,8 @@ async function syncWindowToPill(options?: { animate?: boolean; morph?: boolean }
     height,
     animate: options?.animate ?? !prefersReducedMotion(),
   });
-  window.requestAnimationFrame(() => {
-    window.requestAnimationFrame(() => {
+  lifecycle.requestAnimationFrame(() => {
+    lifecycle.requestAnimationFrame(() => {
       hud?.classList.remove("is-morphing");
       pushStopBoundsToNative();
       pushDismissBoundsToNative();
@@ -563,12 +577,12 @@ function fadeWindowAlpha(requestId: number) {
       const t = Math.min((now - start) / EXIT_TRANSITION_MS, 1);
       setWindowAlpha(1 - t);
       if (t < 1) {
-        window.requestAnimationFrame(step);
+        lifecycle.requestAnimationFrame(step);
       } else {
         resolve();
       }
     };
-    window.requestAnimationFrame(step);
+    lifecycle.requestAnimationFrame(step);
   });
 }
 
@@ -789,6 +803,10 @@ async function showHudNow(requestId: number, options?: { fresh?: boolean; morph?
 const FRAME_SETTLE_DELAY_MS = 120;
 let frameSettleTimer: number | undefined;
 
+lifecycle.addCleanup(() => {
+  window.clearTimeout(frameSettleTimer);
+});
+
 function clearFrameSettleTimer() {
   if (frameSettleTimer !== undefined) {
     window.clearTimeout(frameSettleTimer);
@@ -963,8 +981,8 @@ function playErrorReveal() {
     hud.classList.remove("hud-reveal-collapsed");
     return;
   }
-  requestAnimationFrame(() =>
-    requestAnimationFrame(() => hud?.classList.remove("hud-reveal-collapsed")),
+  lifecycle.requestAnimationFrame(() =>
+    lifecycle.requestAnimationFrame(() => hud?.classList.remove("hud-reveal-collapsed")),
   );
 }
 
@@ -1125,25 +1143,35 @@ meetingDismissButton?.addEventListener("click", (event) => {
   void hideHud();
 });
 
-void listen("dictation-event", async (event) => {
-  await handleDictationEventPayload(event.payload);
-}).catch(() => {});
+lifecycle.trackUnlisten(
+  listen("dictation-event", async (event) => {
+    await handleDictationEventPayload(event.payload);
+  }),
+);
 
-void listen("meeting-detection-event", async (event) => {
-  await handleMeetingDetectionEventPayload(event.payload);
-}).catch(() => {});
+lifecycle.trackUnlisten(
+  listen("meeting-detection-event", async (event) => {
+    await handleMeetingDetectionEventPayload(event.payload);
+  }),
+);
 
-void listen<boolean>("hud-stop-hover", (event) => {
-  setStopHover(Boolean(event.payload));
-}).catch(() => {});
+lifecycle.trackUnlisten(
+  listen<boolean>("hud-stop-hover", (event) => {
+    setStopHover(Boolean(event.payload));
+  }),
+);
 
-void listen<boolean>("hud-dismiss-hover", (event) => {
-  setDismissHover(Boolean(event.payload));
-}).catch(() => {});
+lifecycle.trackUnlisten(
+  listen<boolean>("hud-dismiss-hover", (event) => {
+    setDismissHover(Boolean(event.payload));
+  }),
+);
 
-void listen<boolean>("hud-record-hover", (event) => {
-  setRecordHover(Boolean(event.payload));
-}).catch(() => {});
+lifecycle.trackUnlisten(
+  listen<boolean>("hud-record-hover", (event) => {
+    setRecordHover(Boolean(event.payload));
+  }),
+);
 
 // Cold-start companion to the await in syncWindowToPill: the Diatype load
 // may only BEGIN once the prompt first paints text, after the measurement.
@@ -1161,16 +1189,24 @@ if (typeof document.fonts?.ready?.then === "function") {
 // only the dev-only demo drivers dispatch these window events (standalone
 // page, no bridge), so production builds skip the dead listeners.
 if (import.meta.env.DEV) {
-  window.addEventListener("dictation-event", (event) => {
-    void handleDictationEventPayload((event as CustomEvent).detail);
-  });
+  window.addEventListener(
+    "dictation-event",
+    (event) => {
+      void handleDictationEventPayload((event as CustomEvent).detail);
+    },
+    { signal: lifecycle.signal },
+  );
 
-  window.addEventListener("meeting-detection-event", (event) => {
-    void handleMeetingDetectionEventPayload((event as CustomEvent).detail);
-  });
+  window.addEventListener(
+    "meeting-detection-event",
+    (event) => {
+      void handleMeetingDetectionEventPayload((event as CustomEvent).detail);
+    },
+    { signal: lifecycle.signal },
+  );
 }
 
-subscribeToOnboardingComplete(showPendingMeetingPromptAfterOnboarding);
+lifecycle.addCleanup(subscribeToOnboardingComplete(showPendingMeetingPromptAfterOnboarding));
 
 // Console drivers for this page when served standalone in a browser:
 // __dictationHud("listening") drives the dictation pill, __meetingHud(

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -19,6 +19,7 @@
 
 import { useSyncExternalStore } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 
 export type BrandId = "rose" | "clay" | "sage" | "ocean" | "plum";
 
@@ -159,10 +160,10 @@ export function initBrand() {
 
 // Secondary windows (HUDs): apply the stored accent on load and keep it in
 // sync when the main window changes it.
-export function subscribeBrand() {
+export function subscribeBrand(): Promise<UnlistenFn> {
   applyBrandVar(getStoredBrand());
-  if (!inTauri()) return;
-  void import("@tauri-apps/api/event").then(({ listen }) =>
+  if (!inTauri()) return Promise.resolve(() => {});
+  return import("@tauri-apps/api/event").then(({ listen }) =>
     listen<BrandId>(ACCENT_EVENT, (event) => applyBrandVar(event.payload, { animate: true })),
   );
 }

--- a/src/lib/hud-lifecycle.ts
+++ b/src/lib/hud-lifecycle.ts
@@ -1,0 +1,75 @@
+import type { UnlistenFn } from "@tauri-apps/api/event";
+
+type Cleanup = () => void;
+
+export function createHudLifecycle() {
+  const abortController = new AbortController();
+  const animationFrameHandles = new Set<number>();
+  const cleanups = new Set<Cleanup>();
+  let disposed = false;
+
+  const addCleanup = (cleanup: Cleanup) => {
+    if (disposed) {
+      cleanup();
+      return;
+    }
+    cleanups.add(cleanup);
+  };
+
+  const trackUnlisten = (unlistenPromise: Promise<UnlistenFn>) => {
+    void unlistenPromise.then(addCleanup).catch(() => {});
+  };
+
+  const requestAnimationFrame = (callback: FrameRequestCallback) => {
+    if (disposed) return 0;
+    let handle = 0;
+    handle = window.requestAnimationFrame((time) => {
+      animationFrameHandles.delete(handle);
+      callback(time);
+    });
+    animationFrameHandles.add(handle);
+    return handle;
+  };
+
+  const cancelAnimationFrame = (handle: number) => {
+    animationFrameHandles.delete(handle);
+    window.cancelAnimationFrame(handle);
+  };
+
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    abortController.abort();
+    for (const handle of animationFrameHandles) {
+      window.cancelAnimationFrame(handle);
+    }
+    animationFrameHandles.clear();
+    for (const cleanup of cleanups) {
+      try {
+        cleanup();
+      } catch {
+        // Continue releasing the rest of the window-owned resources.
+      }
+    }
+    cleanups.clear();
+  };
+
+  // Tauri WKWebView teardown can surface through either browser lifecycle
+  // event, so both paths share the same idempotent disposer.
+  window.addEventListener("beforeunload", dispose, {
+    once: true,
+    signal: abortController.signal,
+  });
+  window.addEventListener("pagehide", dispose, {
+    once: true,
+    signal: abortController.signal,
+  });
+
+  return {
+    addCleanup,
+    cancelAnimationFrame,
+    requestAnimationFrame,
+    signal: abortController.signal,
+    trackUnlisten,
+  };
+}

--- a/src/meeting-hud.ts
+++ b/src/meeting-hud.ts
@@ -18,16 +18,19 @@ import {
 } from "./lib/tauri";
 import { installNativeContextMenuGuard } from "./lib/native-context-menu";
 import { subscribeBrand } from "./lib/brand";
+import { createHudLifecycle } from "./lib/hud-lifecycle";
 import "./styles/meeting-hud.css";
 
+const lifecycle = createHudLifecycle();
+
 // Recolor this HUD window to the selected accent and keep it live-synced.
-subscribeBrand();
+lifecycle.trackUnlisten(subscribeBrand());
 
 const appWindow = getCurrentWindow();
 const pill = document.querySelector<HTMLDivElement>("#mhud");
 const bars = Array.from(document.querySelectorAll<HTMLElement>(".mhud-bar"));
 
-installNativeContextMenuGuard();
+lifecycle.addCleanup(installNativeContextMenuGuard());
 
 // Shares the dictation HUD's + recorder bar's synthesis, ballistics, and
 // travelling-wave motion so all waveforms move identically.
@@ -75,8 +78,8 @@ function applyZone(payload: { vertical: boolean; animate: boolean }) {
   pill.dataset.orient = payload.vertical ? "vertical" : "horizontal";
   if (!payload.animate) {
     // Let the snapped state paint before the transition comes back.
-    window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => pill.classList.remove("mhud-snap"));
+    lifecycle.requestAnimationFrame(() => {
+      lifecycle.requestAnimationFrame(() => pill.classList.remove("mhud-snap"));
     });
   }
 }
@@ -95,9 +98,9 @@ function startBarLoop() {
         : meter.displayed[i];
       bars[i].style.setProperty("--level", value.toFixed(3));
     }
-    window.requestAnimationFrame(tick);
+    lifecycle.requestAnimationFrame(tick);
   };
-  window.requestAnimationFrame(tick);
+  lifecycle.requestAnimationFrame(tick);
 }
 
 function resetBars() {
@@ -123,59 +126,87 @@ const DRAG_THRESHOLD_PX = 4;
 let pressStart: { x: number; y: number } | undefined;
 let dragging = false;
 
-document.addEventListener("pointerdown", (event) => {
-  if (event.button !== 0) return;
-  pressStart = { x: event.screenX, y: event.screenY };
-  dragging = false;
-});
+document.addEventListener(
+  "pointerdown",
+  (event) => {
+    if (event.button !== 0) return;
+    pressStart = { x: event.screenX, y: event.screenY };
+    dragging = false;
+  },
+  { signal: lifecycle.signal },
+);
 
-document.addEventListener("pointermove", (event) => {
-  if (!pressStart || dragging) return;
-  const dx = event.screenX - pressStart.x;
-  const dy = event.screenY - pressStart.y;
-  if (Math.hypot(dx, dy) > DRAG_THRESHOLD_PX) {
-    dragging = true;
-    // Native drag takes over the gesture; pointerup won't fire on the element,
-    // so `dragging` stays true and suppresses the click below.
-    void appWindow.startDragging().catch(() => {});
-  }
-});
+document.addEventListener(
+  "pointermove",
+  (event) => {
+    if (!pressStart || dragging) return;
+    const dx = event.screenX - pressStart.x;
+    const dy = event.screenY - pressStart.y;
+    if (Math.hypot(dx, dy) > DRAG_THRESHOLD_PX) {
+      dragging = true;
+      // Native drag takes over the gesture; pointerup won't fire on the element,
+      // so `dragging` stays true and suppresses the click below.
+      void appWindow.startDragging().catch(() => {});
+    }
+  },
+  { signal: lifecycle.signal },
+);
 
-document.addEventListener("pointerup", (event) => {
-  if (event.button !== 0) return;
-  const wasClick = !!pressStart && !dragging;
-  pressStart = undefined;
-  if (wasClick) reopenJune();
-});
+document.addEventListener(
+  "pointerup",
+  (event) => {
+    if (event.button !== 0) return;
+    const wasClick = !!pressStart && !dragging;
+    pressStart = undefined;
+    if (wasClick) reopenJune();
+  },
+  { signal: lifecycle.signal },
+);
 
-document.addEventListener("keydown", (event) => {
-  if (event.key === "Enter" || event.key === " ") {
-    event.preventDefault();
-    reopenJune();
-  }
-});
+document.addEventListener(
+  "keydown",
+  (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      reopenJune();
+    }
+  },
+  { signal: lifecycle.signal },
+);
 
-void listen<RecordingTelemetryDto>(RECORDING_TELEMETRY_EVENT, (event) => {
-  if (event.payload) applyStatus(event.payload);
-});
+lifecycle.trackUnlisten(
+  listen<RecordingTelemetryDto>(RECORDING_TELEMETRY_EVENT, (event) => {
+    if (event.payload) applyStatus(event.payload);
+  }),
+);
 
-void listen<{ vertical: boolean; animate: boolean }>("meeting-hud-zone", (event) => {
-  if (event.payload) applyZone(event.payload);
-});
+lifecycle.trackUnlisten(
+  listen<{ vertical: boolean; animate: boolean }>("meeting-hud-zone", (event) => {
+    if (event.payload) applyZone(event.payload);
+  }),
+);
 
 // Local mirrors of the Tauri listeners, same as the dictation HUD page:
 // only the dev-only demo driver dispatches these window events (standalone
 // page, no bridge), so production builds skip the dead listeners.
 if (import.meta.env.DEV) {
-  window.addEventListener("meeting-hud-status", (event) => {
-    const status = (event as CustomEvent<RecordingStatusDto>).detail;
-    if (status) applyStatus(status);
-  });
+  window.addEventListener(
+    "meeting-hud-status",
+    (event) => {
+      const status = (event as CustomEvent<RecordingStatusDto>).detail;
+      if (status) applyStatus(status);
+    },
+    { signal: lifecycle.signal },
+  );
 
-  window.addEventListener("meeting-hud-zone", (event) => {
-    const payload = (event as CustomEvent<{ vertical: boolean; animate: boolean }>).detail;
-    if (payload) applyZone(payload);
-  });
+  window.addEventListener(
+    "meeting-hud-zone",
+    (event) => {
+      const payload = (event as CustomEvent<{ vertical: boolean; animate: boolean }>).detail;
+      if (payload) applyZone(payload);
+    },
+    { signal: lifecycle.signal },
+  );
 }
 
 resetBars();

--- a/src/test/agent-hud.test.ts
+++ b/src/test/agent-hud.test.ts
@@ -38,6 +38,7 @@ describe("agent HUD", () => {
   });
 
   afterEach(() => {
+    window.dispatchEvent(new Event("pagehide"));
     vi.useRealTimers();
   });
 

--- a/src/test/hud-listener-lifecycle.test.ts
+++ b/src/test/hud-listener-lifecycle.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type TauriListener = (event: { payload: unknown }) => unknown;
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+  unlistenHandles: [] as ReturnType<typeof vi.fn>[],
+  listen: vi.fn((_event: string, _listener: TauriListener) => {
+    const unlisten = vi.fn();
+    mocks.unlistenHandles.push(unlisten);
+    return Promise.resolve(unlisten);
+  }),
+  hide: vi.fn().mockResolvedValue(undefined),
+  startDragging: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    hide: mocks.hide,
+    startDragging: mocks.startDragging,
+  }),
+}));
+
+describe("HUD listener lifecycle", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.unlistenHandles.length = 0;
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    document.body.innerHTML = `
+      <main id="agent-hud"></main>
+      <main id="hud"></main>
+      <main id="mhud"></main>
+    `;
+  });
+
+  afterEach(() => {
+    window.dispatchEvent(new Event("pagehide"));
+    Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+  });
+
+  it("releases every Tauri listener on beforeunload", async () => {
+    await import("../agent-hud");
+    await import("../hud");
+    await import("../meeting-hud");
+    await vi.waitFor(() => {
+      expect(mocks.unlistenHandles).toHaveLength(15);
+    });
+
+    window.dispatchEvent(new Event("beforeunload"));
+
+    await vi.waitFor(() => {
+      for (const unlisten of mocks.unlistenHandles) {
+        expect(unlisten).toHaveBeenCalledOnce();
+      }
+    });
+  });
+
+  it("releases a Tauri listener that resolves after beforeunload", async () => {
+    const { createHudLifecycle } = await import("../lib/hud-lifecycle");
+    const lifecycle = createHudLifecycle();
+    const unlisten = vi.fn();
+    let resolveUnlisten: ((handle: () => void) => void) | undefined;
+
+    lifecycle.trackUnlisten(
+      new Promise((resolve) => {
+        resolveUnlisten = resolve;
+      }),
+    );
+    window.dispatchEvent(new Event("beforeunload"));
+    resolveUnlisten?.(unlisten);
+    await Promise.resolve();
+
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+});

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -42,6 +42,7 @@ describe("meeting detection HUD", () => {
   });
 
   afterEach(() => {
+    window.dispatchEvent(new Event("pagehide"));
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
## Summary

- Add a shared HUD window lifecycle that releases Tauri event-bus subscriptions on both `beforeunload` and `pagehide`.
- Apply the lifecycle to all three HUD entry points, including accent sync, module-scope window/document listeners, timers, intervals, and animation-frame work.
- Cover all 15 Tauri unlisten handles in jsdom, including handles that resolve after teardown has already started.

Refs JUN-408

## Root cause

The three HUD entry modules registered process-wide Tauri event listeners without retaining the asynchronous unlisten handles. Recreating a HUD window therefore left old callbacks on the Tauri event bus, retaining their page state and increasing the work performed for each later event.

## Validation

- `CI=true pnpm check`
- `CI=true pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/test/hud-listener-lifecycle.test.ts src/test/agent-hud.test.ts src/test/hud-meeting.test.ts`
- `NODE_OPTIONS=--no-experimental-webstorage make verify`
- `CI=true NODE_OPTIONS=--no-experimental-webstorage make local-ci`

- [ ] Tested visually where it matters (not applicable: lifecycle-only change with no rendered-state or style changes).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- HUD layout, styling, animation behavior, or entry-point restructuring.
- Changes to native window creation or the June API.

## Followups

- None. Keep the PR in draft for the requested review round.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary (not applicable: no security-sensitive behavior changed).
- [x] Workflow action references are pinned to full-length commit SHAs (not applicable: no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable: none changed).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable: none changed).
- [x] User-facing copy follows the repo UI conventions (not applicable: no user-facing copy changed).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787423152&installation_model_id=425925&pr_number=934&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F934&signature=23b3218cea6dc165af6c7a5df700036d4ef00ed3514357e2cdf49c9d83babe81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->