### PR TITLE
Bound the public-share rate limiter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,12 +84,15 @@ tauri-lint:  ## clippy (warnings = errors)
 tauri-test:  ## cargo test
 	cargo test --manifest-path src-tauri/Cargo.toml --locked
 
-.PHONY: benchmark-note-transcription-latency benchmark-calendar-account-poll
+.PHONY: benchmark-note-transcription-latency benchmark-calendar-account-poll benchmark-share-rate-limiter
 benchmark-note-transcription-latency:
 	cargo test --manifest-path src-tauri/Cargo.toml --locked --release commands::note_transcription_benchmark::benchmark_post_finalization_note_transcription_latency -- --ignored --exact --nocapture --test-threads=1
 
 benchmark-calendar-account-poll:
 	cargo test --manifest-path src-tauri/Cargo.toml --locked --release connectors::triggers::tests::benchmark_calendar_account_poll_consolidation -- --ignored --exact --nocapture --test-threads=1
+
+benchmark-share-rate-limiter:  ## Benchmark share limiter latency and concurrent throughput
+	cd june-api && cargo bench -p june-api --bench share_rate_limiter --features benchmark --locked
 
 # --- June API backend (june-api/) ---
 june-api-fmt:  ## rustfmt (write)

--- a/docs/private-sharing-design.md
+++ b/docs/private-sharing-design.md
@@ -79,6 +79,23 @@ reserved address. It is rate-limited by client address and otherwise returns
 the same `share_not_found` response for missing, deleted, revoked, or wrong
 rows.
 
+### Rate-limit bounds
+
+Share requests keep the deployed fixed-window budget of 60 requests per
+minute. Authenticated endpoints consume both `user:{user_id}` and
+`ip:{client_address}` counters. Anonymous link views use
+`link-ip:{client_address}`, while viewer token exchanges use
+`ip:{client_address}`.
+
+The in-memory limiter has 64 independently locked shards, tracks at most
+100,000 keys across them, and caps each shard at 4,096 keys so retained hash
+table allocations also stay bounded across expiry generations. Expiry cleanup
+runs one shard at a time outside the request path. At capacity, an unknown key
+is denied until expired capacity is reclaimed. Active counters are never
+evicted to admit new keys, so rotating addresses cannot reset an attacker's
+existing counter. Cap exhaustion can therefore reduce availability under
+extreme churn, but it cannot open an abuse bypass or grow memory without bound.
+
 ## Backward compatibility
 
 Previously issued email-invite links retain their OS Accounts authentication.

--- a/june-api/Cargo.lock
+++ b/june-api/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +34,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -250,6 +265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +301,33 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -389,6 +437,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +483,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -793,6 +880,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,6 +1238,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1306,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64",
+ "criterion",
  "june-config",
  "june-domain",
  "june-services",
@@ -1556,6 +1664,22 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking"
@@ -2093,6 +2217,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2650,6 +2783,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3035,6 +3178,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3188,6 +3341,37 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/june-api/Cargo.toml
+++ b/june-api/Cargo.toml
@@ -52,6 +52,7 @@ uuid = { version = "1", features = ["v4", "v7"] }
 whatlang = "0.18"
 zeroize = { version = "1", features = ["derive"] }
 
+criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
 pretty_assertions = "1"
 rstest = "0.23"
 wiremock = "0.6"

--- a/june-api/crates/api/Cargo.toml
+++ b/june-api/crates/api/Cargo.toml
@@ -10,6 +10,9 @@ publish.workspace = true
 [lints]
 workspace = true
 
+[features]
+benchmark = []
+
 [dependencies]
 axum.workspace = true
 base64.workspace = true
@@ -30,5 +33,11 @@ url.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true
+criterion.workspace = true
 pretty_assertions.workspace = true
 tower = { workspace = true, features = ["util"] }
+
+[[bench]]
+name = "share_rate_limiter"
+harness = false
+required-features = ["benchmark"]

--- a/june-api/crates/api/benches/share_rate_limiter.rs
+++ b/june-api/crates/api/benches/share_rate_limiter.rs
@@ -1,0 +1,134 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use june_api::ShareRateLimiter;
+use std::{
+    hint::black_box,
+    sync::{
+        Arc, Barrier,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+const CAPACITY: usize = 100_000;
+const CARDINALITIES: [usize; 4] = [1, 1_000, 10_000, 100_000];
+const CONCURRENCY_LEVELS: [usize; 3] = [2, 8, 32];
+const REQUESTS_PER_WORKER: usize = 256;
+
+fn populated_limiter(cardinality: usize) -> (Arc<ShareRateLimiter>, Arc<Vec<String>>) {
+    let limiter = Arc::new(ShareRateLimiter::with_capacity(CAPACITY));
+    let keys = Arc::new(
+        (0..cardinality)
+            .map(|index| format!("ip:benchmark:{index}"))
+            .collect::<Vec<_>>(),
+    );
+    for key in keys.iter() {
+        assert!(limiter.allow(key), "benchmark setup exceeded the hard cap");
+    }
+    (limiter, keys)
+}
+
+fn lookup_latency(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("share_rate_limiter/lookup_latency");
+    for cardinality in CARDINALITIES {
+        let (limiter, keys) = populated_limiter(cardinality);
+        let key = &keys[cardinality - 1];
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(cardinality),
+            &cardinality,
+            |bencher, _| {
+                bencher.iter(|| black_box(limiter.allow(black_box(key))));
+            },
+        );
+    }
+    group.finish();
+}
+
+struct ConcurrentHarness {
+    start: Arc<Barrier>,
+    finish: Arc<Barrier>,
+    stop: Arc<AtomicBool>,
+    workers: Vec<thread::JoinHandle<()>>,
+}
+
+impl ConcurrentHarness {
+    fn new(limiter: &Arc<ShareRateLimiter>, keys: &Arc<Vec<String>>, worker_count: usize) -> Self {
+        let start = Arc::new(Barrier::new(worker_count + 1));
+        let finish = Arc::new(Barrier::new(worker_count + 1));
+        let stop = Arc::new(AtomicBool::new(false));
+        let workers = (0..worker_count)
+            .map(|worker_index| {
+                let limiter = limiter.clone();
+                let keys = keys.clone();
+                let start = start.clone();
+                let finish = finish.clone();
+                let stop = stop.clone();
+                thread::spawn(move || {
+                    loop {
+                        start.wait();
+                        if stop.load(Ordering::Acquire) {
+                            return;
+                        }
+                        for request_index in 0..REQUESTS_PER_WORKER {
+                            let key_index =
+                                (worker_index * REQUESTS_PER_WORKER + request_index) % keys.len();
+                            black_box(limiter.allow(black_box(&keys[key_index])));
+                        }
+                        finish.wait();
+                    }
+                })
+            })
+            .collect();
+        Self {
+            start,
+            finish,
+            stop,
+            workers,
+        }
+    }
+
+    fn run_round(&self) {
+        self.start.wait();
+        self.finish.wait();
+    }
+}
+
+impl Drop for ConcurrentHarness {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        self.start.wait();
+        for worker in self.workers.drain(..) {
+            assert!(worker.join().is_ok(), "benchmark worker panicked");
+        }
+    }
+}
+
+fn concurrent_throughput(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("share_rate_limiter/concurrent_throughput");
+    for cardinality in CARDINALITIES {
+        for worker_count in CONCURRENCY_LEVELS {
+            let (limiter, keys) = populated_limiter(cardinality);
+            let harness = ConcurrentHarness::new(&limiter, &keys, worker_count);
+            let requests_per_round = worker_count * REQUESTS_PER_WORKER;
+            group.throughput(Throughput::Elements(
+                u64::try_from(requests_per_round).unwrap_or(u64::MAX),
+            ));
+            group.bench_with_input(
+                BenchmarkId::new(format!("{cardinality}_keys"), worker_count),
+                &(cardinality, worker_count),
+                |bencher, _| bencher.iter(|| harness.run_round()),
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(20)
+        .measurement_time(Duration::from_secs(2));
+    targets = lookup_latency, concurrent_throughput
+}
+criterion_main!(benches);

--- a/june-api/crates/api/src/lib.rs
+++ b/june-api/crates/api/src/lib.rs
@@ -6,6 +6,7 @@ mod envelope;
 mod error;
 mod handlers;
 mod multipart;
+mod share_rate_limit;
 mod state;
 mod validation;
 
@@ -45,6 +46,9 @@ pub use handlers::video::{
     VideoAnimateRequest, VideoGenerateRequest, VideoJobResponse, VideoStatusResponse,
 };
 pub use handlers::web::{WebFetchRequest, WebSearchRequest};
+#[cfg(feature = "benchmark")]
+#[doc(hidden)]
+pub use share_rate_limit::ShareRateLimiter;
 pub use state::{ApiLimits, ApiState, ApiStateParams, AttestationInfo, ShareViewerInfo};
 
 /// Real shipped app version, sent by the desktop client on every request.

--- a/june-api/crates/api/src/share_rate_limit.rs
+++ b/june-api/crates/api/src/share_rate_limit.rs
@@ -1,0 +1,402 @@
+use std::{
+    collections::{HashMap, hash_map::RandomState},
+    hash::BuildHasher,
+    sync::{
+        Arc, Mutex, Weak,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+const SHARD_COUNT: usize = 64;
+const MAX_TRACKED_KEYS: usize = 100_000;
+const MAX_KEYS_PER_SHARD: usize = 4_096;
+const WINDOW: Duration = Duration::from_mins(1);
+const MAX_PER_WINDOW: u32 = 60;
+const CLEANUP_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Clone, Copy)]
+struct Counter {
+    window_started_at: Instant,
+    hits: u32,
+}
+
+struct ShareRateLimiterInner {
+    shards: Box<[Mutex<HashMap<String, Counter>>]>,
+    shard_hasher: RandomState,
+    tracked_keys: AtomicUsize,
+    capacity: usize,
+    per_shard_capacity: usize,
+}
+
+/// Fixed-window limiter for public-share endpoints.
+///
+/// Keys retain the deployed 60 requests/minute semantics. A keyed request
+/// locks only one of 64 shards, while a detached maintenance task expires one
+/// shard at a time outside the request path. The table tracks at most 100,000
+/// keys; once full, unknown keys fail closed instead of evicting an active
+/// counter that an attacker could deliberately reset.
+#[derive(Clone)]
+pub struct ShareRateLimiter {
+    inner: Arc<ShareRateLimiterInner>,
+}
+
+impl Default for ShareRateLimiter {
+    fn default() -> Self {
+        Self::with_capacity(MAX_TRACKED_KEYS)
+    }
+}
+
+impl ShareRateLimiter {
+    #[doc(hidden)]
+    pub fn with_capacity(capacity: usize) -> Self {
+        let shards = (0..SHARD_COUNT)
+            .map(|_| Mutex::new(HashMap::new()))
+            .collect();
+        Self {
+            inner: Arc::new(ShareRateLimiterInner {
+                shards,
+                shard_hasher: RandomState::new(),
+                tracked_keys: AtomicUsize::new(0),
+                capacity,
+                per_shard_capacity: capacity.min(MAX_KEYS_PER_SHARD),
+            }),
+        }
+    }
+
+    /// Returns false when the caller is over budget or the bounded table
+    /// cannot safely admit a new key.
+    pub fn allow(&self, key: &str) -> bool {
+        self.allow_at(key, Instant::now())
+    }
+
+    fn allow_at(&self, key: &str, now: Instant) -> bool {
+        let shard_index = self.shard_index(key);
+        // A poisoned lock must not fail OPEN on a security gate. HashMap
+        // operations preserve structural validity across unwinding, so recover
+        // the shard and keep enforcing its counters.
+        let mut shard = self.inner.shards[shard_index]
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        if let Some(counter) = shard.get_mut(key) {
+            if now.saturating_duration_since(counter.window_started_at) >= WINDOW {
+                *counter = Counter {
+                    window_started_at: now,
+                    hits: 1,
+                };
+                return true;
+            }
+            counter.hits = counter.hits.saturating_add(1);
+            return counter.hits <= MAX_PER_WINDOW;
+        }
+
+        // The global count bounds live key strings. The per-shard ceiling also
+        // bounds retained HashMap bucket allocations across repeated expiry
+        // generations, because HashMap does not automatically shrink.
+        if shard.len() >= self.inner.per_shard_capacity || !self.try_reserve_key() {
+            return false;
+        }
+        shard.insert(
+            key.to_string(),
+            Counter {
+                window_started_at: now,
+                hits: 1,
+            },
+        );
+        true
+    }
+
+    pub(crate) fn start_cleanup(&self) {
+        let weak = Arc::downgrade(&self.inner);
+        // Dropping a Tokio JoinHandle detaches the task. It holds only a Weak,
+        // so it exits after the owning ApiState is dropped.
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            drop(runtime.spawn(cleanup_loop(weak)));
+        }
+    }
+
+    fn try_reserve_key(&self) -> bool {
+        self.inner
+            .tracked_keys
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current < self.inner.capacity).then_some(current + 1)
+            })
+            .is_ok()
+    }
+
+    fn shard_index(&self, key: &str) -> usize {
+        let shard_count = u64::try_from(self.inner.shards.len()).unwrap_or(1);
+        usize::try_from(self.inner.shard_hasher.hash_one(key) % shard_count).unwrap_or_default()
+    }
+
+    fn cleanup_shard_at(&self, shard_index: usize, now: Instant) {
+        let mut shard = self.inner.shards[shard_index]
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let before = shard.len();
+        shard
+            .retain(|_, counter| now.saturating_duration_since(counter.window_started_at) < WINDOW);
+        self.release_keys(before - shard.len());
+    }
+
+    fn release_keys(&self, count: usize) {
+        if count == 0 {
+            return;
+        }
+        // Underflow is unreachable while the map/count invariant holds. If a
+        // future bug violates it in release builds, wrapping high fails closed
+        // instead of under-counting the table and admitting excess keys.
+        let previous = self.inner.tracked_keys.fetch_sub(count, Ordering::AcqRel);
+        debug_assert!(previous >= count, "tracked-key count underflow");
+    }
+
+    #[cfg(test)]
+    fn cleanup_all_at(&self, now: Instant) {
+        for shard_index in 0..self.inner.shards.len() {
+            self.cleanup_shard_at(shard_index, now);
+        }
+    }
+
+    #[cfg(test)]
+    fn tracked_key_count(&self) -> usize {
+        self.inner.tracked_keys.load(Ordering::Acquire)
+    }
+}
+
+async fn cleanup_loop(inner: Weak<ShareRateLimiterInner>) {
+    let mut next_shard = 0;
+    loop {
+        tokio::time::sleep(CLEANUP_INTERVAL).await;
+        let Some(inner) = inner.upgrade() else {
+            return;
+        };
+        let limiter = ShareRateLimiter { inner };
+        limiter.cleanup_shard_at(next_shard, Instant::now());
+        next_shard = (next_shard + 1) % limiter.inner.shards.len();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_KEYS_PER_SHARD, MAX_PER_WINDOW, ShareRateLimiter, WINDOW};
+    use std::{
+        collections::HashMap,
+        sync::{
+            Arc, Barrier,
+            atomic::{AtomicUsize, Ordering},
+            mpsc,
+        },
+        thread,
+        time::{Duration, Instant},
+    };
+
+    #[derive(Default)]
+    struct ReferenceLimiter {
+        hits: HashMap<String, (Instant, u32)>,
+    }
+
+    impl ReferenceLimiter {
+        fn allow_at(&mut self, key: &str, now: Instant) -> bool {
+            self.hits
+                .retain(|_, (start, _)| now.saturating_duration_since(*start) < WINDOW);
+            let entry = self.hits.entry(key.to_string()).or_insert((now, 0));
+            if now.saturating_duration_since(entry.0) >= WINDOW {
+                *entry = (now, 0);
+            }
+            entry.1 += 1;
+            entry.1 <= MAX_PER_WINDOW
+        }
+    }
+
+    #[test]
+    fn fixed_window_semantics_match_the_previous_limiter() {
+        let limiter = ShareRateLimiter::with_capacity(1_000);
+        let mut reference = ReferenceLimiter::default();
+        let start = Instant::now();
+        let identities = ["user:usr_owner", "ip:198.51.100.7", "link-ip:198.51.100.7"];
+
+        for second in [0, 1, 30, 59, 60, 61, 119, 120] {
+            let now = start + Duration::from_secs(second);
+            for identity in identities {
+                for _ in 0..75 {
+                    assert_eq!(
+                        limiter.allow_at(identity, now),
+                        reference.allow_at(identity, now),
+                        "semantic drift for {identity} at second {second}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn exact_window_rollover_resets_only_the_requested_key() {
+        let limiter = ShareRateLimiter::with_capacity(2);
+        let start = Instant::now();
+
+        for _ in 0..MAX_PER_WINDOW {
+            assert!(limiter.allow_at("ip:198.51.100.7", start));
+        }
+        assert!(!limiter.allow_at(
+            "ip:198.51.100.7",
+            start + WINDOW.saturating_sub(Duration::from_nanos(1))
+        ));
+        assert!(limiter.allow_at("user:usr_other", start));
+        assert!(limiter.allow_at("ip:198.51.100.7", start + WINDOW));
+        assert_eq!(limiter.tracked_key_count(), 2);
+    }
+
+    #[test]
+    fn cap_exhaustion_is_fail_closed_and_cannot_reset_an_active_counter() {
+        let limiter = ShareRateLimiter::with_capacity(4);
+        let start = Instant::now();
+        let attacker = "link-ip:203.0.113.9";
+
+        for _ in 0..MAX_PER_WINDOW {
+            assert!(limiter.allow_at(attacker, start));
+        }
+        assert!(!limiter.allow_at(attacker, start));
+        for index in 0..3 {
+            assert!(limiter.allow_at(&format!("ip:198.51.100.{index}"), start));
+        }
+
+        for index in 0..1_000 {
+            assert!(
+                !limiter.allow_at(&format!("link-ip:192.0.2.{index}"), start),
+                "a churn key was admitted after the table reached its cap"
+            );
+        }
+
+        assert_eq!(limiter.tracked_key_count(), 4);
+        assert!(
+            !limiter.allow_at(attacker, start),
+            "key churn evicted and reset the attacker's blocked counter"
+        );
+    }
+
+    #[test]
+    fn expiry_cleanup_reclaims_capacity_without_evicting_live_keys() {
+        let limiter = ShareRateLimiter::with_capacity(2);
+        let start = Instant::now();
+        assert!(limiter.allow_at("ip:expired", start));
+        assert!(limiter.allow_at("ip:live", start + Duration::from_secs(30)));
+        assert!(!limiter.allow_at("ip:new", start + Duration::from_secs(30)));
+
+        limiter.cleanup_all_at(start + WINDOW);
+
+        assert_eq!(limiter.tracked_key_count(), 1);
+        assert!(limiter.allow_at("ip:new", start + WINDOW));
+        assert_eq!(limiter.tracked_key_count(), 2);
+    }
+
+    #[test]
+    fn a_blocked_shard_does_not_serialize_other_shards() {
+        let limiter = ShareRateLimiter::with_capacity(10);
+        let blocked_key = "ip:blocked-shard";
+        let blocked_shard = limiter.shard_index(blocked_key);
+        let free_key = (0..10_000)
+            .map(|index| format!("ip:free-{index}"))
+            .find(|key| limiter.shard_index(key) != blocked_shard)
+            .expect("64 shards must yield a key in another shard");
+        let shard_guard = limiter.inner.shards[blocked_shard]
+            .lock()
+            .expect("test shard lock");
+        let (sender, receiver) = mpsc::channel();
+        let worker_limiter = limiter.clone();
+        let worker = thread::spawn(move || {
+            let _sent = sender.send(worker_limiter.allow(&free_key));
+        });
+
+        let result = receiver.recv_timeout(Duration::from_secs(1));
+        drop(shard_guard);
+        assert!(worker.join().is_ok(), "worker thread panicked");
+        assert!(
+            result.expect("another shard should complete while one shard is held"),
+            "another shard unexpectedly denied its first request"
+        );
+    }
+
+    #[test]
+    fn concurrent_requests_preserve_the_exact_per_key_threshold() {
+        const WORKERS: usize = 8;
+        const REQUESTS_PER_WORKER: usize = 32;
+        let limiter = Arc::new(ShareRateLimiter::with_capacity(10));
+        let barrier = Arc::new(Barrier::new(WORKERS));
+        let allowed = Arc::new(AtomicUsize::new(0));
+        let workers = (0..WORKERS)
+            .map(|_| {
+                let limiter = limiter.clone();
+                let barrier = barrier.clone();
+                let allowed = allowed.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    for _ in 0..REQUESTS_PER_WORKER {
+                        if limiter.allow("user:usr_concurrent") {
+                            allowed.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for worker in workers {
+            assert!(worker.join().is_ok(), "worker thread panicked");
+        }
+
+        assert_eq!(allowed.load(Ordering::Relaxed), MAX_PER_WINDOW as usize);
+    }
+
+    #[test]
+    fn concurrent_key_churn_never_exceeds_the_hard_cap() {
+        const CAPACITY: usize = 1_000;
+        const WORKERS: usize = 8;
+        const KEYS_PER_WORKER: usize = 500;
+        let limiter = Arc::new(ShareRateLimiter::with_capacity(CAPACITY));
+        let barrier = Arc::new(Barrier::new(WORKERS));
+        let allowed = Arc::new(AtomicUsize::new(0));
+        let workers = (0..WORKERS)
+            .map(|worker_index| {
+                let limiter = limiter.clone();
+                let barrier = barrier.clone();
+                let allowed = allowed.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    for key_index in 0..KEYS_PER_WORKER {
+                        let key = format!("ip:{worker_index}:{key_index}");
+                        if limiter.allow(&key) {
+                            allowed.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for worker in workers {
+            assert!(worker.join().is_ok(), "worker thread panicked");
+        }
+
+        assert_eq!(allowed.load(Ordering::Relaxed), CAPACITY);
+        assert_eq!(limiter.tracked_key_count(), CAPACITY);
+    }
+
+    #[test]
+    fn one_shard_cannot_accumulate_unbounded_retained_capacity() {
+        let limiter = ShareRateLimiter::with_capacity(MAX_KEYS_PER_SHARD * 2);
+        let target_shard = 0;
+        let colliding_keys = (0..)
+            .map(|index| format!("ip:collision:{index}"))
+            .filter(|key| limiter.shard_index(key) == target_shard)
+            .take(MAX_KEYS_PER_SHARD + 1)
+            .collect::<Vec<_>>();
+
+        for key in &colliding_keys[..MAX_KEYS_PER_SHARD] {
+            assert!(limiter.allow(key));
+        }
+        assert!(
+            !limiter.allow(&colliding_keys[MAX_KEYS_PER_SHARD]),
+            "one shard admitted more keys than its allocation ceiling"
+        );
+        assert_eq!(limiter.tracked_key_count(), MAX_KEYS_PER_SHARD);
+    }
+}

--- a/june-api/crates/api/src/share_rate_limit.rs
+++ b/june-api/crates/api/src/share_rate_limit.rs
@@ -97,6 +97,9 @@ impl ShareRateLimiter {
         if shard.len() >= self.inner.per_shard_capacity || !self.try_reserve_key() {
             return false;
         }
+        // The shard lock remains held and there is no fallible branch or early
+        // return between a successful reservation and this insert, so every
+        // reservation is paired with exactly one new map entry.
         shard.insert(
             key.to_string(),
             Counter {
@@ -111,8 +114,18 @@ impl ShareRateLimiter {
         let weak = Arc::downgrade(&self.inner);
         // Dropping a Tokio JoinHandle detaches the task. It holds only a Weak,
         // so it exits after the owning ApiState is dropped.
-        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
-            drop(runtime.spawn(cleanup_loop(weak)));
+        match tokio::runtime::Handle::try_current() {
+            Ok(runtime) => drop(runtime.spawn(cleanup_loop(weak))),
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "share-rate-limiter cleanup task not started: no Tokio runtime"
+                );
+                debug_assert!(
+                    tokio::runtime::Handle::try_current().is_ok(),
+                    "share-rate-limiter cleanup task not started: no Tokio runtime"
+                );
+            }
         }
     }
 
@@ -398,5 +411,12 @@ mod tests {
             "one shard admitted more keys than its allocation ceiling"
         );
         assert_eq!(limiter.tracked_key_count(), MAX_KEYS_PER_SHARD);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "share-rate-limiter cleanup task not started: no Tokio runtime")]
+    fn cleanup_start_without_a_runtime_is_loud_in_debug_builds() {
+        ShareRateLimiter::default().start_cleanup();
     }
 }

--- a/june-api/crates/api/src/state.rs
+++ b/june-api/crates/api/src/state.rs
@@ -1,4 +1,5 @@
 use crate::error::ApiError;
+use crate::share_rate_limit::ShareRateLimiter;
 use june_config::BrowserTransportsConfig;
 use june_domain::{TokenVerifier, UserId};
 use june_services::{
@@ -191,46 +192,6 @@ pub struct ShareViewerInfo {
     pub client_id: String,
 }
 
-/// Minimal fixed-window limiter for share endpoints (JUN-308: rate-limit
-/// invite and access attempts). Single-instance CVM makes in-memory state
-/// sufficient; callers consume both a per-user and a per-address budget.
-pub(crate) struct ShareRateLimiter {
-    hits: std::sync::Mutex<std::collections::HashMap<String, (std::time::Instant, u32)>>,
-}
-
-impl Default for ShareRateLimiter {
-    fn default() -> Self {
-        Self {
-            hits: std::sync::Mutex::new(std::collections::HashMap::new()),
-        }
-    }
-}
-
-impl ShareRateLimiter {
-    const WINDOW: std::time::Duration = std::time::Duration::from_mins(1);
-    const MAX_PER_WINDOW: u32 = 60;
-
-    /// Returns false when the caller is over budget for the current window.
-    pub(crate) fn allow(&self, key: &str) -> bool {
-        // A poisoned lock must not fail OPEN on a security gate: recover the
-        // inner map (the state is a counter table; a panicking writer cannot
-        // corrupt it in a way that matters more than losing the gate).
-        let mut hits = self
-            .hits
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let now = std::time::Instant::now();
-        // Opportunistic cleanup keeps the map bounded by active users.
-        hits.retain(|_, (start, _)| now.duration_since(*start) < Self::WINDOW);
-        let entry = hits.entry(key.to_string()).or_insert((now, 0));
-        if now.duration_since(entry.0) >= Self::WINDOW {
-            *entry = (now, 0);
-        }
-        entry.1 += 1;
-        entry.1 <= Self::MAX_PER_WINDOW
-    }
-}
-
 pub struct ApiStateParams {
     pub pricing: Arc<PricingTable>,
     pub computer_use: june_config::ComputerUseConfig,
@@ -254,6 +215,8 @@ pub struct ApiStateParams {
 
 impl ApiState {
     pub fn new(params: ApiStateParams) -> Self {
+        let share_rate = ShareRateLimiter::default();
+        share_rate.start_cleanup();
         Self {
             inner: Arc::new(ApiStateInner {
                 pricing: params.pricing,
@@ -271,7 +234,7 @@ impl ApiState {
                 issue_report_permits: Arc::new(Semaphore::new(ISSUE_REPORT_MAX_CONCURRENCY)),
                 share: params.share,
                 share_viewer: params.share_viewer,
-                share_rate: ShareRateLimiter::default(),
+                share_rate,
                 share_http: reqwest::Client::new(),
                 agent_admission: AgentAdmissionControl::new(
                     params.limits.max_agent_inflight_body_bytes,


### PR DESCRIPTION
## Summary

- Replace the shared O(n) public-share limiter with 64 independently locked shards and move expiry scans off the request path.
- Cap live tracking at 100,000 keys globally and retained entries at 4,096 per shard, failing closed without evicting active counters.
- Preserve the deployed fixed-window budget and key identities, with parity, concurrency, capacity, expiry, and churn-bypass coverage.
- Add Criterion benchmarks for 1, 1,000, 10,000, and 100,000 keys at 2, 8, and 32 concurrent workers.

## Root cause

Every public-share rate-limit check took one synchronous mutex and pruned the entire active-key map before updating one counter. Rotating client addresses therefore made request cost grow with total active keys, serialized all share and viewer-token traffic behind the same scan, and left the counter table without a hard memory bound.

## Validation

- `make verify`
- `make local-ci`
- `make june-api-fmt-check june-api-lint june-api-test`
- `python3 scripts/check-cargo-release-age.py --base origin/main`
- `cargo bench -p june-api --bench share_rate_limiter --features benchmark --locked -- --quick`
- Manual high-stakes standards, specification, and adversarial review; the independent review round is deliberately deferred until after this draft.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). Not applicable: this is a June API concurrency and security change with no UI surface.
- [x] Needs a June API (backend) deploy before it works end to end. The limiter runs in June API.

## Out of scope

- Distributed rate limiting across multiple June API instances.
- Changes to the deployed 60-request, one-minute fixed window, thresholds, or key identities.
- Frontend or share-viewer UI changes.

## Followups

- Run the requested review round on this draft PR.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable: no desktop or release surface changed.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Pending the requested review round.
- [x] User-facing copy follows the repo UI conventions. Not applicable: no user-facing copy changed.

Refs JUN-425

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787443989&installation_model_id=425925&pr_number=950&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F950&signature=2ab46e4a04e2ee7396f0db53821aec2c67000ee9a58a6fd64ae862dce62eee33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->