### PR TITLE
Batch Hermes activity notifications

### DIFF
--- a/src/components/agent/session-event-listener.ts
+++ b/src/components/agent/session-event-listener.ts
@@ -4,6 +4,7 @@ import { HermesGatewayClient } from "../../lib/hermes-gateway";
 import {
   classifyHermesEvent,
   hermesModeFor,
+  isHermesStreamDelta,
   isTerminalHermesEvent,
 } from "../../lib/hermes-control-plane";
 import { unsupportedEventStore } from "../../lib/hermes-unsupported-events";
@@ -24,13 +25,6 @@ import { createLeadingTrailingMicrobatch } from "../../lib/trailing-microbatch";
 import type { createSessionEventListenerDependencies } from "./session-event-listener-types";
 
 const HERMES_STREAM_STATE_BATCH_INTERVAL_MS = 50;
-
-function isHermesStreamDelta(event: ReturnType<typeof classifyHermesEvent>) {
-  return (
-    (event.kind === "transcript" && !event.complete && event.delta !== undefined) ||
-    (event.kind === "reasoning" && !event.full)
-  );
-}
 
 export function createSessionEventListener(dependencies: createSessionEventListenerDependencies) {
   const {

--- a/src/components/agent/session-event-listener.ts
+++ b/src/components/agent/session-event-listener.ts
@@ -1,4 +1,4 @@
-import { dispatchAgentSessionStatus } from "../../lib/agent-events";
+import { dispatchAgentSessionStatus, type AgentSessionStatusDetail } from "../../lib/agent-events";
 import { markAgentRunSucceeded } from "../../lib/agent-run-monitor";
 import { HermesGatewayClient } from "../../lib/hermes-gateway";
 import {
@@ -73,6 +73,12 @@ export function createSessionEventListener(dependencies: createSessionEventListe
       () => setLiveEvents(liveEventsRef.current),
       HERMES_STREAM_STATE_BATCH_INTERVAL_MS,
     );
+    let pendingStreamStatus: AgentSessionStatusDetail | undefined;
+    const streamStatusBatch = createLeadingTrailingMicrobatch(() => {
+      const detail = pendingStreamStatus;
+      pendingStreamStatus = undefined;
+      if (detail) dispatchAgentSessionStatus(detail);
+    }, HERMES_STREAM_STATE_BATCH_INTERVAL_MS);
     const removeListener = gateway.onEvent((event) => {
       if (event.session_id !== runtimeSessionId && event.session_id !== storedSessionId) return;
       const liveEvent = { ...event, receivedAt: new Date().toISOString() };
@@ -174,10 +180,15 @@ export function createSessionEventListener(dependencies: createSessionEventListe
       // same burst that the streamed-markdown presenter reveals in batches.
       // Action, lifecycle, and terminal frames still paint immediately and
       // flush any text already waiting in the batch.
-      if (isHermesStreamDelta(classified)) {
+      const streamDelta = isHermesStreamDelta(classified);
+      if (streamDelta) {
         liveEventsBatch.schedule();
       } else {
         liveEventsBatch.flush();
+        // Menu-bar and Agent HUD status subscribers share the stream boundary.
+        // A semantic frame first publishes any pending "running" summary, then
+        // dispatches its own status immediately below.
+        streamStatusBatch.flushPending();
       }
       const toolEventPhase = classified.kind === "tool" ? classified.phase : undefined;
       if (toolEventPhase === "complete") {
@@ -214,13 +225,19 @@ export function createSessionEventListener(dependencies: createSessionEventListe
         } else if (status === "failed" || status === "cancelled") {
           cancelAgentRunSettlement(storedSessionId);
         }
-        dispatchAgentSessionStatus({
+        const detail = {
           sessionId: storedSessionId,
           title: sessionDisplayTitle,
           status,
           summary: agentStatusSummaryFromHermesEvent(classified, status),
           ...activityCounts,
-        });
+        };
+        if (streamDelta) {
+          pendingStreamStatus = detail;
+          streamStatusBatch.schedule();
+        } else {
+          dispatchAgentSessionStatus(detail);
+        }
       }
       if (isTerminalHermesEvent(classified)) {
         if (!computerUseRunLeaseId) {
@@ -270,6 +287,9 @@ export function createSessionEventListener(dependencies: createSessionEventListe
       // converge here. Publish any trailing delta before cancelling its timer
       // so React never remains behind the authoritative event ref.
       liveEventsBatch.flushPending();
+      // The menu bar and Agent HUD must not remain behind the authoritative
+      // activity projection when a listener is replaced or torn down.
+      streamStatusBatch.flushPending();
       if (sessionGatewayUnlistenRef.current.get(storedSessionId) === unlisten) {
         sessionGatewayUnlistenRef.current.delete(storedSessionId);
       }

--- a/src/lib/hermes-activity-store.ts
+++ b/src/lib/hermes-activity-store.ts
@@ -42,6 +42,7 @@ import type {
 } from "./hermes-control-plane";
 import { nonEmpty } from "./hermes-control-plane";
 import { pendingActionStore } from "./hermes-pending-actions";
+import { createLeadingTrailingMicrobatch } from "./trailing-microbatch";
 
 /**
  * Cap on the number of sessions tracked at once. Live activity is inherently
@@ -49,6 +50,13 @@ import { pendingActionStore } from "./hermes-pending-actions";
  * rows the user hasn't dismissed; eviction drops the oldest by last activity.
  */
 export const ACTIVITY_SESSIONS_CAP = 50;
+
+/**
+ * Subscriber publications are capped at one leading/trailing update per 50 ms
+ * while transcript or reasoning deltas stream. Store mutation remains
+ * synchronous; only observers trail the authoritative projection.
+ */
+export const ACTIVITY_NOTIFICATION_INTERVAL_MS = 50;
 
 /** The phase a session's agent is in, derived from the latest event kind. */
 export type AgentActivityPhase = "running" | "waiting" | "background" | "error" | "complete";
@@ -115,7 +123,7 @@ export type HermesActivityStore = {
   activeCount(): number;
   /** Subscribe to changes (for `useSyncExternalStore`). Returns an unsubscribe. */
   subscribe(listener: () => void): () => void;
-  /** Monotonic version, bumped on every mutation (the snapshot getter). */
+  /** Monotonic version, bumped on every subscriber publication. */
   getVersion(): number;
 };
 
@@ -155,13 +163,24 @@ export function createHermesActivityStore(
   // on mutation so the most-recently-touched row sits last (eviction drops from
   // the front, i.e. the least recently active).
   const bySession = new Map<string, InternalRecord>();
+  // Last authoritative projection observed after each record call. Keep this
+  // separately from `bySession`: pendingActionCount comes from the companion
+  // pending-action store, which the ingress listener updates before calling
+  // record(). Re-reading the mutable row as "previous" would therefore miss a
+  // real count-only change such as two blockers becoming one.
+  const projectedBySession = new Map<string, AgentActivityRecord>();
   const listeners = new Set<() => void>();
   let version = 0;
 
-  function emit(): void {
+  function publish(): void {
     version += 1;
     for (const listener of listeners) listener();
   }
+
+  const notificationBatch = createLeadingTrailingMicrobatch(
+    publish,
+    ACTIVITY_NOTIFICATION_INTERVAL_MS,
+  );
 
   function record(event: JuneHermesEvent, mode: HermesMode): void {
     const sessionId = sessionIdOf(event);
@@ -169,6 +188,7 @@ export function createHermesActivityStore(
 
     const existing = bySession.get(sessionId);
     if (!existing && event.kind === "lifecycle" && event.flavor === "info") return;
+    const previous = projectedBySession.get(sessionId);
     const row: InternalRecord = existing ?? {
       sessionId,
       mode,
@@ -195,15 +215,29 @@ export function createHermesActivityStore(
       row.phase = "waiting";
     }
 
+    const next = toRecord(row);
+    if (sameRecord(previous, next)) return;
+
     // Re-key so this becomes the most-recently-touched entry for eviction.
     bySession.delete(sessionId);
     bySession.set(sessionId, row);
+    projectedBySession.set(sessionId, next);
     evict();
-    emit();
+
+    if (isStreamDelta(event)) {
+      notificationBatch.schedule();
+    } else {
+      // Tool, approval, subagent, completion, and failure changes stay prompt.
+      // Flushing also publishes the latest projection from any queued deltas.
+      notificationBatch.flush();
+    }
   }
 
   function clearSession(sessionId: string): void {
-    if (bySession.delete(sessionId)) emit();
+    if (bySession.delete(sessionId)) {
+      projectedBySession.delete(sessionId);
+      notificationBatch.flush();
+    }
   }
 
   function getRecords(): AgentActivityRecord[] {
@@ -241,6 +275,7 @@ export function createHermesActivityStore(
       for (const [sessionId, row] of bySession) {
         if (!ACTIVE_PHASES.has(row.phase)) {
           bySession.delete(sessionId);
+          projectedBySession.delete(sessionId);
           evicted = true;
           break;
         }
@@ -249,6 +284,7 @@ export function createHermesActivityStore(
       const oldestActive = bySession.keys().next().value;
       if (oldestActive === undefined) break;
       bySession.delete(oldestActive);
+      projectedBySession.delete(oldestActive);
     }
   }
 
@@ -467,6 +503,57 @@ function countActiveSubagents(subagents: Map<string, BackgroundHermesActivity>):
     if (!isTerminalSubagentPhase(subagent.phase)) count += 1;
   }
   return count;
+}
+
+function isStreamDelta(event: JuneHermesEvent): boolean {
+  return (
+    (event.kind === "transcript" && !event.complete && event.delta !== undefined) ||
+    (event.kind === "reasoning" && !event.full)
+  );
+}
+
+/**
+ * Projection equality for one activity row. `lastEventAt` is included: a
+ * burst still publishes its final observed time, but identical replays do not
+ * invalidate subscribers.
+ */
+function sameRecord(previous: AgentActivityRecord | undefined, next: AgentActivityRecord): boolean {
+  if (!previous) return false;
+  if (
+    previous.id !== next.id ||
+    previous.mode !== next.mode ||
+    previous.sessionId !== next.sessionId ||
+    previous.title !== next.title ||
+    previous.phase !== next.phase ||
+    previous.currentTool !== next.currentTool ||
+    previous.pendingActionCount !== next.pendingActionCount ||
+    previous.subagentCount !== next.subagentCount ||
+    previous.lastEventAt !== next.lastEventAt ||
+    previous.subagents.length !== next.subagents.length
+  ) {
+    return false;
+  }
+  return previous.subagents.every((subagent, index) =>
+    sameBackgroundActivity(subagent, next.subagents[index]),
+  );
+}
+
+function sameBackgroundActivity(
+  previous: BackgroundHermesActivity,
+  next: BackgroundHermesActivity,
+): boolean {
+  return (
+    previous.subagentId === next.subagentId &&
+    previous.handle === next.handle &&
+    previous.parentSessionId === next.parentSessionId &&
+    previous.phase === next.phase &&
+    previous.goal === next.goal &&
+    previous.currentTool === next.currentTool &&
+    previous.resultPreview === next.resultPreview &&
+    previous.taskIndex === next.taskIndex &&
+    previous.taskCount === next.taskCount &&
+    previous.lastEventAt === next.lastEventAt
+  );
 }
 
 /**

--- a/src/lib/hermes-activity-store.ts
+++ b/src/lib/hermes-activity-store.ts
@@ -40,7 +40,7 @@ import type {
   HermesMode,
   JuneHermesEvent,
 } from "./hermes-control-plane";
-import { nonEmpty } from "./hermes-control-plane";
+import { isHermesStreamDelta, nonEmpty } from "./hermes-control-plane";
 import { pendingActionStore } from "./hermes-pending-actions";
 import { createLeadingTrailingMicrobatch } from "./trailing-microbatch";
 
@@ -224,7 +224,7 @@ export function createHermesActivityStore(
     projectedBySession.set(sessionId, next);
     evict();
 
-    if (isStreamDelta(event)) {
+    if (isHermesStreamDelta(event)) {
       notificationBatch.schedule();
     } else {
       // Tool, approval, subagent, completion, and failure changes stay prompt.
@@ -503,13 +503,6 @@ function countActiveSubagents(subagents: Map<string, BackgroundHermesActivity>):
     if (!isTerminalSubagentPhase(subagent.phase)) count += 1;
   }
   return count;
-}
-
-function isStreamDelta(event: JuneHermesEvent): boolean {
-  return (
-    (event.kind === "transcript" && !event.complete && event.delta !== undefined) ||
-    (event.kind === "reasoning" && !event.full)
-  );
 }
 
 /**

--- a/src/lib/hermes-control-plane/events.ts
+++ b/src/lib/hermes-control-plane/events.ts
@@ -257,6 +257,14 @@ export type JuneHermesEvent =
  * exhaustiveness assertions. */
 export type JuneHermesEventKind = JuneHermesEvent["kind"];
 
+/** True when an event carries an incremental transcript or reasoning chunk. */
+export function isHermesStreamDelta(event: JuneHermesEvent): boolean {
+  return (
+    (event.kind === "transcript" && !event.complete && event.delta !== undefined) ||
+    (event.kind === "reasoning" && !event.full)
+  );
+}
+
 /** True for classified events that end the current agent run.
  *
  * A successful `message.complete` seals one assistant transcript segment. It

--- a/src/test/hermes-activity-store.test.ts
+++ b/src/test/hermes-activity-store.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { classifyHermesEvent, createSteeringEvent } from "../lib/hermes-control-plane";
 import type { JuneHermesEvent } from "../lib/hermes-control-plane";
-import { ACTIVITY_SESSIONS_CAP, createHermesActivityStore } from "../lib/hermes-activity-store";
+import {
+  ACTIVITY_NOTIFICATION_INTERVAL_MS,
+  ACTIVITY_SESSIONS_CAP,
+  createHermesActivityStore,
+} from "../lib/hermes-activity-store";
 
 // Classify a raw frame and assert it produced the expected kind, so a test
 // can't silently feed the wrong event into the store.
@@ -365,11 +369,92 @@ describe("createHermesActivityStore", () => {
     expect(store.getRecords()).toHaveLength(0);
   });
 
-  it("bumps the version on every mutation for useSyncExternalStore", () => {
+  it("bumps the version when a mutation is published to useSyncExternalStore", () => {
     const store = createHermesActivityStore();
     const before = store.getVersion();
     store.record(classified("tool.start", "s1", { tool_name: "a" }), "sandboxed");
     expect(store.getVersion()).toBeGreaterThan(before);
+  });
+
+  it("micro-batches a 5,000-delta burst and publishes the final synchronous state", () => {
+    const store = createHermesActivityStore();
+    const publishedRecords: ReturnType<typeof store.getRecord>[] = [];
+    store.subscribe(() => publishedRecords.push(store.getRecord("s1")));
+
+    for (let index = 0; index < 5_000; index += 1) {
+      const type = index % 2 === 0 ? "message.delta" : "thinking.delta";
+      const payload = index % 2 === 0 ? { delta: `text-${index}` } : { delta: `thought-${index}` };
+      store.record(classified(type, "s1", payload), "sandboxed");
+      advance(1);
+    }
+
+    // Mutation is authoritative and synchronous even while the trailing
+    // subscriber publication is waiting at the 50 ms boundary.
+    const finalRecord = store.getRecord("s1");
+    expect(finalRecord?.phase).toBe("running");
+    expect(finalRecord?.lastEventAt).toBe(now - 1);
+    expect(publishedRecords).toHaveLength(1);
+
+    vi.advanceTimersByTime(ACTIVITY_NOTIFICATION_INTERVAL_MS);
+
+    expect(publishedRecords).toHaveLength(2);
+    expect(publishedRecords.at(-1)).toEqual(finalRecord);
+  });
+
+  it("does not notify when an event leaves the projected record unchanged", () => {
+    const store = createHermesActivityStore();
+    const listener = vi.fn();
+    store.subscribe(listener);
+    const event = classified("tool.start", "s1", { tool_name: "a" });
+
+    store.record(event, "sandboxed");
+    vi.advanceTimersByTime(ACTIVITY_NOTIFICATION_INTERVAL_MS);
+    const publishedVersion = store.getVersion();
+
+    store.record(event, "sandboxed");
+    vi.runAllTimers();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(store.getVersion()).toBe(publishedVersion);
+  });
+
+  it("publishes a pending-action count change even when the session stays waiting", () => {
+    let pendingCount = 2;
+    const store = createHermesActivityStore({ pendingCountFor: () => pendingCount });
+    const listener = vi.fn();
+    store.subscribe(listener);
+    store.record(classified("approval.request", "s1", { request_id: "first" }), "sandboxed");
+    expect(store.getRecord("s1")?.pendingActionCount).toBe(2);
+
+    pendingCount = 1;
+    store.record(
+      classified("approval.resolved", "s1", { request_id: "first", approved: true }),
+      "sandboxed",
+    );
+
+    expect(store.getRecord("s1")).toMatchObject({
+      phase: "waiting",
+      pendingActionCount: 1,
+    });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("applies and publishes a terminal event immediately during a delta batch", () => {
+    const store = createHermesActivityStore();
+    const listener = vi.fn();
+    store.subscribe(listener);
+    store.record(classified("message.delta", "s1", { delta: "first" }), "sandboxed");
+    advance(1);
+    store.record(classified("thinking.delta", "s1", { delta: "second" }), "sandboxed");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    store.record(classified("session.info", "s1", { running: false }), "sandboxed");
+
+    expect(store.getRecord("s1")?.phase).toBe("complete");
+    expect(store.activeCount()).toBe(0);
+    expect(listener).toHaveBeenCalledTimes(2);
+    vi.runAllTimers();
+    expect(listener).toHaveBeenCalledTimes(2);
   });
 
   it("notifies subscribers and stops after unsubscribe", () => {

--- a/src/test/session-event-listener.test.ts
+++ b/src/test/session-event-listener.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AGENT_SESSION_STATUS_EVENT, type AgentSessionStatusDetail } from "../lib/agent-events";
+import type { HermesGatewayClient, HermesGatewayEvent } from "../lib/hermes-gateway";
+import type { JuneHermesEvent } from "../lib/hermes-control-plane";
+import { createSessionEventListener } from "../components/agent/session-event-listener";
+import { agentStatusFromHermesEvent } from "../components/agent/session-state-helpers";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createSessionEventListener activity publications", () => {
+  it("bounds stream status subscribers and still releases the run lease on the terminal frame", () => {
+    vi.useFakeTimers();
+    let eventHandler: ((event: HermesGatewayEvent) => void) | undefined;
+    const gateway = {
+      onEvent(handler: (event: HermesGatewayEvent) => void) {
+        eventHandler = handler;
+        return () => {
+          eventHandler = undefined;
+        };
+      },
+    } as unknown as HermesGatewayClient;
+    const setLiveEvents = vi.fn();
+    const releaseComputerUseRun = vi.fn().mockResolvedValue(undefined);
+    const statuses: AgentSessionStatusDetail[] = [];
+    const onStatus = (event: Event) => {
+      statuses.push((event as CustomEvent<AgentSessionStatusDetail>).detail);
+    };
+    window.addEventListener(AGENT_SESSION_STATUS_EVENT, onStatus);
+
+    const sessionGatewayUnlistenRef = { current: new Map<string, () => void>() };
+    const liveEventsRef = { current: {} as Record<string, JuneHermesEvent[]> };
+    const { attachHermesSessionEventListener } = createSessionEventListener({
+      cancelAgentRunSettlement: vi.fn(),
+      clearSessionActivity: vi.fn(() => ({ activeCount: 0, needsUserCount: 0 })),
+      clearSubmittedSteers: vi.fn(),
+      continueAfterCompletedAgentRun: vi.fn(),
+      liveEventsRef,
+      pendingSteerBySessionIdRef: { current: {} },
+      promotePendingIssueReportToReview: vi.fn(() => true),
+      recordHermesActivityAndDeriveStatus: (event) => agentStatusFromHermesEvent(event),
+      refreshHermesSession: vi.fn().mockResolvedValue(undefined),
+      releaseAllComputerUseRuns: vi.fn().mockResolvedValue(undefined),
+      releaseComputerUseRun,
+      sessionGatewayUnlistenRef,
+      sessionThinkingAppliedRef: { current: {} },
+      sessionThinkingEfforts: () => ({}),
+      sessionThinkingEffortsRef: { current: {} },
+      setLiveEvents,
+      withStoredHermesSessionId: (event, storedSessionId) =>
+        ({ ...event, sessionId: storedSessionId }) as JuneHermesEvent,
+    });
+
+    attachHermesSessionEventListener({
+      gateway,
+      runtimeSessionId: "runtime-session",
+      sessionDisplayTitle: "Long response",
+      storedSessionId: "stored-session",
+      computerUseRunLeaseId: "stored-session:lease",
+    });
+
+    for (let index = 0; index < 5_000; index += 1) {
+      eventHandler?.({
+        type: "thinking.delta",
+        session_id: "runtime-session",
+        payload: { delta: `thought-${index}` },
+      });
+    }
+
+    expect(statuses).toHaveLength(1);
+    expect(statuses[0]).toMatchObject({
+      sessionId: "stored-session",
+      status: "running",
+      summary: "Thinking.",
+    });
+    expect(setLiveEvents).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(50);
+
+    expect(statuses).toHaveLength(2);
+    expect(statuses.at(-1)).toMatchObject({
+      sessionId: "stored-session",
+      status: "running",
+      summary: "Thinking.",
+    });
+    expect(setLiveEvents).toHaveBeenCalledTimes(2);
+
+    eventHandler?.({
+      type: "session.info",
+      session_id: "runtime-session",
+      payload: { running: false },
+    });
+
+    expect(statuses.at(-1)).toMatchObject({
+      sessionId: "stored-session",
+      status: "completed",
+    });
+    expect(releaseComputerUseRun).toHaveBeenCalledWith("stored-session", "stored-session:lease");
+    expect(eventHandler).toBeUndefined();
+    vi.runAllTimers();
+    expect(statuses).toHaveLength(3);
+
+    window.removeEventListener(AGENT_SESSION_STATUS_EVENT, onStatus);
+  });
+});


### PR DESCRIPTION
## Summary

- Keep Hermes activity projection mutation synchronous while coalescing transcript and reasoning subscriber publications on the existing 50 ms leading/trailing boundary.
- Batch the session status events consumed by the menu bar and Agent HUD on the same boundary, while action, lifecycle, and terminal events remain prompt.
- Cover 5,000-event bursts, exact no-op updates, pending-action count-only changes, and terminal lease release timing.

Refs JUN-428

## Root cause

The stream work from #909 batched React publication of the visible transcript, but every classified stream frame still invalidated `hermesActivityStore` subscribers and dispatched a session status event. Those paths made Agent activity indicators, the menu bar, and the Agent HUD update once per raw transcript or reasoning delta.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` - 3,509 passed, 2 skipped
- `make verify` - frontend gates plus Tauri and June API fmt, clippy, and tests passed; sandbox-blocked native targets were rerun with system access
- Exact #923 Computer use run lease release test
- `NODE_OPTIONS=--no-experimental-webstorage make local-ci` - `signoff/frontend` succeeded; `signoff/rust-macos` posted as not applicable

- [ ] Tested visually where it matters (not applicable: this changes nonvisual store and event publication timing).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Hermes event classification, mutation order, terminal-event control flow, settlement, and Computer use lease semantics.
- Activity, menu bar, or HUD visual design changes.

## Followups

- Keep this PR in draft for the requested review round; no implementation followup is currently deferred.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary (none).
- [x] Workflow action references are pinned to full-length commit SHAs (no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable).
- [x] User-facing copy follows the repo UI conventions (no user-facing copy changes).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787434340&installation_model_id=425925&pr_number=944&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F944&signature=7b29c1907f0bebea44e2d738f61707f89b4b0f6f6f58167912dbc676bfc860d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->