### PR TITLE
Index agent artifacts incrementally

### DIFF
--- a/docs/hermes-architecture.md
+++ b/docs/hermes-architecture.md
@@ -140,6 +140,16 @@ classified events into `AgentChatTurn` / `AgentChatPart[]` for rendering.
   on the fresh connection. The submit's real requests, including
   `session.create` and `prompt.submit`, are sent once with their ordinary
   deadlines.
+- **Artifact discovery is indexed outside the render hot path.**
+  `artifact-index.ts` seeds one flat file index from the Bridge snapshot,
+  coalesces concurrent refreshes, and preserves June-owned writes that land
+  while an older snapshot is in flight. Imports and generated media update the
+  index directly; file-producing tool completions request a reconcile; a
+  15-second mounted-session reconcile catches files added, removed, or renamed
+  outside June. Transcript and reasoning deltas only query the index. File-path
+  and filename aliases are compiled once per index change into a multi-pattern
+  matcher, so assigning files to conversation turns does not compare every turn
+  with every file.
 - **Browser approvals are event-led.** The browser-approval change event
   refreshes pending approvals promptly. Snapshot reads are limited to initial
   subscription, listener reattachment, and focus, visibility, or online

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -112,6 +112,7 @@ import { createImageSlashActions } from "./image-slash-actions";
 import { createSubmitHermesSession } from "./session-submission";
 import type { SubmitHermesSession } from "./session-submission-types";
 import { createSubmitComposer } from "./composer/submit-composer";
+import { ARTIFACT_INDEX_RECONCILE_INTERVAL_MS, createAgentArtifactIndex } from "./artifact-index";
 export type { AgentWorkspaceOrigin } from "./agent-workspace-types";
 export { SkillsToolsPanel } from "./management/SkillsToolsPanel";
 export {
@@ -530,9 +531,6 @@ export function AgentWorkspace({
     setSelectedMessagingPlatformId,
     messagingEnvEdits,
     setMessagingEnvEdits,
-    filesystemSnapshot,
-    setFilesystemSnapshot,
-    setFilesystemLoading,
     artifactPanel,
     setArtifactPanel,
     usagePanelSessionId,
@@ -567,6 +565,7 @@ export function AgentWorkspace({
     continuity,
     selectedHermesSessionId,
   });
+  const artifactIndex = useMemo(() => createAgentArtifactIndex(), []);
 
   useEffect(() => {
     let cancelled = false;
@@ -879,12 +878,12 @@ export function AgentWorkspace({
     chatArtifacts,
   } = useAgentSelection({
     attachments,
+    artifactIndex,
     category,
     composerSizeWarning,
     creditActionsDisabledReason,
     defaultGenerationModelId,
     draft,
-    filesystemSnapshot,
     generationCostQuality,
     generationModels,
     hermesSessionItems,
@@ -1097,7 +1096,9 @@ export function AgentWorkspace({
       void (async () => {
         const imported: AgentArtifact[] = [];
         for (const sample of buildSampleArtifactFiles()) {
-          imported.push(await importHermesBridgeFileBytes(sample.name, sample.bytes));
+          const file = await importHermesBridgeFileBytes(sample.name, sample.bytes);
+          artifactIndex.upsertImportedFile(file);
+          imported.push(file);
         }
         setDevArtifacts(imported);
         setArtifactPanel({ view: "list" });
@@ -1105,7 +1106,7 @@ export function AgentWorkspace({
     };
     window.addEventListener(AGENT_DEV_FILES_EVENT, onDevFiles);
     return () => window.removeEventListener(AGENT_DEV_FILES_EVENT, onDevFiles);
-  }, []);
+  }, [artifactIndex]);
 
   let stopHermesSessionImplementation: ReturnType<
     typeof createTaskControlActions
@@ -1681,12 +1682,11 @@ export function AgentWorkspace({
     if (!bridge.running || !hermesSessionsHydrated || !selectedHermesSessionId) return;
     if (isProvisionalHermesSessionId(selectedHermesSessionId)) return;
     void loadFilesystemSnapshot();
-  }, [
-    bridge.running,
-    hermesSessionsHydrated,
-    selectedHermesSessionId,
-    selectedHermesMessages.length,
-  ]);
+    const reconcileInterval = window.setInterval(() => {
+      void loadFilesystemSnapshot();
+    }, ARTIFACT_INDEX_RECONCILE_INTERVAL_MS);
+    return () => window.clearInterval(reconcileInterval);
+  }, [bridge.running, hermesSessionsHydrated, selectedHermesSessionId]);
 
   useTaskHydration({
     hydratedTaskIdsRef,
@@ -1777,12 +1777,11 @@ export function AgentWorkspace({
 
   const { loadSkillCommands, loadCapabilities, loadMessagingPlatforms, loadFilesystemSnapshot } =
     createManagementLoaders({
+      artifactIndex,
       ensureHermesGateway,
       selectedHermesSessionIdRef,
       setCapabilityLoading,
       setError,
-      setFilesystemLoading,
-      setFilesystemSnapshot,
       setMessagingPlatforms,
       setSelectedMessagingPlatformId,
       setSkillCommandLoading,
@@ -1806,7 +1805,7 @@ export function AgentWorkspace({
     creditActionsDisabledReason,
     imageSafeModeConsentRequestRef,
     imageSlashBaseTurnId,
-    loadFilesystemSnapshot,
+    recordImportedArtifact: artifactIndex.upsertImportedFile,
     newSessionModeRef,
     pendingFastPathImagesRef,
     setError,
@@ -1979,7 +1978,7 @@ export function AgentWorkspace({
     clearComposerCommandDraft,
     composerDispatchWasInvalidated,
     creditActionsDisabledReason,
-    loadFilesystemSnapshot,
+    recordFilesystemArtifact: artifactIndex.upsert,
     newSessionModeRef,
     requestImageSafeModeConsent,
     setError,
@@ -2154,7 +2153,7 @@ export function AgentWorkspace({
     agentAttachmentFromImportedFile,
     composerEditorRef,
     creditActionsDisabledReason,
-    loadFilesystemSnapshot,
+    recordImportedArtifact: artifactIndex.upsertImportedFile,
     setComposerAttachments,
     setError,
     setImportingFiles,
@@ -2279,6 +2278,9 @@ export function AgentWorkspace({
     clearSubmittedSteers,
     continueAfterCompletedAgentRun,
     liveEventsRef,
+    onArtifactFilesystemChange: (event) => {
+      if (artifactIndex.recordToolEvent(event)) void loadFilesystemSnapshot();
+    },
     pendingSteerBySessionIdRef,
     promotePendingIssueReportToReview,
     recordHermesActivityAndDeriveStatus,
@@ -2685,6 +2687,7 @@ export function AgentWorkspace({
     openTimelineArtifact,
   } = useAgentChatPresentation({
     DOWNLOAD_TOAST_ID,
+    artifactIndex,
     chatArtifacts,
     devArtifacts,
     imageTurnsBySession,

--- a/src/components/agent/artifact-index.ts
+++ b/src/components/agent/artifact-index.ts
@@ -1,0 +1,467 @@
+import type { AgentChatTurn } from "../../lib/agent-chat-runtime";
+import { artifactsFromToolEvent } from "../../lib/hermes-artifact-store";
+import type { JuneHermesEvent } from "../../lib/hermes-control-plane";
+import type {
+  HermesFilesystemEntry,
+  HermesFilesystemSnapshot,
+  ImportedHermesFile,
+} from "../../lib/tauri";
+import type { AgentArtifact } from "./chat-turns/AgentArtifactPanel";
+
+export const ARTIFACT_INDEX_RECONCILE_INTERVAL_MS = 15_000;
+
+type ArtifactMutation =
+  | { revision: number; type: "upsert"; artifact: AgentArtifact }
+  | { revision: number; type: "remove"; path: string }
+  | {
+      revision: number;
+      type: "rename";
+      previousPath: string;
+      artifact: AgentArtifact;
+    };
+
+type ArtifactMutationInput =
+  | { type: "upsert"; artifact: AgentArtifact }
+  | { type: "remove"; path: string }
+  | {
+      type: "rename";
+      previousPath: string;
+      artifact: AgentArtifact;
+    };
+
+type AliasMatch = {
+  nameArtifactIndexes: Set<number>;
+  pathArtifactIndexes: Set<number>;
+};
+
+type AliasOutput = {
+  nameArtifactIndexes: number[];
+  pathArtifactIndexes: number[];
+};
+
+type AliasNode = {
+  next: Map<string, number>;
+  failure: number;
+  outputIndexes: number[];
+};
+
+export type AgentArtifactIndex = {
+  assignArtifactsToTurns(turns: AgentChatTurn[]): Map<string, AgentArtifact[]>;
+  getArtifacts(): AgentArtifact[];
+  getVersion(): number;
+  recordToolEvent(event: JuneHermesEvent): boolean;
+  reconcile(snapshot: HermesFilesystemSnapshot): void;
+  refresh(scan: () => Promise<HermesFilesystemSnapshot>): Promise<void>;
+  remove(path: string): void;
+  rename(previousPath: string, artifact: AgentArtifact): void;
+  shouldRefreshForEvent(event: JuneHermesEvent): boolean;
+  subscribe(listener: () => void): () => void;
+  upsert(artifact: AgentArtifact): void;
+  upsertImportedFile(file: ImportedHermesFile): void;
+};
+
+/**
+ * A mutable, workspace-scoped index of the exact flat file set returned by the
+ * native filesystem snapshot. Full snapshots reconcile removals and external
+ * changes; June-owned writes update the hot-path index immediately.
+ */
+export function createAgentArtifactIndex(): AgentArtifactIndex {
+  let artifacts: AgentArtifact[] = [];
+  let matcher = new ArtifactAliasMatcher([]);
+  let version = 0;
+  let revision = 0;
+  let mutations: ArtifactMutation[] = [];
+  let refreshInFlight: Promise<void> | null = null;
+  let activeRefreshRevision: number | null = null;
+  let refreshQueued = false;
+  let queuedScan: (() => Promise<HermesFilesystemSnapshot>) | null = null;
+  const listeners = new Set<() => void>();
+
+  function publish(nextArtifacts: AgentArtifact[]) {
+    if (artifactListsEqual(artifacts, nextArtifacts)) return;
+    artifacts = nextArtifacts;
+    matcher = new ArtifactAliasMatcher(artifacts);
+    version += 1;
+    for (const listener of listeners) listener();
+  }
+
+  function recordMutation(mutation: ArtifactMutationInput) {
+    revision += 1;
+    const nextMutation = { ...mutation, revision } as ArtifactMutation;
+    mutations.push(nextMutation);
+    publish(applyArtifactMutation(artifacts, nextMutation));
+  }
+
+  function applySnapshot(snapshot: HermesFilesystemSnapshot, startedRevision: number) {
+    let nextArtifacts = artifactsFromFilesystemSnapshot(snapshot);
+    const concurrentMutations = mutations.filter((mutation) => mutation.revision > startedRevision);
+    for (const mutation of concurrentMutations) {
+      nextArtifacts = applyArtifactMutation(nextArtifacts, mutation);
+    }
+    const appliedRevision = revision;
+    publish(nextArtifacts);
+    mutations = mutations.filter((mutation) => mutation.revision > appliedRevision);
+  }
+
+  function reconcile(snapshot: HermesFilesystemSnapshot) {
+    applySnapshot(snapshot, revision);
+  }
+
+  function refresh(scan: () => Promise<HermesFilesystemSnapshot>) {
+    if (refreshInFlight) {
+      if (activeRefreshRevision !== null && revision > activeRefreshRevision) {
+        refreshQueued = true;
+        queuedScan = scan;
+      }
+      return refreshInFlight;
+    }
+    const pending = (async () => {
+      let nextScan = scan;
+      do {
+        refreshQueued = false;
+        queuedScan = null;
+        const startedRevision = revision;
+        activeRefreshRevision = startedRevision;
+        const snapshot = await nextScan();
+        activeRefreshRevision = null;
+        if (refreshQueued && revision > startedRevision) {
+          nextScan = queuedScan ?? scan;
+          continue;
+        }
+        applySnapshot(snapshot, startedRevision);
+        nextScan = queuedScan ?? scan;
+      } while (refreshQueued);
+    })();
+    const wrapped = pending.finally(() => {
+      if (refreshInFlight === wrapped) {
+        activeRefreshRevision = null;
+        refreshInFlight = null;
+        refreshQueued = false;
+        queuedScan = null;
+      }
+    });
+    refreshInFlight = wrapped;
+    return wrapped;
+  }
+
+  function upsert(artifact: AgentArtifact) {
+    const path = artifact.path.trim();
+    const name = artifact.name.trim();
+    if (!path || !name) return;
+    recordMutation({
+      type: "upsert",
+      artifact: { ...artifact, name, path },
+    });
+  }
+
+  function remove(path: string) {
+    const normalized = path.trim();
+    if (!normalized) return;
+    recordMutation({ type: "remove", path: normalized });
+  }
+
+  function rename(previousPath: string, artifact: AgentArtifact) {
+    const normalizedPreviousPath = previousPath.trim();
+    const path = artifact.path.trim();
+    const name = artifact.name.trim();
+    if (!normalizedPreviousPath || !path || !name) return;
+    recordMutation({
+      type: "rename",
+      previousPath: normalizedPreviousPath,
+      artifact: { ...artifact, name, path },
+    });
+  }
+
+  function upsertImportedFile(file: ImportedHermesFile) {
+    upsert({
+      name: file.name,
+      path: file.path,
+      rootLabel: file.rootLabel,
+      size: file.size,
+    });
+  }
+
+  function shouldRefreshForEvent(event: JuneHermesEvent) {
+    if (event.kind !== "tool" || event.phase !== "complete") return false;
+    const toolName = event.name?.toLowerCase() ?? "";
+    if (
+      /(delete|remove|rename|move|write|create|save|generate|export|edit|patch|append|replace)/.test(
+        toolName,
+      )
+    ) {
+      return true;
+    }
+    return artifactsFromToolEvent(event).some(
+      (artifact) =>
+        artifact.action !== "failed" &&
+        artifact.action !== "read" &&
+        artifact.kind !== "url" &&
+        artifact.kind !== "directory",
+    );
+  }
+
+  function recordToolEvent(event: JuneHermesEvent) {
+    const shouldRefresh = shouldRefreshForEvent(event);
+    if (shouldRefresh) revision += 1;
+    return shouldRefresh;
+  }
+
+  function assignArtifactsToTurns(turns: AgentChatTurn[]) {
+    return assignIndexedArtifactsToTurns(turns, artifacts, matcher);
+  }
+
+  return {
+    assignArtifactsToTurns,
+    getArtifacts: () => artifacts,
+    getVersion: () => version,
+    recordToolEvent,
+    reconcile,
+    refresh,
+    remove,
+    rename,
+    shouldRefreshForEvent,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    upsert,
+    upsertImportedFile,
+  };
+}
+
+export function artifactsFromFilesystemSnapshot(
+  snapshot: HermesFilesystemSnapshot | null,
+): AgentArtifact[] {
+  return (snapshot?.roots ?? []).flatMap((root) =>
+    filesystemEntriesToArtifacts(root.entries, root.label),
+  );
+}
+
+export function workspaceRelativeArtifactPath(path: string) {
+  const workspaceMatch = path.match(/(?:^|[/\\])workspace[/\\](.+)$/);
+  if (workspaceMatch?.[1]) return workspaceMatch[1];
+  return path;
+}
+
+function filesystemEntriesToArtifacts(
+  entries: HermesFilesystemEntry[],
+  rootLabel: string,
+): AgentArtifact[] {
+  return entries.flatMap((entry) => {
+    const children = filesystemEntriesToArtifacts(entry.children ?? [], rootLabel);
+    if (entry.kind !== "file") return children;
+    return [
+      {
+        name: entry.name,
+        path: entry.path,
+        rootLabel,
+        size: entry.size,
+      },
+      ...children,
+    ];
+  });
+}
+
+function applyArtifactMutation(
+  current: AgentArtifact[],
+  mutation: ArtifactMutation,
+): AgentArtifact[] {
+  if (mutation.type === "remove") {
+    return current.filter((artifact) => artifact.path !== mutation.path);
+  }
+  if (mutation.type === "rename") {
+    const previousIndex = current.findIndex((artifact) => artifact.path === mutation.previousPath);
+    const withoutPrevious = current.filter(
+      (artifact) =>
+        artifact.path !== mutation.previousPath && artifact.path !== mutation.artifact.path,
+    );
+    const insertionIndex =
+      previousIndex === -1
+        ? withoutPrevious.length
+        : Math.min(previousIndex, withoutPrevious.length);
+    withoutPrevious.splice(insertionIndex, 0, mutation.artifact);
+    return withoutPrevious;
+  }
+  const existingIndex = current.findIndex((artifact) => artifact.path === mutation.artifact.path);
+  if (existingIndex === -1) return [...current, mutation.artifact];
+  const next = [...current];
+  next[existingIndex] = { ...next[existingIndex], ...mutation.artifact };
+  return next;
+}
+
+// Preserve the original first-mention semantics while querying only aliases
+// present in each turn. User turns claim path mentions without rendering cards;
+// assistant turns may also claim an unclaimed filename; inline media owns its
+// matching file and suppresses the duplicate artifact card.
+function assignIndexedArtifactsToTurns(
+  turns: AgentChatTurn[],
+  artifacts: AgentArtifact[],
+  matcher: ArtifactAliasMatcher,
+): Map<string, AgentArtifact[]> {
+  const byTurn = new Map<string, AgentArtifact[]>();
+  if (!artifacts.length) return byTurn;
+  const claimedPaths = new Set<string>();
+  const claimedNames = new Set<string>();
+  const mediaPaths = new Set<string>();
+  const mediaNames = new Set<string>();
+  for (const turn of turns) {
+    for (const part of turn.parts) {
+      if (part.type !== "image" && part.type !== "video") continue;
+      if (part.path) mediaPaths.add(part.path);
+      else if (part.name) mediaNames.add(part.name.toLowerCase());
+    }
+  }
+
+  for (const turn of turns) {
+    const text = turn.parts
+      .map((part) => (part.type === "text" ? part.text : ""))
+      .join("\n")
+      .toLowerCase();
+    if (!text.trim()) continue;
+    const matches = matcher.match(text);
+    const candidateIndexes = Array.from(
+      new Set([...matches.pathArtifactIndexes, ...matches.nameArtifactIndexes]),
+    ).sort((left, right) => left - right);
+    const mentioned: AgentArtifact[] = [];
+    for (const artifactIndex of candidateIndexes) {
+      const artifact = artifacts[artifactIndex];
+      if (!artifact) continue;
+      const name = artifact.name.toLowerCase();
+      if (!name || claimedPaths.has(artifact.path)) continue;
+      if (mediaPaths.has(artifact.path) || mediaNames.has(name)) continue;
+      const pathMentioned = matches.pathArtifactIndexes.has(artifactIndex);
+      const nameMentioned =
+        turn.role === "assistant" &&
+        !claimedNames.has(name) &&
+        matches.nameArtifactIndexes.has(artifactIndex);
+      if (!pathMentioned && !nameMentioned) continue;
+      claimedPaths.add(artifact.path);
+      claimedNames.add(name);
+      if (turn.role === "assistant") mentioned.push(artifact);
+    }
+    if (mentioned.length) byTurn.set(turn.id, mentioned);
+  }
+  return byTurn;
+}
+
+/** Aho-Corasick matcher over normalized full-path, workspace-relative, and
+ * filename aliases. It is rebuilt only when the indexed artifact set changes. */
+class ArtifactAliasMatcher {
+  private readonly nodes: AliasNode[] = [
+    { next: new Map<string, number>(), failure: 0, outputIndexes: [] },
+  ];
+  private readonly outputs: AliasOutput[] = [];
+
+  constructor(artifacts: AgentArtifact[]) {
+    const outputsByAlias = new Map<string, AliasOutput>();
+    artifacts.forEach((artifact, artifactIndex) => {
+      addAlias(outputsByAlias, artifact.path.toLowerCase(), "pathArtifactIndexes", artifactIndex);
+      addAlias(
+        outputsByAlias,
+        workspaceRelativeArtifactPath(artifact.path).toLowerCase(),
+        "pathArtifactIndexes",
+        artifactIndex,
+      );
+      addAlias(outputsByAlias, artifact.name.toLowerCase(), "nameArtifactIndexes", artifactIndex);
+    });
+    for (const [alias, output] of outputsByAlias) this.insert(alias, output);
+    this.buildFailureLinks();
+  }
+
+  match(text: string): AliasMatch {
+    const result: AliasMatch = {
+      nameArtifactIndexes: new Set<number>(),
+      pathArtifactIndexes: new Set<number>(),
+    };
+    let state = 0;
+    for (const character of text) {
+      while (state !== 0 && !this.nodes[state].next.has(character)) {
+        state = this.nodes[state].failure;
+      }
+      state = this.nodes[state].next.get(character) ?? 0;
+      for (const outputIndex of this.nodes[state].outputIndexes) {
+        const output = this.outputs[outputIndex];
+        if (!output) continue;
+        for (const artifactIndex of output.nameArtifactIndexes) {
+          result.nameArtifactIndexes.add(artifactIndex);
+        }
+        for (const artifactIndex of output.pathArtifactIndexes) {
+          result.pathArtifactIndexes.add(artifactIndex);
+        }
+      }
+    }
+    return result;
+  }
+
+  private insert(alias: string, output: AliasOutput) {
+    if (!alias) return;
+    let state = 0;
+    for (const character of alias) {
+      const existing = this.nodes[state].next.get(character);
+      if (existing !== undefined) {
+        state = existing;
+        continue;
+      }
+      const nextState = this.nodes.length;
+      this.nodes.push({ next: new Map(), failure: 0, outputIndexes: [] });
+      this.nodes[state].next.set(character, nextState);
+      state = nextState;
+    }
+    const outputIndex = this.outputs.length;
+    this.outputs.push(output);
+    this.nodes[state].outputIndexes.push(outputIndex);
+  }
+
+  private buildFailureLinks() {
+    const queue: number[] = [];
+    for (const child of this.nodes[0].next.values()) {
+      queue.push(child);
+      this.nodes[child].failure = 0;
+    }
+    for (let queueIndex = 0; queueIndex < queue.length; queueIndex += 1) {
+      const state = queue[queueIndex];
+      for (const [character, child] of this.nodes[state].next) {
+        queue.push(child);
+        let failure = this.nodes[state].failure;
+        while (failure !== 0 && !this.nodes[failure].next.has(character)) {
+          failure = this.nodes[failure].failure;
+        }
+        this.nodes[child].failure = this.nodes[failure].next.get(character) ?? 0;
+        this.nodes[child].outputIndexes.push(
+          ...this.nodes[this.nodes[child].failure].outputIndexes,
+        );
+      }
+    }
+  }
+}
+
+function addAlias(
+  outputsByAlias: Map<string, AliasOutput>,
+  alias: string,
+  kind: keyof AliasOutput,
+  artifactIndex: number,
+) {
+  if (!alias) return;
+  const output = outputsByAlias.get(alias) ?? {
+    nameArtifactIndexes: [],
+    pathArtifactIndexes: [],
+  };
+  if (!output[kind].includes(artifactIndex)) output[kind].push(artifactIndex);
+  outputsByAlias.set(alias, output);
+}
+
+function artifactListsEqual(left: AgentArtifact[], right: AgentArtifact[]) {
+  return (
+    left.length === right.length &&
+    left.every((artifact, index) => {
+      const candidate = right[index];
+      return (
+        candidate !== undefined &&
+        artifact.name === candidate.name &&
+        artifact.path === candidate.path &&
+        artifact.rootLabel === candidate.rootLabel &&
+        artifact.size === candidate.size
+      );
+    })
+  );
+}

--- a/src/components/agent/artifact-index.ts
+++ b/src/components/agent/artifact-index.ts
@@ -109,7 +109,7 @@ export function createAgentArtifactIndex(): AgentArtifactIndex {
 
   function refresh(scan: () => Promise<HermesFilesystemSnapshot>) {
     if (refreshInFlight) {
-      if (activeRefreshRevision !== null && revision > activeRefreshRevision) {
+      if (activeRefreshRevision === null || revision > activeRefreshRevision) {
         refreshQueued = true;
         queuedScan = scan;
       }
@@ -134,10 +134,15 @@ export function createAgentArtifactIndex(): AgentArtifactIndex {
     })();
     const wrapped = pending.finally(() => {
       if (refreshInFlight === wrapped) {
+        const trailingScan = refreshQueued ? (queuedScan ?? scan) : null;
         activeRefreshRevision = null;
         refreshInFlight = null;
         refreshQueued = false;
         queuedScan = null;
+        // A caller can arrive after the scan loop exits but before this
+        // cleanup microtask runs. Start its queued scan after releasing the
+        // shared slot, and keep existing waiters pending through it.
+        if (trailingScan) return refresh(trailingScan);
       }
     });
     refreshInFlight = wrapped;

--- a/src/components/agent/attachment-import-actions-types.ts
+++ b/src/components/agent/attachment-import-actions-types.ts
@@ -9,7 +9,7 @@ export type createAttachmentImportActionsDependencies = {
   agentAttachmentFromImportedFile: (file: ImportedHermesFile) => AgentAttachment;
   composerEditorRef: React.MutableRefObject<ComposerEditorHandle | null>;
   creditActionsDisabledReason: string | undefined;
-  loadFilesystemSnapshot: () => Promise<void>;
+  recordImportedArtifact: (file: ImportedHermesFile) => void;
   setComposerAttachments: (
     nextValue: AgentAttachment[] | ((current: AgentAttachment[]) => AgentAttachment[]),
   ) => void;

--- a/src/components/agent/attachment-import-actions.ts
+++ b/src/components/agent/attachment-import-actions.ts
@@ -19,7 +19,7 @@ export function createAttachmentImportActions(
     agentAttachmentFromImportedFile,
     composerEditorRef,
     creditActionsDisabledReason,
-    loadFilesystemSnapshot,
+    recordImportedArtifact,
     setComposerAttachments,
     setError,
     setImportingFiles,
@@ -51,7 +51,9 @@ export function createAttachmentImportActions(
       // of staging the whole batch (up to ~400 MB) in memory at once.
       const imported: ImportedHermesFile[] = [];
       for (const item of items) {
-        imported.push(await importItem(item));
+        const file = await importItem(item);
+        recordImportedArtifact(file);
+        imported.push(file);
       }
       const nextAttachments = imported.map(agentAttachmentFromImportedFile);
       if (options.onImported) {
@@ -60,7 +62,6 @@ export function createAttachmentImportActions(
         setComposerAttachments((current) => [...current, ...nextAttachments]);
       }
       setError(null);
-      void loadFilesystemSnapshot();
       return true;
     } catch (err) {
       setError(messageFromError(err));

--- a/src/components/agent/composer/composer-input-helpers.ts
+++ b/src/components/agent/composer/composer-input-helpers.ts
@@ -4,13 +4,10 @@ import {
   type AgentChatTurn,
 } from "../../../lib/agent-chat-runtime";
 import { modelSupportsTools } from "../../../lib/model-privacy";
-import type {
-  HermesFilesystemEntry,
-  HermesFilesystemSnapshot,
-  VeniceModelDto,
-} from "../../../lib/tauri";
+import type { VeniceModelDto } from "../../../lib/tauri";
 import type { AgentArtifact } from "../chat-turns/AgentArtifactPanel";
 import type { AgentAttachment } from "../agent-workspace-models";
+import { workspaceRelativeArtifactPath } from "../artifact-index";
 import type { ReportCategory } from "./reportCategory";
 
 const COMPOSER_TOKEN_ESTIMATE_CHARS_PER_TOKEN = 4;
@@ -23,14 +20,6 @@ export type ComposerInputSizeWarning = {
   modelName: string;
   switchModel?: VeniceModelDto;
 };
-
-export function artifactsFromFilesystemSnapshot(
-  snapshot: HermesFilesystemSnapshot | null,
-): AgentArtifact[] {
-  return (snapshot?.roots ?? []).flatMap((root) =>
-    filesystemEntriesToArtifacts(root.entries, root.label),
-  );
-}
 
 export function composerInputSignatureFor({
   message,
@@ -211,86 +200,7 @@ export function unsupportedImageInputPrompt({
 }
 
 function attachmentPromptPath(path: string) {
-  const workspaceMatch = path.match(/(?:^|[/\\])workspace[/\\](.+)$/);
-  if (workspaceMatch?.[1]) return workspaceMatch[1];
-  return path;
-}
-
-function filesystemEntriesToArtifacts(
-  entries: HermesFilesystemEntry[],
-  rootLabel: string,
-): AgentArtifact[] {
-  return entries.flatMap((entry) => {
-    const children = filesystemEntriesToArtifacts(entry.children ?? [], rootLabel);
-    if (entry.kind !== "file") return children;
-    return [
-      {
-        name: entry.name,
-        path: entry.path,
-        rootLabel,
-        size: entry.size,
-      },
-      ...children,
-    ];
-  });
-}
-
-// Assigns each workspace file to the first turn that mentions it, so its
-// download card renders once instead of at the end of every later response
-// that happens to repeat the file name. User turns can claim a file too, using
-// either the full artifact path or the workspace-relative path injected for
-// attachments, so a file the user just handed us shouldn't bounce back as a
-// download. Name-only matches are also deduplicated by name, so two workspace
-// copies of the same file don't produce twin cards. A file already rendered
-// inline as a generated image/video part never gets a card at all — the inline
-// figure carries its own open/download affordances, and a duplicate file card
-// would otherwise paint above the generation it came from (JUN-305).
-export function assignArtifactsToTurns(
-  turns: AgentChatTurn[],
-  artifacts: AgentArtifact[],
-): Map<string, AgentArtifact[]> {
-  const byTurn = new Map<string, AgentArtifact[]>();
-  if (!artifacts.length) return byTurn;
-  const claimedPaths = new Set<string>();
-  const claimedNames = new Set<string>();
-  const mediaPaths = new Set<string>();
-  const mediaNames = new Set<string>();
-  for (const turn of turns) {
-    for (const part of turn.parts) {
-      if (part.type !== "image" && part.type !== "video") continue;
-      // A path-bearing inline media part is deduped precisely by its path, so it
-      // needn't also claim its basename (which would wrongly suppress an
-      // unrelated later file sharing that name). Only pathless inline media
-      // (e.g. MCP inline image blocks carrying just a filename) fall back to the
-      // fuzzy name match.
-      if (part.path) mediaPaths.add(part.path);
-      else if (part.name) mediaNames.add(part.name.toLowerCase());
-    }
-  }
-  for (const turn of turns) {
-    const text = turn.parts
-      .map((part) => (part.type === "text" ? part.text : ""))
-      .join("\n")
-      .toLowerCase();
-    if (!text.trim()) continue;
-    const mentioned: AgentArtifact[] = [];
-    for (const artifact of artifacts) {
-      const name = artifact.name.toLowerCase();
-      if (!name || claimedPaths.has(artifact.path)) continue;
-      if (mediaPaths.has(artifact.path) || mediaNames.has(name)) continue;
-      const pathMentioned =
-        text.includes(artifact.path.toLowerCase()) ||
-        text.includes(attachmentPromptPath(artifact.path).toLowerCase());
-      const nameMentioned =
-        turn.role === "assistant" && !claimedNames.has(name) && text.includes(name);
-      if (!pathMentioned && !nameMentioned) continue;
-      claimedPaths.add(artifact.path);
-      claimedNames.add(name);
-      if (turn.role === "assistant") mentioned.push(artifact);
-    }
-    if (mentioned.length) byTurn.set(turn.id, mentioned);
-  }
-  return byTurn;
+  return workspaceRelativeArtifactPath(path);
 }
 
 // The inline media renderer owns generated image and video cards, so

--- a/src/components/agent/image-slash-actions-types.ts
+++ b/src/components/agent/image-slash-actions-types.ts
@@ -1,4 +1,4 @@
-import { type HermesSessionInfo } from "../../lib/tauri";
+import { type HermesSessionInfo, type ImportedHermesFile } from "../../lib/tauri";
 import { type HermesSessionDispatchReservation } from "../../lib/hermes-session-dispatch-mutex";
 import { type AgentChatPart, type AgentChatTurn } from "../../lib/agent-chat-runtime";
 import type { AgentAttachment } from "./agent-workspace-models";
@@ -17,7 +17,7 @@ export type createImageSlashActionsDependencies = {
   creditActionsDisabledReason: string | undefined;
   imageSafeModeConsentRequestRef: React.MutableRefObject<ImageSafeModeConsentRequest | null>;
   imageSlashBaseTurnId: (assistantTurnId: string) => string;
-  loadFilesystemSnapshot: () => Promise<void>;
+  recordImportedArtifact: (file: ImportedHermesFile) => void;
   newSessionModeRef: React.MutableRefObject<boolean>;
   pendingFastPathImagesRef: React.MutableRefObject<Record<string, AgentAttachment[]>>;
   setError: (message: string | null, options?: AgentWorkspaceErrorOptions) => void;

--- a/src/components/agent/image-slash-actions.ts
+++ b/src/components/agent/image-slash-actions.ts
@@ -33,7 +33,7 @@ export function createImageSlashActions(dependencies: createImageSlashActionsDep
     creditActionsDisabledReason,
     imageSafeModeConsentRequestRef,
     imageSlashBaseTurnId,
-    loadFilesystemSnapshot,
+    recordImportedArtifact,
     newSessionModeRef,
     pendingFastPathImagesRef,
     setError,
@@ -106,7 +106,7 @@ export function createImageSlashActions(dependencies: createImageSlashActionsDep
         },
         hermesModeFor(sessionId),
       );
-      void loadFilesystemSnapshot();
+      recordImportedArtifact(result.file);
       // JUN-171 (Phase A): hold the generated image so the user's next message
       // carries it into the model's context (lazy attach). No composer chip -
       // it already renders in-thread as the assistant image turn above. Reuses

--- a/src/components/agent/management-loaders-types.ts
+++ b/src/components/agent/management-loaders-types.ts
@@ -1,20 +1,19 @@
 import {
-  type HermesFilesystemSnapshot,
   type HermesMessagingPlatformInfo,
   type HermesSkillInfo,
   type HermesToolsetInfo,
 } from "../../lib/tauri";
 import { HermesGatewayClient } from "../../lib/hermes-gateway";
 import { type AgentWorkspaceErrorOptions } from "./agent-workspace-errors";
+import type { AgentArtifactIndex } from "./artifact-index";
 import type * as React from "react";
 
 export type createManagementLoadersDependencies = {
+  artifactIndex: AgentArtifactIndex;
   ensureHermesGateway: (fullMode?: boolean) => Promise<HermesGatewayClient>;
   selectedHermesSessionIdRef: React.MutableRefObject<string | undefined>;
   setCapabilityLoading: React.Dispatch<React.SetStateAction<boolean>>;
   setError: (message: string | null, options?: AgentWorkspaceErrorOptions) => void;
-  setFilesystemLoading: React.Dispatch<React.SetStateAction<boolean>>;
-  setFilesystemSnapshot: React.Dispatch<React.SetStateAction<HermesFilesystemSnapshot | null>>;
   setMessagingPlatforms: React.Dispatch<React.SetStateAction<HermesMessagingPlatformInfo[] | null>>;
   setSelectedMessagingPlatformId: React.Dispatch<React.SetStateAction<string | undefined>>;
   setSkillCommandLoading: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/components/agent/management-loaders.ts
+++ b/src/components/agent/management-loaders.ts
@@ -16,11 +16,10 @@ import type { createManagementLoadersDependencies } from "./management-loaders-t
 export function createManagementLoaders(dependencies: createManagementLoadersDependencies) {
   const {
     ensureHermesGateway,
+    artifactIndex,
     selectedHermesSessionIdRef,
     setCapabilityLoading,
     setError,
-    setFilesystemLoading,
-    setFilesystemSnapshot,
     setMessagingPlatforms,
     setSelectedMessagingPlatformId,
     setSkillCommandLoading,
@@ -104,19 +103,18 @@ export function createManagementLoaders(dependencies: createManagementLoadersDep
 
   async function loadFilesystemSnapshot() {
     const sessionId = selectedHermesSessionIdRef.current ?? null;
-    setFilesystemLoading(true);
     try {
-      await ensureHermesGateway();
-      setFilesystemSnapshot(await hermesBridgeFilesystemSnapshot());
-      // No setError(null): this refires in the background on message-count
-      // changes, so a success would wipe an unrelated banner (e.g. a failed
-      // send). The banner is dismissable instead.
+      await artifactIndex.refresh(async () => {
+        await ensureHermesGateway();
+        return hermesBridgeFilesystemSnapshot();
+      });
+      // No setError(null): this also runs as a bounded background reconcile,
+      // so a success must not wipe an unrelated banner (for example a failed
+      // send). The banner remains dismissable instead.
     } catch (err) {
       const message = messageFromError(err);
       if (isSessionGoneError(message)) return;
       setError(message, { sessionId });
-    } finally {
-      setFilesystemLoading(false);
     }
   }
 

--- a/src/components/agent/session-event-listener-types.ts
+++ b/src/components/agent/session-event-listener-types.ts
@@ -14,6 +14,7 @@ export type createSessionEventListenerDependencies = {
   clearSubmittedSteers: (sessionId: string, options?: { preserveReservations?: boolean }) => void;
   continueAfterCompletedAgentRun: (storedSessionId: string, source?: symbol) => void;
   liveEventsRef: React.MutableRefObject<Record<string, JuneHermesEvent[]>>;
+  onArtifactFilesystemChange: (event: JuneHermesEvent) => void;
   pendingSteerBySessionIdRef: React.MutableRefObject<Record<string, PendingSteer[]>>;
   promotePendingIssueReportToReview: (
     sessionId: string,

--- a/src/components/agent/session-event-listener.ts
+++ b/src/components/agent/session-event-listener.ts
@@ -33,6 +33,7 @@ export function createSessionEventListener(dependencies: createSessionEventListe
     clearSubmittedSteers,
     continueAfterCompletedAgentRun,
     liveEventsRef,
+    onArtifactFilesystemChange,
     pendingSteerBySessionIdRef,
     promotePendingIssueReportToReview,
     recordHermesActivityAndDeriveStatus,
@@ -161,6 +162,7 @@ export function createSessionEventListener(dependencies: createSessionEventListe
       // unconditional call is safe for every kind. Mode rides along so each
       // artifact can show its blast radius (sandboxed copy vs unrestricted path).
       hermesArtifactStore.record(storedClassified, hermesModeFor(storedSessionId));
+      onArtifactFilesystemChange(storedClassified);
       const nextSessionEvents = appendHermesLiveEvent(
         liveEventsRef.current[storedSessionId] ?? [],
         classified,

--- a/src/components/agent/use-agent-chat-presentation-types.ts
+++ b/src/components/agent/use-agent-chat-presentation-types.ts
@@ -2,11 +2,13 @@ import { type AgentTaskDto, type HermesSessionMessage } from "../../lib/tauri";
 import { type JuneHermesEvent } from "../../lib/hermes-control-plane";
 import { type AgentChatTurn } from "../../lib/agent-chat-runtime";
 import { type AgentArtifact, type AgentArtifactPanelState } from "./chat-turns/AgentArtifactPanel";
+import type { AgentArtifactIndex } from "./artifact-index";
 import type { AgentWorkspaceErrorOptions } from "./agent-workspace-errors";
 import type * as React from "react";
 
 export type UseAgentChatPresentationDependencies = {
   DOWNLOAD_TOAST_ID: "agent-download";
+  artifactIndex: AgentArtifactIndex;
   chatArtifacts: AgentArtifact[];
   devArtifacts: AgentArtifact[];
   imageTurnsBySession: Record<string, AgentChatTurn[]>;

--- a/src/components/agent/use-agent-chat-presentation.tsx
+++ b/src/components/agent/use-agent-chat-presentation.tsx
@@ -17,10 +17,7 @@ import type { JuneHermesEvent } from "../../lib/hermes-control-plane";
 import { upstreamProviderRecoveryIds } from "../../lib/upstream-provider-recovery";
 import { mergeThinkingTurns } from "./chat-turns/TranscriptViews";
 import { type AgentArtifact } from "./chat-turns/AgentArtifactPanel";
-import {
-  assignArtifactsToTurns,
-  surfacedArtifactsFromTurns,
-} from "./composer/composer-input-helpers";
+import { surfacedArtifactsFromTurns } from "./composer/composer-input-helpers";
 import { DownloadToastMessage, ensureDownloadFileExtension } from "./agent-workspace-support";
 import type { UseAgentChatPresentationDependencies } from "./use-agent-chat-presentation-types";
 
@@ -110,6 +107,7 @@ function useStableMapValues<Key, Value>(
 export function useAgentChatPresentation(dependencies: UseAgentChatPresentationDependencies) {
   const {
     DOWNLOAD_TOAST_ID,
+    artifactIndex,
     chatArtifacts,
     devArtifacts,
     imageTurnsBySession,
@@ -182,8 +180,8 @@ export function useAgentChatPresentation(dependencies: UseAgentChatPresentationD
   const presentedTurns = selectedHermesSessionId ? hermesTurns : taskTurns;
   const turnArtifacts = useStableMapValues(
     useMemo(
-      () => assignArtifactsToTurns(presentedTurns, chatArtifacts),
-      [chatArtifacts, presentedTurns],
+      () => artifactIndex.assignArtifactsToTurns(presentedTurns),
+      [artifactIndex, chatArtifacts, presentedTurns],
     ),
     artifactListsEqual,
   );

--- a/src/components/agent/use-agent-runtime-state.ts
+++ b/src/components/agent/use-agent-runtime-state.ts
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import {
   hermesAgentCliAccess,
-  type HermesFilesystemSnapshot,
   type HermesMessagingPlatformInfo,
   type HermesSkillInfo,
   type HermesToolsetInfo,
@@ -286,10 +285,6 @@ export function useAgentRuntimeState(dependencies: UseAgentRuntimeStateDependenc
   const [capabilitySaving, setCapabilitySaving] = useState<string | null>(null);
   const [selectedMessagingPlatformId, setSelectedMessagingPlatformId] = useState<string>();
   const [messagingEnvEdits, setMessagingEnvEdits] = useState<Record<string, string>>({});
-  const [filesystemSnapshot, setFilesystemSnapshot] = useState<HermesFilesystemSnapshot | null>(
-    null,
-  );
-  const [filesystemLoading, setFilesystemLoading] = useState(false);
   const [artifactPanel, setArtifactPanel] = useState<AgentArtifactPanelState | null>(null);
   // The session whose usage/cost panel is open, or null. Self-contained for
   // feature 09; feature 11's activity drawer will later host the same panel.
@@ -464,9 +459,6 @@ export function useAgentRuntimeState(dependencies: UseAgentRuntimeStateDependenc
     setSelectedMessagingPlatformId,
     messagingEnvEdits,
     setMessagingEnvEdits,
-    filesystemSnapshot,
-    setFilesystemSnapshot,
-    setFilesystemLoading,
     artifactPanel,
     setArtifactPanel,
     usagePanelSessionId,

--- a/src/components/agent/use-agent-selection-types.ts
+++ b/src/components/agent/use-agent-selection-types.ts
@@ -1,6 +1,5 @@
 import {
   type AgentTaskDto,
-  type HermesFilesystemSnapshot,
   type HermesSessionInfo,
   type HermesSessionMessage,
   type LocalGenerationSettingsDto,
@@ -9,17 +8,18 @@ import {
 import type { SessionModelSelectionMap } from "../../lib/hermes-session-model-selection";
 import { type ThinkingLevel } from "../../lib/thinking-level";
 import type { AgentAttachment } from "./agent-workspace-models";
+import type { AgentArtifactIndex } from "./artifact-index";
 import type { ComposerInputSizeWarning } from "./composer/composer-input-helpers";
 import type { ReportCategory } from "./composer/reportCategory";
 
 export type UseAgentSelectionDependencies = {
   attachments: AgentAttachment[];
+  artifactIndex: AgentArtifactIndex;
   category: ReportCategory | null;
   composerSizeWarning: ComposerInputSizeWarning | null;
   creditActionsDisabledReason: string | undefined;
   defaultGenerationModelId: string;
   draft: string;
-  filesystemSnapshot: HermesFilesystemSnapshot | null;
   generationCostQuality: number | undefined;
   generationModels: VeniceModelDto[];
   hermesSessionItems: HermesSessionInfo[];

--- a/src/components/agent/use-agent-selection.ts
+++ b/src/components/agent/use-agent-selection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import { pendingImageAttachments } from "../../lib/hermes-image-attach";
 import { shouldBlockTextOnFunding, type TextFundingModelContext } from "../../lib/account-gate";
 import { modelPrivacyBadge, modelSupportsImageInput } from "../../lib/model-privacy";
@@ -15,21 +15,18 @@ import { parseBuiltinComposerSlashCommand } from "../../lib/agent-composer-slash
 import { IMAGE_GENERATION_ENABLED } from "../../lib/feature-flags";
 import { isProvisionalHermesSessionId } from "./agent-workspace-config";
 import { sessionComposerDraftKey, NEW_SESSION_DRAFT_KEY } from "./agent-session-continuity";
-import {
-  artifactsFromFilesystemSnapshot,
-  composerInputSignatureFor,
-} from "./composer/composer-input-helpers";
+import { composerInputSignatureFor } from "./composer/composer-input-helpers";
 import type { UseAgentSelectionDependencies } from "./use-agent-selection-types";
 
 export function useAgentSelection(dependencies: UseAgentSelectionDependencies) {
   const {
     attachments,
+    artifactIndex,
     category,
     composerSizeWarning,
     creditActionsDisabledReason,
     defaultGenerationModelId,
     draft,
-    filesystemSnapshot,
     generationCostQuality,
     generationModels,
     hermesSessionItems,
@@ -203,9 +200,14 @@ export function useAgentSelection(dependencies: UseAgentSelectionDependencies) {
   const composerDraftKeyRef = useRef<string | null>(composerDraftKey);
   composerDraftKeyRef.current = composerDraftKey;
   const restoredComposerDraftKeyRef = useRef<string | null>();
+  const artifactIndexVersion = useSyncExternalStore(
+    artifactIndex.subscribe,
+    artifactIndex.getVersion,
+    artifactIndex.getVersion,
+  );
   const chatArtifacts = useMemo(
-    () => artifactsFromFilesystemSnapshot(filesystemSnapshot),
-    [filesystemSnapshot],
+    () => artifactIndex.getArtifacts(),
+    [artifactIndex, artifactIndexVersion],
   );
 
   return {

--- a/src/components/agent/video-slash-actions-types.ts
+++ b/src/components/agent/video-slash-actions-types.ts
@@ -5,6 +5,7 @@ import type { SubmitHermesSession } from "./session-submission-types";
 import type { ImageSafeModeConsentChoice } from "./agent-workspace-models";
 import { type AgentWorkspaceErrorOptions } from "./agent-workspace-errors";
 import { type CapturedSessionModelTarget } from "./composer/follow-up-queue";
+import type { AgentArtifact } from "./chat-turns/AgentArtifactPanel";
 import type * as React from "react";
 
 export type createVideoSlashActionsDependencies = {
@@ -14,7 +15,7 @@ export type createVideoSlashActionsDependencies = {
     reservation: HermesSessionDispatchReservation | undefined,
   ) => boolean;
   creditActionsDisabledReason: string | undefined;
-  loadFilesystemSnapshot: () => Promise<void>;
+  recordFilesystemArtifact: (artifact: AgentArtifact) => void;
   newSessionModeRef: React.MutableRefObject<boolean>;
   requestImageSafeModeConsent: (
     variant: "slash" | "agent" | "video-slash",

--- a/src/components/agent/video-slash-actions.ts
+++ b/src/components/agent/video-slash-actions.ts
@@ -32,7 +32,7 @@ export function createVideoSlashActions(dependencies: createVideoSlashActionsDep
     clearComposerCommandDraft,
     composerDispatchWasInvalidated,
     creditActionsDisabledReason,
-    loadFilesystemSnapshot,
+    recordFilesystemArtifact,
     newSessionModeRef,
     requestImageSafeModeConsent,
     setError,
@@ -154,7 +154,11 @@ export function createVideoSlashActions(dependencies: createVideoSlashActionsDep
         },
         hermesModeFor(sessionId),
       );
-      void loadFilesystemSnapshot();
+      recordFilesystemArtifact({
+        name,
+        path: result.path,
+        rootLabel: "Workspace",
+      });
     } catch (err) {
       updateVideoSlashPart(sessionId, assistantTurnId, {
         status: "error",
@@ -254,7 +258,11 @@ export function createVideoSlashActions(dependencies: createVideoSlashActionsDep
         },
         hermesModeFor(turn.sessionId),
       );
-      void loadFilesystemSnapshot();
+      recordFilesystemArtifact({
+        name,
+        path: result.path,
+        rootLabel: "Workspace",
+      });
       return;
     }
     // Budget exhausted while the job was still processing: it lives on the

--- a/src/test/agent-artifact-index.test.tsx
+++ b/src/test/agent-artifact-index.test.tsx
@@ -95,6 +95,91 @@ describe("agent artifact index", () => {
     expect(index.getArtifacts().map((item) => item.name)).toEqual(["existing.md"]);
   });
 
+  it("queues a refresh requested after the scan loop exits but before cleanup", async () => {
+    const index = createAgentArtifactIndex();
+    const firstScan = vi.fn(async () => snapshot(["first.md"]));
+    const trailingScan = vi.fn(async () => snapshot(["trailing.md"]));
+    let trailingRefresh: Promise<void> | undefined;
+    const unsubscribe = index.subscribe(() => {
+      unsubscribe();
+      queueMicrotask(() => {
+        trailingRefresh = index.refresh(trailingScan);
+      });
+    });
+
+    await index.refresh(firstScan);
+    await trailingRefresh;
+
+    expect(firstScan).toHaveBeenCalledOnce();
+    expect(trailingScan).toHaveBeenCalledOnce();
+    expect(index.getArtifacts()).toEqual(
+      artifactsFromFilesystemSnapshot(snapshot(["trailing.md"])),
+    );
+  });
+
+  it("matches a full scan after 1,500 seeded mutation sequences and a durable reconcile", async () => {
+    const operationCounts = [0, 0, 0, 0];
+    for (let seed = 1; seed <= 1_500; seed += 1) {
+      const random = seededRandom(seed);
+      const index = createAgentArtifactIndex();
+      const files = new Map<string, number>([
+        ["alpha.md", 10],
+        ["beta.md", 20],
+        ["gamma.md", 30],
+      ]);
+      index.reconcile(snapshotFromFileMap(files));
+
+      for (let step = 0; step < 48; step += 1) {
+        if (files.size === 0) {
+          const fallbackName = `file-${random() % 24}.md`;
+          const fallbackSize = (random() % 4_096) + 1;
+          files.set(fallbackName, fallbackSize);
+          index.upsert(artifactWithSize(fallbackName, fallbackSize));
+        }
+        const operation = random() % 4;
+        operationCounts[operation] += 1;
+        const names = Array.from(files.keys());
+        if (operation === 0) {
+          const name = `file-${random() % 24}.md`;
+          const size = (random() % 4_096) + 1;
+          files.set(name, size);
+          index.upsert(artifactWithSize(name, size));
+        } else if (operation === 1) {
+          const name = names[random() % names.length];
+          files.delete(name);
+          index.remove(`${WORKSPACE_ROOT}/${name}`);
+        } else if (operation === 2) {
+          const previousName = names[random() % names.length];
+          const previousSize = files.get(previousName) ?? 0;
+          let nextIndex = random() % 24;
+          if (`file-${nextIndex}.md` === previousName) nextIndex = (nextIndex + 1) % 24;
+          const nextName = `file-${nextIndex}.md`;
+          files.delete(previousName);
+          files.delete(nextName);
+          files.set(nextName, previousSize);
+          index.rename(
+            `${WORKSPACE_ROOT}/${previousName}`,
+            artifactWithSize(nextName, previousSize),
+          );
+        } else {
+          const name = names[random() % names.length];
+          files.set(name, (random() % 4_096) + 1);
+        }
+
+        if (random() % 13 === 0) {
+          await index.refresh(async () => snapshotFromFileMap(files));
+        }
+      }
+
+      const durableSnapshot = snapshotFromFileMap(files);
+      await index.refresh(async () => durableSnapshot);
+      expect(index.getArtifacts(), `seed ${seed}`).toEqual(
+        artifactsFromFilesystemSnapshot(durableSnapshot),
+      );
+    }
+    expect(operationCounts.every((count) => count > 0)).toBe(true);
+  }, 30_000);
+
   it("preserves the previous artifact-to-turn assignment semantics", () => {
     const artifacts = [
       artifact("report.md"),
@@ -254,11 +339,27 @@ function snapshotFromArtifacts(artifacts: AgentArtifact[]): HermesFilesystemSnap
 }
 
 function artifact(name: string): AgentArtifact {
+  return artifactWithSize(name, name.length);
+}
+
+function artifactWithSize(name: string, size: number): AgentArtifact {
   return {
     name,
     path: `${WORKSPACE_ROOT}/${name}`,
     rootLabel: "Workspace",
-    size: name.length,
+    size,
+  };
+}
+
+function snapshotFromFileMap(files: Map<string, number>) {
+  return snapshot(Array.from(files.keys()), Object.fromEntries(files));
+}
+
+function seededRandom(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    return state;
   };
 }
 

--- a/src/test/agent-artifact-index.test.tsx
+++ b/src/test/agent-artifact-index.test.tsx
@@ -1,0 +1,326 @@
+import { Profiler, useSyncExternalStore } from "react";
+import { act, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentChatTurn } from "../lib/agent-chat-runtime";
+import type { HermesFilesystemSnapshot } from "../lib/tauri";
+import type { AgentArtifact } from "../components/agent/chat-turns/AgentArtifactPanel";
+import {
+  type AgentArtifactIndex,
+  artifactsFromFilesystemSnapshot,
+  createAgentArtifactIndex,
+} from "../components/agent/artifact-index";
+
+const WORKSPACE_ROOT = "/tmp/hermes/workspace";
+
+describe("agent artifact index", () => {
+  it("matches a full scan after add, remove, and rename mutations", () => {
+    const index = createAgentArtifactIndex();
+    index.reconcile(snapshot(["alpha.md", "beta.md"]));
+
+    index.upsert(artifact("gamma.md"));
+    index.remove(`${WORKSPACE_ROOT}/alpha.md`);
+    index.rename(`${WORKSPACE_ROOT}/beta.md`, artifact("renamed.md"));
+
+    const fullScan = snapshot(["renamed.md", "gamma.md"]);
+    expect(index.getArtifacts()).toEqual(artifactsFromFilesystemSnapshot(fullScan));
+
+    index.reconcile(fullScan);
+    expect(index.getArtifacts()).toEqual(artifactsFromFilesystemSnapshot(fullScan));
+  });
+
+  it("picks up external additions, modifications, renames, and removals on reconcile", async () => {
+    const index = createAgentArtifactIndex();
+    let externalSnapshot = snapshot(["report.md"], { "report.md": 10 });
+    const scan = vi.fn(async () => externalSnapshot);
+
+    await index.refresh(scan);
+    externalSnapshot = snapshot(["report.md", "outside.txt"], {
+      "report.md": 42,
+      "outside.txt": 8,
+    });
+    await index.refresh(scan);
+    expect(index.getArtifacts()).toEqual(artifactsFromFilesystemSnapshot(externalSnapshot));
+
+    externalSnapshot = snapshot(["renamed-outside.txt"], { "renamed-outside.txt": 8 });
+    await index.refresh(scan);
+    expect(index.getArtifacts()).toEqual(artifactsFromFilesystemSnapshot(externalSnapshot));
+    expect(scan).toHaveBeenCalledTimes(3);
+  });
+
+  it("coalesces concurrent scans and preserves a write that lands during an older scan", async () => {
+    const index = createAgentArtifactIndex();
+    index.reconcile(snapshot(["existing.md"]));
+    let resolveScan: (value: HermesFilesystemSnapshot) => void = () => {};
+    const scan = vi.fn(
+      () =>
+        new Promise<HermesFilesystemSnapshot>((resolve) => {
+          resolveScan = resolve;
+        }),
+    );
+
+    const firstRefresh = index.refresh(scan);
+    const coalescedRefresh = index.refresh(scan);
+    index.upsert(artifact("created-during-scan.md"));
+    resolveScan(snapshot(["existing.md"]));
+    await Promise.all([firstRefresh, coalescedRefresh]);
+
+    expect(scan).toHaveBeenCalledTimes(1);
+    expect(index.getArtifacts().map((item) => item.name)).toEqual([
+      "existing.md",
+      "created-during-scan.md",
+    ]);
+  });
+
+  it("runs one trailing reconcile when a known write invalidates an in-flight scan", async () => {
+    const index = createAgentArtifactIndex();
+    index.reconcile(snapshot(["existing.md"]));
+    let resolveStaleScan: (value: HermesFilesystemSnapshot) => void = () => {};
+    const scan = vi
+      .fn<() => Promise<HermesFilesystemSnapshot>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStaleScan = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(snapshot(["existing.md"]));
+
+    const staleRefresh = index.refresh(scan);
+    index.upsert(artifact("created-during-scan.md"));
+    const trailingRefresh = index.refresh(scan);
+    resolveStaleScan(snapshot(["existing.md"]));
+    await Promise.all([staleRefresh, trailingRefresh]);
+
+    expect(scan).toHaveBeenCalledTimes(2);
+    expect(index.getArtifacts().map((item) => item.name)).toEqual(["existing.md"]);
+  });
+
+  it("preserves the previous artifact-to-turn assignment semantics", () => {
+    const artifacts = [
+      artifact("report.md"),
+      {
+        ...artifact("report.md"),
+        path: `${WORKSPACE_ROOT}/archive/report.md`,
+      },
+      artifact("diagram.png"),
+      artifact("notes.txt"),
+    ];
+    const turns = [
+      turn("user-1", "user", "Please revise workspace/notes.txt."),
+      turn("assistant-1", "assistant", "Saved report.md and diagram.png."),
+      {
+        ...turn("assistant-2", "assistant", "The report is also in the archive."),
+        parts: [
+          {
+            type: "image" as const,
+            prompt: "diagram",
+            path: `${WORKSPACE_ROOT}/diagram.png`,
+            name: "diagram.png",
+            status: "complete" as const,
+          },
+          { type: "text" as const, text: "The report is also in the archive." },
+        ],
+      },
+    ];
+    const index = createAgentArtifactIndex();
+    index.reconcile(snapshotFromArtifacts(artifacts));
+
+    expect(mapToPaths(index.assignArtifactsToTurns(turns))).toEqual(
+      mapToPaths(legacyAssignArtifactsToTurns(turns, artifacts)),
+    );
+  });
+
+  it.each([
+    1_000, 10_000,
+  ])("indexes %i files across 100 turns without filesystem or render work on the hot path", async (fileCount) => {
+    const index = createAgentArtifactIndex();
+    const sourceSnapshot = snapshot(
+      Array.from({ length: fileCount }, (_, fileIndex) => `artifact-${fileIndex}.md`),
+    );
+    const scan = vi.fn(async () => sourceSnapshot);
+    let renderCommits = 0;
+    const view = render(
+      <Profiler
+        id={`artifact-index-${fileCount}`}
+        onRender={() => {
+          renderCommits += 1;
+        }}
+      >
+        <ArtifactIndexSubscriber index={index} />
+      </Profiler>,
+    );
+    await act(async () => {
+      await index.refresh(scan);
+    });
+    const seededRenderCommits = renderCommits;
+    const snapshotBytes = JSON.stringify(sourceSnapshot).length;
+    const turns = Array.from({ length: 100 }, (_, turnIndex) =>
+      turn(
+        `turn-${turnIndex}`,
+        "assistant",
+        turnIndex === 99 ? `Created artifact-${fileCount - 1}.md.` : `Progress ${turnIndex}.`,
+      ),
+    );
+
+    const legacyStartedAt = performance.now();
+    const legacyAssignments = legacyAssignArtifactsToTurns(
+      turns,
+      artifactsFromFilesystemSnapshot(sourceSnapshot),
+    );
+    const legacyCpuMs = performance.now() - legacyStartedAt;
+    const startedAt = performance.now();
+    const assignments = index.assignArtifactsToTurns(turns);
+    const cpuMs = performance.now() - startedAt;
+    // The previous selected-message-count effect requested and committed one
+    // full snapshot per turn. Model that removed trigger over this fixed
+    // transcript while measuring both assignment implementations directly.
+    const before = {
+      cpuMs: legacyCpuMs,
+      filesystemCalls: turns.length,
+      ipcBytes: snapshotBytes * turns.length,
+      renderCommits: turns.length,
+    };
+    const after = {
+      cpuMs,
+      filesystemCalls: scan.mock.calls.length,
+      ipcBytes: snapshotBytes,
+      renderCommits: renderCommits - seededRenderCommits,
+    };
+    const benchmark = {
+      after,
+      before,
+      fileCount,
+      turnCount: turns.length,
+    };
+    // biome-ignore lint/suspicious/noConsole: benchmark evidence belongs in the test log
+    console.info("[artifact-index benchmark]", benchmark);
+
+    expect(mapToPaths(assignments)).toEqual(mapToPaths(legacyAssignments));
+    expect(assignments.get("turn-99")?.map((item) => item.name)).toEqual([
+      `artifact-${fileCount - 1}.md`,
+    ]);
+    expect(before.filesystemCalls).toBe(100);
+    expect(after.filesystemCalls).toBe(1);
+    expect(after.ipcBytes * 100).toBe(before.ipcBytes);
+    expect(after.renderCommits).toBe(0);
+    expect(Number.isFinite(before.cpuMs)).toBe(true);
+    expect(Number.isFinite(after.cpuMs)).toBe(true);
+    view.unmount();
+  }, 20_000);
+});
+
+function ArtifactIndexSubscriber({ index }: { index: AgentArtifactIndex }) {
+  const version = useSyncExternalStore(index.subscribe, index.getVersion, index.getVersion);
+  return <output>{`${version}:${index.getArtifacts().length}`}</output>;
+}
+
+function snapshot(names: string[], sizes: Record<string, number> = {}): HermesFilesystemSnapshot {
+  return {
+    roots: [
+      {
+        id: "workspace",
+        label: "Workspace",
+        path: WORKSPACE_ROOT,
+        description: "Workspace files.",
+        entries: names.map((name) => ({
+          name,
+          path: `${WORKSPACE_ROOT}/${name}`,
+          kind: "file",
+          size: sizes[name] ?? name.length,
+          modifiedAt: "2026-07-24T00:00:00Z",
+        })),
+      },
+    ],
+  };
+}
+
+function snapshotFromArtifacts(artifacts: AgentArtifact[]): HermesFilesystemSnapshot {
+  return {
+    roots: [
+      {
+        id: "workspace",
+        label: "Workspace",
+        path: WORKSPACE_ROOT,
+        description: "Workspace files.",
+        entries: artifacts.map((item) => ({
+          name: item.name,
+          path: item.path,
+          kind: "file",
+          size: item.size,
+        })),
+      },
+    ],
+  };
+}
+
+function artifact(name: string): AgentArtifact {
+  return {
+    name,
+    path: `${WORKSPACE_ROOT}/${name}`,
+    rootLabel: "Workspace",
+    size: name.length,
+  };
+}
+
+function turn(id: string, role: AgentChatTurn["role"], text: string): AgentChatTurn {
+  return {
+    id,
+    role,
+    createdAt: "2026-07-24T00:00:00Z",
+    status: "complete",
+    parts: [{ type: "text", text }],
+  };
+}
+
+function mapToPaths(assignments: Map<string, AgentArtifact[]>) {
+  return Array.from(assignments, ([turnId, artifacts]) => [
+    turnId,
+    artifacts.map((item) => item.path),
+  ]);
+}
+
+function legacyAssignArtifactsToTurns(
+  turns: AgentChatTurn[],
+  artifacts: AgentArtifact[],
+): Map<string, AgentArtifact[]> {
+  const byTurn = new Map<string, AgentArtifact[]>();
+  const claimedPaths = new Set<string>();
+  const claimedNames = new Set<string>();
+  const mediaPaths = new Set<string>();
+  const mediaNames = new Set<string>();
+  for (const chatTurn of turns) {
+    for (const part of chatTurn.parts) {
+      if (part.type !== "image" && part.type !== "video") continue;
+      if (part.path) mediaPaths.add(part.path);
+      else if (part.name) mediaNames.add(part.name.toLowerCase());
+    }
+  }
+  for (const chatTurn of turns) {
+    const text = chatTurn.parts
+      .map((part) => (part.type === "text" ? part.text : ""))
+      .join("\n")
+      .toLowerCase();
+    if (!text.trim()) continue;
+    const mentioned: AgentArtifact[] = [];
+    for (const item of artifacts) {
+      const name = item.name.toLowerCase();
+      if (!name || claimedPaths.has(item.path)) continue;
+      if (mediaPaths.has(item.path) || mediaNames.has(name)) continue;
+      const pathMentioned =
+        text.includes(item.path.toLowerCase()) ||
+        text.includes(workspaceRelativePath(item.path).toLowerCase());
+      const nameMentioned =
+        chatTurn.role === "assistant" && !claimedNames.has(name) && text.includes(name);
+      if (!pathMentioned && !nameMentioned) continue;
+      claimedPaths.add(item.path);
+      claimedNames.add(name);
+      if (chatTurn.role === "assistant") mentioned.push(item);
+    }
+    if (mentioned.length) byTurn.set(chatTurn.id, mentioned);
+  }
+  return byTurn;
+}
+
+function workspaceRelativePath(path: string) {
+  return path.match(/(?:^|[/\\])workspace[/\\](.+)$/)?.[1] ?? path;
+}

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -49,6 +49,7 @@ import {
   resetHermesIdleSubmitRecoveryForTests,
 } from "../lib/hermes-idle-submit-recovery";
 import { writeAgentSessionContinuity } from "../components/agent/agent-session-continuity";
+import { ARTIFACT_INDEX_RECONCILE_INTERVAL_MS } from "../components/agent/artifact-index";
 
 // The hero greeting cycles per visit, so tests match any entry in the pool.
 const HERO_GREETING = new RegExp(
@@ -11494,6 +11495,51 @@ describe("AgentWorkspace", () => {
       }
     });
     await waitFor(() => expect(mocks.hermesBridgeFilesystemSnapshot).toHaveBeenCalledTimes(1));
+  });
+
+  it("reconciles the artifact index every 15 seconds and clears the interval on unmount", async () => {
+    vi.useFakeTimers();
+    const setInterval = vi.spyOn(window, "setInterval");
+    const clearInterval = vi.spyOn(window, "clearInterval");
+    let view: ReturnType<typeof render> | undefined;
+    try {
+      view = render(<AgentWorkspace initialSession={existingSession} />);
+      await settleUnderFakeTimers(() =>
+        expect(mocks.hermesBridgeFilesystemSnapshot).toHaveBeenCalledTimes(1),
+      );
+      const artifactIntervalIndex = setInterval.mock.calls.findIndex(
+        ([, delay]) => delay === ARTIFACT_INDEX_RECONCILE_INTERVAL_MS,
+      );
+      expect(artifactIntervalIndex).toBeGreaterThanOrEqual(0);
+      const artifactInterval = setInterval.mock.results[artifactIntervalIndex]?.value;
+      mocks.hermesBridgeFilesystemSnapshot.mockClear();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ARTIFACT_INDEX_RECONCILE_INTERVAL_MS - 1);
+      });
+      expect(mocks.hermesBridgeFilesystemSnapshot).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      await settleUnderFakeTimers(() =>
+        expect(mocks.hermesBridgeFilesystemSnapshot).toHaveBeenCalledTimes(1),
+      );
+
+      view.unmount();
+      view = undefined;
+      expect(clearInterval).toHaveBeenCalledWith(artifactInterval);
+      mocks.hermesBridgeFilesystemSnapshot.mockClear();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ARTIFACT_INDEX_RECONCILE_INTERVAL_MS);
+      });
+      expect(mocks.hermesBridgeFilesystemSnapshot).not.toHaveBeenCalled();
+    } finally {
+      view?.unmount();
+      setInterval.mockRestore();
+      clearInterval.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it("renders a workspace file's download card only on the first response that mentions it", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -11449,6 +11449,53 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("keeps ordinary message growth on the artifact index and refreshes after a file write", async () => {
+    const user = userEvent.setup();
+    const workspaceRoot =
+      "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/workspace";
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await waitFor(() => expect(mocks.hermesBridgeFilesystemSnapshot).toHaveBeenCalledTimes(1));
+    mocks.hermesBridgeFilesystemSnapshot.mockClear();
+
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+    await user.type(composer, "Create a report");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "Create a report",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "message.delta",
+          session_id: "runtime-session-1",
+          payload: { delta: "Working on it." },
+        });
+      }
+    });
+    await act(async () => Promise.resolve());
+    expect(mocks.hermesBridgeFilesystemSnapshot).not.toHaveBeenCalled();
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.complete",
+          session_id: "runtime-session-1",
+          payload: {
+            tool_id: "tool-1",
+            tool_name: "write_file",
+            path: `${workspaceRoot}/report.md`,
+          },
+        });
+      }
+    });
+    await waitFor(() => expect(mocks.hermesBridgeFilesystemSnapshot).toHaveBeenCalledTimes(1));
+  });
+
   it("renders a workspace file's download card only on the first response that mentions it", async () => {
     mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
       roots: [

--- a/src/test/session-event-listener.test.ts
+++ b/src/test/session-event-listener.test.ts
@@ -37,6 +37,7 @@ describe("createSessionEventListener activity publications", () => {
       clearSubmittedSteers: vi.fn(),
       continueAfterCompletedAgentRun: vi.fn(),
       liveEventsRef,
+      onArtifactFilesystemChange: vi.fn(),
       pendingSteerBySessionIdRef: { current: {} },
       promotePendingIssueReportToReview: vi.fn(() => true),
       recordHermesActivityAndDeriveStatus: (event) => agentStatusFromHermesEvent(event),


### PR DESCRIPTION
## Summary

- Replace message-count-triggered filesystem snapshots with a workspace-scoped artifact index.
- Seed the index once, update it directly for June-owned imports and generated media, reconcile after file-producing tool events, and run a bounded 15-second external-change reconcile.
- Compile artifact aliases into a multi-pattern matcher so turn presentation no longer compares every turn with every file.
- Preserve the existing artifact set and first-mention rendering semantics.

Refs JUN-430

## Root cause

Artifact discovery was coupled to selected message-count changes. Each ordinary turn or stream update could request a new recursive filesystem snapshot, transfer the whole tree over IPC, commit new React state, and then scan every artifact for every conversation turn. The loader had no coalescing or stale-snapshot guard.

## Validation

- `CI=true pnpm check`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` - 3,534 passed, 2 skipped
- `make verify` - frontend, desktop Rust fmt/clippy/tests, and June API fmt/clippy/tests passed
- `make local-ci` on `3a6ec0a3690de56bbb36e03cc08abd50fe26deea` - `signoff/frontend` and `signoff/rust-macos` passed
- Index regressions cover add/remove/rename parity with a full scan, a 1,500-seed property test with durable reconciliation, external add/modify/rename/remove reconciliation, concurrent refresh coalescing, writes during stale snapshots, the scan-cleanup microtask handoff, and exact legacy turn-assignment semantics.
- Workspace coverage verifies the active-session 15-second reconcile fires on schedule and clears its interval on unmount.

| Files | Path | Filesystem calls | IPC bytes | Frontend CPU | Render commits |
| --- | --- | ---: | ---: | ---: | ---: |
| 1,000 | Before | 100 | 13,390,600 | 19.51 ms | 100 |
| 1,000 | Indexed | 1 | 133,906 | 0.22 ms | 0 |
| 10,000 | Before | 100 | 135,790,600 | 156.75 ms | 100 |
| 10,000 | Indexed | 1 | 1,357,906 | 0.10 ms | 0 |

- [x] Tested visually where it matters - not applicable; this changes artifact discovery internals without changing UI behavior or copy.
- [ ] Needs a June API (backend) deploy before it works end to end - no backend deploy is needed.

## Out of scope

- No artifact types, scan roots, first-mention rules, or download-card behavior changed.
- No native filesystem watcher was added; bounded reconciliation covers external changes while known June writes update the index synchronously.
- No June API changes.

## Followups

- Review round after this draft; do not merge or mark ready yet.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary - none.
- [x] Workflow action references are pinned to full-length commit SHAs - no workflow changes.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review - no such changes.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review - no backend changes.
- [x] User-facing copy follows the repo UI conventions - no user-facing copy changed.
