### PR TITLE
fix(hermes): stabilize startup assets and image attachments

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -358,7 +358,9 @@ _Avoid_: trait (`traits` is a separate, non-authoritative Venice field).
 A file or image referenced by path. Agent-composer attachments and DOM-dropped
 report attachments are imported into the Hermes workspace; native-picker
 issue-report attachments keep their original local paths. Composer images
-additionally get a structured `image.attach_bytes`.
+are snapshotted by Rust into a session-scoped workspace directory and attached
+with `image.attach`; `image.attach_bytes` remains an additive fallback for
+callers without a gateway-local path.
 _Avoid_: upload (unqualified).
 
 **Note reference**:

--- a/docs/adr/0008-image-generation-and-editing-tools.md
+++ b/docs/adr/0008-image-generation-and-editing-tools.md
@@ -282,3 +282,23 @@ and user-uploaded attachments are NOT tool-path edit sources - Hermes provides
 no per-call session identity to MCP servers, so a conversation-scoped
 allow-list is impossible on this transport. Restoring attachment editing needs
 a session-identity mechanism first (recorded as a PR followup).
+
+## Addendum - 2026-07-23 (native path attachment snapshots)
+
+Supersedes the Phase A transport detail above. June's desktop composer no
+longer reads an image into a base64 data URL and sends it through both the
+Tauri IPC bridge and Hermes WebSocket. Before `image.attach`, Rust now
+canonicalizes the source, rejects symbolic links and hidden or sensitive
+paths, requires the file to be under the Hermes workspace or a generated-image
+directory, enforces the existing 50 MB cap, and retains an open source handle.
+It then hardlinks the image when the filesystem permits, otherwise copies from
+that validated handle, into a session-scoped directory under the Hermes
+workspace. The runtime session id is hashed before it contributes to the
+directory name.
+
+The frontend passes only the prepared path to Hermes through `image.attach`.
+`image.attach_bytes` remains an additive wire-compatible fallback for callers
+that cannot provide a gateway-local path. Preview thumbnail generation stays a
+separate bounded operation and is not reused as model input. A rejected native
+path does not silently downgrade to the byte fallback because doing so would
+bypass Rust's path-validation boundary.

--- a/docs/hermes-architecture.md
+++ b/docs/hermes-architecture.md
@@ -63,8 +63,12 @@ classified events into `AgentChatTurn` / `AgentChatPart[]` for rendering.
 4. If the session has a queued model choice, June applies it to the idle live
    session with `config.set` before submitting anything. A failed switch blocks
    the send and leaves the choice queued.
-5. Images are attached via `image.attach_bytes` (bytes read at attach time,
-   never stored on state/trace/artifacts).
+5. Images are attached by asking Rust to validate and snapshot the source into
+   a session-scoped workspace directory, then passing that local path through
+   `image.attach`. Image bytes never cross the JS bridge or Hermes WebSocket on
+   this path. `image.attach_bytes` remains an additive fallback for callers
+   without a gateway-local path; neither path stores bytes in state, traces, or
+   artifacts.
 6. `gateway.request("prompt.submit")` (ack-style) → live `event` frames →
    `classifyHermesEvent` → `agent-chat-runtime` builds turns → React renders.
 

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -119,6 +119,7 @@ const HERMES_IMAGE_PREVIEW_MAX_BYTES: u64 = 5 * 1024 * 1024;
 const HERMES_TEXT_PREVIEW_MAX_BYTES: u64 = 2 * 1024 * 1024;
 const HERMES_SKILL_MAX_BYTES: usize = 512 * 1024;
 const JUNE_PROVIDER_PROXY_MAX_HEADER_BYTES: usize = 32 * 1024;
+const JUNE_WORKSPACE_SESSION_ATTACHMENTS_DIR_NAME: &str = "session-attachments";
 // Must sit ABOVE june-api's aggregate request-string cap
 // (`MAX_AGENT_TOTAL_STRING_CHARS`, 6M chars) counted in BYTES, or this proxy
 // rejects an in-window upload before june-api's larger cap can allow it (JUN-169
@@ -291,6 +292,23 @@ const JUNE_CONNECTOR_MCP_ACCOUNT_ENV: &str = "JUNE_CONNECTOR_ACCOUNT";
 /// its proxy calls skip the approval park. Only the auto servers carry it; the
 /// base action servers do not, so their calls always park (approval mode).
 const JUNE_CONNECTOR_MCP_GRANT_ENV: &str = "JUNE_CONNECTOR_GRANT";
+
+/// Writes an app-owned runtime asset only when its exact bytes changed.
+///
+/// Byte equality is intentional: these files are generated from compile-time
+/// assets, so there is no semantic merge to preserve. Keeping the comparison
+/// here makes every caller share the same missing/read-error behavior and lets
+/// tests assert that an unchanged startup performs zero writes.
+fn write_file_if_changed(path: &Path, contents: &[u8]) -> io::Result<bool> {
+    match fs::read(path) {
+        Ok(existing) if existing == contents => return Ok(false),
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    fs::write(path, contents)?;
+    Ok(true)
+}
 /// Hermes-side per-tool timeout for the connector action servers. Longer than
 /// the read servers because a mutating call can park on the user's approval
 /// (see connectors::approvals, 600s window).
@@ -1292,6 +1310,24 @@ pub struct ImportHermesFileRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct PrepareHermesImageAttachmentRequest {
+    /// The live runtime session that will receive the image. Its digest scopes
+    /// the native snapshot directory without trusting the id as a path.
+    pub session_id: String,
+    /// A June workspace/generated-image reference, never an arbitrary host path.
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreparedHermesImageAttachment {
+    pub path: String,
+    pub mime_type: String,
+    pub size: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ImportedHermesFile {
     pub name: String,
     pub path: String,
@@ -1688,17 +1724,25 @@ async fn start_hermes_bridge_inner(
         .unwrap_or(default_cwd);
     let cwd_display = Some(cwd.to_string_lossy().into_owned());
     let provider_proxy = ensure_provider_proxy(app, bridge, &hermes_home).await?;
-    let june_context_mcp = sync_june_context_mcp(app, &command)?;
-    let june_web_mcp = sync_june_web_mcp(app, &command)?;
-    let june_obsidian_mcp = sync_june_obsidian_mcp(app, &command)?;
-    let june_image_mcp = sync_june_image_mcp(app, &hermes_home, &command)?;
     let video_generation_enabled = crate::feature_flags::VIDEO_GENERATION_ENABLED;
-    let june_video_mcp = if video_generation_enabled {
-        Some(sync_june_video_mcp(app, &hermes_home, &command)?)
-    } else {
-        None
+    let static_mcps = {
+        let app = app.clone();
+        let hermes_home = hermes_home.clone();
+        let command = command.clone();
+        tokio::task::spawn_blocking(move || {
+            sync_june_static_mcps(&app, &hermes_home, &command, video_generation_enabled)
+        })
+        .await
+        .map_err(|error| AppError::new("hermes_bridge_start_failed", error.to_string()))??
     };
-    let june_recorder_mcp = sync_june_recorder_mcp(app, &command)?;
+    let JuneStaticMcpConfigs {
+        context: june_context_mcp,
+        web: june_web_mcp,
+        obsidian: june_obsidian_mcp,
+        image: june_image_mcp,
+        video: june_video_mcp,
+        recorder: june_recorder_mcp,
+    } = static_mcps;
     // These readiness paths are independent and used to run serially on the
     // first Hermes launch. Start them together so Browser setup and connector
     // discovery overlap the Computer use permission probe and driver prewarm.
@@ -1721,7 +1765,15 @@ async fn start_hermes_bridge_inner(
     bridge
         .browser_broker
         .replace_routine_grants(june_browser_mcp.routine_grants.clone());
-    let june_computer_use_mcp = sync_june_computer_use_mcp(app, &command, computer_use_ready)?;
+    let june_computer_use_mcp = {
+        let app = app.clone();
+        let command = command.clone();
+        tokio::task::spawn_blocking(move || {
+            sync_june_computer_use_mcp(&app, &command, computer_use_ready)
+        })
+        .await
+        .map_err(|error| AppError::new("hermes_bridge_start_failed", error.to_string()))??
+    };
     // The private-connector MCP servers are registered only when there is
     // something for them to serve: Gmail and Calendar need a connected Google
     // account (v1: the first connected account); Linear reads need a connected
@@ -1733,60 +1785,75 @@ async fn start_hermes_bridge_inner(
     let connectors_registered = june_connector_mcp
         .as_ref()
         .is_some_and(ConnectorMcpConfigs::has_interactive_servers);
-    sync_hermes_config(
-        app,
-        &hermes_home,
-        provider_proxy.port,
-        &provider_proxy.token,
-        &provider_proxy.memory_token,
-        &provider_proxy.recorder_token,
-        &provider_proxy.routine_browser_token,
-        &provider_proxy.connector_token,
-        &provider_proxy.computer_use_token,
-        &provider_proxy.obsidian_token,
-        supports_vision,
-        &june_context_mcp,
-        &june_web_mcp,
-        &june_obsidian_mcp,
-        &june_image_mcp,
-        june_video_mcp.as_ref(),
-        &june_recorder_mcp,
-        &june_browser_mcp,
-        &june_computer_use_mcp,
-        june_connector_mcp.as_ref(),
-    )?;
-
-    // Wrap the spawn in a macOS Seatbelt write-jail when possible. The model,
-    // its tool calls, and any subprocess it forks all inherit the profile, so
-    // destructive writes (rm -rf of user dirs, dotfile rewrites, TCC db edits)
-    // are denied by the kernel rather than by Hermes' own pattern checks.
-    // Resolved before the soul write so June's self-knowledge about the jail
-    // matches what sandboxed spawns actually enforce.
     let agent_cli_access = agent_cli_access_enabled(app);
-    let sandbox_profile = if full_mode {
-        None
-    } else {
-        prepare_sandbox(app, &hermes_home, agent_cli_access)
+    let browser_use_enabled = crate::experimental_settings::browser_use_enabled(app);
+    let (sandbox_profile, sandbox_available) = {
+        let app = app.clone();
+        let hermes_home = hermes_home.clone();
+        let provider_proxy_port = provider_proxy.port;
+        let provider_proxy_token = provider_proxy.token.clone();
+        let memory_proxy_token = provider_proxy.memory_token.clone();
+        let recorder_proxy_token = provider_proxy.recorder_token.clone();
+        let routine_browser_proxy_token = provider_proxy.routine_browser_token.clone();
+        let connector_proxy_token = provider_proxy.connector_token.clone();
+        let computer_use_proxy_token = provider_proxy.computer_use_token.clone();
+        let obsidian_proxy_token = provider_proxy.obsidian_token.clone();
+        tokio::task::spawn_blocking(move || {
+            sync_hermes_config(
+                &app,
+                &hermes_home,
+                provider_proxy_port,
+                &provider_proxy_token,
+                &memory_proxy_token,
+                &recorder_proxy_token,
+                &routine_browser_proxy_token,
+                &connector_proxy_token,
+                &computer_use_proxy_token,
+                &obsidian_proxy_token,
+                supports_vision,
+                &june_context_mcp,
+                &june_web_mcp,
+                &june_obsidian_mcp,
+                &june_image_mcp,
+                june_video_mcp.as_ref(),
+                &june_recorder_mcp,
+                &june_browser_mcp,
+                &june_computer_use_mcp,
+                june_connector_mcp.as_ref(),
+            )?;
+
+            // Wrap the spawn in a macOS Seatbelt write-jail when possible. The
+            // model and every subprocess inherit it. Resolve it before SOUL so
+            // June's self-knowledge matches the protection actually available.
+            let sandbox_profile = if full_mode {
+                None
+            } else {
+                prepare_sandbox(&app, &hermes_home, agent_cli_access)
+            };
+            let sandboxed = sandbox_profile.is_some();
+            // SOUL.md is shared by both runtime modes, so it describes the
+            // per-session mode split rather than only the process being built.
+            let sandbox_available = if full_mode {
+                sandbox_would_engage(&app, &hermes_home)
+            } else {
+                sandboxed
+            };
+            sync_june_soul(
+                &hermes_home,
+                sandbox_available,
+                agent_cli_access,
+                // None (feature-flagged out) renders no Browser use section.
+                browser_use_enabled.then_some(browser_access),
+                june_memory_enabled(&june_context_mcp.memory_settings_path),
+                video_generation_enabled,
+                connectors_registered,
+            )?;
+            Ok::<_, AppError>((sandbox_profile, sandbox_available))
+        })
+        .await
+        .map_err(|error| AppError::new("hermes_bridge_start_failed", error.to_string()))??
     };
     let sandboxed = sandbox_profile.is_some();
-    // SOUL.md is shared by both processes (single home), so its sandbox
-    // section describes the per-session mode split rather than this spawn.
-    let sandbox_available = if full_mode {
-        sandbox_would_engage(app, &hermes_home)
-    } else {
-        sandboxed
-    };
-    sync_june_soul(
-        &hermes_home,
-        sandbox_available,
-        agent_cli_access,
-        // None (feature-flagged out) renders no browser SOUL section at all;
-        // the grant only matters once the feature exists in this build.
-        crate::experimental_settings::browser_use_enabled(app).then_some(browser_access),
-        june_memory_enabled(&june_context_mcp.memory_settings_path),
-        video_generation_enabled,
-        connectors_registered,
-    )?;
     if sandboxed {
         eprintln!("Spawning Hermes under the macOS Seatbelt write-jail.");
     } else if full_mode {
@@ -2301,6 +2368,15 @@ struct JuneVideoMcpConfig {
 struct JuneRecorderMcpConfig {
     command: String,
     script_path: PathBuf,
+}
+
+struct JuneStaticMcpConfigs {
+    context: JuneContextMcpConfig,
+    web: JuneWebMcpConfig,
+    obsidian: JuneObsidianMcpConfig,
+    image: JuneImageMcpConfig,
+    video: Option<JuneVideoMcpConfig>,
+    recorder: JuneRecorderMcpConfig,
 }
 
 #[derive(Debug, Clone)]
@@ -4640,6 +4716,22 @@ pub async fn hermes_bridge_image_data_url(
     image_source_data_url(&requested)
 }
 
+/// Validates a June-owned image reference and snapshots it into a directory
+/// scoped to the live runtime session. The frontend passes only the returned
+/// native path to Hermes' `image.attach`; image bytes never enter Tauri IPC or
+/// the WebSocket. The legacy data-url command remains available for callers
+/// that genuinely need the remote-client `image.attach_bytes` contract.
+#[tauri::command]
+pub async fn prepare_hermes_bridge_image_attachment(
+    app: AppHandle,
+    request: PrepareHermesImageAttachmentRequest,
+) -> Result<PreparedHermesImageAttachment, AppError> {
+    let hermes_home = resolve_june_hermes_home(&app)?;
+    tokio::task::spawn_blocking(move || prepare_hermes_image_attachment(&hermes_home, &request))
+        .await
+        .map_err(|error| AppError::new("hermes_image_attach_failed", error.to_string()))?
+}
+
 #[tauri::command]
 pub async fn hermes_bridge_file_text(
     app: AppHandle,
@@ -4792,22 +4884,12 @@ fn validate_hermes_file_path(app: &AppHandle, path: &str) -> Result<PathBuf, App
             "This June file is hidden or sensitive.",
         ));
     }
-    let allowed_roots = filesystem_roots(&hermes_home)?
-        .into_iter()
-        .filter_map(|root| root.path.canonicalize().ok())
-        .collect::<Vec<_>>();
-    let mut extended_allowed_roots = allowed_roots.clone();
     // "image_cache" is where the Hermes runtime copies tool-result images;
     // assistant MEDIA: references point at those copies, so dropping it breaks
     // inline rendering and download of every tool-generated image. Add both
     // video dirs now; QA must confirm the exact runtime cache dir for inline
     // generated-video rendering once the frontend/MCP chunks land.
-    extended_allowed_roots.extend(
-        GENERATED_IMAGE_ROOTS
-            .into_iter()
-            .chain(GENERATED_VIDEO_ROOTS)
-            .filter_map(|relative| hermes_home.join(relative).canonicalize().ok()),
-    );
+    let extended_allowed_roots = hermes_file_allowed_roots(&hermes_home)?;
     let allowed = extended_allowed_roots
         .iter()
         .any(|root| requested.starts_with(root));
@@ -4825,6 +4907,173 @@ fn validate_hermes_file_path(app: &AppHandle, path: &str) -> Result<PathBuf, App
     }
     tracing::info!(requested_path = %path, resolved_path = %requested.display(), "validate_hermes_file_path accepted path");
     Ok(requested)
+}
+
+fn prepare_hermes_image_attachment(
+    hermes_home: &Path,
+    request: &PrepareHermesImageAttachmentRequest,
+) -> Result<PreparedHermesImageAttachment, AppError> {
+    let session_id = request.session_id.trim();
+    if session_id.is_empty() {
+        return Err(AppError::new(
+            "hermes_image_attach_failed",
+            "A runtime session id is required to attach an image.",
+        ));
+    }
+
+    let candidate = resolve_hermes_file_candidate(hermes_home, &request.path);
+    let link_metadata = fs::symlink_metadata(&candidate)
+        .map_err(|error| AppError::new("hermes_image_attach_failed", error.to_string()))?;
+    if link_metadata.file_type().is_symlink() {
+        return Err(AppError::new(
+            "hermes_image_attach_denied",
+            "Symbolic links cannot be attached as images.",
+        ));
+    }
+    let source_path = candidate
+        .canonicalize()
+        .map_err(|error| AppError::new("hermes_image_attach_failed", error.to_string()))?;
+    if is_hidden_secret_path(&source_path) {
+        return Err(AppError::new(
+            "hermes_image_attach_denied",
+            "Hidden or sensitive files cannot be attached.",
+        ));
+    }
+    let allowed = hermes_image_attachment_allowed_roots(hermes_home)
+        .iter()
+        .any(|root| source_path.starts_with(root));
+    if !allowed {
+        return Err(AppError::new(
+            "hermes_image_attach_denied",
+            "Only images in June's workspace or generated-image directories can be attached.",
+        ));
+    }
+    let mime_type = image_mime_type(&source_path).ok_or_else(|| {
+        AppError::new(
+            "hermes_image_attach_denied",
+            "This file type cannot be attached as an image.",
+        )
+    })?;
+    let mut source = open_image_attachment_source(&source_path)
+        .map_err(|error| AppError::new("hermes_image_attach_failed", error.to_string()))?;
+    let metadata = source
+        .metadata()
+        .map_err(|error| AppError::new("hermes_image_attach_failed", error.to_string()))?;
+    if !metadata.is_file() {
+        return Err(AppError::new(
+            "hermes_image_attach_denied",
+            "Only image files can be attached.",
+        ));
+    }
+    if metadata.len() > HERMES_IMPORT_MAX_BYTES {
+        return Err(AppError::new(
+            "hermes_image_attach_denied",
+            "Image files must be 50 MB or smaller.",
+        ));
+    }
+
+    // Never interpolate the runtime session id into a path. A stable digest
+    // provides the per-session namespace while treating the wire id as opaque.
+    let session_dir = hermes_home
+        .join("workspace")
+        .join(JUNE_WORKSPACE_SESSION_ATTACHMENTS_DIR_NAME)
+        .join(hex_encode(&sha256_bytes(session_id.as_bytes())));
+    fs::create_dir_all(&session_dir)
+        .map_err(|error| AppError::new("hermes_image_attach_failed", error.to_string()))?;
+    let destination = unique_upload_path(&session_dir, &source_path)
+        .map_err(|error| AppError::new("hermes_image_attach_failed", error.message))?;
+    snapshot_image_source(&mut source, &source_path, &destination)
+        .map_err(|error| AppError::new("hermes_image_attach_failed", error.to_string()))?;
+
+    Ok(PreparedHermesImageAttachment {
+        path: destination.to_string_lossy().into_owned(),
+        mime_type: mime_type.to_string(),
+        size: metadata.len(),
+    })
+}
+
+fn hermes_file_allowed_roots(hermes_home: &Path) -> Result<Vec<PathBuf>, AppError> {
+    let mut roots = filesystem_roots(hermes_home)?
+        .into_iter()
+        .filter_map(|root| root.path.canonicalize().ok())
+        .collect::<Vec<_>>();
+    roots.extend(
+        GENERATED_IMAGE_ROOTS
+            .into_iter()
+            .chain(GENERATED_VIDEO_ROOTS)
+            .filter_map(|relative| hermes_home.join(relative).canonicalize().ok()),
+    );
+    Ok(roots)
+}
+
+fn hermes_image_attachment_allowed_roots(hermes_home: &Path) -> Vec<PathBuf> {
+    std::iter::once(hermes_home.join("workspace"))
+        .chain(
+            GENERATED_IMAGE_ROOTS
+                .into_iter()
+                .map(|relative| hermes_home.join(relative)),
+        )
+        .filter_map(|root| root.canonicalize().ok())
+        .collect()
+}
+
+#[cfg(unix)]
+fn open_image_attachment_source(path: &Path) -> io::Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_image_attachment_source(path: &Path) -> io::Result<fs::File> {
+    fs::File::open(path)
+}
+
+fn snapshot_image_source(
+    source: &mut fs::File,
+    source_path: &Path,
+    destination: &Path,
+) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        if fs::hard_link(source_path, destination).is_ok() {
+            let source_metadata = source.metadata()?;
+            let destination_metadata = fs::metadata(destination)?;
+            if source_metadata.dev() == destination_metadata.dev()
+                && source_metadata.ino() == destination_metadata.ino()
+            {
+                return Ok(());
+            }
+            // The source path changed between validation and link creation.
+            // Drop the wrong snapshot and copy from the retained validated
+            // handle, mirroring note_audio_export's validate-to-read discipline.
+            fs::remove_file(destination)?;
+        }
+    }
+
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    // Do not clean up an AlreadyExists failure: another writer owns that path.
+    let mut output = options.open(destination)?;
+    let write_result = (|| -> io::Result<()> {
+        io::copy(source, &mut output)?;
+        output.flush()?;
+        output.sync_all()
+    })();
+    if write_result.is_err() {
+        let _ = fs::remove_file(destination);
+    }
+    write_result
 }
 
 fn validate_dropped_file_path(path: &str) -> Result<PathBuf, AppError> {
@@ -8840,10 +9089,8 @@ const HERMES_RUNTIME_PATCH_SCRIPT: &str = include_str!("hermes/apply_june_patche
 
 fn write_managed_hermes_patch_script(runtime_dir: &Path) -> Result<PathBuf, AppError> {
     let path = runtime_dir.join("apply-june-hermes-patches.py");
-    if fs::read_to_string(&path).ok().as_deref() != Some(HERMES_RUNTIME_PATCH_SCRIPT) {
-        fs::write(&path, HERMES_RUNTIME_PATCH_SCRIPT)
-            .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
-    }
+    write_file_if_changed(&path, HERMES_RUNTIME_PATCH_SCRIPT.as_bytes())
+        .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
     Ok(path)
 }
 
@@ -8885,10 +9132,7 @@ fn ensure_managed_hermes_sitecustomize(install_dir: &Path) -> Result<(), AppErro
         fs::create_dir_all(&site_packages)
             .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
         let sitecustomize = site_packages.join("sitecustomize.py");
-        if fs::read_to_string(&sitecustomize).ok().as_deref() == Some(HERMES_SITE_CUSTOMIZE) {
-            continue;
-        }
-        fs::write(&sitecustomize, HERMES_SITE_CUSTOMIZE)
+        write_file_if_changed(&sitecustomize, HERMES_SITE_CUSTOMIZE.as_bytes())
             .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
     }
     Ok(())
@@ -9885,6 +10129,24 @@ const CRON_SANDBOXED_TOOLSETS: &[&str] = &[
 /// applies on top of either.
 const UPSTREAM_DISABLED_TOOLSETS: &[&str] = &["browser", "computer_use"];
 
+fn sync_june_static_mcps(
+    app: &AppHandle,
+    hermes_home: &Path,
+    hermes_command: &str,
+    video_generation_enabled: bool,
+) -> Result<JuneStaticMcpConfigs, AppError> {
+    Ok(JuneStaticMcpConfigs {
+        context: sync_june_context_mcp(app, hermes_command)?,
+        web: sync_june_web_mcp(app, hermes_command)?,
+        obsidian: sync_june_obsidian_mcp(app, hermes_command)?,
+        image: sync_june_image_mcp(app, hermes_home, hermes_command)?,
+        video: video_generation_enabled
+            .then(|| sync_june_video_mcp(app, hermes_home, hermes_command))
+            .transpose()?,
+        recorder: sync_june_recorder_mcp(app, hermes_command)?,
+    })
+}
+
 fn sync_june_context_mcp(
     app: &AppHandle,
     hermes_command: &str,
@@ -9895,7 +10157,7 @@ fn sync_june_context_mcp(
     fs::create_dir_all(&mcp_dir)
         .map_err(|error| AppError::new("june_context_mcp_failed", error.to_string()))?;
     let script_path = mcp_dir.join(JUNE_CONTEXT_MCP_SCRIPT_NAME);
-    fs::write(&script_path, JUNE_CONTEXT_MCP_SCRIPT)
+    write_file_if_changed(&script_path, JUNE_CONTEXT_MCP_SCRIPT.as_bytes())
         .map_err(|error| AppError::new("june_context_mcp_failed", error.to_string()))?;
 
     let paths = crate::app_paths::AppPaths::from_data_dir(data_dir)
@@ -9939,7 +10201,7 @@ fn sync_june_obsidian_mcp(
     fs::create_dir_all(&mcp_dir)
         .map_err(|error| AppError::new("june_obsidian_mcp_failed", error.to_string()))?;
     let script_path = mcp_dir.join(JUNE_OBSIDIAN_MCP_SCRIPT_NAME);
-    fs::write(&script_path, JUNE_OBSIDIAN_MCP_SCRIPT)
+    write_file_if_changed(&script_path, JUNE_OBSIDIAN_MCP_SCRIPT.as_bytes())
         .map_err(|error| AppError::new("june_obsidian_mcp_failed", error.to_string()))?;
     Ok(JuneObsidianMcpConfig {
         command: hermes_python_command(hermes_command),
@@ -9954,7 +10216,7 @@ fn sync_june_web_mcp(app: &AppHandle, hermes_command: &str) -> Result<JuneWebMcp
     fs::create_dir_all(&mcp_dir)
         .map_err(|error| AppError::new("june_web_mcp_failed", error.to_string()))?;
     let script_path = mcp_dir.join(JUNE_WEB_MCP_SCRIPT_NAME);
-    fs::write(&script_path, JUNE_WEB_MCP_SCRIPT)
+    write_file_if_changed(&script_path, JUNE_WEB_MCP_SCRIPT.as_bytes())
         .map_err(|error| AppError::new("june_web_mcp_failed", error.to_string()))?;
 
     Ok(JuneWebMcpConfig {
@@ -9974,7 +10236,7 @@ fn sync_june_image_mcp(
     fs::create_dir_all(&mcp_dir)
         .map_err(|error| AppError::new("june_image_mcp_failed", error.to_string()))?;
     let script_path = mcp_dir.join(JUNE_IMAGE_MCP_SCRIPT_NAME);
-    fs::write(&script_path, JUNE_IMAGE_MCP_SCRIPT)
+    write_file_if_changed(&script_path, JUNE_IMAGE_MCP_SCRIPT.as_bytes())
         .map_err(|error| AppError::new("june_image_mcp_failed", error.to_string()))?;
     // Keep generated/edited images in Hermes's image dir. The MCP writes the
     // proxy-returned storage filename here; Rust validates source refs later.
@@ -10006,7 +10268,7 @@ fn sync_june_video_mcp(
     fs::create_dir_all(&mcp_dir)
         .map_err(|error| AppError::new("june_video_mcp_failed", error.to_string()))?;
     let script_path = mcp_dir.join(JUNE_VIDEO_MCP_SCRIPT_NAME);
-    fs::write(&script_path, JUNE_VIDEO_MCP_SCRIPT)
+    write_file_if_changed(&script_path, JUNE_VIDEO_MCP_SCRIPT.as_bytes())
         .map_err(|error| AppError::new("june_video_mcp_failed", error.to_string()))?;
     let videos_dir = hermes_home.join(JUNE_VIDEO_MCP_VIDEOS_DIR_NAME);
     fs::create_dir_all(&videos_dir)
@@ -10029,7 +10291,7 @@ fn sync_june_recorder_mcp(
     fs::create_dir_all(&mcp_dir)
         .map_err(|error| AppError::new("june_recorder_mcp_failed", error.to_string()))?;
     let script_path = mcp_dir.join(JUNE_RECORDER_MCP_SCRIPT_NAME);
-    fs::write(&script_path, JUNE_RECORDER_MCP_SCRIPT)
+    write_file_if_changed(&script_path, JUNE_RECORDER_MCP_SCRIPT.as_bytes())
         .map_err(|error| AppError::new("june_recorder_mcp_failed", error.to_string()))?;
 
     Ok(JuneRecorderMcpConfig {
@@ -10051,11 +10313,16 @@ async fn sync_june_browser_mcp(
     let data_dir = crate::app_paths::app_data_dir(app)
         .map_err(|error| AppError::new("june_browser_mcp_failed", error.to_string()))?;
     let mcp_dir = data_dir.join(JUNE_CONTEXT_MCP_DIR_NAME);
-    fs::create_dir_all(&mcp_dir)
-        .map_err(|error| AppError::new("june_browser_mcp_failed", error.to_string()))?;
-    let script_path = mcp_dir.join(JUNE_BROWSER_MCP_SCRIPT_NAME);
-    fs::write(&script_path, JUNE_BROWSER_MCP_SCRIPT)
-        .map_err(|error| AppError::new("june_browser_mcp_failed", error.to_string()))?;
+    let script_path = tokio::task::spawn_blocking(move || {
+        fs::create_dir_all(&mcp_dir)
+            .map_err(|error| AppError::new("june_browser_mcp_failed", error.to_string()))?;
+        let script_path = mcp_dir.join(JUNE_BROWSER_MCP_SCRIPT_NAME);
+        write_file_if_changed(&script_path, JUNE_BROWSER_MCP_SCRIPT.as_bytes())
+            .map_err(|error| AppError::new("june_browser_mcp_failed", error.to_string()))?;
+        Ok::<_, AppError>(script_path)
+    })
+    .await
+    .map_err(|error| AppError::new("june_browser_mcp_failed", error.to_string()))??;
 
     // While the Browser use feature flag is off, persisted routine opt-ins
     // stay dormant: no per-routine server is rendered and the broker's grant
@@ -10096,7 +10363,7 @@ fn sync_june_computer_use_mcp(
     fs::create_dir_all(&mcp_dir)
         .map_err(|error| AppError::new("june_computer_use_mcp_failed", error.to_string()))?;
     let script_path = mcp_dir.join(crate::computer_use::MCP_SCRIPT_NAME);
-    fs::write(&script_path, crate::computer_use::MCP_SCRIPT)
+    write_file_if_changed(&script_path, crate::computer_use::MCP_SCRIPT.as_bytes())
         .map_err(|error| AppError::new("june_computer_use_mcp_failed", error.to_string()))?;
 
     Ok(JuneComputerUseMcpConfig {
@@ -10245,43 +10512,60 @@ async fn sync_june_connector_mcps(
     let data_dir = crate::app_paths::app_data_dir(app)
         .map_err(|error| AppError::new("june_connector_mcp_failed", error.to_string()))?;
     let mcp_dir = data_dir.join(JUNE_CONTEXT_MCP_DIR_NAME);
-    fs::create_dir_all(&mcp_dir)
-        .map_err(|error| AppError::new("june_connector_mcp_failed", error.to_string()))?;
     let command = hermes_python_command(hermes_command);
 
-    // Write all six scripts up front: the base servers and every auto server
-    // (which reuses the provider action script) point at these paths.
-    let write_script = |script_name: &str, script: &str| -> Result<PathBuf, AppError> {
-        let script_path = mcp_dir.join(script_name);
-        fs::write(&script_path, script)
+    // The base servers and every auto server reuse these paths. Keep their
+    // content comparisons and any first-run writes off the async runtime.
+    let (
+        gmail_read_path,
+        gmail_actions_path,
+        gcal_read_path,
+        gcal_actions_path,
+        linear_read_path,
+        linear_actions_path,
+        github_read_path,
+        github_actions_path,
+        notion_path,
+        notion_actions_path,
+    ) = tokio::task::spawn_blocking(move || {
+        fs::create_dir_all(&mcp_dir)
             .map_err(|error| AppError::new("june_connector_mcp_failed", error.to_string()))?;
-        Ok(script_path)
-    };
-    let gmail_read_path = write_script(JUNE_GMAIL_MCP_SCRIPT_NAME, JUNE_GMAIL_MCP_SCRIPT)?;
-    let gmail_actions_path = write_script(
-        JUNE_GMAIL_ACTIONS_MCP_SCRIPT_NAME,
-        JUNE_GMAIL_ACTIONS_MCP_SCRIPT,
-    )?;
-    let gcal_read_path = write_script(JUNE_GCAL_MCP_SCRIPT_NAME, JUNE_GCAL_MCP_SCRIPT)?;
-    let gcal_actions_path = write_script(
-        JUNE_GCAL_ACTIONS_MCP_SCRIPT_NAME,
-        JUNE_GCAL_ACTIONS_MCP_SCRIPT,
-    )?;
-    let linear_read_path = write_script(JUNE_LINEAR_MCP_SCRIPT_NAME, JUNE_LINEAR_MCP_SCRIPT)?;
-    let linear_actions_path = write_script(
-        JUNE_LINEAR_ACTIONS_MCP_SCRIPT_NAME,
-        JUNE_LINEAR_ACTIONS_MCP_SCRIPT,
-    )?;
-    let github_read_path = write_script(JUNE_GITHUB_MCP_SCRIPT_NAME, JUNE_GITHUB_MCP_SCRIPT)?;
-    let github_actions_path = write_script(
-        JUNE_GITHUB_ACTIONS_MCP_SCRIPT_NAME,
-        JUNE_GITHUB_ACTIONS_MCP_SCRIPT,
-    )?;
-    let notion_path = write_script(JUNE_NOTION_MCP_SCRIPT_NAME, JUNE_NOTION_MCP_SCRIPT)?;
-    let notion_actions_path = write_script(
-        JUNE_NOTION_ACTIONS_MCP_SCRIPT_NAME,
-        JUNE_NOTION_ACTIONS_MCP_SCRIPT,
-    )?;
+        let write_script = |script_name: &str, script: &str| -> Result<PathBuf, AppError> {
+            let script_path = mcp_dir.join(script_name);
+            write_file_if_changed(&script_path, script.as_bytes())
+                .map_err(|error| AppError::new("june_connector_mcp_failed", error.to_string()))?;
+            Ok(script_path)
+        };
+        Ok::<_, AppError>((
+            write_script(JUNE_GMAIL_MCP_SCRIPT_NAME, JUNE_GMAIL_MCP_SCRIPT)?,
+            write_script(
+                JUNE_GMAIL_ACTIONS_MCP_SCRIPT_NAME,
+                JUNE_GMAIL_ACTIONS_MCP_SCRIPT,
+            )?,
+            write_script(JUNE_GCAL_MCP_SCRIPT_NAME, JUNE_GCAL_MCP_SCRIPT)?,
+            write_script(
+                JUNE_GCAL_ACTIONS_MCP_SCRIPT_NAME,
+                JUNE_GCAL_ACTIONS_MCP_SCRIPT,
+            )?,
+            write_script(JUNE_LINEAR_MCP_SCRIPT_NAME, JUNE_LINEAR_MCP_SCRIPT)?,
+            write_script(
+                JUNE_LINEAR_ACTIONS_MCP_SCRIPT_NAME,
+                JUNE_LINEAR_ACTIONS_MCP_SCRIPT,
+            )?,
+            write_script(JUNE_GITHUB_MCP_SCRIPT_NAME, JUNE_GITHUB_MCP_SCRIPT)?,
+            write_script(
+                JUNE_GITHUB_ACTIONS_MCP_SCRIPT_NAME,
+                JUNE_GITHUB_ACTIONS_MCP_SCRIPT,
+            )?,
+            write_script(JUNE_NOTION_MCP_SCRIPT_NAME, JUNE_NOTION_MCP_SCRIPT)?,
+            write_script(
+                JUNE_NOTION_ACTIONS_MCP_SCRIPT_NAME,
+                JUNE_NOTION_ACTIONS_MCP_SCRIPT,
+            )?,
+        ))
+    })
+    .await
+    .map_err(|error| AppError::new("june_connector_mcp_failed", error.to_string()))??;
 
     let notion_config = notion_connected.then(|| JuneConnectorMcpConfig {
         command: command.clone(),
@@ -10837,6 +11121,17 @@ fn backup_corrupt_hermes_config(config_path: &Path, contents: &[u8]) -> Result<P
 fn write_hermes_config_atomic(config_path: &Path, contents: &str) -> Result<(), AppError> {
     let target_path = hermes_config_replacement_target(config_path)
         .map_err(|error| AppError::new("hermes_bridge_config_failed", error.to_string()))?;
+    match fs::read(&target_path) {
+        Ok(existing) if existing == contents.as_bytes() => return Ok(()),
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(AppError::new(
+                "hermes_bridge_config_failed",
+                error.to_string(),
+            ))
+        }
+    }
     let parent = target_path.parent().ok_or_else(|| {
         AppError::new(
             "hermes_bridge_config_failed",
@@ -12097,7 +12392,7 @@ fn sync_june_soul(
     memory_enabled: bool,
     video_generation_enabled: bool,
     connectors_registered: bool,
-) -> Result<(), AppError> {
+) -> Result<bool, AppError> {
     ensure_june_character_file(hermes_home)?;
     let character = load_june_character(hermes_home)
         .unwrap_or_else(|| JUNE_SOUL_CHARACTER_DEFAULT_MD.to_string());
@@ -12138,7 +12433,11 @@ fn sync_june_soul(
     } else {
         format!("{base}{JUNE_SOUL_CONTEXT_MD}{memory_section}{JUNE_SOUL_CLARIFY_MD}{JUNE_SOUL_WEB_MD}{JUNE_SOUL_IMAGE_MD}{video_section}{JUNE_SOUL_RECORDER_MD}{connectors_section}{browser_section}")
     };
-    std::fs::write(hermes_home.join("SOUL.md"), soul)
+    // The identity boundary is never conditional on metadata or a cached
+    // fingerprint: only exact equality with the fully rendered current soul
+    // can skip the write. Any identity, character, grant, or feature change
+    // necessarily produces different bytes and rewrites the whole file.
+    write_file_if_changed(&hermes_home.join("SOUL.md"), soul.as_bytes())
         .map_err(|error| AppError::new("hermes_bridge_soul_failed", error.to_string()))
 }
 
@@ -17065,6 +17364,129 @@ async fn wait_for_hermes(base_url: &str, token: &str) -> Result<(), AppError> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn content_aware_startup_assets_skip_exact_bytes_and_replace_changed_patch_script() {
+        let runtime_dir = tempfile::tempdir().expect("runtime dir");
+        let asset = runtime_dir.path().join("asset.py");
+        assert!(write_file_if_changed(&asset, b"current").expect("first write"));
+        assert!(!write_file_if_changed(&asset, b"current").expect("unchanged write"));
+
+        let patch_path = runtime_dir.path().join("apply-june-hermes-patches.py");
+        fs::write(
+            &patch_path,
+            b"PATCH_SET = \"june-approval-memory-previous\"\n",
+        )
+        .expect("stale patch script");
+        let written_path =
+            write_managed_hermes_patch_script(runtime_dir.path()).expect("refresh patch script");
+        assert_eq!(written_path, patch_path);
+        assert_eq!(
+            fs::read(&patch_path).expect("patched script bytes"),
+            HERMES_RUNTIME_PATCH_SCRIPT.as_bytes()
+        );
+        assert!(
+            !write_file_if_changed(&patch_path, HERMES_RUNTIME_PATCH_SCRIPT.as_bytes())
+                .expect("stable patch script"),
+            "the refreshed patch script must not be rewritten again"
+        );
+    }
+
+    #[test]
+    fn soul_hash_guard_skips_only_the_exact_current_identity() {
+        let home = tempfile::tempdir().expect("Hermes home");
+        assert!(
+            sync_june_soul(home.path(), false, false, Some(false), true, false, false)
+                .expect("initial soul")
+        );
+        assert!(
+            !sync_june_soul(home.path(), false, false, Some(false), true, false, false)
+                .expect("unchanged soul"),
+            "an exact current soul must perform zero writes"
+        );
+
+        fs::write(home.path().join("SOUL.md"), "You are Hermes.\n").expect("tamper soul");
+        assert!(
+            sync_june_soul(home.path(), false, false, Some(false), true, false, false)
+                .expect("repair soul"),
+            "identity drift must always rewrite the full soul"
+        );
+        let repaired = fs::read_to_string(home.path().join("SOUL.md")).expect("repaired soul");
+        assert!(repaired.starts_with("You are June"));
+        assert!(!repaired.starts_with("You are Hermes"));
+    }
+
+    #[test]
+    fn workspace_image_attach_snapshot_round_trips_without_base64() {
+        let home = tempfile::tempdir().expect("Hermes home");
+        let uploads = home.path().join("workspace").join("uploads");
+        fs::create_dir_all(&uploads).expect("uploads");
+        let source = uploads.join("diagram.png");
+        let bytes = b"\x89PNG\r\n\x1a\nnative-path-image";
+        fs::write(&source, bytes).expect("source image");
+
+        let prepared = prepare_hermes_image_attachment(
+            home.path(),
+            &PrepareHermesImageAttachmentRequest {
+                session_id: "runtime-session-1".to_string(),
+                path: source.to_string_lossy().into_owned(),
+            },
+        )
+        .expect("prepare image");
+
+        let prepared_path = PathBuf::from(&prepared.path);
+        assert!(prepared_path.starts_with(
+            home.path()
+                .join("workspace")
+                .join(JUNE_WORKSPACE_SESSION_ATTACHMENTS_DIR_NAME)
+        ));
+        assert_eq!(prepared.mime_type, "image/png");
+        assert_eq!(prepared.size, bytes.len() as u64);
+        assert_eq!(fs::read(prepared_path).expect("prepared bytes"), bytes);
+    }
+
+    #[test]
+    fn workspace_image_attach_rejects_paths_outside_allowed_roots() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("hermes");
+        fs::create_dir_all(home.join("workspace")).expect("workspace");
+        let outside = temp.path().join("outside.png");
+        fs::write(&outside, b"\x89PNG\r\n\x1a\noutside").expect("outside image");
+
+        let error = prepare_hermes_image_attachment(
+            &home,
+            &PrepareHermesImageAttachmentRequest {
+                session_id: "runtime-session-1".to_string(),
+                path: outside.to_string_lossy().into_owned(),
+            },
+        )
+        .expect_err("outside path must fail");
+        assert_eq!(error.code, "hermes_image_attach_denied");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_image_attach_rejects_symbolic_links() {
+        use std::os::unix::fs::symlink;
+
+        let home = tempfile::tempdir().expect("Hermes home");
+        let uploads = home.path().join("workspace").join("uploads");
+        fs::create_dir_all(&uploads).expect("uploads");
+        let target = uploads.join("target.png");
+        fs::write(&target, b"\x89PNG\r\n\x1a\ntarget").expect("target");
+        let link = uploads.join("link.png");
+        symlink(&target, &link).expect("link");
+
+        let error = prepare_hermes_image_attachment(
+            home.path(),
+            &PrepareHermesImageAttachmentRequest {
+                session_id: "runtime-session-1".to_string(),
+                path: link.to_string_lossy().into_owned(),
+            },
+        )
+        .expect_err("symlink must fail");
+        assert_eq!(error.code, "hermes_image_attach_denied");
+    }
+
     // The bundled MCP scripts are written verbatim into the Hermes home and
     // evaluated at import time by the runtime venv. A NameError in module
     // scope (e.g. a tool schema referencing an undefined constant) silently
@@ -21135,6 +21557,28 @@ mcp_servers:
                 .mode()
                 & 0o777,
             0o600
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unchanged_atomic_config_performs_zero_replacement_writes() {
+        use std::os::unix::fs::MetadataExt;
+
+        let home = tempfile::tempdir().expect("tempdir");
+        let config = home.path().join("config.yaml");
+        let contents = "agent:\n  disabled_toolsets: [memory]\n";
+        write_hermes_config_atomic(&config, contents).expect("initial config write");
+        let before = std::fs::metadata(&config).expect("initial config metadata");
+
+        write_hermes_config_atomic(&config, contents).expect("unchanged config sync");
+        let after = std::fs::metadata(&config).expect("unchanged config metadata");
+
+        assert_eq!(after.dev(), before.dev());
+        assert_eq!(
+            after.ino(),
+            before.ino(),
+            "unchanged config bytes must not replace the file"
         );
     }
 

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -5041,6 +5041,7 @@ fn snapshot_image_source(
     {
         use std::os::unix::fs::MetadataExt;
 
+        // June-owned attach sources are unique-named and effectively immutable; later mutation would also change the shared inode.
         if fs::hard_link(source_path, destination).is_ok() {
             let source_metadata = source.metadata()?;
             let destination_metadata = fs::metadata(destination)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -252,6 +252,7 @@ pub fn run() {
             hermes_bridge::download_hermes_bridge_file,
             hermes_bridge::hermes_bridge_file_preview,
             hermes_bridge::hermes_bridge_image_data_url,
+            hermes_bridge::prepare_hermes_bridge_image_attachment,
             hermes_bridge::hermes_bridge_file_text,
             hermes_bridge::import_hermes_bridge_file,
             hermes_bridge::import_hermes_bridge_file_bytes,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -53,11 +53,11 @@ import {
   slashModelResolutionError,
 } from "../../lib/agent-composer-slash-commands";
 import { type ComposerEditorHandle, stripPlaceholder } from "./composer/ComposerEditor";
-import { type NoteReferenceInput } from "./composer/noteReference";
+import type { NoteReferenceInput } from "./composer/noteReference";
 import { sessionUnrestricted } from "../../lib/agent-session-modes";
-import { type AgentChatPart, type AgentChatTurn } from "../../lib/agent-chat-runtime";
+import type { AgentChatPart, AgentChatTurn } from "../../lib/agent-chat-runtime";
 import { ProjectContextSignatureStore } from "../../lib/agent-project-context";
-import { type AgentChatGallerySection } from "../../lib/agent-chat-gallery";
+import type { AgentChatGallerySection } from "../../lib/agent-chat-gallery";
 import { attachScrollThumbFade } from "../../lib/scroll-thumb-fade";
 import type { AgentWorkspaceProps } from "./agent-workspace-types";
 import { useAgentGalleryEvents } from "./use-agent-gallery-events";
@@ -184,7 +184,7 @@ export {
  * for the team instead of treating it as a normal request for help. */
 import type { PendingIssueReport } from "./agent-session-continuity";
 
-import { type AgentWorkspaceError } from "./agent-workspace-errors";
+import type { AgentWorkspaceError } from "./agent-workspace-errors";
 export { agentWorkspaceErrorStateForMessage } from "./agent-workspace-errors";
 
 import {
@@ -194,7 +194,7 @@ import {
   storedVideoSlashTurns,
   videoSlashTurnsBySessionFromStored,
 } from "./composer/media-slash-persistence";
-import { type CapturedSessionModelTarget } from "./composer/follow-up-queue";
+import type { CapturedSessionModelTarget } from "./composer/follow-up-queue";
 
 import {
   persistedReviewableIssueReports,
@@ -418,8 +418,9 @@ export function AgentWorkspace({
   // the model's session history, so a follow-up ("do you think it's nice?")
   // reaches an empty context. Hold each generated image here, keyed by session,
   // and lazily attach it to the user's NEXT prompt via the same
-  // `image.attach_bytes` path composer attachments use — so the image lands in
-  // context exactly when the model first needs it. A ref (not state) on purpose:
+  // native path snapshot composer attachments use, with `image.attach_bytes`
+  // retained for callers that do not have a gateway-local path. The image lands
+  // in context exactly when the model first needs it. A ref (not state) on purpose:
   // it must NOT render a composer chip (the image already shows in-thread; ADR
   // 0003 decision 2). Cleared once attached.
   const {
@@ -2206,12 +2207,13 @@ export function AgentWorkspace({
     });
 
   /**
-   * Attach this turn's pending images to the live session via image.attach_bytes
-   * (feature 19), updating each chip's status and feeding the artifact timeline.
-   * The base64 is read on demand from the workspace file, passed straight to
-   * the typed attachImage, and discarded; it never lands on composer state and
-   * the trace entry is redacted to a byte count. Throws a single blocking error
-   * if any image failed so the prompt is not sent with a missing image.
+   * Attach this turn's pending images to the live session via a Rust-validated
+   * workspace snapshot and `image.attach` (feature 19), updating each chip's
+   * status and feeding the artifact timeline. Image bytes do not cross the JS
+   * bridge or Hermes WebSocket on this path; `image.attach_bytes` remains the
+   * additive fallback for callers without a local path. Throws a single
+   * blocking error if any image failed so the prompt is not sent with a missing
+   * image.
    */
   const { attachPendingImages, clearHeldFastPathImages } = createPendingImageActions({
     pendingFastPathImagesRef,
@@ -3177,7 +3179,7 @@ export {
   branchSourceSessionIdForTurn,
   turnIsConcreteResponse,
 } from "./chat-turns/BranchAndSensitiveActions";
-import { type AgentArtifact } from "./chat-turns/AgentArtifactPanel";
+import type { AgentArtifact } from "./chat-turns/AgentArtifactPanel";
 export { generatedImagePathAliases } from "./composer/composer-input-helpers";
 import {
   agentActivityCountsFromStore,

--- a/src/components/agent/agent-workspace-models.ts
+++ b/src/components/agent/agent-workspace-models.ts
@@ -11,9 +11,9 @@ export type AgentAttachment = ImportedHermesFile & {
    * the next successful prompt submit. */
   attachDataUrl?: string;
   /** Structured attach status (feature 19). Tracks whether this import has been
-   * sent to the model via image.attach_bytes: imported (ready) → attached (acked) →
-   * or failed. Carries file refs only, never the image bytes. Files stay
-   * `imported` (they only ride along as a path in the prompt). */
+   * sent to the model via the native-path image attach flow: imported (ready) →
+   * attached (acked) → or failed. Carries file refs only, never the image bytes.
+   * Files stay `imported` (they only ride along as a path in the prompt). */
   attach: HermesAttachmentState;
 };
 

--- a/src/components/agent/pending-image-actions.ts
+++ b/src/components/agent/pending-image-actions.ts
@@ -1,5 +1,5 @@
-import { hermesBridgeImageDataUrl } from "../../lib/tauri";
-import { HermesGatewayClient } from "../../lib/hermes-gateway";
+import { hermesBridgeImageDataUrl, prepareHermesBridgeImageAttachment } from "../../lib/tauri";
+import type { HermesGatewayClient } from "../../lib/hermes-gateway";
 import {
   createHermesMethods,
   hermesModeFor,
@@ -39,6 +39,9 @@ export function createPendingImageActions(dependencies: createPendingImageAction
       ),
     );
     const deps = {
+      prepareImagePath: prepareHermesBridgeImageAttachment,
+      attachImagePath: methods.attachImagePath,
+      isPathSupported: () => isHermesFeatureSupported("image.attach"),
       attachImage: methods.attachImage,
       readImageData: async (path: string) =>
         heldImageDataByPath.get(path) ?? (await hermesBridgeImageDataUrl(path)),

--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -53,6 +53,7 @@ import {
   hermesBridgeImageDataUrl,
   hermesBridgeSessionMessages,
   hermesBridgeStatus,
+  prepareHermesBridgeImageAttachment,
   providerModelSettings,
   startHermesBridge,
   type HermesSessionMessage,
@@ -734,6 +735,9 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
           if (pendingImages.length) {
             const methods = createHermesMethods(gateway);
             const deps = {
+              prepareImagePath: prepareHermesBridgeImageAttachment,
+              attachImagePath: methods.attachImagePath,
+              isPathSupported: () => isHermesFeatureSupported("image.attach"),
               attachImage: methods.attachImage,
               readImageData: (path: string) => hermesBridgeImageDataUrl(path),
               isSupported: () => isHermesFeatureSupported("image.attach_bytes"),

--- a/src/lib/hermes-artifact-store.ts
+++ b/src/lib/hermes-artifact-store.ts
@@ -58,7 +58,8 @@ export type ArtifactKind = "file" | "image" | "directory" | "url" | "unknown";
  * What the agent did with the artifact. `failed` means the access errored (e.g.
  * a sandboxed write to an unrestricted path was denied). `attached` (feature 19)
  * means the user attached an image into the session via the structured
- * `image.attach_bytes` flow — it shows in the timeline like any other artifact.
+ * native-path `image.attach` flow — it shows in the timeline like any other
+ * artifact.
  */
 export type ArtifactAction = "created" | "modified" | "read" | "downloaded" | "failed" | "attached";
 

--- a/src/lib/hermes-control-plane/compatibility/matrix.ts
+++ b/src/lib/hermes-control-plane/compatibility/matrix.ts
@@ -77,10 +77,10 @@ const CURRENT_PIN = PINNED_HERMES_VERSION;
  * Control-plane methods. Feature 01 (`methods.ts`) provides typed STUBS for the
  * steer/branch/compress/usage/dispatch/sudo/secret/subagent/image surfaces; each
  * flips to `supported` as its owning feature ships UI + tests (see OWNERSHIP).
- * subagent.interrupt is `supported` (feature 13's drawer stop button) and
- * image.attach_bytes is `supported` (feature 19's composer image-attach flow). The
- * four baseline methods June already calls live (grep-confirmed in
- * `AgentWorkspace.tsx`) are `supported`.
+ * subagent.interrupt is `supported` (feature 13's drawer stop button), and both
+ * image.attach and image.attach_bytes are `supported` (feature 19's native path
+ * flow plus its additive byte fallback). The four baseline methods June already
+ * calls live (grep-confirmed in `AgentWorkspace.tsx`) are `supported`.
  */
 const methods: HermesCompatibilitySection = {
   // --- Baseline: June already calls these in the live session flow today. ---
@@ -165,15 +165,15 @@ const methods: HermesCompatibilitySection = {
     since: PIN,
   },
   "image.attach": {
-    status: "unsupported",
+    status: "supported",
     rationale:
-      "The pinned Hermes runtime exposes path-based image.attach, but June's desktop composer uploads client-side image bytes instead so it does not depend on gateway-local file paths.",
-    since: PIN,
+      "The desktop bridge validates and snapshots a June-owned workspace image into a runtime-session directory, then the composer passes only that native path through attachImagePath; image bytes never cross Tauri IPC or the gateway WebSocket. Covered by native path-boundary, hermes-image-attach, control-plane-methods, and agent-workspace tests.",
+    since: CURRENT_PIN,
   },
   "image.attach_bytes": {
     status: "supported",
     rationale:
-      "Feature 19 wires the composer's imported images into image.attach_bytes (attachImage): on submit each pending image is read from the workspace and attached, the chip shows imported/attached/failed, a failed attach blocks the send, and the attachment lands in feature 14's artifact timeline; covered by hermes-image-attach and agent-workspace tests. The base64 is read on demand and never stored in React state or the trace.",
+      "The additive attachImage byte-upload method remains available for remote/legacy callers that cannot use a gateway-local path. The desktop composer now prefers image.attach and does not read base64 on its normal attach path.",
     since: PIN,
   },
   "sudo.respond": {
@@ -313,7 +313,7 @@ const features: HermesCompatibilitySection = {
   imageEditing: {
     status: "partial",
     rationale:
-      "Feature 19 ships explicit source-image selection: imported images attach to the session via image.attach_bytes (so an edit prompt names a concrete image instead of relying on a path in prose), with imported/attached/failed status and the attachment in the artifact timeline. June does not yet render the edited image_generate OUTPUT back inline, so this stays partial rather than supported; covered by hermes-image-attach and agent-workspace tests.",
+      "Feature 19 ships explicit source-image selection: imported images attach to the session through a Rust-validated native path (with image.attach_bytes retained as an additive fallback), with imported/attached/failed status and the attachment in the artifact timeline. June does not yet render the edited image_generate OUTPUT back inline, so this stays partial rather than supported; covered by hermes-image-attach and agent-workspace tests.",
     since: PIN,
   },
   automationBlueprints: {
@@ -394,6 +394,6 @@ export const OWNERSHIP: Readonly<Record<string, readonly string[]>> = Object.fre
   "11": ["events.subagent"],
   "12": ["events.subagent", "features.backgroundSubagentWatch"],
   "13": ["methods.subagent.interrupt"],
-  "19": ["methods.image.attach_bytes", "features.imageEditing"],
+  "19": ["methods.image.attach", "methods.image.attach_bytes", "features.imageEditing"],
   "JUN-210": ["methods.session.create", "features.profile-switching"],
 });

--- a/src/lib/hermes-control-plane/methods.ts
+++ b/src/lib/hermes-control-plane/methods.ts
@@ -98,6 +98,10 @@ export type AttachImageParams = {
   dataBase64: string;
   fileName?: string;
 };
+export type AttachImagePathParams = {
+  sessionId: string;
+  path: string;
+};
 
 /** The typed command surface. Each call resolves to whatever the gateway
  * returns (typed by the caller via the generic on `request`). */
@@ -123,6 +127,11 @@ export type HermesMethods = {
    * immediately, persists it into the session's stored runtime config (so
    * resume keeps it), and emits a fresh session.info. */
   setSessionReasoningEffort(params: SetSessionReasoningEffortParams): Promise<unknown>;
+  /** Preferred desktop attach path. Rust first snapshots the image into the
+   * live session's June workspace directory, then this passes only that native
+   * path to the co-located Hermes gateway. */
+  attachImagePath(params: AttachImagePathParams): Promise<unknown>;
+  /** Additive remote-client fallback for callers without a gateway-local path. */
   attachImage(params: AttachImageParams): Promise<unknown>;
 };
 
@@ -221,6 +230,12 @@ export function createHermesMethods(client: HermesRequestLike): HermesMethods {
         session_id: sessionId,
         key: "reasoning",
         value: effort,
+      });
+    },
+    attachImagePath({ sessionId, path }) {
+      return request("image.attach", {
+        session_id: sessionId,
+        path,
       });
     },
     attachImage({ sessionId, mimeType, dataBase64, fileName }) {

--- a/src/lib/hermes-image-attach.ts
+++ b/src/lib/hermes-image-attach.ts
@@ -1,35 +1,27 @@
 /**
  * Pure orchestration for the structured image attach/edit flow (feature 19).
  *
- * June's existing attachment path imports a dropped/pasted/picked file into the
- * Hermes workspace (`<hermes_home>/workspace/uploads/…`, via the
- * `import_hermes_bridge_file*` bridge commands) and references its PATH in the
- * prompt text. That keeps working. This module adds the STRUCTURED path on top:
- * for image attachments it calls the typed image byte-attach control-plane method
- * (`createHermesMethods(...).attachImage`), so the model/tools receive the image
- * as a first-class input rather than only a path mentioned in prose. Explicit
- * source-image selection is what makes image EDITING reliable (the upstream
- * image_generate edit input shouldn't have to guess which path the user meant).
+ * June imports a dropped/pasted/picked file into the Hermes workspace
+ * (`<hermes_home>/workspace/uploads/…`) before it reaches this module. The
+ * preferred structured path asks Rust to validate and snapshot that workspace
+ * file into a runtime-session directory, then sends only the returned path via
+ * Hermes' local `image.attach` method. No image bytes cross Tauri IPC or the
+ * WebSocket on that path. The additive `image.attach_bytes` flow remains a
+ * fallback for a caller/runtime that cannot use a gateway-local path.
  *
  * It is deliberately UI- and gateway-free (mirrors `hermes-session-steer.ts`):
  * the orchestrator takes its side effects as injected functions, so it is
  * trivially unit-testable and only this seam moves if the wire shape changes.
  *
- * BASE64 DISCIPLINE: the image bytes are read on demand AT ATTACH TIME (through
- * the injected {@link AttachImageDeps.readImageData}, backed by the existing
- * `hermes_bridge_file_preview` bridge command which returns a `data:…;base64,…`
- * url for the workspace file) and discarded the moment the RPC resolves. The
- * base64 NEVER lands on {@link HermesAttachmentState} (which holds only a
- * workspace path + ids), is NEVER passed to the trace buffer (the redacted
- * {@link AttachImageResult.trace} reports only method/session/mime/byte-length),
- * and is NEVER stored in the artifact timeline. Long-term React state keeps file
- * refs and attachment ids, not raw bytes.
+ * BASE64 FALLBACK DISCIPLINE: when path attach is unavailable, bytes are read
+ * only at attach time and discarded when the RPC resolves. Base64 never lands
+ * on attachment state, trace payloads, or the artifact timeline.
  */
 
 import type { ArtifactKind } from "./hermes-artifact-store";
 import type { OutboundTraceInput } from "./hermes-trace-buffer";
-import type { AttachImageParams } from "./hermes-control-plane";
-import type { ImportedHermesFile } from "./tauri";
+import type { AttachImageParams, AttachImagePathParams } from "./hermes-control-plane";
+import type { ImportedHermesFile, PreparedHermesImageAttachment } from "./tauri";
 import { messageFromError } from "./errors";
 
 /**
@@ -83,11 +75,13 @@ export type AttachImageResult = {
   error?: string;
 };
 
-/** Injected side effects. `attachImage` is `createHermesMethods(...).attachImage`;
- * `readImageData` reads the workspace file as a `data:…;base64,…` url (or null
- * if it can't be read as an image); `isSupported` is the feature gate
- * (`() => isHermesFeatureSupported("image.attach_bytes")`). */
+/** Injected side effects. Path attach is preferred when all three path
+ * dependencies are present and supported. The byte dependencies remain
+ * required so remote/legacy callers retain the additive fallback contract. */
 export type AttachImageDeps = {
+  prepareImagePath?: (sessionId: string, path: string) => Promise<PreparedHermesImageAttachment>;
+  attachImagePath?: (params: AttachImagePathParams) => Promise<unknown>;
+  isPathSupported?: () => boolean;
   attachImage: (params: AttachImageParams) => Promise<unknown>;
   readImageData: (path: string) => Promise<string | null>;
   isSupported: () => boolean;
@@ -187,15 +181,13 @@ export function attachErrorNotice(displayName: string, err: unknown): string {
 }
 
 /**
- * Attach one imported image to a Hermes session through the typed image bytes
- * method. Pure w.r.t. injected {@link AttachImageDeps}. Resolves to the next
- * chip {@link HermesAttachmentState} plus, on success, an artifact seed and a
- * REDACTED outbound trace entry; on failure, `state.status` is `failed` and
- * `error` carries recoverable copy. Never throws.
+ * Attach one imported image to a Hermes session. The native path operation is
+ * preferred; byte upload is used only when that additive method is unavailable.
+ * Resolves to the next chip state plus an artifact and redacted trace. Never
+ * throws.
  *
- * Order of guards: feature gate → image-kind → read-bytes → RPC. A gated-off
- * runtime is NOT a failure (the image is still imported and its path rides in
- * the prompt) — it returns the unchanged `imported` state with a notice.
+ * A runtime with neither operation is not a hard failure: the imported path
+ * still rides in the prompt.
  */
 export async function attachImageToSession(
   attachment: HermesAttachmentState,
@@ -203,13 +195,6 @@ export async function attachImageToSession(
   deps: AttachImageDeps,
 ): Promise<AttachImageResult> {
   const withSession: HermesAttachmentState = { ...attachment, sessionId };
-
-  if (!deps.isSupported()) {
-    // Gated off: keep the image imported so the existing path-in-prompt
-    // fallback still carries it. No artifact, no hard failure.
-    return { state: withSession, error: ATTACH_UNSUPPORTED_NOTICE };
-  }
-
   if (attachment.kind !== "image" || !attachment.workspacePath) {
     const error = attachErrorNotice(attachment.displayName, new Error("unsupported file type"));
     return {
@@ -219,25 +204,46 @@ export async function attachImageToSession(
     };
   }
 
+  const { prepareImagePath, attachImagePath } = deps;
+  if (prepareImagePath && attachImagePath && deps.isPathSupported?.()) {
+    try {
+      const prepared = await prepareImagePath(sessionId, attachment.workspacePath);
+      if (!prepared.path || !isAttachableImageType(prepared.mimeType)) {
+        throw new Error("unsupported file type");
+      }
+      const result = await attachImagePath({
+        sessionId,
+        path: prepared.path,
+      });
+      return attachedResult(withSession, result, {
+        method: "image.attach",
+        params: {
+          session_id: sessionId,
+          path: prepared.path,
+          mime_type: prepared.mimeType,
+          bytes: prepared.size,
+        },
+      });
+    } catch (err) {
+      return failedAttachResult(withSession, err);
+    }
+  }
+
+  if (!deps.isSupported()) {
+    // Gated off: keep the image imported so the existing path-in-prompt
+    // fallback still carries it. No artifact, no hard failure.
+    return { state: withSession, error: ATTACH_UNSUPPORTED_NOTICE };
+  }
+
   let parsed: { mimeType: string; dataBase64: string } | null;
   try {
     parsed = parseImageDataUrl(await deps.readImageData(attachment.workspacePath));
   } catch (err) {
-    const error = attachErrorNotice(attachment.displayName, err);
-    return {
-      state: { ...withSession, status: "failed", error },
-      artifact: failedArtifact(withSession),
-      error,
-    };
+    return failedAttachResult(withSession, err);
   }
 
   if (!parsed) {
-    const error = attachErrorNotice(attachment.displayName, new Error("unsupported file type"));
-    return {
-      state: { ...withSession, status: "failed", error },
-      artifact: failedArtifact(withSession),
-      error,
-    };
+    return failedAttachResult(withSession, new Error("unsupported file type"));
   }
 
   try {
@@ -247,42 +253,54 @@ export async function attachImageToSession(
       dataBase64: parsed.dataBase64,
       fileName: attachment.displayName,
     });
-    return {
-      state: {
-        ...withSession,
-        status: "attached",
-        hermesAttachmentId: attachmentIdFrom(result),
-      },
-      artifact: {
-        sessionId,
-        kind: "image",
-        action: "attached",
-        path: attachment.workspacePath,
-        displayName: attachment.displayName,
-        previewAvailable: true,
-      },
+    return attachedResult(withSession, result, {
       // REDACTED on purpose: the trace records that an attach happened and how
       // big it was, never the base64 itself (the trace buffer would otherwise
       // stringify it into its payload preview; the raw content base64 is not a
       // sanitizer-recognized secret key).
-      trace: {
-        sessionId,
-        method: "image.attach_bytes",
-        params: {
-          session_id: sessionId,
-          mime_type: parsed.mimeType,
-          bytes: approxByteLength(parsed.dataBase64),
-        },
+      method: "image.attach_bytes",
+      params: {
+        session_id: sessionId,
+        mime_type: parsed.mimeType,
+        bytes: approxByteLength(parsed.dataBase64),
       },
-    };
+    });
   } catch (err) {
-    const error = attachErrorNotice(attachment.displayName, err);
-    return {
-      state: { ...withSession, status: "failed", error },
-      artifact: failedArtifact(withSession),
-      error,
-    };
+    return failedAttachResult(withSession, err);
   }
+}
+
+function attachedResult(
+  state: HermesAttachmentState,
+  result: unknown,
+  trace: Omit<OutboundTraceInput, "sessionId">,
+): AttachImageResult {
+  const sessionId = state.sessionId ?? "";
+  return {
+    state: {
+      ...state,
+      status: "attached",
+      hermesAttachmentId: attachmentIdFrom(result),
+    },
+    artifact: {
+      sessionId,
+      kind: "image",
+      action: "attached",
+      path: state.workspacePath,
+      displayName: state.displayName,
+      previewAvailable: true,
+    },
+    trace: { sessionId, ...trace },
+  };
+}
+
+function failedAttachResult(state: HermesAttachmentState, err: unknown): AttachImageResult {
+  const error = attachErrorNotice(state.displayName, err);
+  return {
+    state: { ...state, status: "failed", error },
+    artifact: failedArtifact(state),
+    error,
+  };
 }
 
 function failedArtifact(state: HermesAttachmentState): AttachedArtifactSeed {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -635,6 +635,12 @@ export type ImportedHermesFile = {
   previewDataUrl?: string | null;
 };
 
+export type PreparedHermesImageAttachment = {
+  path: string;
+  mimeType: string;
+  size: number;
+};
+
 export type HermesSkillInfo = {
   name: string;
   description?: string;
@@ -1334,6 +1340,12 @@ export async function hermesBridgeFilePreview(path: string) {
 export async function hermesBridgeImageDataUrl(path: string) {
   return invoke<string | null>("hermes_bridge_image_data_url", {
     request: { path },
+  });
+}
+
+export async function prepareHermesBridgeImageAttachment(sessionId: string, path: string) {
+  return invoke<PreparedHermesImageAttachment>("prepare_hermes_bridge_image_attachment", {
+    request: { sessionId, path },
   });
 }
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -97,6 +97,7 @@ const mocks = vi.hoisted(() => ({
   hermesBridgeFilesystemSnapshot: vi.fn(),
   hermesBridgeFilePreview: vi.fn(),
   hermesBridgeImageDataUrl: vi.fn(),
+  prepareHermesBridgeImageAttachment: vi.fn(),
   hermesBridgeFileText: vi.fn(),
   hermesBridgeMessagingPlatforms: vi.fn(),
   hermesBridgeSkills: vi.fn(),
@@ -199,6 +200,7 @@ vi.mock("../lib/tauri", () => ({
   hermesBridgeFilesystemSnapshot: mocks.hermesBridgeFilesystemSnapshot,
   hermesBridgeFilePreview: mocks.hermesBridgeFilePreview,
   hermesBridgeImageDataUrl: mocks.hermesBridgeImageDataUrl,
+  prepareHermesBridgeImageAttachment: mocks.prepareHermesBridgeImageAttachment,
   hermesBridgeFileText: mocks.hermesBridgeFileText,
   hermesBridgeMessagingPlatforms: mocks.hermesBridgeMessagingPlatforms,
   hermesAgentCliAccess: mocks.hermesAgentCliAccess,
@@ -730,10 +732,16 @@ describe("AgentWorkspace", () => {
     mocks.hermesBridgeFilePreview.mockImplementation(async (path: string) =>
       /\.(png|jpe?g|gif|webp|tiff?)$/i.test(path) ? "data:image/png;base64,cHJldmlldw==" : null,
     );
-    // Feature 19's structured image attach reads full image bytes through the
-    // image-source capped command at attach time.
+    // Additive byte fallback for callers without a gateway-local path.
     mocks.hermesBridgeImageDataUrl.mockImplementation(async (path: string) =>
       /\.(png|jpe?g|gif|webp|tiff?)$/i.test(path) ? "data:image/png;base64,cHJldmlldw==" : null,
+    );
+    mocks.prepareHermesBridgeImageAttachment.mockImplementation(
+      async (_sessionId: string, path: string) => ({
+        path: path.replace("/workspace/uploads/", "/workspace/session-attachments/test/"),
+        mimeType: "image/png",
+        size: 1234,
+      }),
     );
     mocks.hermesBridgeFileText.mockResolvedValue(null);
     mocks.importHermesBridgeFile.mockImplementation(async (path: string) => ({
@@ -2479,9 +2487,9 @@ describe("AgentWorkspace", () => {
     await user.type(composer, "use this reference next");
     await user.click(screen.getByRole("button", { name: "Queue next message" }));
 
-    expect(
-      mocks.gatewayRequest.mock.calls.some(([method]) => method === "image.attach_bytes"),
-    ).toBe(false);
+    expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "image.attach")).toBe(
+      false,
+    );
     act(() => {
       for (const handler of mocks.gatewayEventHandlers) {
         handler({
@@ -2493,9 +2501,9 @@ describe("AgentWorkspace", () => {
     });
 
     await waitFor(() =>
-      expect(
-        mocks.gatewayRequest.mock.calls.some(([method]) => method === "image.attach_bytes"),
-      ).toBe(true),
+      expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "image.attach")).toBe(
+        true,
+      ),
     );
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
@@ -2504,9 +2512,7 @@ describe("AgentWorkspace", () => {
       }),
     );
     const methods = mocks.gatewayRequest.mock.calls.map(([method]) => method);
-    expect(methods.indexOf("image.attach_bytes")).toBeLessThan(
-      methods.lastIndexOf("prompt.submit"),
-    );
+    expect(methods.indexOf("image.attach")).toBeLessThan(methods.lastIndexOf("prompt.submit"));
   });
 
   it("retains a failed queued attachment delivery for retry", async () => {
@@ -2679,7 +2685,7 @@ describe("AgentWorkspace", () => {
       if (method === "session.resume") {
         return Promise.resolve({ session_id: "runtime-session-1" });
       }
-      if (method === "image.attach_bytes") {
+      if (method === "image.attach") {
         return Promise.resolve({ attachment_id: "attached-image-1" });
       }
       if (method === "prompt.submit" && params?.text?.includes("use this reference next")) {
@@ -12567,9 +12573,9 @@ describe("AgentWorkspace", () => {
         true,
       ),
     );
-    expect(
-      mocks.gatewayRequest.mock.calls.some(([method]) => method === "image.attach_bytes"),
-    ).toBe(false);
+    expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "image.attach")).toBe(
+      false,
+    );
 
     const submitted = mocks.gatewayRequest.mock.calls.find(
       ([method]) => method === "prompt.submit",
@@ -13003,7 +13009,7 @@ describe("AgentWorkspace", () => {
 
   it("attaches the image when the active model id is unresolved", async () => {
     // Regression: a stale or not-yet-loaded model id must not be assumed
-    // non-vision. The image still attaches via image.attach_bytes rather than
+    // non-vision. The image still attaches via image.attach rather than
     // silently downgrading to the text-only fallback.
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
@@ -13041,9 +13047,9 @@ describe("AgentWorkspace", () => {
     await user.click(sendButton);
 
     await waitFor(() =>
-      expect(
-        mocks.gatewayRequest.mock.calls.some(([method]) => method === "image.attach_bytes"),
-      ).toBe(true),
+      expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "image.attach")).toBe(
+        true,
+      ),
     );
     const submitted = mocks.gatewayRequest.mock.calls.find(
       ([method]) => method === "prompt.submit",
@@ -13069,9 +13075,9 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByRole("button", { name: /^Switch to / })).not.toBeInTheDocument();
   });
 
-  it("attaches a dropped image to the session via image.attach_bytes and marks it attached", async () => {
+  it("attaches a dropped image to the session via image.attach and marks it attached", async () => {
     // Feature 19: on submit, an imported image is sent to the session through
-    // the structured image.attach_bytes RPC, the chip flips to "Attached", and the
+    // the structured image.attach RPC, the chip flips to "Attached", and the
     // attachment lands in the artifact timeline — without the base64 ever
     // reaching the sanitized trace export.
     mockGlmCapabilities(["functionCalling", "supportsVision"]);
@@ -13095,16 +13101,14 @@ describe("AgentWorkspace", () => {
     await user.click(sendButton);
 
     await waitFor(() =>
-      expect(mocks.gatewayRequest).toHaveBeenCalledWith("image.attach_bytes", {
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("image.attach", {
         session_id: "runtime-session-1",
-        mime_type: "image/png",
-        content_base64: "cHJldmlldw==",
-        filename: "screenshot.png",
+        path: "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/workspace/session-attachments/test/screenshot.png",
       }),
     );
-    // image.attach_bytes precedes prompt.submit for the same turn.
+    // image.attach precedes prompt.submit for the same turn.
     const attachIndex = mocks.gatewayRequest.mock.calls.findIndex(
-      ([method]) => method === "image.attach_bytes",
+      ([method]) => method === "image.attach",
     );
     const submitIndex = mocks.gatewayRequest.mock.calls.findIndex(
       ([method]) => method === "prompt.submit",
@@ -13122,13 +13126,13 @@ describe("AgentWorkspace", () => {
 
     // The sanitized trace export records the attach but NEVER the base64.
     const trace = JSON.stringify(hermesTraceBuffer.exportSanitizedTrace("session-1"));
-    expect(trace).toContain("image.attach_bytes");
+    expect(trace).toContain("image.attach");
     expect(trace).not.toContain("cHJldmlldw==");
     expect(trace).not.toContain("content_base64");
   });
 
   it("blocks the prompt and warns when an image attach fails", async () => {
-    // A failed image.attach_bytes must not silently send the prompt with a missing
+    // A failed image.attach must not silently send the prompt with a missing
     // image: the send is blocked, the chip surfaces the failure, and the
     // composer text is restored for a retry.
     mockGlmCapabilities(["functionCalling", "supportsVision"]);
@@ -13143,7 +13147,7 @@ describe("AgentWorkspace", () => {
       if (method === "session.resume") {
         return Promise.resolve({ session_id: "runtime-session-1" });
       }
-      if (method === "image.attach_bytes") {
+      if (method === "image.attach") {
         return Promise.reject(new Error("attach exploded"));
       }
       return Promise.resolve({});
@@ -13168,9 +13172,9 @@ describe("AgentWorkspace", () => {
 
     // The attach was attempted and rejected; prompt.submit must NOT have run.
     await waitFor(() =>
-      expect(
-        mocks.gatewayRequest.mock.calls.some(([method]) => method === "image.attach_bytes"),
-      ).toBe(true),
+      expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "image.attach")).toBe(
+        true,
+      ),
     );
     expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "prompt.submit")).toBe(
       false,
@@ -14046,7 +14050,6 @@ describe("AgentWorkspace", () => {
     resetAgentSessionContinuity();
     mocks.gatewayRequest.mockClear();
     mocks.hermesBridgeFilePreview.mockResolvedValue(null);
-    mocks.hermesBridgeImageDataUrl.mockResolvedValue("data:image/png;base64,ZnVsbC1zaXpl");
     render(<AgentWorkspace />);
 
     expect(await screen.findByText("a red bicycle")).toBeInTheDocument();
@@ -14055,18 +14058,18 @@ describe("AgentWorkspace", () => {
     await user.click(screen.getByRole("button", { name: "Send message" }));
 
     await waitFor(() =>
-      expect(mocks.gatewayRequest).toHaveBeenCalledWith("image.attach_bytes", {
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("image.attach", {
         session_id: "runtime-session-1",
-        mime_type: "image/png",
-        content_base64: "ZnVsbC1zaXpl",
-        filename: "generated-image.png",
+        path: "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/workspace/session-attachments/test/generated-image.png",
       }),
     );
-    expect(mocks.hermesBridgeImageDataUrl).toHaveBeenCalledWith(
+    expect(mocks.prepareHermesBridgeImageAttachment).toHaveBeenCalledWith(
+      "runtime-session-1",
       "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/workspace/uploads/generated-image.png",
     );
+    expect(mocks.hermesBridgeImageDataUrl).not.toHaveBeenCalled();
     const attachIndex = mocks.gatewayRequest.mock.calls.findIndex(
-      ([method]) => method === "image.attach_bytes",
+      ([method]) => method === "image.attach",
     );
     const submitIndex = mocks.gatewayRequest.mock.calls.findIndex(
       ([method]) => method === "prompt.submit",
@@ -14213,11 +14216,9 @@ describe("AgentWorkspace", () => {
     await user.click(screen.getByRole("button", { name: "Send message" }));
 
     await waitFor(() =>
-      expect(mocks.gatewayRequest).toHaveBeenCalledWith("image.attach_bytes", {
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("image.attach", {
         session_id: "runtime-session-1",
-        mime_type: "image/png",
-        content_base64: "aGVsbG8=",
-        filename: "generated-image.png",
+        path: "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/workspace/session-attachments/test/generated-image.png",
       }),
     );
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
@@ -14225,7 +14226,7 @@ describe("AgentWorkspace", () => {
       text: "make it feel calmer\n\n--- Attached Context ---\nPrevious /image request: june the assistant",
     });
     const attachIndex = mocks.gatewayRequest.mock.calls.findIndex(
-      ([method]) => method === "image.attach_bytes",
+      ([method]) => method === "image.attach",
     );
     const submitIndex = mocks.gatewayRequest.mock.calls.findIndex(
       ([method]) => method === "prompt.submit",
@@ -14324,7 +14325,7 @@ describe("AgentWorkspace", () => {
     // JUN-171: the /image image renders in-thread but must also enter the
     // model's session history, so a follow-up ("what do you think?") reaches the
     // model WITH the image. On a vision model the held image is sent via
-    // image.attach_bytes before that follow-up's prompt.submit — and with NO
+    // image.attach before that follow-up's prompt.submit — and with NO
     // composer chip in between (it already renders in-thread).
     mockGlmCapabilities(["functionCalling", "supportsVision"]);
     const user = userEvent.setup();
@@ -14345,27 +14346,27 @@ describe("AgentWorkspace", () => {
     await screen.findByRole("img", { name: "a red bicycle" });
     expect(document.querySelector(".agent-attachment-chip")).toBeNull();
     // The /image itself never attaches (no prompt to carry it yet).
-    expect(
-      mocks.gatewayRequest.mock.calls.some(([method]) => method === "image.attach_bytes"),
-    ).toBe(false);
+    expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "image.attach")).toBe(
+      false,
+    );
 
     await user.type(await screen.findByRole("textbox"), "what do you think");
     const sendButton = screen.getByRole("button", { name: "Send message" });
     await waitFor(() => expect(sendButton).not.toBeDisabled());
     await user.click(sendButton);
 
-    // The generated image lands in the session via image.attach_bytes, keyed to
+    // The generated image lands in the session via image.attach, keyed to
     // the same session, before the follow-up prompt.submit.
     await waitFor(() =>
-      expect(mocks.gatewayRequest).toHaveBeenCalledWith("image.attach_bytes", {
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("image.attach", {
         session_id: "runtime-session-1",
-        mime_type: "image/png",
-        content_base64: "aGVsbG8=",
-        filename: expect.stringMatching(/^generated-image-\d+\.png$/),
+        path: expect.stringMatching(
+          /\/workspace\/session-attachments\/test\/generated-image-\d+\.png$/,
+        ),
       }),
     );
     const attachIndex = mocks.gatewayRequest.mock.calls.findIndex(
-      ([method]) => method === "image.attach_bytes",
+      ([method]) => method === "image.attach",
     );
     const submitIndex = mocks.gatewayRequest.mock.calls.findIndex(
       ([method]) => method === "prompt.submit",
@@ -14375,7 +14376,7 @@ describe("AgentWorkspace", () => {
     // Attached exactly once — the held image is cleared after it goes through,
     // not re-sent.
     expect(
-      mocks.gatewayRequest.mock.calls.filter(([method]) => method === "image.attach_bytes"),
+      mocks.gatewayRequest.mock.calls.filter(([method]) => method === "image.attach"),
     ).toHaveLength(1);
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
       session_id: "runtime-session-1",
@@ -14405,11 +14406,11 @@ describe("AgentWorkspace", () => {
     await user.click(screen.getByRole("button", { name: "Send message" }));
 
     await waitFor(() =>
-      expect(mocks.gatewayRequest).toHaveBeenCalledWith("image.attach_bytes", {
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("image.attach", {
         session_id: "runtime-session-1",
-        mime_type: "image/png",
-        content_base64: "aGVsbG8=",
-        filename: expect.stringMatching(/^generated-image-\d+\.png$/),
+        path: expect.stringMatching(
+          /\/workspace\/session-attachments\/test\/generated-image-\d+\.png$/,
+        ),
       }),
     );
   });
@@ -14458,14 +14459,15 @@ describe("AgentWorkspace", () => {
     await waitFor(() => expect(promptSubmitAttempts).toBe(2));
 
     const attachCalls = mocks.gatewayRequest.mock.calls.filter(
-      ([method]) => method === "image.attach_bytes",
+      ([method]) => method === "image.attach",
     );
     expect(attachCalls).toHaveLength(2);
     for (const [, payload] of attachCalls) {
       expect(payload).toMatchObject({
         session_id: "runtime-session-1",
-        mime_type: "image/png",
-        content_base64: "aGVsbG8=",
+        path: expect.stringMatching(
+          /\/workspace\/session-attachments\/test\/generated-image-\d+\.png$/,
+        ),
       });
     }
   });

--- a/src/test/hermes-compatibility-matrix.test.ts
+++ b/src/test/hermes-compatibility-matrix.test.ts
@@ -137,16 +137,12 @@ describe("isHermesFeatureSupported — honest support gate", () => {
     expect(isHermesFeatureSupported("automationBlueprints")).toBe(false);
   });
 
-  it("reports feature 19's image.attach_bytes + image editing once shipped", () => {
-    // Feature 19 wires the composer's imported images into image.attach_bytes
-    // (attachImage) with imported/attached/failed status, a failed-attach submit
-    // block, and the attachment fed into feature 14's artifact timeline, so its
-    // owned method key flips planned → supported; the imageEditing feature is
-    // partial (explicit source-image selection ships; the edited output is not
-    // rendered inline yet). Covered by hermes-image-attach and agent-workspace
-    // tests.
-    expect(getFeatureStatus("image.attach")).toBe("unsupported");
-    expect(isHermesFeatureSupported("image.attach")).toBe(false);
+  it("reports native path attach, byte fallback, and image editing", () => {
+    // The desktop path validates and snapshots workspace images in Rust before
+    // calling image.attach; image.attach_bytes remains the additive fallback.
+    // imageEditing stays partial because edited output is not rendered inline.
+    expect(getFeatureStatus("image.attach")).toBe("supported");
+    expect(isHermesFeatureSupported("image.attach")).toBe(true);
     expect(getFeatureStatus("image.attach_bytes")).toBe("supported");
     expect(isHermesFeatureSupported("image.attach_bytes")).toBe(true);
     expect(getFeatureStatus("imageEditing")).toBe("partial");

--- a/src/test/hermes-control-plane-methods.test.ts
+++ b/src/test/hermes-control-plane-methods.test.ts
@@ -175,6 +175,18 @@ describe("createHermesMethods — typed command wrappers", () => {
     });
   });
 
+  it("attachImagePath forwards only a native path to image.attach", async () => {
+    const { request, methods } = setup();
+    await methods.attachImagePath({
+      sessionId: "runtime-1",
+      path: "/workspace/session-attachments/abc/diagram.png",
+    });
+    expect(request).toHaveBeenCalledWith("image.attach", {
+      session_id: "runtime-1",
+      path: "/workspace/session-attachments/abc/diagram.png",
+    });
+  });
+
   it("omits undefined optional params rather than sending nulls", async () => {
     const { request, methods } = setup();
     await methods.branchSession({ sessionId: "s1" });

--- a/src/test/hermes-image-attach.test.tsx
+++ b/src/test/hermes-image-attach.test.tsx
@@ -102,7 +102,37 @@ describe("attachImageToSession", () => {
     };
   }
 
-  it("reads bytes, calls image.attach_bytes, and flips status to attached", async () => {
+  it("prefers the native path round trip and never reads or sends base64", async () => {
+    const deps = {
+      ...baseDeps(),
+      prepareImagePath: vi.fn().mockResolvedValue({
+        path: "/ws/session-attachments/abc/diagram.png",
+        mimeType: "image/png",
+        size: 1234,
+      }),
+      attachImagePath: vi.fn().mockResolvedValue({ attachment_id: "att-path" }),
+      isPathSupported: () => true,
+    };
+    const result = await attachImageToSession(
+      attachmentStateFrom(PNG, "runtime-1"),
+      "runtime-1",
+      deps,
+    );
+
+    expect(deps.prepareImagePath).toHaveBeenCalledWith("runtime-1", "/ws/uploads/diagram.png");
+    expect(deps.attachImagePath).toHaveBeenCalledWith({
+      sessionId: "runtime-1",
+      path: "/ws/session-attachments/abc/diagram.png",
+    });
+    expect(deps.readImageData).not.toHaveBeenCalled();
+    expect(deps.attachImage).not.toHaveBeenCalled();
+    expect(result.state.status).toBe("attached");
+    expect(result.state.hermesAttachmentId).toBe("att-path");
+    expect(result.trace?.method).toBe("image.attach");
+    expect(JSON.stringify(result)).not.toContain("aGVsbG8=");
+  });
+
+  it("keeps image.attach_bytes as an additive fallback", async () => {
     const deps = baseDeps();
     const result = await attachImageToSession(attachmentStateFrom(PNG, "ws-1"), "ws-1", deps);
 
@@ -117,6 +147,25 @@ describe("attachImageToSession", () => {
     expect(result.state.hermesAttachmentId).toBe("att-9");
     expect(result.state.sessionId).toBe("ws-1");
     expect(result.error).toBeUndefined();
+  });
+
+  it("does not bypass a native path rejection through the byte fallback", async () => {
+    const deps = {
+      ...baseDeps(),
+      prepareImagePath: vi.fn().mockRejectedValue(new Error("outside allowed roots")),
+      attachImagePath: vi.fn(),
+      isPathSupported: () => true,
+    };
+    const result = await attachImageToSession(
+      attachmentStateFrom(PNG, "runtime-1"),
+      "runtime-1",
+      deps,
+    );
+
+    expect(deps.attachImagePath).not.toHaveBeenCalled();
+    expect(deps.readImageData).not.toHaveBeenCalled();
+    expect(deps.attachImage).not.toHaveBeenCalled();
+    expect(result.state.status).toBe("failed");
   });
 
   it("uses the preview mime when the filename has no useful extension", async () => {

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -37,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   gatewayConnect: vi.fn(),
   gatewayEventHandlers: new Set<(event: Record<string, unknown>) => void>(),
   hermesBridgeImageDataUrl: vi.fn(),
+  prepareHermesBridgeImageAttachment: vi.fn(),
   hermesBridgeSessionMessages: vi.fn(),
   listHermesSessions: vi.fn(),
   hermesBridgeStatus: vi.fn(),
@@ -60,6 +61,7 @@ vi.mock("../lib/agent-run-monitor", () => ({
 vi.mock("../lib/tauri", () => ({
   dictationHelperCommand: vi.fn(),
   hermesBridgeImageDataUrl: mocks.hermesBridgeImageDataUrl,
+  prepareHermesBridgeImageAttachment: mocks.prepareHermesBridgeImageAttachment,
   hermesBridgeSessionMessages: mocks.hermesBridgeSessionMessages,
   hermesBridgeStatus: mocks.hermesBridgeStatus,
   importHermesBridgeFile: vi.fn(),
@@ -189,6 +191,13 @@ describe("note chat session map", () => {
       return Promise.resolve({});
     });
     mocks.gatewayConnect.mockResolvedValue(undefined);
+    mocks.prepareHermesBridgeImageAttachment.mockImplementation(
+      async (_sessionId: string, path: string) => ({
+        path: `/workspace/session-attachments/test/${path.split("/").pop() ?? "image.png"}`,
+        mimeType: "image/png",
+        size: 1234,
+      }),
+    );
     mocks.canAttributeUntaggedAgentRun.mockReturnValue(true);
   });
 


### PR DESCRIPTION
## Summary

- Make June-owned Hermes MCP scripts, runtime patch assets, `config.yaml`, and `SOUL.md` content-aware so unchanged startup assets are not rewritten.
- Preserve the runtime patch-set provenance check so a changed June patch version still forces a fresh patched runtime, and move synchronous startup preparation off Tokio worker threads.
- Add a security-sensitive native image attachment boundary that validates June-owned paths, rejects symlinks and paths outside the allowed roots, enforces the 50 MB cap, snapshots the file into a runtime-session workspace directory, and sends only the native path to Hermes.
- Keep `image.attach_bytes` as an additive fallback for callers without a gateway-local path; bounded preview/thumbnail generation remains separate.

Refs JUN-395

## Root cause

Hermes startup rewrote every generated MCP/config/identity asset even when the bytes were unchanged. Image attachment also loaded up to 50 MB into JavaScript as a base64 data URL and then sent that payload across both Tauri IPC and the Hermes WebSocket, despite the desktop app and Hermes sharing a local filesystem.

## Validation

- `make verify`
- `make local-ci` (`signoff/frontend` and `signoff/rust-macos` on `8973ea148d3171d44220fc63824b9f6b9ae9601f`)
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --locked -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` (3,497 passed, 2 skipped)

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording).
  - Not tested visually: this changes the native transport and startup write path without changing rendered UI.
- [ ] Needs a June API (backend) deploy before it works end to end.
  - No June API deploy is required.

## Out of scope

- Removing the additive `image.attach_bytes` fallback.
- Changing thumbnail/preview generation or its existing size bound.
- Changing the pinned Hermes patch set or gateway protocol beyond adding the already-supported local-path call to June's typed control plane.

## Followups

- Run the requested review round while this PR remains draft.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow files changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable: none changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable: June API is unchanged.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787427415&installation_model_id=425925&pr_number=938&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F938&signature=1cb8535dc90a6dafeb7329b29603748ec9368e022da524e5f62b2f79273927f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->