### PR TITLE
docs: hyphenate follow-ups in CONTRIBUTING.md PR conventions list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Rules that fail review if violated (full list in [spec/index.md](spec/index.md))
 PR conventions, in brief (details in [AGENTS.md](AGENTS.md)):
 
 - Fill in the PR template: what changed, validation, root cause for bug
-  fixes, out of scope, followups.
+  fixes, out of scope, follow-ups.
 - Attach a screenshot or recording for UI changes.
 - Describe behavior generically; avoid naming or comparing other products in
   PR titles, descriptions, and release notes.


### PR DESCRIPTION
## Description
This PR fixes hyphenation consistency for `follow-ups` in `CONTRIBUTING.md` under PR conventions.

## Details
Hyphenated `followups` -> `follow-ups`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787428903&installation_model_id=425925&pr_number=939&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F939&signature=a8fc5926c7c508139f59d1de3307393d65aa6581985a380c726128a96e6cdfef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->