### PR TITLE
perf: paint before optional launch work

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -144,6 +144,7 @@ Per-repo config the engineering skills read before acting (see the
 - [qa/agent-driven-integration.md](qa/agent-driven-integration.md) — QA strategy (3 layers, skill-first agent-driven)
 - [qa/computer-use-parity.md](qa/computer-use-parity.md) - JUN-278 parity, stricter safety differences, evidence map, and signed/manual release matrix
 - [qa/jun-334-note-transcription-latency.md](qa/jun-334-note-transcription-latency.md) — measured baseline and proof for note transcription latency
+- [qa/jun-391-paint-first.md](qa/jun-391-paint-first.md) - launch boundary tradeoff, experimental flag audit, and controlled time-to-first-frame evidence
 - `qa/feature-user-stories.tsv` — story → code → test traceability matrix
 - `qa/agent-e2e-qa-runs/` — dated end-to-end QA run logs
 

--- a/docs/qa/jun-391-paint-first.md
+++ b/docs/qa/jun-391-paint-first.md
@@ -1,0 +1,48 @@
+# JUN-391 paint-first launch
+
+JUN-391 changes the launch tradeoff from "avoid a workspace fallback flash" to
+"show a stable first frame as soon as React can render." The account/loading
+shell and the code-split workspace skeleton are acceptable launch states. A
+blank window while optional IPC or workspace parsing completes is not.
+
+## Launch boundary
+
+`src/main.tsx` mounts React without awaiting the experimental-flags IPC or the
+default Agent workspace import. After the browser has had one paint
+opportunity, the frontend starts three independent background tasks:
+
+1. hydrate experimental flags;
+2. ask the native shell to run browser cleanup and start the dictation helper;
+3. prefetch the remaining code-split workspaces during idle time.
+
+The native command returns immediately after scheduling its worker. Browser
+profile cleanup retains a one-time gate that also runs before the first managed
+browser profile is created, so an unusually early routine cannot race cleanup.
+Dictation helper startup reuses the existing shutdown-aware store, settings
+reapplication, retry supervision, and a single-flight guard.
+
+## Experimental flag audit
+
+The only persisted experimental capability is Browser use. Its live React
+subscribers are Settings and Routines, neither of which is part of the launch
+frame. The cached/static default remains available synchronously, and the
+persisted value applies when IPC resolves. No flag needs to stay on the
+synchronous launch path.
+
+## Measurement
+
+The comparison used Chromium against Vite with a faked Tauri bridge, an
+1180 by 780 viewport, warmed frontend assets, and an intentionally delayed
+`experimental_flags_get` response of 700 ms. Time to first frame was measured
+at the first animation frame after `#root` gained a child over five reloads.
+
+| Build | Samples (ms) | Median |
+| --- | --- | --- |
+| `origin/main` before JUN-391 | 1867, 877, 887, 869, 877 | 877 ms |
+| JUN-391 | 313, 161, 168, 165, 168 | 168 ms |
+
+At 200 ms, the baseline capture is still blank. The changed build shows the
+June shell and workspace skeleton. These are controlled development numbers,
+not a native release-build benchmark; they isolate the delayed IPC dependency
+and document the visible launch sequence. The PR carries both screenshots as
+the UI-class evidence.

--- a/src-tauri/src/browser/launcher.rs
+++ b/src-tauri/src/browser/launcher.rs
@@ -129,16 +129,16 @@ fn which_in_path(name: &str) -> Option<PathBuf> {
 }
 
 /// Root directory holding every ephemeral browser profile, under app-controlled
-/// temporary storage. The app sweeps it once at startup (see
+/// temporary storage. The app sweeps it once after first paint (see
 /// [`sweep_profiles_root`]) so a crash that skipped Drop never leaves a stale
 /// profile behind on the next run.
 pub fn profiles_root() -> PathBuf {
     std::env::temp_dir().join("co.opensoftware.june.browser-profiles")
 }
 
-/// Best-effort delete of everything under [`profiles_root`]. Called once at app
-/// startup, before any session exists; all errors are ignored (a missing root
-/// is already the desired state).
+/// Best-effort delete of everything under [`profiles_root`]. Called through the
+/// browser module's one-time gate before any session creates a new profile; all
+/// errors are ignored (a missing root is already the desired state).
 pub fn sweep_profiles_root() {
     sweep_profiles_root_at(&profiles_root());
 }
@@ -157,6 +157,9 @@ pub struct EphemeralProfile {
 impl EphemeralProfile {
     /// Creates a new uuid-named profile directory under [`profiles_root`].
     pub fn create() -> io::Result<EphemeralProfile> {
+        // The post-paint background task normally wins. This same Once gate is
+        // the race-free fallback when a routine starts unusually early.
+        super::setup_on_app_start();
         Self::create_in(&profiles_root())
     }
 

--- a/src-tauri/src/browser/mod.rs
+++ b/src-tauri/src/browser/mod.rs
@@ -13,14 +13,20 @@ use std::future::Future;
 #[cfg(test)]
 use std::path::Path;
 use std::pin::Pin;
+use std::sync::Once;
+
+static STARTUP_PROFILE_SWEEP: Once = Once::new();
 
 /// Boxed future used by the injectable resolver seam.
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Reaps profiles left by a crashed prior run before managed sessions can
-/// start in this app process.
+/// start in this app process. The renderer normally starts this after its first
+/// paint; [`launcher::EphemeralProfile::create`] calls the same one-time gate
+/// so an unusually early automatic routine waits for cleanup instead of racing
+/// it.
 pub(crate) fn setup_on_app_start() {
-    launcher::sweep_profiles_root();
+    STARTUP_PROFILE_SWEEP.call_once(launcher::sweep_profiles_root);
 }
 
 #[cfg(test)]

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -97,6 +97,9 @@ pub struct HelperState {
     /// Set only on intentional teardown (app quit / [`stop_helper`]) so the
     /// supervisor can tell a deliberate stop from a crash and skip respawning.
     shutting_down: AtomicBool,
+    /// Collapses repeated first-paint signals into one potentially blocking
+    /// orphan sweep and helper spawn.
+    initial_start_in_flight: AtomicBool,
     /// Consecutive rapid respawn attempts, used to cap a crash loop. Reset once
     /// a respawned helper survives long enough to be considered healthy.
     respawn_failures: AtomicU32,
@@ -108,6 +111,7 @@ impl Default for HelperState {
             process: Mutex::new(None),
             composer_registration: Mutex::new(None),
             shutting_down: AtomicBool::new(false),
+            initial_start_in_flight: AtomicBool::new(false),
             respawn_failures: AtomicU32::new(0),
         }
     }
@@ -846,39 +850,9 @@ pub fn setup(app: &mut tauri::App) {
         controller: Mutex::new(ShortcutActivationController::default()),
     });
 
-    // Install state before spawning so a helper that exits immediately can be
-    // observed by its stdout supervisor instead of disappearing during setup.
+    // Install every command/shutdown-owned state synchronously. The helper
+    // itself starts only after the renderer's first paint.
     app.manage(HelperState::default());
-    let helper_started = match spawn_helper(app.handle()) {
-        Ok(helper) => {
-            let helper_state = app.state::<HelperState>();
-            matches!(
-                store_respawned_helper(&helper_state, helper),
-                StoreRespawnedHelper::Stored
-            )
-        }
-        Err(error) => {
-            tracing::warn!(
-                error = %error.message,
-                "failed to start dictation helper during setup; retrying in background"
-            );
-            false
-        }
-    };
-
-    if helper_started {
-        let settings = app.state::<DictationSettingsState>();
-        let helper_state = app.state::<HelperState>();
-        let settings = settings
-            .settings
-            .lock()
-            .ok()
-            .map(|settings| settings.clone());
-        if let Some(settings) = settings {
-            let _ = apply_microphone_setting(&helper_state, &settings.microphone);
-            let _ = apply_shortcut_settings(&helper_state, &settings);
-        }
-    }
 
     let settings = app
         .state::<DictationSettingsState>()
@@ -887,20 +861,74 @@ pub fn setup(app: &mut tauri::App) {
         .map(|settings| settings.clone())
         .unwrap_or_default();
     let helper_expected = cfg!(any(target_os = "macos", target_os = "windows"));
-    let event = if helper_started || !helper_expected {
-        initial_hotkey_event(&settings)
-    } else {
+    let event = if helper_expected {
         helper_unavailable_event("restarting", "Dictation is starting.")
+    } else {
+        initial_hotkey_event(&settings)
     };
     app.manage(HotkeyStatus {
         event: Mutex::new(event.clone()),
     });
     let _ = app.emit("dictation-event", event.to_string());
+}
 
-    if helper_expected && !helper_started {
-        let app_handle = app.handle().clone();
-        thread::spawn(move || supervise_initial_helper_start(&app_handle));
+struct InitialHelperStartInProgress<'a>(&'a AtomicBool);
+
+impl<'a> InitialHelperStartInProgress<'a> {
+    fn try_begin(in_flight: &'a AtomicBool) -> Option<Self> {
+        in_flight
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+            .then_some(Self(in_flight))
     }
+}
+
+impl Drop for InitialHelperStartInProgress<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Starts the persistent dictation helper from a native background thread
+/// after the renderer's first paint. Shutdown owns the terminal
+/// `shutting_down` bit; both the initial store and every retry honor it so a
+/// late startup can never resurrect the helper during teardown.
+pub(crate) fn start_helper_after_first_paint(app: &AppHandle) {
+    if !cfg!(any(target_os = "macos", target_os = "windows")) {
+        return;
+    }
+    let Some(state) = app.try_state::<HelperState>() else {
+        return;
+    };
+    let Some(_start_in_progress) =
+        InitialHelperStartInProgress::try_begin(&state.initial_start_in_flight)
+    else {
+        return;
+    };
+    if state.shutting_down.load(Ordering::SeqCst)
+        || state.process.lock().is_ok_and(|process| process.is_some())
+    {
+        return;
+    }
+
+    match spawn_helper(app) {
+        Ok(helper) => match store_respawned_helper(&state, helper) {
+            StoreRespawnedHelper::Stored => {
+                reapply_helper_settings(app);
+                return;
+            }
+            StoreRespawnedHelper::ExitedBeforeStore => {}
+            StoreRespawnedHelper::Abandoned => return,
+        },
+        Err(error) => {
+            tracing::warn!(
+                error = %error.message,
+                "failed to start dictation helper after first paint; retrying"
+            );
+        }
+    }
+
+    supervise_initial_helper_start(app);
 }
 
 #[tauri::command]
@@ -3477,8 +3505,8 @@ fn send_helper_shutdown_nonblocking(mut stdin: ChildStdin) {
 }
 
 /// Re-applies the persisted microphone and shortcut settings to a just-respawned
-/// helper and re-arms the hotkey, mirroring the one-time wiring in [`setup`]. The
-/// hotkey-ready event also clears the "dictation restarting" notice in the UI.
+/// helper and re-arms the hotkey. The hotkey-ready event also clears the
+/// "dictation restarting" notice in the UI.
 fn reapply_helper_settings(app: &AppHandle) {
     let Some(helper_state) = app.try_state::<HelperState>() else {
         return;
@@ -5943,6 +5971,18 @@ pub fn key_code_for_code(code: &str) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn initial_helper_start_is_single_flight_and_reopens_after_completion() {
+        let in_flight = AtomicBool::new(false);
+        let first = InitialHelperStartInProgress::try_begin(&in_flight)
+            .expect("first helper start acquires the flight");
+
+        assert!(InitialHelperStartInProgress::try_begin(&in_flight).is_none());
+
+        drop(first);
+        assert!(InitialHelperStartInProgress::try_begin(&in_flight).is_some());
+    }
 
     #[cfg(target_os = "macos")]
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,9 +36,12 @@ pub mod updates;
 pub mod video_download_url;
 
 use serde::Deserialize;
-use std::sync::Mutex;
 #[cfg(target_os = "macos")]
 use std::sync::OnceLock;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Mutex,
+};
 use tauri::{Emitter, Manager};
 
 const CHECK_FOR_UPDATES_MENU_ID: &str = "check_for_updates";
@@ -83,6 +86,19 @@ struct RegisteredRecordingPresenceBounds {
 
 #[derive(Default)]
 struct RecordingPresenceBoundsState(Mutex<Option<RegisteredRecordingPresenceBounds>>);
+
+#[derive(Default)]
+struct AfterFirstPaintStartup {
+    scheduled: AtomicBool,
+}
+
+impl AfterFirstPaintStartup {
+    fn try_schedule(&self) -> bool {
+        self.scheduled
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+}
 
 #[cfg(target_os = "macos")]
 static MAIN_WINDOW_APP: OnceLock<tauri::AppHandle> = OnceLock::new();
@@ -164,6 +180,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             theme_icon::set_dock_icon,
             print_current_webview,
+            start_after_first_paint,
             commands::bootstrap_app,
             commands::experimental_flags_get,
             commands::experimental_flags_set,
@@ -410,6 +427,7 @@ pub fn run() {
             updates::relaunch_for_update,
         ])
         .manage(RecordingPresenceBoundsState::default())
+        .manage(AfterFirstPaintStartup::default())
         .manage(note_save_flush::NoteSaveFlushState::default())
         .manage(hermes_bridge::HermesBridge::default())
         .manage(computer_use::ComputerUseState::default())
@@ -419,7 +437,6 @@ pub fn run() {
         .manage(connectors::ConnectFlow::default())
         .manage(connectors::NotionConnectFlow::default())
         .setup(|app| {
-            browser::setup_on_app_start();
             setup_app_menu(app)?;
             menu_bar::setup(app)?;
             experimental_settings::setup(app)?;
@@ -518,7 +535,9 @@ fn single_instance_enabled_for_build(debug_assertions: bool, force_dev: bool) ->
 
 #[cfg(all(test, desktop))]
 mod tests {
-    use super::{should_emit_close_tab_event, single_instance_enabled_for_build};
+    use super::{
+        should_emit_close_tab_event, single_instance_enabled_for_build, AfterFirstPaintStartup,
+    };
 
     #[test]
     fn single_instance_is_disabled_for_dev_builds_by_default() {
@@ -540,6 +559,14 @@ mod tests {
         assert!(should_emit_close_tab_event(Some(true)));
         assert!(!should_emit_close_tab_event(Some(false)));
         assert!(!should_emit_close_tab_event(None));
+    }
+
+    #[test]
+    fn after_first_paint_startup_is_scheduled_once() {
+        let startup = AfterFirstPaintStartup::default();
+
+        assert!(startup.try_schedule());
+        assert!(!startup.try_schedule());
     }
 }
 
@@ -704,6 +731,40 @@ fn main_window_focus_state(app: &tauri::AppHandle) -> Option<bool> {
 
 fn should_emit_close_tab_event(main_window_focused: Option<bool>) -> bool {
     main_window_focused == Some(true)
+}
+
+/// Moves process/helper startup behind the renderer's first visible frame. The
+/// command returns as soon as the worker is scheduled; each owned subsystem
+/// keeps its own one-time or shutdown-aware guard.
+#[tauri::command]
+fn start_after_first_paint(app: tauri::AppHandle, state: tauri::State<'_, AfterFirstPaintStartup>) {
+    if !state.try_schedule() {
+        return;
+    }
+    let worker_app = app.clone();
+    if let Err(error) = std::thread::Builder::new()
+        .name("june-after-first-paint".to_string())
+        .spawn(move || {
+            if !worker_app
+                .state::<shutdown::ShutdownCoordinator>()
+                .is_idle()
+            {
+                return;
+            }
+            browser::setup_on_app_start();
+            if worker_app
+                .state::<shutdown::ShutdownCoordinator>()
+                .is_idle()
+            {
+                dictation::start_helper_after_first_paint(&worker_app);
+            }
+        })
+    {
+        app.state::<AfterFirstPaintStartup>()
+            .scheduled
+            .store(false, Ordering::SeqCst);
+        tracing::warn!(%error, "could not schedule after-first-paint startup");
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/shutdown.rs
+++ b/src-tauri/src/shutdown.rs
@@ -149,7 +149,7 @@ impl ShutdownCoordinator {
         matches!(*self.lock_phase(), ShutdownPhase::Finalizing(_))
     }
 
-    fn is_idle(&self) -> bool {
+    pub(crate) fn is_idle(&self) -> bool {
         matches!(*self.lock_phase(), ShutdownPhase::Idle)
     }
 }

--- a/src/app/launch-startup.ts
+++ b/src/app/launch-startup.ts
@@ -1,0 +1,31 @@
+import { invoke } from "@tauri-apps/api/core";
+import { initializeExperimentalFlags } from "../lib/experimental-flags";
+import { prefetchRemainingWorkspacesAfterPaint } from "./workspace-lazy";
+
+export const START_AFTER_FIRST_PAINT_COMMAND = "start_after_first_paint";
+
+/**
+ * Starts optional launch work only after React has had a rendering
+ * opportunity. Two animation frames make the boundary explicit: React mounts
+ * before the first callback, the browser paints, then the second callback
+ * starts work without making any of it a first-frame prerequisite.
+ */
+export function scheduleLaunchWorkAfterFirstPaint() {
+  let cancelled = false;
+  let secondFrame: number | undefined;
+  const firstFrame = window.requestAnimationFrame(() => {
+    if (cancelled) return;
+    secondFrame = window.requestAnimationFrame(() => {
+      if (cancelled) return;
+      void initializeExperimentalFlags();
+      void invoke(START_AFTER_FIRST_PAINT_COMMAND).catch(() => undefined);
+      prefetchRemainingWorkspacesAfterPaint();
+    });
+  });
+
+  return () => {
+    cancelled = true;
+    window.cancelAnimationFrame(firstFrame);
+    if (secondFrame !== undefined) window.cancelAnimationFrame(secondFrame);
+  };
+}

--- a/src/app/workspace-lazy.tsx
+++ b/src/app/workspace-lazy.tsx
@@ -191,5 +191,3 @@ function WorkspaceFallback() {
     </section>
   );
 }
-
-export const preloadInitialWorkspace = agentWorkspace.preload;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,12 +9,7 @@ import { initTheme } from "./lib/theme";
 import { initBrand } from "./lib/brand";
 import { initFontScale, installFontScaleShortcuts } from "./lib/font-scale";
 import { installExternalLinkOpener } from "./lib/external-links";
-import { initializeExperimentalFlags } from "./lib/experimental-flags";
-import { isMacLikePlatform, isWindowsPlatform } from "./lib/platform";
-import {
-  prefetchRemainingWorkspacesAfterPaint,
-  preloadInitialWorkspace,
-} from "./app/workspace-lazy";
+import { scheduleLaunchWorkAfterFirstPaint } from "./app/launch-startup";
 import "./styles/app.css";
 
 declare global {
@@ -36,16 +31,12 @@ initFontScale();
 installFontScaleShortcuts();
 installExternalLinkOpener();
 installNativeContextMenuGuard();
-// Intentionally await the default Agent workspace before mounting React. This
-// trades some first-paint parsing for a stable launch with no fallback flash;
-// JUN-391 owns the broader paint-first startup work. The remaining workspaces
-// are fetched after first paint below.
-await Promise.all([
-  initializeExperimentalFlags(),
-  isMacLikePlatform() || isWindowsPlatform()
-    ? preloadInitialWorkspace().catch(() => undefined)
-    : Promise.resolve(),
-]);
+// Paint the account/loading shell or workspace fallback immediately. The
+// previous await-before-render preload avoided a fallback flash, but made a
+// code-split workspace and experimental-flags IPC prerequisites for any frame.
+// JUN-391 deliberately accepts the stable skeleton so launch never stays blank
+// behind optional work; flags, native helpers, and remaining preloads start
+// after the browser has had a rendering opportunity below.
 
 // Console driver for the agent HUD overlay window: __agentHud("demo") etc.
 // from this window's devtools. Emits on the Tauri bus only, so fake demo
@@ -106,4 +97,4 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     {import.meta.env.DEV ? <Agentation /> : null}
   </React.StrictMode>,
 );
-prefetchRemainingWorkspacesAfterPaint();
+scheduleLaunchWorkAfterFirstPaint();

--- a/src/test/launch-startup.test.ts
+++ b/src/test/launch-startup.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  scheduleLaunchWorkAfterFirstPaint,
+  START_AFTER_FIRST_PAINT_COMMAND,
+} from "../app/launch-startup";
+
+const mocks = vi.hoisted(() => ({
+  initializeExperimentalFlags: vi.fn().mockResolvedValue(undefined),
+  invoke: vi.fn().mockResolvedValue(undefined),
+  prefetchRemainingWorkspacesAfterPaint: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("../lib/experimental-flags", () => ({
+  initializeExperimentalFlags: mocks.initializeExperimentalFlags,
+}));
+
+vi.mock("../app/workspace-lazy", () => ({
+  prefetchRemainingWorkspacesAfterPaint: mocks.prefetchRemainingWorkspacesAfterPaint,
+}));
+
+describe("launch startup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps optional startup work behind the first paint boundary", () => {
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+
+    scheduleLaunchWorkAfterFirstPaint();
+
+    expect(mocks.initializeExperimentalFlags).not.toHaveBeenCalled();
+    expect(mocks.invoke).not.toHaveBeenCalled();
+    expect(mocks.prefetchRemainingWorkspacesAfterPaint).not.toHaveBeenCalled();
+
+    frames.shift()?.(0);
+
+    expect(mocks.initializeExperimentalFlags).not.toHaveBeenCalled();
+    expect(mocks.invoke).not.toHaveBeenCalled();
+    expect(mocks.prefetchRemainingWorkspacesAfterPaint).not.toHaveBeenCalled();
+
+    frames.shift()?.(16);
+
+    expect(mocks.initializeExperimentalFlags).toHaveBeenCalledOnce();
+    expect(mocks.invoke).toHaveBeenCalledWith(START_AFTER_FIRST_PAINT_COMMAND);
+    expect(mocks.prefetchRemainingWorkspacesAfterPaint).toHaveBeenCalledOnce();
+  });
+
+  it("can cancel before the post-paint frame runs", () => {
+    const frames: FrameRequestCallback[] = [];
+    const cancelAnimationFrame = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => undefined);
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+
+    const cancel = scheduleLaunchWorkAfterFirstPaint();
+    frames.shift()?.(0);
+    cancel();
+    frames.shift()?.(16);
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(1);
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(1);
+    expect(mocks.initializeExperimentalFlags).not.toHaveBeenCalled();
+    expect(mocks.invoke).not.toHaveBeenCalled();
+    expect(mocks.prefetchRemainingWorkspacesAfterPaint).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Mount React immediately, then hydrate experimental flags and prefetch optional workspaces after the first painted frame.
- Move stale browser-profile cleanup and dictation-helper startup into a native after-first-paint worker while preserving browser cleanup-before-first-profile, helper single-flight behavior, retry supervision, and shutdown ownership.
- Update the launch tradeoff documentation to make the stable shell and workspace skeleton the preferred launch state.

UI-CLASS stabilization initiative: this draft is held for the user's merge decision regardless of automated review score. Do not mark it ready or merge it automatically.

Refs JUN-391

## Root cause

The renderer's top-level module awaited both `experimental_flags_get` and the default Agent workspace import before mounting React. Native Tauri setup also swept browser profiles and spawned the dictation helper before the webview could paint, so optional IPC, parsing, filesystem cleanup, and helper startup all sat on the blank-window launch path.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` - 217 files, 3,498 passed, 2 skipped
- `NODE_OPTIONS=--no-experimental-webstorage make local-ci` - `signoff/frontend` and `signoff/rust-macos` passed on `93209e9251b8d4051d294def7b82fb5ed286487c`
- Focused native single-flight tests for the after-first-paint coordinator and dictation helper startup
- Controlled Chromium and Vite fake-Tauri bridge measurement at 1180 by 780, with warmed assets and `experimental_flags_get` delayed by 700 ms. First frame was the first animation frame after `#root` gained a child over five reloads:

| Build | Samples (ms) | Median |
| --- | --- | --- |
| `origin/main` | 1867, 877, 887, 869, 877 | 877 ms |
| This PR | 313, 161, 168, 165, 168 | 168 ms |

At the same 200 ms point, the baseline is blank and this PR has painted the June shell and stable workspace skeleton.

### Before at 200 ms

![Blank baseline window at 200 ms](https://app.opensoftware.co/api/v1/files/fil_W0HJrJBK9QLv/download)

### After at 200 ms

![June shell and workspace skeleton at 200 ms](https://app.opensoftware.co/api/v1/files/fil_29T1C4i4WQhz/download)

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Reworking unrelated startup tasks that already run after paint.
- Treating the controlled development measurement as a native release-build benchmark.
- Changing the Browser use capability or its persisted value.

## Followups

- The user decides whether and when this UI-class stabilization draft is merged. Automated review results must not advance it to ready or merge it.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. None are present.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow files changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. None changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. None changed.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787429687&installation_model_id=425925&pr_number=941&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F941&signature=ccf6a48cb24eb60222a7cce59042acb84b39f3fcbe8a847c97fe41ad6dbec975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->