### PR TITLE
perf(notes): avoid redundant preview serialization

### DIFF
--- a/src/components/note-editor/NotePreview.tsx
+++ b/src/components/note-editor/NotePreview.tsx
@@ -17,6 +17,16 @@ type NotePreviewProps = {
   emptyPlaceholder?: string;
 };
 
+type NotePreviewSerializationState = {
+  noteId: string;
+  lastSerializedMarkdown: string;
+  editorDirty: boolean;
+  focusedExternalMarkdown: {
+    editorMarkdown: string;
+    externalMarkdown: string;
+  } | null;
+};
+
 export function NotePreview({
   noteId,
   markdown,
@@ -27,10 +37,24 @@ export function NotePreview({
   const wrapRef = useRef<HTMLDivElement>(null);
   const [toolbar, setToolbar] = useState<{ x: number; y: number } | null>(null);
   const initialHtml = useMemo(() => markdownToHtml(markdown), [noteId]);
-  const focusedExternalMarkdown = useRef<{
-    editorMarkdown: string;
-    externalMarkdown: string;
-  } | null>(null);
+  const serializationStateRef = useRef<NotePreviewSerializationState>({
+    noteId,
+    lastSerializedMarkdown: markdown,
+    editorDirty: false,
+    focusedExternalMarkdown: null,
+  });
+  if (serializationStateRef.current.noteId !== noteId) {
+    serializationStateRef.current = {
+      noteId,
+      lastSerializedMarkdown: markdown,
+      editorDirty: false,
+      focusedExternalMarkdown: null,
+    };
+  }
+  // Capture the note-keyed object in each editor callback. A late blur from
+  // the previous editor can then finish reconciling that note after a switch
+  // without reading the new note's serialization state.
+  const serializationState = serializationStateRef.current;
 
   const editor = useEditor(
     {
@@ -55,21 +79,33 @@ export function NotePreview({
           "aria-multiline": "true",
         },
       },
-      onUpdate: ({ editor }) => {
-        onChange(noteId, htmlToMarkdown(editor.view.dom));
+      onUpdate: ({ editor, transaction }) => {
+        if (!transaction.docChanged) return;
+        const editorMarkdown = htmlToMarkdown(editor.view.dom);
+        serializationState.lastSerializedMarkdown = editorMarkdown;
+        serializationState.editorDirty = true;
+        onChange(noteId, editorMarkdown);
       },
-      onBlur: ({ editor }) => {
+      onBlur: () => {
         // `noteId` here is the value at editor-creation time — the
         // useEditor dep list tears the editor down on note change, so
         // this closure always reflects the note the editor was bound
         // to, even when blur fires during teardown.
-        const editorMarkdown = htmlToMarkdown(editor.view.dom);
-        const mergedMarkdown = mergeFocusedExternalMarkdown(
-          editorMarkdown,
-          focusedExternalMarkdown.current,
-        );
-        focusedExternalMarkdown.current = null;
-        onChange(noteId, mergedMarkdown);
+        const pendingExternalMarkdown = serializationState.focusedExternalMarkdown;
+        serializationState.focusedExternalMarkdown = null;
+        if (serializationState.editorDirty || pendingExternalMarkdown) {
+          if (pendingExternalMarkdown) {
+            const mergedMarkdown = mergeFocusedExternalMarkdown(
+              serializationState.lastSerializedMarkdown,
+              pendingExternalMarkdown,
+            );
+            serializationState.lastSerializedMarkdown = mergedMarkdown;
+            onChange(noteId, mergedMarkdown);
+          }
+          serializationState.editorDirty = false;
+        }
+        // onUpdate already queued the exact latest user edit. Blur only
+        // reconciles a focused external append, then flushes that queue.
         onBlur?.(noteId);
       },
     },
@@ -108,11 +144,11 @@ export function NotePreview({
   useEffect(() => {
     if (!editor || editor.isDestroyed) return;
     try {
-      const current = htmlToMarkdown(editor.view.dom).trim();
+      const current = serializationState.lastSerializedMarkdown.trim();
       if (current === markdown.trim()) return;
       if (editor.isFocused) {
-        focusedExternalMarkdown.current = {
-          editorMarkdown: htmlToMarkdown(editor.view.dom),
+        serializationState.focusedExternalMarkdown = {
+          editorMarkdown: serializationState.lastSerializedMarkdown,
           externalMarkdown: markdown,
         };
         return;
@@ -120,11 +156,14 @@ export function NotePreview({
       editor.commands.setContent(markdownToHtml(markdown), {
         emitUpdate: false,
       });
+      serializationState.lastSerializedMarkdown = markdown;
+      serializationState.editorDirty = false;
+      serializationState.focusedExternalMarkdown = null;
     } catch {
       // Editor is mid-teardown or view isn't ready yet — the next
       // mount will paint the correct content.
     }
-  }, [editor, markdown]);
+  }, [editor, markdown, serializationState]);
 
   function applyFormat(command: "h1" | "bullet" | "bold") {
     if (!editor) return;
@@ -299,7 +338,7 @@ function inlineToMarkdown(node: Node): string {
   return inner;
 }
 
-function htmlToMarkdown(root: HTMLElement): string {
+export function htmlToMarkdown(root: HTMLElement): string {
   const blocks: string[] = [];
   for (const node of Array.from(root.childNodes)) {
     if (node.nodeType === Node.TEXT_NODE) {

--- a/src/components/note-editor/NotePreview.tsx
+++ b/src/components/note-editor/NotePreview.tsx
@@ -87,6 +87,8 @@ export function NotePreview({
         onChange(noteId, editorMarkdown);
       },
       onBlur: () => {
+        // ProseMirror flushes an active IME composition through onUpdate
+        // before invoking onBlur, so this cache includes its final text.
         // `noteId` here is the value at editor-creation time — the
         // useEditor dep list tears the editor down on note change, so
         // this closure always reflects the note the editor was bound
@@ -99,7 +101,6 @@ export function NotePreview({
               serializationState.lastSerializedMarkdown,
               pendingExternalMarkdown,
             );
-            serializationState.lastSerializedMarkdown = mergedMarkdown;
             onChange(noteId, mergedMarkdown);
           }
           serializationState.editorDirty = false;

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -1061,9 +1061,30 @@ describe("NoteEditor", () => {
         })}
       />,
     );
+    await user.type(editor, " written live");
     fireEvent.blur(editor);
 
-    expect(onContentChange).toHaveBeenLastCalledWith("note-1", "Manual notes\n\nGenerated note");
+    expect(onContentChange).toHaveBeenLastCalledWith(
+      "note-1",
+      "Manual notes written live\n\nGenerated note",
+    );
+
+    const mergedMarkdown = onContentChange.mock.lastCall?.[1];
+    expect(mergedMarkdown).toBe("Manual notes written live\n\nGenerated note");
+    rerender(
+      <NoteEditor
+        {...props}
+        onContentChange={onContentChange}
+        note={note({
+          generatedContent: "Generated note",
+          editedContent: mergedMarkdown,
+        })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(editor).toHaveTextContent("Generated note");
+    });
   });
 
   it("offers retry when transcript failed and audio exists", async () => {

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -1,7 +1,8 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { NoteEditor } from "../components/note-editor/NoteEditor";
+import { htmlToMarkdown } from "../components/note-editor/NotePreview";
 import type { NoteDto, RecoverableRecordingDto } from "../lib/tauri";
 
 const now = "2026-05-19T10:00:00Z";
@@ -968,8 +969,70 @@ describe("NoteEditor", () => {
     await user.type(editor, "Unsaved thought");
 
     expect(onContentChange).toHaveBeenLastCalledWith("note-1", "Unsaved thought");
+    const updateCallCount = onContentChange.mock.calls.length;
     fireEvent.blur(editor);
+    expect(onContentChange).toHaveBeenCalledTimes(updateCallCount);
     expect(onFlushNote).toHaveBeenCalledWith("note-1");
+  });
+
+  it("does not echo clean blur or unfocused external content through onContentChange", async () => {
+    const user = userEvent.setup();
+    const onContentChange = vi.fn();
+    const onFlushNote = vi.fn();
+    const { rerender } = render(
+      <NoteEditor
+        {...props}
+        note={note({ generatedContent: "", editedContent: "Before generation" })}
+        onContentChange={onContentChange}
+        onFlushNote={onFlushNote}
+      />,
+    );
+    const editor = screen.getByRole("textbox", { name: "Generated note" });
+
+    rerender(
+      <NoteEditor
+        {...props}
+        note={note({
+          generatedContent: "",
+          editedContent: "Generated content arrived externally",
+        })}
+        onContentChange={onContentChange}
+        onFlushNote={onFlushNote}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(editor).toHaveTextContent("Generated content arrived externally");
+    });
+    expect(onContentChange).not.toHaveBeenCalled();
+
+    await user.click(editor);
+    fireEvent.blur(editor);
+
+    expect(onContentChange).not.toHaveBeenCalled();
+    expect(onFlushNote).toHaveBeenCalledWith("note-1");
+  });
+
+  it("keeps saved markdown stable for nested lists, code blocks, and Unicode", () => {
+    const editorDom = document.createElement("div");
+    editorDom.innerHTML = [
+      "<ul>",
+      "<li><p>Parent 😀</p><ul><li><p><strong>Nested café</strong></p></li></ul></li>",
+      "</ul>",
+      '<pre><code>const π = "λ";\nconsole.log(π);</code></pre>',
+      "<p>Zażółć <em>gęślą</em> jaźń</p>",
+    ].join("");
+
+    // This is the legacy DOM serializer's exact pre-optimization output.
+    // Actual user edits still take this path; blur now reuses that result.
+    expect(htmlToMarkdown(editorDom)).toBe(
+      [
+        "- Parent 😀**Nested café**",
+        "- **Nested café**",
+        'const π = "λ";\nconsole.log(π);',
+        "Zażółć *gęślą* jaźń",
+      ].join("\n\n"),
+    );
   });
 
   it("does not erase generated append content that arrives while editing", async () => {


### PR DESCRIPTION
## Summary

- Cache NotePreview's last serialized markdown per note and track document edits from `transaction.docChanged`.
- Reuse the cached result on blur and external markdown prop changes, while preserving focused external-append reconciliation and the debounced note-save flush.
- Add regression coverage for clean blur/external updates and legacy saved markdown across nested lists, code blocks, and Unicode.

Refs JUN-404

## Root cause

NotePreview used `htmlToMarkdown(editor.view.dom)` both when a document update queued an edit and again on every blur. Its external markdown synchronization effect also serialized the full live editor DOM merely to compare current and incoming content. After the debounced note-save controller landed, blur only needed to flush the already queued edit, so the second serialization became duplicate O(n) work on long notes.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `CI=true NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/test/note-editor.test.tsx` (50 passed)
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` (3,494 passed, 2 skipped)
- `CI=true NODE_OPTIONS=--no-experimental-webstorage make local-ci` (`signoff/frontend` passed; `signoff/rust-macos` not applicable and passed)
- Visual validation not run: this is intentionally a zero-visual-change, pure compute-path optimization.

- [ ] Tested visually where it matters (not applicable: no rendered or interaction changes).
- [ ] Needs a June API (backend) deploy before it works end to end. No - desktop frontend only.

## Out of scope

- Changing the existing markdown conversion semantics.
- Replacing the DOM converter with a new ProseMirror document serializer.
- Changing NoteSaveController debounce or patch behavior.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. Not applicable.
- [x] Workflow action references are pinned to full-length commit SHAs. Not applicable.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787425187&installation_model_id=425925&pr_number=935&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F935&signature=3042d905f91bc6bc711f601b82a1435e60a4705b4a009665ffcef3e40ada0e50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->