### PR TITLE
fix(connectors): make trigger replacement and cursor reset atomic

### DIFF
--- a/src-tauri/migrations/023_connector_trigger_uniqueness.sql
+++ b/src-tauri/migrations/023_connector_trigger_uniqueness.sql
@@ -1,0 +1,16 @@
+-- A routine owns one connector trigger. Legacy delete-then-insert writes could
+-- leave duplicates after a concurrent replacement, so preserve the newest
+-- configured row before enforcing that invariant in SQLite.
+DELETE FROM connector_triggers AS stale
+WHERE EXISTS (
+  SELECT 1
+  FROM connector_triggers AS newer
+  WHERE newer.job_id = stale.job_id
+    AND (
+      newer.created_at > stale.created_at
+      OR (newer.created_at = stale.created_at AND newer.rowid > stale.rowid)
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_connector_triggers_job_id_unique
+ON connector_triggers (job_id);

--- a/src-tauri/src/connectors/commands.rs
+++ b/src-tauri/src/connectors/commands.rs
@@ -634,24 +634,8 @@ pub async fn connector_trigger_set(
     let config_json = serde_json::to_string(&config)
         .map_err(|e| AppError::new("connector_trigger_invalid_config", e.to_string()))?;
 
-    // A fresh Gmail subscription must baseline from the current history id, not
-    // from a stale per-account cursor a previous (now deleted) email routine
-    // left behind. When this call establishes the account's first email trigger
-    // (checked before the insert, so an edit of an account that already has one
-    // does not count), clear the cursor: the daemon then reseeds like a
-    // first-time subscription and won't fire for mail that arrived before this
-    // routine existed. Checked before writing the trigger row below.
-    let reset_email_cursor = request.kind == "email_received"
-        && !repos
-            .list_connector_triggers(None)
-            .await?
-            .iter()
-            .any(|trigger| {
-                trigger.kind == "email_received" && trigger.account_id == request.account_id
-            });
-
     let record = repos
-        .set_connector_trigger(
+        .replace_connector_trigger(
             &request.job_id,
             &request.kind,
             &request.account_id,
@@ -659,11 +643,6 @@ pub async fn connector_trigger_set(
         )
         .await?;
 
-    if reset_email_cursor {
-        repos
-            .clear_trigger_cursor(&request.account_id, "email_received")
-            .await?;
-    }
     Ok(ConnectorTriggerDto {
         config,
         id: record.id,

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -753,6 +753,16 @@ const MIGRATIONS: &[Migration] = &[
             ),
         ],
     },
+    Migration {
+        version: 30,
+        name: "connector_trigger_uniqueness",
+        requirements: &[SchemaRequirement::Index(
+            "idx_connector_triggers_job_id_unique",
+        )],
+        steps: &[MigrationStep::Sql(include_str!(
+            "../../migrations/023_connector_trigger_uniqueness.sql"
+        ))],
+    },
 ];
 
 struct AppliedMigration {
@@ -1251,6 +1261,66 @@ mod tests {
 
         assert!(table_exists(&pool, "browser_action_outcomes").await);
         assert!(table_exists(&pool, "connector_actions").await);
+        assert_latest_stamp(&pool).await;
+    }
+
+    #[tokio::test]
+    async fn connector_trigger_uniqueness_migration_keeps_latest_configuration() {
+        let pool = test_pool().await;
+        run_migration_catalog(&pool, &MIGRATIONS[..29])
+            .await
+            .expect("pre-uniqueness schema");
+        for (id, kind, config, created_at) in [
+            (
+                "trigger-old",
+                "email_received",
+                r#"{"query":"is:unread"}"#,
+                "2026-07-24T08:00:00Z",
+            ),
+            (
+                "trigger-new",
+                "event_upcoming",
+                r#"{"leadMinutes":30}"#,
+                "2026-07-24T09:00:00Z",
+            ),
+        ] {
+            query(
+                "INSERT INTO connector_triggers
+                 (id, job_id, kind, account_id, config, created_at)
+                 VALUES (?, 'job-1', ?, 'user@example.com', ?, ?)",
+            )
+            .bind(id)
+            .bind(kind)
+            .bind(config)
+            .bind(created_at)
+            .execute(&pool)
+            .await
+            .expect("legacy duplicate trigger");
+        }
+
+        run_migrations(&pool).await.expect("uniqueness migration");
+
+        let row = query(
+            "SELECT id, kind, config
+             FROM connector_triggers
+             WHERE job_id = 'job-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("preserved trigger");
+        assert_eq!(row.get::<String, _>("id"), "trigger-new");
+        assert_eq!(row.get::<String, _>("kind"), "event_upcoming");
+        assert_eq!(row.get::<String, _>("config"), r#"{"leadMinutes":30}"#);
+
+        let duplicate = query(
+            "INSERT INTO connector_triggers
+             (id, job_id, kind, account_id, config, created_at)
+             VALUES ('trigger-duplicate', 'job-1', 'email_received',
+                     'user@example.com', '{}', '2026-07-24T10:00:00Z')",
+        )
+        .execute(&pool)
+        .await;
+        assert!(duplicate.is_err(), "job_id uniqueness must be enforced");
         assert_latest_stamp(&pool).await;
     }
 

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -885,44 +885,91 @@ impl Repositories {
         Ok(rows.into_iter().map(connector_trigger_from_row).collect())
     }
 
-    /// Set the trigger for a routine. A routine has exactly one trigger, so any
-    /// existing trigger for the job (whatever its kind or account) is removed
-    /// first: without this, editing a routine from `email_received` to
-    /// `event_upcoming` (or to another account) would leave the old row behind,
-    /// and the daemon would fire the routine from both.
-    pub async fn set_connector_trigger(
+    /// Replace the trigger for a routine and, when this creates an account's
+    /// first email subscription, reset its Gmail history cursor atomically.
+    ///
+    /// `BEGIN IMMEDIATE` serializes competing replacements before the
+    /// first-subscription check. Readers therefore observe either the complete
+    /// old trigger+cursor state or the complete new state, and a failed write
+    /// rolls both pieces back together.
+    pub async fn replace_connector_trigger(
         &self,
         job_id: &str,
         kind: &str,
         account_id: &str,
         config_json: &str,
     ) -> Result<ConnectorTriggerRecord, sqlx::error::Error> {
-        query("DELETE FROM connector_triggers WHERE job_id = ?")
+        let mut transaction = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+        let replace_result = async {
+            // Check before deleting this job's old trigger. Editing an existing
+            // email subscription for the same account must retain its cursor;
+            // only the account's first active email subscription re-baselines.
+            let reset_email_cursor = kind == "email_received"
+                && query(
+                    "SELECT 1
+                     FROM connector_triggers
+                     WHERE kind = 'email_received' AND account_id = ?
+                     LIMIT 1",
+                )
+                .bind(account_id)
+                .fetch_optional(&mut *transaction)
+                .await?
+                .is_none();
+
+            query("DELETE FROM connector_triggers WHERE job_id = ?")
+                .bind(job_id)
+                .execute(&mut *transaction)
+                .await?;
+
+            let id = Uuid::new_v4().to_string();
+            let now = timestamp();
+            query(
+                "INSERT INTO connector_triggers (id, job_id, kind, account_id, config, created_at)
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&id)
             .bind(job_id)
-            .execute(&self.pool)
+            .bind(kind)
+            .bind(account_id)
+            .bind(config_json)
+            .bind(&now)
+            .execute(&mut *transaction)
             .await?;
-        let id = Uuid::new_v4().to_string();
-        let now = timestamp();
-        query(
-            "INSERT INTO connector_triggers (id, job_id, kind, account_id, config, created_at)
-             VALUES (?, ?, ?, ?, ?, ?)",
-        )
-        .bind(&id)
-        .bind(job_id)
-        .bind(kind)
-        .bind(account_id)
-        .bind(config_json)
-        .bind(&now)
-        .execute(&self.pool)
-        .await?;
-        let row = query(
-            "SELECT id, job_id, kind, account_id, config, created_at
-             FROM connector_triggers WHERE id = ?",
-        )
-        .bind(&id)
-        .fetch_one(&self.pool)
-        .await?;
-        Ok(connector_trigger_from_row(row))
+
+            if reset_email_cursor {
+                query(
+                    "DELETE FROM trigger_cursors
+                     WHERE account_id = ? AND kind = 'email_received'",
+                )
+                .bind(account_id)
+                .execute(&mut *transaction)
+                .await?;
+            }
+
+            let row = query(
+                "SELECT id, job_id, kind, account_id, config, created_at
+                 FROM connector_triggers WHERE id = ?",
+            )
+            .bind(&id)
+            .fetch_one(&mut *transaction)
+            .await?;
+            Ok(connector_trigger_from_row(row))
+        }
+        .await;
+
+        match replace_result {
+            Ok(record) => {
+                transaction.commit().await?;
+                Ok(record)
+            }
+            Err(error) => match transaction.rollback().await {
+                Ok(()) => Err(error),
+                Err(rollback_error) => Err(sqlx::Error::Protocol(format!(
+                    "connector trigger replacement failed ({error}); rollback also failed \
+                     ({rollback_error})"
+                ))),
+            },
+        }
     }
 
     pub async fn delete_connector_trigger(&self, id: &str) -> Result<bool, sqlx::error::Error> {
@@ -6231,9 +6278,11 @@ mod tests {
     };
     use sqlx::query::query;
     use sqlx::row::Row;
+    use sqlx_sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+    use std::time::Duration as StdDuration;
 
     async fn test_repositories() -> Repositories {
-        let pool = sqlx_sqlite::SqlitePoolOptions::new()
+        let pool = SqlitePoolOptions::new()
             .max_connections(1)
             .connect("sqlite::memory:")
             .await
@@ -6242,6 +6291,24 @@ mod tests {
             .await
             .expect("migrations");
         Repositories::new(pool)
+    }
+
+    async fn concurrent_test_repositories() -> (tempfile::TempDir, Repositories) {
+        let directory = tempfile::tempdir().expect("temporary database directory");
+        let options = SqliteConnectOptions::new()
+            .filename(directory.path().join("connector-concurrency.sqlite3"))
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(StdDuration::from_secs(2));
+        let pool = SqlitePoolOptions::new()
+            .max_connections(2)
+            .connect_with(options)
+            .await
+            .expect("file-backed sqlite");
+        crate::db::migrations::run_migrations(&pool)
+            .await
+            .expect("migrations");
+        (directory, Repositories::new(pool))
     }
 
     fn scopes(values: &[&str]) -> Vec<String> {
@@ -8055,7 +8122,7 @@ mod tests {
             .await
             .expect("insert account");
         repos
-            .set_connector_trigger("job-1", "email_received", "user@example.com", "{}")
+            .replace_connector_trigger("job-1", "email_received", "user@example.com", "{}")
             .await
             .expect("set trigger");
         repos
@@ -8467,7 +8534,7 @@ mod tests {
             .await
             .expect("account");
         repos
-            .set_connector_trigger("job-1", "event_upcoming", "user@example.com", "{}")
+            .replace_connector_trigger("job-1", "event_upcoming", "user@example.com", "{}")
             .await
             .expect("trigger");
         repos
@@ -8584,10 +8651,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn connector_trigger_set_keeps_one_trigger_per_job() {
+    async fn connector_trigger_replacement_keeps_one_trigger_per_job() {
         let repos = test_repositories().await;
         let first = repos
-            .set_connector_trigger(
+            .replace_connector_trigger(
                 "job-1",
                 "email_received",
                 "user@example.com",
@@ -8599,7 +8666,7 @@ mod tests {
         // Changing the kind (or account) replaces the routine's single trigger
         // rather than adding a second row the daemon would also fire.
         let replaced = repos
-            .set_connector_trigger("job-1", "event_upcoming", "other@example.com", "{}")
+            .replace_connector_trigger("job-1", "event_upcoming", "other@example.com", "{}")
             .await
             .expect("replace trigger");
         assert_ne!(first.id, replaced.id);
@@ -8626,6 +8693,238 @@ mod tests {
             .await
             .expect("list after delete")
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn connector_trigger_failure_after_delete_rolls_back_old_state() {
+        let repos = test_repositories().await;
+        repos
+            .replace_connector_trigger("job-1", "event_upcoming", "user@example.com", "{}")
+            .await
+            .expect("old trigger");
+        repos
+            .set_trigger_cursor("user@example.com", "email_received", "stale-50")
+            .await
+            .expect("stale cursor");
+        query(
+            "CREATE TRIGGER fail_connector_trigger_after_delete
+             AFTER DELETE ON connector_triggers
+             WHEN OLD.job_id = 'job-1'
+             BEGIN
+               SELECT RAISE(ABORT, 'injected failure after trigger delete');
+             END",
+        )
+        .execute(&repos.pool)
+        .await
+        .expect("fault trigger");
+
+        let error = repos
+            .replace_connector_trigger("job-1", "email_received", "user@example.com", "{}")
+            .await
+            .expect_err("replacement must fail");
+        assert!(error.to_string().contains("injected failure"));
+
+        let triggers = repos
+            .list_connector_triggers(Some("job-1"))
+            .await
+            .expect("old trigger after rollback");
+        assert_eq!(triggers.len(), 1);
+        assert_eq!(triggers[0].kind, "event_upcoming");
+        assert_eq!(
+            repos
+                .trigger_cursor("user@example.com", "email_received")
+                .await
+                .expect("old cursor after rollback")
+                .as_deref(),
+            Some("stale-50")
+        );
+    }
+
+    #[tokio::test]
+    async fn connector_trigger_failure_before_cursor_reset_rolls_back_new_trigger() {
+        let repos = test_repositories().await;
+        repos
+            .replace_connector_trigger("job-1", "event_upcoming", "user@example.com", "{}")
+            .await
+            .expect("old trigger");
+        repos
+            .set_trigger_cursor("user@example.com", "email_received", "stale-50")
+            .await
+            .expect("stale cursor");
+        query(
+            "CREATE TRIGGER fail_email_cursor_reset
+             BEFORE DELETE ON trigger_cursors
+             WHEN OLD.account_id = 'user@example.com' AND OLD.kind = 'email_received'
+             BEGIN
+               SELECT RAISE(ABORT, 'injected failure before cursor reset');
+             END",
+        )
+        .execute(&repos.pool)
+        .await
+        .expect("fault trigger");
+
+        let error = repos
+            .replace_connector_trigger("job-1", "email_received", "user@example.com", "{}")
+            .await
+            .expect_err("replacement must fail");
+        assert!(error.to_string().contains("injected failure"));
+
+        let triggers = repos
+            .list_connector_triggers(Some("job-1"))
+            .await
+            .expect("old trigger after rollback");
+        assert_eq!(triggers.len(), 1);
+        assert_eq!(triggers[0].kind, "event_upcoming");
+        assert_eq!(
+            repos
+                .trigger_cursor("user@example.com", "email_received")
+                .await
+                .expect("old cursor after rollback")
+                .as_deref(),
+            Some("stale-50")
+        );
+    }
+
+    async fn simulate_email_poll(
+        repos: &Repositories,
+        current_history_id: u64,
+        message_history_ids: &[u64],
+    ) -> usize {
+        let Some(cursor) = repos
+            .trigger_cursor("user@example.com", "email_received")
+            .await
+            .expect("read simulated poll cursor")
+        else {
+            repos
+                .set_trigger_cursor(
+                    "user@example.com",
+                    "email_received",
+                    &current_history_id.to_string(),
+                )
+                .await
+                .expect("seed simulated poll cursor");
+            return 0;
+        };
+        let cursor: u64 = cursor.parse().expect("numeric test cursor");
+        let fire_count = usize::from(
+            message_history_ids
+                .iter()
+                .any(|history_id| *history_id > cursor),
+        );
+        repos
+            .set_trigger_cursor(
+                "user@example.com",
+                "email_received",
+                &current_history_id.to_string(),
+            )
+            .await
+            .expect("advance simulated poll cursor");
+        fire_count
+    }
+
+    #[tokio::test]
+    async fn first_email_after_trigger_replacement_fires_exactly_once() {
+        let repos = test_repositories().await;
+        repos
+            .replace_connector_trigger("job-1", "event_upcoming", "user@example.com", "{}")
+            .await
+            .expect("old event trigger");
+        repos
+            .set_trigger_cursor("user@example.com", "email_received", "50")
+            .await
+            .expect("stale cursor");
+
+        repos
+            .replace_connector_trigger("job-1", "email_received", "user@example.com", "{}")
+            .await
+            .expect("first email subscription");
+        assert!(repos
+            .trigger_cursor("user@example.com", "email_received")
+            .await
+            .expect("cursor reset")
+            .is_none());
+
+        let mut fire_count = simulate_email_poll(&repos, 100, &[]).await;
+        fire_count += simulate_email_poll(&repos, 101, &[101]).await;
+        fire_count += simulate_email_poll(&repos, 101, &[101]).await;
+
+        // Editing an existing subscription is a replacement, not a reconnect:
+        // retaining cursor 101 prevents the already-fired mail from repeating.
+        repos
+            .replace_connector_trigger(
+                "job-1",
+                "email_received",
+                "user@example.com",
+                r#"{"query":"is:unread"}"#,
+            )
+            .await
+            .expect("edit email trigger");
+        assert_eq!(
+            repos
+                .trigger_cursor("user@example.com", "email_received")
+                .await
+                .expect("cursor retained")
+                .as_deref(),
+            Some("101")
+        );
+        fire_count += simulate_email_poll(&repos, 101, &[101]).await;
+        assert_eq!(fire_count, 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_poll_snapshot_sees_no_trigger_cursor_half_state() {
+        let (_directory, repos) = concurrent_test_repositories().await;
+        repos
+            .replace_connector_trigger("job-1", "event_upcoming", "user@example.com", "{}")
+            .await
+            .expect("old event trigger");
+        repos
+            .set_trigger_cursor("user@example.com", "email_received", "stale-50")
+            .await
+            .expect("stale cursor");
+
+        let mut poll_snapshot = repos.pool.begin().await.expect("poll snapshot");
+        let old_kind: String = query("SELECT kind FROM connector_triggers WHERE job_id = 'job-1'")
+            .fetch_one(&mut *poll_snapshot)
+            .await
+            .expect("old trigger in snapshot")
+            .get("kind");
+        assert_eq!(old_kind, "event_upcoming");
+
+        repos
+            .replace_connector_trigger("job-1", "email_received", "user@example.com", "{}")
+            .await
+            .expect("concurrent replacement");
+
+        let snapshot_kind: String =
+            query("SELECT kind FROM connector_triggers WHERE job_id = 'job-1'")
+                .fetch_one(&mut *poll_snapshot)
+                .await
+                .expect("stable trigger snapshot")
+                .get("kind");
+        let snapshot_cursor: String = query(
+            "SELECT cursor FROM trigger_cursors
+             WHERE account_id = 'user@example.com' AND kind = 'email_received'",
+        )
+        .fetch_one(&mut *poll_snapshot)
+        .await
+        .expect("stable cursor snapshot")
+        .get("cursor");
+        assert_eq!(snapshot_kind, "event_upcoming");
+        assert_eq!(snapshot_cursor, "stale-50");
+        poll_snapshot.commit().await.expect("finish poll snapshot");
+
+        let triggers = repos
+            .list_connector_triggers(Some("job-1"))
+            .await
+            .expect("new trigger");
+        assert_eq!(triggers.len(), 1);
+        assert_eq!(triggers[0].kind, "email_received");
+        assert!(repos
+            .trigger_cursor("user@example.com", "email_received")
+            .await
+            .expect("new cursor state")
+            .is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Replace a routine's connector trigger and conditionally reset its first-email cursor in one `BEGIN IMMEDIATE` transaction.
- Enforce one connector trigger per job with an additive migration that preserves the newest legacy configuration before adding a unique index.
- Cover rollback at both former failure points, exactly-once first-email behavior, concurrent reader visibility, and legacy migration behavior.

## Root cause

Trigger replacement deleted the old row and inserted the new row as separate autocommit statements. The command then cleared the first-email cursor in a third write after computing whether the subscription was new outside any transaction. A crash or concurrent daemon poll could therefore observe a missing or replaced trigger paired with the stale cursor, and the non-unique job index also allowed duplicate trigger rows.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --locked -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- Focused rollback, migration, exactly-once, and concurrent snapshot tests
- `make local-ci` on `051f366edb2aedeff3e866a37c22a3680e33e25d` (`signoff/frontend` not applicable; `signoff/rust-macos` passed)

- [x] Tested visually where it matters (not applicable: no UI changes).
- [ ] Needs a June API (backend) deploy before it works end to end. Desktop-only persistence change.

## Out of scope

- Connector polling cadence, provider API behavior, and UI changes.
- June API changes or deploys.

## Followups

- Keep this PR in draft for the requested review round.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs (not applicable: no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable).
- [x] User-facing copy follows the repo UI conventions (not applicable: no user-facing copy).

Refs JUN-427

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787443097&installation_model_id=425925&pr_number=949&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F949&signature=e4b1a3e62bf80d46391780be371e790a1a5fad33ab7d96ac5dbca159b42a8282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->