### PR TITLE
perf(recording): isolate telemetry from App state

### DIFF
--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -49,7 +49,11 @@ While capture is active, the native meeting-HUD supervisor samples capture at
 10 Hz and emits the additive `recording-telemetry` Tauri event. Its narrow
 payload carries the recording session id, state, elapsed time, audio levels,
 and live warnings; both the main renderer and meeting HUD subscribe to that
-single stream. Stable metadata still comes from the recording commands, and
+single stream. In the main renderer, the latest sample stays in a narrow
+external store: waveform subscribers receive level samples at 10 Hz, elapsed
+time subscribers publish only on whole-second boundaries, and the root App
+reducer receives only lifecycle, Source-health, and actionable-warning changes.
+Stable metadata still comes from the recording commands, and
 `get_recording_status` remains available as a read-only compatibility command.
 Recovery durability is independent of telemetry: a recording-scoped worker
 requests a ring watermark flush and checkpoints elapsed time every 500 ms after

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -72,6 +72,7 @@ import {
   notifyRecordingAutoPaused,
   notifyRecordingStillMeetingPrompt,
 } from "../lib/recording-notifications";
+import { RecordingTelemetryProvider } from "../lib/recording-telemetry-store";
 import {
   OPEN_SETTINGS_EVENT,
   buildAgentMenuBarState,
@@ -293,6 +294,7 @@ export function App() {
     calendarContextNoteUpdatesRef,
     pendingCalendarContextAdoptionsRef,
     recordingNoteId,
+    recordingTelemetryStore,
     recordingStatusRef,
     dictationWorkflowActiveRef,
     recordingInactivityTrackerRef,
@@ -1377,6 +1379,7 @@ export function App() {
 
   useRecordingTelemetry({
     dispatch,
+    recordingTelemetryStore,
     recordingStatusRef,
   });
 
@@ -1788,42 +1791,53 @@ export function App() {
   });
 
   useEffect(() => {
-    const status = state.recordingStatus;
-    const now = Date.now();
-    const decision = nextRecordingInactivityDecision(
-      recordingInactivityTrackerRef.current,
-      status,
-      now,
-    );
-    recordingInactivityTrackerRef.current = decision.tracker;
+    const evaluateLatestStatus = () => {
+      const status = recordingTelemetryStore.getStatus();
+      const now = Date.now();
+      const decision = nextRecordingInactivityDecision(
+        recordingInactivityTrackerRef.current,
+        status,
+        now,
+      );
+      recordingInactivityTrackerRef.current = decision.tracker;
 
-    if (
-      recordingInactivityPrompt &&
-      (!status ||
-        status.sessionId !== recordingInactivityPrompt.sessionId ||
-        status.state !== "recording" ||
-        recordingHasActivity(status))
-    ) {
-      setRecordingInactivityPrompt(null);
-      return;
-    }
+      if (
+        recordingInactivityPrompt &&
+        (!status ||
+          status.sessionId !== recordingInactivityPrompt.sessionId ||
+          status.state !== "recording" ||
+          recordingHasActivity(status))
+      ) {
+        setRecordingInactivityPrompt(null);
+        return;
+      }
 
-    if (
-      !status ||
-      !decision.shouldPrompt ||
-      recordingInactivityPrompt?.sessionId === status.sessionId
-    ) {
-      return;
-    }
+      if (
+        !status ||
+        !decision.shouldPrompt ||
+        recordingInactivityPrompt?.sessionId === status.sessionId
+      ) {
+        return;
+      }
 
-    const prompt = {
-      sessionId: status.sessionId,
-      expiresAt: now + RECORDING_INACTIVITY_RESPONSE_MS,
+      const prompt = {
+        sessionId: status.sessionId,
+        expiresAt: now + RECORDING_INACTIVITY_RESPONSE_MS,
+      };
+      setRecordingInactivityNow(now);
+      setRecordingInactivityPrompt(prompt);
+      void notifyRecordingStillMeetingPrompt(status.sessionId);
     };
-    setRecordingInactivityNow(now);
-    setRecordingInactivityPrompt(prompt);
-    void notifyRecordingStillMeetingPrompt(status.sessionId);
-  }, [recordingInactivityPrompt, state.recordingStatus]);
+
+    evaluateLatestStatus();
+    return recordingTelemetryStore.subscribeStatus(evaluateLatestStatus);
+  }, [
+    recordingInactivityPrompt,
+    recordingInactivityTrackerRef,
+    recordingTelemetryStore,
+    setRecordingInactivityNow,
+    setRecordingInactivityPrompt,
+  ]);
 
   useEffect(() => {
     if (!recordingInactivityPrompt) return;
@@ -2019,7 +2033,7 @@ export function App() {
     topUpLabel,
   });
 
-  return renderAppLayout({
+  const appLayout = renderAppLayout({
     accessibilityBannerDismissed,
     accessibilityBlocked,
     account,
@@ -2129,6 +2143,11 @@ export function App() {
     updateStatusLeaving,
     workspaceContent,
   });
+  return (
+    <RecordingTelemetryProvider store={recordingTelemetryStore}>
+      {appLayout}
+    </RecordingTelemetryProvider>
+  );
 }
 
 // The collapsed transform is driven by `aria-pressed` on the parent button.

--- a/src/app/use-app-state.ts
+++ b/src/app/use-app-state.ts
@@ -11,6 +11,10 @@ import type { AgentSessionStatusDetail } from "../lib/agent-events";
 import { useActiveHermesProfileName } from "../lib/active-hermes-profile";
 import type { SessionProfileMap } from "../lib/session-profile-filter";
 import type { RecordingInactivityTracker } from "../lib/recording-inactivity";
+import {
+  createRecordingTelemetryStore,
+  type RecordingTelemetryStore,
+} from "../lib/recording-telemetry-store";
 import { getAgentHudEnabled } from "../lib/agent-hud-settings";
 import type { NoteDto, HermesSessionInfo } from "../lib/tauri";
 import type { RecordingSourceMode, RecordingSourceReadinessDto } from "../lib/tauri";
@@ -235,6 +239,11 @@ export function useAppState() {
   // setRecordingNote so they can't drift.
   const [recordingNoteId, setRecordingNoteIdState] = useState<string | undefined>(undefined);
   const recordingStatusRef = useRef(state.recordingStatus);
+  const recordingTelemetryStoreRef = useRef<RecordingTelemetryStore | null>(null);
+  if (!recordingTelemetryStoreRef.current) {
+    recordingTelemetryStoreRef.current = createRecordingTelemetryStore(state.recordingStatus);
+  }
+  const recordingTelemetryStore = recordingTelemetryStoreRef.current;
   const dictationWorkflowActiveRef = useRef(false);
   const recordingInactivityTrackerRef = useRef<RecordingInactivityTracker>({});
   const [recordingInactivityPrompt, setRecordingInactivityPrompt] =
@@ -244,7 +253,8 @@ export function useAppState() {
   const [liveTranscriptEvents, setLiveTranscriptEvents] = useState<LiveTranscriptEventDto[]>([]);
   useEffect(() => {
     recordingStatusRef.current = state.recordingStatus;
-  }, [state.recordingStatus]);
+    recordingTelemetryStore.setStatus(state.recordingStatus);
+  }, [recordingTelemetryStore, state.recordingStatus]);
   const setRecordingNote = useCallback((noteId: string | undefined) => {
     recordingNoteIdRef.current = noteId;
     setRecordingNoteIdState(noteId);
@@ -370,6 +380,7 @@ export function useAppState() {
     calendarContextNoteUpdatesRef,
     pendingCalendarContextAdoptionsRef,
     recordingNoteId,
+    recordingTelemetryStore,
     recordingStatusRef,
     dictationWorkflowActiveRef,
     recordingInactivityTrackerRef,

--- a/src/app/use-recording-telemetry-types.ts
+++ b/src/app/use-recording-telemetry-types.ts
@@ -1,8 +1,10 @@
 import type * as React from "react";
+import type { RecordingTelemetryStore } from "../lib/recording-telemetry-store";
 import type { RecordingStatusDto } from "../lib/tauri";
 import type { NotesAction } from "./state/app-state";
 
 export type UseRecordingTelemetryDependencies = {
   dispatch: React.Dispatch<NotesAction>;
+  recordingTelemetryStore: RecordingTelemetryStore;
   recordingStatusRef: React.MutableRefObject<RecordingStatusDto | undefined>;
 };

--- a/src/app/use-recording-telemetry.ts
+++ b/src/app/use-recording-telemetry.ts
@@ -1,11 +1,11 @@
 import { listen } from "@tauri-apps/api/event";
 import { useEffect } from "react";
 import { RECORDING_TELEMETRY_EVENT, type RecordingTelemetryDto } from "../lib/tauri";
-import { mergeRecordingTelemetry } from "../lib/recording-telemetry";
+import { mergeRecordingTelemetry, sameRecordingSemantics } from "../lib/recording-telemetry";
 import type { UseRecordingTelemetryDependencies } from "./use-recording-telemetry-types";
 
 export function useRecordingTelemetry(dependencies: UseRecordingTelemetryDependencies) {
-  const { dispatch, recordingStatusRef } = dependencies;
+  const { dispatch, recordingTelemetryStore, recordingStatusRef } = dependencies;
 
   useEffect(() => {
     let unlisten: (() => void) | undefined;
@@ -17,9 +17,10 @@ export function useRecordingTelemetry(dependencies: UseRecordingTelemetryDepende
       }
       const next = mergeRecordingTelemetry(current, event.payload);
       recordingStatusRef.current = next;
-      if (next) {
+      recordingTelemetryStore.setStatus(next);
+      if (next && !sameRecordingSemantics(current, next)) {
         dispatch({ type: "recordingStatusChanged", status: next });
-      } else {
+      } else if (!next) {
         dispatch({ type: "recordingSessionLost", sessionId: event.payload.sessionId });
       }
     }).then((cleanup) => {
@@ -30,5 +31,5 @@ export function useRecordingTelemetry(dependencies: UseRecordingTelemetryDepende
       aborted = true;
       unlisten?.();
     };
-  }, [dispatch, recordingStatusRef]);
+  }, [dispatch, recordingStatusRef, recordingTelemetryStore]);
 }

--- a/src/components/recorder/GlobalRecorderPill.tsx
+++ b/src/components/recorder/GlobalRecorderPill.tsx
@@ -36,7 +36,7 @@ export function GlobalRecorderPill({ status, title, onOpen }: GlobalRecorderPill
       aria-label={`Open recording: ${title}`}
       title="Open recording"
     >
-      <Waveform level={meterLevel} active={recording} />
+      <Waveform level={meterLevel} sessionId={status.sessionId} active={recording} />
     </button>
   );
 }

--- a/src/components/recorder/RecorderBar.tsx
+++ b/src/components/recorder/RecorderBar.tsx
@@ -2,6 +2,7 @@ import { IconPause } from "central-icons-filled/IconPause";
 import { IconPlay } from "central-icons-filled/IconPlay";
 import { IconStop } from "central-icons-filled/IconStop";
 import type { RecordingStatusDto } from "../../lib/tauri";
+import { useRecordingElapsedMs } from "../../lib/recording-telemetry-store";
 import { combineSourceAudioLevels, Waveform } from "./Waveform";
 
 type RecorderBarProps = {
@@ -14,6 +15,7 @@ type RecorderBarProps = {
 export function RecorderBar({ status, onPause, onResume, onDone }: RecorderBarProps) {
   const paused = status.state === "paused";
   const controlsEnabled = status.state === "recording" || status.state === "paused";
+  const elapsedMs = useRecordingElapsedMs(status.sessionId, status.elapsedMs);
   // status.level is mic-only; status.sources carries mic+system when available.
   const meterLevel =
     status.sources && status.sources.length > 0
@@ -40,8 +42,12 @@ export function RecorderBar({ status, onPause, onResume, onDone }: RecorderBarPr
         {paused ? <IconPlay size={14} /> : <IconPause size={14} />}
       </button>
       <div className="recorder-meter">
-        <span className="elapsed">{formatElapsed(status.elapsedMs)}</span>
-        <Waveform level={meterLevel} active={status.state === "recording"} />
+        <span className="elapsed">{formatElapsed(elapsedMs)}</span>
+        <Waveform
+          level={meterLevel}
+          sessionId={status.sessionId}
+          active={status.state === "recording"}
+        />
       </div>
       <button
         type="button"

--- a/src/components/recorder/Waveform.tsx
+++ b/src/components/recorder/Waveform.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { AudioLevelDto } from "../../lib/tauri";
+import { useRecordingTelemetryLevel } from "../../lib/recording-telemetry-store";
 import {
   createBarMeter,
   IDLE_LEVEL,
@@ -25,6 +26,7 @@ export {
 
 type WaveformProps = {
   level: AudioLevelDto;
+  sessionId?: string;
   // Whether recording is live. The idle carrier shimmer only travels while
   // active; when paused the bars settle and hold (CSS also dims them).
   active?: boolean;
@@ -36,7 +38,8 @@ type WaveformProps = {
 // deque, so the bars die down immediately. See the push effect below.
 const POLL_WINDOW_PEAKS = 6;
 
-export function Waveform({ level, active = true }: WaveformProps) {
+export function Waveform({ level, sessionId, active = true }: WaveformProps) {
+  const telemetryLevel = useRecordingTelemetryLevel(sessionId, level);
   const refs = useRef<Array<HTMLSpanElement | null>>([]);
   // Shares the dictation HUD's synthesis + ballistics AND its travelling-wave
   // motion, with the recorder's own taller 7-bar layout and peak-based shaping.
@@ -64,10 +67,11 @@ export function Waveform({ level, active = true }: WaveformProps) {
     // so we max only the freshest few entries (~the 50ms poll at typical buffer
     // sizes). The cumulative `peak` is a since-start max (frozen), so it's only
     // the empty-history fallback.
-    const recent = level.recentPeaks;
-    const raw = recent.length > 0 ? Math.max(...recent.slice(-POLL_WINDOW_PEAKS)) : level.peak;
+    const recent = telemetryLevel.recentPeaks;
+    const raw =
+      recent.length > 0 ? Math.max(...recent.slice(-POLL_WINDOW_PEAKS)) : telemetryLevel.peak;
     meterRef.current.pushLevel(visualPeakScale(raw));
-  }, [level]);
+  }, [telemetryLevel]);
 
   useEffect(() => {
     const meter = meterRef.current;

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1601,7 +1601,7 @@ function SidebarRecordingIndicator({
       title="Open recording"
     >
       <span className="sidebar-recording-dot" aria-hidden />
-      <Waveform level={meterLevel} active={recording} />
+      <Waveform level={meterLevel} sessionId={status.sessionId} active={recording} />
     </button>
   );
 }

--- a/src/lib/recording-telemetry-store.tsx
+++ b/src/lib/recording-telemetry-store.tsx
@@ -1,0 +1,138 @@
+import { createContext, type PropsWithChildren, useContext, useSyncExternalStore } from "react";
+import type { AudioLevelDto, RecordingStatusDto, SourceStatusDto } from "./tauri";
+import { meterLevelForSources } from "./recorder-levels";
+
+type StoreListener = () => void;
+
+type RecordingLevelSnapshot = {
+  sessionId: string;
+  level: AudioLevelDto;
+  sources?: SourceStatusDto[];
+};
+
+type RecordingElapsedSnapshot = {
+  sessionId: string;
+  elapsedMs: number;
+};
+
+export type RecordingTelemetryStore = {
+  getStatus: () => RecordingStatusDto | undefined;
+  getLevelSnapshot: () => RecordingLevelSnapshot | undefined;
+  getElapsedSnapshot: () => RecordingElapsedSnapshot | undefined;
+  subscribeStatus: (listener: StoreListener) => () => void;
+  subscribeLevel: (listener: StoreListener) => () => void;
+  subscribeElapsed: (listener: StoreListener) => () => void;
+  setStatus: (status: RecordingStatusDto | undefined) => void;
+};
+
+function subscribe(listeners: Set<StoreListener>, listener: StoreListener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function notify(listeners: Set<StoreListener>) {
+  for (const listener of listeners) listener();
+}
+
+function elapsedSnapshot(status: RecordingStatusDto | undefined) {
+  if (!status) return undefined;
+  return {
+    sessionId: status.sessionId,
+    elapsedMs: Math.floor(Math.max(0, status.elapsedMs) / 1000) * 1000,
+  };
+}
+
+function sameElapsedSnapshot(
+  current: RecordingElapsedSnapshot | undefined,
+  next: RecordingElapsedSnapshot | undefined,
+) {
+  return current?.sessionId === next?.sessionId && current?.elapsedMs === next?.elapsedMs;
+}
+
+/** The authoritative renderer-side recording sample stays outside React.
+ * Consumers subscribe only to the cadence they render: level at native
+ * telemetry cadence, elapsed time on whole-second boundaries, and imperative
+ * observers (such as inactivity detection) on every sample. */
+export function createRecordingTelemetryStore(
+  initialStatus?: RecordingStatusDto,
+): RecordingTelemetryStore {
+  let status = initialStatus;
+  let level = initialStatus
+    ? {
+        sessionId: initialStatus.sessionId,
+        level: initialStatus.level,
+        sources: initialStatus.sources,
+      }
+    : undefined;
+  let elapsed = elapsedSnapshot(initialStatus);
+  const statusListeners = new Set<StoreListener>();
+  const levelListeners = new Set<StoreListener>();
+  const elapsedListeners = new Set<StoreListener>();
+
+  return {
+    getStatus: () => status,
+    getLevelSnapshot: () => level,
+    getElapsedSnapshot: () => elapsed,
+    subscribeStatus: (listener) => subscribe(statusListeners, listener),
+    subscribeLevel: (listener) => subscribe(levelListeners, listener),
+    subscribeElapsed: (listener) => subscribe(elapsedListeners, listener),
+    setStatus: (nextStatus) => {
+      if (Object.is(status, nextStatus)) return;
+
+      const nextElapsed = elapsedSnapshot(nextStatus);
+      const elapsedChanged = !sameElapsedSnapshot(elapsed, nextElapsed);
+      status = nextStatus;
+      level = nextStatus
+        ? {
+            sessionId: nextStatus.sessionId,
+            level: nextStatus.level,
+            sources: nextStatus.sources,
+          }
+        : undefined;
+      elapsed = nextElapsed;
+
+      notify(statusListeners);
+      notify(levelListeners);
+      if (elapsedChanged) notify(elapsedListeners);
+    },
+  };
+}
+
+const RecordingTelemetryStoreContext = createContext<RecordingTelemetryStore | undefined>(
+  undefined,
+);
+const subscribeToNothing = () => () => {};
+const getNoLevelSnapshot = () => undefined;
+const getNoElapsedSnapshot = () => undefined;
+
+export function RecordingTelemetryProvider({
+  children,
+  store,
+}: PropsWithChildren<{ store: RecordingTelemetryStore }>) {
+  return (
+    <RecordingTelemetryStoreContext.Provider value={store}>
+      {children}
+    </RecordingTelemetryStoreContext.Provider>
+  );
+}
+
+export function useRecordingTelemetryLevel(sessionId: string | undefined, fallback: AudioLevelDto) {
+  const store = useContext(RecordingTelemetryStoreContext);
+  const snapshot = useSyncExternalStore(
+    store?.subscribeLevel ?? subscribeToNothing,
+    store?.getLevelSnapshot ?? getNoLevelSnapshot,
+    store?.getLevelSnapshot ?? getNoLevelSnapshot,
+  );
+  if (!snapshot || (sessionId && snapshot.sessionId !== sessionId)) return fallback;
+  return meterLevelForSources(snapshot.level, snapshot.sources);
+}
+
+export function useRecordingElapsedMs(sessionId: string, fallback: number) {
+  const store = useContext(RecordingTelemetryStoreContext);
+  const snapshot = useSyncExternalStore(
+    store?.subscribeElapsed ?? subscribeToNothing,
+    store?.getElapsedSnapshot ?? getNoElapsedSnapshot,
+    store?.getElapsedSnapshot ?? getNoElapsedSnapshot,
+  );
+  return snapshot?.sessionId === sessionId ? snapshot.elapsedMs : fallback;
+}

--- a/src/lib/recording-telemetry-store.tsx
+++ b/src/lib/recording-telemetry-store.tsx
@@ -89,7 +89,7 @@ export function createRecordingTelemetryStore(
             sources: nextStatus.sources,
           }
         : undefined;
-      elapsed = nextElapsed;
+      if (elapsedChanged) elapsed = nextElapsed;
 
       notify(statusListeners);
       notify(levelListeners);

--- a/src/lib/recording-telemetry.ts
+++ b/src/lib/recording-telemetry.ts
@@ -28,6 +28,51 @@ export function mergeRecordingTelemetry(
   };
 }
 
+/** Compare only the recording facts broad app state is responsible for.
+ * Elapsed time and levels belong to the narrow telemetry store; lifecycle,
+ * Source health, and actionable warnings still publish through the reducer. */
+export function sameRecordingSemantics(current: RecordingStatusDto, next: RecordingStatusDto) {
+  return (
+    current.sessionId === next.sessionId &&
+    current.state === next.state &&
+    current.silenceWarning === next.silenceWarning &&
+    sameSourceSemantics(current.sources, next.sources) &&
+    sameWarnings(current.warnings, next.warnings)
+  );
+}
+
+function sameSourceSemantics(
+  current: SourceStatusDto[] | undefined,
+  next: SourceStatusDto[] | undefined,
+) {
+  if (current === next) return true;
+  if ((current?.length ?? 0) !== (next?.length ?? 0)) return false;
+  return (current ?? []).every((source, index) => {
+    const candidate = next?.[index];
+    return (
+      source.source === candidate?.source &&
+      source.state === candidate.state &&
+      source.silenceWarning === candidate.silenceWarning
+    );
+  });
+}
+
+function sameWarnings(
+  current: RecordingStatusDto["warnings"],
+  next: RecordingStatusDto["warnings"],
+) {
+  if (current === next) return true;
+  if ((current?.length ?? 0) !== (next?.length ?? 0)) return false;
+  return (current ?? []).every((warning, index) => {
+    const candidate = next?.[index];
+    return (
+      warning.source === candidate?.source &&
+      warning.code === candidate.code &&
+      warning.message === candidate.message
+    );
+  });
+}
+
 function mergeSourceTelemetry(
   current: SourceStatusDto[] | undefined,
   telemetry: RecordingSourceTelemetryDto[],

--- a/src/test/recording-telemetry-rendering.test.tsx
+++ b/src/test/recording-telemetry-rendering.test.tsx
@@ -181,4 +181,18 @@ describe("recording telemetry render isolation", () => {
     );
     expect(appRender).toHaveBeenCalledTimes(3);
   });
+
+  it("keeps the elapsed snapshot identity stable within a whole-second boundary", () => {
+    const initialStatus = status();
+    const store = createRecordingTelemetryStore(initialStatus);
+    const initialElapsed = store.getElapsedSnapshot();
+
+    store.setStatus({
+      ...initialStatus,
+      elapsedMs: 900,
+      level: { peak: 0.8, rms: 0.5, recentPeaks: [0.7, 0.8] },
+    });
+
+    expect(store.getElapsedSnapshot()).toBe(initialElapsed);
+  });
 });

--- a/src/test/recording-telemetry-rendering.test.tsx
+++ b/src/test/recording-telemetry-rendering.test.tsx
@@ -1,0 +1,184 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { useReducer, useRef } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useRecordingTelemetry } from "../app/use-recording-telemetry";
+import { createInitialState, notesReducer } from "../app/state/app-state";
+import {
+  createRecordingTelemetryStore,
+  RecordingTelemetryProvider,
+  useRecordingElapsedMs,
+} from "../lib/recording-telemetry-store";
+import type { RecordingStatusDto, RecordingTelemetryDto } from "../lib/tauri";
+
+type TauriListener = (event: { payload: RecordingTelemetryDto }) => unknown;
+
+const mocks = vi.hoisted(() => ({
+  listeners: new Map<string, TauriListener>(),
+  listen: vi.fn((event: string, listener: TauriListener) => {
+    mocks.listeners.set(event, listener);
+    return Promise.resolve(() => mocks.listeners.delete(event));
+  }),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
+}));
+
+function status(): RecordingStatusDto {
+  return {
+    sessionId: "session-1",
+    state: "recording",
+    elapsedMs: 0,
+    level: { peak: 0, rms: 0, recentPeaks: [] },
+    silenceWarning: false,
+    bytesWritten: 1024,
+    sources: [
+      {
+        source: "microphone",
+        state: "recording",
+        elapsedMs: 0,
+        bytesWritten: 1024,
+        level: { peak: 0, rms: 0, recentPeaks: [] },
+        silenceWarning: false,
+        pathFinalized: false,
+      },
+    ],
+    warnings: [],
+  };
+}
+
+function telemetry(overrides: Partial<RecordingTelemetryDto> = {}): RecordingTelemetryDto {
+  return {
+    sessionId: "session-1",
+    state: "recording",
+    elapsedMs: 1500,
+    level: { peak: 0.4, rms: 0.2, recentPeaks: [0.3, 0.4] },
+    silenceWarning: false,
+    sources: [
+      {
+        source: "microphone",
+        state: "recording",
+        elapsedMs: 1500,
+        level: { peak: 0.4, rms: 0.2, recentPeaks: [0.3, 0.4] },
+        silenceWarning: false,
+      },
+    ],
+    warnings: [],
+    ...overrides,
+  };
+}
+
+function AppLevelProbe({ onRender }: { onRender: () => void }) {
+  onRender();
+  return null;
+}
+
+function ElapsedProbe({
+  fallback,
+  onRender,
+}: {
+  fallback: RecordingStatusDto;
+  onRender: () => void;
+}) {
+  onRender();
+  const elapsedMs = useRecordingElapsedMs(fallback.sessionId, fallback.elapsedMs);
+  return <output aria-label="Elapsed seconds">{Math.floor(elapsedMs / 1000)}</output>;
+}
+
+function RecordingHarness({
+  onAppRender,
+  onElapsedRender,
+}: {
+  onAppRender: () => void;
+  onElapsedRender: () => void;
+}) {
+  const initialStatusRef = useRef(status());
+  const [state, dispatch] = useReducer(notesReducer, {
+    ...createInitialState(),
+    recordingStatus: initialStatusRef.current,
+  });
+  const recordingStatusRef = useRef<RecordingStatusDto | undefined>(initialStatusRef.current);
+  const storeRef = useRef(createRecordingTelemetryStore(initialStatusRef.current));
+
+  useRecordingTelemetry({
+    dispatch,
+    recordingTelemetryStore: storeRef.current,
+    recordingStatusRef,
+  });
+
+  const currentStatus = state.recordingStatus;
+  if (!currentStatus) return null;
+
+  return (
+    <RecordingTelemetryProvider store={storeRef.current}>
+      <AppLevelProbe onRender={onAppRender} />
+      <span data-testid="recording-state">{currentStatus.state}</span>
+      <span data-testid="recording-warning">{currentStatus.warnings?.[0]?.message}</span>
+      <ElapsedProbe fallback={currentStatus} onRender={onElapsedRender} />
+    </RecordingTelemetryProvider>
+  );
+}
+
+describe("recording telemetry render isolation", () => {
+  beforeEach(() => {
+    mocks.listeners.clear();
+    mocks.listen.mockClear();
+  });
+
+  it("keeps ticks out of the App render path while lifecycle changes still propagate", async () => {
+    const appRender = vi.fn();
+    const elapsedRender = vi.fn();
+    render(<RecordingHarness onAppRender={appRender} onElapsedRender={elapsedRender} />);
+    await waitFor(() => expect(mocks.listeners.has("recording-telemetry")).toBe(true));
+
+    expect(appRender).toHaveBeenCalledTimes(1);
+    expect(elapsedRender).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      mocks.listeners.get("recording-telemetry")?.({ payload: telemetry() });
+    });
+
+    expect(screen.getByRole("status", { name: "Elapsed seconds" })).toHaveTextContent("1");
+    expect(appRender).toHaveBeenCalledTimes(1);
+    expect(elapsedRender).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      mocks.listeners.get("recording-telemetry")?.({
+        payload: telemetry({ elapsedMs: 1900 }),
+      });
+    });
+
+    expect(appRender).toHaveBeenCalledTimes(1);
+    expect(elapsedRender).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      mocks.listeners.get("recording-telemetry")?.({
+        payload: telemetry({ state: "paused", elapsedMs: 2000 }),
+      });
+    });
+
+    expect(screen.getByTestId("recording-state")).toHaveTextContent("paused");
+    expect(appRender).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      mocks.listeners.get("recording-telemetry")?.({
+        payload: telemetry({
+          state: "paused",
+          elapsedMs: 2100,
+          warnings: [
+            {
+              source: "microphone",
+              code: "microphone_stream_stalled",
+              message: "Microphone input stopped unexpectedly.",
+            },
+          ],
+        }),
+      });
+    });
+
+    expect(screen.getByTestId("recording-warning")).toHaveTextContent(
+      "Microphone input stopped unexpectedly.",
+    );
+    expect(appRender).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/test/recording-telemetry.test.ts
+++ b/src/test/recording-telemetry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mergeRecordingTelemetry } from "../lib/recording-telemetry";
+import { mergeRecordingTelemetry, sameRecordingSemantics } from "../lib/recording-telemetry";
 import type { RecordingStatusDto, RecordingTelemetryDto } from "../lib/tauri";
 
 function status(): RecordingStatusDto {
@@ -88,5 +88,59 @@ describe("recording telemetry", () => {
     expect(
       mergeRecordingTelemetry(current, telemetry({ sessionId: "newer-session", state: "idle" })),
     ).toBe(current);
+  });
+});
+
+describe("same recording semantics", () => {
+  it("ignores elapsed time and level-only changes", () => {
+    const current = status();
+    const currentSource = current.sources?.[0];
+    if (!currentSource) throw new Error("expected microphone Source");
+
+    expect(
+      sameRecordingSemantics(current, {
+        ...current,
+        elapsedMs: 900,
+        level: { peak: 0.8, rms: 0.5, recentPeaks: [0.7, 0.8] },
+        sources: [
+          {
+            ...currentSource,
+            elapsedMs: 900,
+            level: { peak: 0.8, rms: 0.5, recentPeaks: [0.7, 0.8] },
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("detects per-Source state and silence warnings plus warning-set changes", () => {
+    const current = status();
+    const currentSource = current.sources?.[0];
+    if (!currentSource) throw new Error("expected microphone Source");
+
+    expect(
+      sameRecordingSemantics(current, {
+        ...current,
+        sources: [{ ...currentSource, state: "paused" }],
+      }),
+    ).toBe(false);
+    expect(
+      sameRecordingSemantics(current, {
+        ...current,
+        sources: [{ ...currentSource, silenceWarning: true }],
+      }),
+    ).toBe(false);
+    expect(
+      sameRecordingSemantics(current, {
+        ...current,
+        warnings: [
+          {
+            source: "microphone",
+            code: "microphone_stream_stalled",
+            message: "Microphone input stopped unexpectedly.",
+          },
+        ],
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Keep the native 10 Hz recording telemetry sample in a per-App external store instead of dispatching every sample through the root reducer.
- Publish level samples only to the recorder waveforms, publish elapsed time on whole-second boundaries, and keep lifecycle, Source-health, and actionable-warning changes in App state.
- Preserve recording inactivity detection as an imperative telemetry observer and retain the existing waveform rAF/CSS-variable rendering path.

Refs JUN-429

## Root cause

PR #910 routed every `recording-telemetry` sample through `recordingStatusChanged`. Because the reducer replaced `state.recordingStatus` for each 100 ms sample, the root App render path rebuilt the workspace layout, sidebar, note editor, and recorder surfaces even when only audio levels or elapsed time changed.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` - 217 files passed; 3508 tests passed, 2 skipped
- `make local-ci` - `signoff/frontend` passed on `b3319ed50c46a9b7e8992ac28ee4dcf873a99bf6`; `signoff/rust-macos` not applicable
- Added render-count and direct comparator regression tests proving telemetry ticks do not re-render an App-level probe while lifecycle, Source-health, and warning transitions still propagate.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). Not run: this changes no markup, CSS, or visual behavior; the affected render behavior is covered by regression tests.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend change or deploy is required.

## Out of scope

- Changing the native telemetry event contract or its 10 Hz sampling cadence.
- Changing recording, pause/resume, recovery, or audio capture correctness.
- Redesigning recorder, waveform, sidebar, or meeting HUD visuals.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. This change is not security-sensitive.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow actions changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such changes.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend changes.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.
