### PR TITLE
Recover idle Gateway stalls on submit

### DIFF
--- a/docs/hermes-architecture.md
+++ b/docs/hermes-architecture.md
@@ -125,7 +125,11 @@ classified events into `AgentChatTurn` / `AgentChatPart[]` for rendering.
   heartbeat: three consecutive request timeouts invalidate every open client
   for that runtime mode, converting a silently stalled OPEN socket into the
   established unexpected-close and reconnect path without adding another
-  periodic request.
+  periodic request. When that polling is dormant because the mode has no
+  working sessions, the first Gateway request of a new submit instead gets a
+  three-second liveness deadline. A timeout force-disconnects the mode and
+  retries that transport request once on the fresh connection; the rest of the
+  submit keeps ordinary request deadlines.
 - **Browser approvals are event-led.** The browser-approval change event
   refreshes pending approvals promptly. Snapshot reads are limited to initial
   subscription, listener reattachment, and focus, visibility, or online

--- a/docs/hermes-architecture.md
+++ b/docs/hermes-architecture.md
@@ -126,10 +126,12 @@ classified events into `AgentChatTurn` / `AgentChatPart[]` for rendering.
   for that runtime mode, converting a silently stalled OPEN socket into the
   established unexpected-close and reconnect path without adding another
   periodic request. When that polling is dormant because the mode has no
-  working sessions, the first Gateway request of a new submit instead gets a
-  three-second liveness deadline. A timeout force-disconnects the mode and
-  retries that transport request once on the fresh connection; the rest of the
-  submit keeps ordinary request deadlines.
+  working sessions, a new submit first sends one read-only
+  `session.active_list` preflight with a three-second liveness deadline. A
+  timeout force-disconnects the mode and retries only that safe preflight once
+  on the fresh connection. The submit's real requests, including
+  `session.create` and `prompt.submit`, are sent once with their ordinary
+  deadlines.
 - **Browser approvals are event-led.** The browser-approval change event
   refreshes pending approvals promptly. Snapshot reads are limited to initial
   subscription, listener reattachment, and focus, visibility, or online

--- a/docs/hermes-gateway-gotchas.md
+++ b/docs/hermes-gateway-gotchas.md
@@ -34,7 +34,11 @@ send protocol-level ping frames. June therefore treats the existing
 `session.active_list` cycle as its liveness signal. Three consecutive request
 timeouts force-disconnect all clients for that runtime mode so the ordinary
 close/reconnect recovery path runs. Do not add a second always-on heartbeat
-request.
+request. When no working session owns that cycle, only the first Gateway
+request of a new submit gets a three-second liveness deadline. Its timeout
+force-disconnects the mode and retries that request once; this is
+submit-scoped transport recovery, not a second composer submission or a change
+to the heartbeat counters.
 
 **App teardown is ordered and bounded.** Ordinary quit enters the idempotent
 shutdown coordinator from `RunEvent::ExitRequested`; update relaunch enters the

--- a/docs/hermes-gateway-gotchas.md
+++ b/docs/hermes-gateway-gotchas.md
@@ -34,11 +34,12 @@ send protocol-level ping frames. June therefore treats the existing
 `session.active_list` cycle as its liveness signal. Three consecutive request
 timeouts force-disconnect all clients for that runtime mode so the ordinary
 close/reconnect recovery path runs. Do not add a second always-on heartbeat
-request. When no working session owns that cycle, only the first Gateway
-request of a new submit gets a three-second liveness deadline. Its timeout
-force-disconnects the mode and retries that request once; this is
-submit-scoped transport recovery, not a second composer submission or a change
-to the heartbeat counters.
+request. When no working session owns that cycle, a new submit sends one
+read-only `session.active_list` preflight with a three-second liveness
+deadline. Its timeout force-disconnects the mode and retries only the safe
+preflight once. The real submit requests keep their normal deadlines and are
+never transport-retried; this is submit-scoped recovery, not a second composer
+submission or a change to the heartbeat counters.
 
 **App teardown is ordered and bounded.** Ordinary quit enters the idempotent
 shutdown coordinator from `RunEvent::ExitRequested`; update relaunch enters the

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -34,6 +34,7 @@ import {
   createHermesMethods,
   hermesModeFor,
   type JuneHermesEvent,
+  type HermesRequestLike,
 } from "../../lib/hermes-control-plane";
 import { normalizeSteerText } from "../../lib/hermes-session-steer";
 import { pendingActionStore } from "../../lib/hermes-pending-actions";
@@ -1913,6 +1914,7 @@ export function AgentWorkspace({
     sessionId: string,
     level: ThinkingLevel,
     explicitRuntimeSessionId?: string,
+    requestClient?: HermesRequestLike,
   ) {
     const effort = thinkingEffortForLevel(level);
     const runtimeSessionId = explicitRuntimeSessionId ?? runtimeSessionIdsRef.current[sessionId];
@@ -1922,7 +1924,7 @@ export function AgentWorkspace({
       return;
     }
     try {
-      const gateway = await ensureHermesGateway(sessionUnrestricted(sessionId));
+      const gateway = requestClient ?? (await ensureHermesGateway(sessionUnrestricted(sessionId)));
       await createHermesMethods(gateway).setSessionReasoningEffort({
         sessionId: runtimeSessionId,
         effort,

--- a/src/components/agent/pending-image-actions.ts
+++ b/src/components/agent/pending-image-actions.ts
@@ -1,9 +1,9 @@
 import { hermesBridgeImageDataUrl, prepareHermesBridgeImageAttachment } from "../../lib/tauri";
-import type { HermesGatewayClient } from "../../lib/hermes-gateway";
 import {
   createHermesMethods,
   hermesModeFor,
   isHermesFeatureSupported,
+  type HermesRequestLike,
 } from "../../lib/hermes-control-plane";
 import {
   attachImageToSession,
@@ -23,7 +23,7 @@ export function createPendingImageActions(dependencies: createPendingImageAction
   const { pendingFastPathImagesRef, setComposerAttachments } = dependencies;
 
   async function attachPendingImages(
-    gateway: HermesGatewayClient,
+    gateway: HermesRequestLike,
     runtimeSessionId: string,
     storedSessionId: string,
     turnAttachments: AgentAttachment[],

--- a/src/components/agent/session-submission-types.ts
+++ b/src/components/agent/session-submission-types.ts
@@ -17,7 +17,8 @@ export type SubmitHermesSession = (
 ) => Promise<string | undefined>;
 import type { AgentProjectContext } from "../../lib/agent-project-context";
 import { ProjectContextSignatureStore } from "../../lib/agent-project-context";
-import { HermesGatewayClient } from "../../lib/hermes-gateway";
+import type { HermesRequestLike } from "../../lib/hermes-control-plane";
+import type { HermesGatewayClient } from "../../lib/hermes-gateway";
 import type { HermesSessionDispatchReservation } from "../../lib/hermes-session-dispatch-mutex";
 import { type SessionModelSelectionMap } from "../../lib/hermes-session-model-selection";
 import {
@@ -44,6 +45,7 @@ export type SubmitHermesSessionDependencies = {
     sessionId: string,
     level: ThinkingLevel,
     explicitRuntimeSessionId?: string,
+    requestClient?: HermesRequestLike,
   ) => Promise<void>;
   attachHermesSessionEventListener: ({
     gateway,
@@ -59,7 +61,7 @@ export type SubmitHermesSessionDependencies = {
     computerUseRunLeaseId?: string;
   }) => () => void;
   attachPendingImages: (
-    gateway: HermesGatewayClient,
+    gateway: HermesRequestLike,
     runtimeSessionId: string,
     storedSessionId: string,
     turnAttachments: AgentAttachment[],

--- a/src/components/agent/session-submission.ts
+++ b/src/components/agent/session-submission.ts
@@ -11,8 +11,10 @@ import { withTimeout } from "../../lib/async-timeout";
 import { toolsetsForComputerUseAgentRun } from "../../lib/computer-use-agent-run";
 import { messageFromError } from "../../lib/errors";
 import { titleFromPrompt } from "../../lib/hermes-adapter";
+import { hasHermesActiveSessionSnapshotSubscribers } from "../../lib/hermes-active-session-snapshots";
 import { createHermesMethods, hermesModeFor } from "../../lib/hermes-control-plane";
 import { isSessionBusyError } from "../../lib/hermes-gateway";
+import { createHermesIdleSubmitGateway } from "../../lib/hermes-idle-submit-recovery";
 import { pendingImageAttachments } from "../../lib/hermes-image-attach";
 import { applySessionModelWhenIdle } from "../../lib/hermes-next-prompt-model";
 import {
@@ -185,6 +187,9 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
         .replace(/^([a-z])/, (match) => match.toUpperCase());
     }
     const targetStoredSessionId = modelTarget.targetStoredSessionId ?? undefined;
+    const submitFullMode = targetStoredSessionId
+      ? sessionUnrestricted(targetStoredSessionId)
+      : fullModeDraftRef.current;
     let dispatchReservation =
       options?.dispatchReservation ??
       (targetStoredSessionId ? reserveHermesSessionDispatch(targetStoredSessionId) : undefined);
@@ -291,14 +296,10 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
     // the mode its session was created with. Without this, one Unrestricted
     // session would leave the runtime unsandboxed under every other
     // session's follow-ups.
-    const { created, createdUnderProfile, gateway, sessionTitle, storedSessionId } =
+    const { created, createdUnderProfile, submitGateway, sessionTitle, storedSessionId } =
       await (async () => {
         const [nextGateway] = await Promise.all([
-          ensureHermesGateway(
-            targetStoredSessionId
-              ? sessionUnrestricted(targetStoredSessionId)
-              : fullModeDraftRef.current,
-          ),
+          ensureHermesGateway(submitFullMode),
           // Re-read the sticky active profile for every brand-new session so an
           // out-of-band switch (Hermes CLI, upstream dashboard) is honored
           // without a workspace remount. Runs in parallel with gateway setup
@@ -316,9 +317,15 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
           : getActiveHermesProfileName();
         const underProfile =
           nextUnderProfileName !== undefined && nextUnderProfileName !== "default";
+        const submitGateway = createHermesIdleSubmitGateway({
+          fullMode: submitFullMode,
+          gateway: nextGateway,
+          shouldProbeFirstRequest: () => !hasHermesActiveSessionSnapshotSubscribers(submitFullMode),
+          reconnect: () => ensureHermesGateway(submitFullMode),
+        });
         const nextCreated = targetStoredSessionId
           ? undefined
-          : await createHermesMethods(nextGateway).createSession<HermesRuntimeSessionResponse>({
+          : await createHermesMethods(submitGateway).createSession<HermesRuntimeSessionResponse>({
               title: fallbackSessionTitle,
               cols: 96,
               // session.create treats `model` as a per-session override.
@@ -341,7 +348,7 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
         return {
           created: nextCreated,
           createdUnderProfile: underProfile ? nextUnderProfileName : undefined,
-          gateway: nextGateway,
+          submitGateway,
           sessionTitle: fallbackSessionTitle,
           storedSessionId: nextStoredSessionId,
         };
@@ -464,7 +471,7 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
         created?.session_id ??
         runtimeSessionIdsRef.current[storedSessionId] ??
         (
-          await gateway.request<HermesRuntimeSessionResponse>("session.resume", {
+          await submitGateway.request<HermesRuntimeSessionResponse>("session.resume", {
             session_id: storedSessionId,
             cols: 96,
           })
@@ -487,7 +494,12 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
     // runtime is already known to be at it (see applyThinkingLevelToSession).
     const thinkingSessionLevel = sessionThinkingEfforts()[storedSessionId];
     if (thinkingSessionLevel) {
-      await applyThinkingLevelToSession(storedSessionId, thinkingSessionLevel, runtimeSessionId);
+      await applyThinkingLevelToSession(
+        storedSessionId,
+        thinkingSessionLevel,
+        runtimeSessionId,
+        submitGateway,
+      );
     }
     const dispatchPreparedSession = async (): Promise<string | undefined> => {
       // Re-read after acquiring the cross-surface lock. NoteChat may have sent
@@ -507,7 +519,7 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
       if (mustApplyCapturedModel) {
         try {
           await applySessionModelWhenIdle(() =>
-            createHermesMethods(gateway).switchActiveSessionModel({
+            createHermesMethods(submitGateway).switchActiveSessionModel({
               mode: hermesModeFor(storedSessionId),
               sessionId: runtimeSessionId,
               model: targetSessionModelId,
@@ -546,7 +558,7 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
         // retry — the prompt is NOT sent with a silently-missing image.
         try {
           const updatedAttachments = await attachPendingImages(
-            gateway,
+            submitGateway,
             runtimeSessionId,
             storedSessionId,
             agentRunAttachments,
@@ -677,7 +689,7 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
         computerUseRunStarted = true;
         rememberComputerUseRun(storedSessionId, computerUseRunLeaseId);
         attachHermesSessionEventListener({
-          gateway,
+          gateway: submitGateway.currentGateway(),
           runtimeSessionId,
           sessionDisplayTitle,
           storedSessionId,
@@ -693,7 +705,7 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
           method: "prompt.submit",
           params: { session_id: runtimeSessionId, text: preparedProjectPrompt.text },
         });
-        await createHermesMethods(gateway).submitPrompt({
+        await createHermesMethods(submitGateway).submitPrompt({
           sessionId: runtimeSessionId,
           text: preparedProjectPrompt.text,
           ...(scopedAgentRunToolsets ? { enabledToolsets: scopedAgentRunToolsets } : {}),

--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -12,12 +12,14 @@ import {
 } from "../../lib/active-hermes-profile";
 import { messageFromError } from "../../lib/errors";
 import { listHermesSessions } from "../../lib/hermes-adapter";
+import { hasHermesActiveSessionSnapshotSubscribers } from "../../lib/hermes-active-session-snapshots";
 import { hermesConnectionForMode } from "../../lib/hermes-connection";
 import { classifyHermesEvent } from "../../lib/hermes-control-plane/event-classifier";
 import { createHermesMethods } from "../../lib/hermes-control-plane/methods";
 import { isTerminalHermesEvent, type JuneHermesEvent } from "../../lib/hermes-control-plane/events";
 import { isHermesFeatureSupported } from "../../lib/hermes-control-plane/compatibility/support";
 import { HermesGatewayClient, isSessionBusyError } from "../../lib/hermes-gateway";
+import { createHermesIdleSubmitGateway } from "../../lib/hermes-idle-submit-recovery";
 import { applySessionModelWhenIdle } from "../../lib/hermes-next-prompt-model";
 import {
   canAttributeUntaggedAgentRun,
@@ -599,6 +601,16 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
       try {
         const gateway = await connectGateway(true);
         if (!gateway) throw new Error("Hermes gateway is not connected.");
+        const submitGateway = createHermesIdleSubmitGateway({
+          fullMode: false,
+          gateway,
+          shouldProbeFirstRequest: () => !hasHermesActiveSessionSnapshotSubscribers(false),
+          reconnect: async () => {
+            const reconnected = await connectGateway(true);
+            if (!reconnected) throw new Error("Hermes gateway is not connected.");
+            return reconnected;
+          },
+        });
         // Read after connectGateway so its refreshActiveHermesProfile has
         // reconciled the sticky pointer.
         const activeProfile = getActiveHermesProfileName();
@@ -631,12 +643,15 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
           }
         }
         if (!activeStoredSessionId) {
-          const created = await gateway.request<HermesRuntimeSessionResponse>("session.create", {
-            title: noteTitle.trim() || "Note chat",
-            cols: 96,
-            ...(capturedHermesModelId ? { model: capturedHermesModelId } : {}),
-            ...(activeProfile !== "default" ? { profile: activeProfile } : {}),
-          });
+          const created = await submitGateway.request<HermesRuntimeSessionResponse>(
+            "session.create",
+            {
+              title: noteTitle.trim() || "Note chat",
+              cols: 96,
+              ...(capturedHermesModelId ? { model: capturedHermesModelId } : {}),
+              ...(activeProfile !== "default" ? { profile: activeProfile } : {}),
+            },
+          );
           activeStoredSessionId = created.stored_session_id ?? created.session_id;
           if (!activeStoredSessionId) throw new Error("Hermes did not create a session.");
           dispatchReservation = reserveHermesSessionDispatch(activeStoredSessionId);
@@ -670,10 +685,13 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
           }
         }
         if (!runtimeSessionId) {
-          const resumed = await gateway.request<HermesRuntimeSessionResponse>("session.resume", {
-            session_id: activeStoredSessionId,
-            cols: 96,
-          });
+          const resumed = await submitGateway.request<HermesRuntimeSessionResponse>(
+            "session.resume",
+            {
+              session_id: activeStoredSessionId,
+              cols: 96,
+            },
+          );
           runtimeSessionId = resumed.session_id;
           if (!runtimeSessionId) throw new Error("Hermes did not resume the session.");
         }
@@ -703,7 +721,7 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
             // of the prompt. Failure blocks the send; silently using the prior
             // model would betray the picker.
             await applySessionModelWhenIdle(() =>
-              createHermesMethods(gateway).switchActiveSessionModel({
+              createHermesMethods(submitGateway).switchActiveSessionModel({
                 mode: "sandboxed",
                 sessionId: runtimeSessionId,
                 model: modelToApply,
@@ -733,7 +751,7 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
             attachments.map((attachment) => attachment.attach),
           );
           if (pendingImages.length) {
-            const methods = createHermesMethods(gateway);
+            const methods = createHermesMethods(submitGateway);
             const deps = {
               prepareImagePath: prepareHermesBridgeImageAttachment,
               attachImagePath: methods.attachImagePath,
@@ -749,7 +767,7 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
               }
             }
           }
-          await gateway.request("prompt.submit", {
+          await submitGateway.request("prompt.submit", {
             session_id: runtimeSessionId,
             text: content,
           });

--- a/src/lib/hermes-active-session-snapshots.ts
+++ b/src/lib/hermes-active-session-snapshots.ts
@@ -41,6 +41,12 @@ function modeHasListeners(fullMode: boolean) {
   return Boolean(listenersByMode.get(fullMode)?.size);
 }
 
+/** Whether working-session consumers currently keep this mode's shared
+ * lifecycle and heartbeat polling active. */
+export function hasHermesActiveSessionSnapshotSubscribers(fullMode: boolean) {
+  return modeHasListeners(fullMode);
+}
+
 function closeObserver(fullMode: boolean) {
   const observer = observersByMode.get(fullMode);
   if (!observer) return;

--- a/src/lib/hermes-idle-submit-recovery.ts
+++ b/src/lib/hermes-idle-submit-recovery.ts
@@ -5,6 +5,7 @@ import {
 } from "./hermes-gateway";
 
 export const HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS = 3_000;
+const HERMES_IDLE_SUBMIT_PROBE_METHOD = "session.active_list";
 
 export type HermesSubmitGateway = {
   currentGateway(): HermesGatewayClient;
@@ -18,14 +19,63 @@ type HermesIdleSubmitRecoveryOptions = {
   reconnect: () => Promise<HermesGatewayClient>;
 };
 
+const idleSubmitPreflights = new Map<boolean, Promise<HermesGatewayClient>>();
+
+export function resetHermesIdleSubmitRecoveryForTests() {
+  idleSubmitPreflights.clear();
+}
+
+function startIdleSubmitPreflight({
+  fullMode,
+  gateway,
+  reconnect,
+}: Omit<HermesIdleSubmitRecoveryOptions, "shouldProbeFirstRequest">) {
+  const existing = idleSubmitPreflights.get(fullMode);
+  if (existing) return existing;
+
+  const preflight = (async () => {
+    try {
+      await gateway.request(
+        HERMES_IDLE_SUBMIT_PROBE_METHOD,
+        {},
+        HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS,
+      );
+      return gateway;
+    } catch (error) {
+      if (!(error instanceof HermesGatewayRequestTimeoutError)) throw error;
+      forceDisconnectHermesGatewayClients(fullMode);
+      const recoveredGateway = await reconnect();
+      await recoveredGateway.request(
+        HERMES_IDLE_SUBMIT_PROBE_METHOD,
+        {},
+        HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS,
+      );
+      return recoveredGateway;
+    }
+  })();
+  idleSubmitPreflights.set(fullMode, preflight);
+  const clearPreflight = () => {
+    if (idleSubmitPreflights.get(fullMode) === preflight) {
+      idleSubmitPreflights.delete(fullMode);
+    }
+  };
+  void preflight.then(clearPreflight, clearPreflight);
+  return preflight;
+}
+
 /**
- * Gives only the first Gateway request of an idle submit a short deadline.
- * A silent OPEN socket cannot be distinguished from a healthy one before a
- * request, so a timeout converts it into the established unexpected-close
- * path and retries the same transport request once on a fresh connection.
+ * Runs one read-only liveness request before the first Gateway request of an
+ * idle submit.
  *
- * The helper is scoped to one submit. It never retries prompt preparation or
- * the composer action, and later requests keep their caller/default deadlines.
+ * A silent OPEN socket cannot be distinguished from a healthy one before a
+ * request, so a preflight timeout converts it into the established
+ * unexpected-close path and retries only the read-only preflight once on a
+ * fresh connection. The caller's actual request is sent exactly once with its
+ * ordinary deadline. In particular, prompt.submit and session.create are
+ * never the probe and are never transport-retried.
+ *
+ * Same-mode submits share an in-flight preflight so one recovery cannot close
+ * a socket while another submit is sending its first request.
  */
 export function createHermesIdleSubmitGateway({
   fullMode,
@@ -52,22 +102,21 @@ export function createHermesIdleSubmitGateway({
       params: Record<string, unknown> = {},
       timeoutMs?: number,
     ): Promise<T> {
-      const useIdleProbe = firstRequest && shouldProbeFirstRequest();
+      const inFlightPreflight = idleSubmitPreflights.get(fullMode);
+      const useIdleProbe =
+        firstRequest && (inFlightPreflight !== undefined || shouldProbeFirstRequest());
       firstRequest = false;
-      if (!useIdleProbe) return requestNormally<T>(method, params, timeoutMs);
-
-      const probeTimeoutMs =
-        timeoutMs === undefined
-          ? HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS
-          : Math.min(timeoutMs, HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS);
-      try {
-        return await currentGateway.request<T>(method, params, probeTimeoutMs);
-      } catch (error) {
-        if (!(error instanceof HermesGatewayRequestTimeoutError)) throw error;
-        forceDisconnectHermesGatewayClients(fullMode);
-        currentGateway = await reconnect();
-        return requestNormally<T>(method, params, timeoutMs);
+      if (useIdleProbe) {
+        const preflight =
+          inFlightPreflight ??
+          startIdleSubmitPreflight({
+            fullMode,
+            gateway: currentGateway,
+            reconnect,
+          });
+        currentGateway = await preflight;
       }
+      return requestNormally<T>(method, params, timeoutMs);
     },
   };
 }

--- a/src/lib/hermes-idle-submit-recovery.ts
+++ b/src/lib/hermes-idle-submit-recovery.ts
@@ -1,0 +1,73 @@
+import {
+  forceDisconnectHermesGatewayClients,
+  type HermesGatewayClient,
+  HermesGatewayRequestTimeoutError,
+} from "./hermes-gateway";
+
+export const HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS = 3_000;
+
+export type HermesSubmitGateway = {
+  currentGateway(): HermesGatewayClient;
+  request<T>(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<T>;
+};
+
+type HermesIdleSubmitRecoveryOptions = {
+  fullMode: boolean;
+  gateway: HermesGatewayClient;
+  shouldProbeFirstRequest: () => boolean;
+  reconnect: () => Promise<HermesGatewayClient>;
+};
+
+/**
+ * Gives only the first Gateway request of an idle submit a short deadline.
+ * A silent OPEN socket cannot be distinguished from a healthy one before a
+ * request, so a timeout converts it into the established unexpected-close
+ * path and retries the same transport request once on a fresh connection.
+ *
+ * The helper is scoped to one submit. It never retries prompt preparation or
+ * the composer action, and later requests keep their caller/default deadlines.
+ */
+export function createHermesIdleSubmitGateway({
+  fullMode,
+  gateway,
+  shouldProbeFirstRequest,
+  reconnect,
+}: HermesIdleSubmitRecoveryOptions): HermesSubmitGateway {
+  let currentGateway = gateway;
+  let firstRequest = true;
+
+  const requestNormally = <T>(
+    method: string,
+    params: Record<string, unknown>,
+    timeoutMs?: number,
+  ) =>
+    timeoutMs === undefined
+      ? currentGateway.request<T>(method, params)
+      : currentGateway.request<T>(method, params, timeoutMs);
+
+  return {
+    currentGateway: () => currentGateway,
+    async request<T>(
+      method: string,
+      params: Record<string, unknown> = {},
+      timeoutMs?: number,
+    ): Promise<T> {
+      const useIdleProbe = firstRequest && shouldProbeFirstRequest();
+      firstRequest = false;
+      if (!useIdleProbe) return requestNormally<T>(method, params, timeoutMs);
+
+      const probeTimeoutMs =
+        timeoutMs === undefined
+          ? HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS
+          : Math.min(timeoutMs, HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS);
+      try {
+        return await currentGateway.request<T>(method, params, probeTimeoutMs);
+      } catch (error) {
+        if (!(error instanceof HermesGatewayRequestTimeoutError)) throw error;
+        forceDisconnectHermesGatewayClients(fullMode);
+        currentGateway = await reconnect();
+        return requestNormally<T>(method, params, timeoutMs);
+      }
+    },
+  };
+}

--- a/src/test/agent-run-monitor.test.ts
+++ b/src/test/agent-run-monitor.test.ts
@@ -109,7 +109,10 @@ import {
   resetAgentRunMonitoringForTests,
   startAgentRunMonitoring,
 } from "../lib/agent-run-monitor";
-import { resetHermesActiveSessionSnapshotsForTests } from "../lib/hermes-active-session-snapshots";
+import {
+  hasHermesActiveSessionSnapshotSubscribers,
+  resetHermesActiveSessionSnapshotsForTests,
+} from "../lib/hermes-active-session-snapshots";
 
 const SANDBOXED_CONNECTION = {
   baseUrl: "http://127.0.0.1:9000",
@@ -196,6 +199,18 @@ describe("agent run monitor", () => {
     resetHermesActiveSessionSnapshotsForTests();
     vi.clearAllTimers();
     vi.useRealTimers();
+  });
+
+  it("reports which runtime mode currently has working-session snapshot subscribers", () => {
+    expect(hasHermesActiveSessionSnapshotSubscribers(false)).toBe(false);
+    expect(hasHermesActiveSessionSnapshotSubscribers(true)).toBe(false);
+
+    startRun();
+    expect(hasHermesActiveSessionSnapshotSubscribers(false)).toBe(true);
+    expect(hasHermesActiveSessionSnapshotSubscribers(true)).toBe(false);
+
+    expect(cancelAgentRunMonitoring("stored-1")).toBe(true);
+    expect(hasHermesActiveSessionSnapshotSubscribers(false)).toBe(false);
   });
 
   it("survives the submitting caller going away and settles from persisted runtime state", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -44,6 +44,7 @@ import { unsupportedEventStore } from "../lib/hermes-unsupported-events";
 import { readSessionModelSelections } from "../lib/hermes-session-model-selection";
 import { reserveHermesSessionDispatch } from "../lib/hermes-session-dispatch-mutex";
 import { resetHermesActiveSessionSnapshotsForTests } from "../lib/hermes-active-session-snapshots";
+import { HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS } from "../lib/hermes-idle-submit-recovery";
 
 // The hero greeting cycles per visit, so tests match any entry in the pool.
 const HERO_GREETING = new RegExp(
@@ -8298,6 +8299,91 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("Summarize Current Page")).toBeInTheDocument();
     expect(screen.queryByText("Untitled session")).toBeNull();
     expect(window.sessionStorage.getItem(AGENT_NEW_SESSION_PENDING_KEY)).toBeNull();
+  });
+
+  it("recovers an idle first-submit stall without resubmitting the composer action", async () => {
+    let createCalls = 0;
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        createCalls += 1;
+        if (createCalls === 1) return new Promise(() => undefined);
+        return Promise.resolve({
+          session_id: "runtime-session-2",
+          stored_session_id: "session-2",
+        });
+      }
+      return Promise.resolve({});
+    });
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "recover the idle submit" }),
+    );
+
+    vi.useFakeTimers();
+    try {
+      const startedAt = Date.now();
+      render(<AgentWorkspace />);
+      await settleUnderFakeTimers(() => expect(createCalls).toBe(1), { maxMs: 1_000 });
+
+      // The request hangs without a WebSocket close. Its submit-scoped deadline
+      // forces the existing mode disconnect and retries only the transport call.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS);
+      });
+      await settleUnderFakeTimers(
+        () =>
+          expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+            session_id: "runtime-session-2",
+            text: "recover the idle submit",
+          }),
+        { maxMs: 2_000 },
+      );
+
+      expect(Date.now() - startedAt).toBeLessThan(10_000);
+      expect(createCalls).toBe(2);
+      expect(mocks.forceDisconnectGatewayClients).toHaveBeenCalledTimes(1);
+      expect(mocks.forceDisconnectGatewayClients).toHaveBeenCalledWith(false);
+      expect(mocks.startAgentRunMonitoring).toHaveBeenCalledTimes(1);
+      expect(window.sessionStorage.getItem(AGENT_NEW_SESSION_PENDING_KEY)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces the idle-submit retry failure without a third transport attempt", async () => {
+    let createCalls = 0;
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        createCalls += 1;
+        if (createCalls === 1) return new Promise(() => undefined);
+        return Promise.reject(new Error("Gateway still unavailable."));
+      }
+      return Promise.resolve({});
+    });
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "surface the retry failure" }),
+    );
+
+    vi.useFakeTimers();
+    try {
+      render(<AgentWorkspace />);
+      await settleUnderFakeTimers(() => expect(createCalls).toBe(1), { maxMs: 1_000 });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS);
+      });
+      await settleUnderFakeTimers(
+        () => expect(screen.getByText("Gateway still unavailable.")).toBeInTheDocument(),
+        { maxMs: 2_000 },
+      );
+
+      expect(createCalls).toBe(2);
+      expect(mocks.forceDisconnectGatewayClients).toHaveBeenCalledTimes(1);
+      expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("prompt.submit", expect.anything());
+      expect(mocks.startAgentRunMonitoring).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("narrows an explicit Computer use agent run to the app-owned toolset", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -44,7 +44,11 @@ import { unsupportedEventStore } from "../lib/hermes-unsupported-events";
 import { readSessionModelSelections } from "../lib/hermes-session-model-selection";
 import { reserveHermesSessionDispatch } from "../lib/hermes-session-dispatch-mutex";
 import { resetHermesActiveSessionSnapshotsForTests } from "../lib/hermes-active-session-snapshots";
-import { HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS } from "../lib/hermes-idle-submit-recovery";
+import {
+  HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS,
+  resetHermesIdleSubmitRecoveryForTests,
+} from "../lib/hermes-idle-submit-recovery";
+import { writeAgentSessionContinuity } from "../components/agent/agent-session-continuity";
 
 // The hero greeting cycles per visit, so tests match any entry in the pool.
 const HERO_GREETING = new RegExp(
@@ -142,6 +146,7 @@ const mocks = vi.hoisted(() => ({
   listHermesSessions: vi.fn(),
   listSessionProfiles: vi.fn(),
   gatewayRequest: vi.fn(),
+  gatewayRequestTimeouts: [] as Array<{ method: string; timeoutMs: number | undefined }>,
   forceDisconnectGatewayClients: vi.fn(),
   markAgentRunSucceeded: vi.fn(),
   releaseAgentRunSettlement: vi.fn(),
@@ -291,6 +296,7 @@ vi.mock("../lib/hermes-gateway", async (importOriginal) => {
         return () => mocks.gatewayCloseHandlers.delete(handler);
       });
       request<T>(method: string, params: Record<string, unknown>, timeoutMs?: number) {
+        mocks.gatewayRequestTimeouts.push({ method, timeoutMs });
         const response = mocks.gatewayRequest(method, params) as Promise<T>;
         if (timeoutMs === undefined) return response;
         return new Promise<T>((resolve, reject) => {
@@ -603,10 +609,12 @@ describe("AgentWorkspace", () => {
     mocks.gatewayEventHandlers.clear();
     mocks.gatewayCloseHandlers.clear();
     mocks.gatewayInstances.length = 0;
+    mocks.gatewayRequestTimeouts.length = 0;
     mocks.forceDisconnectGatewayClients.mockImplementation(() => {
       for (const handler of [...mocks.gatewayCloseHandlers]) handler();
     });
     resetHermesActiveSessionSnapshotsForTests();
+    resetHermesIdleSubmitRecoveryForTests();
     // Auto-cleanup unmounts the workspace after each test, which snapshots
     // any still-working session for the next mount — across tests that would
     // leak one test's mid-run session into the next.
@@ -8301,16 +8309,35 @@ describe("AgentWorkspace", () => {
     expect(window.sessionStorage.getItem(AGENT_NEW_SESSION_PENDING_KEY)).toBeNull();
   });
 
-  it("recovers an idle first-submit stall without resubmitting the composer action", async () => {
+  it("recovers an idle preflight stall without duplicating a new session or prompt", async () => {
+    let activeListCalls = 0;
+    let preflightCallsAtCreate = 0;
+    let preflightCallsAtSubmit = 0;
     let createCalls = 0;
     mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.active_list") {
+        activeListCalls += 1;
+        if (activeListCalls === 1) return new Promise(() => undefined);
+        return Promise.resolve({ sessions: [] });
+      }
       if (method === "session.create") {
+        preflightCallsAtCreate = mocks.gatewayRequestTimeouts.filter(
+          (request) =>
+            request.method === "session.active_list" &&
+            request.timeoutMs === HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS,
+        ).length;
         createCalls += 1;
-        if (createCalls === 1) return new Promise(() => undefined);
         return Promise.resolve({
           session_id: "runtime-session-2",
           stored_session_id: "session-2",
         });
+      }
+      if (method === "prompt.submit") {
+        preflightCallsAtSubmit = mocks.gatewayRequestTimeouts.filter(
+          (request) =>
+            request.method === "session.active_list" &&
+            request.timeoutMs === HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS,
+        ).length;
       }
       return Promise.resolve({});
     });
@@ -8323,10 +8350,11 @@ describe("AgentWorkspace", () => {
     try {
       const startedAt = Date.now();
       render(<AgentWorkspace />);
-      await settleUnderFakeTimers(() => expect(createCalls).toBe(1), { maxMs: 1_000 });
+      await settleUnderFakeTimers(() => expect(activeListCalls).toBe(1), { maxMs: 1_000 });
 
-      // The request hangs without a WebSocket close. Its submit-scoped deadline
-      // forces the existing mode disconnect and retries only the transport call.
+      // The read-only preflight hangs without a WebSocket close. Its
+      // submit-scoped deadline forces the existing mode disconnect and retries
+      // only that safe request.
       await act(async () => {
         await vi.advanceTimersByTimeAsync(HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS);
       });
@@ -8340,7 +8368,12 @@ describe("AgentWorkspace", () => {
       );
 
       expect(Date.now() - startedAt).toBeLessThan(10_000);
-      expect(createCalls).toBe(2);
+      expect(preflightCallsAtCreate).toBe(2);
+      expect(preflightCallsAtSubmit).toBe(2);
+      expect(createCalls).toBe(1);
+      expect(
+        mocks.gatewayRequest.mock.calls.filter(([method]) => method === "prompt.submit"),
+      ).toHaveLength(1);
       expect(mocks.forceDisconnectGatewayClients).toHaveBeenCalledTimes(1);
       expect(mocks.forceDisconnectGatewayClients).toHaveBeenCalledWith(false);
       expect(mocks.startAgentRunMonitoring).toHaveBeenCalledTimes(1);
@@ -8350,37 +8383,68 @@ describe("AgentWorkspace", () => {
     }
   });
 
-  it("surfaces the idle-submit retry failure without a third transport attempt", async () => {
-    let createCalls = 0;
+  it("submits exactly once after recovering an idle stall with a cached runtime id", async () => {
+    let activeListCalls = 0;
+    let preflightCallsAtSubmit = 0;
     mocks.gatewayRequest.mockImplementation((method: string) => {
-      if (method === "session.create") {
-        createCalls += 1;
-        if (createCalls === 1) return new Promise(() => undefined);
-        return Promise.reject(new Error("Gateway still unavailable."));
+      if (method === "session.active_list") {
+        activeListCalls += 1;
+        if (activeListCalls === 1) return new Promise(() => undefined);
+        return Promise.resolve({ sessions: [] });
+      }
+      if (method === "prompt.submit") {
+        preflightCallsAtSubmit = mocks.gatewayRequestTimeouts.filter(
+          (request) =>
+            request.method === "session.active_list" &&
+            request.timeoutMs === HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS,
+        ).length;
       }
       return Promise.resolve({});
     });
-    window.sessionStorage.setItem(
-      AGENT_NEW_SESSION_PENDING_KEY,
-      JSON.stringify({ createdAt: Date.now(), prompt: "surface the retry failure" }),
-    );
+    writeAgentSessionContinuity({
+      sessionItems: [existingSession],
+      pendingMessages: {},
+      runtimeSessionIds: { "session-1": "runtime-session-1" },
+      liveEvents: {},
+      titleOverrides: {},
+      titleSources: {},
+      pendingIssueReports: {},
+      reviewableIssueReports: {},
+      diagnosisRefreshIssueReportSessionIds: [],
+      submittingIssueReportSessionIds: [],
+      queuedAttachmentFollowUps: {},
+    });
 
+    const user = userEvent.setup();
+    render(<AgentWorkspace initialSession={existingSession} />);
+    await user.type(
+      await screen.findByRole("textbox", { name: "Message June" }),
+      "recover the cached runtime",
+    );
     vi.useFakeTimers();
     try {
-      render(<AgentWorkspace />);
-      await settleUnderFakeTimers(() => expect(createCalls).toBe(1), { maxMs: 1_000 });
+      fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+      await settleUnderFakeTimers(() => expect(activeListCalls).toBe(1), { maxMs: 1_000 });
       await act(async () => {
         await vi.advanceTimersByTimeAsync(HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS);
       });
       await settleUnderFakeTimers(
-        () => expect(screen.getByText("Gateway still unavailable.")).toBeInTheDocument(),
+        () =>
+          expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+            session_id: "runtime-session-1",
+            text: "recover the cached runtime",
+          }),
         { maxMs: 2_000 },
       );
 
-      expect(createCalls).toBe(2);
+      expect(preflightCallsAtSubmit).toBe(2);
       expect(mocks.forceDisconnectGatewayClients).toHaveBeenCalledTimes(1);
-      expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("prompt.submit", expect.anything());
-      expect(mocks.startAgentRunMonitoring).not.toHaveBeenCalled();
+      expect(
+        mocks.gatewayRequest.mock.calls.filter(([method]) => method === "prompt.submit"),
+      ).toHaveLength(1);
+      expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("session.create", expect.anything());
+      expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("session.resume", expect.anything());
+      expect(mocks.startAgentRunMonitoring).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }
@@ -9885,6 +9949,7 @@ describe("AgentWorkspace", () => {
       timestamp: new Date().toISOString(),
     };
     let replyPersisted = false;
+    let activeListStalled = false;
     mocks.listHermesSessionMessages.mockImplementation(async () =>
       replyPersisted ? [...userOnly, reply] : userOnly,
     );
@@ -9896,10 +9961,14 @@ describe("AgentWorkspace", () => {
         });
       }
       if (method === "session.active_list") {
+        if (!activeListStalled) return Promise.resolve({ sessions: [] });
         return new Promise(() => undefined);
       }
       if (method === "session.resume") {
         return Promise.resolve({ session_id: "runtime-session-recovered" });
+      }
+      if (method === "prompt.submit") {
+        activeListStalled = true;
       }
       return Promise.resolve({});
     });

--- a/src/test/hermes-gateway.test.ts
+++ b/src/test/hermes-gateway.test.ts
@@ -7,6 +7,10 @@ import {
   HermesGatewaySendQueueOverflowError,
   isSessionBusyError,
 } from "../lib/hermes-gateway";
+import {
+  createHermesIdleSubmitGateway,
+  HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS,
+} from "../lib/hermes-idle-submit-recovery";
 
 type Listener = (event: unknown) => void;
 
@@ -385,5 +389,170 @@ describe("HermesGatewayClient", () => {
     expect(recovered.readyState).toBe(FakeWebSocket.OPEN);
     expect(onClose).toHaveBeenCalledOnce();
     client.close();
+  });
+
+  it("bounds an idle submit stall by reconnecting and retrying its first request once", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new HermesGatewayClient(false);
+      const connecting = client.connect("ws://gateway");
+      FakeWebSocket.instances[0].open();
+      await connecting;
+      const reconnect = vi.fn(async () => {
+        const reconnecting = client.connect("ws://gateway");
+        FakeWebSocket.instances.at(-1)?.open();
+        await reconnecting;
+        return client;
+      });
+      const submitGateway = createHermesIdleSubmitGateway({
+        fullMode: false,
+        gateway: client,
+        shouldProbeFirstRequest: () => true,
+        reconnect,
+      });
+      const startedAt = Date.now();
+      const pending = submitGateway.request<{ session_id: string }>("session.create", {
+        title: "Recovered submit",
+      });
+
+      // The first socket remains OPEN but never produces a response frame.
+      await vi.advanceTimersByTimeAsync(HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS);
+      expect(reconnect).toHaveBeenCalledOnce();
+      expect(FakeWebSocket.instances).toHaveLength(2);
+
+      const recovered = FakeWebSocket.instances[1];
+      const retriedFrame = JSON.parse(recovered.sent[0]) as { id: number; method: string };
+      expect(retriedFrame.method).toBe("session.create");
+      recovered.message({ id: retriedFrame.id, result: { session_id: "runtime-recovered" } });
+
+      await expect(pending).resolves.toEqual({ session_id: "runtime-recovered" });
+      expect(Date.now() - startedAt).toBeLessThan(10_000);
+      expect(FakeWebSocket.instances[0].sent).toHaveLength(1);
+      expect(recovered.sent).toHaveLength(1);
+      client.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a healthy idle submit on one connection and scopes the short deadline to its first request", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new HermesGatewayClient(false);
+      const connecting = client.connect("ws://gateway");
+      const socket = FakeWebSocket.instances[0];
+      socket.open();
+      await connecting;
+      const reconnect = vi.fn(async () => client);
+      const submitGateway = createHermesIdleSubmitGateway({
+        fullMode: false,
+        gateway: client,
+        shouldProbeFirstRequest: () => true,
+        reconnect,
+      });
+      const creating = submitGateway.request<{ session_id: string }>("session.create", {
+        title: "Healthy submit",
+      });
+      const createFrame = JSON.parse(socket.sent[0]) as { id: number };
+      socket.message({ id: createFrame.id, result: { session_id: "runtime-healthy" } });
+      await expect(creating).resolves.toEqual({ session_id: "runtime-healthy" });
+
+      const submitting = submitGateway.request<{ accepted: boolean }>("prompt.submit", {
+        session_id: "runtime-healthy",
+        text: "Continue normally",
+      });
+      await vi.advanceTimersByTimeAsync(HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS + 1);
+      expect(reconnect).not.toHaveBeenCalled();
+      expect(socket.readyState).toBe(FakeWebSocket.OPEN);
+
+      const submitFrame = JSON.parse(socket.sent[1]) as { id: number };
+      socket.message({ id: submitFrame.id, result: { accepted: true } });
+      await expect(submitting).resolves.toEqual({ accepted: true });
+      expect(FakeWebSocket.instances).toHaveLength(1);
+      client.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves the healthy active-submit request deadline unchanged", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new HermesGatewayClient(false);
+      const connecting = client.connect("ws://gateway");
+      const socket = FakeWebSocket.instances[0];
+      socket.open();
+      await connecting;
+      const reconnect = vi.fn(async () => client);
+      let workingSessionExists = false;
+      const submitGateway = createHermesIdleSubmitGateway({
+        fullMode: false,
+        gateway: client,
+        shouldProbeFirstRequest: () => !workingSessionExists,
+        reconnect,
+      });
+      // A run can start after submit preparation begins but before its first
+      // Gateway request. Read the shared lifecycle signal at request time so
+      // that race cannot force-disconnect active work.
+      workingSessionExists = true;
+      const pending = submitGateway.request<{ accepted: boolean }>("prompt.submit", {
+        session_id: "runtime-active",
+        text: "Keep going",
+      });
+
+      await vi.advanceTimersByTimeAsync(HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS + 1);
+      expect(reconnect).not.toHaveBeenCalled();
+      expect(socket.readyState).toBe(FakeWebSocket.OPEN);
+
+      const frame = JSON.parse(socket.sent[0]) as { id: number };
+      socket.message({ id: frame.id, result: { accepted: true } });
+      await expect(pending).resolves.toEqual({ accepted: true });
+      client.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces a retry failure without attempting a second reconnect", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new HermesGatewayClient(false);
+      const connecting = client.connect("ws://gateway");
+      FakeWebSocket.instances[0].open();
+      await connecting;
+      const reconnect = vi.fn(async () => {
+        const reconnecting = client.connect("ws://gateway");
+        FakeWebSocket.instances.at(-1)?.open();
+        await reconnecting;
+        return client;
+      });
+      const submitGateway = createHermesIdleSubmitGateway({
+        fullMode: false,
+        gateway: client,
+        shouldProbeFirstRequest: () => true,
+        reconnect,
+      });
+      const pending = submitGateway.request("session.resume", {
+        session_id: "stored-session",
+      });
+
+      await vi.advanceTimersByTimeAsync(HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS);
+      const recovered = FakeWebSocket.instances[1];
+      const retriedFrame = JSON.parse(recovered.sent[0]) as { id: number };
+      recovered.message({
+        id: retriedFrame.id,
+        error: { code: 5001, message: "Gateway still unavailable." },
+      });
+
+      await expect(pending).rejects.toMatchObject({
+        code: 5001,
+        message: "Gateway still unavailable.",
+      });
+      expect(reconnect).toHaveBeenCalledOnce();
+      expect(FakeWebSocket.instances).toHaveLength(2);
+      client.close();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/test/hermes-gateway.test.ts
+++ b/src/test/hermes-gateway.test.ts
@@ -391,7 +391,7 @@ describe("HermesGatewayClient", () => {
     client.close();
   });
 
-  it("bounds an idle submit stall by reconnecting and retrying its first request once", async () => {
+  it("bounds an idle submit stall by retrying only a read-only preflight", async () => {
     vi.useFakeTimers();
     try {
       const client = new HermesGatewayClient(false);
@@ -411,31 +411,44 @@ describe("HermesGatewayClient", () => {
         reconnect,
       });
       const startedAt = Date.now();
-      const pending = submitGateway.request<{ session_id: string }>("session.create", {
-        title: "Recovered submit",
+      const pending = submitGateway.request<{ accepted: boolean }>("prompt.submit", {
+        session_id: "runtime-cached",
+        text: "Recovered submit",
       });
 
-      // The first socket remains OPEN but never produces a response frame.
+      // The first socket remains OPEN but never answers the safe preflight.
+      const stalled = FakeWebSocket.instances[0];
+      const stalledFrame = JSON.parse(stalled.sent[0]) as { method: string };
+      expect(stalledFrame.method).toBe("session.active_list");
       await vi.advanceTimersByTimeAsync(HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS);
       expect(reconnect).toHaveBeenCalledOnce();
       expect(FakeWebSocket.instances).toHaveLength(2);
 
       const recovered = FakeWebSocket.instances[1];
-      const retriedFrame = JSON.parse(recovered.sent[0]) as { id: number; method: string };
-      expect(retriedFrame.method).toBe("session.create");
-      recovered.message({ id: retriedFrame.id, result: { session_id: "runtime-recovered" } });
+      const retriedProbe = JSON.parse(recovered.sent[0]) as { id: number; method: string };
+      expect(retriedProbe.method).toBe("session.active_list");
+      recovered.message({ id: retriedProbe.id, result: { sessions: [] } });
+      await vi.advanceTimersByTimeAsync(0);
 
-      await expect(pending).resolves.toEqual({ session_id: "runtime-recovered" });
+      const submitFrame = JSON.parse(recovered.sent[1]) as { id: number; method: string };
+      expect(submitFrame.method).toBe("prompt.submit");
+      const allMethods = FakeWebSocket.instances.flatMap((socket) =>
+        socket.sent.map((raw) => (JSON.parse(raw) as { method: string }).method),
+      );
+      expect(allMethods.filter((method) => method === "prompt.submit")).toHaveLength(1);
+      recovered.message({ id: submitFrame.id, result: { accepted: true } });
+
+      await expect(pending).resolves.toEqual({ accepted: true });
       expect(Date.now() - startedAt).toBeLessThan(10_000);
-      expect(FakeWebSocket.instances[0].sent).toHaveLength(1);
-      expect(recovered.sent).toHaveLength(1);
+      expect(stalled.sent).toHaveLength(1);
+      expect(recovered.sent).toHaveLength(2);
       client.close();
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("keeps a healthy idle submit on one connection and scopes the short deadline to its first request", async () => {
+  it("keeps a healthy idle submit on one connection and sends mutating requests once", async () => {
     vi.useFakeTimers();
     try {
       const client = new HermesGatewayClient(false);
@@ -453,7 +466,13 @@ describe("HermesGatewayClient", () => {
       const creating = submitGateway.request<{ session_id: string }>("session.create", {
         title: "Healthy submit",
       });
-      const createFrame = JSON.parse(socket.sent[0]) as { id: number };
+      const probeFrame = JSON.parse(socket.sent[0]) as { id: number; method: string };
+      expect(probeFrame.method).toBe("session.active_list");
+      socket.message({ id: probeFrame.id, result: { sessions: [] } });
+      await vi.advanceTimersByTimeAsync(0);
+
+      const createFrame = JSON.parse(socket.sent[1]) as { id: number; method: string };
+      expect(createFrame.method).toBe("session.create");
       socket.message({ id: createFrame.id, result: { session_id: "runtime-healthy" } });
       await expect(creating).resolves.toEqual({ session_id: "runtime-healthy" });
 
@@ -465,10 +484,59 @@ describe("HermesGatewayClient", () => {
       expect(reconnect).not.toHaveBeenCalled();
       expect(socket.readyState).toBe(FakeWebSocket.OPEN);
 
-      const submitFrame = JSON.parse(socket.sent[1]) as { id: number };
+      const submitFrame = JSON.parse(socket.sent[2]) as { id: number; method: string };
+      expect(submitFrame.method).toBe("prompt.submit");
       socket.message({ id: submitFrame.id, result: { accepted: true } });
       await expect(submitting).resolves.toEqual({ accepted: true });
+      expect(socket.sent.map((raw) => (JSON.parse(raw) as { method: string }).method)).toEqual([
+        "session.active_list",
+        "session.create",
+        "prompt.submit",
+      ]);
       expect(FakeWebSocket.instances).toHaveLength(1);
+      client.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry a live prompt.submit whose acknowledgement takes four seconds", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new HermesGatewayClient(false);
+      const connecting = client.connect("ws://gateway");
+      const socket = FakeWebSocket.instances[0];
+      socket.open();
+      await connecting;
+      const reconnect = vi.fn(async () => client);
+      const submitGateway = createHermesIdleSubmitGateway({
+        fullMode: false,
+        gateway: client,
+        shouldProbeFirstRequest: () => true,
+        reconnect,
+      });
+      const pending = submitGateway.request<{ accepted: boolean }>("prompt.submit", {
+        session_id: "runtime-cached",
+        text: "Wait for the live runtime",
+      });
+      const probeFrame = JSON.parse(socket.sent[0]) as { id: number; method: string };
+      expect(probeFrame.method).toBe("session.active_list");
+      socket.message({ id: probeFrame.id, result: { sessions: [] } });
+      await vi.advanceTimersByTimeAsync(0);
+
+      const submitFrame = JSON.parse(socket.sent[1]) as { id: number; method: string };
+      expect(submitFrame.method).toBe("prompt.submit");
+      await vi.advanceTimersByTimeAsync(4_000);
+
+      expect(reconnect).not.toHaveBeenCalled();
+      expect(socket.readyState).toBe(FakeWebSocket.OPEN);
+      expect(
+        socket.sent.filter(
+          (raw) => (JSON.parse(raw) as { method: string }).method === "prompt.submit",
+        ),
+      ).toHaveLength(1);
+      socket.message({ id: submitFrame.id, result: { accepted: true } });
+      await expect(pending).resolves.toEqual({ accepted: true });
       client.close();
     } finally {
       vi.useRealTimers();
@@ -513,7 +581,7 @@ describe("HermesGatewayClient", () => {
     }
   });
 
-  it("surfaces a retry failure without attempting a second reconnect", async () => {
+  it("surfaces a preflight retry failure without sending the caller request", async () => {
     vi.useFakeTimers();
     try {
       const client = new HermesGatewayClient(false);
@@ -550,6 +618,68 @@ describe("HermesGatewayClient", () => {
       });
       expect(reconnect).toHaveBeenCalledOnce();
       expect(FakeWebSocket.instances).toHaveLength(2);
+      const methods = FakeWebSocket.instances.flatMap((socket) =>
+        socket.sent.map((raw) => (JSON.parse(raw) as { method: string }).method),
+      );
+      expect(methods).toEqual(["session.active_list", "session.active_list"]);
+      client.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shares a same-mode preflight so recovery cannot interrupt a concurrent submit", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new HermesGatewayClient(false);
+      const connecting = client.connect("ws://gateway");
+      FakeWebSocket.instances[0].open();
+      await connecting;
+      const reconnect = vi.fn(async () => {
+        const reconnecting = client.connect("ws://gateway");
+        FakeWebSocket.instances.at(-1)?.open();
+        await reconnecting;
+        return client;
+      });
+      const firstGateway = createHermesIdleSubmitGateway({
+        fullMode: false,
+        gateway: client,
+        shouldProbeFirstRequest: () => true,
+        reconnect,
+      });
+      const secondGateway = createHermesIdleSubmitGateway({
+        fullMode: false,
+        gateway: client,
+        shouldProbeFirstRequest: () => true,
+        reconnect,
+      });
+      const first = firstGateway.request<{ accepted: boolean }>("prompt.submit", {
+        session_id: "runtime-one",
+        text: "First",
+      });
+      const second = secondGateway.request<{ accepted: boolean }>("prompt.submit", {
+        session_id: "runtime-two",
+        text: "Second",
+      });
+
+      expect(FakeWebSocket.instances[0].sent).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS);
+      const recovered = FakeWebSocket.instances[1];
+      expect(recovered.sent).toHaveLength(1);
+      const probe = JSON.parse(recovered.sent[0]) as { id: number; method: string };
+      expect(probe.method).toBe("session.active_list");
+      recovered.message({ id: probe.id, result: { sessions: [] } });
+      await vi.advanceTimersByTimeAsync(0);
+
+      const submitFrames = recovered.sent
+        .map((raw) => JSON.parse(raw) as { id: number; method: string })
+        .filter((frame) => frame.method === "prompt.submit");
+      expect(submitFrames).toHaveLength(2);
+      recovered.message({ id: submitFrames[0].id, result: { accepted: true } });
+      recovered.message({ id: submitFrames[1].id, result: { accepted: true } });
+      await expect(first).resolves.toEqual({ accepted: true });
+      await expect(second).resolves.toEqual({ accepted: true });
+      expect(reconnect).toHaveBeenCalledOnce();
       client.close();
     } finally {
       vi.useRealTimers();

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -29,12 +29,18 @@ import {
 import { PROVIDER_MODEL_SETTINGS_CHANGED_EVENT } from "../lib/model-privacy";
 import { AGENT_SESSION_STATUS_EVENT, type AgentSessionStatusDetail } from "../lib/agent-events";
 import { UPSTREAM_PROVIDER_FAILURE_RETRY_PROMPT } from "../lib/agent-chat-runtime";
+import {
+  HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS,
+  resetHermesIdleSubmitRecoveryForTests,
+} from "../lib/hermes-idle-submit-recovery";
 
 const mocks = vi.hoisted(() => ({
   canAttributeUntaggedAgentRun: vi.fn(() => true),
   cancelAgentRunMonitoring: vi.fn(),
+  forceDisconnectGatewayClients: vi.fn(),
   gatewayRequest: vi.fn(),
   gatewayConnect: vi.fn(),
+  gatewayCloseHandlers: new Set<() => void>(),
   gatewayEventHandlers: new Set<(event: Record<string, unknown>) => void>(),
   hermesBridgeImageDataUrl: vi.fn(),
   prepareHermesBridgeImageAttachment: vi.fn(),
@@ -85,6 +91,7 @@ vi.mock("../lib/hermes-gateway", async (importOriginal) => {
   const original = await importOriginal<typeof import("../lib/hermes-gateway")>();
   return {
     ...original,
+    forceDisconnectHermesGatewayClients: mocks.forceDisconnectGatewayClients,
     HermesGatewayClient: class {
       connect = mocks.gatewayConnect;
       close = vi.fn();
@@ -92,7 +99,10 @@ vi.mock("../lib/hermes-gateway", async (importOriginal) => {
         mocks.gatewayEventHandlers.add(handler);
         return () => mocks.gatewayEventHandlers.delete(handler);
       });
-      onClose = vi.fn();
+      onClose = vi.fn((handler: () => void) => {
+        mocks.gatewayCloseHandlers.add(handler);
+        return () => mocks.gatewayCloseHandlers.delete(handler);
+      });
       request<T>(method: string, params: Record<string, unknown>, timeoutMs?: number) {
         const response = mocks.gatewayRequest(method, params) as Promise<T>;
         if (timeoutMs === undefined) return response;
@@ -169,7 +179,13 @@ function noteChat(overrides: Partial<NoteChat> = {}): NoteChat {
 
 describe("note chat session map", () => {
   beforeEach(() => {
+    for (const handler of [...mocks.gatewayCloseHandlers]) handler();
+    mocks.gatewayCloseHandlers.clear();
     vi.clearAllMocks();
+    mocks.forceDisconnectGatewayClients.mockImplementation(() => {
+      for (const handler of [...mocks.gatewayCloseHandlers]) handler();
+    });
+    resetHermesIdleSubmitRecoveryForTests();
     window.localStorage.clear();
     mocks.hermesBridgeStatus.mockResolvedValue({
       running: true,
@@ -309,6 +325,70 @@ describe("note chat session map", () => {
       text: UPSTREAM_PROVIDER_FAILURE_RETRY_PROMPT,
     });
     expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("session.create", expect.anything());
+  });
+
+  it("submits exactly once after recovering an idle stall with a cached note-chat runtime", async () => {
+    rememberNoteChatSession("note-1", "stored-note-chat");
+    mocks.listHermesSessions.mockResolvedValue([{ id: "stored-note-chat" }]);
+    const { result } = renderHook(() => useNoteChat({ id: "note-1", title: "Launch planning" }));
+
+    await waitFor(() => expect(result.current.storedSessionId).toBe("stored-note-chat"));
+    await act(async () => {
+      expect(await result.current.submit("Warm the runtime.")).toMatchObject({
+        accepted: true,
+        current: true,
+      });
+    });
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "turn.completed",
+          session_id: "runtime-note-chat",
+          payload: { status: "success" },
+        });
+      }
+    });
+    await waitFor(() => expect(result.current.working).toBe(false));
+
+    let activeListCalls = 0;
+    mocks.gatewayRequest.mockClear();
+    mocks.forceDisconnectGatewayClients.mockClear();
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.active_list") {
+        activeListCalls += 1;
+        if (activeListCalls === 1) return new Promise(() => undefined);
+        return Promise.resolve({ sessions: [] });
+      }
+      return Promise.resolve({});
+    });
+
+    vi.useFakeTimers();
+    try {
+      let recovered: NoteChatSubmitResult | undefined;
+      await act(async () => {
+        const pending = result.current.submit("Use the cached runtime once.");
+        await vi.advanceTimersByTimeAsync(HERMES_IDLE_SUBMIT_PROBE_TIMEOUT_MS);
+        recovered = await pending;
+      });
+
+      expect(recovered).toMatchObject({ accepted: true, current: true });
+      expect(mocks.forceDisconnectGatewayClients).toHaveBeenCalledOnce();
+      expect(
+        mocks.gatewayRequest.mock.calls.filter(([method]) => method === "prompt.submit"),
+      ).toEqual([
+        [
+          "prompt.submit",
+          {
+            session_id: "runtime-note-chat",
+            text: "Use the cached runtime once.",
+          },
+        ],
+      ]);
+      expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("session.create", expect.anything());
+      expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("session.resume", expect.anything());
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("hydrates the applied model for a legacy chat without a selection entry", async () => {
@@ -1054,6 +1134,7 @@ describe("note chat session map", () => {
     });
 
     expect(mocks.gatewayRequest.mock.calls).toEqual([
+      ["session.active_list", {}],
       [
         "config.set",
         {

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -81,19 +81,41 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
 }));
 
-vi.mock("../lib/hermes-gateway", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../lib/hermes-gateway")>()),
-  HermesGatewayClient: class {
-    connect = mocks.gatewayConnect;
-    close = vi.fn();
-    onEvent = vi.fn((handler: (event: Record<string, unknown>) => void) => {
-      mocks.gatewayEventHandlers.add(handler);
-      return () => mocks.gatewayEventHandlers.delete(handler);
-    });
-    onClose = vi.fn();
-    request = mocks.gatewayRequest;
-  },
-}));
+vi.mock("../lib/hermes-gateway", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../lib/hermes-gateway")>();
+  return {
+    ...original,
+    HermesGatewayClient: class {
+      connect = mocks.gatewayConnect;
+      close = vi.fn();
+      onEvent = vi.fn((handler: (event: Record<string, unknown>) => void) => {
+        mocks.gatewayEventHandlers.add(handler);
+        return () => mocks.gatewayEventHandlers.delete(handler);
+      });
+      onClose = vi.fn();
+      request<T>(method: string, params: Record<string, unknown>, timeoutMs?: number) {
+        const response = mocks.gatewayRequest(method, params) as Promise<T>;
+        if (timeoutMs === undefined) return response;
+        return new Promise<T>((resolve, reject) => {
+          const timer = window.setTimeout(
+            () => reject(new original.HermesGatewayRequestTimeoutError(method)),
+            timeoutMs,
+          );
+          void Promise.resolve(response).then(
+            (value) => {
+              window.clearTimeout(timer);
+              resolve(value);
+            },
+            (error) => {
+              window.clearTimeout(timer);
+              reject(error);
+            },
+          );
+        });
+      }
+    },
+  };
+});
 
 const STORAGE_KEY = "june.noteChat.sessionsByNote.v1";
 


### PR DESCRIPTION
## Summary

- Before the first mutating RPC of an idle submit, send one read-only `session.active_list` liveness request with a three-second deadline.
- If that safe preflight times out, force-disconnect the target runtime mode, reconnect, and retry only the preflight once.
- Send `session.create`, `session.resume`, and `prompt.submit` at most once with their normal deadlines; concurrent same-mode idle submits share the preflight.
- Keep the healthy and active-submit paths unchanged without adding idle polling or changing heartbeat counters.

## Root cause

The shared `session.active_list` heartbeat only runs while working-session consumers are subscribed. A silently stalled OPEN socket could therefore remain undetected while idle, and the next submit inherited the 120-second default timeout. The original recovery wrapped whichever RPC happened to be first, which could be non-idempotent `prompt.submit` for a cached runtime session or `session.create` for a new one. Retrying either after a false three-second timeout could duplicate a run, credits, or an empty session.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` (216 files; 3,514 passed, 2 skipped)
- `make local-ci` on `018069c5de1bdd5da55d20267f8a3a55b693e528` (`signoff/frontend` passed; `signoff/rust-macos` passed as not applicable)
- Fault-injection coverage verifies cached-runtime idle-stall recovery in under 10 seconds with exactly one `prompt.submit`, a live four-second submit acknowledgement without reconnect or double-submit, new-session recovery with exactly one `session.create`, a surfaced second preflight failure, and shared recovery for concurrent same-mode submits.

- [ ] Tested visually where it matters (not applicable: transport-only behavior with no UI changes).
- [ ] Needs a June API (backend) deploy before it works end to end (no: desktop-only change).

## Out of scope

- Always-on idle polling or any new periodic Gateway traffic.
- Changes to heartbeat miss counters or working-session settlement.
- June API changes.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary (not applicable: no security boundary changed).
- [x] Workflow action references are pinned to full-length commit SHAs (not applicable: no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable).
- [x] User-facing copy follows the repo UI conventions (not applicable: no UI copy changes).

Refs JUN-433