### PR TITLE
Serialize and coalesce P3A delivery

### DIFF
--- a/docs/telemetry-p3a-implementation-plan.md
+++ b/docs/telemetry-p3a-implementation-plan.md
@@ -140,8 +140,12 @@ catalog CI test green.
   the only delivery drain: it reads the durable cursor, sends increments
   serially, persists `p3a_counters.reported_value` after every accepted report,
   and retries failures with bounded exponential backoff. A startup wake-up
-  resumes any pending cursor after restart. Producers never wait for backlog
-  delivery, and concurrent events coalesce into the active or next drain.
+  resumes any pending cursor after restart, and transient repository-open
+  failures retry without terminating the reporter. Producers never wait for
+  backlog delivery, and concurrent events coalesce into the active or next
+  drain. Consent transitions invalidate in-flight attempts: network I/O never
+  holds the transition gate, and a stale result cannot advance the cursor after
+  opt-out, including across a later re-enable.
   Reports still include an ISO week so OS Accounts can aggregate by reporting
   period, but no precise event timestamp is sent.
 - Transport uses `june_api.rs`'s authenticated JSON helper. This protects the

--- a/docs/telemetry-p3a-implementation-plan.md
+++ b/docs/telemetry-p3a-implementation-plan.md
@@ -12,9 +12,10 @@
 │                    │ (no-op unless consented)     │
 │                    ▼                              │
 │   local counter + reported cursor (sqlite)        │
-│                    │ immediate retry-aware flush  │
+│                    │ coalesced wake-up signal     │
 │                    ▼                              │
-│   event bucket ──► one POST per event increment   │
+│   one reporter ──► one POST per event increment   │
+│     (serialized, bounded retry backoff)            │
 │                 user-authenticated to June API    │
 └────────────────────┬──────────────────────────────┘
                      ▼
@@ -134,12 +135,15 @@ catalog CI test green.
 
 ### Desktop: transport
 
-- The current implementation uploads event-count questions immediately after
-  the local counter increments. `p3a_counters.reported_value` is a retry cursor:
-  if three events happened and two uploads succeeded, the next event or app
-  activity retries only the remaining unsent increment. Reports still include an
-  ISO week so OS Accounts can aggregate by reporting period, but no precise
-  event timestamp is sent.
+- Event producers persist the local counter increment, then send a non-blocking
+  wake-up through a bounded coalescing channel. One process-owned reporter is
+  the only delivery drain: it reads the durable cursor, sends increments
+  serially, persists `p3a_counters.reported_value` after every accepted report,
+  and retries failures with bounded exponential backoff. A startup wake-up
+  resumes any pending cursor after restart. Producers never wait for backlog
+  delivery, and concurrent events coalesce into the active or next drain.
+  Reports still include an ISO week so OS Accounts can aggregate by reporting
+  period, but no precise event timestamp is sent.
 - Transport uses `june_api.rs`'s authenticated JSON helper. This protects the
   public June API route from unauthenticated writes while keeping user identity
   out of the telemetry report and out of the OS Accounts aggregate write.

--- a/src-tauri/src/p3a/mod.rs
+++ b/src-tauri/src/p3a/mod.rs
@@ -8,9 +8,18 @@ use crate::{
 };
 use chrono::{Datelike, Utc};
 use serde::{Deserialize, Serialize};
-use std::{fs, future::Future, path::PathBuf, sync::Mutex, time::Duration};
+use std::{
+    fs,
+    future::Future,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
 use tauri::{AppHandle, Manager, State};
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{mpsc, OwnedRwLockReadGuard, RwLock};
 
 const CONSENT_VERSION: u32 = 1;
 const P3A_SCHEMA_VERSION: u32 = 1;
@@ -21,7 +30,8 @@ const REPORT_RETRY_MAX_DELAY: Duration = Duration::from_secs(60);
 pub struct P3aSettingsState {
     path: PathBuf,
     settings: Mutex<P3aSettings>,
-    transition_gate: RwLock<()>,
+    transition_gate: Arc<RwLock<()>>,
+    consent_revision: AtomicU64,
 }
 
 #[derive(Clone)]
@@ -47,8 +57,27 @@ struct PendingEventReport {
     bucket: u8,
 }
 
+struct CursorCommitPermit {
+    _consent_guard: Option<OwnedRwLockReadGuard<()>>,
+}
+
+impl CursorCommitPermit {
+    fn for_consent(consent_guard: OwnedRwLockReadGuard<()>) -> Self {
+        Self {
+            _consent_guard: Some(consent_guard),
+        }
+    }
+
+    #[cfg(test)]
+    fn for_test() -> Self {
+        Self {
+            _consent_guard: None,
+        }
+    }
+}
+
 enum SubmitOutcome {
-    Accepted,
+    Accepted(CursorCommitPermit),
     Paused,
     Retry(AppError),
 }
@@ -109,7 +138,8 @@ pub fn setup(app: &mut tauri::App) {
     app.manage(P3aSettingsState {
         path,
         settings: Mutex::new(settings),
-        transition_gate: RwLock::new(()),
+        transition_gate: Arc::new(RwLock::new(())),
+        consent_revision: AtomicU64::new(0),
     });
     app.manage(P3aReporterState { signal_tx });
 
@@ -151,6 +181,7 @@ pub async fn set_p3a_enabled(
     request: SetP3aEnabledRequest,
 ) -> Result<P3aSettingsResponse, AppError> {
     let _transition = state.transition_gate.write().await;
+    state.consent_revision.fetch_add(1, Ordering::AcqRel);
     if !request.enabled {
         clear_local_counters(&app).await?;
     }
@@ -227,24 +258,63 @@ fn signal_reporter(app: &AppHandle) {
 }
 
 fn reporting_enabled(app: &AppHandle) -> Result<bool, AppError> {
-    app.state::<P3aSettingsState>()
+    reporting_enabled_for_state(&app.state::<P3aSettingsState>())
+}
+
+fn reporting_enabled_for_state(state: &P3aSettingsState) -> Result<bool, AppError> {
+    state
         .settings
         .lock()
         .map(|settings| settings.enabled)
         .map_err(|_| AppError::new("p3a_settings_unavailable", "Settings lock failed."))
 }
 
-async fn run_app_reporter(app: AppHandle, signal_rx: mpsc::Receiver<()>) {
-    let repos = match crate::commands::repositories(&app).await {
-        Ok(repos) => repos,
-        Err(error) => {
-            tracing::warn!(
-                error_code = %error.code,
-                error_message = %error.message,
-                "P3A reporter could not open local counters"
-            );
-            return;
+fn enabled_consent_revision(state: &P3aSettingsState) -> Result<Option<u64>, AppError> {
+    reporting_enabled_for_state(state)
+        .map(|enabled| enabled.then(|| state.consent_revision.load(Ordering::Acquire)))
+}
+
+async fn open_reporter_repositories<Open, OpenFuture, Wait, WaitFuture>(
+    signal_rx: &mpsc::Receiver<()>,
+    mut open: Open,
+    wait: Wait,
+) -> Option<Repositories>
+where
+    Open: FnMut() -> OpenFuture,
+    OpenFuture: Future<Output = Result<Repositories, AppError>>,
+    Wait: Fn(Duration) -> WaitFuture,
+    WaitFuture: Future<Output = ()>,
+{
+    let mut retry_delay = REPORT_RETRY_BASE_DELAY;
+    loop {
+        match open().await {
+            Ok(repos) => return Some(repos),
+            Err(error) => {
+                tracing::warn!(
+                    error_code = %error.code,
+                    error_message = %error.message,
+                    retry_delay_ms = retry_delay.as_millis(),
+                    "P3A reporter could not open local counters; retrying"
+                );
+            }
         }
+        if signal_rx.is_closed() {
+            return None;
+        }
+        wait(retry_delay).await;
+        retry_delay = next_retry_delay(retry_delay);
+    }
+}
+
+async fn run_app_reporter(app: AppHandle, signal_rx: mpsc::Receiver<()>) {
+    let Some(repos) = open_reporter_repositories(
+        &signal_rx,
+        || crate::commands::repositories(&app),
+        tokio::time::sleep,
+    )
+    .await
+    else {
+        return;
     };
     let submit_app = app.clone();
     run_reporter(
@@ -350,8 +420,8 @@ where
             epoch: report.epoch.clone(),
             bucket,
         };
-        match submit(event).await {
-            SubmitOutcome::Accepted => {}
+        let commit_permit = match submit(event).await {
+            SubmitOutcome::Accepted(commit_permit) => commit_permit,
             SubmitOutcome::Paused => return FlushOutcome::Paused,
             SubmitOutcome::Retry(error) => {
                 tracing::warn!(
@@ -364,7 +434,7 @@ where
                 );
                 return FlushOutcome::Retry;
             }
-        }
+        };
         reported_value = reported_value.saturating_add(1);
         if let Err(error) = repos
             .mark_p3a_events_reported(question.id(), &report.epoch, reported_value)
@@ -379,32 +449,60 @@ where
             );
             return FlushOutcome::Retry;
         }
+        drop(commit_permit);
     }
     FlushOutcome::Complete
 }
 
-async fn submit_event_report(app: &AppHandle, report: PendingEventReport) -> SubmitOutcome {
-    let state = app.state::<P3aSettingsState>();
-    let _transition = state.transition_gate.read().await;
-    match reporting_enabled(app) {
-        Ok(true) => {}
-        Ok(false) => return SubmitOutcome::Paused,
+async fn submit_with_consent<Submit, SubmitFuture>(
+    state: &P3aSettingsState,
+    submit: Submit,
+) -> SubmitOutcome
+where
+    Submit: FnOnce() -> SubmitFuture,
+    SubmitFuture: Future<Output = Result<(), AppError>>,
+{
+    let attempt_revision = {
+        let _transition = state.transition_gate.read().await;
+        match enabled_consent_revision(state) {
+            Ok(Some(revision)) => revision,
+            Ok(None) => return SubmitOutcome::Paused,
+            Err(error) => return SubmitOutcome::Retry(error),
+        }
+    };
+
+    let result = submit().await;
+
+    // Re-enter the consent gate only after network I/O finishes. A queued
+    // opt-out therefore takes priority and can clear counters immediately.
+    // Keep this short guard through the local cursor update so disable cannot
+    // race between the post-send consent check and durable commit.
+    let consent_guard = state.transition_gate.clone().read_owned().await;
+    match enabled_consent_revision(state) {
+        Ok(Some(current_revision)) if current_revision == attempt_revision => {}
+        Ok(_) => return SubmitOutcome::Paused,
         Err(error) => return SubmitOutcome::Retry(error),
     }
 
-    match submit_p3a_report(JuneP3aReportRequest {
+    match result {
+        Ok(()) => SubmitOutcome::Accepted(CursorCommitPermit::for_consent(consent_guard)),
+        Err(error) => SubmitOutcome::Retry(error),
+    }
+}
+
+async fn submit_event_report(app: &AppHandle, report: PendingEventReport) -> SubmitOutcome {
+    let request = JuneP3aReportRequest {
         schema: P3A_SCHEMA_VERSION,
         question_id: report.question.id().to_string(),
         epoch: report.epoch,
         platform: current_platform().to_string(),
         version_series: current_version_series(),
         bucket: report.bucket,
+    };
+    submit_with_consent(&app.state::<P3aSettingsState>(), || {
+        submit_p3a_report(request)
     })
     .await
-    {
-        Ok(()) => SubmitOutcome::Accepted,
-        Err(error) => SubmitOutcome::Retry(error),
-    }
 }
 
 async fn clear_local_counters(app: &AppHandle) -> Result<(), AppError> {
@@ -530,9 +628,11 @@ fn is_valid_iso_week(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_valid_iso_week, iso_week_for, next_retry_delay, persist_event_and_signal, run_reporter,
-        sanitize_settings, version_series, P3aReporterState, P3aSettings, SubmitOutcome,
-        REPORTER_SIGNAL_CAPACITY, REPORT_RETRY_BASE_DELAY, REPORT_RETRY_MAX_DELAY,
+        is_valid_iso_week, iso_week_for, next_retry_delay, open_reporter_repositories,
+        persist_event_and_signal, run_reporter, sanitize_settings, submit_pending_event_report,
+        submit_with_consent, version_series, CursorCommitPermit, FlushOutcome, P3aReporterState,
+        P3aSettings, P3aSettingsState, SubmitOutcome, REPORTER_SIGNAL_CAPACITY,
+        REPORT_RETRY_BASE_DELAY, REPORT_RETRY_MAX_DELAY,
     };
     use crate::{
         db::{migrations::run_migrations, repositories::Repositories},
@@ -542,14 +642,15 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use sqlx_sqlite::SqlitePoolOptions;
     use std::{
+        path::PathBuf,
         sync::{
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicU64, AtomicUsize, Ordering},
             Arc, Mutex,
         },
         time::Duration,
     };
     use tokio::{
-        sync::{mpsc, Barrier, Notify},
+        sync::{mpsc, Barrier, Notify, RwLock},
         time::{timeout, Instant},
     };
 
@@ -568,6 +669,19 @@ mod tests {
     fn reporter_channel() -> (P3aReporterState, mpsc::Receiver<()>) {
         let (signal_tx, signal_rx) = mpsc::channel(REPORTER_SIGNAL_CAPACITY);
         (P3aReporterState { signal_tx }, signal_rx)
+    }
+
+    fn enabled_settings_state() -> Arc<P3aSettingsState> {
+        Arc::new(P3aSettingsState {
+            path: PathBuf::from("unused-p3a-settings.json"),
+            settings: Mutex::new(P3aSettings {
+                enabled: true,
+                consent_version: 1,
+                consented_at_week: Some(TEST_EPOCH.to_string()),
+            }),
+            transition_gate: Arc::new(RwLock::new(())),
+            consent_revision: AtomicU64::new(0),
+        })
     }
 
     async fn wait_for_reported(repos: &Repositories, question: Question, expected: u64) {
@@ -610,7 +724,7 @@ mod tests {
             }
             self.accepted.fetch_add(1, Ordering::SeqCst);
             self.active.fetch_sub(1, Ordering::SeqCst);
-            SubmitOutcome::Accepted
+            SubmitOutcome::Accepted(CursorCommitPermit::for_test())
         }
     }
 
@@ -641,7 +755,7 @@ mod tests {
                 SubmitOutcome::Retry(AppError::new("test_failure", "Fake sink failed."))
             } else {
                 self.accepted.fetch_add(1, Ordering::SeqCst);
-                SubmitOutcome::Accepted
+                SubmitOutcome::Accepted(CursorCommitPermit::for_test())
             };
             self.active.fetch_sub(1, Ordering::SeqCst);
             outcome
@@ -669,7 +783,7 @@ mod tests {
             let call = self.calls.fetch_add(1, Ordering::SeqCst);
             if call < self.accepted_before_failure {
                 self.accepted.fetch_add(1, Ordering::SeqCst);
-                SubmitOutcome::Accepted
+                SubmitOutcome::Accepted(CursorCommitPermit::for_test())
             } else {
                 self.failed.notify_one();
                 SubmitOutcome::Retry(AppError::new("test_failure", "Fake sink failed."))
@@ -719,6 +833,130 @@ mod tests {
         assert!(!is_valid_iso_week("2026-W00"));
         assert!(!is_valid_iso_week("2026-W54"));
         assert!(!is_valid_iso_week("2026-28"));
+    }
+
+    #[tokio::test]
+    async fn disable_does_not_wait_for_stalled_send_or_commit_it_after_reenable() {
+        let repos = test_repositories().await;
+        repos
+            .increment_p3a_counter(Question::DictationSessions.id(), TEST_EPOCH, 1)
+            .await
+            .expect("pending event should persist");
+        let report = repos
+            .unreported_p3a_counters()
+            .await
+            .expect("pending event should load")
+            .pop()
+            .expect("pending event should exist");
+        let state = enabled_settings_state();
+        let send_started = Arc::new(Notify::new());
+        let release_send = Arc::new(Notify::new());
+        let task_repos = repos.clone();
+        let task_state = state.clone();
+        let task_send_started = send_started.clone();
+        let task_release_send = release_send.clone();
+        let delivery = tokio::spawn(async move {
+            submit_pending_event_report(&task_repos, report, &move |_| {
+                let state = task_state.clone();
+                let send_started = task_send_started.clone();
+                let release_send = task_release_send.clone();
+                async move {
+                    submit_with_consent(&state, || async move {
+                        send_started.notify_one();
+                        release_send.notified().await;
+                        Ok(())
+                    })
+                    .await
+                }
+            })
+            .await
+        });
+
+        send_started.notified().await;
+        timeout(Duration::from_secs(1), async {
+            let _transition = state.transition_gate.write().await;
+            state.consent_revision.fetch_add(1, Ordering::AcqRel);
+            repos
+                .clear_p3a_counters()
+                .await
+                .expect("disable should clear pending counters");
+            state.settings.lock().expect("settings lock").enabled = false;
+        })
+        .await
+        .expect("disable should not wait for the stalled network send");
+
+        // Re-enable before the old send completes to cover the consent ABA
+        // race. A sentinel row then makes any stale cursor commit observable.
+        {
+            let _transition = state.transition_gate.write().await;
+            state.consent_revision.fetch_add(1, Ordering::AcqRel);
+            state.settings.lock().expect("settings lock").enabled = true;
+        }
+        repos
+            .increment_p3a_counter(Question::DictationSessions.id(), TEST_EPOCH, 1)
+            .await
+            .expect("sentinel event should persist");
+        release_send.notify_one();
+
+        assert_eq!(
+            delivery.await.expect("delivery task should finish"),
+            FlushOutcome::Paused
+        );
+        let state = repos
+            .p3a_counter_state(Question::DictationSessions.id(), TEST_EPOCH)
+            .await
+            .expect("sentinel state should load")
+            .expect("sentinel state should exist");
+        assert_eq!(state.raw_value, 1);
+        assert_eq!(state.reported_value, 0);
+    }
+
+    #[tokio::test]
+    async fn reporter_retries_repository_open_without_closing_its_receiver() {
+        let repos = test_repositories().await;
+        let (_reporter, signal_rx) = reporter_channel();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let open_attempts = attempts.clone();
+        let open_repos = repos.clone();
+        let delays = Arc::new(Mutex::new(Vec::new()));
+        let retry_delays = delays.clone();
+
+        let opened = open_reporter_repositories(
+            &signal_rx,
+            move || {
+                let attempt = open_attempts.fetch_add(1, Ordering::SeqCst);
+                let repos = open_repos.clone();
+                async move {
+                    if attempt < 2 {
+                        Err(AppError::new(
+                            "test_open_failed",
+                            "Fake repository open failed.",
+                        ))
+                    } else {
+                        Ok(repos)
+                    }
+                }
+            },
+            move |delay| {
+                retry_delays.lock().expect("delay lock").push(delay);
+                async {}
+            },
+        )
+        .await
+        .expect("reporter should recover after transient open failures");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        assert_eq!(
+            *delays.lock().expect("delay lock"),
+            vec![
+                REPORT_RETRY_BASE_DELAY,
+                REPORT_RETRY_BASE_DELAY.checked_mul(2).unwrap()
+            ]
+        );
+        opened
+            .increment_p3a_counter(Question::AgentSessions.id(), TEST_EPOCH, 1)
+            .await
+            .expect("recovered repositories should remain usable");
     }
 
     #[tokio::test]

--- a/src-tauri/src/p3a/mod.rs
+++ b/src-tauri/src/p3a/mod.rs
@@ -8,15 +8,56 @@ use crate::{
 };
 use chrono::{Datelike, Utc};
 use serde::{Deserialize, Serialize};
-use std::{fs, path::PathBuf, sync::Mutex};
+use std::{fs, future::Future, path::PathBuf, sync::Mutex, time::Duration};
 use tauri::{AppHandle, Manager, State};
+use tokio::sync::{mpsc, RwLock};
 
 const CONSENT_VERSION: u32 = 1;
 const P3A_SCHEMA_VERSION: u32 = 1;
+const REPORTER_SIGNAL_CAPACITY: usize = 1;
+const REPORT_RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
+const REPORT_RETRY_MAX_DELAY: Duration = Duration::from_secs(60);
 
 pub struct P3aSettingsState {
     path: PathBuf,
     settings: Mutex<P3aSettings>,
+    transition_gate: RwLock<()>,
+}
+
+#[derive(Clone)]
+pub struct P3aReporterState {
+    signal_tx: mpsc::Sender<()>,
+}
+
+impl P3aReporterState {
+    fn signal(&self) {
+        match self.signal_tx.try_send(()) {
+            Ok(()) | Err(mpsc::error::TrySendError::Full(())) => {}
+            Err(mpsc::error::TrySendError::Closed(())) => {
+                tracing::warn!("P3A reporter is unavailable");
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PendingEventReport {
+    question: Question,
+    epoch: String,
+    bucket: u8,
+}
+
+enum SubmitOutcome {
+    Accepted,
+    Paused,
+    Retry(AppError),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FlushOutcome {
+    Complete,
+    Paused,
+    Retry,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -63,10 +104,20 @@ pub struct P3aQuestionCatalogResponse {
 pub fn setup(app: &mut tauri::App) {
     let path = settings_path(app.handle()).unwrap_or_else(|| PathBuf::from("p3a-settings.json"));
     let settings = load_settings_from_disk(app.handle());
+    let reporting_enabled = settings.enabled;
+    let (signal_tx, signal_rx) = mpsc::channel(REPORTER_SIGNAL_CAPACITY);
     app.manage(P3aSettingsState {
         path,
         settings: Mutex::new(settings),
+        transition_gate: RwLock::new(()),
     });
+    app.manage(P3aReporterState { signal_tx });
+
+    let app_handle = app.handle().clone();
+    tauri::async_runtime::spawn(run_app_reporter(app_handle, signal_rx));
+    if reporting_enabled {
+        signal_reporter(app.handle());
+    }
 }
 
 #[tauri::command]
@@ -99,25 +150,31 @@ pub async fn set_p3a_enabled(
     state: State<'_, P3aSettingsState>,
     request: SetP3aEnabledRequest,
 ) -> Result<P3aSettingsResponse, AppError> {
+    let _transition = state.transition_gate.write().await;
     if !request.enabled {
         clear_local_counters(&app).await?;
     }
 
-    let mut settings = state
-        .settings
-        .lock()
-        .map_err(|_| AppError::new("p3a_settings_unavailable", "Settings lock failed."))?;
-    settings.enabled = request.enabled;
-    settings.consent_version = CONSENT_VERSION;
-    settings.consented_at_week = if request.enabled {
-        Some(current_iso_week())
-    } else {
-        None
+    let updated = {
+        let mut settings = state
+            .settings
+            .lock()
+            .map_err(|_| AppError::new("p3a_settings_unavailable", "Settings lock failed."))?;
+        let updated = P3aSettings {
+            enabled: request.enabled,
+            consent_version: CONSENT_VERSION,
+            consented_at_week: request.enabled.then(current_iso_week),
+        };
+        save_settings(&state, &updated)?;
+        *settings = updated.clone();
+        updated
     };
-    save_settings(&state, &settings)?;
-    Ok(P3aSettingsResponse {
-        settings: settings.clone(),
-    })
+
+    if request.enabled {
+        signal_reporter(&app);
+    }
+
+    Ok(P3aSettingsResponse { settings: updated })
 }
 
 #[tauri::command]
@@ -142,93 +199,212 @@ pub fn record_question_best_effort(app: AppHandle, question: Question) {
 
 pub async fn record_question(app: &AppHandle, question: Question) -> Result<(), AppError> {
     let state = app.state::<P3aSettingsState>();
-    let enabled = state
-        .settings
-        .lock()
-        .map_err(|_| AppError::new("p3a_settings_unavailable", "Settings lock failed."))?
-        .enabled;
-    if !enabled {
+    let _transition = state.transition_gate.read().await;
+    if !reporting_enabled(app)? {
         return Ok(());
     }
     let repos = crate::commands::repositories(app).await?;
     let epoch = current_iso_week();
-    repos
-        .increment_p3a_counter(question.id(), &epoch, 1)
+    persist_event_and_signal(&repos, &app.state::<P3aReporterState>(), question, &epoch)
         .await
         .map_err(|error| AppError::new("p3a_counter_failed", error.to_string()))?;
-    flush_pending_event_reports(&repos).await;
     Ok(())
 }
 
-async fn flush_pending_event_reports(repos: &Repositories) {
+async fn persist_event_and_signal(
+    repos: &Repositories,
+    reporter: &P3aReporterState,
+    question: Question,
+    epoch: &str,
+) -> Result<(), sqlx::error::Error> {
+    repos.increment_p3a_counter(question.id(), epoch, 1).await?;
+    reporter.signal();
+    Ok(())
+}
+
+fn signal_reporter(app: &AppHandle) {
+    app.state::<P3aReporterState>().signal();
+}
+
+fn reporting_enabled(app: &AppHandle) -> Result<bool, AppError> {
+    app.state::<P3aSettingsState>()
+        .settings
+        .lock()
+        .map(|settings| settings.enabled)
+        .map_err(|_| AppError::new("p3a_settings_unavailable", "Settings lock failed."))
+}
+
+async fn run_app_reporter(app: AppHandle, signal_rx: mpsc::Receiver<()>) {
+    let repos = match crate::commands::repositories(&app).await {
+        Ok(repos) => repos,
+        Err(error) => {
+            tracing::warn!(
+                error_code = %error.code,
+                error_message = %error.message,
+                "P3A reporter could not open local counters"
+            );
+            return;
+        }
+    };
+    let submit_app = app.clone();
+    run_reporter(
+        repos,
+        signal_rx,
+        move |report| {
+            let app = submit_app.clone();
+            async move { submit_event_report(&app, report).await }
+        },
+        tokio::time::sleep,
+    )
+    .await;
+}
+
+async fn run_reporter<Submit, SubmitFuture, Wait, WaitFuture>(
+    repos: Repositories,
+    mut signal_rx: mpsc::Receiver<()>,
+    submit: Submit,
+    wait: Wait,
+) where
+    Submit: Fn(PendingEventReport) -> SubmitFuture,
+    SubmitFuture: Future<Output = SubmitOutcome>,
+    Wait: Fn(Duration) -> WaitFuture,
+    WaitFuture: Future<Output = ()>,
+{
+    while signal_rx.recv().await.is_some() {
+        let mut retry_delay = REPORT_RETRY_BASE_DELAY;
+        loop {
+            drain_coalesced_signals(&mut signal_rx);
+            match flush_pending_event_reports(&repos, &submit).await {
+                FlushOutcome::Complete | FlushOutcome::Paused => break,
+                FlushOutcome::Retry => {
+                    wait(retry_delay).await;
+                    if signal_rx.is_closed() {
+                        return;
+                    }
+                    retry_delay = next_retry_delay(retry_delay);
+                }
+            }
+        }
+    }
+}
+
+fn drain_coalesced_signals(signal_rx: &mut mpsc::Receiver<()>) {
+    while signal_rx.try_recv().is_ok() {}
+}
+
+fn next_retry_delay(current: Duration) -> Duration {
+    current
+        .checked_mul(2)
+        .unwrap_or(REPORT_RETRY_MAX_DELAY)
+        .min(REPORT_RETRY_MAX_DELAY)
+}
+
+async fn flush_pending_event_reports<Submit, SubmitFuture>(
+    repos: &Repositories,
+    submit: &Submit,
+) -> FlushOutcome
+where
+    Submit: Fn(PendingEventReport) -> SubmitFuture,
+    SubmitFuture: Future<Output = SubmitOutcome>,
+{
     let pending = match repos.unreported_p3a_counters().await {
         Ok(pending) => pending,
         Err(error) => {
             tracing::warn!(%error, "P3A pending event query failed");
-            return;
+            return FlushOutcome::Retry;
         }
     };
     for report in pending {
-        submit_pending_event_report(repos, report).await;
+        match submit_pending_event_report(repos, report, submit).await {
+            FlushOutcome::Complete => {}
+            outcome => return outcome,
+        }
     }
+    FlushOutcome::Complete
 }
 
-async fn submit_pending_event_report(repos: &Repositories, report: P3aPendingReport) {
+async fn submit_pending_event_report<Submit, SubmitFuture>(
+    repos: &Repositories,
+    report: P3aPendingReport,
+    submit: &Submit,
+) -> FlushOutcome
+where
+    Submit: Fn(PendingEventReport) -> SubmitFuture,
+    SubmitFuture: Future<Output = SubmitOutcome>,
+{
     let Some(question) = Question::from_id(&report.question_id) else {
         tracing::warn!(question_id = %report.question_id, "Skipping unknown P3A counter");
-        return;
+        return FlushOutcome::Complete;
     };
 
     let pending_events = report.raw_value.saturating_sub(report.reported_value);
     if pending_events == 0 {
-        return;
+        return FlushOutcome::Complete;
     }
 
     let mut reported_value = report.reported_value;
     let bucket = question.event_bucket();
     for _ in 0..pending_events {
-        if let Err(error) = submit_event_report(question, &report.epoch, bucket).await {
+        let event = PendingEventReport {
+            question,
+            epoch: report.epoch.clone(),
+            bucket,
+        };
+        match submit(event).await {
+            SubmitOutcome::Accepted => {}
+            SubmitOutcome::Paused => return FlushOutcome::Paused,
+            SubmitOutcome::Retry(error) => {
+                tracing::warn!(
+                    question_id = question.id(),
+                    epoch = %report.epoch,
+                    bucket,
+                    error_code = %error.code,
+                    error_message = %error.message,
+                    "P3A event upload failed"
+                );
+                return FlushOutcome::Retry;
+            }
+        }
+        reported_value = reported_value.saturating_add(1);
+        if let Err(error) = repos
+            .mark_p3a_events_reported(question.id(), &report.epoch, reported_value)
+            .await
+        {
             tracing::warn!(
                 question_id = question.id(),
                 epoch = %report.epoch,
-                bucket,
-                error_code = %error.code,
-                error_message = %error.message,
-                "P3A event upload failed"
+                reported_value,
+                %error,
+                "P3A reported event cursor update failed"
             );
-            break;
+            return FlushOutcome::Retry;
         }
-        reported_value = reported_value.saturating_add(1);
     }
-
-    if reported_value == report.reported_value {
-        return;
-    }
-
-    if let Err(error) = repos
-        .mark_p3a_events_reported(question.id(), &report.epoch, reported_value)
-        .await
-    {
-        tracing::warn!(
-            question_id = question.id(),
-            epoch = %report.epoch,
-            reported_value,
-            %error,
-            "P3A reported event cursor update failed"
-        );
-    }
+    FlushOutcome::Complete
 }
 
-async fn submit_event_report(question: Question, epoch: &str, bucket: u8) -> Result<(), AppError> {
-    submit_p3a_report(JuneP3aReportRequest {
+async fn submit_event_report(app: &AppHandle, report: PendingEventReport) -> SubmitOutcome {
+    let state = app.state::<P3aSettingsState>();
+    let _transition = state.transition_gate.read().await;
+    match reporting_enabled(app) {
+        Ok(true) => {}
+        Ok(false) => return SubmitOutcome::Paused,
+        Err(error) => return SubmitOutcome::Retry(error),
+    }
+
+    match submit_p3a_report(JuneP3aReportRequest {
         schema: P3A_SCHEMA_VERSION,
-        question_id: question.id().to_string(),
-        epoch: epoch.to_owned(),
+        question_id: report.question.id().to_string(),
+        epoch: report.epoch,
         platform: current_platform().to_string(),
         version_series: current_version_series(),
-        bucket,
+        bucket: report.bucket,
     })
     .await
+    {
+        Ok(()) => SubmitOutcome::Accepted,
+        Err(error) => SubmitOutcome::Retry(error),
+    }
 }
 
 async fn clear_local_counters(app: &AppHandle) -> Result<(), AppError> {
@@ -353,8 +529,153 @@ fn is_valid_iso_week(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_valid_iso_week, iso_week_for, sanitize_settings, version_series, P3aSettings};
+    use super::{
+        is_valid_iso_week, iso_week_for, next_retry_delay, persist_event_and_signal, run_reporter,
+        sanitize_settings, version_series, P3aReporterState, P3aSettings, SubmitOutcome,
+        REPORTER_SIGNAL_CAPACITY, REPORT_RETRY_BASE_DELAY, REPORT_RETRY_MAX_DELAY,
+    };
+    use crate::{
+        db::{migrations::run_migrations, repositories::Repositories},
+        domain::types::AppError,
+        p3a::questions::Question,
+    };
     use chrono::{TimeZone, Utc};
+    use sqlx_sqlite::SqlitePoolOptions;
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc, Mutex,
+        },
+        time::Duration,
+    };
+    use tokio::{
+        sync::{mpsc, Barrier, Notify},
+        time::{timeout, Instant},
+    };
+
+    const TEST_EPOCH: &str = "2026-W28";
+
+    async fn test_repositories() -> Repositories {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite should open");
+        run_migrations(&pool).await.expect("migrations should run");
+        Repositories::new(pool)
+    }
+
+    fn reporter_channel() -> (P3aReporterState, mpsc::Receiver<()>) {
+        let (signal_tx, signal_rx) = mpsc::channel(REPORTER_SIGNAL_CAPACITY);
+        (P3aReporterState { signal_tx }, signal_rx)
+    }
+
+    async fn wait_for_reported(repos: &Repositories, question: Question, expected: u64) {
+        timeout(Duration::from_secs(2), async {
+            loop {
+                let reported = repos
+                    .p3a_counter_state(question.id(), TEST_EPOCH)
+                    .await
+                    .expect("counter state should load")
+                    .map(|state| state.reported_value)
+                    .unwrap_or_default();
+                if reported == expected {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("reporter should advance the cursor");
+    }
+
+    #[derive(Default)]
+    struct DelayedSink {
+        calls: AtomicUsize,
+        accepted: AtomicUsize,
+        active: AtomicUsize,
+        max_active: AtomicUsize,
+        first_started: Notify,
+        release_first: Notify,
+    }
+
+    impl DelayedSink {
+        async fn submit(&self) -> SubmitOutcome {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_active.fetch_max(active, Ordering::SeqCst);
+            if call == 0 {
+                self.first_started.notify_one();
+                self.release_first.notified().await;
+            }
+            self.accepted.fetch_add(1, Ordering::SeqCst);
+            self.active.fetch_sub(1, Ordering::SeqCst);
+            SubmitOutcome::Accepted
+        }
+    }
+
+    struct FailThenAcceptSink {
+        failures: usize,
+        calls: AtomicUsize,
+        accepted: AtomicUsize,
+        active: AtomicUsize,
+        max_active: AtomicUsize,
+    }
+
+    impl FailThenAcceptSink {
+        fn new(failures: usize) -> Self {
+            Self {
+                failures,
+                calls: AtomicUsize::new(0),
+                accepted: AtomicUsize::new(0),
+                active: AtomicUsize::new(0),
+                max_active: AtomicUsize::new(0),
+            }
+        }
+
+        async fn submit(&self) -> SubmitOutcome {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_active.fetch_max(active, Ordering::SeqCst);
+            let outcome = if call < self.failures {
+                SubmitOutcome::Retry(AppError::new("test_failure", "Fake sink failed."))
+            } else {
+                self.accepted.fetch_add(1, Ordering::SeqCst);
+                SubmitOutcome::Accepted
+            };
+            self.active.fetch_sub(1, Ordering::SeqCst);
+            outcome
+        }
+    }
+
+    struct StopAfterAcceptedSink {
+        accepted_before_failure: usize,
+        calls: AtomicUsize,
+        accepted: AtomicUsize,
+        failed: Notify,
+    }
+
+    impl StopAfterAcceptedSink {
+        fn new(accepted_before_failure: usize) -> Self {
+            Self {
+                accepted_before_failure,
+                calls: AtomicUsize::new(0),
+                accepted: AtomicUsize::new(0),
+                failed: Notify::new(),
+            }
+        }
+
+        async fn submit(&self) -> SubmitOutcome {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call < self.accepted_before_failure {
+                self.accepted.fetch_add(1, Ordering::SeqCst);
+                SubmitOutcome::Accepted
+            } else {
+                self.failed.notify_one();
+                SubmitOutcome::Retry(AppError::new("test_failure", "Fake sink failed."))
+            }
+        }
+    }
 
     #[test]
     fn formats_iso_week() {
@@ -398,5 +719,197 @@ mod tests {
         assert!(!is_valid_iso_week("2026-W00"));
         assert!(!is_valid_iso_week("2026-W54"));
         assert!(!is_valid_iso_week("2026-28"));
+    }
+
+    #[tokio::test]
+    async fn serializes_and_coalesces_concurrent_event_delivery() {
+        let repos = test_repositories().await;
+        let (reporter, signal_rx) = reporter_channel();
+        let reporter = Arc::new(reporter);
+        let sink = Arc::new(DelayedSink::default());
+        let worker_sink = sink.clone();
+        let worker = tokio::spawn(run_reporter(
+            repos.clone(),
+            signal_rx,
+            move |_| {
+                let sink = worker_sink.clone();
+                async move { sink.submit().await }
+            },
+            |_| async {},
+        ));
+
+        let barrier = Arc::new(Barrier::new(21));
+        let mut producers = Vec::new();
+        for _ in 0..20 {
+            let repos = repos.clone();
+            let reporter = reporter.clone();
+            let barrier = barrier.clone();
+            producers.push(tokio::spawn(async move {
+                barrier.wait().await;
+                persist_event_and_signal(
+                    &repos,
+                    &reporter,
+                    Question::DictationSessions,
+                    TEST_EPOCH,
+                )
+                .await
+                .expect("event should persist");
+            }));
+        }
+        barrier.wait().await;
+        for producer in producers {
+            producer.await.expect("producer should finish");
+        }
+
+        sink.first_started.notified().await;
+        sink.release_first.notify_one();
+        wait_for_reported(&repos, Question::DictationSessions, 20).await;
+
+        assert_eq!(sink.calls.load(Ordering::SeqCst), 20);
+        assert_eq!(sink.accepted.load(Ordering::SeqCst), 20);
+        assert_eq!(sink.max_active.load(Ordering::SeqCst), 1);
+
+        drop(reporter);
+        worker.await.expect("reporter should stop");
+    }
+
+    #[tokio::test]
+    async fn producer_does_not_wait_for_a_large_backlog() {
+        let repos = test_repositories().await;
+        repos
+            .increment_p3a_counter(Question::DictationSessions.id(), TEST_EPOCH, 10_000)
+            .await
+            .expect("backlog should persist");
+        let (reporter, signal_rx) = reporter_channel();
+        let sink = Arc::new(DelayedSink::default());
+        let worker_sink = sink.clone();
+        let worker = tokio::spawn(run_reporter(
+            repos.clone(),
+            signal_rx,
+            move |_| {
+                let sink = worker_sink.clone();
+                async move { sink.submit().await }
+            },
+            |_| async {},
+        ));
+
+        reporter.signal();
+        sink.first_started.notified().await;
+        let started = Instant::now();
+        timeout(
+            Duration::from_secs(1),
+            persist_event_and_signal(&repos, &reporter, Question::DictationSessions, TEST_EPOCH),
+        )
+        .await
+        .expect("producer should not wait for the blocked reporter")
+        .expect("event should persist");
+        assert!(started.elapsed() < Duration::from_secs(1));
+
+        worker.abort();
+        let _ = worker.await;
+    }
+
+    #[tokio::test]
+    async fn retries_on_one_worker_with_bounded_backoff() {
+        let repos = test_repositories().await;
+        let (reporter, signal_rx) = reporter_channel();
+        let sink = Arc::new(FailThenAcceptSink::new(2));
+        let worker_sink = sink.clone();
+        let delays = Arc::new(Mutex::new(Vec::new()));
+        let worker_delays = delays.clone();
+        let worker = tokio::spawn(run_reporter(
+            repos.clone(),
+            signal_rx,
+            move |_| {
+                let sink = worker_sink.clone();
+                async move { sink.submit().await }
+            },
+            move |delay| {
+                worker_delays.lock().expect("delay lock").push(delay);
+                async {}
+            },
+        ));
+
+        persist_event_and_signal(&repos, &reporter, Question::AgentSessions, TEST_EPOCH)
+            .await
+            .expect("event should persist");
+        wait_for_reported(&repos, Question::AgentSessions, 1).await;
+
+        assert_eq!(sink.calls.load(Ordering::SeqCst), 3);
+        assert_eq!(sink.accepted.load(Ordering::SeqCst), 1);
+        assert_eq!(sink.max_active.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            *delays.lock().expect("delay lock"),
+            vec![
+                REPORT_RETRY_BASE_DELAY,
+                REPORT_RETRY_BASE_DELAY.checked_mul(2).unwrap()
+            ]
+        );
+        assert_eq!(
+            next_retry_delay(REPORT_RETRY_MAX_DELAY),
+            REPORT_RETRY_MAX_DELAY
+        );
+
+        drop(reporter);
+        worker.await.expect("reporter should stop");
+    }
+
+    #[tokio::test]
+    async fn restart_resumes_from_each_durable_accepted_cursor() {
+        let repos = test_repositories().await;
+        repos
+            .increment_p3a_counter(Question::NotesMeetingsRecorded.id(), TEST_EPOCH, 5)
+            .await
+            .expect("backlog should persist");
+
+        let (first_reporter, first_signal_rx) = reporter_channel();
+        let first_sink = Arc::new(StopAfterAcceptedSink::new(2));
+        let worker_sink = first_sink.clone();
+        let retry_release = Arc::new(Notify::new());
+        let worker_retry_release = retry_release.clone();
+        let first_worker = tokio::spawn(run_reporter(
+            repos.clone(),
+            first_signal_rx,
+            move |_| {
+                let sink = worker_sink.clone();
+                async move { sink.submit().await }
+            },
+            move |_| {
+                let retry_release = worker_retry_release.clone();
+                async move { retry_release.notified().await }
+            },
+        ));
+        first_reporter.signal();
+        first_sink.failed.notified().await;
+        wait_for_reported(&repos, Question::NotesMeetingsRecorded, 2).await;
+        drop(first_reporter);
+        retry_release.notify_one();
+        first_worker.await.expect("first reporter should stop");
+
+        let (second_reporter, second_signal_rx) = reporter_channel();
+        let second_sink = Arc::new(FailThenAcceptSink::new(0));
+        let worker_sink = second_sink.clone();
+        let second_worker = tokio::spawn(run_reporter(
+            repos.clone(),
+            second_signal_rx,
+            move |_| {
+                let sink = worker_sink.clone();
+                async move { sink.submit().await }
+            },
+            |_| async {},
+        ));
+        second_reporter.signal();
+        wait_for_reported(&repos, Question::NotesMeetingsRecorded, 5).await;
+
+        assert_eq!(first_sink.accepted.load(Ordering::SeqCst), 2);
+        assert_eq!(second_sink.accepted.load(Ordering::SeqCst), 3);
+        assert_eq!(
+            first_sink.accepted.load(Ordering::SeqCst)
+                + second_sink.accepted.load(Ordering::SeqCst),
+            5
+        );
+
+        drop(second_reporter);
+        second_worker.await.expect("second reporter should stop");
     }
 }


### PR DESCRIPTION
## Summary

- Replace per-event P3A backlog drains with one process-owned reporter.
- Persist each event locally, then wake the reporter through a bounded channel that coalesces concurrent signals.
- Serialize delivery, advance the durable cursor after every accepted report, and retry failures on the same worker with bounded exponential backoff.
- Preserve opt-out behavior by coordinating recording and delivery with consent transitions.
- Document the serialized delivery architecture.

Privacy: this changes only P3A delivery mechanics. It does not change what is reported, add data, add fields, change questions or buckets, or change the existing one-report-per-event wire format.

Refs JUN-424

## Root cause

Every P3A producer incremented its SQLite counter and then independently drained all pending counters. Concurrent producers could read the same `raw_value` and `reported_value` cursor snapshot, upload the same pending range, and only afterward advance the shared cursor. During an outage, each new event also launched another backlog drain, creating a request stampede.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --locked -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` (3,513 passed, 2 skipped)
- `make verify`
- `make local-ci` (`signoff/frontend` and `signoff/rust-macos` successful on the pushed SHA)
- Added deterministic delayed/failing-sink tests for 20 concurrent producers, single-flight delivery, signal coalescing, a 10,000-event backlog, bounded retry backoff, and restart cursor resumption without duplicate accepted reports.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). Not applicable: this is a background native delivery-mechanics change with no UI surface.
- [ ] Needs a June API (backend) deploy before it works end to end. No: the desktop keeps the existing June API request contract.

## Out of scope

- Changing the P3A report schema, question catalog, buckets, aggregation dimensions, endpoint, authentication, or local counter schema.
- Adding a batch or count field; the current June API contract accepts one event report at a time.
- Changing any analytics data or collecting any new data.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such surfaces changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend surfaces changed.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787439134&installation_model_id=425925&pr_number=948&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F948&signature=e344c0d290bcba51b85344ddc63633cacc988f1321aa116b8a599e71aec6fdc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->