### PR TITLE
Stabilize Hermes gateway WebSocket transport

### DIFF
--- a/src/lib/hermes-gateway.ts
+++ b/src/lib/hermes-gateway.ts
@@ -362,6 +362,9 @@ export class HermesGatewayClient {
       if (queued.socket === this.socket) {
         try {
           for (const handler of queued.handlers) {
+            // Deliberately drop in-flight frames when external teardown
+            // unsubscribes after ingress. Unlike the old synchronous loop,
+            // this is benign for the realistic Stop-mid-stream case.
             if (this.handlers.has(handler)) handler(queued.event);
           }
         } catch (error) {

--- a/src/lib/hermes-gateway.ts
+++ b/src/lib/hermes-gateway.ts
@@ -44,6 +44,30 @@ type Frame = {
   error?: { code?: number; message?: string };
 };
 
+type QueuedSend = {
+  id: string | number;
+  method: string;
+  payload: string;
+};
+
+type QueuedEvent = {
+  event: HermesGatewayEvent;
+  handlers: readonly ((event: HermesGatewayEvent) => void)[];
+  socket: WebSocket;
+};
+
+// Browser WebSockets expose bufferedAmount but no drain event. Stop adding to
+// the browser-owned buffer once it reaches 1 MiB, then poll until it drains
+// enough to resume the bounded application-owned FIFO.
+const SEND_BUFFER_HIGH_WATER_BYTES = 1024 * 1024;
+const SEND_QUEUE_LIMIT = 128;
+const SEND_QUEUE_POLL_INTERVAL_MS = 16;
+
+// Leave half of a 60 Hz frame for rendering and other main-thread work. One
+// handler cannot be preempted, but a burst of individually cheap frames is
+// split into FIFO batches with a task boundary between them.
+const EVENT_DISPATCH_BUDGET_MS = 8;
+
 const clientsByMode = new Map<boolean, Set<HermesGatewayClient>>();
 
 /** RPC rejection from the gateway, keeping the JSON-RPC error code so callers
@@ -67,6 +91,17 @@ export class HermesGatewayRequestTimeoutError extends Error {
   constructor(method: string) {
     super(`Hermes request timed out: ${method}`);
     this.name = "HermesGatewayRequestTimeoutError";
+    this.method = method;
+  }
+}
+
+/** A request could not enter the bounded application-owned send queue. */
+export class HermesGatewaySendQueueOverflowError extends Error {
+  readonly method: string;
+
+  constructor(method: string) {
+    super(`Hermes send queue is full; request was not sent: ${method}`);
+    this.name = "HermesGatewaySendQueueOverflowError";
     this.method = method;
   }
 }
@@ -95,6 +130,12 @@ export class HermesGatewayClient {
   private connectPromise?: Promise<void>;
   private handlers = new Set<(event: HermesGatewayEvent) => void>();
   private closeHandlers = new Set<() => void>();
+  private sendQueue: QueuedSend[] = [];
+  private sendQueueTimer?: number;
+  private eventQueue: QueuedEvent[] = [];
+  private eventQueueHead = 0;
+  private eventDispatchScheduled = false;
+  private eventDispatchTimer?: number;
 
   constructor(private readonly fullMode?: boolean) {
     this.registerForMode();
@@ -110,7 +151,7 @@ export class HermesGatewayClient {
     this.registerForMode();
     const socket = new WebSocket(wsUrl);
     this.socket = socket;
-    socket.addEventListener("message", (event) => this.handleMessage(event.data));
+    socket.addEventListener("message", (event) => this.handleMessage(socket, event.data));
     socket.addEventListener("close", () => {
       // A stale socket's close event must not reject requests pending on
       // the socket that replaced it, nor notify close listeners.
@@ -162,6 +203,8 @@ export class HermesGatewayClient {
     const socket = this.socket;
     this.socket = undefined;
     this.unregisterFromMode();
+    this.rejectQueuedSends(new Error("Hermes gateway connection closed."));
+    this.clearTransportQueues();
     socket?.close();
   }
 
@@ -203,15 +246,80 @@ export class HermesGatewayClient {
       };
       pending.timer = window.setTimeout(() => {
         if (this.pending.delete(id)) {
+          this.removeQueuedSend(id);
           reject(new HermesGatewayRequestTimeoutError(method));
         }
       }, timeoutMs);
       this.pending.set(id, pending);
-      socket.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+      try {
+        this.sendOrQueue(socket, {
+          id,
+          method,
+          payload: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+        });
+      } catch (error) {
+        if (this.pending.delete(id)) {
+          if (pending.timer) window.clearTimeout(pending.timer);
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      }
     });
   }
 
-  private handleMessage(raw: unknown) {
+  private sendOrQueue(socket: WebSocket, send: QueuedSend) {
+    if (this.sendQueue.length === 0 && socket.bufferedAmount < SEND_BUFFER_HIGH_WATER_BYTES) {
+      socket.send(send.payload);
+      return;
+    }
+    if (this.sendQueue.length >= SEND_QUEUE_LIMIT) {
+      throw new HermesGatewaySendQueueOverflowError(send.method);
+    }
+    this.sendQueue.push(send);
+    this.flushSendQueue(socket);
+  }
+
+  private flushSendQueue(socket: WebSocket) {
+    if (this.socket !== socket || socket.readyState !== WebSocket.OPEN) return;
+    while (this.sendQueue.length > 0 && socket.bufferedAmount < SEND_BUFFER_HIGH_WATER_BYTES) {
+      const send = this.sendQueue.shift();
+      if (!send || !this.pending.has(send.id)) continue;
+      try {
+        socket.send(send.payload);
+      } catch (error) {
+        const pending = this.pending.get(send.id);
+        if (!pending) continue;
+        if (pending.timer) window.clearTimeout(pending.timer);
+        this.pending.delete(send.id);
+        pending.reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+    if (this.sendQueue.length > 0) {
+      this.scheduleSendQueueFlush(socket);
+    } else if (this.sendQueueTimer !== undefined) {
+      window.clearTimeout(this.sendQueueTimer);
+      this.sendQueueTimer = undefined;
+    }
+  }
+
+  private scheduleSendQueueFlush(socket: WebSocket) {
+    if (this.sendQueueTimer !== undefined) return;
+    this.sendQueueTimer = window.setTimeout(() => {
+      this.sendQueueTimer = undefined;
+      this.flushSendQueue(socket);
+    }, SEND_QUEUE_POLL_INTERVAL_MS);
+  }
+
+  private removeQueuedSend(id: string | number) {
+    const index = this.sendQueue.findIndex((send) => send.id === id);
+    if (index !== -1) this.sendQueue.splice(index, 1);
+    if (this.sendQueue.length === 0 && this.sendQueueTimer !== undefined) {
+      window.clearTimeout(this.sendQueueTimer);
+      this.sendQueueTimer = undefined;
+    }
+  }
+
+  private handleMessage(socket: WebSocket, raw: unknown) {
+    if (this.socket !== socket) return;
     let frame: Frame;
     try {
       frame = JSON.parse(String(raw)) as Frame;
@@ -233,8 +341,51 @@ export class HermesGatewayClient {
       return;
     }
     if (frame.method === "event" && frame.params?.type) {
-      for (const handler of this.handlers) handler(frame.params);
+      // Capture listener ownership at ingress so a listener attached while a
+      // burst is yielding cannot observe frames that predate its subscription.
+      this.eventQueue.push({ event: frame.params, handlers: [...this.handlers], socket });
+      this.scheduleEventDispatch();
     }
+  }
+
+  private scheduleEventDispatch() {
+    if (this.eventDispatchScheduled) return;
+    this.eventDispatchScheduled = true;
+    queueMicrotask(() => this.dispatchEventBatch());
+  }
+
+  private dispatchEventBatch() {
+    const startedAt = performance.now();
+    while (this.eventQueueHead < this.eventQueue.length) {
+      const queued = this.eventQueue[this.eventQueueHead];
+      this.eventQueueHead += 1;
+      if (queued.socket === this.socket) {
+        try {
+          for (const handler of queued.handlers) {
+            if (this.handlers.has(handler)) handler(queued.event);
+          }
+        } catch (error) {
+          // Match browser event-listener behavior: report a handler failure
+          // without stranding later frames in the transport queue.
+          window.setTimeout(() => {
+            throw error;
+          }, 0);
+        }
+      }
+      if (performance.now() - startedAt >= EVENT_DISPATCH_BUDGET_MS) break;
+    }
+    if (this.eventQueueHead < this.eventQueue.length) {
+      // A microtask starts each batch; a timer between batches is the actual
+      // event-loop yield that lets rendering and input run.
+      this.eventDispatchTimer = window.setTimeout(() => {
+        this.eventDispatchTimer = undefined;
+        queueMicrotask(() => this.dispatchEventBatch());
+      }, 0);
+      return;
+    }
+    this.eventQueue = [];
+    this.eventQueueHead = 0;
+    this.eventDispatchScheduled = false;
   }
 
   private rejectAll(error: Error) {
@@ -245,12 +396,38 @@ export class HermesGatewayClient {
     }
   }
 
+  private rejectQueuedSends(error: Error) {
+    for (const send of this.sendQueue) {
+      const pending = this.pending.get(send.id);
+      if (!pending) continue;
+      if (pending.timer) window.clearTimeout(pending.timer);
+      pending.reject(error);
+      this.pending.delete(send.id);
+    }
+  }
+
   private handleUnexpectedClose(socket: WebSocket) {
     if (this.socket !== socket) return;
     this.socket = undefined;
     this.unregisterFromMode();
     this.rejectAll(new Error("Hermes gateway connection closed."));
+    this.clearTransportQueues();
     for (const handler of [...this.closeHandlers]) handler();
+  }
+
+  private clearTransportQueues() {
+    this.sendQueue = [];
+    if (this.sendQueueTimer !== undefined) {
+      window.clearTimeout(this.sendQueueTimer);
+      this.sendQueueTimer = undefined;
+    }
+    this.eventQueue = [];
+    this.eventQueueHead = 0;
+    this.eventDispatchScheduled = false;
+    if (this.eventDispatchTimer !== undefined) {
+      window.clearTimeout(this.eventDispatchTimer);
+      this.eventDispatchTimer = undefined;
+    }
   }
 
   private registerForMode() {

--- a/src/test/hermes-gateway.test.ts
+++ b/src/test/hermes-gateway.test.ts
@@ -3,6 +3,8 @@ import {
   forceDisconnectHermesGatewayClients,
   HermesGatewayClient,
   HermesGatewayError,
+  HermesGatewayRequestTimeoutError,
+  HermesGatewaySendQueueOverflowError,
   isSessionBusyError,
 } from "../lib/hermes-gateway";
 
@@ -16,6 +18,7 @@ class FakeWebSocket {
   static instances: FakeWebSocket[] = [];
 
   readyState = FakeWebSocket.CONNECTING;
+  bufferedAmount = 0;
   sent: string[] = [];
   private listeners = new Map<string, Listener[]>();
 
@@ -76,6 +79,8 @@ describe("HermesGatewayClient", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -187,6 +192,152 @@ describe("HermesGatewayClient", () => {
     expect((error as HermesGatewayError).code).toBe(4009);
     expect(isSessionBusyError(error)).toBe(true);
     expect(isSessionBusyError(new Error("session busy"))).toBe(false);
+  });
+
+  it("queues sends behind socket backpressure and flushes them in request order", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new HermesGatewayClient();
+      const connecting = client.connect("ws://gateway");
+      const socket = FakeWebSocket.instances[0];
+      socket.open();
+      await connecting;
+
+      socket.bufferedAmount = Number.MAX_SAFE_INTEGER;
+      const first = client.request<{ ok: string }>("first");
+      const second = client.request<{ ok: string }>("second");
+      expect(socket.sent).toEqual([]);
+
+      socket.bufferedAmount = 0;
+      await vi.advanceTimersByTimeAsync(16);
+
+      const frames = socket.sent.map((raw) => JSON.parse(raw) as { id: number; method: string });
+      expect(frames.map((frame) => frame.method)).toEqual(["first", "second"]);
+
+      socket.message({ id: frames[0].id, result: { ok: "first" } });
+      socket.message({ id: frames[1].id, result: { ok: "second" } });
+      await expect(first).resolves.toEqual({ ok: "first" });
+      await expect(second).resolves.toEqual({ ok: "second" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects a request that would overflow the bounded send queue", async () => {
+    const client = new HermesGatewayClient();
+    const connecting = client.connect("ws://gateway");
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+    await connecting;
+
+    socket.bufferedAmount = Number.MAX_SAFE_INTEGER;
+    const queued = Array.from({ length: 128 }, (_, index) =>
+      client.request(`queued.${index}`).catch((error: unknown) => error),
+    );
+
+    const overflow = client.request("overflow");
+    await expect(overflow).rejects.toBeInstanceOf(HermesGatewaySendQueueOverflowError);
+    await expect(overflow).rejects.toMatchObject({ method: "overflow" });
+    expect(socket.sent).toEqual([]);
+
+    client.close();
+    const errors = await Promise.all(queued);
+    expect(errors).toHaveLength(128);
+    expect(errors.every((error) => error instanceof Error)).toBe(true);
+  });
+
+  it("keeps request timeout accounting active while a send waits for drain", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new HermesGatewayClient();
+      const connecting = client.connect("ws://gateway");
+      const socket = FakeWebSocket.instances[0];
+      socket.open();
+      await connecting;
+
+      socket.bufferedAmount = Number.MAX_SAFE_INTEGER;
+      const pending = client.request("session.active_list", {}, 25);
+      const timedOut = pending.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(25);
+      await expect(timedOut).resolves.toBeInstanceOf(HermesGatewayRequestTimeoutError);
+
+      socket.bufferedAmount = 0;
+      await vi.advanceTimersByTimeAsync(16);
+      expect(socket.sent).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dispatches a 500-frame burst in ordered, yielding time-budgeted batches", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new HermesGatewayClient();
+      const connecting = client.connect("ws://gateway");
+      const socket = FakeWebSocket.instances[0];
+      socket.open();
+      await connecting;
+
+      let simulatedNow = 0;
+      let batch = 0;
+      const batchSizes: number[] = [];
+      const received: number[] = [];
+      vi.spyOn(performance, "now").mockImplementation(() => simulatedNow);
+      const setTimeout = window.setTimeout.bind(window);
+      vi.spyOn(window, "setTimeout").mockImplementation(((
+        handler: TimerHandler,
+        timeout?: number,
+        ...args: unknown[]
+      ) => {
+        if (timeout === 0) batch += 1;
+        return setTimeout(handler, timeout, ...args);
+      }) as typeof window.setTimeout);
+      client.onEvent((event) => {
+        const index = (event.payload as { index: number }).index;
+        received.push(index);
+        batchSizes[batch] = (batchSizes[batch] ?? 0) + 1;
+        simulatedNow += 1;
+      });
+
+      for (let index = 0; index < 500; index += 1) {
+        socket.message({
+          method: "event",
+          params: { type: "message.delta", session_id: "session-1", payload: { index } },
+        });
+      }
+
+      expect(received).toEqual([]);
+      await Promise.resolve();
+      expect(received.length).toBeGreaterThan(0);
+      expect(received.length).toBeLessThan(500);
+
+      await vi.runAllTimersAsync();
+
+      expect(received).toEqual(Array.from({ length: 500 }, (_, index) => index));
+      expect(batchSizes.length).toBeGreaterThan(1);
+      expect(Math.max(...batchSizes)).toBeLessThanOrEqual(8);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not replay a queued frame to a listener attached after ingress", async () => {
+    const client = new HermesGatewayClient();
+    const connecting = client.connect("ws://gateway");
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+    await connecting;
+
+    socket.message({
+      method: "event",
+      params: { type: "message.delta", session_id: "session-1" },
+    });
+    const lateListener = vi.fn();
+    client.onEvent(lateListener);
+
+    await Promise.resolve();
+    expect(lateListener).not.toHaveBeenCalled();
   });
 
   it("notifies close listeners on unexpected drops but not on explicit close", async () => {


### PR DESCRIPTION
## Summary

- Gate outbound WebSocket requests on `bufferedAmount`, queue them in a bounded FIFO, and reject the request that exceeds the queue limit instead of dropping it.
- Dispatch inbound Hermes events in ordered, time-budgeted batches with an event-loop yield between batches while keeping JSON-RPC responses synchronous for timeout and heartbeat accounting.
- Clear socket-owned send and event queues during close and force-disconnect recovery so stale work cannot cross transports.

Refs JUN-403

## Root cause

The gateway sent every request directly into the browser-owned WebSocket buffer without inspecting `bufferedAmount`, so a slow transport could accumulate unbounded writes. It also ran every event handler inline from the WebSocket message callback, allowing bursts of streaming notifications to monopolize the main thread.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` (216 files passed; 3,499 tests passed; 2 skipped)
- `env NODE_OPTIONS=--no-experimental-webstorage make verify`
- `env NODE_OPTIONS=--no-experimental-webstorage make local-ci` (`signoff/frontend` passed; `signoff/rust-macos` not applicable and posted)

- [ ] Tested visually where it matters (not applicable: transport-only change with no UI surface).
- [ ] Needs a June API (backend) deploy before it works end to end (not applicable: desktop transport change only).

## Out of scope

- Changing the merged stream delta rendering batches from JUN-388.
- Changing Hermes wire contracts, lease or settlement ordering, heartbeat thresholds, or force-disconnect policy.

## Followups

- Run the requested review round while this PR remains in draft.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary (not applicable: no security-sensitive behavior changed).
- [x] Workflow action references are pinned to full-length commit SHAs (not applicable: no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable: none changed).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable: no backend changes).
- [x] User-facing copy follows the repo UI conventions (not applicable: no user-facing copy).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787426467&installation_model_id=425925&pr_number=937&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F937&signature=f346733e844ad7f95214713f1ec824aefdf8dd7553794b43f1bfae1ec3c7abe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->