### PR TITLE
Consolidate Hermes run submission across chat surfaces

### DIFF
--- a/docs/hermes-architecture.md
+++ b/docs/hermes-architecture.md
@@ -41,10 +41,19 @@ classified events into `AgentChatTurn` / `AgentChatPart[]` for rendering.
 
 ## Submit flow
 
-1. Composer text → `AgentWorkspace.submit`.
+1. Agent Workspace or Note Chat captures the surface-specific prompt,
+   Send-time model target, attachments, and optimistic presentation state.
 2. `ensureHermesGateway(unrestricted?)` picks/creates a `HermesGatewayClient`
-   from `gatewaysRef` — **one gateway per write-mode**.
-3. `gateway.request("session.create")` returns **both** a `stored_session_id`
+   from `gatewaysRef` - **one gateway per write-mode**.
+3. Both surfaces call `submitHermesRun`
+   (`src/lib/hermes-run-submission.ts`). The shared module owns the ordered run
+   protocol: idle-safe Gateway preflight, create/resume resolution, explicit
+   profile assignment, the stored-session FIFO, thinking/model application,
+   attachments, optional attended-run lease begin, one `prompt.submit`, and
+   the monitoring handoff. Surface adapters supply their legitimate
+   differences; Note Chat stays sandboxed and does not open a Computer use run
+   lease.
+4. `gateway.request("session.create")` returns **both** a `stored_session_id`
    (June's persistent id) and a `session_id` (the live runtime id);
    `ensureHermesBridgeSession` persists the mapping. An explicit request to use
    Computer use also carries `enabled_toolsets: ["june_computer_use"]`.
@@ -60,16 +69,16 @@ classified events into `AgentChatTurn` / `AgentChatPart[]` for rendering.
    sessions until a slash command is actually dispatched. Named profiles retain
    their independent tool policy and do not accept the default profile's narrow
    scope.
-4. If the session has a queued model choice, June applies it to the idle live
+5. If the session has a queued model choice, June applies it to the idle live
    session with `config.set` before submitting anything. A failed switch blocks
    the send and leaves the choice queued.
-5. Images are attached by asking Rust to validate and snapshot the source into
+6. Images are attached by asking Rust to validate and snapshot the source into
    a session-scoped workspace directory, then passing that local path through
    `image.attach`. Image bytes never cross the JS bridge or Hermes WebSocket on
    this path. `image.attach_bytes` remains an additive fallback for callers
    without a gateway-local path; neither path stores bytes in state, traces, or
    artifacts.
-6. `gateway.request("prompt.submit")` (ack-style) → live `event` frames →
+7. `gateway.request("prompt.submit")` (ack-style) → live `event` frames →
    `classifyHermesEvent` → `agent-chat-runtime` builds turns → React renders.
 
 ## Key concepts

--- a/src/components/agent/session-submission.ts
+++ b/src/components/agent/session-submission.ts
@@ -704,8 +704,7 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
         },
       });
 
-      // The shared module returns normally after acknowledgement even if a
-      // local monitoring/session refresh hook failed afterwards.
+      // Ignore postAcknowledgementError only because loadHermesSessions swallows wire errors and every other post-ack op is non-throwing; surface it like Note Chat if that changes.
       return options?.skipPrompt ? runResult.storedSessionId : undefined;
     } catch (err) {
       clearQueuedIssueReport();

--- a/src/components/agent/session-submission.ts
+++ b/src/components/agent/session-submission.ts
@@ -12,11 +12,9 @@ import { toolsetsForComputerUseAgentRun } from "../../lib/computer-use-agent-run
 import { messageFromError } from "../../lib/errors";
 import { titleFromPrompt } from "../../lib/hermes-adapter";
 import { hasHermesActiveSessionSnapshotSubscribers } from "../../lib/hermes-active-session-snapshots";
-import { createHermesMethods, hermesModeFor } from "../../lib/hermes-control-plane";
 import { isSessionBusyError } from "../../lib/hermes-gateway";
-import { createHermesIdleSubmitGateway } from "../../lib/hermes-idle-submit-recovery";
 import { pendingImageAttachments } from "../../lib/hermes-image-attach";
-import { applySessionModelWhenIdle } from "../../lib/hermes-next-prompt-model";
+import { submitHermesRun } from "../../lib/hermes-run-submission";
 import {
   type HermesSessionDispatchReservation,
   reserveHermesSessionDispatch,
@@ -41,7 +39,6 @@ import {
 import { rememberSessionThinkingLevel, thinkingEffortForLevel } from "../../lib/thinking-level";
 import { AUTO_MODEL_ID } from "../settings/ModelPickerDialog";
 import type { PendingIssueReport } from "./agent-session-continuity";
-import type { HermesRuntimeSessionResponse } from "./agent-session-continuity";
 import type { AgentAttachment } from "./agent-workspace-models";
 import { unsupportedImageInputPrompt } from "./composer/composer-input-helpers";
 import {
@@ -284,6 +281,26 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
             ...(targetSessionModelId ? { model: targetSessionModelId } : {}),
           });
     let storedSessionIdForRollback: string | undefined;
+    let pendingUserMessage: HermesSessionMessage | undefined;
+    let promptStageStarted = false;
+    let preparedProjectContextSignature: string | null | undefined;
+    let scopedAgentRunToolsets = agentRunToolsets;
+    let createdSessionModelId: string | undefined;
+    const sessionDisplayTitle = fallbackSessionTitle;
+    const queuedIssueReport = options?.issueReport;
+    if (queuedIssueReport && targetStoredSessionId) {
+      queuedIssueReport.diagnosisStartedAt = new Date().toISOString();
+    }
+    const clearQueuedIssueReport = () => {
+      const storedSessionId = storedSessionIdForRollback;
+      if (
+        storedSessionId &&
+        queuedIssueReport &&
+        pendingIssueReportsRef.current.get(storedSessionId) === queuedIssueReport
+      ) {
+        pendingIssueReportsRef.current.delete(storedSessionId);
+      }
+    };
     const rollbackOptimisticBeforePrompt = (err: unknown): never => {
       dispatchReservation?.cancel();
       if (optimisticSession) {
@@ -296,493 +313,440 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
     // the mode its session was created with. Without this, one Unrestricted
     // session would leave the runtime unsandboxed under every other
     // session's follow-ups.
-    const { created, createdUnderProfile, submitGateway, sessionTitle, storedSessionId } =
-      await (async () => {
-        const [nextGateway] = await Promise.all([
-          ensureHermesGateway(submitFullMode),
-          // Re-read the sticky active profile for every brand-new session so an
-          // out-of-band switch (Hermes CLI, upstream dashboard) is honored
-          // without a workspace remount. Runs in parallel with gateway setup
-          // (no added wall-clock) and never throws; the store keeps the
-          // last-known value on failure. Both runtimes share one Hermes home,
-          // so the value is mode-independent.
-          targetStoredSessionId
-            ? Promise.resolve()
-            : refreshActiveHermesProfile({
-                mode: fullModeDraftRef.current ? "unrestricted" : "sandboxed",
-              }),
-        ]);
-        const nextUnderProfileName = targetStoredSessionId
-          ? undefined
-          : getActiveHermesProfileName();
-        const underProfile =
-          nextUnderProfileName !== undefined && nextUnderProfileName !== "default";
-        const submitGateway = createHermesIdleSubmitGateway({
-          fullMode: submitFullMode,
-          gateway: nextGateway,
-          shouldProbeFirstRequest: () => !hasHermesActiveSessionSnapshotSubscribers(submitFullMode),
-          reconnect: () => ensureHermesGateway(submitFullMode),
-        });
-        const nextCreated = targetStoredSessionId
-          ? undefined
-          : await createHermesMethods(submitGateway).createSession<HermesRuntimeSessionResponse>({
-              title: fallbackSessionTitle,
-              cols: 96,
-              // session.create treats `model` as a per-session override.
-              // Under a named profile the override would silently bypass the
-              // profile's own configured text model - the point of profiles -
-              // so it is omitted and the profile's model applies. The
-              // thinking level's reasoning_effort follows the same rule.
-              ...(targetSessionModelId && !underProfile ? { model: targetSessionModelId } : {}),
-              ...(!underProfile
-                ? { reasoningEffort: thinkingEffortForLevel(thinkingLevelRef.current) }
-                : {}),
-              ...(underProfile ? { profile: nextUnderProfileName } : {}),
-              ...(agentRunToolsets && !underProfile ? { enabledToolsets: agentRunToolsets } : {}),
-            });
-        const nextStoredSessionId =
-          targetStoredSessionId ?? nextCreated?.stored_session_id ?? nextCreated?.session_id;
-        if (!nextStoredSessionId) {
-          throw new Error("Hermes did not create a session.");
-        }
-        return {
-          created: nextCreated,
-          createdUnderProfile: underProfile ? nextUnderProfileName : undefined,
-          submitGateway,
-          sessionTitle: fallbackSessionTitle,
-          storedSessionId: nextStoredSessionId,
-        };
-      })().catch(rollbackOptimisticBeforePrompt);
-    storedSessionIdForRollback = storedSessionId;
-    if (created) {
-      clearBackgroundSessionTitleGuard(storedSessionId);
-    }
-    if (createdUnderProfile) {
-      await assignSessionToProfile(storedSessionId, createdUnderProfile).catch(
-        rollbackOptimisticBeforePrompt,
-      );
-      profileOwnedSessionIdsRef.current.add(storedSessionId);
-    }
-    const scopedAgentRunToolsets =
-      createdUnderProfile || profileOwnedSessionIdsRef.current.has(storedSessionId)
-        ? null
-        : agentRunToolsets;
-    const createdSessionModelId = createdUnderProfile ? undefined : targetSessionModelId;
-    const activeDispatchReservation =
-      dispatchReservation ?? reserveHermesSessionDispatch(storedSessionId);
-    dispatchReservation = activeDispatchReservation;
-    // Once session.create returns, this Send's captured target is no longer a
-    // provisional "new session". If a later attach or prompt step fails after
-    // the user has started another draft, recovery can now retain the original
-    // message as an Up next item on the durable session.
-    if (!modelTarget.targetStoredSessionId) {
-      modelTarget.targetStoredSessionId = storedSessionId;
-    }
-    if (created && !createdUnderProfile) {
-      // Record the new session's level as its own (persisted, so a relaunch
-      // still shows this chat at its level), and mark its runtime as already
-      // at it: the create pinned this effort, so the re-assert path must not
-      // fire a redundant config.set on the session's first turns. Skipped
-      // under a named profile, where the profile's own config applies.
-      const createdLevel = thinkingLevelRef.current;
-      sessionThinkingEffortsRef.current = {
-        ...sessionThinkingEfforts(),
-        [storedSessionId]: createdLevel,
-      };
-      rememberSessionThinkingLevel(storedSessionId, createdLevel);
-      sessionThinkingAppliedRef.current = {
-        ...sessionThinkingAppliedRef.current,
-        [storedSessionId]: {
-          runtimeId: created.session_id ?? "",
-          effort: thinkingEffortForLevel(createdLevel),
-        },
-      };
-    }
-    const queuedIssueReport = options?.issueReport;
-    if (queuedIssueReport && targetStoredSessionId) {
-      queuedIssueReport.diagnosisStartedAt = new Date().toISOString();
-    }
-    const clearQueuedIssueReport = () => {
-      if (
-        queuedIssueReport &&
-        pendingIssueReportsRef.current.get(storedSessionId) === queuedIssueReport
-      ) {
-        pendingIssueReportsRef.current.delete(storedSessionId);
-      }
-    };
-    if (options?.issueReport) {
-      pendingIssueReportsRef.current.set(storedSessionId, options.issueReport);
-    }
-    if (!targetStoredSessionId) {
-      rememberSessionMode(storedSessionId, fullModeDraftRef.current);
-    }
-    const sessionDisplayTitle = sessionTitle;
-    const ensureStoredHermesSession = () =>
-      ensureHermesBridgeSession({
-        sessionId: storedSessionId,
-        ...(!targetStoredSessionId ? { title: sessionDisplayTitle } : {}),
-        ...(createdSessionModelId ? { model: createdSessionModelId } : {}),
-      });
-    if (optimisticSession) {
-      await ensureStoredHermesSession().catch(rollbackOptimisticBeforePrompt);
-      migrateOptimisticHermesSession({
-        clearModel: Boolean(createdUnderProfile),
-        createdAt: optimisticSession.createdAt,
-        displayContent,
-        fromSessionId: optimisticSession.id,
-        ...(createdSessionModelId ? { model: createdSessionModelId } : {}),
-        title: sessionDisplayTitle,
-        toSessionId: storedSessionId,
-      });
-    }
-    if (initialTitleSuggestionPromise) {
-      void applyInitialSessionTitleSuggestion(storedSessionId, initialTitleSuggestionPromise);
-    }
-    if (!targetStoredSessionId && !options?.skipPrompt && !createdUnderProfile) {
-      const latestDefaultSelection: SessionModelSelection = {
-        modelId: defaultGenerationModelIdRef.current,
-        ...(defaultGenerationModelIdRef.current === AUTO_MODEL_ID &&
-        generationCostQualityRef.current !== undefined
-          ? { costQuality: generationCostQualityRef.current }
-          : {}),
-      };
-      const defaultChangedAfterSend =
-        modelTarget.globalIntentRevision !== generationSelectionIntentRevisionRef.current &&
-        latestDefaultSelection.modelId &&
-        !sameSessionModelSelection(latestDefaultSelection, targetSessionModelSelection);
-      if (defaultChangedAfterSend && !sessionModelSelectionsRef.current[storedSessionId]) {
-        commitSessionModelSelections(
-          stageSessionModelSelection(storedSessionId, latestDefaultSelection),
-        );
-      }
-      // session.create already fixed the live route to the Send-time snapshot.
-      // Preserve any newer staged picker choice while recording that actual
-      // live route separately.
-      commitSessionModelSelections(
-        rememberAppliedSessionModelSelection(storedSessionId, targetSessionModelSelection),
-      );
-    }
-    if (!optimisticSession) {
-      await withTimeout(ensureStoredHermesSession(), 2500).catch(() => undefined);
-    }
-    let runtimeSessionId: string | undefined;
+    const [gateway] = await Promise.all([
+      ensureHermesGateway(submitFullMode),
+      // Re-read the sticky active profile for every brand-new session so an
+      // out-of-band switch is honored without a workspace remount. Both
+      // runtimes share one Hermes home, so the value is mode-independent.
+      targetStoredSessionId
+        ? Promise.resolve()
+        : refreshActiveHermesProfile({
+            mode: submitFullMode ? "unrestricted" : "sandboxed",
+          }),
+    ]).catch(rollbackOptimisticBeforePrompt);
+    const nextUnderProfileName = targetStoredSessionId ? undefined : getActiveHermesProfileName();
+    const underProfile = nextUnderProfileName !== undefined && nextUnderProfileName !== "default";
+
     try {
-      runtimeSessionId =
-        created?.session_id ??
-        runtimeSessionIdsRef.current[storedSessionId] ??
-        (
-          await submitGateway.request<HermesRuntimeSessionResponse>("session.resume", {
-            session_id: storedSessionId,
-            cols: 96,
-          })
-        ).session_id;
-    } catch (err) {
-      activeDispatchReservation.cancel();
-      clearQueuedIssueReport();
-      if (optimisticSession) {
-        removeOptimisticHermesSession(optimisticSession.id, storedSessionIdForRollback);
-      }
-      throw err;
-    }
-    if (!runtimeSessionId) {
-      clearQueuedIssueReport();
-      rollbackOptimisticBeforePrompt(new Error("Hermes did not resume the session."));
-    }
-    // A thinking level picked while this session's runtime was down (or a
-    // live retune that failed) re-asserts here, before the prompt, so the
-    // turn runs at the level the control shows. No-op when the current
-    // runtime is already known to be at it (see applyThinkingLevelToSession).
-    const thinkingSessionLevel = sessionThinkingEfforts()[storedSessionId];
-    if (thinkingSessionLevel) {
-      await applyThinkingLevelToSession(
-        storedSessionId,
-        thinkingSessionLevel,
-        runtimeSessionId,
-        submitGateway,
-      );
-    }
-    const dispatchPreparedSession = async (): Promise<string | undefined> => {
-      // Re-read after acquiring the cross-surface lock. NoteChat may have sent
-      // this same stored session and changed its live model after this Send was
-      // captured; if so, restore the captured route before accepting the prompt.
-      const currentModelEntry = readSessionModelSelections()[storedSessionId];
-      const currentStoredModelId = currentModelEntry?.appliedSelection
-        ? hermesModelIdForSelection(currentModelEntry.appliedSelection)
-        : undefined;
-      const mustApplyCapturedModel =
-        !options?.skipPrompt &&
-        (shouldApplySessionModel ||
-          activeDispatchReservation.queuedBehindPrior ||
-          (Boolean(targetStoredSessionId) &&
-            currentStoredModelId !== undefined &&
-            currentStoredModelId !== targetSessionModelId));
-      if (mustApplyCapturedModel) {
-        try {
-          await applySessionModelWhenIdle(() =>
-            createHermesMethods(submitGateway).switchActiveSessionModel({
-              mode: hermesModeFor(storedSessionId),
-              sessionId: runtimeSessionId,
-              model: targetSessionModelId,
-            }),
-          );
-        } catch (err) {
-          clearQueuedIssueReport();
-          rollbackOptimisticBeforePrompt(err);
-        }
-        if (targetSessionModelRevision !== undefined) {
-          commitSessionModelSelections(
-            markSessionModelSelectionApplied(
-              storedSessionId,
-              targetSessionModelRevision,
-              targetSessionModelSelection,
-            ),
-          );
-        } else {
-          commitSessionModelSelections(
-            rememberAppliedSessionModelSelection(storedSessionId, targetSessionModelSelection),
-          );
-        }
-        const applyModel = (sessions: HermesSessionInfo[]) =>
-          sessions.map((session) =>
-            session.id === storedSessionId ? { ...session, model: targetSessionModelId } : session,
-          );
-        hermesSessionItemsRef.current = applyModel(hermesSessionItemsRef.current);
-        setHermesSessionItems((current) => applyModel(current));
-      }
-      if (!imageInputFallbackContent) {
-        // Feature 19: send any imported images to the session through the
-        // structured image attach flow before the prompt, so the model/tools see
-        // them as first-class inputs (not just a path mentioned in prose) and an
-        // image-edit prompt names a concrete source. A failed attach throws here,
-        // which the submit() catch turns into a restored composer the user can
-        // retry — the prompt is NOT sent with a silently-missing image.
-        try {
-          const updatedAttachments = await attachPendingImages(
-            submitGateway,
-            runtimeSessionId,
-            storedSessionId,
-            agentRunAttachments,
-          );
-          options?.onAttachmentsUpdated?.(updatedAttachments);
-        } catch (err) {
-          clearQueuedIssueReport();
-          rollbackOptimisticBeforePrompt(err);
-        }
-      }
-      const createdAt = optimisticSession?.createdAt ?? new Date().toISOString();
-      setRuntimeSessionIds((current) => ({
-        ...current,
-        [storedSessionId]: runtimeSessionId,
-      }));
-      if (!optimisticSession) {
-        if (!targetStoredSessionId && options?.skipPrompt) {
-          // Media commands do not have a provisional stored session id to receive a
-          // picker change while session.create/ensure/resume is in flight. Keep
-          // the Send-time model on the media agent run, then take one final snapshot
-          // of the new-session default immediately before the stored session
-          // becomes active. From that point onward the picker stages changes
-          // directly against the stored id.
-          const latestDefaultSelection: SessionModelSelection = {
-            modelId: defaultGenerationModelIdRef.current,
-            ...(defaultGenerationModelIdRef.current === AUTO_MODEL_ID &&
-            generationCostQualityRef.current !== undefined
-              ? { costQuality: generationCostQualityRef.current }
-              : {}),
-          };
-          const defaultChangedAfterSend =
-            modelTarget.globalIntentRevision !== generationSelectionIntentRevisionRef.current &&
-            latestDefaultSelection.modelId &&
-            !sameSessionModelSelection(latestDefaultSelection, targetSessionModelSelection);
-          if (defaultChangedAfterSend) {
-            commitSessionModelSelections(
-              stageSessionModelSelection(storedSessionId, latestDefaultSelection),
-            );
-          }
-          commitSessionModelSelections(
-            rememberAppliedSessionModelSelection(storedSessionId, targetSessionModelSelection),
-          );
-        }
-        if (options?.selectSession !== false) {
-          newSessionModeRef.current = false;
-          setNewSessionMode(false);
-          selectedHermesSessionIdRef.current = storedSessionId;
-          setSelectedHermesSessionId(storedSessionId);
-          setSelectedTaskId(undefined);
-        }
-        const optimisticSessionItem: HermesSessionInfo = {
-          id: storedSessionId,
-          title: sessionDisplayTitle,
-          preview: displayContent,
-          started_at: createdAt,
-          last_active: createdAt,
-          message_count: 1,
-          ...(createdSessionModelId ? { model: createdSessionModelId } : {}),
-        };
-        setHermesSessionItems((current) => {
-          const existingSession = current.find((session) => session.id === storedSessionId);
-          if (existingSession) {
-            const mergedSession: HermesSessionInfo = targetStoredSessionId
-              ? {
-                  ...existingSession,
-                  title: existingSession.title?.trim()
-                    ? existingSession.title
-                    : sessionDisplayTitle,
-                  preview: displayContent,
-                  last_active: createdAt,
-                  message_count:
-                    typeof existingSession.message_count === "number"
-                      ? existingSession.message_count + 1
-                      : optimisticSessionItem.message_count,
-                  ...(targetSessionModelId && !existingSession.model?.trim()
-                    ? { model: targetSessionModelId }
+      const runResult = await submitHermesRun<string>({
+        fullMode: submitFullMode,
+        gateway,
+        reconnectGateway: () => ensureHermesGateway(submitFullMode),
+        shouldProbeFirstRequest: () => !hasHermesActiveSessionSnapshotSubscribers(submitFullMode),
+        storedSessionId: targetStoredSessionId,
+        runtimeSessionId: targetStoredSessionId
+          ? runtimeSessionIdsRef.current[targetStoredSessionId]
+          : undefined,
+        dispatchReservation,
+        ...(!targetStoredSessionId
+          ? {
+              createSession: () => ({
+                params: {
+                  title: sessionDisplayTitle,
+                  cols: 96,
+                  // A named profile owns its text model and reasoning effort.
+                  ...(targetSessionModelId && !underProfile ? { model: targetSessionModelId } : {}),
+                  ...(!underProfile
+                    ? { reasoningEffort: thinkingEffortForLevel(thinkingLevelRef.current) }
                     : {}),
-                }
-              : { ...existingSession, ...optimisticSessionItem };
-            return current.map((session) =>
-              session.id === storedSessionId ? mergedSession : session,
+                  ...(underProfile && nextUnderProfileName
+                    ? { profile: nextUnderProfileName }
+                    : {}),
+                  ...(agentRunToolsets && !underProfile
+                    ? { enabledToolsets: agentRunToolsets }
+                    : {}),
+                },
+                ...(underProfile && nextUnderProfileName
+                  ? {
+                      profileAssignment: {
+                        profile: nextUnderProfileName,
+                        assign: assignSessionToProfile,
+                      },
+                    }
+                  : {}),
+              }),
+            }
+          : {}),
+        onSessionCreated: ({ dispatchReservation: activeReservation, storedSessionId }) => {
+          storedSessionIdForRollback = storedSessionId;
+          dispatchReservation = activeReservation;
+          clearBackgroundSessionTitleGuard(storedSessionId);
+        },
+        onSessionResolved: async ({
+          created,
+          createdUnderProfile,
+          dispatchReservation: activeReservation,
+          storedSessionId,
+        }) => {
+          storedSessionIdForRollback = storedSessionId;
+          dispatchReservation = activeReservation;
+          if (createdUnderProfile) {
+            profileOwnedSessionIdsRef.current.add(storedSessionId);
+          }
+          scopedAgentRunToolsets =
+            createdUnderProfile || profileOwnedSessionIdsRef.current.has(storedSessionId)
+              ? null
+              : agentRunToolsets;
+          createdSessionModelId = createdUnderProfile ? undefined : targetSessionModelId;
+          // The provisional new-session target becomes durable as soon as
+          // session.create resolves, so later recovery stays on this session.
+          if (!modelTarget.targetStoredSessionId) {
+            modelTarget.targetStoredSessionId = storedSessionId;
+          }
+          if (created && !createdUnderProfile) {
+            const createdLevel = thinkingLevelRef.current;
+            sessionThinkingEffortsRef.current = {
+              ...sessionThinkingEfforts(),
+              [storedSessionId]: createdLevel,
+            };
+            rememberSessionThinkingLevel(storedSessionId, createdLevel);
+            sessionThinkingAppliedRef.current = {
+              ...sessionThinkingAppliedRef.current,
+              [storedSessionId]: {
+                runtimeId: created.session_id ?? "",
+                effort: thinkingEffortForLevel(createdLevel),
+              },
+            };
+          }
+          if (queuedIssueReport) {
+            pendingIssueReportsRef.current.set(storedSessionId, queuedIssueReport);
+          }
+          if (!targetStoredSessionId) {
+            rememberSessionMode(storedSessionId, fullModeDraftRef.current);
+          }
+          const ensureStoredHermesSession = () =>
+            ensureHermesBridgeSession({
+              sessionId: storedSessionId,
+              ...(!targetStoredSessionId ? { title: sessionDisplayTitle } : {}),
+              ...(createdSessionModelId ? { model: createdSessionModelId } : {}),
+            });
+          if (optimisticSession) {
+            await ensureStoredHermesSession().catch(rollbackOptimisticBeforePrompt);
+            migrateOptimisticHermesSession({
+              clearModel: Boolean(createdUnderProfile),
+              createdAt: optimisticSession.createdAt,
+              displayContent,
+              fromSessionId: optimisticSession.id,
+              ...(createdSessionModelId ? { model: createdSessionModelId } : {}),
+              title: sessionDisplayTitle,
+              toSessionId: storedSessionId,
+            });
+          }
+          if (initialTitleSuggestionPromise) {
+            void applyInitialSessionTitleSuggestion(storedSessionId, initialTitleSuggestionPromise);
+          }
+          if (!targetStoredSessionId && !options?.skipPrompt && !createdUnderProfile) {
+            const latestDefaultSelection: SessionModelSelection = {
+              modelId: defaultGenerationModelIdRef.current,
+              ...(defaultGenerationModelIdRef.current === AUTO_MODEL_ID &&
+              generationCostQualityRef.current !== undefined
+                ? { costQuality: generationCostQualityRef.current }
+                : {}),
+            };
+            const defaultChangedAfterSend =
+              modelTarget.globalIntentRevision !== generationSelectionIntentRevisionRef.current &&
+              latestDefaultSelection.modelId &&
+              !sameSessionModelSelection(latestDefaultSelection, targetSessionModelSelection);
+            if (defaultChangedAfterSend && !sessionModelSelectionsRef.current[storedSessionId]) {
+              commitSessionModelSelections(
+                stageSessionModelSelection(storedSessionId, latestDefaultSelection),
+              );
+            }
+            commitSessionModelSelections(
+              rememberAppliedSessionModelSelection(storedSessionId, targetSessionModelSelection),
             );
           }
-          return [optimisticSessionItem, ...current];
-        });
-      }
-      const pendingUserMessage: HermesSessionMessage = {
-        id: optimisticSession?.userMessage.id ?? `pending:user:${Date.now()}`,
-        role: "user",
-        content: displayContent,
-        timestamp: createdAt,
-      };
-      if (!optimisticSession && !options?.skipPrompt) {
-        setPendingHermesMessages((current) => {
-          const next = {
+          if (!optimisticSession) {
+            await withTimeout(ensureStoredHermesSession(), 2500).catch(() => undefined);
+          }
+        },
+        applyThinkingLevel: async ({ runtimeSessionId, storedSessionId, submitGateway }) => {
+          // Re-assert a stored level only at this ordered run boundary.
+          const thinkingSessionLevel = sessionThinkingEfforts()[storedSessionId];
+          if (thinkingSessionLevel) {
+            await applyThinkingLevelToSession(
+              storedSessionId,
+              thinkingSessionLevel,
+              runtimeSessionId,
+              submitGateway,
+            );
+          }
+        },
+        model: {
+          mode: submitFullMode ? "unrestricted" : "sandboxed",
+          modelId: targetSessionModelId,
+          shouldApply: ({ dispatchReservation: activeReservation, storedSessionId }) => {
+            // Re-read under the cross-surface FIFO because Note Chat may have
+            // changed the live model after this Send captured its target.
+            const currentModelEntry = readSessionModelSelections()[storedSessionId];
+            const currentStoredModelId = currentModelEntry?.appliedSelection
+              ? hermesModelIdForSelection(currentModelEntry.appliedSelection)
+              : undefined;
+            return (
+              !options?.skipPrompt &&
+              (shouldApplySessionModel ||
+                activeReservation.queuedBehindPrior ||
+                (Boolean(targetStoredSessionId) &&
+                  currentStoredModelId !== undefined &&
+                  currentStoredModelId !== targetSessionModelId))
+            );
+          },
+          onApplied: ({ storedSessionId }) => {
+            if (targetSessionModelRevision !== undefined) {
+              commitSessionModelSelections(
+                markSessionModelSelectionApplied(
+                  storedSessionId,
+                  targetSessionModelRevision,
+                  targetSessionModelSelection,
+                ),
+              );
+            } else {
+              commitSessionModelSelections(
+                rememberAppliedSessionModelSelection(storedSessionId, targetSessionModelSelection),
+              );
+            }
+            const applyModel = (sessions: HermesSessionInfo[]) =>
+              sessions.map((session) =>
+                session.id === storedSessionId
+                  ? { ...session, model: targetSessionModelId }
+                  : session,
+              );
+            hermesSessionItemsRef.current = applyModel(hermesSessionItemsRef.current);
+            setHermesSessionItems((current) => applyModel(current));
+          },
+        },
+        attach: async ({ runtimeSessionId, storedSessionId, submitGateway }) => {
+          if (imageInputFallbackContent) return;
+          try {
+            const updatedAttachments = await attachPendingImages(
+              submitGateway,
+              runtimeSessionId,
+              storedSessionId,
+              agentRunAttachments,
+            );
+            options?.onAttachmentsUpdated?.(updatedAttachments);
+          } catch (err) {
+            clearQueuedIssueReport();
+            rollbackOptimisticBeforePrompt(err);
+          }
+        },
+        preparePrompt: ({ runtimeSessionId, storedSessionId }) => {
+          const createdAt = optimisticSession?.createdAt ?? new Date().toISOString();
+          setRuntimeSessionIds((current) => ({
             ...current,
-            [storedSessionId]: [...(current[storedSessionId] ?? []), pendingUserMessage],
+            [storedSessionId]: runtimeSessionId,
+          }));
+          if (!optimisticSession) {
+            if (!targetStoredSessionId && options?.skipPrompt) {
+              const latestDefaultSelection: SessionModelSelection = {
+                modelId: defaultGenerationModelIdRef.current,
+                ...(defaultGenerationModelIdRef.current === AUTO_MODEL_ID &&
+                generationCostQualityRef.current !== undefined
+                  ? { costQuality: generationCostQualityRef.current }
+                  : {}),
+              };
+              const defaultChangedAfterSend =
+                modelTarget.globalIntentRevision !== generationSelectionIntentRevisionRef.current &&
+                latestDefaultSelection.modelId &&
+                !sameSessionModelSelection(latestDefaultSelection, targetSessionModelSelection);
+              if (defaultChangedAfterSend) {
+                commitSessionModelSelections(
+                  stageSessionModelSelection(storedSessionId, latestDefaultSelection),
+                );
+              }
+              commitSessionModelSelections(
+                rememberAppliedSessionModelSelection(storedSessionId, targetSessionModelSelection),
+              );
+            }
+            if (options?.selectSession !== false) {
+              newSessionModeRef.current = false;
+              setNewSessionMode(false);
+              selectedHermesSessionIdRef.current = storedSessionId;
+              setSelectedHermesSessionId(storedSessionId);
+              setSelectedTaskId(undefined);
+            }
+            const optimisticSessionItem: HermesSessionInfo = {
+              id: storedSessionId,
+              title: sessionDisplayTitle,
+              preview: displayContent,
+              started_at: createdAt,
+              last_active: createdAt,
+              message_count: 1,
+              ...(createdSessionModelId ? { model: createdSessionModelId } : {}),
+            };
+            setHermesSessionItems((current) => {
+              const existingSession = current.find((session) => session.id === storedSessionId);
+              if (existingSession) {
+                const mergedSession: HermesSessionInfo = targetStoredSessionId
+                  ? {
+                      ...existingSession,
+                      title: existingSession.title?.trim()
+                        ? existingSession.title
+                        : sessionDisplayTitle,
+                      preview: displayContent,
+                      last_active: createdAt,
+                      message_count:
+                        typeof existingSession.message_count === "number"
+                          ? existingSession.message_count + 1
+                          : optimisticSessionItem.message_count,
+                      ...(targetSessionModelId && !existingSession.model?.trim()
+                        ? { model: targetSessionModelId }
+                        : {}),
+                    }
+                  : { ...existingSession, ...optimisticSessionItem };
+                return current.map((session) =>
+                  session.id === storedSessionId ? mergedSession : session,
+                );
+              }
+              return [optimisticSessionItem, ...current];
+            });
+          }
+          pendingUserMessage = {
+            id: optimisticSession?.userMessage.id ?? `pending:user:${Date.now()}`,
+            role: "user",
+            content: displayContent,
+            timestamp: createdAt,
           };
-          pendingHermesMessagesRef.current = next;
-          return next;
-        });
+          if (!optimisticSession && !options?.skipPrompt) {
+            setPendingHermesMessages((current) => {
+              const next = {
+                ...current,
+                [storedSessionId]: [
+                  ...(current[storedSessionId] ?? []),
+                  pendingUserMessage as HermesSessionMessage,
+                ],
+              };
+              pendingHermesMessagesRef.current = next;
+              return next;
+            });
+          }
+          // `/image` creates/selects the session and presents the user bubble
+          // without starting an agent run.
+          if (options?.skipPrompt) return undefined;
+          promptStageStarted = true;
+          recordSessionRunningActivity(storedSessionId);
+          dispatchAgentSessionStatus({
+            sessionId: storedSessionId,
+            title: sessionDisplayTitle,
+            prompt: displayContent,
+            status: "running",
+            summary: "June is working.",
+          });
+          const targetProjectContext = explicitSession
+            ? resolveSessionProjectContext?.(storedSessionId)
+            : submittedProjectContext;
+          const preparedProjectPrompt = prepareProjectPrompt(
+            promptSubmitContent,
+            targetProjectContext,
+            projectContextSignaturesBySessionId.get(storedSessionId),
+          );
+          preparedProjectContextSignature = preparedProjectPrompt.contextSignature;
+          return {
+            text: preparedProjectPrompt.text,
+            ...(scopedAgentRunToolsets ? { enabledToolsets: scopedAgentRunToolsets } : {}),
+          };
+        },
+        runLease: {
+          begin: async ({ storedSessionId }) => {
+            const runLeaseId = `${storedSessionId}:${crypto.randomUUID()}`;
+            await computerUseBeginRun(runLeaseId);
+            try {
+              rememberComputerUseRun(storedSessionId, runLeaseId);
+              return runLeaseId;
+            } catch (err) {
+              await releaseComputerUseRun(storedSessionId, runLeaseId);
+              throw err;
+            }
+          },
+          release: ({ storedSessionId }, runLeaseId) =>
+            releaseComputerUseRun(storedSessionId, runLeaseId),
+        },
+        beforePrompt: (
+          { runtimeSessionId, storedSessionId, submitGateway },
+          prompt,
+          computerUseRunLeaseId,
+        ) => {
+          attachHermesSessionEventListener({
+            gateway: submitGateway.currentGateway(),
+            runtimeSessionId,
+            sessionDisplayTitle,
+            storedSessionId,
+            computerUseRunLeaseId,
+          });
+          hermesTraceBuffer.recordOutbound({
+            sessionId: storedSessionId,
+            method: "prompt.submit",
+            params: { session_id: runtimeSessionId, text: prompt.text },
+          });
+        },
+        afterPromptAcknowledged: async ({ runtimeSessionId, storedSessionId }) => {
+          startAgentRunMonitoring({
+            storedSessionId,
+            runtimeSessionId,
+            title: sessionDisplayTitle,
+            fullMode: sessionUnrestricted(storedSessionId),
+            settlementHeld: true,
+          });
+          if (preparedProjectContextSignature !== undefined) {
+            projectContextSignaturesBySessionId.set(
+              storedSessionId,
+              preparedProjectContextSignature,
+            );
+          }
+          clearHeldFastPathImages(storedSessionId, heldFastPathImages);
+          markStoredVideoSlashContextsSent(
+            storedSessionId,
+            heldVideoContexts.map((videoContext) => videoContext.id),
+          );
+          await loadHermesSessions({
+            suppressStartupRequestError: !hermesSessionsHydratedRef.current,
+          });
+        },
+      });
+
+      // The shared module returns normally after acknowledgement even if a
+      // local monitoring/session refresh hook failed afterwards.
+      return options?.skipPrompt ? runResult.storedSessionId : undefined;
+    } catch (err) {
+      clearQueuedIssueReport();
+      const storedSessionId = storedSessionIdForRollback;
+      if (!promptStageStarted || !storedSessionId || !pendingUserMessage) {
+        if (optimisticSession) {
+          removeOptimisticHermesSession(optimisticSession.id, storedSessionId);
+        }
+        throw err;
       }
-      // `/image`: the session exists and the user bubble is shown — hand the id
-      // back and let the caller render the generated image. No prompt.submit, so
-      // the model is never called and no "working" loader competes with the
-      // image's own in-thread loader.
-      if (options?.skipPrompt) return storedSessionId;
-      recordSessionRunningActivity(storedSessionId);
+
+      hermesTraceBuffer.recordError({
+        sessionId: storedSessionId,
+        method: "prompt.submit",
+        message: messageFromError(err),
+      });
+      setPendingHermesMessages((current) => {
+        const next = {
+          ...current,
+          [storedSessionId]: (current[storedSessionId] ?? []).filter(
+            (message) => message.id !== pendingUserMessage?.id,
+          ),
+        };
+        pendingHermesMessagesRef.current = next;
+        return next;
+      });
+      if (isSessionBusyError(err)) {
+        // The prior agent run still owns the session. Keep its listener and
+        // working state; callers translate this into the composer notice.
+        throw err;
+      }
+      sessionGatewayUnlistenRef.current.get(storedSessionId)?.();
+      recordSessionErrorActivity(storedSessionId, messageFromError(err));
       dispatchAgentSessionStatus({
         sessionId: storedSessionId,
         title: sessionDisplayTitle,
-        prompt: displayContent,
-        status: "running",
-        summary: "June is working.",
+        status: "failed",
+        summary: messageFromError(err),
       });
-      const computerUseRunLeaseId = `${storedSessionId}:${crypto.randomUUID()}`;
-      let computerUseRunStarted = false;
-      try {
-        const targetProjectContext = explicitSession
-          ? resolveSessionProjectContext?.(storedSessionId)
-          : submittedProjectContext;
-        const preparedProjectPrompt = prepareProjectPrompt(
-          promptSubmitContent,
-          targetProjectContext,
-          projectContextSignaturesBySessionId.get(storedSessionId),
-        );
-        await computerUseBeginRun(computerUseRunLeaseId);
-        computerUseRunStarted = true;
-        rememberComputerUseRun(storedSessionId, computerUseRunLeaseId);
-        attachHermesSessionEventListener({
-          gateway: submitGateway.currentGateway(),
-          runtimeSessionId,
-          sessionDisplayTitle,
-          storedSessionId,
-          computerUseRunLeaseId,
-        });
-        // Feature 15: record the outbound prompt.submit in the trace buffer. Its
-        // params are sanitized before storage (the text is the user's own prompt,
-        // kept; any secret-like value would be masked). This is the primary
-        // outbound call from this surface; other RPCs go direct via
-        // gateway.request and are not yet traced (see feature 15 notes).
-        hermesTraceBuffer.recordOutbound({
-          sessionId: storedSessionId,
-          method: "prompt.submit",
-          params: { session_id: runtimeSessionId, text: preparedProjectPrompt.text },
-        });
-        await createHermesMethods(submitGateway).submitPrompt({
-          sessionId: runtimeSessionId,
-          text: preparedProjectPrompt.text,
-          ...(scopedAgentRunToolsets ? { enabledToolsets: scopedAgentRunToolsets } : {}),
-        });
-        startAgentRunMonitoring({
-          storedSessionId,
-          runtimeSessionId,
-          title: sessionDisplayTitle,
-          fullMode: sessionUnrestricted(storedSessionId),
-          settlementHeld: true,
-        });
-        projectContextSignaturesBySessionId.set(
-          storedSessionId,
-          preparedProjectPrompt.contextSignature,
-        );
-        // JUN-171 (Phase A): the held fast-path images have now ridden along
-        // with a successful follow-up prompt, either as structured image bytes or
-        // in the non-vision path fallback. Clear only after prompt.submit accepts
-        // the message, so a rejected submit can be retried with the same image
-        // context.
-        clearHeldFastPathImages(storedSessionId, heldFastPathImages);
-        // Same contract for the video fold: clear only after prompt.submit
-        // accepts, so a rejected submit retries with the same video context.
-        markStoredVideoSlashContextsSent(
-          storedSessionId,
-          heldVideoContexts.map((videoContext) => videoContext.id),
-        );
-        await loadHermesSessions({
-          suppressStartupRequestError: !hermesSessionsHydratedRef.current,
-        });
-      } catch (err) {
-        if (computerUseRunStarted) {
-          await releaseComputerUseRun(storedSessionId, computerUseRunLeaseId);
-        }
-        // Record the rejection so the trace panel shows failed outbound calls
-        // alongside the inbound stream. messageFromError yields a user-safe string.
-        hermesTraceBuffer.recordError({
-          sessionId: storedSessionId,
-          method: "prompt.submit",
-          message: messageFromError(err),
-        });
-        // A queued report must not outlive its failed prompt; submit() re-arms
-        // issue-report mode so the retry can queue it again.
-        clearQueuedIssueReport();
-        // The prompt never entered the session, so its optimistic bubble must
-        // not linger — a retained pending message renders below every later
-        // persisted message and reads as a send June ignored.
-        setPendingHermesMessages((current) => {
-          const next = {
-            ...current,
-            [storedSessionId]: (current[storedSessionId] ?? []).filter(
-              (message) => message.id !== pendingUserMessage.id,
-            ),
-          };
-          pendingHermesMessagesRef.current = next;
-          return next;
-        });
-        if (isSessionBusyError(err)) {
-          // The gateway rejected this prompt because the previous agent run is still
-          // running — the session itself is healthy, so keep the listener and
-          // working state. Callers translate this into the composer notice.
-          throw err;
-        }
-        sessionGatewayUnlistenRef.current.get(storedSessionId)?.();
-        recordSessionErrorActivity(storedSessionId, messageFromError(err));
-        dispatchAgentSessionStatus({
-          sessionId: storedSessionId,
-          title: sessionDisplayTitle,
-          status: "failed",
-          summary: messageFromError(err),
-        });
-        throw err;
-      }
-      return undefined;
-    };
-
-    return activeDispatchReservation.run(dispatchPreparedSession);
+      throw err;
+    }
   }
 
   return submitHermesSession;

--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -660,13 +660,8 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
                 }),
               }
             : {}),
-          onSessionCreated: ({
-            created,
-            dispatchReservation: activeReservation,
-            storedSessionId,
-          }) => {
+          onSessionCreated: ({ dispatchReservation: activeReservation, storedSessionId }) => {
             dispatchReservation = activeReservation;
-            if (!created) return;
             capturedAppliedHermesModelId = capturedHermesModelId;
             if (submissionIsCurrent()) {
               appliedHermesModelIdRef.current = capturedHermesModelId;

--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -19,8 +19,6 @@ import { createHermesMethods } from "../../lib/hermes-control-plane/methods";
 import { isTerminalHermesEvent, type JuneHermesEvent } from "../../lib/hermes-control-plane/events";
 import { isHermesFeatureSupported } from "../../lib/hermes-control-plane/compatibility/support";
 import { HermesGatewayClient, isSessionBusyError } from "../../lib/hermes-gateway";
-import { createHermesIdleSubmitGateway } from "../../lib/hermes-idle-submit-recovery";
-import { applySessionModelWhenIdle } from "../../lib/hermes-next-prompt-model";
 import {
   canAttributeUntaggedAgentRun,
   cancelAgentRunMonitoring,
@@ -28,6 +26,7 @@ import {
   startAgentRunMonitoring,
 } from "../../lib/agent-run-monitor";
 import { dispatchAgentSessionStatus } from "../../lib/agent-events";
+import { submitHermesRun } from "../../lib/hermes-run-submission";
 import {
   reserveHermesSessionDispatch,
   type HermesSessionDispatchReservation,
@@ -63,11 +62,6 @@ import {
 } from "../../lib/tauri";
 import { noteReferenceToken, type NoteReferenceInput } from "../agent/composer/noteReference";
 import { noteChatSessionIdFor, rememberNoteChatSession } from "./noteChatSessions";
-
-type HermesRuntimeSessionResponse = {
-  session_id?: string;
-  stored_session_id?: string;
-};
 
 /** A file imported into the June workspace for this chat, plus its structured
  * attach state — the panel-side shape of the workspace's AgentAttachment. */
@@ -601,16 +595,6 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
       try {
         const gateway = await connectGateway(true);
         if (!gateway) throw new Error("Hermes gateway is not connected.");
-        const submitGateway = createHermesIdleSubmitGateway({
-          fullMode: false,
-          gateway,
-          shouldProbeFirstRequest: () => !hasHermesActiveSessionSnapshotSubscribers(false),
-          reconnect: async () => {
-            const reconnected = await connectGateway(true);
-            if (!reconnected) throw new Error("Hermes gateway is not connected.");
-            return reconnected;
-          },
-        });
         // Read after connectGateway so its refreshActiveHermesProfile has
         // reconciled the sticky pointer.
         const activeProfile = getActiveHermesProfileName();
@@ -627,10 +611,8 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
           capturedModelSelection = await defaultModelSelectionSnapshot;
           capturedHermesModelId = hermesModelIdForSelection(capturedModelSelection);
         }
-        let activeStoredSessionId = startingStoredSessionId;
-        let runtimeSessionId = startingRuntimeSessionId;
-        if (activeStoredSessionId && !capturedModelSelection) {
-          const metadata = await reconcileStoredSessionModelMetadata(activeStoredSessionId);
+        if (startingStoredSessionId && !capturedModelSelection) {
+          const metadata = await reconcileStoredSessionModelMetadata(startingStoredSessionId);
           if (metadata) {
             capturedModelSelection = metadata.selection;
             capturedHermesModelId = hermesModelIdForSelection(metadata.selection);
@@ -642,115 +624,127 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
             }
           }
         }
-        if (!activeStoredSessionId) {
-          const created = await submitGateway.request<HermesRuntimeSessionResponse>(
-            "session.create",
-            {
-              title: noteTitle.trim() || "Note chat",
-              cols: 96,
-              ...(capturedHermesModelId ? { model: capturedHermesModelId } : {}),
-              ...(activeProfile !== "default" ? { profile: activeProfile } : {}),
-            },
-          );
-          activeStoredSessionId = created.stored_session_id ?? created.session_id;
-          if (!activeStoredSessionId) throw new Error("Hermes did not create a session.");
-          dispatchReservation = reserveHermesSessionDispatch(activeStoredSessionId);
-          runtimeSessionId = created.session_id;
-          capturedAppliedHermesModelId = capturedHermesModelId;
-          if (submissionIsCurrent()) {
-            appliedHermesModelIdRef.current = capturedHermesModelId;
-            storedSessionMetadataHydratedRef.current = true;
-            setAppliedHermesModelId(capturedHermesModelId);
-            storedSessionIdRef.current = activeStoredSessionId;
-            setStoredSessionId(activeStoredSessionId);
-          }
-          rememberNoteChatSession(noteId, activeStoredSessionId);
-          if (activeProfile !== "default") {
-            // The chat list scopes by the session→profile map (ADR 0031): an
-            // unstamped named-profile chat would surface under default.
-            await assignSessionToProfile(activeStoredSessionId, activeProfile);
-          }
-          const latestSelection = submissionIsCurrent()
-            ? pendingModelSelectionRef.current
-            : capturedModelSelection;
-          if (capturedModelSelection) {
-            rememberAppliedSessionModelSelection(activeStoredSessionId, capturedModelSelection);
-          }
-          if (
-            latestSelection &&
-            (!capturedModelSelection ||
-              !sameSessionModelSelection(latestSelection, capturedModelSelection))
-          ) {
-            stageSessionModelSelection(activeStoredSessionId, latestSelection);
-          }
-        }
-        if (!runtimeSessionId) {
-          const resumed = await submitGateway.request<HermesRuntimeSessionResponse>(
-            "session.resume",
-            {
-              session_id: activeStoredSessionId,
-              cols: 96,
-            },
-          );
-          runtimeSessionId = resumed.session_id;
-          if (!runtimeSessionId) throw new Error("Hermes did not resume the session.");
-        }
-        if (submissionIsCurrent()) runtimeSessionIdRef.current = runtimeSessionId;
-        const activeDispatchReservation =
-          dispatchReservation ?? reserveHermesSessionDispatch(activeStoredSessionId);
-        dispatchReservation = activeDispatchReservation;
-        await activeDispatchReservation.run(async () => {
-          // Re-read under the shared lock. AgentWorkspace can dispatch the same
-          // session from its still-mounted surface, so its accepted send may
-          // have changed the live model after this NoteChat send was captured.
-          const currentModelEntry = readSessionModelSelections()[activeStoredSessionId];
-          const currentStoredModelId = currentModelEntry?.appliedSelection
-            ? hermesModelIdForSelection(currentModelEntry.appliedSelection)
-            : currentModelEntry
-              ? undefined
-              : capturedAppliedHermesModelId;
-          const modelToApply = capturedHermesModelId;
-          if (
-            modelToApply &&
-            (hasPendingSessionModelSelection(capturedModelEntry) ||
-              activeDispatchReservation.queuedBehindPrior ||
-              modelToApply !== capturedAppliedHermesModelId ||
-              (currentStoredModelId !== undefined && currentStoredModelId !== modelToApply))
-          ) {
-            // Apply only after the session is idle/resumed and immediately ahead
-            // of the prompt. Failure blocks the send; silently using the prior
-            // model would betray the picker.
-            await applySessionModelWhenIdle(() =>
-              createHermesMethods(submitGateway).switchActiveSessionModel({
-                mode: "sandboxed",
-                sessionId: runtimeSessionId,
-                model: modelToApply,
-              }),
-            );
-            capturedAppliedHermesModelId = modelToApply;
+        const runResult = await submitHermesRun({
+          fullMode: false,
+          gateway,
+          reconnectGateway: async () => {
+            const reconnected = await connectGateway(true);
+            if (!reconnected) throw new Error("Hermes gateway is not connected.");
+            return reconnected;
+          },
+          shouldProbeFirstRequest: () => !hasHermesActiveSessionSnapshotSubscribers(false),
+          storedSessionId: startingStoredSessionId,
+          runtimeSessionId: startingRuntimeSessionId,
+          dispatchReservation,
+          ...(!startingStoredSessionId
+            ? {
+                createSession: () => ({
+                  params: {
+                    title: noteTitle.trim() || "Note chat",
+                    cols: 96,
+                    ...(capturedHermesModelId ? { model: capturedHermesModelId } : {}),
+                    ...(activeProfile !== "default" ? { profile: activeProfile } : {}),
+                  },
+                  ...(activeProfile !== "default"
+                    ? {
+                        profileAssignment: {
+                          profile: activeProfile,
+                          // The chat list scopes by the session→profile map
+                          // (ADR 0031). onSessionCreated pairs the note locally
+                          // before this profile stamp, preserving Note Chat's
+                          // existing ordering.
+                          assign: assignSessionToProfile,
+                        },
+                      }
+                    : {}),
+                }),
+              }
+            : {}),
+          onSessionCreated: ({
+            created,
+            dispatchReservation: activeReservation,
+            storedSessionId,
+          }) => {
+            dispatchReservation = activeReservation;
+            if (!created) return;
+            capturedAppliedHermesModelId = capturedHermesModelId;
             if (submissionIsCurrent()) {
-              appliedHermesModelIdRef.current = modelToApply;
+              appliedHermesModelIdRef.current = capturedHermesModelId;
               storedSessionMetadataHydratedRef.current = true;
-              setAppliedHermesModelId(modelToApply);
+              setAppliedHermesModelId(capturedHermesModelId);
+              storedSessionIdRef.current = storedSessionId;
+              setStoredSessionId(storedSessionId);
             }
-            if (capturedModelEntry && capturedModelSelection) {
-              markSessionModelSelectionApplied(
-                activeStoredSessionId,
-                capturedModelEntry.revision,
-                capturedModelSelection,
-              );
-            } else if (capturedModelSelection) {
-              rememberAppliedSessionModelSelection(activeStoredSessionId, capturedModelSelection);
+            rememberNoteChatSession(noteId, storedSessionId);
+          },
+          onSessionResolved: ({ created, storedSessionId }) => {
+            if (!created) return;
+            const latestSelection = submissionIsCurrent()
+              ? pendingModelSelectionRef.current
+              : capturedModelSelection;
+            if (capturedModelSelection) {
+              rememberAppliedSessionModelSelection(storedSessionId, capturedModelSelection);
             }
-          }
-          // Images go to the model as first-class inputs before the prompt,
-          // like the workspace's feature-19 flow. A failed attach throws so the
-          // prompt is never sent with a silently-missing image; an unsupported
-          // runtime keeps the image imported and the path block still carries it.
-          const pendingImages = pendingImageAttachments(
-            attachments.map((attachment) => attachment.attach),
-          );
-          if (pendingImages.length) {
+            if (
+              latestSelection &&
+              (!capturedModelSelection ||
+                !sameSessionModelSelection(latestSelection, capturedModelSelection))
+            ) {
+              stageSessionModelSelection(storedSessionId, latestSelection);
+            }
+          },
+          onRuntimeSessionResolved: ({ runtimeSessionId }) => {
+            if (submissionIsCurrent()) runtimeSessionIdRef.current = runtimeSessionId;
+          },
+          ...(capturedHermesModelId
+            ? {
+                model: {
+                  mode: "sandboxed" as const,
+                  modelId: capturedHermesModelId,
+                  shouldApply: ({ dispatchReservation: activeReservation, storedSessionId }) => {
+                    // Re-read under the shared lock. AgentWorkspace can dispatch
+                    // the same stored session from its still-mounted surface.
+                    const currentModelEntry = readSessionModelSelections()[storedSessionId];
+                    const currentStoredModelId = currentModelEntry?.appliedSelection
+                      ? hermesModelIdForSelection(currentModelEntry.appliedSelection)
+                      : currentModelEntry
+                        ? undefined
+                        : capturedAppliedHermesModelId;
+                    return (
+                      hasPendingSessionModelSelection(capturedModelEntry) ||
+                      activeReservation.queuedBehindPrior ||
+                      capturedHermesModelId !== capturedAppliedHermesModelId ||
+                      (currentStoredModelId !== undefined &&
+                        currentStoredModelId !== capturedHermesModelId)
+                    );
+                  },
+                  onApplied: ({ storedSessionId }) => {
+                    capturedAppliedHermesModelId = capturedHermesModelId;
+                    if (submissionIsCurrent()) {
+                      appliedHermesModelIdRef.current = capturedHermesModelId;
+                      storedSessionMetadataHydratedRef.current = true;
+                      setAppliedHermesModelId(capturedHermesModelId);
+                    }
+                    if (capturedModelEntry && capturedModelSelection) {
+                      markSessionModelSelectionApplied(
+                        storedSessionId,
+                        capturedModelEntry.revision,
+                        capturedModelSelection,
+                      );
+                    } else if (capturedModelSelection) {
+                      rememberAppliedSessionModelSelection(storedSessionId, capturedModelSelection);
+                    }
+                  },
+                },
+              }
+            : {}),
+          attach: async ({ runtimeSessionId, submitGateway }) => {
+            // Images remain first-class inputs ahead of the prompt. A failed
+            // attach rejects the run before prompt.submit.
+            const pendingImages = pendingImageAttachments(
+              attachments.map((attachment) => attachment.attach),
+            );
+            if (!pendingImages.length) return;
             const methods = createHermesMethods(submitGateway);
             const deps = {
               prepareImagePath: prepareHermesBridgeImageAttachment,
@@ -766,24 +760,24 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
                 throw new Error(result.error ?? `Could not attach ${image.displayName}.`);
               }
             }
-          }
-          await submitGateway.request("prompt.submit", {
-            session_id: runtimeSessionId,
-            text: content,
-          });
-          // Hermes ownership starts here. Later local bookkeeping failures must
-          // not re-arm recovery keys or look like a rejected submit.
-          promptAccepted = true;
-          startAgentRunMonitoring({
-            storedSessionId: activeStoredSessionId,
-            runtimeSessionId,
-            title: noteTitle.trim() || "Note chat",
-            fullMode: false,
-            settlementHeld: false,
-          });
-          stoppedRuntimeSessionIdRef.current = undefined;
-          stoppedRunRef.current = false;
+          },
+          preparePrompt: () => ({ text: content }),
+          afterPromptAcknowledged: ({ runtimeSessionId, storedSessionId }) => {
+            startAgentRunMonitoring({
+              storedSessionId,
+              runtimeSessionId,
+              title: noteTitle.trim() || "Note chat",
+              fullMode: false,
+              settlementHeld: false,
+            });
+            stoppedRuntimeSessionIdRef.current = undefined;
+            stoppedRunRef.current = false;
+          },
         });
+        promptAccepted = runResult.promptAccepted;
+        if (runResult.postAcknowledgementError !== undefined && submissionIsCurrent()) {
+          setError(messageFromError(runResult.postAcknowledgementError));
+        }
         // Hermes accepted the prompt even if this panel later unmounted or
         // switched notes. Callers that only care about UI ownership should
         // check `current`; recovery keys must key off `accepted`.

--- a/src/lib/hermes-run-submission.ts
+++ b/src/lib/hermes-run-submission.ts
@@ -1,0 +1,249 @@
+import {
+  createHermesMethods,
+  type CreateSessionParams,
+  type HermesMode,
+} from "./hermes-control-plane";
+import type { HermesGatewayClient } from "./hermes-gateway";
+import {
+  createHermesIdleSubmitGateway,
+  type HermesSubmitGateway,
+} from "./hermes-idle-submit-recovery";
+import { applySessionModelWhenIdle } from "./hermes-next-prompt-model";
+import {
+  reserveHermesSessionDispatch,
+  type HermesSessionDispatchReservation,
+} from "./hermes-session-dispatch-mutex";
+
+type MaybePromise<Value> = Value | Promise<Value>;
+
+export type HermesRuntimeSessionResponse = {
+  session_id?: string;
+  stored_session_id?: string;
+};
+
+export type HermesRunSessionCreation = {
+  params: CreateSessionParams;
+  profileAssignment?: {
+    profile: string;
+    assign: (storedSessionId: string, profile: string) => Promise<void>;
+    timing?: "before-session-resolved" | "after-session-resolved";
+  };
+};
+
+export type HermesRunSubmissionContext = {
+  created: HermesRuntimeSessionResponse | undefined;
+  createdUnderProfile: string | undefined;
+  dispatchReservation: HermesSessionDispatchReservation;
+  runtimeSessionId: string;
+  storedSessionId: string;
+  submitGateway: HermesSubmitGateway;
+};
+
+type HermesResolvedSessionContext = Omit<HermesRunSubmissionContext, "runtimeSessionId">;
+
+export type HermesPreparedRunPrompt = {
+  text: string;
+  enabledToolsets?: readonly string[];
+};
+
+export type HermesRunSubmissionResult = HermesRunSubmissionContext & {
+  promptAccepted: boolean;
+  postAcknowledgementError?: unknown;
+};
+
+export type HermesRunSubmissionOptions<RunLease = never> = {
+  fullMode: boolean;
+  gateway: HermesGatewayClient;
+  reconnectGateway: () => Promise<HermesGatewayClient>;
+  shouldProbeFirstRequest: () => boolean;
+  storedSessionId?: string;
+  runtimeSessionId?: string;
+  dispatchReservation?: HermesSessionDispatchReservation;
+  createSession?: () => MaybePromise<HermesRunSessionCreation>;
+  onSessionCreated?: (context: HermesResolvedSessionContext) => MaybePromise<void>;
+  onSessionResolved?: (context: HermesResolvedSessionContext) => MaybePromise<void>;
+  onRuntimeSessionResolved?: (context: HermesRunSubmissionContext) => MaybePromise<void>;
+  applyThinkingLevel?: (context: HermesRunSubmissionContext) => MaybePromise<void>;
+  model?: {
+    mode: HermesMode;
+    modelId: string;
+    shouldApply: (context: HermesRunSubmissionContext) => boolean;
+    onApplied?: (context: HermesRunSubmissionContext) => MaybePromise<void>;
+  };
+  attach?: (context: HermesRunSubmissionContext) => MaybePromise<void>;
+  preparePrompt: (
+    context: HermesRunSubmissionContext,
+  ) => MaybePromise<HermesPreparedRunPrompt | undefined>;
+  runLease?: {
+    begin: (context: HermesRunSubmissionContext) => Promise<RunLease>;
+    release: (context: HermesRunSubmissionContext, lease: RunLease) => Promise<void>;
+  };
+  beforePrompt?: (
+    context: HermesRunSubmissionContext,
+    prompt: HermesPreparedRunPrompt,
+    lease: RunLease | undefined,
+  ) => MaybePromise<void>;
+  afterPromptAcknowledged?: (
+    context: HermesRunSubmissionContext,
+    prompt: HermesPreparedRunPrompt,
+    lease: RunLease | undefined,
+  ) => MaybePromise<void>;
+};
+
+/**
+ * Owns the ordered Hermes run protocol shared by every visible chat surface.
+ *
+ * Presentation and surface-local persistence stay in callbacks, but callers
+ * cannot reorder the liveness preflight, create/resume resolution, per-session
+ * FIFO, thinking/model application, attachments, lease begin, prompt
+ * acknowledgement, and monitoring handoff. Only the read-only idle probe may
+ * transport-retry; a busy model change may wait and retry its documented 4009
+ * response. Session creation, resume, attachments, and prompt submission are
+ * otherwise invoked once by this module.
+ */
+export async function submitHermesRun<RunLease = never>({
+  fullMode,
+  gateway,
+  reconnectGateway,
+  shouldProbeFirstRequest,
+  storedSessionId: initialStoredSessionId,
+  runtimeSessionId: initialRuntimeSessionId,
+  dispatchReservation: initialDispatchReservation,
+  createSession,
+  onSessionCreated,
+  onSessionResolved,
+  onRuntimeSessionResolved,
+  applyThinkingLevel,
+  model,
+  attach,
+  preparePrompt,
+  runLease,
+  beforePrompt,
+  afterPromptAcknowledged,
+}: HermesRunSubmissionOptions<RunLease>): Promise<HermesRunSubmissionResult> {
+  const submitGateway = createHermesIdleSubmitGateway({
+    fullMode,
+    gateway,
+    shouldProbeFirstRequest,
+    reconnect: reconnectGateway,
+  });
+  let dispatchReservation = initialDispatchReservation;
+
+  try {
+    let storedSessionId = initialStoredSessionId;
+    let created: HermesRuntimeSessionResponse | undefined;
+    let createdUnderProfile: string | undefined;
+    let profileAssignment: HermesRunSessionCreation["profileAssignment"];
+
+    if (!storedSessionId) {
+      if (!createSession) {
+        throw new Error("Hermes session creation parameters were not provided.");
+      }
+      const creation = await createSession();
+      created = await createHermesMethods(
+        submitGateway,
+      ).createSession<HermesRuntimeSessionResponse>(creation.params);
+      storedSessionId = created.stored_session_id ?? created.session_id;
+      if (!storedSessionId) {
+        throw new Error("Hermes did not create a session.");
+      }
+      dispatchReservation = reserveHermesSessionDispatch(storedSessionId);
+      profileAssignment = creation.profileAssignment;
+      if (profileAssignment) {
+        createdUnderProfile = profileAssignment.profile;
+      }
+    }
+
+    dispatchReservation ??= reserveHermesSessionDispatch(storedSessionId);
+    const resolvedSessionContext: HermesResolvedSessionContext = {
+      created,
+      createdUnderProfile,
+      dispatchReservation,
+      storedSessionId,
+      submitGateway,
+    };
+    if (created) {
+      await onSessionCreated?.(resolvedSessionContext);
+    }
+    if (profileAssignment && profileAssignment.timing !== "after-session-resolved") {
+      await profileAssignment.assign(storedSessionId, profileAssignment.profile);
+    }
+    await onSessionResolved?.(resolvedSessionContext);
+    if (profileAssignment?.timing === "after-session-resolved") {
+      await profileAssignment.assign(storedSessionId, profileAssignment.profile);
+    }
+
+    const runtimeSessionId =
+      created?.session_id ??
+      initialRuntimeSessionId ??
+      (
+        await submitGateway.request<HermesRuntimeSessionResponse>("session.resume", {
+          session_id: storedSessionId,
+          cols: 96,
+        })
+      ).session_id;
+    if (!runtimeSessionId) {
+      throw new Error("Hermes did not resume the session.");
+    }
+
+    const context: HermesRunSubmissionContext = {
+      ...resolvedSessionContext,
+      runtimeSessionId,
+    };
+    await onRuntimeSessionResolved?.(context);
+
+    return await dispatchReservation.run(async () => {
+      await applyThinkingLevel?.(context);
+      if (model?.shouldApply(context)) {
+        await applySessionModelWhenIdle(() =>
+          createHermesMethods(submitGateway).switchActiveSessionModel({
+            mode: model.mode,
+            sessionId: runtimeSessionId,
+            model: model.modelId,
+          }),
+        );
+        await model.onApplied?.(context);
+      }
+      await attach?.(context);
+
+      const prompt = await preparePrompt(context);
+      if (!prompt) {
+        return {
+          ...context,
+          promptAccepted: false,
+        };
+      }
+
+      let lease: RunLease | undefined;
+      try {
+        lease = await runLease?.begin(context);
+        await beforePrompt?.(context, prompt, lease);
+        await createHermesMethods(submitGateway).submitPrompt({
+          sessionId: runtimeSessionId,
+          text: prompt.text,
+          ...(prompt.enabledToolsets ? { enabledToolsets: prompt.enabledToolsets } : {}),
+        });
+      } catch (error) {
+        if (lease !== undefined && runLease) {
+          await runLease.release(context, lease);
+        }
+        throw error;
+      }
+
+      let postAcknowledgementError: unknown;
+      try {
+        await afterPromptAcknowledged?.(context, prompt, lease);
+      } catch (error) {
+        postAcknowledgementError = error;
+      }
+      return {
+        ...context,
+        promptAccepted: true,
+        ...(postAcknowledgementError === undefined ? {} : { postAcknowledgementError }),
+      };
+    });
+  } catch (error) {
+    dispatchReservation?.cancel();
+    throw error;
+  }
+}

--- a/src/lib/hermes-run-submission.ts
+++ b/src/lib/hermes-run-submission.ts
@@ -221,7 +221,7 @@ export async function submitHermesRun<RunLease = never>({
         });
       } catch (error) {
         if (lease !== undefined && runLease) {
-          await runLease.release(context, lease);
+          await runLease.release(context, lease).catch(() => undefined);
         }
         throw error;
       }

--- a/src/lib/hermes-run-submission.ts
+++ b/src/lib/hermes-run-submission.ts
@@ -26,7 +26,6 @@ export type HermesRunSessionCreation = {
   profileAssignment?: {
     profile: string;
     assign: (storedSessionId: string, profile: string) => Promise<void>;
-    timing?: "before-session-resolved" | "after-session-resolved";
   };
 };
 
@@ -165,13 +164,10 @@ export async function submitHermesRun<RunLease = never>({
     if (created) {
       await onSessionCreated?.(resolvedSessionContext);
     }
-    if (profileAssignment && profileAssignment.timing !== "after-session-resolved") {
+    if (profileAssignment) {
       await profileAssignment.assign(storedSessionId, profileAssignment.profile);
     }
     await onSessionResolved?.(resolvedSessionContext);
-    if (profileAssignment?.timing === "after-session-resolved") {
-      await profileAssignment.assign(storedSessionId, profileAssignment.profile);
-    }
 
     const runtimeSessionId =
       created?.session_id ??
@@ -243,6 +239,7 @@ export async function submitHermesRun<RunLease = never>({
       };
     });
   } catch (error) {
+    // cancel() is a no-op once run() has begun, so this only releases pre-dispatch failures.
     dispatchReservation?.cancel();
     throw error;
   }

--- a/src/test/hermes-run-submission.test.ts
+++ b/src/test/hermes-run-submission.test.ts
@@ -275,7 +275,9 @@ describe("Hermes run submission", () => {
       if (method === "prompt.submit") throw promptError;
       return {};
     });
-    const release = vi.fn(async () => undefined);
+    const release = vi.fn(async () => {
+      throw new Error("lease release failed");
+    });
 
     await expect(
       submitHermesRun<string>({

--- a/src/test/hermes-run-submission.test.ts
+++ b/src/test/hermes-run-submission.test.ts
@@ -1,0 +1,378 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  HermesGatewayError,
+  HermesGatewayRequestTimeoutError,
+  type HermesGatewayClient,
+} from "../lib/hermes-gateway";
+import { resetHermesIdleSubmitRecoveryForTests } from "../lib/hermes-idle-submit-recovery";
+import { type HermesRuntimeSessionResponse, submitHermesRun } from "../lib/hermes-run-submission";
+
+function gatewayWith(
+  request: (
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => Promise<unknown>,
+): HermesGatewayClient {
+  return { request: vi.fn(request) } as unknown as HermesGatewayClient;
+}
+
+describe("Hermes run submission", () => {
+  beforeEach(() => {
+    resetHermesIdleSubmitRecoveryForTests();
+  });
+
+  it("owns the fresh named-profile run sequence through acknowledgement", async () => {
+    const order: string[] = [];
+    const gateway = gatewayWith(async (method) => {
+      order.push(`wire:${method}`);
+      if (method === "session.create") {
+        return {
+          stored_session_id: "stored-fresh",
+          session_id: "runtime-fresh",
+        } satisfies HermesRuntimeSessionResponse;
+      }
+      return {};
+    });
+    const releaseLease = vi.fn(async () => undefined);
+
+    const result = await submitHermesRun<string>({
+      fullMode: false,
+      gateway,
+      reconnectGateway: async () => gateway,
+      shouldProbeFirstRequest: () => false,
+      createSession: () => ({
+        params: {
+          title: "Launch plan",
+          cols: 96,
+          model: "__june_remote_generation__:model-a",
+          reasoningEffort: "medium",
+          profile: "research",
+        },
+        profileAssignment: {
+          profile: "research",
+          assign: async (storedSessionId, profile) => {
+            order.push(`assign:${storedSessionId}:${profile}`);
+          },
+        },
+      }),
+      onSessionResolved: ({ storedSessionId }) => {
+        order.push(`session:${storedSessionId}`);
+      },
+      onRuntimeSessionResolved: ({ runtimeSessionId }) => {
+        order.push(`runtime:${runtimeSessionId}`);
+      },
+      applyThinkingLevel: () => {
+        order.push("thinking");
+      },
+      model: {
+        mode: "sandboxed",
+        modelId: "__june_remote_generation__:model-a",
+        shouldApply: () => true,
+        onApplied: () => {
+          order.push("model");
+        },
+      },
+      attach: () => {
+        order.push("attach");
+      },
+      preparePrompt: () => {
+        order.push("prepare");
+        return { text: "Review the plan." };
+      },
+      runLease: {
+        begin: async () => {
+          order.push("lease");
+          return "lease-1";
+        },
+        release: releaseLease,
+      },
+      beforePrompt: () => {
+        order.push("before");
+      },
+      afterPromptAcknowledged: () => {
+        order.push("after");
+      },
+    });
+
+    expect(result).toMatchObject({
+      storedSessionId: "stored-fresh",
+      runtimeSessionId: "runtime-fresh",
+      createdUnderProfile: "research",
+      promptAccepted: true,
+    });
+    expect(order).toEqual([
+      "wire:session.create",
+      "assign:stored-fresh:research",
+      "session:stored-fresh",
+      "runtime:runtime-fresh",
+      "thinking",
+      "wire:config.set",
+      "model",
+      "attach",
+      "prepare",
+      "lease",
+      "before",
+      "wire:prompt.submit",
+      "after",
+    ]);
+    expect(releaseLease).not.toHaveBeenCalled();
+  });
+
+  it("keeps Note Chat behind Agent Workspace in the shared stored-session FIFO", async () => {
+    const order: string[] = [];
+    let releaseWorkspaceAttach: () => void = () => undefined;
+    const workspaceGateway = gatewayWith(async (method) => {
+      order.push(`workspace:${method}`);
+      return {};
+    });
+    const noteChatGateway = gatewayWith(async (method) => {
+      order.push(`note-chat:${method}`);
+      return {};
+    });
+
+    const workspaceSubmission = submitHermesRun({
+      fullMode: false,
+      gateway: workspaceGateway,
+      reconnectGateway: async () => workspaceGateway,
+      shouldProbeFirstRequest: () => false,
+      storedSessionId: "stored-existing",
+      runtimeSessionId: "runtime-existing",
+      attach: async () => {
+        order.push("workspace:attach");
+        await new Promise<void>((resolve) => {
+          releaseWorkspaceAttach = resolve;
+        });
+      },
+      preparePrompt: () => ({ text: "Workspace first." }),
+    });
+    await vi.waitFor(() => expect(order).toContain("workspace:attach"));
+
+    const noteChatSubmission = submitHermesRun({
+      fullMode: false,
+      gateway: noteChatGateway,
+      reconnectGateway: async () => noteChatGateway,
+      shouldProbeFirstRequest: () => false,
+      storedSessionId: "stored-existing",
+      runtimeSessionId: "runtime-existing",
+      model: {
+        mode: "sandboxed",
+        modelId: "__june_remote_generation__:model-b",
+        shouldApply: ({ dispatchReservation }) => dispatchReservation.queuedBehindPrior,
+      },
+      preparePrompt: () => ({ text: "Note Chat second." }),
+    });
+
+    await Promise.resolve();
+    expect(order).not.toContain("note-chat:config.set");
+    expect(order).not.toContain("note-chat:prompt.submit");
+
+    releaseWorkspaceAttach();
+    await expect(workspaceSubmission).resolves.toMatchObject({ promptAccepted: true });
+    await expect(noteChatSubmission).resolves.toMatchObject({ promptAccepted: true });
+    expect(order).toEqual([
+      "workspace:attach",
+      "workspace:prompt.submit",
+      "note-chat:config.set",
+      "note-chat:prompt.submit",
+    ]);
+  });
+
+  it("resumes a stored session once before submitting on its runtime id", async () => {
+    const gateway = gatewayWith(async (method) => {
+      if (method === "session.resume") return { session_id: "runtime-resumed" };
+      return {};
+    });
+
+    const result = await submitHermesRun({
+      fullMode: false,
+      gateway,
+      reconnectGateway: async () => gateway,
+      shouldProbeFirstRequest: () => false,
+      storedSessionId: "stored-resumed",
+      preparePrompt: () => ({ text: "Continue once." }),
+    });
+
+    expect(result).toMatchObject({
+      storedSessionId: "stored-resumed",
+      runtimeSessionId: "runtime-resumed",
+      promptAccepted: true,
+    });
+    expect(gateway.request).toHaveBeenCalledTimes(2);
+    expect(gateway.request).toHaveBeenNthCalledWith(1, "session.resume", {
+      session_id: "stored-resumed",
+      cols: 96,
+    });
+    expect(gateway.request).toHaveBeenNthCalledWith(2, "prompt.submit", {
+      session_id: "runtime-resumed",
+      text: "Continue once.",
+    });
+  });
+
+  it("blocks prompt submission when an attachment fails", async () => {
+    const gateway = gatewayWith(async () => ({}));
+
+    await expect(
+      submitHermesRun({
+        fullMode: false,
+        gateway,
+        reconnectGateway: async () => gateway,
+        shouldProbeFirstRequest: () => false,
+        storedSessionId: "stored-existing",
+        runtimeSessionId: "runtime-existing",
+        attach: () => {
+          throw new Error("attachment failed");
+        },
+        preparePrompt: () => ({ text: "Inspect it." }),
+      }),
+    ).rejects.toThrow("attachment failed");
+    expect(gateway.request).not.toHaveBeenCalledWith("prompt.submit", expect.anything());
+  });
+
+  it("waits out a busy model change before submitting the prompt", async () => {
+    let modelAttempts = 0;
+    const calls: string[] = [];
+    const gateway = gatewayWith(async (method) => {
+      calls.push(method);
+      if (method === "config.set") {
+        modelAttempts += 1;
+        if (modelAttempts < 3) throw new HermesGatewayError("session busy", 4009);
+      }
+      return {};
+    });
+
+    vi.useFakeTimers();
+    try {
+      const submission = submitHermesRun({
+        fullMode: false,
+        gateway,
+        reconnectGateway: async () => gateway,
+        shouldProbeFirstRequest: () => false,
+        storedSessionId: "stored-busy",
+        runtimeSessionId: "runtime-busy",
+        model: {
+          mode: "sandboxed",
+          modelId: "__june_remote_generation__:model-c",
+          shouldApply: () => true,
+        },
+        preparePrompt: () => ({ text: "Use the captured model." }),
+      });
+      await vi.runAllTimersAsync();
+
+      await expect(submission).resolves.toMatchObject({ promptAccepted: true });
+      expect(modelAttempts).toBe(3);
+      expect(calls.at(-1)).toBe("prompt.submit");
+      expect(calls.filter((method) => method === "prompt.submit")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("releases the exact run lease when prompt submission is rejected", async () => {
+    const promptError = new Error("prompt rejected");
+    const gateway = gatewayWith(async (method) => {
+      if (method === "prompt.submit") throw promptError;
+      return {};
+    });
+    const release = vi.fn(async () => undefined);
+
+    await expect(
+      submitHermesRun<string>({
+        fullMode: false,
+        gateway,
+        reconnectGateway: async () => gateway,
+        shouldProbeFirstRequest: () => false,
+        storedSessionId: "stored-lease",
+        runtimeSessionId: "runtime-lease",
+        preparePrompt: () => ({ text: "Reject this." }),
+        runLease: {
+          begin: async () => "lease-1",
+          release,
+        },
+      }),
+    ).rejects.toBe(promptError);
+    expect(release).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storedSessionId: "stored-lease",
+        runtimeSessionId: "runtime-lease",
+      }),
+      "lease-1",
+    );
+  });
+
+  it("keeps acknowledgement authoritative when later bookkeeping fails", async () => {
+    const gateway = gatewayWith(async () => ({}));
+    const bookkeepingError = new Error("monitor failed after acknowledgement");
+
+    const result = await submitHermesRun({
+      fullMode: false,
+      gateway,
+      reconnectGateway: async () => gateway,
+      shouldProbeFirstRequest: () => false,
+      storedSessionId: "stored-existing",
+      runtimeSessionId: "runtime-existing",
+      preparePrompt: () => ({ text: "Accepted once." }),
+      afterPromptAcknowledged: () => {
+        throw bookkeepingError;
+      },
+    });
+
+    expect(result.promptAccepted).toBe(true);
+    expect(result.postAcknowledgementError).toBe(bookkeepingError);
+    expect(gateway.request).toHaveBeenCalledTimes(1);
+    expect(gateway.request).toHaveBeenCalledWith("prompt.submit", {
+      session_id: "runtime-existing",
+      text: "Accepted once.",
+    });
+  });
+
+  it("retries only the idle probe before creating and submitting exactly once", async () => {
+    const initialGateway = gatewayWith(async (method) => {
+      if (method === "session.active_list") {
+        throw new HermesGatewayRequestTimeoutError(method);
+      }
+      throw new Error(`Unexpected initial request: ${method}`);
+    });
+    const recoveredGateway = gatewayWith(async (method) => {
+      if (method === "session.active_list") return { sessions: [] };
+      if (method === "session.create") {
+        return {
+          stored_session_id: "stored-recovered",
+          session_id: "runtime-recovered",
+        } satisfies HermesRuntimeSessionResponse;
+      }
+      return {};
+    });
+
+    const result = await submitHermesRun({
+      fullMode: false,
+      gateway: initialGateway,
+      reconnectGateway: async () => recoveredGateway,
+      shouldProbeFirstRequest: () => true,
+      createSession: () => ({
+        params: { title: "Recovered", cols: 96 },
+      }),
+      preparePrompt: () => ({ text: "Submit once." }),
+    });
+
+    expect(result).toMatchObject({ promptAccepted: true });
+    expect(initialGateway.request).toHaveBeenCalledOnce();
+    expect(recoveredGateway.request).toHaveBeenCalledWith(
+      "session.active_list",
+      {},
+      expect.any(Number),
+    );
+    expect(
+      vi
+        .mocked(recoveredGateway.request)
+        .mock.calls.filter(([method]) => method === "session.create"),
+    ).toHaveLength(1);
+    expect(
+      vi
+        .mocked(recoveredGateway.request)
+        .mock.calls.filter(([method]) => method === "prompt.submit"),
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Add one shared Hermes run-submission module for Agent Workspace and Note Chat.
- Centralize idle-safe Gateway preflight, create/resume resolution, profile assignment, stored-session FIFO dispatch, thinking/model application, attachments, optional attended-run lease begin, prompt acknowledgement, and monitoring handoff.
- Preserve each surface's existing policy: Agent Workspace retains thinking, toolset, optimistic-session, and run-lease behavior; Note Chat remains sandboxed and lease-free.
- Keep the guarantees from #923, #937, and #943 on both callers, including one prompt submission after idle recovery and authoritative post-ack acceptance.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` (3,542 passed, 2 skipped)
- `pnpm exec vitest run src/test/hermes-run-submission.test.ts src/test/note-chat-sessions.test.ts`
- `make local-ci` on `fd1152bcb22cddf09bdab7a9b54bf76ff7219a5b`

- [x] Tested visually where it matters: not applicable - this is a behavior-preserving protocol refactor with no UI or user-facing copy changes.
- [ ] Needs a June API (backend) deploy before it works end to end. No - desktop-only refactor.

## Out of scope

- Changing visible chat behavior or Hermes wire contracts.
- Reworking the Gateway transport/backpressure implementation or terminal run-lease release logic.
- Consolidating branch, recovery, or read-only session resume flows that do not submit a run.

## Followups

- None. Keep the PR in draft for the requested review round.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. Not applicable.
- [x] Workflow action references are pinned to full-length commit SHAs. Not applicable.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

Refs JUN-422

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787449429&installation_model_id=425925&pr_number=953&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F953&signature=124d8a8f8ed6baa3066f26ea11526cacf30fae168d59114a18f714d4a5df21bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->