### PR TITLE
feat(audio): add optional Microphone noise suppression

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -140,6 +140,13 @@ Preparing a source WAV for transcription: downmix to mono, resample to 16 kHz,
 apply bounded gain toward a target peak.
 _Avoid_: conversion, resampling (that is one step of it).
 
+**Microphone noise suppression**:
+Optional local preparation of a derived Microphone transcription input after
+Turn detection and speaker-bleed trimming. The finalized Source WAV remains the
+replay and recovery source of truth; disabling the setting uses it directly.
+_Avoid_: noise cancellation (implies removal), voice isolation (names
+platform-specific APIs), recording filter (capture remains untouched).
+
 **Live transcript preview**:
 Optional, ephemeral chunked transcription shown while recording. Revisable,
 never written to `transcripts`, never the note's source of truth (see

--- a/docs/adr/0038-derived-microphone-noise-suppression.md
+++ b/docs/adr/0038-derived-microphone-noise-suppression.md
@@ -67,6 +67,23 @@ trait, with no archive or orchestration change.
 - Product acceptance remains held until the user chooses gate-only or approves
   the neural dependency and reviews measured audio and transcription impact.
 
+## 2026-07-24 review addendum: cost boundaries
+
+The deterministic derived path is a transient cache, not a second retained
+recording. Its cleanup token shares the existing Turn-WAV lifetime guard, so
+the file remains available through blocking Turn preparation, provider work,
+and transcript-coverage calculation, including when the caller is cancelled.
+It is deleted after those consumers drain, and the private cache directory is
+removed when empty. A completed derivative left by a process crash can still
+be reused by Retry and is then removed through the same guard.
+
+The durable configuration fingerprint records suppression only when the
+denoiser actually produced a different transcription input. Clean bypass and
+raw fallback both use the suppression-off fingerprint because the provider
+receives the same audio bytes. This prevents a setting toggle from causing a
+billed re-transcription of byte-identical clean audio while still invalidating
+cached text whenever suppression was applied.
+
 ## Rejected alternatives
 
 - **Rewrite the finalized Microphone WAV.** This destroys the recovery

--- a/docs/adr/0038-derived-microphone-noise-suppression.md
+++ b/docs/adr/0038-derived-microphone-noise-suppression.md
@@ -84,6 +84,29 @@ receives the same audio bytes. This prevents a setting toggle from causing a
 billed re-transcription of byte-identical clean audio while still invalidating
 cached text whenever suppression was applied.
 
+## 2026-07-24 dependency approval addendum
+
+The user approved `nnnoiseless` 0.5.2. June now uses an `RnnoiseDenoiser` as
+the primary implementation behind the existing seam and keeps spectral
+subtraction only as an initialization fallback.
+
+RNNoise declares 48 kHz, 480-sample, non-overlapping frames. The existing
+streaming resampler therefore converts the mono Source input to 48 kHz, and
+the exact-length writer pads only the final processing frame while writing
+exactly the resampled Source duration. The surrounding pipeline continues to
+use normalized `f32` PCM. Only the RNNoise adapter scales those samples to the
+16-bit magnitude range expected by `nnnoiseless`, then scales its output back.
+Ordinary Turn normalization still produces the 16 kHz provider input.
+
+The selected denoiser id is included in the deterministic cache path,
+fingerprint, and Source checkpoint. A failed RNNoise construction logs a
+warning and selects the existing 16 kHz spectral implementation without
+changing archive, retry, cleanup, or orchestration behavior.
+
+Dependency approval does not resolve the held product-quality decision.
+Representative real-voice transcription, listening, and long-recording checks
+remain required before promotion.
+
 ## Rejected alternatives
 
 - **Rewrite the finalized Microphone WAV.** This destroys the recovery

--- a/docs/adr/0038-derived-microphone-noise-suppression.md
+++ b/docs/adr/0038-derived-microphone-noise-suppression.md
@@ -1,0 +1,84 @@
+# ADR 0038: Derive Microphone noise suppression input after Turn detection
+
+Date: 2026-07-24
+Status: proposed, held for product and quality approval
+
+## Context
+
+Microphone recordings can contain fans, rain, keyboard impacts, and other
+ambient noise that reduces note-transcription quality. The finalized Source WAV
+is June's recovery and replay authority. Rewriting it would make suppression
+irreversible and could permanently damage speech.
+
+Noise suppression can also change the energy and similarity evidence used for
+Turn detection and speaker-bleed trimming. Applying it before those stages
+could move timestamps or change Source attribution. Applying it independently
+to every Turn would repeat work during retries and could produce inconsistent
+overlap boundaries.
+
+Offline neural suppression is generally stronger on keyboard-like transients,
+but adding a new audio-model crate is a separate supply-chain and product
+decision. June needs a reviewable pipeline boundary without assuming that
+approval.
+
+## Decision
+
+Microphone noise suppression is an optional, persisted setting that defaults
+off. It runs locally after raw Source Turn detection and speaker-bleed trimming,
+but before Turn extraction, normalization, and transcription. System audio does
+not pass through suppression.
+
+June derives one full-length mono 16 kHz WAV beside the finalized recording in
+a private `.june-transcription-input` cache. The cache key includes the
+finalized input content and denoiser version. The derived file is written
+atomically and reused by retry. Only downstream Microphone `source_path` values
+are replaced; Source identities, Turn bounds, and the finalized WAV remain
+unchanged.
+
+The processing boundary is a small `Denoiser` trait whose `process` method
+mutates one normalized `f32` frame. Implementations declare their sample rate,
+frame length, and hop length. Suppression failure leaves paths unchanged,
+records a Microphone-specific warning checkpoint, and continues with the
+finalized WAV. The durable job configuration fingerprint includes the actual
+derived, clean-bypass, or raw-fallback outcome. A later successful derivation
+therefore cannot reuse text produced during an earlier raw fallback.
+
+Until a neural dependency is approved, June ships an interim implementation
+using the existing FFT dependency. A first streaming pass estimates the noise
+floor and stationary spectrum. A second pass applies conservative spectral
+subtraction with temporal and frequency smoothing, a gain floor, and a
+clean-input bypass.
+
+`nnnoiseless` 0.5.2 is the recommended future implementation of this seam. It
+is a pure-Rust RNNoise port under BSD-3-Clause, released 2025-12-18, and is
+older than the repository's seven-day dependency cooldown. It is not added by
+this decision. Approval would add an `RnnoiseDenoiser` behind the existing
+trait, with no archive or orchestration change.
+
+## Consequences
+
+- Users can disable suppression when it harms a voice or microphone.
+- Capture callbacks and finalized recording writes are unchanged.
+- Raw evidence determines Source attribution and Turn timestamps.
+- Retries reuse deterministic derived input and configuration fingerprints
+  invalidate completed jobs when suppression is enabled.
+- The no-dependency fallback primarily helps steady noise. It is not expected
+  to match a neural suppressor on keyboard-like transients.
+- Product acceptance remains held until the user chooses gate-only or approves
+  the neural dependency and reviews measured audio and transcription impact.
+
+## Rejected alternatives
+
+- **Rewrite the finalized Microphone WAV.** This destroys the recovery
+  authority and makes suppression harm irreversible.
+- **Suppress in the capture callback.** This adds real-time work to a
+  deliberately allocation-free path and bakes the result into the archive.
+- **Suppress before Turn detection.** This can change timestamps and
+  speaker-bleed attribution.
+- **Use platform voice-isolation APIs.** Availability and behavior differ
+  across supported macOS and Windows versions, weakening deterministic
+  cross-platform retry behavior.
+- **Use only a hard noise gate.** Hard thresholds clip quiet speech and do
+  little for noise overlapping speech.
+- **Add a bundled heavyweight model.** The footprint and deployment cost are
+  disproportionate to this stabilization change.

--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -131,9 +131,16 @@ When **Microphone noise suppression** is enabled, June first derives a mono
 16 kHz Microphone WAV through a bounded-memory two-pass process. This happens
 after Turn detection and speaker-bleed trimming, so source attribution,
 timestamps, and System audio are unchanged. The finalized Microphone WAV is
-never modified. A content-and-version fingerprint reuses the derived WAV on
-retry; derivation failure records a Source warning checkpoint and falls back to
-the finalized WAV.
+never modified. A content-and-version fingerprint can reuse a completed
+derivative after an interrupted attempt. The derived WAV shares the transient
+Turn-audio lifetime guard and is removed after transcription and coverage
+consumers drain. Derivation failure records a Source warning checkpoint and
+falls back to the finalized WAV.
+
+Only an actually applied derivative changes the durable transcription
+configuration fingerprint. A clean bypass or raw fallback keeps the
+suppression-off identity because transcription receives the same audio bytes,
+so toggling the setting cannot bill for a byte-identical clean recording.
 
 The interim implementation estimates a stationary noise spectrum from the same
 low-percentile noise-floor principle used by Turn detection, then applies

--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -128,27 +128,29 @@ Energy-based, per-source, **no diarization**:
 ## Normalization and chunking
 
 When **Microphone noise suppression** is enabled, June first derives a mono
-16 kHz Microphone WAV through a bounded-memory two-pass process. This happens
-after Turn detection and speaker-bleed trimming, so source attribution,
-timestamps, and System audio are unchanged. The finalized Microphone WAV is
-never modified. A content-and-version fingerprint can reuse a completed
-derivative after an interrupted attempt. The derived WAV shares the transient
-Turn-audio lifetime guard and is removed after transcription and coverage
-consumers drain. Derivation failure records a Source warning checkpoint and
-falls back to the finalized WAV.
+Microphone WAV through a bounded-memory two-pass process. This happens after
+Turn detection and speaker-bleed trimming, so source attribution, timestamps,
+and System audio are unchanged. The finalized Microphone WAV is never
+modified. A content-and-version fingerprint can reuse a completed derivative
+after an interrupted attempt. The derived WAV shares the transient Turn-audio
+lifetime guard and is removed after transcription and coverage consumers
+drain. Derivation failure records a Source warning checkpoint and falls back
+to the finalized WAV.
 
 Only an actually applied derivative changes the durable transcription
 configuration fingerprint. A clean bypass or raw fallback keeps the
 suppression-off identity because transcription receives the same audio bytes,
 so toggling the setting cannot bill for a byte-identical clean recording.
 
-The interim implementation estimates a stationary noise spectrum from the same
-low-percentile noise-floor principle used by Turn detection, then applies
-smoothed spectral subtraction with a gain floor. It is deliberately
-conservative and bypasses clean inputs. It is more effective for steady room
-noise than short keyboard-like transients. The `Denoiser` frame interface lets
-a stronger offline implementation replace it without changing archive,
-pipeline, or persistence contracts.
+The first pass estimates a low-percentile noise floor and bypasses inputs that
+are already clean. Noisy inputs use `nnnoiseless` 0.5.2 through the `Denoiser`
+frame interface. The existing streaming resampler supplies 48 kHz,
+480-sample, non-overlapping frames; the adapter alone converts normalized
+`f32` samples to RNNoise's 16-bit magnitude range and back. The writer pads
+the final processing frame but emits exactly the resampled Source length. If
+RNNoise construction fails, June logs a warning and uses the conservative
+16 kHz spectral-subtraction implementation. The following ordinary
+normalization step still emits mono 16 kHz provider input.
 
 Before transcription each turn WAV is downmixed to **mono**, resampled to
 **16 kHz**, and gain-adjusted toward a target peak (bounded, with a

--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -38,8 +38,9 @@ preview).
 4. **`process_saved_source_audio`** (`src-tauri/src/domain/processing.rs`) runs
    the batch pipeline for microphone-only and dual-Source recordings:
    `drop_silent_system_sources` → dual-Source `turns::detect_turns` (or one
-   authoritative full-Source microphone job) → reconcile durable fingerprinted
-   note-transcription jobs → bounded Turn preparation → one
+   authoritative full-Source microphone job) → optional derived Microphone
+   noise suppression → reconcile durable fingerprinted note-transcription jobs
+   → bounded Turn preparation → one
    in-flight provider request per Source → atomically persist each successful
    job and transcript row → **note generation**. Full-Source fallbacks are
    prepared lazily when a Source is materially incomplete and atomically
@@ -72,6 +73,8 @@ waiting for the full timeout.
   main.swift` — the system-audio helper and its readiness/permission probes.
 - `src-tauri/src/audio/turns.rs` — turn detection, coalescing, WAV extraction,
   normalization, chunking, per-source configs.
+- `src-tauri/src/audio/noise_suppression.rs` - optional, cached Microphone
+  transcription input and the replaceable frame-level denoiser seam.
 - `src-tauri/src/audio/live_preview.rs` — mic/system preview workers, the
   `WavTailReader` that tails the helper's growing WAV.
 - `src-tauri/src/audio/{validation,recovery}.rs` — artifact validation and
@@ -123,6 +126,22 @@ Energy-based, per-source, **no diarization**:
   the whole turn, so a user's reply that merged with an echo survives.
 
 ## Normalization and chunking
+
+When **Microphone noise suppression** is enabled, June first derives a mono
+16 kHz Microphone WAV through a bounded-memory two-pass process. This happens
+after Turn detection and speaker-bleed trimming, so source attribution,
+timestamps, and System audio are unchanged. The finalized Microphone WAV is
+never modified. A content-and-version fingerprint reuses the derived WAV on
+retry; derivation failure records a Source warning checkpoint and falls back to
+the finalized WAV.
+
+The interim implementation estimates a stationary noise spectrum from the same
+low-percentile noise-floor principle used by Turn detection, then applies
+smoothed spectral subtraction with a gain floor. It is deliberately
+conservative and bypasses clean inputs. It is more effective for steady room
+noise than short keyboard-like transients. The `Denoiser` frame interface lets
+a stronger offline implementation replace it without changing archive,
+pipeline, or persistence contracts.
 
 Before transcription each turn WAV is downmixed to **mono**, resampled to
 **16 kHz**, and gain-adjusted toward a target peak (bounded, with a

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ decision. See "When to add an ADR" in [AGENTS.md](../AGENTS.md).
 - [adr/0035](adr/0035-extension-releases-follow-desktop-rc-promotion.md) - Chrome Web Store packages are reviewed during desktop RC and the exact staged bytes publish after stable desktop promotion
 - [adr/0036](adr/0036-github-connector-app-user-tokens.md) - GitHub connector uses GitHub App user access tokens only (no app private key on device or backend), local-mode custody per ADR-0016, June-side read/write gating, approval-only writes
 - [adr/0037](adr/0037-versioned-local-sqlite-migrations.md) - June's local SQLite schema uses an append-only release-ordered catalog, introspection-based legacy stamping, and one transaction for all pending migrations
+- [adr/0038](adr/0038-derived-microphone-noise-suppression.md) - optional Microphone noise suppression creates a cached transcription input after raw Turn detection and never rewrites the finalized Source WAV
 
 ## Enforceable rules (spec/)
 
@@ -145,6 +146,7 @@ Per-repo config the engineering skills read before acting (see the
 - [qa/agent-driven-integration.md](qa/agent-driven-integration.md) — QA strategy (3 layers, skill-first agent-driven)
 - [qa/computer-use-parity.md](qa/computer-use-parity.md) - JUN-278 parity, stricter safety differences, evidence map, and signed/manual release matrix
 - [qa/jun-334-note-transcription-latency.md](qa/jun-334-note-transcription-latency.md) — measured baseline and proof for note transcription latency
+- [qa/jun-416-noise-suppression.md](qa/jun-416-noise-suppression.md) - reproducible fixture methodology and measured limits for the interim no-dependency suppressor
 - `qa/feature-user-stories.tsv` — story → code → test traceability matrix
 - `qa/agent-e2e-qa-runs/` — dated end-to-end QA run logs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ decision. See "When to add an ADR" in [AGENTS.md](../AGENTS.md).
 - [adr/0035](adr/0035-extension-releases-follow-desktop-rc-promotion.md) - Chrome Web Store packages are reviewed during desktop RC and the exact staged bytes publish after stable desktop promotion
 - [adr/0036](adr/0036-github-connector-app-user-tokens.md) - GitHub connector uses GitHub App user access tokens only (no app private key on device or backend), local-mode custody per ADR-0016, June-side read/write gating, approval-only writes
 - [adr/0037](adr/0037-versioned-local-sqlite-migrations.md) - June's local SQLite schema uses an append-only release-ordered catalog, introspection-based legacy stamping, and one transaction for all pending migrations
-- [adr/0038](adr/0038-derived-microphone-noise-suppression.md) - optional Microphone noise suppression creates a cached transcription input after raw Turn detection and never rewrites the finalized Source WAV
+- [adr/0038](adr/0038-derived-microphone-noise-suppression.md) - optional Microphone noise suppression creates a transient transcription input after raw Turn detection and never rewrites the finalized Source WAV
 
 ## Enforceable rules (spec/)
 

--- a/docs/qa/jun-416-noise-suppression.md
+++ b/docs/qa/jun-416-noise-suppression.md
@@ -14,8 +14,9 @@ broadband noise, and keyboard-like transients. The 16-second reference has
 three seconds of leading silence and about three seconds of trailing silence,
 so the noise estimator sees quiet regions as it would in natural speech. Each
 noisy WAV passes through
-`suppress_microphone_wav_for_transcription`, the same cached derivation called
-by saved-audio processing. The original SHA-256 is checked before and after.
+`suppress_microphone_wav_for_transcription`, the same transient derivation
+called by saved-audio processing. The original SHA-256 is checked before and
+after.
 The reproducible invocation is:
 
 ```sh
@@ -61,6 +62,20 @@ No ASR comparison or blinded listening panel was run in this environment.
 Therefore this evidence makes no transcription-accuracy, clean-speech WER,
 consonant-preservation, or perceptual-quality claim. Those remain blocking
 product-quality checks for the held feature.
+
+## Cost and resampling regressions
+
+Automated coverage also checks the non-quality boundaries found during review:
+
+- a clean bypass and a raw fallback produce the same durable transcription
+  configuration fingerprint as suppression off, while an applied derivative
+  changes it;
+- the derived WAV and its empty `.june-transcription-input` directory are
+  removed after the retained transcription consumer drains, while the
+  finalized input remains byte-identical; and
+- a 2.25-second 48 kHz noisy input runs through the production streaming
+  resampler and suppressor without error, producing exactly 36,000 mono 16 kHz
+  samples while preserving the input bytes.
 
 ## Expected limitation
 

--- a/docs/qa/jun-416-noise-suppression.md
+++ b/docs/qa/jun-416-noise-suppression.md
@@ -1,0 +1,69 @@
+# JUN-416 Microphone noise suppression evidence
+
+Status: interim fallback evaluated on 2026-07-24
+
+This document records the reproducible evaluation for the interim
+no-new-dependency spectral suppressor. It must not be read as product
+acceptance: JUN-416 remains held for the user's product and quality decision.
+
+## Method
+
+The evidence set uses a fixed, non-private macOS synthetic speech reference
+mixed separately with deterministic fan-like stationary noise, rain-like
+broadband noise, and keyboard-like transients. The 16-second reference has
+three seconds of leading silence and about three seconds of trailing silence,
+so the noise estimator sees quiet regions as it would in natural speech. Each
+noisy WAV passes through
+`suppress_microphone_wav_for_transcription`, the same cached derivation called
+by saved-audio processing. The original SHA-256 is checked before and after.
+The reproducible invocation is:
+
+```sh
+cargo run --manifest-path src-tauri/Cargo.toml \
+  --example noise_suppression_eval -- input.wav output.wav
+```
+
+The example also runs the ordinary streaming normalization stage. Add
+`--without-suppression` to produce the setting-off control through that same
+normalization path.
+
+For each fixture:
+
+1. Compare the noisy and derived files against the clean reference over the
+   same sample count.
+2. Report reference SNR and scale-invariant SNR (SI-SNR) before and after.
+   SI-SNR is relevant because downstream normalization deliberately changes
+   gain. These synthetic metrics isolate signal fidelity; neither is a
+   perceptual speech-quality score.
+3. Generate before and after spectrograms and retain both clips for listening.
+4. Record whether suppression applied or conservatively bypassed.
+
+## Results
+
+| Fixture | Decision | Reference SNR change | SI-SNR change | Quiet-region RMS |
+| --- | --- | ---: | ---: | ---: |
+| Fan plus hum | Applied, estimated floor -37.5 dBFS | 7.55 to 8.31 dB (+0.76) | 7.23 to 11.29 dB (+4.06) | -32.56 to -42.54 dBFS |
+| Rain-like broadband | Applied, estimated floor -29.0 dBFS | 0.90 to 2.95 dB (+2.06) | -0.25 to 5.12 dB (+5.37) | -25.83 to -41.26 dBFS |
+| Keyboard-like impacts | Clean-floor bypass at -95.5 dBFS | 4.90 to 4.90 dB (+0.00) | 3.40 to 3.40 dB (+0.00) | -30.61 to -30.61 dBFS |
+
+The input SHA-256 remained identical before and after every run. The evidence
+archive contains the clean reference, original noisy mixes, setting-off
+normalized controls, setting-on outputs, and side-by-side spectrograms:
+[download the JUN-416 evidence archive](https://app.opensoftware.co/api/v1/files/fil_l2JqMGvo55RO/download).
+
+The fallback measurably reduces steady noise, especially quiet-region energy,
+but neither steady fixture reaches the issue's 6 dB SI-SNR target. It does not
+reduce isolated keyboard transients when the stationary floor is clean, by
+design: bypass is safer than deriving an aggressive profile from speech and
+impacts.
+
+No ASR comparison or blinded listening panel was run in this environment.
+Therefore this evidence makes no transcription-accuracy, clean-speech WER,
+consonant-preservation, or perceptual-quality claim. Those remain blocking
+product-quality checks for the held feature.
+
+## Expected limitation
+
+The spectral fallback estimates a stationary profile. The results confirm that
+it helps steady noise more than isolated keyboard impacts. This limitation is
+evidence for the dependency decision, not a reason to overstate the fallback.

--- a/docs/qa/jun-416-noise-suppression.md
+++ b/docs/qa/jun-416-noise-suppression.md
@@ -1,23 +1,27 @@
 # JUN-416 Microphone noise suppression evidence
 
-Status: interim fallback evaluated on 2026-07-24
+Status: spectral fallback baseline evaluated on 2026-07-24; RNNoise adapter
+unit-verified on 2026-07-24
 
-This document records the reproducible evaluation for the interim
-no-new-dependency spectral suppressor. It must not be read as product
-acceptance: JUN-416 remains held for the user's product and quality decision.
+This document records the evaluation baseline for the spectral fallback and
+the deterministic regressions for the approved RNNoise adapter. It must not be
+read as product acceptance: JUN-416 remains held for the user's product and
+quality decision.
 
 ## Method
 
-The evidence set uses a fixed, non-private macOS synthetic speech reference
-mixed separately with deterministic fan-like stationary noise, rain-like
-broadband noise, and keyboard-like transients. The 16-second reference has
-three seconds of leading silence and about three seconds of trailing silence,
+The spectral evidence set uses a fixed, non-private macOS synthetic speech
+reference mixed separately with deterministic fan-like stationary noise,
+rain-like broadband noise, and keyboard-like transients. The 16-second
+reference has three seconds of leading silence and about three seconds of
+trailing silence,
 so the noise estimator sees quiet regions as it would in natural speech. Each
 noisy WAV passes through
 `suppress_microphone_wav_for_transcription`, the same transient derivation
 called by saved-audio processing. The original SHA-256 is checked before and
-after.
-The reproducible invocation is:
+after. The results below were produced from commit
+`b50f1dbb9249c729ca0590ef774a9ae1dbd0d745`, where the spectral implementation
+was the default. On the current branch, the same invocation evaluates RNNoise:
 
 ```sh
 cargo run --manifest-path src-tauri/Cargo.toml \
@@ -67,18 +71,25 @@ product-quality checks for the held feature.
 
 Automated coverage also checks the non-quality boundaries found during review:
 
+- RNNoise declares 48 kHz, 480-sample, non-overlapping frames and rejects an
+  incorrectly sized frame;
+- deterministic noise-only input loses energy while a speech-band harmonic
+  fixture retains energy and produces finite samples;
+- an injected RNNoise construction failure selects the spectral fallback;
 - a clean bypass and a raw fallback produce the same durable transcription
   configuration fingerprint as suppression off, while an applied derivative
   changes it;
 - the derived WAV and its empty `.june-transcription-input` directory are
   removed after the retained transcription consumer drains, while the
   finalized input remains byte-identical; and
-- a 2.25-second 48 kHz noisy input runs through the production streaming
-  resampler and suppressor without error, producing exactly 36,000 mono 16 kHz
-  samples while preserving the input bytes.
+- a 1.003-second 44.1 kHz noisy input runs through the production streaming
+  resampler and RNNoise with a partial final frame, producing the exact
+  expected mono 48 kHz length while preserving the input bytes.
 
 ## Expected limitation
 
-The spectral fallback estimates a stationary profile. The results confirm that
-it helps steady noise more than isolated keyboard impacts. This limitation is
-evidence for the dependency decision, not a reason to overstate the fallback.
+The spectral fallback still estimates a stationary profile and is now used
+only if RNNoise construction fails. The existing results confirm that fallback
+helps steady noise more than isolated keyboard impacts. The RNNoise adapter
+tests prove framing and deterministic signal boundaries, not perceptual quality
+or transcription accuracy.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -76,6 +76,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "anymap3"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5dfbc6d8d2675589ccbe4d0fd61df2419075625f8c1a62325e718e2b0049f9"
+
+[[package]]
 name = "apple-cf"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +128,12 @@ dependencies = [
  "wl-clipboard-rs",
  "x11rb",
 ]
+
+[[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "arrayref"
@@ -303,6 +315,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "auto-launch"
@@ -637,6 +660,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_lex",
+ "indexmap 1.9.3",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,7 +1004,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.118",
 ]
 
@@ -972,10 +1020,123 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7381b67da416b639690ac77c73b86a7b5e64a29e31d1f75fb3b1102301ef355a"
+dependencies = [
+ "dasp_envelope",
+ "dasp_frame",
+ "dasp_interpolate",
+ "dasp_peak",
+ "dasp_ring_buffer",
+ "dasp_rms",
+ "dasp_sample",
+ "dasp_signal",
+ "dasp_slice",
+ "dasp_window",
+]
+
+[[package]]
+name = "dasp_envelope"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec617ce7016f101a87fe85ed44180839744265fae73bb4aa43e7ece1b7668b6"
+dependencies = [
+ "dasp_frame",
+ "dasp_peak",
+ "dasp_ring_buffer",
+ "dasp_rms",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_frame"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a3937f5fe2135702897535c8d4a5553f8b116f76c1529088797f2eee7c5cd6"
+dependencies = [
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_interpolate"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc975a6563bb7ca7ec0a6c784ead49983a21c24835b0bc96eea11ee407c7486"
+dependencies = [
+ "dasp_frame",
+ "dasp_ring_buffer",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_peak"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf88559d79c21f3d8523d91250c397f9a15b5fc72fbb3f87fdb0a37b79915bf"
+dependencies = [
+ "dasp_frame",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_ring_buffer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d79e19b89618a543c4adec9c5a347fe378a19041699b3278e616e387511ea1"
+
+[[package]]
+name = "dasp_rms"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6c5dcb30b7e5014486e2822537ea2beae50b19722ffe2ed7549ab03774575aa"
+dependencies = [
+ "dasp_frame",
+ "dasp_ring_buffer",
+ "dasp_sample",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "dasp_signal"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1ab7d01689c6ed4eae3d38fe1cea08cba761573fbd2d592528d55b421077e7"
+dependencies = [
+ "dasp_envelope",
+ "dasp_frame",
+ "dasp_interpolate",
+ "dasp_peak",
+ "dasp_ring_buffer",
+ "dasp_rms",
+ "dasp_sample",
+ "dasp_window",
+]
+
+[[package]]
+name = "dasp_slice"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1c7335d58e7baedafa516cb361360ff38d6f4d3f9d9d5ee2a2fc8e27178fa1"
+dependencies = [
+ "dasp_frame",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_window"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ded7b88821d2ce4e8b842c9f1c86ac911891ab89443cc1de750cae764c5076"
+dependencies = [
+ "dasp_sample",
+]
 
 [[package]]
 name = "data-encoding"
@@ -1235,6 +1396,19 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "easyfft"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767e39eef2ad8a3b6f1d733be3ec70364d21d437d06d4f18ea76ce08df20b75f"
+dependencies = [
+ "array-init",
+ "generic_singleton",
+ "num-complex",
+ "realfft",
+ "rustfft",
+]
 
 [[package]]
 name = "either"
@@ -1719,6 +1893,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic_singleton"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6e923c8e978e57cf63e2e200ca967d1d20f0ea2662b28f6d4e11c44aa6ab16"
+dependencies = [
+ "anymap3",
+ "parking_lot",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +2160,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -2837,6 +3030,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nnnoiseless"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805d5964d1e7a0006a7fdced7dae75084d66d18b35f1dfe81bd76929b1f8da0c"
+dependencies = [
+ "anyhow",
+ "clap",
+ "dasp",
+ "dasp_interpolate",
+ "dasp_ring_buffer",
+ "easyfft",
+ "hound",
+ "once_cell",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2876,6 +3085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -3354,6 +3564,7 @@ dependencies = [
  "hound",
  "keyring",
  "libc",
+ "nnnoiseless",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
@@ -3401,6 +3612,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "osakit"
@@ -3660,7 +3877,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
@@ -3947,6 +4164,15 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -4938,6 +5164,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -5526,6 +5758,21 @@ dependencies = [
  "new_debug_unreachable",
  "utf-8",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,6 +57,7 @@ libc = "0.2"
 # Strips the Windows `\\?\` verbatim path prefix canonicalize() adds so it
 # never leaks into config.yaml or the UI. No-op on non-Windows.
 dunce = "1.0"
+nnnoiseless = "0.5.2"
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls", "stream"] }
 # Pure-Rust FFT for the echo-rejection similarity gate (GCC-PHAT lag estimation).

--- a/src-tauri/examples/noise_suppression_eval.rs
+++ b/src-tauri/examples/noise_suppression_eval.rs
@@ -54,6 +54,10 @@ fn run() -> Result<(), String> {
         result.as_ref().is_some_and(|result| result.applied)
     );
     println!(
+        "algorithm={}",
+        result.as_ref().map_or("none", |result| result.denoiser_id)
+    );
+    println!(
         "cacheHit={}",
         result.as_ref().is_some_and(|result| result.cache_hit)
     );

--- a/src-tauri/examples/noise_suppression_eval.rs
+++ b/src-tauri/examples/noise_suppression_eval.rs
@@ -1,0 +1,84 @@
+use os_june_lib::audio::{
+    noise_suppression::suppress_microphone_wav_for_transcription,
+    turns::normalize_wav_for_transcription,
+};
+use sha2::{Digest, Sha256};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let mut arguments = env::args_os().skip(1);
+    let input = arguments.next().map(PathBuf::from).ok_or_else(usage)?;
+    let output = arguments.next().map(PathBuf::from).ok_or_else(usage)?;
+    let bypass_suppression = match arguments.next() {
+        None => false,
+        Some(flag) if flag == "--without-suppression" => true,
+        Some(_) => return Err(usage()),
+    };
+    if arguments.next().is_some() {
+        return Err(usage());
+    }
+
+    let archive_before = sha256_file(&input)?;
+    let result = if bypass_suppression {
+        None
+    } else {
+        Some(suppress_microphone_wav_for_transcription(&input).map_err(|error| error.message)?)
+    };
+    let transcription_input = result
+        .as_ref()
+        .map_or(input.as_path(), |result| result.path.as_path());
+    let normalized = normalize_wav_for_transcription(transcription_input, &output)
+        .map_err(|error| error.message)?;
+    if normalized != output {
+        std::fs::copy(normalized, &output).map_err(|error| error.to_string())?;
+    }
+    let archive_after = sha256_file(&input)?;
+    if archive_before != archive_after {
+        return Err("The finalized input WAV changed during evaluation.".to_string());
+    }
+
+    println!("input={}", input.display());
+    println!("output={}", output.display());
+    println!(
+        "algorithmApplied={}",
+        result.as_ref().is_some_and(|result| result.applied)
+    );
+    println!(
+        "cacheHit={}",
+        result.as_ref().is_some_and(|result| result.cache_hit)
+    );
+    println!(
+        "noiseFloorDbfs={}",
+        result
+            .as_ref()
+            .and_then(|result| result.noise_floor_dbfs)
+            .map_or_else(|| "not-measured".to_string(), |floor| format!("{floor:.2}"))
+    );
+    println!(
+        "fingerprint={}",
+        result
+            .as_ref()
+            .map_or("none", |result| result.fingerprint.as_str())
+    );
+    println!("archiveSha256={archive_after}");
+    Ok(())
+}
+
+fn usage() -> String {
+    "Usage: noise_suppression_eval <input.wav> <output.wav> [--without-suppression]".to_string()
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let bytes = std::fs::read(path).map_err(|error| error.to_string())?;
+    Ok(format!("{:x}", Sha256::digest(bytes)))
+}

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -2,6 +2,7 @@ pub mod capture;
 mod capture_buffer;
 pub mod echo;
 pub mod live_preview;
+pub mod noise_suppression;
 pub mod recovery;
 pub mod system_audio;
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/audio/noise_suppression.rs
+++ b/src-tauri/src/audio/noise_suppression.rs
@@ -2,12 +2,12 @@
 //!
 //! The finalized source WAV is never modified. This module downmixes and
 //! resamples it into a fingerprinted, atomically-written derived WAV that Turn
-//! extraction can use instead. The frame-level [`Denoiser`] seam deliberately
-//! keeps the interim dependency-free spectral implementation replaceable by a
-//! stronger RNNoise implementation after its dependency is approved.
+//! extraction can use instead. The frame-level [`Denoiser`] seam keeps RNNoise
+//! framing separate from the spectral fallback and the surrounding pipeline.
 
 use crate::domain::types::AppError;
 use hound::{SampleFormat, WavReader, WavSpec, WavWriter};
+use nnnoiseless::DenoiseState;
 use rustfft::{num_complex::Complex, Fft, FftPlanner};
 use sha2::{Digest, Sha256};
 use std::{
@@ -17,9 +17,13 @@ use std::{
     sync::Arc,
 };
 
+pub const RNNOISE_DENOISER_ID: &str = "nnnoiseless-0.5.2-v1";
 pub const SPECTRAL_DENOISER_ID: &str = "spectral-subtraction-v1";
 
 const TARGET_SAMPLE_RATE: u32 = 16_000;
+const RNNOISE_SAMPLE_RATE: u32 = 48_000;
+const RNNOISE_FRAME_SAMPLES: usize = DenoiseState::FRAME_SIZE;
+const RNNOISE_PCM_SCALE: f32 = i16::MAX as f32;
 const SPECTRAL_FRAME_SAMPLES: usize = 512;
 const SPECTRAL_HOP_SAMPLES: usize = SPECTRAL_FRAME_SAMPLES / 2;
 const SPECTRAL_BINS: usize = (SPECTRAL_FRAME_SAMPLES / 2) + 1;
@@ -42,8 +46,8 @@ const CACHE_FINGERPRINT_DOMAIN: &[u8] = b"june-microphone-noise-suppression-v1\0
 ///
 /// When `hop_samples() < frame_samples()`, the implementation must apply the
 /// shared sine analysis and synthesis window. The streaming seam overlap-adds
-/// and normalizes those frames. A future RNNoise implementation can instead
-/// declare 48 kHz, 480-sample, non-overlapping frames and process them directly.
+/// and normalizes those frames. RNNoise instead declares 48 kHz, 480-sample,
+/// non-overlapping frames and processes them directly.
 pub trait Denoiser: Send {
     fn sample_rate(&self) -> u32;
     fn frame_samples(&self) -> usize;
@@ -56,6 +60,7 @@ pub struct NoiseSuppressionOutput {
     pub path: PathBuf,
     pub cache_hit: bool,
     pub applied: bool,
+    pub denoiser_id: &'static str,
     pub fingerprint: String,
     pub noise_floor_dbfs: Option<f32>,
     pub cleanup: Option<DerivedTranscriptionInputCleanup>,
@@ -120,17 +125,25 @@ pub fn suppress_microphone_wav_for_transcription(
     input_path: &Path,
 ) -> Result<NoiseSuppressionOutput, AppError> {
     let input_sha256 = sha256_file(input_path)?;
-    let fingerprint = derived_fingerprint(&input_sha256);
-    let cache_path = derived_cache_path(input_path, &fingerprint)?;
-    let expected_samples = expected_resampled_samples(input_path, TARGET_SAMPLE_RATE)?;
+    let primary_fingerprint = derived_fingerprint(RNNOISE_DENOISER_ID, &input_sha256);
+    let primary_cache_path =
+        derived_cache_path(input_path, RNNOISE_DENOISER_ID, &primary_fingerprint)?;
+    let primary_expected_samples = expected_resampled_samples(input_path, RNNOISE_SAMPLE_RATE)?;
 
-    if valid_cached_wav(&cache_path, expected_samples) {
+    if valid_cached_wav(
+        &primary_cache_path,
+        RNNOISE_SAMPLE_RATE,
+        primary_expected_samples,
+    ) {
         return Ok(NoiseSuppressionOutput {
-            cleanup: Some(DerivedTranscriptionInputCleanup::new(cache_path.clone())),
-            path: cache_path,
+            cleanup: Some(DerivedTranscriptionInputCleanup::new(
+                primary_cache_path.clone(),
+            )),
+            path: primary_cache_path,
             cache_hit: true,
             applied: true,
-            fingerprint,
+            denoiser_id: RNNOISE_DENOISER_ID,
+            fingerprint: primary_fingerprint,
             noise_floor_dbfs: None,
         });
     }
@@ -141,9 +154,30 @@ pub fn suppress_microphone_wav_for_transcription(
             path: input_path.to_path_buf(),
             cache_hit: false,
             applied: false,
-            fingerprint,
+            denoiser_id: RNNOISE_DENOISER_ID,
+            fingerprint: primary_fingerprint,
             noise_floor_dbfs: Some(profile.noise_floor_dbfs),
             cleanup: None,
+        });
+    }
+
+    let SelectedDenoiser {
+        id: denoiser_id,
+        denoiser,
+    } = select_denoiser(profile.clone());
+    let fingerprint = derived_fingerprint(denoiser_id, &input_sha256);
+    let cache_path = derived_cache_path(input_path, denoiser_id, &fingerprint)?;
+    let denoiser_sample_rate = denoiser.sample_rate();
+    let expected_samples = expected_resampled_samples(input_path, denoiser_sample_rate)?;
+    if valid_cached_wav(&cache_path, denoiser_sample_rate, expected_samples) {
+        return Ok(NoiseSuppressionOutput {
+            cleanup: Some(DerivedTranscriptionInputCleanup::new(cache_path.clone())),
+            path: cache_path,
+            cache_hit: true,
+            applied: true,
+            denoiser_id,
+            fingerprint,
+            noise_floor_dbfs: Some(profile.noise_floor_dbfs),
         });
     }
 
@@ -155,8 +189,7 @@ pub fn suppress_microphone_wav_for_transcription(
         ".noise-suppression-{}.tmp.wav",
         uuid::Uuid::new_v4()
     ));
-    let denoiser = SpectralSubtractionDenoiser::new(profile.clone());
-    let write_result = write_denoised_wav(input_path, &temporary_path, Box::new(denoiser));
+    let write_result = write_denoised_wav(input_path, &temporary_path, denoiser);
     if let Err(error) = write_result {
         let _ = std::fs::remove_file(&temporary_path);
         return Err(error);
@@ -171,9 +204,92 @@ pub fn suppress_microphone_wav_for_transcription(
         path: cache_path,
         cache_hit: false,
         applied: true,
+        denoiser_id,
         fingerprint,
         noise_floor_dbfs: Some(profile.noise_floor_dbfs),
     })
+}
+
+struct SelectedDenoiser {
+    id: &'static str,
+    denoiser: Box<dyn Denoiser>,
+}
+
+fn select_denoiser(profile: NoiseProfile) -> SelectedDenoiser {
+    select_denoiser_from_result(profile, RnnoiseDenoiser::new())
+}
+
+fn select_denoiser_from_result(
+    profile: NoiseProfile,
+    rnnoise: Result<RnnoiseDenoiser, AppError>,
+) -> SelectedDenoiser {
+    match rnnoise {
+        Ok(denoiser) => SelectedDenoiser {
+            id: RNNOISE_DENOISER_ID,
+            denoiser: Box::new(denoiser),
+        },
+        Err(error) => {
+            tracing::warn!(
+                error_code = %error.code,
+                error = %error.message,
+                fallback = SPECTRAL_DENOISER_ID,
+                "failed to initialize RNNoise denoiser; using spectral fallback"
+            );
+            SelectedDenoiser {
+                id: SPECTRAL_DENOISER_ID,
+                denoiser: Box::new(SpectralSubtractionDenoiser::new(profile)),
+            }
+        }
+    }
+}
+
+struct RnnoiseDenoiser {
+    state: Box<DenoiseState<'static>>,
+    output: [f32; RNNOISE_FRAME_SAMPLES],
+}
+
+impl RnnoiseDenoiser {
+    fn new() -> Result<Self, AppError> {
+        let state = std::panic::catch_unwind(DenoiseState::new)
+            .map_err(|_| noise_error("RNNoise model initialization panicked."))?;
+        Ok(Self {
+            state,
+            output: [0.0; RNNOISE_FRAME_SAMPLES],
+        })
+    }
+}
+
+impl Denoiser for RnnoiseDenoiser {
+    fn sample_rate(&self) -> u32 {
+        RNNOISE_SAMPLE_RATE
+    }
+
+    fn frame_samples(&self) -> usize {
+        RNNOISE_FRAME_SAMPLES
+    }
+
+    fn hop_samples(&self) -> usize {
+        RNNOISE_FRAME_SAMPLES
+    }
+
+    fn process(&mut self, frame: &mut [f32]) -> Result<(), AppError> {
+        if frame.len() != RNNOISE_FRAME_SAMPLES {
+            return Err(noise_error(format!(
+                "Expected {} RNNoise samples, received {}.",
+                RNNOISE_FRAME_SAMPLES,
+                frame.len()
+            )));
+        }
+
+        for sample in frame.iter_mut() {
+            *sample *= RNNOISE_PCM_SCALE;
+        }
+        self.state.process_frame(&mut self.output, frame);
+        for (sample, denoised) in frame.iter_mut().zip(self.output.iter().copied()) {
+            *sample = denoised / RNNOISE_PCM_SCALE;
+        }
+        Ok(())
+    }
 }
 
 struct SpectralSubtractionDenoiser {
@@ -640,7 +756,7 @@ fn ensure_supported_pcm(spec: WavSpec) -> Result<(), AppError> {
     ))
 }
 
-fn valid_cached_wav(path: &Path, expected_samples: usize) -> bool {
+fn valid_cached_wav(path: &Path, sample_rate: u32, expected_samples: usize) -> bool {
     let Ok(reader) = WavReader::open(path) else {
         return false;
     };
@@ -648,7 +764,7 @@ fn valid_cached_wav(path: &Path, expected_samples: usize) -> bool {
     spec.sample_format == SampleFormat::Int
         && spec.bits_per_sample == 16
         && spec.channels == 1
-        && spec.sample_rate == TARGET_SAMPLE_RATE
+        && spec.sample_rate == sample_rate
         && reader.duration() as usize == expected_samples
 }
 
@@ -669,17 +785,21 @@ fn sha256_file(path: &Path) -> Result<String, AppError> {
     Ok(format!("{:x}", digest.finalize()))
 }
 
-fn derived_fingerprint(input_sha256: &str) -> String {
+fn derived_fingerprint(denoiser_id: &str, input_sha256: &str) -> String {
     let mut digest = Sha256::new();
     digest.update(CACHE_FINGERPRINT_DOMAIN);
-    digest.update((SPECTRAL_DENOISER_ID.len() as u64).to_be_bytes());
-    digest.update(SPECTRAL_DENOISER_ID.as_bytes());
+    digest.update((denoiser_id.len() as u64).to_be_bytes());
+    digest.update(denoiser_id.as_bytes());
     digest.update((input_sha256.len() as u64).to_be_bytes());
     digest.update(input_sha256.as_bytes());
     format!("{:x}", digest.finalize())
 }
 
-fn derived_cache_path(input_path: &Path, fingerprint: &str) -> Result<PathBuf, AppError> {
+fn derived_cache_path(
+    input_path: &Path,
+    denoiser_id: &str,
+    fingerprint: &str,
+) -> Result<PathBuf, AppError> {
     let parent = input_path
         .parent()
         .ok_or_else(|| noise_error("Could not determine the Microphone source directory."))?;
@@ -687,10 +807,9 @@ fn derived_cache_path(input_path: &Path, fingerprint: &str) -> Result<PathBuf, A
         .file_stem()
         .and_then(|value| value.to_str())
         .unwrap_or("microphone");
-    Ok(parent.join(CACHE_DIRECTORY).join(format!(
-        "{stem}-{SPECTRAL_DENOISER_ID}-{}.wav",
-        &fingerprint[..16]
-    )))
+    Ok(parent
+        .join(CACHE_DIRECTORY)
+        .join(format!("{stem}-{denoiser_id}-{}.wav", &fingerprint[..16])))
 }
 
 fn sine_window(len: usize) -> Vec<f32> {
@@ -735,7 +854,7 @@ mod tests {
     };
 
     #[test]
-    fn spectral_suppression_preserves_archive_and_reuses_cached_derivative() {
+    fn rnnoise_suppression_preserves_archive_and_reuses_cached_derivative() {
         let dir = test_dir("cache");
         let input = dir.join("microphone.wav");
         write_stationary_noise_fixture(&input, 4.0, true);
@@ -744,12 +863,18 @@ mod tests {
         let first = suppress_microphone_wav_for_transcription(&input).unwrap();
         assert!(first.applied);
         assert!(!first.cache_hit);
+        assert_eq!(first.denoiser_id, RNNOISE_DENOISER_ID);
         assert_ne!(first.path, input);
+        assert_eq!(
+            WavReader::open(&first.path).unwrap().spec().sample_rate,
+            RNNOISE_SAMPLE_RATE
+        );
         assert_eq!(std::fs::read(&input).unwrap(), original);
 
         let second = suppress_microphone_wav_for_transcription(&input).unwrap();
         assert!(second.applied);
         assert!(second.cache_hit);
+        assert_eq!(second.denoiser_id, RNNOISE_DENOISER_ID);
         assert_eq!(second.path, first.path);
         assert_eq!(
             std::fs::read(&second.path).unwrap(),
@@ -765,7 +890,7 @@ mod tests {
     }
 
     #[test]
-    fn clean_digital_speech_bypasses_spectral_processing() {
+    fn clean_digital_speech_bypasses_noise_suppression() {
         let dir = test_dir("clean");
         let input = dir.join("microphone.wav");
         write_clean_speech_fixture(&input, 3.0);
@@ -774,10 +899,114 @@ mod tests {
 
         assert!(!output.applied);
         assert!(!output.cache_hit);
+        assert_eq!(output.denoiser_id, RNNOISE_DENOISER_ID);
         assert_eq!(output.path, input);
         assert!(output
             .noise_floor_dbfs
             .is_some_and(|floor| floor <= CLEAN_NOISE_FLOOR_DBFS));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn rnnoise_declares_48khz_non_overlapping_frames() {
+        let denoiser = RnnoiseDenoiser::new().unwrap();
+
+        assert_eq!(denoiser.sample_rate(), RNNOISE_SAMPLE_RATE);
+        assert_eq!(denoiser.frame_samples(), 480);
+        assert_eq!(denoiser.hop_samples(), 480);
+    }
+
+    #[test]
+    fn rnnoise_rejects_an_invalid_frame_size() {
+        let mut denoiser = RnnoiseDenoiser::new().unwrap();
+        let mut frame = vec![0.0; RNNOISE_FRAME_SAMPLES - 1];
+
+        let error = denoiser.process(&mut frame).unwrap_err();
+
+        assert_eq!(error.code, "microphone_noise_suppression_failed");
+        assert!(error.message.contains("Expected 480 RNNoise samples"));
+    }
+
+    #[test]
+    fn rnnoise_reduces_noise_only_energy() {
+        let mut denoiser = RnnoiseDenoiser::new().unwrap();
+        let mut random_state = 0x1234_5678_u32;
+        let mut input_energy = 0.0_f64;
+        let mut output_energy = 0.0_f64;
+
+        for frame_index in 0..80 {
+            let mut frame = [0.0_f32; RNNOISE_FRAME_SAMPLES];
+            for (sample_index, sample) in frame.iter_mut().enumerate() {
+                let absolute_index = (frame_index * RNNOISE_FRAME_SAMPLES) + sample_index;
+                let time = absolute_index as f32 / RNNOISE_SAMPLE_RATE as f32;
+                random_state = random_state
+                    .wrapping_mul(1_664_525)
+                    .wrapping_add(1_013_904_223);
+                let white = ((random_state >> 8) as f32 / 0x00ff_ffff as f32) * 2.0 - 1.0;
+                *sample = (2.0 * std::f32::consts::PI * 95.0 * time).sin() * 0.035 + white * 0.025;
+            }
+            let input = frame;
+            denoiser.process(&mut frame).unwrap();
+            if frame_index >= 10 {
+                input_energy += frame_energy(&input);
+                output_energy += frame_energy(&frame);
+            }
+        }
+
+        assert!(
+            output_energy < input_energy * 0.5,
+            "expected RNNoise to reduce steady noise energy; input={input_energy:.3} output={output_energy:.3}"
+        );
+    }
+
+    #[test]
+    fn rnnoise_preserves_speech_band_tone_energy() {
+        let mut denoiser = RnnoiseDenoiser::new().unwrap();
+        let mut input_energy = 0.0_f64;
+        let mut output_energy = 0.0_f64;
+
+        for frame_index in 0..80 {
+            let mut frame = [0.0_f32; RNNOISE_FRAME_SAMPLES];
+            for (sample_index, sample) in frame.iter_mut().enumerate() {
+                let absolute_index = (frame_index * RNNOISE_FRAME_SAMPLES) + sample_index;
+                let time = absolute_index as f32 / RNNOISE_SAMPLE_RATE as f32;
+                let envelope = 0.65 + (2.0 * std::f32::consts::PI * 3.0 * time).sin().abs() * 0.35;
+                *sample = envelope
+                    * ((2.0 * std::f32::consts::PI * 180.0 * time).sin() * 0.18
+                        + (2.0 * std::f32::consts::PI * 360.0 * time).sin() * 0.09
+                        + (2.0 * std::f32::consts::PI * 720.0 * time).sin() * 0.04);
+            }
+            let input = frame;
+            denoiser.process(&mut frame).unwrap();
+            assert!(frame.iter().all(|sample| sample.is_finite()));
+            if frame_index >= 10 {
+                input_energy += frame_energy(&input);
+                output_energy += frame_energy(&frame);
+            }
+        }
+
+        assert!(
+            output_energy > input_energy * 0.25,
+            "expected RNNoise to retain speech-band tone energy; input={input_energy:.3} output={output_energy:.3}"
+        );
+    }
+
+    #[test]
+    fn rnnoise_construction_failure_selects_spectral_fallback() {
+        let dir = test_dir("selection-fallback");
+        let input = dir.join("microphone.wav");
+        write_stationary_noise_fixture(&input, 1.0, true);
+        let profile = analyze_noise_profile(&input).unwrap();
+
+        let selected = select_denoiser_from_result(
+            profile,
+            Err(noise_error("injected RNNoise initialization failure")),
+        );
+
+        assert_eq!(selected.id, SPECTRAL_DENOISER_ID);
+        assert_eq!(selected.denoiser.sample_rate(), TARGET_SAMPLE_RATE);
+        assert_eq!(selected.denoiser.frame_samples(), SPECTRAL_FRAME_SAMPLES);
+        assert_eq!(selected.denoiser.hop_samples(), SPECTRAL_HOP_SAMPLES);
         let _ = std::fs::remove_dir_all(dir);
     }
 
@@ -832,14 +1061,20 @@ mod tests {
         let dir = test_dir("snr");
         let clean_path = dir.join("clean.wav");
         let noisy_path = dir.join("noisy.wav");
+        let denoised_path = dir.join("denoised.wav");
         write_clean_speech_fixture(&clean_path, 4.0);
         write_stationary_noise_fixture(&noisy_path, 4.0, true);
 
-        let output = suppress_microphone_wav_for_transcription(&noisy_path).unwrap();
-        assert!(output.applied);
+        let profile = analyze_noise_profile(&noisy_path).unwrap();
+        write_denoised_wav(
+            &noisy_path,
+            &denoised_path,
+            Box::new(SpectralSubtractionDenoiser::new(profile)),
+        )
+        .unwrap();
         let clean = read_samples(&clean_path);
         let noisy = read_samples(&noisy_path);
-        let denoised = read_samples(&output.path);
+        let denoised = read_samples(&denoised_path);
         let before = reference_snr_db(&clean, &noisy);
         let after = reference_snr_db(&clean, &denoised);
 
@@ -851,22 +1086,23 @@ mod tests {
     }
 
     #[test]
-    fn spectral_suppression_resamples_48khz_input_to_expected_length() {
-        let dir = test_dir("resample-48khz");
+    fn rnnoise_resamples_and_writes_an_exact_partial_frame_length() {
+        let dir = test_dir("resample-exact-length");
         let input = dir.join("microphone.wav");
-        let seconds = 2.25;
-        write_fixture_at_sample_rate(&input, seconds, true, 48_000);
+        let seconds = 1.003;
+        let input_sample_rate = 44_100;
+        write_fixture_at_sample_rate(&input, seconds, true, input_sample_rate);
         let original = std::fs::read(&input).unwrap();
+        let expected_samples = expected_resampled_samples(&input, RNNOISE_SAMPLE_RATE).unwrap();
+        assert_ne!(expected_samples % RNNOISE_FRAME_SAMPLES, 0);
 
         let output = suppress_microphone_wav_for_transcription(&input).unwrap();
 
         assert!(output.applied);
+        assert_eq!(output.denoiser_id, RNNOISE_DENOISER_ID);
         let reader = WavReader::open(&output.path).unwrap();
-        assert_eq!(reader.spec().sample_rate, TARGET_SAMPLE_RATE);
-        assert_eq!(
-            reader.duration() as usize,
-            (seconds * TARGET_SAMPLE_RATE as f32) as usize
-        );
+        assert_eq!(reader.spec().sample_rate, RNNOISE_SAMPLE_RATE);
+        assert_eq!(reader.duration() as usize, expected_samples);
         assert_eq!(std::fs::read(&input).unwrap(), original);
         let _ = std::fs::remove_dir_all(dir);
     }
@@ -957,5 +1193,9 @@ mod tests {
             .sum::<f64>()
             .max(f64::EPSILON);
         (10.0 * (signal / error).log10()) as f32
+    }
+
+    fn frame_energy(frame: &[f32]) -> f64 {
+        frame.iter().map(|sample| (*sample as f64).powi(2)).sum()
     }
 }

--- a/src-tauri/src/audio/noise_suppression.rs
+++ b/src-tauri/src/audio/noise_suppression.rs
@@ -1,0 +1,878 @@
+//! Offline Microphone noise suppression for derived transcription input.
+//!
+//! The finalized source WAV is never modified. This module downmixes and
+//! resamples it into a fingerprinted, atomically-written derived WAV that Turn
+//! extraction can use instead. The frame-level [`Denoiser`] seam deliberately
+//! keeps the interim dependency-free spectral implementation replaceable by a
+//! stronger RNNoise implementation after its dependency is approved.
+
+use crate::domain::types::AppError;
+use hound::{SampleFormat, WavReader, WavSpec, WavWriter};
+use rustfft::{num_complex::Complex, Fft, FftPlanner};
+use sha2::{Digest, Sha256};
+use std::{
+    fs::File,
+    io::{BufReader, Read},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+pub const SPECTRAL_DENOISER_ID: &str = "spectral-subtraction-v1";
+
+const TARGET_SAMPLE_RATE: u32 = 16_000;
+const SPECTRAL_FRAME_SAMPLES: usize = 512;
+const SPECTRAL_HOP_SAMPLES: usize = SPECTRAL_FRAME_SAMPLES / 2;
+const SPECTRAL_BINS: usize = (SPECTRAL_FRAME_SAMPLES / 2) + 1;
+const RMS_HISTOGRAM_BINS: usize = 192;
+const MIN_DBFS: f32 = -96.0;
+const MAX_DBFS: f32 = 0.0;
+const NOISE_PERCENTILE: f32 = 0.20;
+const NOISE_PROFILE_MARGIN_DB: f32 = 3.0;
+const CLEAN_NOISE_FLOOR_DBFS: f32 = -58.0;
+const SPECTRAL_OVERSUBTRACTION: f32 = 1.5;
+const MIN_POWER_RATIO: f32 = 0.035;
+const MIN_SPECTRAL_GAIN: f32 = 0.18;
+const HIGH_SNR_DB: f32 = 14.0;
+const PCM_CHUNK_SAMPLE_BUDGET: usize = 16 * 1024;
+const CACHE_DIRECTORY: &str = ".june-transcription-input";
+const CACHE_FINGERPRINT_DOMAIN: &[u8] = b"june-microphone-noise-suppression-v1\0";
+
+/// One replaceable frame processor. Implementations declare the PCM shape they
+/// accept, then mutate a normalized `f32` frame in place.
+///
+/// When `hop_samples() < frame_samples()`, the implementation must apply the
+/// shared sine analysis and synthesis window. The streaming seam overlap-adds
+/// and normalizes those frames. A future RNNoise implementation can instead
+/// declare 48 kHz, 480-sample, non-overlapping frames and process them directly.
+pub trait Denoiser: Send {
+    fn sample_rate(&self) -> u32;
+    fn frame_samples(&self) -> usize;
+    fn hop_samples(&self) -> usize;
+    fn process(&mut self, frame: &mut [f32]) -> Result<(), AppError>;
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NoiseSuppressionOutput {
+    pub path: PathBuf,
+    pub cache_hit: bool,
+    pub applied: bool,
+    pub fingerprint: String,
+    pub noise_floor_dbfs: Option<f32>,
+}
+
+#[derive(Debug, Clone)]
+struct NoiseProfile {
+    power: Vec<f32>,
+    noise_floor_dbfs: f32,
+}
+
+/// Produces or reuses a deterministic derived transcription-input WAV.
+///
+/// Clean inputs are returned unchanged to avoid needlessly touching speech.
+/// Errors are intentionally returned to the caller, which owns the
+/// source-specific diagnostic and raw-WAV fallback policy.
+pub fn suppress_microphone_wav_for_transcription(
+    input_path: &Path,
+) -> Result<NoiseSuppressionOutput, AppError> {
+    let input_sha256 = sha256_file(input_path)?;
+    let fingerprint = derived_fingerprint(&input_sha256);
+    let cache_path = derived_cache_path(input_path, &fingerprint)?;
+    let expected_samples = expected_resampled_samples(input_path, TARGET_SAMPLE_RATE)?;
+
+    if valid_cached_wav(&cache_path, expected_samples) {
+        return Ok(NoiseSuppressionOutput {
+            path: cache_path,
+            cache_hit: true,
+            applied: true,
+            fingerprint,
+            noise_floor_dbfs: None,
+        });
+    }
+
+    let profile = analyze_noise_profile(input_path)?;
+    if profile.noise_floor_dbfs <= CLEAN_NOISE_FLOOR_DBFS {
+        return Ok(NoiseSuppressionOutput {
+            path: input_path.to_path_buf(),
+            cache_hit: false,
+            applied: false,
+            fingerprint,
+            noise_floor_dbfs: Some(profile.noise_floor_dbfs),
+        });
+    }
+
+    let parent = cache_path.parent().ok_or_else(|| {
+        noise_error("Could not determine the derived transcription-input directory.")
+    })?;
+    std::fs::create_dir_all(parent).map_err(|error| noise_error(error.to_string()))?;
+    let temporary_path = parent.join(format!(
+        ".noise-suppression-{}.tmp.wav",
+        uuid::Uuid::new_v4()
+    ));
+    let denoiser = SpectralSubtractionDenoiser::new(profile.clone());
+    let write_result = write_denoised_wav(input_path, &temporary_path, Box::new(denoiser));
+    if let Err(error) = write_result {
+        let _ = std::fs::remove_file(&temporary_path);
+        return Err(error);
+    }
+    if let Err(error) = crate::hermes_bridge::replace_file(&temporary_path, &cache_path) {
+        let _ = std::fs::remove_file(&temporary_path);
+        return Err(noise_error(error.to_string()));
+    }
+
+    Ok(NoiseSuppressionOutput {
+        path: cache_path,
+        cache_hit: false,
+        applied: true,
+        fingerprint,
+        noise_floor_dbfs: Some(profile.noise_floor_dbfs),
+    })
+}
+
+struct SpectralSubtractionDenoiser {
+    forward: Arc<dyn Fft<f32>>,
+    inverse: Arc<dyn Fft<f32>>,
+    spectrum: Vec<Complex<f32>>,
+    noise_power: Vec<f32>,
+    previous_gain: Vec<f32>,
+    target_gain: Vec<f32>,
+    smoothed_gain: Vec<f32>,
+    window: Vec<f32>,
+}
+
+impl SpectralSubtractionDenoiser {
+    fn new(profile: NoiseProfile) -> Self {
+        let mut planner = FftPlanner::<f32>::new();
+        Self {
+            forward: planner.plan_fft_forward(SPECTRAL_FRAME_SAMPLES),
+            inverse: planner.plan_fft_inverse(SPECTRAL_FRAME_SAMPLES),
+            spectrum: vec![Complex::new(0.0, 0.0); SPECTRAL_FRAME_SAMPLES],
+            noise_power: profile.power,
+            previous_gain: vec![1.0; SPECTRAL_BINS],
+            target_gain: vec![1.0; SPECTRAL_BINS],
+            smoothed_gain: vec![1.0; SPECTRAL_BINS],
+            window: sine_window(SPECTRAL_FRAME_SAMPLES),
+        }
+    }
+}
+
+impl Denoiser for SpectralSubtractionDenoiser {
+    fn sample_rate(&self) -> u32 {
+        TARGET_SAMPLE_RATE
+    }
+
+    fn frame_samples(&self) -> usize {
+        SPECTRAL_FRAME_SAMPLES
+    }
+
+    fn hop_samples(&self) -> usize {
+        SPECTRAL_HOP_SAMPLES
+    }
+
+    fn process(&mut self, frame: &mut [f32]) -> Result<(), AppError> {
+        if frame.len() != SPECTRAL_FRAME_SAMPLES {
+            return Err(noise_error(format!(
+                "Expected {} samples, received {}.",
+                SPECTRAL_FRAME_SAMPLES,
+                frame.len()
+            )));
+        }
+
+        for (index, sample) in frame.iter().copied().enumerate() {
+            self.spectrum[index] = Complex::new(sample * self.window[index], 0.0);
+        }
+        self.forward.process(&mut self.spectrum);
+
+        for bin in 0..SPECTRAL_BINS {
+            let power = self.spectrum[bin].norm_sqr();
+            let noise = self.noise_power.get(bin).copied().unwrap_or(0.0);
+            if noise <= f32::EPSILON || power <= f32::EPSILON {
+                self.target_gain[bin] = 1.0;
+                continue;
+            }
+            let snr_db = 10.0 * (power / noise).max(f32::EPSILON).log10();
+            let residual_power =
+                (power - (SPECTRAL_OVERSUBTRACTION * noise)).max(power * MIN_POWER_RATIO);
+            let spectral_gain = (residual_power / power)
+                .sqrt()
+                .clamp(MIN_SPECTRAL_GAIN, 1.0);
+            let speech_weight = (snr_db / HIGH_SNR_DB).clamp(0.0, 1.0);
+            self.target_gain[bin] =
+                spectral_gain + ((1.0 - spectral_gain) * speech_weight * speech_weight);
+        }
+
+        for bin in 0..SPECTRAL_BINS {
+            let left = bin.saturating_sub(1);
+            let right = (bin + 1).min(SPECTRAL_BINS - 1);
+            let frequency_smoothed =
+                (self.target_gain[left] + (2.0 * self.target_gain[bin]) + self.target_gain[right])
+                    / 4.0;
+            let previous = self.previous_gain[bin];
+            // Reduce noise promptly, then release slowly to avoid audible
+            // pumping at word endings and quiet syllables.
+            let smoothing = if frequency_smoothed < previous {
+                0.55
+            } else {
+                0.88
+            };
+            let gain = (smoothing * previous) + ((1.0 - smoothing) * frequency_smoothed);
+            self.smoothed_gain[bin] = gain.clamp(MIN_SPECTRAL_GAIN, 1.0);
+        }
+        self.previous_gain.copy_from_slice(&self.smoothed_gain);
+
+        for bin in 0..SPECTRAL_BINS {
+            self.spectrum[bin] *= self.smoothed_gain[bin];
+            if bin > 0 && bin < SPECTRAL_FRAME_SAMPLES / 2 {
+                let mirror = SPECTRAL_FRAME_SAMPLES - bin;
+                self.spectrum[mirror] *= self.smoothed_gain[bin];
+            }
+        }
+        self.inverse.process(&mut self.spectrum);
+        let inverse_scale = 1.0 / SPECTRAL_FRAME_SAMPLES as f32;
+        for (index, sample) in frame.iter_mut().enumerate() {
+            *sample = self.spectrum[index].re * inverse_scale * self.window[index];
+        }
+        Ok(())
+    }
+}
+
+fn analyze_noise_profile(input_path: &Path) -> Result<NoiseProfile, AppError> {
+    let mut planner = FftPlanner::<f32>::new();
+    let fft = planner.plan_fft_forward(SPECTRAL_FRAME_SAMPLES);
+    let window = sine_window(SPECTRAL_FRAME_SAMPLES);
+    let mut spectrum = vec![Complex::new(0.0, 0.0); SPECTRAL_FRAME_SAMPLES];
+    let mut counts = vec![0_u64; RMS_HISTOGRAM_BINS];
+    let mut power_sums = vec![vec![0.0_f64; SPECTRAL_BINS]; RMS_HISTOGRAM_BINS];
+    let mut frame_count = 0_u64;
+
+    for_each_overlapping_frame(
+        input_path,
+        TARGET_SAMPLE_RATE,
+        SPECTRAL_FRAME_SAMPLES,
+        SPECTRAL_HOP_SAMPLES,
+        |frame, valid_samples| {
+            let valid_samples = valid_samples.max(1);
+            let rms = (frame[..valid_samples]
+                .iter()
+                .map(|sample| (*sample as f64).powi(2))
+                .sum::<f64>()
+                / valid_samples as f64)
+                .sqrt() as f32;
+            let dbfs = amplitude_dbfs(rms);
+            let histogram_bin = dbfs_histogram_bin(dbfs);
+            counts[histogram_bin] += 1;
+            frame_count += 1;
+
+            for (index, sample) in frame.iter().copied().enumerate() {
+                spectrum[index] = Complex::new(sample * window[index], 0.0);
+            }
+            fft.process(&mut spectrum);
+            for bin in 0..SPECTRAL_BINS {
+                power_sums[histogram_bin][bin] += spectrum[bin].norm_sqr() as f64;
+            }
+            Ok(())
+        },
+    )?;
+
+    if frame_count == 0 {
+        return Err(noise_error(
+            "The Microphone source contains no PCM samples.",
+        ));
+    }
+    let percentile_rank = ((frame_count as f32 * NOISE_PERCENTILE).ceil() as u64).max(1);
+    let mut seen = 0_u64;
+    let mut percentile_bin = 0_usize;
+    for (bin, count) in counts.iter().copied().enumerate() {
+        seen += count;
+        if seen >= percentile_rank {
+            percentile_bin = bin;
+            break;
+        }
+    }
+    let margin_bins = ((NOISE_PROFILE_MARGIN_DB / histogram_bin_width()).ceil() as usize).max(1);
+    let profile_max_bin = (percentile_bin + margin_bins).min(RMS_HISTOGRAM_BINS - 1);
+    let profile_frame_count = counts[..=profile_max_bin].iter().sum::<u64>().max(1);
+    let mut power = vec![0.0_f32; SPECTRAL_BINS];
+    for (bin, output) in power.iter_mut().enumerate() {
+        let total = power_sums[..=profile_max_bin]
+            .iter()
+            .map(|values| values[bin])
+            .sum::<f64>();
+        *output = (total / profile_frame_count as f64) as f32;
+    }
+
+    Ok(NoiseProfile {
+        power,
+        noise_floor_dbfs: histogram_bin_upper_dbfs(percentile_bin),
+    })
+}
+
+fn write_denoised_wav(
+    input_path: &Path,
+    output_path: &Path,
+    mut denoiser: Box<dyn Denoiser>,
+) -> Result<(), AppError> {
+    let frame_samples = denoiser.frame_samples();
+    let hop_samples = denoiser.hop_samples();
+    if frame_samples == 0 || hop_samples == 0 || hop_samples > frame_samples {
+        return Err(noise_error("The denoiser declared an invalid frame shape."));
+    }
+    let output_spec = WavSpec {
+        channels: 1,
+        sample_rate: denoiser.sample_rate(),
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+    let mut writer = WavWriter::create(output_path, output_spec)
+        .map_err(|error| noise_error(error.to_string()))?;
+    let expected_samples = expected_resampled_samples(input_path, denoiser.sample_rate())?;
+    let mut overlap = vec![0.0_f32; frame_samples];
+    let mut overlap_weight = vec![0.0_f32; frame_samples];
+    let reconstruction_window = if hop_samples < frame_samples {
+        sine_window(frame_samples)
+    } else {
+        vec![1.0; frame_samples]
+    };
+    let mut written_samples = 0_usize;
+
+    let processing_result = for_each_overlapping_frame(
+        input_path,
+        denoiser.sample_rate(),
+        frame_samples,
+        hop_samples,
+        |frame, _valid_samples| {
+            denoiser.process(frame)?;
+            for index in 0..frame_samples {
+                overlap[index] += frame[index];
+                overlap_weight[index] += reconstruction_window[index].powi(2);
+            }
+            let samples_to_write =
+                hop_samples.min(expected_samples.saturating_sub(written_samples));
+            for index in 0..samples_to_write {
+                let normalized = if overlap_weight[index] > f32::EPSILON {
+                    overlap[index] / overlap_weight[index]
+                } else {
+                    overlap[index]
+                };
+                writer
+                    .write_sample(f32_to_i16(normalized))
+                    .map_err(|error| noise_error(error.to_string()))?;
+            }
+            written_samples += samples_to_write;
+            overlap.copy_within(hop_samples.., 0);
+            overlap[(frame_samples - hop_samples)..].fill(0.0);
+            overlap_weight.copy_within(hop_samples.., 0);
+            overlap_weight[(frame_samples - hop_samples)..].fill(0.0);
+            Ok(())
+        },
+    );
+    if let Err(error) = processing_result {
+        drop(writer);
+        return Err(error);
+    }
+    if written_samples != expected_samples {
+        drop(writer);
+        return Err(noise_error(format!(
+            "Noise suppression wrote {written_samples} samples; expected {expected_samples}."
+        )));
+    }
+    writer
+        .finalize()
+        .map_err(|error| noise_error(error.to_string()))
+}
+
+fn for_each_overlapping_frame(
+    input_path: &Path,
+    output_rate: u32,
+    frame_samples: usize,
+    hop_samples: usize,
+    mut on_frame: impl FnMut(&mut [f32], usize) -> Result<(), AppError>,
+) -> Result<(), AppError> {
+    let expected_samples = expected_resampled_samples(input_path, output_rate)?;
+    if expected_samples == 0 {
+        return Ok(());
+    }
+    let mut buffer = vec![0.0_f32; frame_samples];
+    let mut frame = vec![0.0_f32; frame_samples];
+    let mut buffered = 0_usize;
+    let mut frame_start = 0_usize;
+    for_each_resampled_mono_sample(input_path, output_rate, |sample| {
+        buffer[buffered] = sample;
+        buffered += 1;
+        if buffered == frame_samples {
+            frame.copy_from_slice(&buffer);
+            on_frame(&mut frame, frame_samples)?;
+            buffer.copy_within(hop_samples.., 0);
+            buffered = frame_samples - hop_samples;
+            frame_start += hop_samples;
+        }
+        Ok(())
+    })?;
+
+    while frame_start < expected_samples {
+        let valid_samples = expected_samples
+            .saturating_sub(frame_start)
+            .min(frame_samples);
+        buffer[buffered..].fill(0.0);
+        frame.copy_from_slice(&buffer);
+        on_frame(&mut frame, valid_samples)?;
+        buffer.copy_within(hop_samples.., 0);
+        buffer[(frame_samples - hop_samples)..].fill(0.0);
+        buffered = frame_samples - hop_samples;
+        frame_start += hop_samples;
+    }
+    Ok(())
+}
+
+fn for_each_resampled_mono_sample(
+    input_path: &Path,
+    output_rate: u32,
+    mut on_sample: impl FnMut(f32) -> Result<(), AppError>,
+) -> Result<(), AppError> {
+    let mut reader = WavReader::open(input_path).map_err(|error| noise_error(error.to_string()))?;
+    let spec = reader.spec();
+    ensure_supported_pcm(spec)?;
+    let channel_count = spec.channels.max(1) as usize;
+    let mono_sample_count = reader.duration() as usize;
+    let mut resampler = StreamingLinearResampler::new(
+        mono_sample_count,
+        spec.sample_rate.max(1),
+        output_rate.max(1),
+    );
+    let mut chunk = Vec::with_capacity(PCM_CHUNK_SAMPLE_BUDGET);
+    let mut frame_sum = 0_i32;
+    let mut samples_in_frame = 0_usize;
+    let mut samples = reader.samples::<i16>();
+
+    loop {
+        chunk.clear();
+        for _ in 0..PCM_CHUNK_SAMPLE_BUDGET {
+            let Some(sample) = samples.next() else {
+                break;
+            };
+            chunk.push(sample.map_err(|error| noise_error(error.to_string()))?);
+        }
+        if chunk.is_empty() {
+            break;
+        }
+        for sample in chunk.iter().copied() {
+            frame_sum += sample as i32;
+            samples_in_frame += 1;
+            if samples_in_frame == channel_count {
+                let mono = (frame_sum / samples_in_frame as i32)
+                    .clamp(i16::MIN as i32, i16::MAX as i32) as i16;
+                resampler.push(mono, |sample| on_sample(sample as f32 / i16::MAX as f32))?;
+                frame_sum = 0;
+                samples_in_frame = 0;
+            }
+        }
+    }
+    if samples_in_frame > 0 {
+        let mono =
+            (frame_sum / samples_in_frame as i32).clamp(i16::MIN as i32, i16::MAX as i32) as i16;
+        resampler.push(mono, |sample| on_sample(sample as f32 / i16::MAX as f32))?;
+    }
+    resampler.ensure_complete()
+}
+
+struct StreamingLinearResampler {
+    ratio: f64,
+    total_input_samples: usize,
+    output_len: usize,
+    next_output_index: usize,
+    next_input_index: usize,
+    previous_sample: Option<i16>,
+}
+
+impl StreamingLinearResampler {
+    fn new(total_input_samples: usize, input_rate: u32, output_rate: u32) -> Self {
+        let ratio = input_rate as f64 / output_rate as f64;
+        let output_len = if total_input_samples == 0 {
+            0
+        } else if input_rate == output_rate {
+            total_input_samples
+        } else {
+            ((total_input_samples as f64) / ratio).ceil().max(1.0) as usize
+        };
+        Self {
+            ratio,
+            total_input_samples,
+            output_len,
+            next_output_index: 0,
+            next_input_index: 0,
+            previous_sample: None,
+        }
+    }
+
+    fn push(
+        &mut self,
+        sample: i16,
+        mut on_sample: impl FnMut(i16) -> Result<(), AppError>,
+    ) -> Result<(), AppError> {
+        let current_input_index = self.next_input_index;
+        while self.next_output_index < self.output_len {
+            let source_pos = self.next_output_index as f64 * self.ratio;
+            let left_index = source_pos.floor() as usize;
+            let right_index = (left_index + 1).min(self.total_input_samples - 1);
+            if right_index > current_input_index {
+                break;
+            }
+            let left = self.sample_at(left_index, current_input_index, sample)? as f64;
+            let right = self.sample_at(right_index, current_input_index, sample)? as f64;
+            let fraction = source_pos - left_index as f64;
+            let resampled = (left + ((right - left) * fraction))
+                .round()
+                .clamp(i16::MIN as f64, i16::MAX as f64) as i16;
+            on_sample(resampled)?;
+            self.next_output_index += 1;
+        }
+        self.previous_sample = Some(sample);
+        self.next_input_index += 1;
+        Ok(())
+    }
+
+    fn sample_at(
+        &self,
+        requested_index: usize,
+        current_input_index: usize,
+        current_sample: i16,
+    ) -> Result<i16, AppError> {
+        if requested_index == current_input_index {
+            return Ok(current_sample);
+        }
+        if requested_index + 1 == current_input_index {
+            return self
+                .previous_sample
+                .ok_or_else(|| noise_error("The resampler lost its previous sample."));
+        }
+        Err(noise_error(
+            "The resampler advanced past a required sample.",
+        ))
+    }
+
+    fn ensure_complete(&self) -> Result<(), AppError> {
+        if self.next_input_index == self.total_input_samples
+            && self.next_output_index == self.output_len
+        {
+            return Ok(());
+        }
+        Err(noise_error(
+            "The resampler did not consume the expected sample counts.",
+        ))
+    }
+}
+
+fn expected_resampled_samples(input_path: &Path, output_rate: u32) -> Result<usize, AppError> {
+    let reader = WavReader::open(input_path).map_err(|error| noise_error(error.to_string()))?;
+    let spec = reader.spec();
+    ensure_supported_pcm(spec)?;
+    let input_samples = reader.duration() as usize;
+    if input_samples == 0 {
+        return Ok(0);
+    }
+    if spec.sample_rate == output_rate {
+        return Ok(input_samples);
+    }
+    Ok(
+        ((input_samples as f64 * output_rate as f64) / spec.sample_rate.max(1) as f64)
+            .ceil()
+            .max(1.0) as usize,
+    )
+}
+
+fn ensure_supported_pcm(spec: WavSpec) -> Result<(), AppError> {
+    if spec.sample_format == SampleFormat::Int
+        && spec.bits_per_sample == 16
+        && spec.channels > 0
+        && spec.sample_rate > 0
+    {
+        return Ok(());
+    }
+    Err(noise_error(
+        "Only 16-bit PCM WAV noise suppression is supported.",
+    ))
+}
+
+fn valid_cached_wav(path: &Path, expected_samples: usize) -> bool {
+    let Ok(reader) = WavReader::open(path) else {
+        return false;
+    };
+    let spec = reader.spec();
+    spec.sample_format == SampleFormat::Int
+        && spec.bits_per_sample == 16
+        && spec.channels == 1
+        && spec.sample_rate == TARGET_SAMPLE_RATE
+        && reader.duration() as usize == expected_samples
+}
+
+fn sha256_file(path: &Path) -> Result<String, AppError> {
+    let file = File::open(path).map_err(|error| noise_error(error.to_string()))?;
+    let mut reader = BufReader::new(file);
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|error| noise_error(error.to_string()))?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+fn derived_fingerprint(input_sha256: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(CACHE_FINGERPRINT_DOMAIN);
+    digest.update((SPECTRAL_DENOISER_ID.len() as u64).to_be_bytes());
+    digest.update(SPECTRAL_DENOISER_ID.as_bytes());
+    digest.update((input_sha256.len() as u64).to_be_bytes());
+    digest.update(input_sha256.as_bytes());
+    format!("{:x}", digest.finalize())
+}
+
+fn derived_cache_path(input_path: &Path, fingerprint: &str) -> Result<PathBuf, AppError> {
+    let parent = input_path
+        .parent()
+        .ok_or_else(|| noise_error("Could not determine the Microphone source directory."))?;
+    let stem = input_path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("microphone");
+    Ok(parent.join(CACHE_DIRECTORY).join(format!(
+        "{stem}-{SPECTRAL_DENOISER_ID}-{}.wav",
+        &fingerprint[..16]
+    )))
+}
+
+fn sine_window(len: usize) -> Vec<f32> {
+    (0..len)
+        .map(|index| (std::f32::consts::PI * (index as f32 + 0.5) / len as f32).sin())
+        .collect()
+}
+
+fn amplitude_dbfs(amplitude: f32) -> f32 {
+    20.0 * amplitude.max(10.0_f32.powf(MIN_DBFS / 20.0)).log10()
+}
+
+fn histogram_bin_width() -> f32 {
+    (MAX_DBFS - MIN_DBFS) / RMS_HISTOGRAM_BINS as f32
+}
+
+fn dbfs_histogram_bin(dbfs: f32) -> usize {
+    (((dbfs.clamp(MIN_DBFS, MAX_DBFS) - MIN_DBFS) / histogram_bin_width()).floor() as usize)
+        .min(RMS_HISTOGRAM_BINS - 1)
+}
+
+fn histogram_bin_upper_dbfs(bin: usize) -> f32 {
+    (MIN_DBFS + ((bin + 1) as f32 * histogram_bin_width())).min(MAX_DBFS)
+}
+
+fn f32_to_i16(sample: f32) -> i16 {
+    (sample.clamp(-1.0, 1.0) * i16::MAX as f32)
+        .round()
+        .clamp(i16::MIN as f32, i16::MAX as f32) as i16
+}
+
+fn noise_error(message: impl Into<String>) -> AppError {
+    AppError::new("microphone_noise_suppression_failed", message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    #[test]
+    fn spectral_suppression_preserves_archive_and_reuses_cached_derivative() {
+        let dir = test_dir("cache");
+        let input = dir.join("microphone.wav");
+        write_stationary_noise_fixture(&input, 4.0, true);
+        let original = std::fs::read(&input).unwrap();
+
+        let first = suppress_microphone_wav_for_transcription(&input).unwrap();
+        assert!(first.applied);
+        assert!(!first.cache_hit);
+        assert_ne!(first.path, input);
+        assert_eq!(std::fs::read(&input).unwrap(), original);
+
+        let second = suppress_microphone_wav_for_transcription(&input).unwrap();
+        assert!(second.applied);
+        assert!(second.cache_hit);
+        assert_eq!(second.path, first.path);
+        assert_eq!(
+            std::fs::read(&second.path).unwrap(),
+            std::fs::read(&first.path).unwrap()
+        );
+        assert_eq!(std::fs::read(&input).unwrap(), original);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn clean_digital_speech_bypasses_spectral_processing() {
+        let dir = test_dir("clean");
+        let input = dir.join("microphone.wav");
+        write_clean_speech_fixture(&input, 3.0);
+
+        let output = suppress_microphone_wav_for_transcription(&input).unwrap();
+
+        assert!(!output.applied);
+        assert!(!output.cache_hit);
+        assert_eq!(output.path, input);
+        assert!(output
+            .noise_floor_dbfs
+            .is_some_and(|floor| floor <= CLEAN_NOISE_FLOOR_DBFS));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn failing_denoiser_leaves_no_complete_derived_wav() {
+        struct FailingDenoiser {
+            calls: Arc<AtomicUsize>,
+        }
+        impl Denoiser for FailingDenoiser {
+            fn sample_rate(&self) -> u32 {
+                TARGET_SAMPLE_RATE
+            }
+
+            fn frame_samples(&self) -> usize {
+                480
+            }
+
+            fn hop_samples(&self) -> usize {
+                480
+            }
+
+            fn process(&mut self, _frame: &mut [f32]) -> Result<(), AppError> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Err(noise_error("injected denoiser failure"))
+            }
+        }
+
+        let dir = test_dir("failure");
+        let input = dir.join("microphone.wav");
+        let output = dir.join("derived.wav");
+        write_stationary_noise_fixture(&input, 1.0, true);
+        let original = std::fs::read(&input).unwrap();
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let error = write_denoised_wav(
+            &input,
+            &output,
+            Box::new(FailingDenoiser {
+                calls: Arc::clone(&calls),
+            }),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "microphone_noise_suppression_failed");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(std::fs::read(input).unwrap(), original);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn spectral_fallback_improves_stationary_noise_snr() {
+        let dir = test_dir("snr");
+        let clean_path = dir.join("clean.wav");
+        let noisy_path = dir.join("noisy.wav");
+        write_clean_speech_fixture(&clean_path, 4.0);
+        write_stationary_noise_fixture(&noisy_path, 4.0, true);
+
+        let output = suppress_microphone_wav_for_transcription(&noisy_path).unwrap();
+        assert!(output.applied);
+        let clean = read_samples(&clean_path);
+        let noisy = read_samples(&noisy_path);
+        let denoised = read_samples(&output.path);
+        let before = reference_snr_db(&clean, &noisy);
+        let after = reference_snr_db(&clean, &denoised);
+
+        assert!(
+            after > before + 2.0,
+            "expected a measurable stationary-noise improvement; before={before:.2} dB after={after:.2} dB"
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    fn test_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "os-june-noise-suppression-{label}-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_clean_speech_fixture(path: &Path, seconds: f32) {
+        write_fixture(path, seconds, false);
+    }
+
+    fn write_stationary_noise_fixture(path: &Path, seconds: f32, include_noise: bool) {
+        write_fixture(path, seconds, include_noise);
+    }
+
+    fn write_fixture(path: &Path, seconds: f32, include_noise: bool) {
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: TARGET_SAMPLE_RATE,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        };
+        let sample_count = (seconds * TARGET_SAMPLE_RATE as f32) as usize;
+        let mut writer = WavWriter::create(path, spec).unwrap();
+        let mut random_state = 0x1234_5678_u32;
+        for index in 0..sample_count {
+            let time = index as f32 / TARGET_SAMPLE_RATE as f32;
+            let speech_active = (time % 2.0) >= 0.55;
+            let envelope = if speech_active {
+                let phase = (time % 2.0) - 0.55;
+                (phase / 0.08).clamp(0.0, 1.0) * ((1.45 - phase) / 0.12).clamp(0.0, 1.0)
+            } else {
+                0.0
+            };
+            let clean = envelope
+                * ((2.0 * std::f32::consts::PI * 180.0 * time).sin() * 0.18
+                    + (2.0 * std::f32::consts::PI * 360.0 * time).sin() * 0.09
+                    + (2.0 * std::f32::consts::PI * 720.0 * time).sin() * 0.04);
+            random_state = random_state
+                .wrapping_mul(1_664_525)
+                .wrapping_add(1_013_904_223);
+            let white = ((random_state >> 8) as f32 / 0x00ff_ffff as f32) * 2.0 - 1.0;
+            let noise = if include_noise {
+                (2.0 * std::f32::consts::PI * 95.0 * time).sin() * 0.035
+                    + (2.0 * std::f32::consts::PI * 190.0 * time).sin() * 0.018
+                    + white * 0.012
+            } else {
+                0.0
+            };
+            writer.write_sample(f32_to_i16(clean + noise)).unwrap();
+        }
+        writer.finalize().unwrap();
+    }
+
+    fn read_samples(path: &Path) -> Vec<f32> {
+        WavReader::open(path)
+            .unwrap()
+            .samples::<i16>()
+            .map(|sample| sample.unwrap() as f32 / i16::MAX as f32)
+            .collect()
+    }
+
+    fn reference_snr_db(reference: &[f32], candidate: &[f32]) -> f32 {
+        let len = reference.len().min(candidate.len());
+        let signal = reference[..len]
+            .iter()
+            .map(|sample| (*sample as f64).powi(2))
+            .sum::<f64>();
+        let error = reference[..len]
+            .iter()
+            .zip(&candidate[..len])
+            .map(|(reference, candidate)| (*candidate as f64 - *reference as f64).powi(2))
+            .sum::<f64>()
+            .max(f64::EPSILON);
+        (10.0 * (signal / error).log10()) as f32
+    }
+}

--- a/src-tauri/src/audio/noise_suppression.rs
+++ b/src-tauri/src/audio/noise_suppression.rs
@@ -51,13 +51,58 @@ pub trait Denoiser: Send {
     fn process(&mut self, frame: &mut [f32]) -> Result<(), AppError>;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug)]
 pub struct NoiseSuppressionOutput {
     pub path: PathBuf,
     pub cache_hit: bool,
     pub applied: bool,
     pub fingerprint: String,
     pub noise_floor_dbfs: Option<f32>,
+    pub cleanup: Option<DerivedTranscriptionInputCleanup>,
+}
+
+/// Keeps one derived transcription input alive until every preparation and
+/// provider task that can read it has drained.
+///
+/// The deterministic path remains reusable after a process crash, but normal
+/// completion and cancellation remove it instead of retaining a second
+/// recording-sized WAV indefinitely.
+#[derive(Debug)]
+pub struct DerivedTranscriptionInputCleanup {
+    path: PathBuf,
+}
+
+impl DerivedTranscriptionInputCleanup {
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl Drop for DerivedTranscriptionInputCleanup {
+    fn drop(&mut self) {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                tracing::warn!(
+                    path = %self.path.display(),
+                    %error,
+                    "failed to remove derived transcription input"
+                );
+                return;
+            }
+        }
+
+        let Some(parent) = self.path.parent() else {
+            return;
+        };
+        let directory_is_empty = std::fs::read_dir(parent)
+            .ok()
+            .is_some_and(|mut entries| entries.next().is_none());
+        if directory_is_empty {
+            let _ = std::fs::remove_dir(parent);
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -81,6 +126,7 @@ pub fn suppress_microphone_wav_for_transcription(
 
     if valid_cached_wav(&cache_path, expected_samples) {
         return Ok(NoiseSuppressionOutput {
+            cleanup: Some(DerivedTranscriptionInputCleanup::new(cache_path.clone())),
             path: cache_path,
             cache_hit: true,
             applied: true,
@@ -97,6 +143,7 @@ pub fn suppress_microphone_wav_for_transcription(
             applied: false,
             fingerprint,
             noise_floor_dbfs: Some(profile.noise_floor_dbfs),
+            cleanup: None,
         });
     }
 
@@ -120,6 +167,7 @@ pub fn suppress_microphone_wav_for_transcription(
     }
 
     Ok(NoiseSuppressionOutput {
+        cleanup: Some(DerivedTranscriptionInputCleanup::new(cache_path.clone())),
         path: cache_path,
         cache_hit: false,
         applied: true,
@@ -708,6 +756,11 @@ mod tests {
             std::fs::read(&first.path).unwrap()
         );
         assert_eq!(std::fs::read(&input).unwrap(), original);
+        let derived = first.path.clone();
+        drop(second);
+        drop(first);
+        assert!(!derived.exists());
+        assert!(!dir.join(CACHE_DIRECTORY).exists());
         let _ = std::fs::remove_dir_all(dir);
     }
 
@@ -797,6 +850,27 @@ mod tests {
         let _ = std::fs::remove_dir_all(dir);
     }
 
+    #[test]
+    fn spectral_suppression_resamples_48khz_input_to_expected_length() {
+        let dir = test_dir("resample-48khz");
+        let input = dir.join("microphone.wav");
+        let seconds = 2.25;
+        write_fixture_at_sample_rate(&input, seconds, true, 48_000);
+        let original = std::fs::read(&input).unwrap();
+
+        let output = suppress_microphone_wav_for_transcription(&input).unwrap();
+
+        assert!(output.applied);
+        let reader = WavReader::open(&output.path).unwrap();
+        assert_eq!(reader.spec().sample_rate, TARGET_SAMPLE_RATE);
+        assert_eq!(
+            reader.duration() as usize,
+            (seconds * TARGET_SAMPLE_RATE as f32) as usize
+        );
+        assert_eq!(std::fs::read(&input).unwrap(), original);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
     fn test_dir(label: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(
             "os-june-noise-suppression-{label}-{}",
@@ -815,17 +889,26 @@ mod tests {
     }
 
     fn write_fixture(path: &Path, seconds: f32, include_noise: bool) {
+        write_fixture_at_sample_rate(path, seconds, include_noise, TARGET_SAMPLE_RATE);
+    }
+
+    fn write_fixture_at_sample_rate(
+        path: &Path,
+        seconds: f32,
+        include_noise: bool,
+        sample_rate: u32,
+    ) {
         let spec = WavSpec {
             channels: 1,
-            sample_rate: TARGET_SAMPLE_RATE,
+            sample_rate,
             bits_per_sample: 16,
             sample_format: SampleFormat::Int,
         };
-        let sample_count = (seconds * TARGET_SAMPLE_RATE as f32) as usize;
+        let sample_count = (seconds * sample_rate as f32) as usize;
         let mut writer = WavWriter::create(path, spec).unwrap();
         let mut random_state = 0x1234_5678_u32;
         for index in 0..sample_count {
-            let time = index as f32 / TARGET_SAMPLE_RATE as f32;
+            let time = index as f32 / sample_rate as f32;
             let speech_active = (time % 2.0) >= 0.55;
             let envelope = if speech_active {
                 let phase = (time % 2.0) - 0.55;

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -191,7 +191,7 @@ async fn apply_microphone_noise_suppression(
                     "noise_suppression",
                     Some(
                         serde_json::json!({
-                            "algorithm": SPECTRAL_DENOISER_ID,
+                            "algorithm": output.denoiser_id,
                             "cacheHit": output.cache_hit,
                             "durationMs": elapsed_ms(suppression_started),
                             "noiseFloorDbfs": output.noise_floor_dbfs,
@@ -270,7 +270,7 @@ async fn persist_noise_suppression_fallback(
             "noise_suppression_warning",
             Some(
                 serde_json::json!({
-                    "algorithm": SPECTRAL_DENOISER_ID,
+                    "algorithm": crate::audio::noise_suppression::RNNOISE_DENOISER_ID,
                     "durationMs": duration_ms,
                     "errorCode": error_code,
                     "message": message,

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -1,6 +1,7 @@
 use crate::{
     audio::{
         live_preview::PREVIEW_CHUNK_MS,
+        noise_suppression::{suppress_microphone_wav_for_transcription, SPECTRAL_DENOISER_ID},
         turns::{
             coalesce_turns_for_transcription_avoiding_echo, detect_turns_with_report,
             normalize_wav_for_transcription, split_wav_for_transcription,
@@ -113,6 +114,7 @@ fn note_transcription_span_id(
 fn note_transcription_configuration_fingerprint(
     title: &str,
     dictionary_context: Option<&str>,
+    microphone_noise_suppression: Option<&str>,
 ) -> String {
     let mut digest = Sha256::new();
     digest.update(b"june-note-transcription-configuration-v1\0");
@@ -130,7 +132,159 @@ fn note_transcription_configuration_fingerprint(
             None => digest.update(b"none"),
         }
     }
+    if let Some(suppression_fingerprint) = microphone_noise_suppression {
+        digest.update(b"microphone-noise-suppression");
+        digest.update((SPECTRAL_DENOISER_ID.len() as u64).to_be_bytes());
+        digest.update(SPECTRAL_DENOISER_ID.as_bytes());
+        digest.update((suppression_fingerprint.len() as u64).to_be_bytes());
+        digest.update(suppression_fingerprint.as_bytes());
+    }
     format!("{:x}", digest.finalize())
+}
+
+async fn apply_microphone_noise_suppression(
+    repos: &Repositories,
+    session_id: &str,
+    sources: &mut [SourceAudioForProcessing],
+    turns: &mut [AudioTurn],
+) -> String {
+    let Some((artifact_id, source_path)) = sources
+        .iter()
+        .find(|(_artifact_id, source, _source_path, _recorded_silence)| source == "microphone")
+        .map(|(artifact_id, _source, source_path, _recorded_silence)| {
+            (artifact_id.clone(), source_path.clone())
+        })
+    else {
+        return "microphone-source-missing".to_string();
+    };
+    let suppression_started = Instant::now();
+    let result = tokio::task::spawn_blocking(move || {
+        suppress_microphone_wav_for_transcription(&source_path)
+    })
+    .await;
+
+    match result {
+        Ok(Ok(output)) => {
+            replace_microphone_transcription_path(sources, turns, &artifact_id, &output.path);
+            let status = if output.applied {
+                "applied"
+            } else {
+                "bypassed_clean"
+            };
+            let durable_fingerprint = format!("{status}:{}", output.fingerprint);
+            if let Err(error) = repos
+                .add_source_checkpoint(
+                    session_id,
+                    Some(artifact_id.as_str()),
+                    Some("microphone"),
+                    "noise_suppression",
+                    Some(
+                        serde_json::json!({
+                            "algorithm": SPECTRAL_DENOISER_ID,
+                            "cacheHit": output.cache_hit,
+                            "durationMs": elapsed_ms(suppression_started),
+                            "noiseFloorDbfs": output.noise_floor_dbfs,
+                            "outputFingerprint": &output.fingerprint,
+                            "status": status,
+                        })
+                        .to_string(),
+                    ),
+                )
+                .await
+            {
+                tracing::warn!(
+                    %session_id,
+                    %error,
+                    "failed to persist noise_suppression checkpoint"
+                );
+            }
+            durable_fingerprint
+        }
+        Ok(Err(error)) => {
+            persist_noise_suppression_fallback(
+                repos,
+                session_id,
+                &artifact_id,
+                elapsed_ms(suppression_started),
+                &error.code,
+                &error.message,
+            )
+            .await;
+            format!("raw-fallback:{SPECTRAL_DENOISER_ID}")
+        }
+        Err(error) => {
+            persist_noise_suppression_fallback(
+                repos,
+                session_id,
+                &artifact_id,
+                elapsed_ms(suppression_started),
+                "noise_suppression_task_failed",
+                &error.to_string(),
+            )
+            .await;
+            format!("raw-fallback:{SPECTRAL_DENOISER_ID}")
+        }
+    }
+}
+
+async fn persist_noise_suppression_fallback(
+    repos: &Repositories,
+    session_id: &str,
+    artifact_id: &str,
+    duration_ms: i64,
+    error_code: &str,
+    message: &str,
+) {
+    tracing::warn!(
+        %session_id,
+        %artifact_id,
+        %error_code,
+        error = %message,
+        "Microphone noise suppression failed; using the finalized source WAV"
+    );
+    if let Err(error) = repos
+        .add_source_checkpoint(
+            session_id,
+            Some(artifact_id),
+            Some("microphone"),
+            "noise_suppression_warning",
+            Some(
+                serde_json::json!({
+                    "algorithm": SPECTRAL_DENOISER_ID,
+                    "durationMs": duration_ms,
+                    "errorCode": error_code,
+                    "message": message,
+                    "status": "raw_fallback",
+                })
+                .to_string(),
+            ),
+        )
+        .await
+    {
+        tracing::warn!(
+            %session_id,
+            %error,
+            "failed to persist noise_suppression_warning checkpoint"
+        );
+    }
+}
+
+fn replace_microphone_transcription_path(
+    sources: &mut [SourceAudioForProcessing],
+    turns: &mut [AudioTurn],
+    artifact_id: &str,
+    transcription_path: &Path,
+) {
+    for (source_artifact_id, source, source_path, _recorded_silence) in sources {
+        if source_artifact_id == artifact_id && source == "microphone" {
+            *source_path = transcription_path.to_path_buf();
+        }
+    }
+    for turn in turns {
+        if turn.artifact_id == artifact_id && turn.source == "microphone" {
+            turn.source_path = transcription_path.to_path_buf();
+        }
+    }
 }
 
 #[cfg(test)]
@@ -957,6 +1111,7 @@ pub(crate) async fn process_saved_source_audio(
         .set_note_status(note_id, ProcessingStatus::Transcribing, None)
         .await?;
     let transcription_provider = crate::providers::configured_transcription_provider();
+    let microphone_noise_suppression = crate::providers::microphone_noise_suppression();
     let dictionary_entries = match repos.list_dictionary_entries().await {
         Ok(entries) => entries,
         Err(error) => {
@@ -976,7 +1131,7 @@ pub(crate) async fn process_saved_source_audio(
     let pipeline_setup = async {
         let detection_started = Instant::now();
         let SilentSystemDropOutcome {
-            kept: sources,
+            kept: mut sources,
             dropped,
         } = partition_silent_system_sources(sources);
         for drop in &dropped {
@@ -1006,19 +1161,12 @@ pub(crate) async fn process_saved_source_audio(
                 );
             }
         }
-        let (turns, echo_rejection) = if source_mode == RecordingSourceMode::MicrophoneOnly {
+        let (mut turns, echo_rejection) = if source_mode == RecordingSourceMode::MicrophoneOnly {
             // Microphone-only capture has no attribution problem to solve.
             // Keep it on the same durable pipeline, but represent the saved
             // WAV as one full-Source job instead of paying the dual-Source
             // VAD and echo-rejection cost.
-            (
-                add_full_source_turns_for_missing_sources(
-                    &sources,
-                    Vec::new(),
-                    &EchoRejectionReport::default(),
-                ),
-                EchoRejectionReport::default(),
-            )
+            (Vec::new(), EchoRejectionReport::default())
         } else {
             let detection_sources = sources
                 .iter()
@@ -1061,6 +1209,14 @@ pub(crate) async fn process_saved_source_audio(
                 tracing::warn!(%session_id, %error, "failed to persist echo_rejection checkpoint");
             }
         }
+        let noise_suppression_fingerprint = if microphone_noise_suppression {
+            Some(
+                apply_microphone_noise_suppression(repos, session_id, &mut sources, &mut turns)
+                    .await,
+            )
+        } else {
+            None
+        };
         let turns = add_full_source_turns_for_missing_sources(&sources, turns, &echo_rejection);
         let turns = coalesce_turns_for_transcription_avoiding_echo(
             turns,
@@ -1119,8 +1275,11 @@ pub(crate) async fn process_saved_source_audio(
             };
             all_preparation_jobs.push(descriptor.clone());
         }
-        let configuration_fingerprint =
-            note_transcription_configuration_fingerprint(&title, dictionary_context.as_deref());
+        let configuration_fingerprint = note_transcription_configuration_fingerprint(
+            &title,
+            dictionary_context.as_deref(),
+            noise_suppression_fingerprint.as_deref(),
+        );
         let mut fallback_plans = build_source_fallback_plans(&all_preparation_jobs)
             .into_iter()
             .filter(SourceFallbackPlan::eligible)
@@ -6012,19 +6171,97 @@ mod tests {
 
     #[test]
     fn durable_configuration_fingerprint_tracks_output_affecting_context() {
-        let base = note_transcription_configuration_fingerprint("Meeting", Some("- June"));
+        let base = note_transcription_configuration_fingerprint("Meeting", Some("- June"), None);
         assert_eq!(
             base,
-            note_transcription_configuration_fingerprint("Meeting", Some("- June"))
+            note_transcription_configuration_fingerprint("Meeting", Some("- June"), None)
         );
         assert_ne!(
             base,
-            note_transcription_configuration_fingerprint("Renamed meeting", Some("- June"))
+            note_transcription_configuration_fingerprint("Renamed meeting", Some("- June"), None)
         );
         assert_ne!(
             base,
-            note_transcription_configuration_fingerprint("Meeting", Some("- Junho"))
+            note_transcription_configuration_fingerprint("Meeting", Some("- Junho"), None)
         );
+        assert_ne!(
+            base,
+            note_transcription_configuration_fingerprint(
+                "Meeting",
+                Some("- June"),
+                Some("applied:derived-a"),
+            )
+        );
+        assert_ne!(
+            note_transcription_configuration_fingerprint(
+                "Meeting",
+                Some("- June"),
+                Some("raw-fallback:spectral-subtraction-v1"),
+            ),
+            note_transcription_configuration_fingerprint(
+                "Meeting",
+                Some("- June"),
+                Some("applied:derived-a"),
+            )
+        );
+    }
+
+    #[test]
+    fn derived_microphone_path_does_not_change_system_or_turn_bounds() {
+        let raw_microphone = PathBuf::from("microphone-raw.wav");
+        let raw_system = PathBuf::from("system-raw.wav");
+        let derived_microphone = PathBuf::from("microphone-denoised.wav");
+        let mut sources = vec![
+            (
+                "microphone-artifact".to_string(),
+                "microphone".to_string(),
+                raw_microphone,
+                false,
+            ),
+            (
+                "system-artifact".to_string(),
+                "system".to_string(),
+                raw_system.clone(),
+                false,
+            ),
+        ];
+        let mut turns = vec![
+            test_audio_turn(
+                "microphone-artifact",
+                "microphone",
+                PathBuf::from("microphone-raw.wav"),
+                0,
+                1_000,
+                2_000,
+            ),
+            test_audio_turn(
+                "system-artifact",
+                "system",
+                raw_system.clone(),
+                1,
+                2_500,
+                4_000,
+            ),
+        ];
+
+        replace_microphone_transcription_path(
+            &mut sources,
+            &mut turns,
+            "microphone-artifact",
+            &derived_microphone,
+        );
+
+        assert_eq!(sources[0].2, derived_microphone);
+        assert_eq!(sources[1].2, raw_system);
+        assert_eq!(
+            turns[0].source_path,
+            PathBuf::from("microphone-denoised.wav")
+        );
+        assert_eq!(turns[0].start_ms, 1_000);
+        assert_eq!(turns[0].end_ms, 2_000);
+        assert_eq!(turns[1].source_path, PathBuf::from("system-raw.wav"));
+        assert_eq!(turns[1].start_ms, 2_500);
+        assert_eq!(turns[1].end_ms, 4_000);
     }
 
     #[tokio::test]

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -1,7 +1,10 @@
 use crate::{
     audio::{
         live_preview::PREVIEW_CHUNK_MS,
-        noise_suppression::{suppress_microphone_wav_for_transcription, SPECTRAL_DENOISER_ID},
+        noise_suppression::{
+            suppress_microphone_wav_for_transcription, DerivedTranscriptionInputCleanup,
+            SPECTRAL_DENOISER_ID,
+        },
         turns::{
             coalesce_turns_for_transcription_avoiding_echo, detect_turns_with_report,
             normalize_wav_for_transcription, split_wav_for_transcription,
@@ -142,12 +145,19 @@ fn note_transcription_configuration_fingerprint(
     format!("{:x}", digest.finalize())
 }
 
+fn noise_suppression_transcription_fingerprint(
+    applied: bool,
+    output_fingerprint: &str,
+) -> Option<String> {
+    applied.then(|| format!("applied:{output_fingerprint}"))
+}
+
 async fn apply_microphone_noise_suppression(
     repos: &Repositories,
     session_id: &str,
     sources: &mut [SourceAudioForProcessing],
     turns: &mut [AudioTurn],
-) -> String {
+) -> MicrophoneNoiseSuppressionResult {
     let Some((artifact_id, source_path)) = sources
         .iter()
         .find(|(_artifact_id, source, _source_path, _recorded_silence)| source == "microphone")
@@ -155,7 +165,7 @@ async fn apply_microphone_noise_suppression(
             (artifact_id.clone(), source_path.clone())
         })
     else {
-        return "microphone-source-missing".to_string();
+        return MicrophoneNoiseSuppressionResult::default();
     };
     let suppression_started = Instant::now();
     let result = tokio::task::spawn_blocking(move || {
@@ -171,7 +181,8 @@ async fn apply_microphone_noise_suppression(
             } else {
                 "bypassed_clean"
             };
-            let durable_fingerprint = format!("{status}:{}", output.fingerprint);
+            let transcription_fingerprint =
+                noise_suppression_transcription_fingerprint(output.applied, &output.fingerprint);
             if let Err(error) = repos
                 .add_source_checkpoint(
                     session_id,
@@ -198,7 +209,10 @@ async fn apply_microphone_noise_suppression(
                     "failed to persist noise_suppression checkpoint"
                 );
             }
-            durable_fingerprint
+            MicrophoneNoiseSuppressionResult {
+                transcription_fingerprint,
+                cleanup: output.cleanup,
+            }
         }
         Ok(Err(error)) => {
             persist_noise_suppression_fallback(
@@ -210,7 +224,7 @@ async fn apply_microphone_noise_suppression(
                 &error.message,
             )
             .await;
-            format!("raw-fallback:{SPECTRAL_DENOISER_ID}")
+            MicrophoneNoiseSuppressionResult::default()
         }
         Err(error) => {
             persist_noise_suppression_fallback(
@@ -222,9 +236,15 @@ async fn apply_microphone_noise_suppression(
                 &error.to_string(),
             )
             .await;
-            format!("raw-fallback:{SPECTRAL_DENOISER_ID}")
+            MicrophoneNoiseSuppressionResult::default()
         }
     }
+}
+
+#[derive(Debug, Default)]
+struct MicrophoneNoiseSuppressionResult {
+    transcription_fingerprint: Option<String>,
+    cleanup: Option<DerivedTranscriptionInputCleanup>,
 }
 
 async fn persist_noise_suppression_fallback(
@@ -576,6 +596,11 @@ impl Drop for TempDirCleanup {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.0);
     }
+}
+
+struct PipelineAudioCleanup {
+    _turn_wav_dir: TempDirCleanup,
+    _derived_transcription_input: Option<DerivedTranscriptionInputCleanup>,
 }
 
 fn session_temp_dir(prefix: &str, session_id: &str) -> PathBuf {
@@ -1209,13 +1234,10 @@ pub(crate) async fn process_saved_source_audio(
                 tracing::warn!(%session_id, %error, "failed to persist echo_rejection checkpoint");
             }
         }
-        let noise_suppression_fingerprint = if microphone_noise_suppression {
-            Some(
-                apply_microphone_noise_suppression(repos, session_id, &mut sources, &mut turns)
-                    .await,
-            )
+        let noise_suppression = if microphone_noise_suppression {
+            apply_microphone_noise_suppression(repos, session_id, &mut sources, &mut turns).await
         } else {
-            None
+            MicrophoneNoiseSuppressionResult::default()
         };
         let turns = add_full_source_turns_for_missing_sources(&sources, turns, &echo_rejection);
         let turns = coalesce_turns_for_transcription_avoiding_echo(
@@ -1247,7 +1269,10 @@ pub(crate) async fn process_saved_source_audio(
         let _ = std::fs::remove_dir_all(&turn_wav_dir);
         std::fs::create_dir_all(&turn_wav_dir)
             .map_err(|error| AppError::new("audio_turn_failed", error.to_string()))?;
-        let turn_wav_dir_cleanup = Arc::new(TempDirCleanup(turn_wav_dir.clone()));
+        let pipeline_audio_cleanup = Arc::new(PipelineAudioCleanup {
+            _turn_wav_dir: TempDirCleanup(turn_wav_dir.clone()),
+            _derived_transcription_input: noise_suppression.cleanup,
+        });
 
         let mut all_preparation_jobs = Vec::new();
         for turn in turns {
@@ -1278,7 +1303,7 @@ pub(crate) async fn process_saved_source_audio(
         let configuration_fingerprint = note_transcription_configuration_fingerprint(
             &title,
             dictionary_context.as_deref(),
-            noise_suppression_fingerprint.as_deref(),
+            noise_suppression.transcription_fingerprint.as_deref(),
         );
         let mut fallback_plans = build_source_fallback_plans(&all_preparation_jobs)
             .into_iter()
@@ -1458,7 +1483,7 @@ pub(crate) async fn process_saved_source_audio(
         Ok::<_, AppError>((
             sources,
             coverage_turns,
-            turn_wav_dir_cleanup,
+            pipeline_audio_cleanup,
             preparation_jobs,
             fallback_plans,
             cached_candidates,
@@ -1468,7 +1493,7 @@ pub(crate) async fn process_saved_source_audio(
     let (
         sources,
         coverage_turns,
-        turn_wav_dir_cleanup,
+        pipeline_audio_cleanup,
         preparation_jobs,
         fallback_plans,
         cached_candidates,
@@ -1532,7 +1557,7 @@ pub(crate) async fn process_saved_source_audio(
     };
     let transcriber = retain_cleanup_during_note_transcription(
         instrument_turn_transcriber(default_turn_transcriber(), timeline.clone()),
-        Arc::clone(&turn_wav_dir_cleanup),
+        Arc::clone(&pipeline_audio_cleanup),
     );
     let pipeline_result = prepare_and_transcribe_turn_jobs_bounded(
         preparation_jobs,
@@ -1541,8 +1566,8 @@ pub(crate) async fn process_saved_source_audio(
         transcription_provider.clone(),
         title.clone(),
         dictionary_context,
-        guarded_turn_preparer(Arc::clone(&turn_wav_dir_cleanup)),
-        guarded_fallback_preparer(Arc::clone(&turn_wav_dir_cleanup)),
+        guarded_turn_preparer(Arc::clone(&pipeline_audio_cleanup)),
+        guarded_fallback_preparer(Arc::clone(&pipeline_audio_cleanup)),
         transcriber,
         Some(job_claimer),
         Some(result_sink),
@@ -1564,7 +1589,6 @@ pub(crate) async fn process_saved_source_audio(
     repos
         .supersede_pending_note_transcription_fallbacks(session_id)
         .await?;
-    drop(turn_wav_dir_cleanup);
 
     let mut fresh_outcome = pipeline.outcome;
     for source in &fresh_outcome.replaced_sources {
@@ -1654,6 +1678,7 @@ pub(crate) async fn process_saved_source_audio(
         &persisted_transcripts,
         &visible_failures,
     );
+    drop(pipeline_audio_cleanup);
     // Coverage is diagnostic only and must never fail note processing: a
     // checkpoint that cannot be serialized or persisted is logged and skipped.
     match serde_json::to_string(&transcript_coverage) {
@@ -2235,9 +2260,13 @@ type TurnJobClaimer = Arc<dyn Fn(String) -> TurnClaimFuture + Send + Sync>;
 type TurnResultFuture = Pin<Box<dyn Future<Output = Result<(), AppError>> + Send>>;
 type TurnResultSink = Arc<dyn Fn(CompletedTurnTranscription) -> TurnResultFuture + Send + Sync>;
 
-fn retain_cleanup_during_blocking_work<Input: 'static, Output: 'static>(
+fn retain_cleanup_during_blocking_work<
+    Input: 'static,
+    Output: 'static,
+    Cleanup: Send + Sync + 'static,
+>(
     inner: Arc<dyn Fn(Input) -> Result<Output, AppError> + Send + Sync>,
-    cleanup: Arc<TempDirCleanup>,
+    cleanup: Arc<Cleanup>,
 ) -> Arc<dyn Fn(Input) -> Result<Output, AppError> + Send + Sync> {
     Arc::new(move |input| {
         let _cleanup = Arc::clone(&cleanup);
@@ -2245,26 +2274,28 @@ fn retain_cleanup_during_blocking_work<Input: 'static, Output: 'static>(
     })
 }
 
-fn retain_cleanup_during_turn_preparation(
+fn retain_cleanup_during_turn_preparation<Cleanup: Send + Sync + 'static>(
     inner: TurnPreparer,
-    cleanup: Arc<TempDirCleanup>,
+    cleanup: Arc<Cleanup>,
 ) -> TurnPreparer {
     retain_cleanup_during_blocking_work(inner, cleanup)
 }
 
-fn guarded_turn_preparer(cleanup: Arc<TempDirCleanup>) -> TurnPreparer {
+fn guarded_turn_preparer<Cleanup: Send + Sync + 'static>(cleanup: Arc<Cleanup>) -> TurnPreparer {
     let inner: TurnPreparer = Arc::new(prepare_turn_job);
     retain_cleanup_during_turn_preparation(inner, cleanup)
 }
 
-fn guarded_fallback_preparer(cleanup: Arc<TempDirCleanup>) -> SourceFallbackPreparer {
+fn guarded_fallback_preparer<Cleanup: Send + Sync + 'static>(
+    cleanup: Arc<Cleanup>,
+) -> SourceFallbackPreparer {
     let inner: SourceFallbackPreparer = Arc::new(prepare_source_fallback);
     retain_cleanup_during_blocking_work(inner, cleanup)
 }
 
-fn retain_cleanup_during_note_transcription(
+fn retain_cleanup_during_note_transcription<Cleanup: Send + Sync + 'static>(
     inner: TurnTranscriber,
-    cleanup: Arc<TempDirCleanup>,
+    cleanup: Arc<Cleanup>,
 ) -> TurnTranscriber {
     Arc::new(move |request| {
         let cleanup = Arc::clone(&cleanup);
@@ -6172,9 +6203,31 @@ mod tests {
     #[test]
     fn durable_configuration_fingerprint_tracks_output_affecting_context() {
         let base = note_transcription_configuration_fingerprint("Meeting", Some("- June"), None);
+        let clean_bypass =
+            noise_suppression_transcription_fingerprint(false, "clean-input-fingerprint");
+        let raw_fallback = MicrophoneNoiseSuppressionResult::default().transcription_fingerprint;
+        let applied = noise_suppression_transcription_fingerprint(true, "derived-a");
         assert_eq!(
             base,
             note_transcription_configuration_fingerprint("Meeting", Some("- June"), None)
+        );
+        assert_eq!(
+            base,
+            note_transcription_configuration_fingerprint(
+                "Meeting",
+                Some("- June"),
+                clean_bypass.as_deref(),
+            ),
+            "clean bypass must not invalidate a byte-identical cached transcript"
+        );
+        assert_eq!(
+            base,
+            note_transcription_configuration_fingerprint(
+                "Meeting",
+                Some("- June"),
+                raw_fallback.as_deref(),
+            ),
+            "raw fallback must retain the unsuppressed cache identity"
         );
         assert_ne!(
             base,
@@ -6189,19 +6242,7 @@ mod tests {
             note_transcription_configuration_fingerprint(
                 "Meeting",
                 Some("- June"),
-                Some("applied:derived-a"),
-            )
-        );
-        assert_ne!(
-            note_transcription_configuration_fingerprint(
-                "Meeting",
-                Some("- June"),
-                Some("raw-fallback:spectral-subtraction-v1"),
-            ),
-            note_transcription_configuration_fingerprint(
-                "Meeting",
-                Some("- June"),
-                Some("applied:derived-a"),
+                applied.as_deref(),
             )
         );
     }
@@ -7678,11 +7719,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn note_transcription_future_retains_turn_wav_temp_dir_after_wrapper_drop() {
+    async fn note_transcription_future_retains_transient_audio_after_wrapper_drop() {
         let root = tempfile::tempdir().expect("temp root");
         let turn_wav_dir = root.path().join("session").join("turns");
         std::fs::create_dir_all(&turn_wav_dir).expect("turn WAV temp dir");
-        let turn_wav_dir_cleanup = Arc::new(TempDirCleanup(turn_wav_dir.clone()));
+        let raw_microphone = root.path().join("session").join("microphone.wav");
+        write_loud_wav(&raw_microphone, 48_000, 48_000);
+        let mut suppression =
+            suppress_microphone_wav_for_transcription(&raw_microphone).expect("suppress noise");
+        assert!(suppression.applied);
+        let derived_input = suppression.path.clone();
+        let pipeline_audio_cleanup = Arc::new(PipelineAudioCleanup {
+            _turn_wav_dir: TempDirCleanup(turn_wav_dir.clone()),
+            _derived_transcription_input: suppression.cleanup.take(),
+        });
         let provider_gate = Arc::new(tokio::sync::Semaphore::new(0));
         let (provider_started_tx, mut provider_started_rx) = tokio::sync::mpsc::unbounded_channel();
         let inner = {
@@ -7699,7 +7749,7 @@ mod tests {
             }) as TurnTranscriber
         };
         let guarded =
-            retain_cleanup_during_note_transcription(inner, Arc::clone(&turn_wav_dir_cleanup));
+            retain_cleanup_during_note_transcription(inner, Arc::clone(&pipeline_audio_cleanup));
         let future = guarded(TranscriptionRequest {
             provider: crate::providers::OPENAI_PROVIDER.to_string(),
             audio_path: PathBuf::from("prepared.wav"),
@@ -7711,10 +7761,14 @@ mod tests {
         });
 
         drop(guarded);
-        drop(turn_wav_dir_cleanup);
+        drop(pipeline_audio_cleanup);
         assert!(
             turn_wav_dir.exists(),
             "the returned note transcription future must own the cleanup guard"
+        );
+        assert!(
+            derived_input.exists(),
+            "the derived input must outlive its provider future"
         );
 
         let provider = tokio::spawn(future);
@@ -7729,6 +7783,7 @@ mod tests {
             .expect("provider task panicked")
             .expect("provider failed");
         assert!(!turn_wav_dir.exists());
+        assert!(!derived_input.exists());
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -342,6 +342,7 @@ pub fn run() {
             providers::clear_venice_api_key,
             providers::set_image_safe_mode,
             providers::set_live_transcription,
+            providers::set_microphone_noise_suppression,
             providers::set_image_safe_mode_prompt_dismissed,
             image_safety::image_prompt_may_be_explicit,
             providers::generate_image,

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -111,6 +111,10 @@ pub struct ProviderModelSettings {
     /// preview lanes entirely, so nothing is sent or billed.
     #[serde(default = "default_live_transcription")]
     pub live_transcription: bool,
+    /// When true, June creates a denoised, local Microphone transcription
+    /// input after Turn detection. The finalized source WAV remains unchanged.
+    #[serde(default)]
+    pub microphone_noise_suppression: bool,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub profile_overrides: BTreeMap<String, ProfileModelOverrides>,
 }
@@ -156,6 +160,7 @@ pub struct ProviderModelSettingsDto {
     pub image_safe_mode: bool,
     pub image_safe_mode_prompt_dismissed: bool,
     pub live_transcription: bool,
+    pub microphone_noise_suppression: bool,
 }
 
 impl From<&ProviderModelSettings> for ProviderModelSettingsDto {
@@ -177,6 +182,7 @@ impl From<&ProviderModelSettings> for ProviderModelSettingsDto {
             image_safe_mode: settings.image_safe_mode,
             image_safe_mode_prompt_dismissed: settings.image_safe_mode_prompt_dismissed,
             live_transcription: settings.live_transcription,
+            microphone_noise_suppression: settings.microphone_noise_suppression,
         }
     }
 }
@@ -410,6 +416,10 @@ pub fn image_safe_mode_prompt_dismissed() -> bool {
 
 pub fn live_transcription() -> bool {
     current_settings().live_transcription
+}
+
+pub fn microphone_noise_suppression() -> bool {
+    current_settings().microphone_noise_suppression
 }
 
 /// Context window (tokens) of the configured generation model, looked up in
@@ -673,6 +683,12 @@ pub struct SetLiveTranscriptionRequest {
     pub enabled: bool,
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SetMicrophoneNoiseSuppressionRequest {
+    pub enabled: bool,
+}
+
 #[tauri::command]
 pub fn set_live_transcription(
     state: State<'_, ProviderSettingsState>,
@@ -687,6 +703,23 @@ fn set_live_transcription_impl(
 ) -> Result<ProviderModelSettingsDto, AppError> {
     update_settings(state, |settings| {
         settings.live_transcription = request.enabled;
+    })
+}
+
+#[tauri::command]
+pub fn set_microphone_noise_suppression(
+    state: State<'_, ProviderSettingsState>,
+    request: SetMicrophoneNoiseSuppressionRequest,
+) -> Result<ProviderModelSettingsDto, AppError> {
+    set_microphone_noise_suppression_impl(&state, request)
+}
+
+fn set_microphone_noise_suppression_impl(
+    state: &ProviderSettingsState,
+    request: SetMicrophoneNoiseSuppressionRequest,
+) -> Result<ProviderModelSettingsDto, AppError> {
+    update_settings(state, |settings| {
+        settings.microphone_noise_suppression = request.enabled;
     })
 }
 
@@ -1285,6 +1318,7 @@ fn default_settings() -> ProviderModelSettings {
         image_safe_mode_prompt_dismissed: false,
         image_safe_mode_set_by_user: false,
         live_transcription: true,
+        microphone_noise_suppression: false,
         profile_overrides: BTreeMap::new(),
     }
 }
@@ -1422,6 +1456,7 @@ fn sanitize_settings(
         image_safe_mode_prompt_dismissed: settings.image_safe_mode_prompt_dismissed,
         image_safe_mode_set_by_user: settings.image_safe_mode_set_by_user,
         live_transcription: settings.live_transcription,
+        microphone_noise_suppression: settings.microphone_noise_suppression,
         profile_overrides: sanitize_profile_overrides(settings.profile_overrides),
     }
 }
@@ -2115,6 +2150,44 @@ mod tests {
         let saved: ProviderModelSettings =
             serde_json::from_str(&fs::read_to_string(&state.path).unwrap()).unwrap();
         assert!(saved.live_transcription);
+    }
+
+    #[test]
+    fn microphone_noise_suppression_defaults_off_for_existing_settings() {
+        let settings = serde_json::from_value::<ProviderModelSettings>(serde_json::json!({
+            "transcriptionProvider": "venice",
+            "transcriptionModel": "nvidia/parakeet-tdt-0.6b-v3",
+            "generationModel": "zai-org-glm-5-2",
+            "imageModel": "venice-sd35"
+        }))
+        .unwrap();
+
+        assert!(!settings.microphone_noise_suppression);
+    }
+
+    #[test]
+    fn set_microphone_noise_suppression_persists_the_toggle() {
+        let state = test_state();
+
+        let updated = set_microphone_noise_suppression_impl(
+            &state,
+            SetMicrophoneNoiseSuppressionRequest { enabled: true },
+        )
+        .unwrap();
+        assert!(updated.microphone_noise_suppression);
+        let saved: ProviderModelSettings =
+            serde_json::from_str(&fs::read_to_string(&state.path).unwrap()).unwrap();
+        assert!(saved.microphone_noise_suppression);
+
+        let updated = set_microphone_noise_suppression_impl(
+            &state,
+            SetMicrophoneNoiseSuppressionRequest { enabled: false },
+        )
+        .unwrap();
+        assert!(!updated.microphone_noise_suppression);
+        let saved: ProviderModelSettings =
+            serde_json::from_str(&fs::read_to_string(&state.path).unwrap()).unwrap();
+        assert!(!saved.microphone_noise_suppression);
     }
 
     #[test]

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -30,6 +30,7 @@ import {
   setDictationShortcut,
   setImageSafeMode,
   setLiveTranscription,
+  setMicrophoneNoiseSuppression,
   setCostQuality,
   setVeniceApiKey,
   setVeniceModel,
@@ -310,6 +311,7 @@ const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
   imageSafeMode: true,
   imageSafeModePromptDismissed: false,
   liveTranscription: true,
+  microphoneNoiseSuppression: false,
 };
 
 type ProviderModelSettingsSnapshot = {
@@ -1411,6 +1413,20 @@ export function AppSettings({
     }
   }
 
+  async function toggleMicrophoneNoiseSuppression(enabled: boolean) {
+    try {
+      const next = await setMicrophoneNoiseSuppression(enabled);
+      setProviderSettings(next);
+      setStatus(
+        enabled
+          ? "Microphone noise suppression on for future note transcriptions."
+          : "Microphone noise suppression off.",
+      );
+    } catch (error) {
+      setStatus(messageFromError(error));
+    }
+  }
+
   async function toggleImageSafeMode(enabled: boolean) {
     try {
       const next = await setImageSafeMode(enabled);
@@ -2242,6 +2258,24 @@ export function AppSettings({
                             checked={providerSettings.liveTranscription}
                             aria-label="Show a live transcript while recording"
                             onCheckedChange={toggleLiveTranscription}
+                          />
+                        </div>
+                      </div>
+                      <div className="settings-row-divider" aria-hidden />
+                      <div className="settings-row">
+                        <div className="settings-row-info">
+                          <h3 className="settings-row-title">Microphone noise suppression</h3>
+                          <p className="settings-row-description">
+                            Reduce steady room noise before note transcription. Your original
+                            Microphone recording stays unchanged. Turn this off if speech sounds
+                            less natural.
+                          </p>
+                        </div>
+                        <div className="settings-row-control">
+                          <Switch
+                            checked={providerSettings.microphoneNoiseSuppression}
+                            aria-label="Reduce Microphone noise before note transcription"
+                            onCheckedChange={toggleMicrophoneNoiseSuppression}
                           />
                         </div>
                       </div>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -261,6 +261,9 @@ export type ProviderModelSettingsDto = {
    * usage and disclosed in Settings, so previews from this build are sent as
    * consented (JUN-375). Off stops the preview lanes entirely. */
   liveTranscription: boolean;
+  /** Local noise suppression for the derived Microphone transcription input.
+   * Off by default. The finalized source recording stays unchanged. */
+  microphoneNoiseSuppression: boolean;
 };
 
 export type ProfileModelOverridesDto = {
@@ -2130,6 +2133,12 @@ export async function setImageSafeMode(enabled: boolean) {
 // as extra usage when on, no preview audio leaves the device when off.
 export async function setLiveTranscription(enabled: boolean) {
   return invoke<ProviderModelSettingsDto>("set_live_transcription", {
+    request: { enabled },
+  });
+}
+
+export async function setMicrophoneNoiseSuppression(enabled: boolean) {
+  return invoke<ProviderModelSettingsDto>("set_microphone_noise_suppression", {
     request: { enabled },
   });
 }

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -36,6 +36,7 @@ const mocks = vi.hoisted(() => ({
   clearVeniceApiKey: vi.fn(),
   setImageSafeMode: vi.fn(),
   setLiveTranscription: vi.fn(),
+  setMicrophoneNoiseSuppression: vi.fn(),
   setCostQuality: vi.fn(),
   setImageSafeModePromptDismissed: vi.fn(),
   setProfileModelOverrides: vi.fn(),
@@ -127,6 +128,7 @@ vi.mock("../lib/tauri", () => ({
   clearVeniceApiKey: mocks.clearVeniceApiKey,
   setImageSafeMode: mocks.setImageSafeMode,
   setLiveTranscription: mocks.setLiveTranscription,
+  setMicrophoneNoiseSuppression: mocks.setMicrophoneNoiseSuppression,
   setCostQuality: mocks.setCostQuality,
   setImageSafeModePromptDismissed: mocks.setImageSafeModePromptDismissed,
   setProfileModelOverrides: mocks.setProfileModelOverrides,
@@ -267,6 +269,7 @@ function buildProviderSettings() {
     imageSafeMode: true,
     imageSafeModePromptDismissed: false,
     liveTranscription: true,
+    microphoneNoiseSuppression: false,
     costQuality: 50,
   };
 }
@@ -545,6 +548,10 @@ describe("AppSettings", () => {
     mocks.setLiveTranscription.mockImplementation(async (enabled: boolean) => ({
       ...buildProviderSettings(),
       liveTranscription: enabled,
+    }));
+    mocks.setMicrophoneNoiseSuppression.mockImplementation(async (enabled: boolean) => ({
+      ...buildProviderSettings(),
+      microphoneNoiseSuppression: enabled,
     }));
     mocks.setCostQuality.mockImplementation(async (costQuality: number) => ({
       ...buildProviderSettings(),
@@ -3457,7 +3464,7 @@ describe("AppSettings", () => {
     expect(screen.getByText("Enter a local endpoint and model ID first.")).toBeInTheDocument();
   });
 
-  it("shows the Live transcription toggle with disclosure copy in More options", async () => {
+  it("shows persisted voice-processing toggles in More options", async () => {
     const user = userEvent.setup();
 
     render(
@@ -3492,6 +3499,25 @@ describe("AppSettings", () => {
       screen.getByText(
         "Show a live transcript while you record. This transcribes audio twice, so it may use extra credits; turning it off shows the transcript only after the recording ends.",
       ),
+    ).toBeInTheDocument();
+
+    const noiseSuppressionToggle = screen.getByRole("switch", {
+      name: "Reduce Microphone noise before note transcription",
+    });
+    expect(voiceSection).toContainElement(noiseSuppressionToggle);
+    expect(noiseSuppressionToggle).not.toBeChecked();
+    expect(
+      screen.getByText(
+        "Reduce steady room noise before note transcription. Your original Microphone recording stays unchanged. Turn this off if speech sounds less natural.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(noiseSuppressionToggle);
+
+    expect(mocks.setMicrophoneNoiseSuppression).toHaveBeenCalledWith(true);
+    await waitFor(() => expect(noiseSuppressionToggle).toBeChecked());
+    expect(
+      await screen.findByText("Microphone noise suppression on for future note transcriptions."),
     ).toBeInTheDocument();
 
     await user.click(toggle);


### PR DESCRIPTION
> [!IMPORTANT]
> **HELD for the user's product and quality call regardless of automated score. Do not mark ready or merge.**
>
> **Dependency decision:** `nnnoiseless` 0.5.2 is approved and implemented. RNNoise is now the primary denoiser when Microphone noise suppression is enabled; the existing spectral implementation remains the construction-failure fallback. This resolves the dependency choice, not the held product-quality decision.

Refs JUN-416

## Summary

- Adds a persisted **Microphone noise suppression** setting under Voice > More options, default off.
- Keeps the finalized raw PCM Microphone WAV byte-for-byte unchanged. Turn detection and speaker-bleed trimming use raw audio; only the derived transcription input is suppressed.
- Implements `RnnoiseDenoiser` behind the existing frame-level `Denoiser` trait and pins the approved `nnnoiseless` 0.5.2 dependency.
- Uses the existing streaming resampler to supply mono 48 kHz audio in 480-sample, non-overlapping frames. Only the RNNoise adapter scales normalized `f32` samples to the 16-bit magnitude range and back.
- Preserves the exact-length writer: a partial final frame is zero-padded for processing, but the derivative contains exactly the resampled Source duration.
- Keeps the conservative 16 kHz spectral-subtraction denoiser as a warning-logged fallback if RNNoise construction fails.
- Uses the selected denoiser id in the deterministic cache path, output fingerprint, and Source checkpoint.
- Uses a deterministic, atomically written `.june-transcription-input` derivative while transcription consumers are active. The derivative shares the cancellation-safe Turn-WAV lifetime guard and is deleted after provider work and transcript coverage drain; the private directory is removed when empty.
- Changes durable transcription cache identity only when suppression is actually applied. Clean bypass and raw fallback retain the suppression-off identity because transcription receives the same audio bytes, avoiding a billed re-transcription when the setting is toggled for clean audio.
- On suppression failure, records a Microphone-specific warning and continues from the untouched finalized WAV.
- Documents the dependency approval addendum in ADR 0038 and separates the spectral baseline from the RNNoise adapter regressions in `docs/qa/jun-416-noise-suppression.md`.

## Root cause

The existing noise-floor logic rejected noise-only activity and normalization prepared provider input, but noise overlapping real speech remained in the transcription input. There was no optional post-detection suppression seam, and applying a filter during capture would have destructively changed June's recovery and replay authority.

The first implementation also treated a byte-identical clean bypass as a distinct durable transcription configuration and retained completed derived WAVs indefinitely. That could trigger a billed re-transcription without changing provider input and roughly double retained Microphone storage for denoised sessions.

## Review findings addressed

- **Billing:** clean bypass and raw fallback use the suppression-off transcription fingerprint. Only `applied:true` adds the selected denoiser/output fingerprint, so only changed provider audio invalidates cached text.
- **Storage:** the derivative cleanup token is retained by the same generic `Arc` guard as transient Turn WAVs. It outlives blocking preparation and provider futures, survives caller cancellation until those consumers drain, remains available through coverage calculation, then removes the file and empty private directory.
- **RNNoise contract:** the adapter declares 48 kHz, 480-sample frames, scales only at the adapter boundary, rejects incorrectly sized frames, and uses the existing streaming resampler and exact-length writer.
- **Fallback:** an injected RNNoise construction failure deterministically selects the existing spectral implementation and records the selected algorithm in cache and diagnostic identity.

## Dependency implementation

The approved dependency is pinned at 0.5.2 in `src-tauri/Cargo.toml` and `src-tauri/Cargo.lock`.

- implementation: pure Rust RNNoise port
- license: BSD-3-Clause
- release date: 2025-12-18
- supply-chain age: passed the repository's seven-day minimum release age for all 24 newly locked crate versions
- sources: [crate documentation](https://docs.rs/crate/nnnoiseless/0.5.2), [manifest](https://docs.rs/crate/nnnoiseless/0.5.2/source/Cargo.toml.orig), [denoiser source](https://docs.rs/crate/nnnoiseless/0.5.2/source/src/denoise.rs)

The archived-WAV, setting, retry, cleanup, and orchestration contracts remain unchanged.

## Validation

### Automated

- `python3 scripts/check-cargo-release-age.py --base origin/main` - passed; 10 manifests locked, 24 new crate versions checked, 0 excluded.
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check` - passed.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --locked -- -D warnings` - passed.
- `pnpm test:rust` - passed; 1,415 library tests passed, 0 failed, 6 ignored, and every desktop integration suite passed.
- Focused noise-suppression suite - 10 passed, including noise-only energy reduction, speech-band energy retention, construction fallback, cache/archive preservation, invalid frame size, and a partial-frame 44.1 kHz to 48 kHz exact-length regression.
- `make verify` - passed in full: Biome, TypeScript, 221 frontend test files with 3,521 passed and 2 skipped tests, Tauri format/clippy/tests, and June API format/clippy/tests.
- `make local-ci` - passed on pushed SHA `b02654a54ad02ca0702789a7e42c995468157103`; `signoff/frontend` and `signoff/rust-macos` are green on that exact SHA.
- Standard pre-publish Standards and Spec review axes were applied in-session under the repository's no-subagent instruction; no material findings remained.

### Audio evidence

The table below is the spectral fallback baseline from commit `b50f1dbb9249c729ca0590ef774a9ae1dbd0d745`. A non-private, deterministic 16-second synthetic speech reference with leading and trailing quiet regions was mixed separately with fan plus hum, rain-like broadband noise, and keyboard-like impulses. Each setting-off control and setting-on output passed through the same ordinary normalization stage. Input SHA-256 was checked before and after.

| Fixture | Spectral baseline decision | Reference SNR | SI-SNR | Quiet-region RMS |
| --- | --- | ---: | ---: | ---: |
| Fan plus hum | Applied, floor -37.5 dBFS | 7.55 to 8.31 dB (+0.76) | 7.23 to 11.29 dB (+4.06) | -32.56 to -42.54 dBFS |
| Rain-like broadband | Applied, floor -29.0 dBFS | 0.90 to 2.95 dB (+2.06) | -0.25 to 5.12 dB (+5.37) | -25.83 to -41.26 dBFS |
| Keyboard-like impacts | Clean-floor bypass, -95.5 dBFS | 4.90 to 4.90 dB (+0.00) | 3.40 to 3.40 dB (+0.00) | -30.61 to -30.61 dBFS |

The archive SHA remained identical in every run. [Download the input, setting-off controls, setting-on clips, and spectrograms](https://app.opensoftware.co/api/v1/files/fil_l2JqMGvo55RO/download).

The RNNoise follow-up adds deterministic signal and boundary regressions, not new perceptual or transcription-quality evidence. No ASR/WER comparison, clean-speech WER regression, blinded listening panel, or 60-minute capture run was completed. No transcription-quality gain is claimed.

### Visual

The original setting UI was tested in the real browser preview with the Tauri bridge stub: opened Voice > More options, confirmed the setting defaults off, toggled it on, and observed no console or page errors. [View the screenshot](https://app.opensoftware.co/api/v1/files/fil_Ph8JXVPc7CfQ/download). This follow-up changes only Rust pipeline behavior, tests, and documentation, so no new visual evidence was required.

- [x] Tested visually where it matters (the original UI change; screenshot attached above).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend change is required.

## Out of scope

- Suppressing System audio, changing capture callbacks, rewriting the finalized WAV, diarization, or removing nearby voices.
- Enabling the setting by default.
- Claiming the issue's full quality threshold from deterministic unit tests or the spectral fallback baseline.
- Shipping the held feature as accepted.

## Followups

- Before promotion, run representative real-voice ASR/WER and blinded listening checks, including quiet/high-pitched voices and at least one 60-minute recording.
- Keep this PR draft and held until the product-quality review is explicit.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] The new dependency is pinned, licensed BSD-3-Clause, and passed the repository's release-age gate.
- [x] Security-sensitive changes were called out in the summary. No service, credential, or network boundary changed.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow action changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such change is present.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend change is present.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787457238&installation_model_id=425925&pr_number=956&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com/open-software-network/os-june/pull/956&signature=510606ca40973da3172e969d69d453d19f0f019a2934162c3cf4e2b57183603b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
