### PR TITLE
Harden video download egress ranges

### DIFF
--- a/src-tauri/src/video_download_url.rs
+++ b/src-tauri/src/video_download_url.rs
@@ -14,14 +14,15 @@ pub fn validate_video_download_url(url: &str) -> Result<(reqwest::Url, Vec<Socke
     let host = parsed
         .host_str()
         .ok_or_else(|| "video download URL must include a host".to_string())?;
-    if let Ok(ip) = host.parse::<IpAddr>() {
+    let socket_host = host_without_ipv6_brackets(host);
+    if let Ok(ip) = socket_host.parse::<IpAddr>() {
         reject_non_public_ip(ip)?;
     }
 
     let port = parsed
         .port_or_known_default()
         .ok_or_else(|| "video download URL must include a resolvable port".to_string())?;
-    let addrs: Vec<_> = (host, port)
+    let addrs: Vec<_> = (socket_host, port)
         .to_socket_addrs()
         .map_err(|_| "video download URL host could not be resolved".to_string())?
         .collect();
@@ -43,16 +44,25 @@ pub fn video_download_client_builder(
     let host = parsed
         .host_str()
         .ok_or_else(|| "video download URL must include a host".to_string())?;
+    let socket_host = host_without_ipv6_brackets(host);
     if validated_addrs.is_empty() {
         return Err("video download URL host did not resolve".to_string());
     }
 
-    // Venice pre-signed video URLs are direct GETs. If a provider later needs
-    // CDN redirects, add a custom policy that validates and pins every hop.
+    // Venice pre-signed video URLs are direct GETs. Redirects fail closed, so
+    // no hop can bypass the validation and address pinning above. If a provider
+    // later needs CDN redirects, validate, resolve, and pin every hop before
+    // following it.
     Ok(reqwest::Client::builder()
         .no_proxy()
         .redirect(reqwest::redirect::Policy::none())
-        .resolve_to_addrs(host, validated_addrs))
+        .resolve_to_addrs(socket_host, validated_addrs))
+}
+
+fn host_without_ipv6_brackets(host: &str) -> &str {
+    host.strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host)
 }
 
 fn reject_non_public_ip(ip: IpAddr) -> Result<(), String> {
@@ -77,6 +87,7 @@ fn is_non_public_ipv4(ip: Ipv4Addr) -> bool {
         || ip.is_broadcast()
         || ip.is_multicast()
         || is_cgnat_ipv4(ip)
+        || is_special_use_ipv4(ip)
 }
 
 fn is_cgnat_ipv4(ip: Ipv4Addr) -> bool {
@@ -84,36 +95,132 @@ fn is_cgnat_ipv4(ip: Ipv4Addr) -> bool {
     octets[0] == 100 && CGNAT_IPV4_SECOND_OCTET.contains(&octets[1])
 }
 
+fn is_special_use_ipv4(ip: Ipv4Addr) -> bool {
+    // IANA IPv4 Special-Purpose Address Registry blocks that are not covered by
+    // the standard library predicates above:
+    // - 0.0.0.0/8 ("This network")
+    // - 192.0.0.0/24 (IETF protocol assignments)
+    // - 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 (documentation)
+    // - 192.88.99.0/24 (deprecated 6to4 relay anycast)
+    // - 198.18.0.0/15 (benchmarking)
+    // - 240.0.0.0/4 (reserved)
+    matches!(
+        ip.octets(),
+        [0, _, _, _]
+            | [192, 0, 0 | 2, _]
+            | [192, 88, 99, _]
+            | [198, 18..=19, _, _]
+            | [198, 51, 100, _]
+            | [203, 0, 113, _]
+            | [240..=255, _, _, _]
+    )
+}
+
 fn is_non_public_ipv6(ip: Ipv6Addr) -> bool {
     if ip.is_loopback() || ip.is_unspecified() || ip.is_multicast() {
         return true;
     }
 
-    let octets = ip.octets();
-    if matches!(octets[0], 0xfc | 0xfd) {
+    // IANA IPv6 Special-Purpose Address Registry: ::ffff:0:0/96
+    // (IPv4-mapped). Classify the address the socket will actually reach.
+    if let Some(ipv4) = ip.to_ipv4_mapped() {
+        return is_non_public_ipv4(ipv4);
+    }
+
+    let segments = ip.segments();
+    // Deprecated IPv4-compatible IPv6 addresses occupy ::/96. Unlike mapped
+    // addresses, these must not be accepted even when the trailing IPv4 is
+    // public.
+    if segments[..6].iter().all(|segment| *segment == 0) {
         return true;
     }
-    if octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80 {
+    if is_local_nat64_ipv6(segments) {
+        return true;
+    }
+    if is_well_known_nat64_ipv6(segments) {
+        return is_non_public_ipv4(ipv4_from_segments(segments[6], segments[7]));
+    }
+    if is_6to4_ipv6(segments) {
+        return is_non_public_ipv4(ipv4_from_segments(segments[1], segments[2]));
+    }
+
+    let first = segments[0];
+    if (first & 0xfe00) == 0xfc00
+        || (first & 0xffc0) == 0xfe80
+        || is_benchmarking_ipv6(segments)
+        || is_ietf_protocol_assignment_ipv6(segments)
+        || is_documentation_ipv6(segments)
+        || is_srv6_sid_ipv6(segments)
+        || is_discard_only_ipv6(segments)
+    {
         return true;
     }
 
-    if let Some(ipv4) = embedded_ipv4(octets) {
-        return is_non_public_ipv4(ipv4);
+    // Globally routable IPv6 unicast space is currently allocated from
+    // 2000::/3. The translation prefixes above are handled before this gate.
+    if (first & 0xe000) != 0x2000 {
+        return true;
     }
 
     false
 }
 
-fn embedded_ipv4(octets: [u8; 16]) -> Option<Ipv4Addr> {
-    let prefix_is_zero = octets[..10].iter().all(|octet| *octet == 0);
-    let is_mapped = prefix_is_zero && octets[10] == 0xff && octets[11] == 0xff;
-    let is_compatible = octets[..12].iter().all(|octet| *octet == 0);
-    if is_mapped || is_compatible {
-        return Some(Ipv4Addr::new(
-            octets[12], octets[13], octets[14], octets[15],
-        ));
-    }
-    None
+fn is_local_nat64_ipv6(segments: [u16; 8]) -> bool {
+    // IANA IPv6 Special-Purpose Address Registry: 64:ff9b:1::/48,
+    // IPv4-IPv6 translation for local use, is not globally reachable.
+    segments[0] == 0x0064 && segments[1] == 0xff9b && segments[2] == 0x0001
+}
+
+fn is_well_known_nat64_ipv6(segments: [u16; 8]) -> bool {
+    // IANA IPv6 Special-Purpose Address Registry: 64:ff9b::/96,
+    // the well-known IPv4-IPv6 translation prefix. Its embedded IPv4 address
+    // determines whether the destination is public.
+    segments[0] == 0x0064
+        && segments[1] == 0xff9b
+        && segments[2] == 0
+        && segments[3] == 0
+        && segments[4] == 0
+        && segments[5] == 0
+}
+
+fn is_6to4_ipv6(segments: [u16; 8]) -> bool {
+    // IANA IPv6 Special-Purpose Address Registry: 2002::/16 (6to4).
+    // The next 32 bits carry the IPv4 destination to classify.
+    segments[0] == 0x2002
+}
+
+fn is_ietf_protocol_assignment_ipv6(segments: [u16; 8]) -> bool {
+    // IANA IPv6 Special-Purpose Address Registry: 2001::/23. This includes
+    // 2001::/32 (Teredo) and 2001:2::/48 (benchmarking).
+    segments[0] == 0x2001 && (segments[1] & 0xfe00) == 0
+}
+
+fn is_documentation_ipv6(segments: [u16; 8]) -> bool {
+    // IANA IPv6 Special-Purpose Address Registry documentation blocks:
+    // 2001:db8::/32 and 3fff::/20.
+    (segments[0] == 0x2001 && segments[1] == 0x0db8)
+        || (segments[0] == 0x3fff && (segments[1] & 0xf000) == 0)
+}
+
+fn is_srv6_sid_ipv6(segments: [u16; 8]) -> bool {
+    // IANA IPv6 Special-Purpose Address Registry: 5f00::/16 (SRv6 SIDs).
+    segments[0] == 0x5f00
+}
+
+fn is_discard_only_ipv6(segments: [u16; 8]) -> bool {
+    // IANA IPv6 Special-Purpose Address Registry: 100::/64 (discard-only).
+    segments[0] == 0x0100 && segments[1] == 0 && segments[2] == 0 && segments[3] == 0
+}
+
+fn is_benchmarking_ipv6(segments: [u16; 8]) -> bool {
+    // IANA IPv6 Special-Purpose Address Registry: 2001:2::/48 (benchmarking).
+    segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0
+}
+
+fn ipv4_from_segments(high: u16, low: u16) -> Ipv4Addr {
+    let [a, b] = high.to_be_bytes();
+    let [c, d] = low.to_be_bytes();
+    Ipv4Addr::new(a, b, c, d)
 }
 
 #[cfg(test)]
@@ -137,6 +244,13 @@ mod tests {
         assert!(!is_non_public_ip(IpAddr::V6(
             "2606:2800:220:1:248:1893:25c8:1946".parse().unwrap()
         )));
+    }
+
+    #[test]
+    fn public_embedded_ipv4_destinations_are_allowed() {
+        for ip in ["::ffff:5db8:d822", "64:ff9b::5db8:d822", "2002:5db8:d822::"] {
+            assert!(!is_non_public_ip(IpAddr::V6(ip.parse().unwrap())), "{ip}");
+        }
     }
 
     #[test]
@@ -166,11 +280,180 @@ mod tests {
     }
 
     #[test]
+    fn rejects_this_network_ipv4_range() {
+        assert_non_public_urls(&[
+            "https://0.0.0.1/video.mp4",
+            "https://0.255.255.255/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_ietf_protocol_assignments_ipv4_range() {
+        assert_non_public_urls(&[
+            "https://192.0.0.1/video.mp4",
+            "https://192.0.0.255/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_test_net_1_ipv4_range() {
+        assert_non_public_urls(&[
+            "https://192.0.2.1/video.mp4",
+            "https://192.0.2.255/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_deprecated_6to4_relay_anycast_ipv4_range() {
+        assert_non_public_urls(&[
+            "https://192.88.99.1/video.mp4",
+            "https://192.88.99.255/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_benchmarking_ipv4_range() {
+        assert_non_public_urls(&[
+            "https://198.18.0.1/video.mp4",
+            "https://198.19.255.255/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_test_net_2_ipv4_range() {
+        assert_non_public_urls(&[
+            "https://198.51.100.1/video.mp4",
+            "https://198.51.100.255/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_test_net_3_ipv4_range() {
+        assert_non_public_urls(&[
+            "https://203.0.113.1/video.mp4",
+            "https://203.0.113.255/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_reserved_ipv4_range() {
+        assert_non_public_urls(&[
+            "https://240.0.0.1/video.mp4",
+            "https://255.255.255.254/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_ipv4_mapped_ipv6_with_non_public_destination() {
+        assert_non_public_urls(&[
+            "https://[::ffff:a00:1]/video.mp4",
+            "https://[::ffff:c000:201]/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_ipv4_compatible_ipv6_range() {
+        assert_non_public_urls(&["https://[::5db8:d822]/video.mp4"]);
+    }
+
+    #[test]
+    fn rejects_well_known_nat64_with_non_public_destination() {
+        assert_non_public_urls(&[
+            "https://[64:ff9b::a00:1]/video.mp4",
+            "https://[64:ff9b::c000:201]/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_local_use_nat64_ipv6_range() {
+        assert_non_public_urls(&[
+            "https://[64:ff9b:1::1]/video.mp4",
+            "https://[64:ff9b:1:ffff:ffff:ffff:ffff:ffff]/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_discard_only_ipv6_range() {
+        assert_non_public_urls(&[
+            "https://[100::1]/video.mp4",
+            "https://[100::ffff:ffff:ffff:ffff]/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_ietf_protocol_assignments_ipv6_range() {
+        assert_non_public_urls(&[
+            "https://[2001::1]/video.mp4",
+            "https://[2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff]/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_teredo_ipv6_range() {
+        assert_non_public_urls(&[
+            "https://[2001:0:1::1]/video.mp4",
+            "https://[2001:0:ffff:ffff:ffff:ffff:ffff:ffff]/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_benchmarking_ipv6_range() {
+        assert_non_public_urls(&[
+            "https://[2001:2::1]/video.mp4",
+            "https://[2001:2:0:ffff:ffff:ffff:ffff:ffff]/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_documentation_2001_db8_ipv6_range() {
+        assert_non_public_urls(&[
+            "https://[2001:db8::1]/video.mp4",
+            "https://[2001:db8:ffff:ffff:ffff:ffff:ffff:ffff]/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_6to4_with_non_public_destination() {
+        assert_non_public_urls(&[
+            "https://[2002:a00:1::]/video.mp4",
+            "https://[2002:c000:201::]/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_documentation_3fff_ipv6_range() {
+        assert_non_public_urls(&[
+            "https://[3fff::1]/video.mp4",
+            "https://[3fff:fff:ffff:ffff:ffff:ffff:ffff:ffff]/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_srv6_sid_ipv6_range() {
+        assert_non_public_urls(&[
+            "https://[5f00::1]/video.mp4",
+            "https://[5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff]/video.mp4",
+        ]);
+    }
+
+    #[test]
+    fn rejects_unallocated_global_ipv6_space() {
+        assert_non_public_urls(&["https://[4000::1]/video.mp4"]);
+    }
+
+    #[test]
     fn allows_public_ip_literal() {
         let (_parsed, addrs) =
             validate_video_download_url("https://93.184.216.34/video.mp4").unwrap();
-
         assert_eq!(addrs, vec![SocketAddr::from(([93, 184, 216, 34], 443))]);
+
+        let (_parsed, addrs) =
+            validate_video_download_url("https://[2606:2800:220:1:248:1893:25c8:1946]/video.mp4")
+                .unwrap();
+        assert_eq!(
+            addrs,
+            vec!["[2606:2800:220:1:248:1893:25c8:1946]:443".parse().unwrap()]
+        );
     }
 
     #[tokio::test]
@@ -199,6 +482,16 @@ mod tests {
         redirect_thread.join().unwrap();
         assert!(!target_hit.load(Ordering::SeqCst));
         target_thread.join().unwrap();
+    }
+
+    fn assert_non_public_urls(urls: &[&str]) {
+        for url in urls {
+            assert_eq!(
+                validate_video_download_url(url).unwrap_err(),
+                "video download URL host resolved to a non-public address",
+                "{url}"
+            );
+        }
     }
 
     fn spawn_one_response_server(


### PR DESCRIPTION
## Summary

- Security-sensitive SSRF hardening: reject the missing IANA IPv4 and IPv6 special-purpose ranges in provider-returned video download URLs.
- Validate embedded IPv4 destinations carried by IPv4-mapped IPv6, well-known NAT64, and 6to4 addresses, and reject local-use NAT64, Teredo/IETF, documentation, benchmarking, discard-only, SRv6 SID, reserved, and unallocated IPv6 space.
- Normalize bracketed IPv6 URL hosts before literal classification and socket resolution, while retaining pinned DNS results and fail-closed redirect handling.
- Add a rejection test for each newly covered range plus public IPv4, IPv6, and public embedded-destination controls.

## Root cause

The desktop video-download predicate covered loopback, private, link-local, multicast, unspecified, CGNAT, and selected embedded IPv4 cases, but omitted multiple IANA special-purpose and IPv6 transition ranges. IPv6 literals also retained URL brackets when passed to the socket resolver, so some were rejected as unresolvable before reaching the non-public-address classifier.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --locked -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked` (1,396 unit tests passed; integration suites passed)
- Focused `video_download_url` suite (27 passed)
- `make local-ci` (`signoff/frontend`: not applicable; `signoff/rust-macos`: success)
- Live walkthrough skipped: this is a low-level network policy change with no UI surface; deterministic range and redirect tests are the meaningful validation.

- [x] Tested visually where it matters (not applicable: Rust-only network policy with no UI change).
- [ ] Needs a June API (backend) deploy before it works end to end. No - this is desktop-only hardening.

## Out of scope

- Following provider redirects; redirects remain disabled and fail closed.
- Changing June API contracts or deployment behavior.
- Refactoring the desktop and June API workspaces into a new shared crate.

## Followups

- None required for this stabilization change.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. (No workflow changes.)
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. (No such changes.)
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (No backend changes.)
- [x] User-facing copy follows the repo UI conventions. (No user-facing copy changes.)

Refs JUN-432

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787438108&installation_model_id=425925&pr_number=946&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F946&signature=c4626fc9223516e2baa950d10af9d791b6ebee7089e81af28ad79afb00503e94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->