### PR TITLE
test(db): guard divergent physical column order

### DIFF
--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -206,8 +206,8 @@ const FOLDER_LOCAL_PATH_COLUMN: &[ColumnDefinition] = &[ColumnDefinition {
 // databases; folders.profile precedes local_path when fresh but follows it when
 // upgraded. All access must name columns explicitly; never rely on cid order,
 // positional decoding, or SELECT *. The integration guard in
-// tests/sql_query_guards.rs enforces the unqualified star-select rule for both
-// affected tables.
+// tests/sql_query_guards.rs enforces the projection star-select rule for both
+// affected tables, including qualified stars.
 const MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -205,7 +205,9 @@ const FOLDER_LOCAL_PATH_COLUMN: &[ColumnDefinition] = &[ColumnDefinition {
 // transcripts.source_mode is cid 14 on fresh databases but cid 17 on upgraded
 // databases; folders.profile precedes local_path when fresh but follows it when
 // upgraded. All access must name columns explicitly; never rely on cid order,
-// positional decoding, or SELECT *.
+// positional decoding, or SELECT *. The integration guard in
+// tests/sql_query_guards.rs enforces the unqualified star-select rule for both
+// affected tables.
 const MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,

--- a/src-tauri/tests/sql_query_guards.rs
+++ b/src-tauri/tests/sql_query_guards.rs
@@ -6,7 +6,7 @@ use std::{
 const COLUMN_ORDER_DIVERGENT_TABLES: &[&str] = &["transcripts", "folders"];
 
 #[test]
-fn column_order_divergent_tables_never_use_unqualified_star_selects() {
+fn column_order_divergent_tables_never_use_projection_star_selects() {
     let source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     let mut source_files = Vec::new();
     collect_source_files(&source_root, &mut source_files);
@@ -18,9 +18,9 @@ fn column_order_divergent_tables_never_use_unqualified_star_selects() {
             .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
         let tokens = sql_tokens(&source);
         for table in COLUMN_ORDER_DIVERGENT_TABLES {
-            if has_unqualified_star_select(&tokens, table) {
+            if has_projection_star_select_from_table(&tokens, table) {
                 let relative_path = path.strip_prefix(&source_root).unwrap_or(&path).display();
-                violations.push(format!("{relative_path}: SELECT * FROM {table}"));
+                violations.push(format!("{relative_path}: projection star from {table}"));
             }
         }
     }
@@ -34,12 +34,31 @@ fn column_order_divergent_tables_never_use_unqualified_star_selects() {
 }
 
 #[test]
-fn star_select_guard_is_case_and_whitespace_insensitive() {
-    let tokens = sql_tokens("SeLeCt\n  *\tFROM\ntranscripts");
-    assert!(has_unqualified_star_select(&tokens, "transcripts"));
+fn star_select_guard_detects_projection_star_shapes() {
+    for (query, table) in [
+        ("SeLeCt\n  *\tFROM\ntranscripts", "transcripts"),
+        ("SELECT t.* FROM transcripts t", "transcripts"),
+        ("SELECT transcripts.* FROM transcripts", "transcripts"),
+        ("SELECT *, extra FROM folders", "folders"),
+    ] {
+        let tokens = sql_tokens(query);
+        assert!(
+            has_projection_star_select_from_table(&tokens, table),
+            "star projection should be rejected: {query}"
+        );
+    }
 
     let tokens = sql_tokens("SELECT id, text FROM transcripts");
-    assert!(!has_unqualified_star_select(&tokens, "transcripts"));
+    assert!(!has_projection_star_select_from_table(
+        &tokens,
+        "transcripts"
+    ));
+
+    let tokens = sql_tokens("SELECT COUNT(*) AS count FROM transcripts");
+    assert!(!has_projection_star_select_from_table(
+        &tokens,
+        "transcripts"
+    ));
 }
 
 fn collect_source_files(directory: &Path, files: &mut Vec<PathBuf>) {
@@ -71,8 +90,8 @@ fn sql_tokens(source: &str) -> Vec<String> {
         if !word.is_empty() {
             tokens.push(std::mem::take(&mut word));
         }
-        if character == '*' {
-            tokens.push("*".to_string());
+        if matches!(character, '*' | '(' | ')' | '.' | ';') {
+            tokens.push(character.to_string());
         }
     }
     if !word.is_empty() {
@@ -81,8 +100,40 @@ fn sql_tokens(source: &str) -> Vec<String> {
     tokens
 }
 
-fn has_unqualified_star_select(tokens: &[String], table: &str) -> bool {
-    tokens.windows(4).any(|window| {
-        window[0] == "select" && window[1] == "*" && window[2] == "from" && window[3] == table
-    })
+fn has_projection_star_select_from_table(tokens: &[String], table: &str) -> bool {
+    for select_index in tokens
+        .iter()
+        .enumerate()
+        .filter_map(|(index, token)| (token == "select").then_some(index))
+    {
+        let mut parenthesis_depth = 0_u32;
+        let mut has_projection_star = false;
+        for (index, token) in tokens.iter().enumerate().skip(select_index + 1) {
+            match token.as_str() {
+                "(" => parenthesis_depth += 1,
+                ")" if parenthesis_depth == 0 => break,
+                ")" => parenthesis_depth -= 1,
+                "*" if parenthesis_depth == 0 => has_projection_star = true,
+                "from" if parenthesis_depth == 0 => {
+                    if has_projection_star && from_targets_table(tokens, index, table) {
+                        return true;
+                    }
+                    break;
+                }
+                "select" | ";" if parenthesis_depth == 0 => break,
+                _ => {}
+            }
+        }
+    }
+    false
+}
+
+fn from_targets_table(tokens: &[String], from_index: usize, table: &str) -> bool {
+    tokens
+        .get(from_index + 1)
+        .is_some_and(|token| token == table)
+        || (tokens.get(from_index + 2).is_some_and(|token| token == ".")
+            && tokens
+                .get(from_index + 3)
+                .is_some_and(|token| token == table))
 }

--- a/src-tauri/tests/sql_query_guards.rs
+++ b/src-tauri/tests/sql_query_guards.rs
@@ -1,0 +1,88 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+const COLUMN_ORDER_DIVERGENT_TABLES: &[&str] = &["transcripts", "folders"];
+
+#[test]
+fn column_order_divergent_tables_never_use_unqualified_star_selects() {
+    let source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut source_files = Vec::new();
+    collect_source_files(&source_root, &mut source_files);
+    source_files.sort();
+
+    let mut violations = Vec::new();
+    for path in source_files {
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+        let tokens = sql_tokens(&source);
+        for table in COLUMN_ORDER_DIVERGENT_TABLES {
+            if has_unqualified_star_select(&tokens, table) {
+                let relative_path = path.strip_prefix(&source_root).unwrap_or(&path).display();
+                violations.push(format!("{relative_path}: SELECT * FROM {table}"));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "fresh and upgraded databases have different physical column order; \
+         name every selected column for transcripts and folders:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn star_select_guard_is_case_and_whitespace_insensitive() {
+    let tokens = sql_tokens("SeLeCt\n  *\tFROM\ntranscripts");
+    assert!(has_unqualified_star_select(&tokens, "transcripts"));
+
+    let tokens = sql_tokens("SELECT id, text FROM transcripts");
+    assert!(!has_unqualified_star_select(&tokens, "transcripts"));
+}
+
+fn collect_source_files(directory: &Path, files: &mut Vec<PathBuf>) {
+    let entries = fs::read_dir(directory)
+        .unwrap_or_else(|error| panic!("read source directory {}: {error}", directory.display()));
+    for entry in entries {
+        let entry = entry.unwrap_or_else(|error| panic!("read source directory entry: {error}"));
+        let path = entry.path();
+        if path.is_dir() {
+            collect_source_files(&path, files);
+        } else if matches!(
+            path.extension().and_then(|extension| extension.to_str()),
+            Some("rs" | "py")
+        ) {
+            files.push(path);
+        }
+    }
+}
+
+fn sql_tokens(source: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut word = String::new();
+    for character in source.chars() {
+        if character.is_ascii_alphanumeric() || character == '_' {
+            word.push(character.to_ascii_lowercase());
+            continue;
+        }
+
+        if !word.is_empty() {
+            tokens.push(std::mem::take(&mut word));
+        }
+        if character == '*' {
+            tokens.push("*".to_string());
+        }
+    }
+    if !word.is_empty() {
+        tokens.push(word);
+    }
+    tokens
+}
+
+fn has_unqualified_star_select(tokens: &[String], table: &str) -> bool {
+    tokens.windows(4).any(|window| {
+        window[0] == "select" && window[1] == "*" && window[2] == "from" && window[3] == table
+    })
+}


### PR DESCRIPTION
## Summary

- Add a dependency-free Rust integration test that rejects bare, qualified, and comma-followed projection stars from `transcripts` and `folders` across Rust source files.
- Ignore stars nested in expressions such as `COUNT(*)`, so aggregate queries and by-name column access remain unaffected.
- Link the existing migration warning to the guard so the physical-order divergence and column-name-only rule remain discoverable together.
- Verify PR #940's existing `source_mode` cid and `folders.profile` / `local_path` ordering comments against the old replay runner and current migration catalog.

## Root cause

The versioned migration catalog applies fresh-database columns in release order, while upgraded databases retain the old replay runner's physical `ensure_columns` order. Current queries enumerate columns and decode by name, so behavior is correct today, but the initial guard only recognized the four-token `SELECT * FROM <table>` shape. Qualified projections such as `SELECT t.* FROM transcripts t` and comma-followed projections such as `SELECT *, extra FROM folders` could still expose the divergent physical layouts.

## Validation

- Regression-first: the qualified-star case failed before the matcher fix and passes afterward.
- `cargo test --locked --test sql_query_guards`
- `make tauri-fmt-check tauri-lint tauri-test`
- `make local-ci` on `32d0b4a309dd07cbc02e1da74bea6a010c40d3e9`
  - `signoff/frontend`: success (not applicable)
  - `signoff/rust-macos`: success

- [x] Tested visually where it matters. Not applicable: this is a source guard and migration comment with no UI or runtime behavior.
- [ ] Needs a June API (backend) deploy before it works end to end. No June API deploy is required.

## Out of scope

- Rebuilding either table to normalize physical column order.
- Generalized static analysis for positional row access beyond the documented column-name-only rule.

## Followups

- None.

Refs JUN-435

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. Not applicable: no security-sensitive behavior changed.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow changes.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787447872&installation_model_id=425925&pr_number=952&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F952&signature=a1d836c6b414ecd9b5583e1e35c28b6b972f2ba1831aa06db78940c189035049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->