### PR TITLE
Poll Calendar once per account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,12 @@ tauri-lint:  ## clippy (warnings = errors)
 tauri-test:  ## cargo test
 	cargo test --manifest-path src-tauri/Cargo.toml --locked
 
-.PHONY: benchmark-note-transcription-latency
+.PHONY: benchmark-note-transcription-latency benchmark-calendar-account-poll
 benchmark-note-transcription-latency:
 	cargo test --manifest-path src-tauri/Cargo.toml --locked --release commands::note_transcription_benchmark::benchmark_post_finalization_note_transcription_latency -- --ignored --exact --nocapture --test-threads=1
+
+benchmark-calendar-account-poll:
+	cargo test --manifest-path src-tauri/Cargo.toml --locked --release connectors::triggers::tests::benchmark_calendar_account_poll_consolidation -- --ignored --exact --nocapture --test-threads=1
 
 # --- June API backend (june-api/) ---
 june-api-fmt:  ## rustfmt (write)

--- a/src-tauri/src/connectors/triggers.rs
+++ b/src-tauri/src/connectors/triggers.rs
@@ -21,8 +21,12 @@ use crate::db::repositories::{ConnectorTriggerRecord, Repositories};
 use crate::domain::types::AppError;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tauri::AppHandle;
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
 
 const STARTUP_DELAY: Duration = Duration::from_secs(30);
 const GMAIL_PERIOD: Duration = Duration::from_secs(90);
@@ -33,6 +37,8 @@ const BACKOFF_PERIOD: Duration = Duration::from_secs(300);
 const MIN_SLEEP: Duration = Duration::from_secs(5);
 const BATTERY_LOW_PERCENT: u32 = 20;
 const DEFAULT_LEAD_MINUTES: i64 = 15;
+const MAX_CALENDAR_ACCOUNT_CONCURRENCY: usize = 4;
+const MAX_EVENT_PAGES: usize = 20;
 const EMAIL_KIND: &str = "email_received";
 const EVENT_KIND: &str = "event_upcoming";
 
@@ -121,13 +127,7 @@ async fn poll_kind(app: &AppHandle, kind: &str) -> bool {
             }
         }
     } else {
-        // event_upcoming is per job: each carries its own lead time and fired
-        // set, so poll each trigger independently.
-        for trigger in relevant {
-            if let Err(error) = poll_event_trigger(app, &repos, &trigger).await {
-                tracing::warn!(error_code = %error.code, kind, "connector event trigger poll failed");
-            }
-        }
+        poll_calendar_accounts(app, &repos, relevant).await;
     }
     true
 }
@@ -254,24 +254,164 @@ async fn call_gmail_history(
 
 // --- Calendar -----------------------------------------------------------------
 
-async fn poll_event_trigger(
+#[derive(Debug)]
+struct CalendarTriggerPlan {
+    trigger: ConnectorTriggerRecord,
+    lead_minutes: i64,
+    external_only: bool,
+}
+
+#[derive(Debug)]
+struct CalendarAccountPlan {
+    account_id: String,
+    max_lead_minutes: i64,
+    triggers: Vec<CalendarTriggerPlan>,
+}
+
+fn calendar_account_plans(triggers: Vec<ConnectorTriggerRecord>) -> Vec<CalendarAccountPlan> {
+    let mut by_account: HashMap<String, Vec<CalendarTriggerPlan>> = HashMap::new();
+    for trigger in triggers {
+        let account_id = trigger.account_id.clone();
+        by_account
+            .entry(account_id)
+            .or_default()
+            .push(CalendarTriggerPlan {
+                lead_minutes: lead_minutes_from_config(&trigger.config),
+                external_only: external_only_from_config(&trigger.config),
+                trigger,
+            });
+    }
+
+    let mut plans: Vec<CalendarAccountPlan> = by_account
+        .into_iter()
+        .map(|(account_id, triggers)| CalendarAccountPlan {
+            max_lead_minutes: triggers
+                .iter()
+                .map(|trigger| trigger.lead_minutes)
+                .max()
+                .unwrap_or(DEFAULT_LEAD_MINUTES),
+            account_id,
+            triggers,
+        })
+        .collect();
+    plans.sort_by(|left, right| left.account_id.cmp(&right.account_id));
+    plans
+}
+
+async fn poll_calendar_accounts(
     app: &AppHandle,
     repos: &Repositories,
-    trigger: &ConnectorTriggerRecord,
-) -> Result<(), AppError> {
-    let account_id = &trigger.account_id;
-    let job_id = &trigger.job_id;
-    let lead_minutes = lead_minutes_from_config(&trigger.config);
-    let external_only = external_only_from_config(&trigger.config);
-    // The account id is the connected Google address, so its domain is the
-    // org/home domain an "external guest" is measured against.
-    let account_domain = email_domain(account_id);
-    let cursor_kind = format!("{EVENT_KIND}:{job_id}");
+    triggers: Vec<ConnectorTriggerRecord>,
+) {
+    let plans = calendar_account_plans(triggers);
+    let app = app.clone();
+    let repos = repos.clone();
+    let results =
+        run_calendar_account_polls(plans, MAX_CALENDAR_ACCOUNT_CONCURRENCY, move |plan| {
+            let app = app.clone();
+            let repos = repos.clone();
+            async move { poll_calendar_account(&app, &repos, plan).await }
+        })
+        .await;
 
+    for result in results {
+        if let Err(error) = result {
+            tracing::warn!(
+                error_code = %error.code,
+                kind = EVENT_KIND,
+                "connector calendar account poll failed"
+            );
+        }
+    }
+}
+
+async fn run_calendar_account_polls<F, Fut>(
+    plans: Vec<CalendarAccountPlan>,
+    max_concurrency: usize,
+    poll_account: F,
+) -> Vec<Result<(), AppError>>
+where
+    F: Fn(CalendarAccountPlan) -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = Result<(), AppError>> + Send + 'static,
+{
+    let semaphore = Arc::new(Semaphore::new(max_concurrency.max(1)));
+    let mut tasks = JoinSet::new();
+    for plan in plans {
+        let semaphore = semaphore.clone();
+        let poll_account = poll_account.clone();
+        tasks.spawn(async move {
+            let _permit = semaphore.acquire_owned().await.map_err(|error| {
+                AppError::new(
+                    "connector_calendar_poll_task_failed",
+                    format!("Calendar poll concurrency gate closed: {error}"),
+                )
+            })?;
+            poll_account(plan).await
+        });
+    }
+
+    let mut results = Vec::with_capacity(tasks.len());
+    while let Some(result) = tasks.join_next().await {
+        results.push(result.unwrap_or_else(|error| {
+            Err(AppError::new(
+                "connector_calendar_poll_task_failed",
+                format!("Calendar account poll task failed: {error}"),
+            ))
+        }));
+    }
+    results
+}
+
+async fn poll_calendar_account(
+    app: &AppHandle,
+    repos: &Repositories,
+    plan: CalendarAccountPlan,
+) -> Result<(), AppError> {
+    let account_id = &plan.account_id;
     let token = crate::connectors::google_access_token(app, account_id).await?;
     let now = Utc::now();
+    let items =
+        match fetch_calendar_events(app, account_id, token, &now, plan.max_lead_minutes).await {
+            Ok(items) => items,
+            Err(error) if error.code == "connector_sync_token_expired" => {
+                // Window mode never sends a sync token, but preserve the existing
+                // defensive reset for every routine consuming this account.
+                for trigger in &plan.triggers {
+                    let cursor_kind = format!("{EVENT_KIND}:{}", trigger.trigger.job_id);
+                    let _ = repos
+                        .set_trigger_cursor(account_id, &cursor_kind, "{}")
+                        .await;
+                }
+                return Ok(());
+            }
+            Err(error) => return Err(error),
+        };
+
+    // Every trigger keeps its own audience rule, lead time, fired cursor, and
+    // wake result. Only the provider scan above is shared.
+    for trigger in &plan.triggers {
+        if let Err(error) =
+            apply_calendar_events_to_trigger(app, repos, trigger, &now, &items).await
+        {
+            tracing::warn!(
+                error_code = %error.code,
+                kind = EVENT_KIND,
+                "connector event trigger poll failed"
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn fetch_calendar_events(
+    app: &AppHandle,
+    account_id: &str,
+    mut token: String,
+    now: &DateTime<Utc>,
+    max_lead_minutes: i64,
+) -> Result<Vec<google::EventSummary>, AppError> {
     // Scan a little past the lead window so an event is seen before it starts.
-    let time_max = now + ChronoDuration::minutes(lead_minutes + 5);
+    let time_max = *now + ChronoDuration::minutes(max_lead_minutes + 5);
     let base_params = ListEventsParams {
         time_min: Some(now.to_rfc3339()),
         time_max: Some(time_max.to_rfc3339()),
@@ -283,7 +423,6 @@ async fn poll_event_trigger(
     // 25-event page, and a matching event on a later page must not be missed,
     // or the routine silently skips its trigger. Bounded by a page cap so a
     // pathological calendar can never spin the poll forever.
-    const MAX_EVENT_PAGES: usize = 20;
     let mut items: Vec<google::EventSummary> = Vec::new();
     let mut page_token: Option<String> = None;
     for _ in 0..MAX_EVENT_PAGES {
@@ -291,17 +430,14 @@ async fn poll_event_trigger(
             page_token: page_token.take(),
             ..base_params.clone()
         };
-        let page = match call_list_events(app, account_id, &token, &params).await {
+        let page = match google::list_events(&token, &params).await {
             Ok(page) => page,
-            Err(error) if error.code == "connector_sync_token_expired" => {
-                // Window mode never sends a sync token, but clear the cursor
-                // defensively so a stale one can never wedge the poll.
-                let _ = repos
-                    .set_trigger_cursor(account_id, &cursor_kind, "{}")
-                    .await;
-                return Ok(());
+            Err(GoogleApiError::Unauthorized) => {
+                token =
+                    crate::connectors::force_refresh_google_access_token(app, account_id).await?;
+                google::list_events(&token, &params).await?
             }
-            Err(error) => return Err(error),
+            Err(error) => return Err(error.into()),
         };
         items.extend(page.items);
         match page.next_page_token {
@@ -309,32 +445,22 @@ async fn poll_event_trigger(
             None => break,
         }
     }
+    Ok(items)
+}
 
+async fn apply_calendar_events_to_trigger(
+    app: &AppHandle,
+    repos: &Repositories,
+    plan: &CalendarTriggerPlan,
+    now: &DateTime<Utc>,
+    items: &[google::EventSummary],
+) -> Result<(), AppError> {
+    let trigger = &plan.trigger;
+    let account_id = &trigger.account_id;
+    let job_id = &trigger.job_id;
+    let cursor_kind = format!("{EVENT_KIND}:{job_id}");
     let mut fired = load_fired(repos, account_id, &cursor_kind).await;
-    let lead_cutoff = now + ChronoDuration::minutes(lead_minutes);
-
-    // Collect the events that should wake the routine this cycle; do not mark
-    // them fired yet, so a failed wake does not skip them.
-    let mut to_fire: Vec<(String, i64)> = Vec::new();
-    for event in &items {
-        if fired.contains_key(&event.id) {
-            continue;
-        }
-        let Some(start) = event.start.as_deref().and_then(parse_event_start) else {
-            continue;
-        };
-        let starts_soon = start >= now && start <= lead_cutoff;
-        let has_external = event
-            .attendees
-            .iter()
-            .any(|attendee| attendee_is_external(attendee, account_domain));
-        // When the routine opts out of external-only, internal and solo events
-        // fire too; otherwise a meeting needs at least one outside-domain guest.
-        let passes_audience = !external_only || has_external;
-        if starts_soon && passes_audience {
-            to_fire.push((event.id.clone(), start.timestamp()));
-        }
-    }
+    let to_fire = calendar_events_to_fire(plan, now, items, &fired);
 
     // Prune events whose start time is in the past so the cursor stays small.
     let before = fired.len();
@@ -360,23 +486,35 @@ async fn poll_event_trigger(
     Ok(())
 }
 
-async fn call_list_events(
-    app: &AppHandle,
-    account_id: &str,
-    token: &str,
-    params: &ListEventsParams,
-) -> Result<google::EventsPage, AppError> {
-    match google::list_events(token, params).await {
-        Ok(page) => Ok(page),
-        Err(GoogleApiError::Unauthorized) => {
-            let token =
-                crate::connectors::force_refresh_google_access_token(app, account_id).await?;
-            google::list_events(&token, params)
-                .await
-                .map_err(Into::into)
+fn calendar_events_to_fire(
+    plan: &CalendarTriggerPlan,
+    now: &DateTime<Utc>,
+    items: &[google::EventSummary],
+    fired: &HashMap<String, i64>,
+) -> Vec<(String, i64)> {
+    let account_domain = email_domain(&plan.trigger.account_id);
+    let lead_cutoff = *now + ChronoDuration::minutes(plan.lead_minutes);
+    let mut to_fire = Vec::new();
+    for event in items {
+        if fired.contains_key(&event.id) {
+            continue;
         }
-        Err(error) => Err(error.into()),
+        let Some(start) = event.start.as_deref().and_then(parse_event_start) else {
+            continue;
+        };
+        let starts_soon = start >= *now && start <= lead_cutoff;
+        let has_external = event
+            .attendees
+            .iter()
+            .any(|attendee| attendee_is_external(attendee, account_domain));
+        // When the routine opts out of external-only, internal and solo events
+        // fire too; otherwise a meeting needs at least one outside-domain guest.
+        let passes_audience = !plan.external_only || has_external;
+        if starts_soon && passes_audience {
+            to_fire.push((event.id.clone(), start.timestamp()));
+        }
     }
+    to_fire
 }
 
 async fn load_fired(
@@ -503,6 +641,9 @@ fn parse_battery_percent(text: &str) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+    use tokio::sync::Notify;
 
     #[test]
     fn parses_battery_percent_from_pmset_output() {
@@ -539,6 +680,387 @@ mod tests {
             email: email.map(str::to_string),
             response_status: None,
             is_self,
+        }
+    }
+
+    fn calendar_trigger(
+        job_id: &str,
+        account_id: &str,
+        lead_minutes: i64,
+        external_only: bool,
+    ) -> ConnectorTriggerRecord {
+        ConnectorTriggerRecord {
+            id: format!("trigger-{job_id}"),
+            job_id: job_id.to_string(),
+            kind: EVENT_KIND.to_string(),
+            account_id: account_id.to_string(),
+            config: serde_json::json!({
+                "leadMinutes": lead_minutes,
+                "externalOnly": external_only,
+            })
+            .to_string(),
+            created_at: "2026-07-24T08:00:00Z".to_string(),
+        }
+    }
+
+    fn calendar_event(
+        id: &str,
+        now: &DateTime<Utc>,
+        starts_in_minutes: i64,
+        attendee_email: Option<&str>,
+    ) -> google::EventSummary {
+        google::EventSummary {
+            id: id.to_string(),
+            summary: None,
+            start: Some((*now + ChronoDuration::minutes(starts_in_minutes)).to_rfc3339()),
+            end: None,
+            attendees: attendee_email
+                .map(|email| vec![attendee(Some(email), false)])
+                .unwrap_or_default(),
+            location: None,
+            organizer: None,
+            html_link: None,
+            status: None,
+        }
+    }
+
+    fn fixed_calendar_now() -> DateTime<Utc> {
+        parse_event_start("2026-07-24T10:00:00Z").expect("fixed test time")
+    }
+
+    fn sorted_event_ids(events: Vec<(String, i64)>) -> Vec<String> {
+        let mut ids: Vec<String> = events.into_iter().map(|(id, _)| id).collect();
+        ids.sort();
+        ids
+    }
+
+    #[tokio::test]
+    async fn ten_routines_share_one_calendar_fetch_without_changing_trigger_rules() {
+        let account_id = "alex@acme.com";
+        let triggers: Vec<ConnectorTriggerRecord> = (0..10)
+            .map(|index| match index % 4 {
+                0 => calendar_trigger(&format!("job-{index}"), account_id, 10, true),
+                1 => calendar_trigger(&format!("job-{index}"), account_id, 10, false),
+                2 => calendar_trigger(&format!("job-{index}"), account_id, 30, true),
+                _ => calendar_trigger(&format!("job-{index}"), account_id, 30, false),
+            })
+            .collect();
+        let plans = calendar_account_plans(triggers);
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].account_id, account_id);
+        assert_eq!(plans[0].max_lead_minutes, 30);
+        assert_eq!(plans[0].triggers.len(), 10);
+
+        let now = Arc::new(fixed_calendar_now());
+        // The shared maximum window can return events beyond a particular
+        // routine's lead time. Local fanout must still apply that routine's
+        // original cutoff and audience rule.
+        let events = Arc::new(vec![
+            calendar_event("internal-soon", &now, 5, Some("dana@acme.com")),
+            calendar_event("external-soon", &now, 5, Some("guest@partner.com")),
+            calendar_event("external-later", &now, 20, Some("guest@partner.com")),
+            calendar_event("outside-lead", &now, 34, Some("guest@partner.com")),
+        ]);
+        let fetches = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::new(Mutex::new(HashMap::<String, Vec<String>>::new()));
+
+        let results = run_calendar_account_polls(plans, 4, {
+            let now = now.clone();
+            let events = events.clone();
+            let fetches = fetches.clone();
+            let observed = observed.clone();
+            move |plan| {
+                let now = now.clone();
+                let events = events.clone();
+                let fetches = fetches.clone();
+                let observed = observed.clone();
+                async move {
+                    fetches.fetch_add(1, Ordering::SeqCst);
+                    for trigger in &plan.triggers {
+                        assert_eq!(trigger.trigger.account_id, plan.account_id);
+                        let mut fired = HashMap::new();
+                        // Only job-0 has seen this event. The same-config job-4
+                        // must still fire, proving fired state stays per routine.
+                        if trigger.trigger.job_id == "job-0" {
+                            fired.insert(
+                                "external-soon".to_string(),
+                                (*now + ChronoDuration::minutes(5)).timestamp(),
+                            );
+                        }
+                        let ids = sorted_event_ids(calendar_events_to_fire(
+                            trigger, &now, &events, &fired,
+                        ));
+                        observed
+                            .lock()
+                            .expect("observed trigger results")
+                            .insert(trigger.trigger.job_id.clone(), ids);
+                    }
+                    Ok(())
+                }
+            }
+        })
+        .await;
+
+        assert!(results.iter().all(Result::is_ok));
+        assert_eq!(fetches.load(Ordering::SeqCst), 1);
+        let observed = observed.lock().expect("observed trigger results");
+        for index in 0..10 {
+            let expected: Vec<&str> = match index % 4 {
+                0 if index == 0 => vec![],
+                0 => vec!["external-soon"],
+                1 => vec!["external-soon", "internal-soon"],
+                2 => vec!["external-later", "external-soon"],
+                _ => vec!["external-later", "external-soon", "internal-soon"],
+            };
+            assert_eq!(
+                observed.get(&format!("job-{index}")),
+                Some(&expected.into_iter().map(str::to_string).collect())
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn calendar_accounts_keep_fetches_and_trigger_results_isolated() {
+        let plans = calendar_account_plans(vec![
+            calendar_trigger("job-acme", "alex@acme.com", 15, true),
+            calendar_trigger("job-beta", "bea@beta.com", 30, true),
+        ]);
+        assert_eq!(plans.len(), 2);
+
+        let now = Arc::new(fixed_calendar_now());
+        let events = Arc::new(HashMap::from([
+            (
+                "alex@acme.com".to_string(),
+                vec![calendar_event(
+                    "acme-external",
+                    &now,
+                    5,
+                    Some("guest@partner.com"),
+                )],
+            ),
+            (
+                "bea@beta.com".to_string(),
+                vec![calendar_event(
+                    "beta-internal",
+                    &now,
+                    5,
+                    Some("coworker@beta.com"),
+                )],
+            ),
+        ]));
+        let fetches = Arc::new(Mutex::new(HashMap::<String, usize>::new()));
+        let observed = Arc::new(Mutex::new(HashMap::<String, Vec<String>>::new()));
+
+        let results = run_calendar_account_polls(plans, 2, {
+            let now = now.clone();
+            let events = events.clone();
+            let fetches = fetches.clone();
+            let observed = observed.clone();
+            move |plan| {
+                let now = now.clone();
+                let events = events.clone();
+                let fetches = fetches.clone();
+                let observed = observed.clone();
+                async move {
+                    *fetches
+                        .lock()
+                        .expect("fetch counts")
+                        .entry(plan.account_id.clone())
+                        .or_default() += 1;
+                    let account_events = events.get(&plan.account_id).expect("events for account");
+                    for trigger in &plan.triggers {
+                        assert_eq!(trigger.trigger.account_id, plan.account_id);
+                        let ids = sorted_event_ids(calendar_events_to_fire(
+                            trigger,
+                            &now,
+                            account_events,
+                            &HashMap::new(),
+                        ));
+                        observed
+                            .lock()
+                            .expect("observed trigger results")
+                            .insert(trigger.trigger.job_id.clone(), ids);
+                    }
+                    Ok(())
+                }
+            }
+        })
+        .await;
+
+        assert!(results.iter().all(Result::is_ok));
+        assert_eq!(
+            *fetches.lock().expect("fetch counts"),
+            HashMap::from([
+                ("alex@acme.com".to_string(), 1),
+                ("bea@beta.com".to_string(), 1),
+            ])
+        );
+        assert_eq!(
+            *observed.lock().expect("observed trigger results"),
+            HashMap::from([
+                ("job-acme".to_string(), vec!["acme-external".to_string()]),
+                ("job-beta".to_string(), vec![]),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn calendar_account_poll_concurrency_is_bounded() {
+        let account_count = MAX_CALENDAR_ACCOUNT_CONCURRENCY + 3;
+        let plans = calendar_account_plans(
+            (0..account_count)
+                .map(|index| {
+                    let account_id = format!("user-{index}@example.com");
+                    calendar_trigger(&format!("job-{index}"), &account_id, 15, true)
+                })
+                .collect(),
+        );
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+
+        let results = run_calendar_account_polls(plans, MAX_CALENDAR_ACCOUNT_CONCURRENCY, {
+            let active = active.clone();
+            let peak = peak.clone();
+            move |_| {
+                let active = active.clone();
+                let peak = peak.clone();
+                async move {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(current, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            }
+        })
+        .await;
+
+        assert!(results.iter().all(Result::is_ok));
+        assert_eq!(
+            peak.load(Ordering::SeqCst),
+            MAX_CALENDAR_ACCOUNT_CONCURRENCY
+        );
+    }
+
+    #[tokio::test]
+    async fn slow_calendar_account_does_not_starve_another_account() {
+        let plans = calendar_account_plans(vec![
+            calendar_trigger("job-slow", "a-slow@example.com", 15, true),
+            calendar_trigger("job-fast", "b-fast@example.com", 15, true),
+        ]);
+        let slow_started = Arc::new(Notify::new());
+        let release_slow = Arc::new(Notify::new());
+        let fast_finished = Arc::new(Notify::new());
+        let polling = tokio::spawn(run_calendar_account_polls(plans, 2, {
+            let slow_started = slow_started.clone();
+            let release_slow = release_slow.clone();
+            let fast_finished = fast_finished.clone();
+            move |plan| {
+                let slow_started = slow_started.clone();
+                let release_slow = release_slow.clone();
+                let fast_finished = fast_finished.clone();
+                async move {
+                    if plan.account_id.starts_with("a-slow") {
+                        slow_started.notify_one();
+                        release_slow.notified().await;
+                    } else {
+                        fast_finished.notify_one();
+                    }
+                    Ok(())
+                }
+            }
+        }));
+
+        tokio::time::timeout(Duration::from_secs(1), slow_started.notified())
+            .await
+            .expect("slow account started");
+        tokio::time::timeout(Duration::from_secs(1), fast_finished.notified())
+            .await
+            .expect("fast account finished while the slow account was blocked");
+        assert!(!polling.is_finished());
+        release_slow.notify_one();
+        let results = polling.await.expect("calendar polling task");
+        assert!(results.iter().all(Result::is_ok));
+    }
+
+    #[tokio::test]
+    #[ignore = "JUN-426 diagnostic benchmark"]
+    async fn benchmark_calendar_account_poll_consolidation() {
+        let now = fixed_calendar_now();
+        let events = Arc::new(vec![calendar_event(
+            "benchmark-event",
+            &now,
+            5,
+            Some("guest@partner.com"),
+        )]);
+        for routine_count in [1_usize, 10, 100] {
+            let plans = calendar_account_plans(
+                (0..routine_count)
+                    .map(|index| {
+                        calendar_trigger(
+                            &format!("benchmark-job-{index}"),
+                            "benchmark@acme.com",
+                            15,
+                            true,
+                        )
+                    })
+                    .collect(),
+            );
+            let credential_loads = Arc::new(AtomicUsize::new(0));
+            let google_requests = Arc::new(AtomicUsize::new(0));
+            let trigger_evaluations = Arc::new(AtomicUsize::new(0));
+            let active = Arc::new(AtomicUsize::new(0));
+            let peak = Arc::new(AtomicUsize::new(0));
+            let started = Instant::now();
+
+            let results = run_calendar_account_polls(plans, 4, {
+                let events = events.clone();
+                let credential_loads = credential_loads.clone();
+                let google_requests = google_requests.clone();
+                let trigger_evaluations = trigger_evaluations.clone();
+                let active = active.clone();
+                let peak = peak.clone();
+                move |plan| {
+                    let events = events.clone();
+                    let credential_loads = credential_loads.clone();
+                    let google_requests = google_requests.clone();
+                    let trigger_evaluations = trigger_evaluations.clone();
+                    let active = active.clone();
+                    let peak = peak.clone();
+                    async move {
+                        credential_loads.fetch_add(1, Ordering::SeqCst);
+                        google_requests.fetch_add(1, Ordering::SeqCst);
+                        let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        peak.fetch_max(current, Ordering::SeqCst);
+                        for trigger in &plan.triggers {
+                            let _ = calendar_events_to_fire(
+                                trigger,
+                                &fixed_calendar_now(),
+                                &events,
+                                &HashMap::new(),
+                            );
+                            trigger_evaluations.fetch_add(1, Ordering::SeqCst);
+                        }
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        Ok(())
+                    }
+                }
+            })
+            .await;
+            assert!(results.iter().all(Result::is_ok));
+
+            println!(
+                "JUN426_BENCHMARK {}",
+                serde_json::json!({
+                    "routines": routine_count,
+                    "accounts": 1,
+                    "credentialLoads": credential_loads.load(Ordering::SeqCst),
+                    "googleRequests": google_requests.load(Ordering::SeqCst),
+                    "triggerEvaluations": trigger_evaluations.load(Ordering::SeqCst),
+                    "wallTimeMicros": started.elapsed().as_micros(),
+                    "peakConcurrency": peak.load(Ordering::SeqCst),
+                })
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- Build one Calendar poll plan per exact connector account, load credentials once, and scan the maximum required event window once per cycle.
- Fan the account-scoped event snapshot through every consuming routine while preserving each routine's lead time, audience policy, fired cursor, and failed-wake retry behavior.
- Bound Calendar account polling to four concurrent accounts so a slow account does not serialize the rest.
- Keep connector data isolated by account throughout grouping, fetching, filtering, cursor persistence, and wake dispatch.

## Root cause

Calendar triggers were iterated per routine. Each routine independently loaded the same account credentials and repeated the same paginated `events.list` window scan, so N routines on one account caused N credential loads and up to `20 x N` Google requests. Accounts were also processed serially, allowing one slow scan to delay unrelated accounts.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --locked -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` (218 files, 3,513 passed, 2 skipped)
- `cargo test --manifest-path src-tauri/Cargo.toml --locked connectors::triggers::tests -- --nocapture` (10 passed, 1 benchmark ignored)
- `make benchmark-calendar-account-poll` (1, 10, and 100 routines each report one credential load and one one-page Google request; trigger evaluations scale 1/10/100)
- `make local-ci` on `3c877bf7b1bbb7d5965c96b8ed323e24b55d5965` (`signoff/frontend` not applicable, `signoff/rust-macos` passed)
- Formal independent review battery deferred to the requested post-draft review round.

- [x] Tested visually where it matters (not applicable: no UI or user-facing behavior changed).
- [ ] Needs a June API (backend) deploy before it works end to end. No: this is a desktop-only trigger-daemon change.

## Out of scope

- Gmail polling behavior.
- Connector account setup or multi-account selection UX.
- Trigger configuration, cursor schema, routine scheduling contracts, and connector grants.
- June API behavior or deployment.

## Followups

- Run the independent review round while this PR remains draft.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs (no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable).
- [x] User-facing copy follows the repo UI conventions (no user-facing copy changes).

Refs JUN-426

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787438732&installation_model_id=425925&pr_number=947&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F947&signature=3f861f353559bdf51b3785bcbc3c13e427e9eb23644bac463fc88a04c57e85aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->