### PR TITLE
feat(agent): add per-turn development diagnostics (JUN-436)

### DIFF
--- a/src-tauri/src/experimental_settings.rs
+++ b/src-tauri/src/experimental_settings.rs
@@ -19,6 +19,8 @@ pub struct ExperimentalSettings {
     pub unlocked: bool,
     #[serde(default)]
     pub browser_use: bool,
+    #[serde(default)]
+    pub turn_diagnostics: bool,
 }
 
 pub struct ExperimentalSettingsState {

--- a/src-tauri/src/experimental_settings.rs
+++ b/src-tauri/src/experimental_settings.rs
@@ -162,6 +162,7 @@ mod tests {
         let settings = ExperimentalSettings {
             unlocked: true,
             browser_use: true,
+            turn_diagnostics: true,
         };
 
         save_settings(&path, &settings).expect("save experimental settings");

--- a/src/components/agent/AgentDetailContent.tsx
+++ b/src/components/agent/AgentDetailContent.tsx
@@ -8,7 +8,6 @@ import { upstreamProviderRecoveryStore } from "../../lib/upstream-provider-recov
 import {
   formatTurnDiagnostics,
   getTurnDiagnostics,
-  getTurnDiagnosticsVersion,
   subscribeTurnDiagnostics,
 } from "../../lib/turn-diagnostics";
 import { useExperimentalFlags } from "../../lib/experimental-flags";
@@ -81,13 +80,9 @@ function TurnDiagnosticsLine({
   sessionId: string;
   sessionRunning: boolean;
 }) {
-  useSyncExternalStore(
-    subscribeTurnDiagnostics,
-    getTurnDiagnosticsVersion,
-    getTurnDiagnosticsVersion,
-  );
+  const getSnapshot = useCallback(() => getTurnDiagnostics(sessionId), [sessionId]);
+  const diagnostics = useSyncExternalStore(subscribeTurnDiagnostics, getSnapshot, getSnapshot);
   if (sessionRunning) return null;
-  const diagnostics = getTurnDiagnostics(sessionId);
   if (!diagnostics) return null;
   return (
     <div className="agent-turn-diagnostics" role="status" aria-label="Turn diagnostics">

--- a/src/components/agent/AgentDetailContent.tsx
+++ b/src/components/agent/AgentDetailContent.tsx
@@ -1,10 +1,17 @@
 import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
 import { IconStopCircle } from "central-icons/IconStopCircle";
-import { memo, useCallback, useMemo, useRef } from "react";
+import { memo, useCallback, useMemo, useRef, useSyncExternalStore } from "react";
 import { sessionUnrestricted } from "../../lib/agent-session-modes";
 import type { AgentChatTurn } from "../../lib/agent-chat-runtime";
 import { hermesTraceBuffer } from "../../lib/hermes-trace-buffer";
 import { upstreamProviderRecoveryStore } from "../../lib/upstream-provider-recovery";
+import {
+  formatTurnDiagnostics,
+  getTurnDiagnostics,
+  getTurnDiagnosticsVersion,
+  subscribeTurnDiagnostics,
+} from "../../lib/turn-diagnostics";
+import { useExperimentalFlags } from "../../lib/experimental-flags";
 import { AgentThinking } from "./AgentThinking";
 import type { RenderAgentDetailContentDependencies } from "./AgentDetailContent-types";
 import { HermesTracePanel } from "./HermesTracePanel";
@@ -62,6 +69,32 @@ const StreamingAgentChatTurn = memo(function StreamingAgentChatTurn({
 }) {
   return renderTurn(turn);
 });
+
+/** Dev-only per-turn diagnostics line (JUN-436). Subscribes to the
+ * turn-diagnostics store and renders a concise timing/token summary after the
+ * last completed turn. Only renders when the experimental flag is on, the
+ * session has diagnostics, and the session is not actively running. */
+function TurnDiagnosticsLine({
+  sessionId,
+  sessionRunning,
+}: {
+  sessionId: string;
+  sessionRunning: boolean;
+}) {
+  useSyncExternalStore(
+    subscribeTurnDiagnostics,
+    getTurnDiagnosticsVersion,
+    getTurnDiagnosticsVersion,
+  );
+  if (sessionRunning) return null;
+  const diagnostics = getTurnDiagnostics(sessionId);
+  if (!diagnostics) return null;
+  return (
+    <div className="agent-turn-diagnostics" role="status" aria-label="Turn diagnostics">
+      {formatTurnDiagnostics(diagnostics)}
+    </div>
+  );
+}
 
 function AgentChatTranscriptRows({
   renderTurn,
@@ -489,6 +522,8 @@ export function AgentDetailContent(dependencies: RenderAgentDetailContentDepende
   );
 
   const closeGallery = useCallback(() => setGalleryDesired(false), []);
+  const experimentalFlags = useExperimentalFlags();
+  const turnDiagnosticsEnabled = experimentalFlags.turn_diagnostics;
   const openRawTrace = useCallback(
     (sessionId: string) => setRawTraceSession(sessionId),
     [setRawTraceSession],
@@ -541,6 +576,12 @@ export function AgentDetailContent(dependencies: RenderAgentDetailContentDepende
         onClose={closeRawTrace}
       />
       <AgentChatTranscriptRows turns={hermesTurns} renderTurn={renderHermesTurn} />
+      {turnDiagnosticsEnabled && selectedHermesSessionId ? (
+        <TurnDiagnosticsLine
+          sessionId={selectedHermesSessionId}
+          sessionRunning={workingSessionIds.has(selectedHermesSessionId)}
+        />
+      ) : null}
       {browserApprovalCards}
       <AgentThinking
         visible={

--- a/src/components/agent/gateway-recovery-actions-types.ts
+++ b/src/components/agent/gateway-recovery-actions-types.ts
@@ -10,6 +10,7 @@ import { type AgentApprovalChoice } from "../../lib/agent-chat-runtime";
 import type { SubmitHermesSession } from "./session-submission-types";
 import { type AgentWorkspaceErrorOptions } from "./agent-workspace-errors";
 import { type CapturedSessionModelTarget } from "./composer/follow-up-queue";
+import type { TurnDiagnosticsContext } from "../../lib/turn-diagnostics";
 import type * as React from "react";
 
 export type createGatewayRecoveryActionsDependencies = {
@@ -21,12 +22,14 @@ export type createGatewayRecoveryActionsDependencies = {
     sessionDisplayTitle,
     storedSessionId,
     computerUseRunLeaseId,
+    turnDiagnostics,
   }: {
     gateway: HermesGatewayClient;
     runtimeSessionId: string;
     sessionDisplayTitle: string;
     storedSessionId: string;
     computerUseRunLeaseId?: string;
+    turnDiagnostics?: TurnDiagnosticsContext;
   }) => () => void;
   captureSessionModelTarget: (explicitSession?: HermesSessionInfo) => CapturedSessionModelTarget;
   ensureHermesGateway: (fullMode?: boolean) => Promise<HermesGatewayClient>;

--- a/src/components/agent/session-event-listener.ts
+++ b/src/components/agent/session-event-listener.ts
@@ -21,6 +21,7 @@ import { appendHermesLiveEvent } from "../../lib/agent-chat-runtime";
 import {
   type TurnDiagnosticsContext,
   type TurnTimingState,
+  type TurnUsageSnapshot,
   TURN_DIAGNOSTICS_USAGE_TIMEOUT_MS,
   computeTurnDiagnostics,
   publishTurnDiagnostics,
@@ -288,7 +289,7 @@ export function createSessionEventListener(dependencies: createSessionEventListe
           turnTiming.terminalAt = eventAt;
           const finalizedTiming = { ...turnTiming };
           void (async () => {
-            let usageAfter = {};
+            let usageAfter: TurnUsageSnapshot = {};
             try {
               const raw = await createHermesMethods(gateway).getSessionUsage(
                 { sessionId: runtimeSessionId },

--- a/src/components/agent/session-event-listener.ts
+++ b/src/components/agent/session-event-listener.ts
@@ -3,6 +3,7 @@ import { markAgentRunSucceeded } from "../../lib/agent-run-monitor";
 import { HermesGatewayClient } from "../../lib/hermes-gateway";
 import {
   classifyHermesEvent,
+  createHermesMethods,
   hermesModeFor,
   isHermesStreamDelta,
   isTerminalHermesEvent,
@@ -11,12 +12,23 @@ import { unsupportedEventStore } from "../../lib/hermes-unsupported-events";
 import { pendingActionStore } from "../../lib/hermes-pending-actions";
 import { hermesArtifactStore } from "../../lib/hermes-artifact-store";
 import { hermesTraceBuffer } from "../../lib/hermes-trace-buffer";
+import { parseSessionUsage } from "../../lib/hermes-session-usage";
 import {
   rememberSessionThinkingLevel,
   thinkingEffortForLevel,
   thinkingLevelForEffort,
 } from "../../lib/thinking-level";
 import { appendHermesLiveEvent } from "../../lib/agent-chat-runtime";
+import { experimentalTurnDiagnosticsEnabled } from "../../lib/experimental-flags";
+import {
+  type TurnTimingState,
+  type TurnUsageSnapshot,
+  cacheSnapshotFromRaw,
+  clearTurnDiagnostics,
+  computeTurnDiagnostics,
+  publishTurnDiagnostics,
+  snapshotFromUsage,
+} from "../../lib/turn-diagnostics";
 import {
   agentActivityCountsFromStore,
   agentStatusSummaryFromHermesEvent,
@@ -64,6 +76,30 @@ export function createSessionEventListener(dependencies: createSessionEventListe
     sessionGatewayUnlistenRef.current.get(storedSessionId)?.();
     const agentRunCompletionSource = Symbol(storedSessionId);
     let unlisten = () => {};
+    const turnDiagnosticsEnabled = experimentalTurnDiagnosticsEnabled();
+    const turnTiming: TurnTimingState | null = turnDiagnosticsEnabled
+      ? { submitAt: performance.now() }
+      : null;
+    let usageBefore: TurnUsageSnapshot | undefined;
+    if (turnDiagnosticsEnabled && turnTiming) {
+      // Clear any previous diagnostics so stale data from a prior run does not
+      // reappear while this run is in progress.
+      clearTurnDiagnostics(storedSessionId);
+      // Fire-and-forget: snapshot session usage before the prompt is submitted
+      // so we can delta against the post-turn snapshot. If the RPC races with
+      // the first event, the baseline stays undefined and token fields are
+      // omitted from the diagnostic (timing is still reported).
+      createHermesMethods(gateway)
+        .getSessionUsage({ sessionId: runtimeSessionId })
+        .then((raw) => {
+          const parsed = parseSessionUsage(runtimeSessionId, raw);
+          usageBefore = {
+            ...snapshotFromUsage(parsed),
+            ...cacheSnapshotFromRaw(raw),
+          };
+        })
+        .catch(() => undefined);
+    }
     const liveEventsBatch = createLeadingTrailingMicrobatch(
       () => setLiveEvents(liveEventsRef.current),
       HERMES_STREAM_STATE_BATCH_INTERVAL_MS,
@@ -76,6 +112,10 @@ export function createSessionEventListener(dependencies: createSessionEventListe
     }, HERMES_STREAM_STATE_BATCH_INTERVAL_MS);
     const removeListener = gateway.onEvent((event) => {
       if (event.session_id !== runtimeSessionId && event.session_id !== storedSessionId) return;
+      // Record the monotonic timestamp immediately at ingress, before any
+      // classification or store work, so timing boundaries are not inflated by
+      // main-thread processing.
+      const eventAt = performance.now();
       const liveEvent = { ...event, receivedAt: new Date().toISOString() };
       // Classify the raw frame once at ingress. Stores and transcript rendering
       // consume the typed event; the raw frame remains only for trace capture
@@ -87,6 +127,25 @@ export function createSessionEventListener(dependencies: createSessionEventListe
       // trace panel can reconstruct the session. recordInbound re-classifies and
       // sanitizes internally; nothing raw is retained.
       hermesTraceBuffer.recordInbound(liveEvent, { storedSessionId });
+      // JUN-436: capture per-turn timing boundaries for diagnostics.
+      if (turnTiming) {
+        if (
+          turnTiming.firstTokenAt === undefined &&
+          classified.kind === "transcript" &&
+          typeof classified.delta === "string" &&
+          classified.delta.length > 0 &&
+          !classified.complete
+        ) {
+          turnTiming.firstTokenAt = eventAt;
+        }
+        if (
+          classified.kind === "transcript" &&
+          classified.complete === true &&
+          classified.failed !== true
+        ) {
+          turnTiming.lastMessageCompleteAt = eventAt;
+        }
+      }
       // The runtime's session.info is the source of truth for the effort a
       // session ACTUALLY runs at (emitted after every build and on every
       // live retune): hydrate the per-session record from it so the composer
@@ -240,6 +299,32 @@ export function createSessionEventListener(dependencies: createSessionEventListe
           void releaseAllComputerUseRuns(storedSessionId);
         }
         unlisten();
+        // JUN-436: finalize per-turn diagnostics. Record the terminal timestamp
+        // from the ingress clock and fetch post-turn usage to compute the delta.
+        // Published async when the usage RPC resolves; if it fails, no
+        // diagnostics appear for this turn.
+        if (turnTiming) {
+          turnTiming.terminalAt = eventAt;
+          const finalizedTiming = { ...turnTiming };
+          createHermesMethods(gateway)
+            .getSessionUsage({ sessionId: runtimeSessionId })
+            .then((raw) => {
+              const parsed = parseSessionUsage(runtimeSessionId, raw);
+              const usageAfter: TurnUsageSnapshot = {
+                ...snapshotFromUsage(parsed),
+                ...cacheSnapshotFromRaw(raw),
+              };
+              const diagnostics = computeTurnDiagnostics(
+                finalizedTiming,
+                usageBefore ?? {},
+                usageAfter,
+              );
+              if (diagnostics) {
+                publishTurnDiagnostics(storedSessionId, diagnostics);
+              }
+            })
+            .catch(() => undefined);
+        }
         if (!activityCounts) {
           clearSessionActivity(storedSessionId);
         }

--- a/src/components/agent/session-event-listener.ts
+++ b/src/components/agent/session-event-listener.ts
@@ -12,22 +12,19 @@ import { unsupportedEventStore } from "../../lib/hermes-unsupported-events";
 import { pendingActionStore } from "../../lib/hermes-pending-actions";
 import { hermesArtifactStore } from "../../lib/hermes-artifact-store";
 import { hermesTraceBuffer } from "../../lib/hermes-trace-buffer";
-import { parseSessionUsage } from "../../lib/hermes-session-usage";
 import {
   rememberSessionThinkingLevel,
   thinkingEffortForLevel,
   thinkingLevelForEffort,
 } from "../../lib/thinking-level";
 import { appendHermesLiveEvent } from "../../lib/agent-chat-runtime";
-import { experimentalTurnDiagnosticsEnabled } from "../../lib/experimental-flags";
 import {
+  type TurnDiagnosticsContext,
   type TurnTimingState,
-  type TurnUsageSnapshot,
-  cacheSnapshotFromRaw,
-  clearTurnDiagnostics,
+  TURN_DIAGNOSTICS_USAGE_TIMEOUT_MS,
   computeTurnDiagnostics,
   publishTurnDiagnostics,
-  snapshotFromUsage,
+  snapshotFromRawUsage,
 } from "../../lib/turn-diagnostics";
 import {
   agentActivityCountsFromStore,
@@ -66,40 +63,23 @@ export function createSessionEventListener(dependencies: createSessionEventListe
     sessionDisplayTitle,
     storedSessionId,
     computerUseRunLeaseId,
+    turnDiagnostics,
   }: {
     gateway: HermesGatewayClient;
     runtimeSessionId: string;
     sessionDisplayTitle: string;
     storedSessionId: string;
     computerUseRunLeaseId?: string;
+    turnDiagnostics?: TurnDiagnosticsContext;
   }) {
     sessionGatewayUnlistenRef.current.get(storedSessionId)?.();
     const agentRunCompletionSource = Symbol(storedSessionId);
     let unlisten = () => {};
-    const turnDiagnosticsEnabled = experimentalTurnDiagnosticsEnabled();
-    const turnTiming: TurnTimingState | null = turnDiagnosticsEnabled
-      ? { submitAt: performance.now() }
+    const turnTiming: TurnTimingState | null = turnDiagnostics
+      ? { startAt: turnDiagnostics.startAt }
       : null;
-    let usageBefore: TurnUsageSnapshot | undefined;
-    if (turnDiagnosticsEnabled && turnTiming) {
-      // Clear any previous diagnostics so stale data from a prior run does not
-      // reappear while this run is in progress.
-      clearTurnDiagnostics(storedSessionId);
-      // Fire-and-forget: snapshot session usage before the prompt is submitted
-      // so we can delta against the post-turn snapshot. If the RPC races with
-      // the first event, the baseline stays undefined and token fields are
-      // omitted from the diagnostic (timing is still reported).
-      createHermesMethods(gateway)
-        .getSessionUsage({ sessionId: runtimeSessionId })
-        .then((raw) => {
-          const parsed = parseSessionUsage(runtimeSessionId, raw);
-          usageBefore = {
-            ...snapshotFromUsage(parsed),
-            ...cacheSnapshotFromRaw(raw),
-          };
-        })
-        .catch(() => undefined);
-    }
+    const usageBefore = turnDiagnostics?.usageBefore;
+    let diagnosticsFinalized = false;
     const liveEventsBatch = createLeadingTrailingMicrobatch(
       () => setLiveEvents(liveEventsRef.current),
       HERMES_STREAM_STATE_BATCH_INTERVAL_MS,
@@ -301,29 +281,28 @@ export function createSessionEventListener(dependencies: createSessionEventListe
         unlisten();
         // JUN-436: finalize per-turn diagnostics. Record the terminal timestamp
         // from the ingress clock and fetch post-turn usage to compute the delta.
-        // Published async when the usage RPC resolves; if it fails, no
-        // diagnostics appear for this turn.
-        if (turnTiming) {
+        // Published exactly once: timing always publishes; usage success enriches
+        // with token/model fields, while usage failure only omits those fields.
+        if (turnTiming && !diagnosticsFinalized) {
+          diagnosticsFinalized = true;
           turnTiming.terminalAt = eventAt;
           const finalizedTiming = { ...turnTiming };
-          createHermesMethods(gateway)
-            .getSessionUsage({ sessionId: runtimeSessionId })
-            .then((raw) => {
-              const parsed = parseSessionUsage(runtimeSessionId, raw);
-              const usageAfter: TurnUsageSnapshot = {
-                ...snapshotFromUsage(parsed),
-                ...cacheSnapshotFromRaw(raw),
-              };
-              const diagnostics = computeTurnDiagnostics(
-                finalizedTiming,
-                usageBefore ?? {},
-                usageAfter,
+          void (async () => {
+            let usageAfter = {};
+            try {
+              const raw = await createHermesMethods(gateway).getSessionUsage(
+                { sessionId: runtimeSessionId },
+                TURN_DIAGNOSTICS_USAGE_TIMEOUT_MS,
               );
-              if (diagnostics) {
-                publishTurnDiagnostics(storedSessionId, diagnostics);
-              }
-            })
-            .catch(() => undefined);
+              usageAfter = snapshotFromRawUsage(runtimeSessionId, raw);
+            } catch {
+              // Usage RPC failed or timed out: publish timing-only diagnostics.
+            }
+            const diagnostics = computeTurnDiagnostics(finalizedTiming, usageBefore, usageAfter);
+            if (diagnostics) {
+              publishTurnDiagnostics(storedSessionId, diagnostics);
+            }
+          })();
         }
         if (!activityCounts) {
           clearSessionActivity(storedSessionId);

--- a/src/components/agent/session-submission-types.ts
+++ b/src/components/agent/session-submission-types.ts
@@ -31,6 +31,8 @@ import type { PendingIssueReport } from "./agent-session-continuity";
 import type { AgentAttachment } from "./agent-workspace-models";
 import { type CapturedSessionModelTarget } from "./composer/follow-up-queue";
 
+import type { TurnDiagnosticsContext } from "../../lib/turn-diagnostics";
+
 export type SubmitHermesSessionDependencies = {
   AGENT_TITLE_MAX_CHARS: 48;
   agentSessionTitleForPrompt: (
@@ -53,12 +55,14 @@ export type SubmitHermesSessionDependencies = {
     sessionDisplayTitle,
     storedSessionId,
     computerUseRunLeaseId,
+    turnDiagnostics,
   }: {
     gateway: HermesGatewayClient;
     runtimeSessionId: string;
     sessionDisplayTitle: string;
     storedSessionId: string;
     computerUseRunLeaseId?: string;
+    turnDiagnostics?: TurnDiagnosticsContext;
   }) => () => void;
   attachPendingImages: (
     gateway: HermesRequestLike,

--- a/src/components/agent/session-submission.ts
+++ b/src/components/agent/session-submission.ts
@@ -29,6 +29,15 @@ import {
 } from "../../lib/hermes-session-model-selection";
 import { hermesTraceBuffer } from "../../lib/hermes-trace-buffer";
 import { modelSupportsImageInput } from "../../lib/model-privacy";
+import { experimentalTurnDiagnosticsEnabled } from "../../lib/experimental-flags";
+import {
+  type TurnDiagnosticsContext,
+  type TurnUsageSnapshot,
+  TURN_DIAGNOSTICS_USAGE_TIMEOUT_MS,
+  clearTurnDiagnostics,
+  snapshotFromRawUsage,
+} from "../../lib/turn-diagnostics";
+import { createHermesMethods } from "../../lib/hermes-control-plane";
 import {
   assignSessionToProfile,
   computerUseBeginRun,
@@ -661,17 +670,37 @@ export function createSubmitHermesSession(dependencies: SubmitHermesSessionDepen
           release: ({ storedSessionId }, runLeaseId) =>
             releaseComputerUseRun(storedSessionId, runLeaseId),
         },
-        beforePrompt: (
+        beforePrompt: async (
           { runtimeSessionId, storedSessionId, submitGateway },
           prompt,
           computerUseRunLeaseId,
         ) => {
+          const gateway = submitGateway.currentGateway();
+          let turnDiagnostics: TurnDiagnosticsContext | undefined;
+          if (experimentalTurnDiagnosticsEnabled()) {
+            clearTurnDiagnostics(storedSessionId);
+            let usageBefore: TurnUsageSnapshot | undefined;
+            try {
+              const raw = await createHermesMethods(gateway).getSessionUsage(
+                { sessionId: runtimeSessionId },
+                TURN_DIAGNOSTICS_USAGE_TIMEOUT_MS,
+              );
+              usageBefore = snapshotFromRawUsage(runtimeSessionId, raw);
+            } catch {
+              // Baseline RPC failed or timed out: token fields will be omitted.
+            }
+            turnDiagnostics = {
+              startAt: performance.now(),
+              usageBefore,
+            };
+          }
           attachHermesSessionEventListener({
-            gateway: submitGateway.currentGateway(),
+            gateway,
             runtimeSessionId,
             sessionDisplayTitle,
             storedSessionId,
             computerUseRunLeaseId,
+            turnDiagnostics,
           });
           hermesTraceBuffer.recordOutbound({
             sessionId: storedSessionId,

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -2919,8 +2919,9 @@ export function AppSettings({
                     <div className="settings-row-info">
                       <h3 className="settings-row-title">Turn diagnostics</h3>
                       <p className="settings-row-description">
-                        Show per-turn timing and token diagnostics in the agent chat. Includes
-                        provider vs agent overhead breakdown, TPS, and cache metrics.
+                        Show timing spans and available token usage for the latest completed agent
+                        turn. Timing spans are end to end and do not isolate upstream provider
+                        latency.
                       </p>
                     </div>
                     <div className="settings-row-control">

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1652,6 +1652,7 @@ export function AppSettings({
     void setExperimentalFlags({
       unlocked: true,
       browser_use: experimentalFlags.browser_use,
+      turn_diagnostics: experimentalFlags.turn_diagnostics,
     })
       .then(() => toast("Experiments are unlocked"))
       .catch((error) => setExperimentalError(messageFromError(error)))
@@ -1660,13 +1661,18 @@ export function AppSettings({
       });
   }
 
-  async function updateExperimentalFlags(update: { unlocked?: boolean; browser_use?: boolean }) {
+  async function updateExperimentalFlags(update: {
+    unlocked?: boolean;
+    browser_use?: boolean;
+    turn_diagnostics?: boolean;
+  }) {
     setExperimentalOperation("flags");
     setExperimentalError(undefined);
     try {
       await setExperimentalFlags({
         unlocked: update.unlocked ?? experimentalFlags.unlocked,
         browser_use: update.browser_use ?? experimentalFlags.browser_use,
+        turn_diagnostics: update.turn_diagnostics ?? experimentalFlags.turn_diagnostics,
       });
     } catch (error) {
       setExperimentalError(messageFromError(error));
@@ -2904,6 +2910,26 @@ export function AppSettings({
                         aria-label="Enable experimental Browser use"
                         onCheckedChange={(browser_use) =>
                           void updateExperimentalFlags({ browser_use })
+                        }
+                      />
+                    </div>
+                  </div>
+
+                  <div className="settings-row">
+                    <div className="settings-row-info">
+                      <h3 className="settings-row-title">Turn diagnostics</h3>
+                      <p className="settings-row-description">
+                        Show per-turn timing and token diagnostics in the agent chat. Includes
+                        provider vs agent overhead breakdown, TPS, and cache metrics.
+                      </p>
+                    </div>
+                    <div className="settings-row-control">
+                      <Switch
+                        checked={experimentalFlags.turn_diagnostics}
+                        disabled={experimentalOperation !== undefined}
+                        aria-label="Enable per-turn diagnostics"
+                        onCheckedChange={(turn_diagnostics) =>
+                          void updateExperimentalFlags({ turn_diagnostics })
                         }
                       />
                     </div>

--- a/src/lib/experimental-flags.ts
+++ b/src/lib/experimental-flags.ts
@@ -8,6 +8,7 @@ export const EXPERIMENTAL_FLAGS_CHANGED_EVENT = "experimental-flags-changed";
 export type ExperimentalFlags = {
   unlocked: boolean;
   browser_use: boolean;
+  turn_diagnostics: boolean;
 };
 
 type ExperimentalFlagsCache = ExperimentalFlags & {
@@ -21,6 +22,7 @@ export type ExperimentalFlagsSnapshot = ExperimentalFlagsCache & {
 const DEFAULT_FLAGS: ExperimentalFlags = {
   unlocked: false,
   browser_use: false,
+  turn_diagnostics: false,
 };
 
 let cache: ExperimentalFlagsCache = { ...DEFAULT_FLAGS, loaded: false };
@@ -33,6 +35,7 @@ function normalizeFlags(flags: ExperimentalFlags): ExperimentalFlags {
   return {
     unlocked: flags?.unlocked === true,
     browser_use: flags?.browser_use === true,
+    turn_diagnostics: flags?.turn_diagnostics === true,
   };
 }
 
@@ -41,6 +44,7 @@ function publish(flags: ExperimentalFlags, loaded = true) {
   if (
     cache.unlocked === normalized.unlocked &&
     cache.browser_use === normalized.browser_use &&
+    cache.turn_diagnostics === normalized.turn_diagnostics &&
     cache.loaded === loaded
   ) {
     return;
@@ -108,10 +112,16 @@ export function experimentalBrowserUseEnabled() {
   return BROWSER_USE_ENABLED || cache.browser_use;
 }
 
+/** Synchronous effective value for the per-turn diagnostics flag. */
+export function experimentalTurnDiagnosticsEnabled() {
+  return cache.turn_diagnostics;
+}
+
 export function getCachedExperimentalFlags(): ExperimentalFlags {
   return {
     unlocked: cache.unlocked,
     browser_use: cache.browser_use,
+    turn_diagnostics: cache.turn_diagnostics,
   };
 }
 

--- a/src/lib/hermes-control-plane/methods.ts
+++ b/src/lib/hermes-control-plane/methods.ts
@@ -111,7 +111,7 @@ export type HermesMethods = {
   steerSession(params: SteerSessionParams): Promise<unknown>;
   branchSession(params: BranchSessionParams): Promise<unknown>;
   compressSession(params: CompressSessionParams): Promise<unknown>;
-  getSessionUsage(params: SessionUsageParams): Promise<unknown>;
+  getSessionUsage(params: SessionUsageParams, timeoutMs?: number): Promise<unknown>;
   dispatchCommand(params: DispatchCommandParams): Promise<unknown>;
   /** Switches the model on an idle live session with session-scoped
    * `config.set`. Hermes rejects this mutation with 4009 while the session is
@@ -181,8 +181,8 @@ export function createHermesMethods(client: HermesRequestLike): HermesMethods {
     compressSession({ sessionId }) {
       return request("session.compress", { session_id: sessionId });
     },
-    getSessionUsage({ sessionId }) {
-      return request("session.usage", { session_id: sessionId });
+    getSessionUsage({ sessionId }, timeoutMs) {
+      return request("session.usage", { session_id: sessionId }, timeoutMs);
     },
     dispatchCommand({ sessionId, command, args }) {
       return request("command.dispatch", {

--- a/src/lib/turn-diagnostics.ts
+++ b/src/lib/turn-diagnostics.ts
@@ -14,7 +14,8 @@
  * names. No prompt contents, credentials, or raw payloads are retained.
  */
 
-import type { SessionUsage } from "./hermes-session-usage";
+import { asRecord } from "./hermes-control-plane";
+import { parseSessionUsage, type SessionUsage } from "./hermes-session-usage";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -23,8 +24,10 @@ import type { SessionUsage } from "./hermes-session-usage";
 /** Mutable timing state captured during one agent run. Uses `performance.now()`
  * for monotonic elapsed measurement. */
 export type TurnTimingState = {
-  /** `performance.now()` at listener attach (just before `prompt.submit`). */
-  submitAt: number;
+  /** Captured in `beforePrompt` after the baseline usage attempt, immediately
+   * before listener setup and `prompt.submit` dispatch. Includes gateway
+   * invocation and transport in TTFT/total duration. */
+  startAt: number;
   /** First non-empty assistant transcript delta (time to first token). */
   firstTokenAt?: number;
   /** Last successful `message.complete` (end of the last assistant segment). */
@@ -46,9 +49,10 @@ export type TurnUsageSnapshot = {
 
 /** Computed diagnostics ready for display. */
 export type TurnDiagnostics = {
-  /** Monotonic milliseconds from submit to terminal. */
+  /** Monotonic milliseconds from diagnostic start boundary to terminal. */
   totalDurationMs: number;
-  /** Submit to first token (end-to-end time to first token). */
+  /** Diagnostic start boundary to first assistant transcript delta (end-to-end
+   * time to first token). */
   ttftMs: number;
   /** First token to last message.complete (active streaming + tool calls +
    * inter-segment orchestration). Not pure provider time. */
@@ -67,8 +71,10 @@ export type TurnDiagnostics = {
   cacheReadTokens?: number;
   /** Cache write tokens (delta, or undefined if baseline was unavailable). */
   cacheWriteTokens?: number;
-  /** Output throughput: output tokens / response span seconds. */
-  tps?: number;
+  /** Completion-token delta divided by first-token-to-last-complete elapsed
+   * seconds. Includes tool calls, multiple assistant segments, and orchestration
+   * gaps. Not pure upstream-provider generation throughput. */
+  responseSpanTokensPerSecond?: number;
   /** Model name from usage snapshot. */
   model?: string;
   /** Provider name from usage snapshot. */
@@ -77,11 +83,27 @@ export type TurnDiagnostics = {
   finalizedAt: string;
 };
 
+/** Bounded timeout for diagnostic usage RPCs so they never delay prompt
+ * dispatch or summary publication by the gateway's default request timeout. */
+export const TURN_DIAGNOSTICS_USAGE_TIMEOUT_MS = 500;
+
+/** Pre-computed diagnostics context passed from `beforePrompt` into the session
+ * event listener. Only the real send path provides this; recovery/restoration
+ * listeners do not, preventing partial-turn diagnostics. */
+export type TurnDiagnosticsContext = {
+  startAt: number;
+  usageBefore?: TurnUsageSnapshot;
+};
+
 // ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
 
 const listeners = new Set<() => void>();
+/** One latest completed diagnostic is retained per stored session. Starting a
+ * new instrumented turn clears it. Diagnostics are ephemeral and are not
+ * associated with durable transcript turn IDs. Per-turn history is out of
+ * scope. */
 const diagnosticsBySession = new Map<string, TurnDiagnostics>();
 let version = 0;
 
@@ -138,6 +160,14 @@ export function snapshotFromUsage(usage: SessionUsage | undefined): TurnUsageSna
   };
 }
 
+/** Parse a raw `session.usage` result into a complete diagnostic snapshot. */
+export function snapshotFromRawUsage(sessionId: string, raw: unknown): TurnUsageSnapshot {
+  return {
+    ...snapshotFromUsage(parseSessionUsage(sessionId, raw)),
+    ...cacheSnapshotFromRaw(raw),
+  };
+}
+
 /** Extract cache token fields from a raw `session.usage` result. The normalized
  * `SessionUsage` parser does not currently surface cache metrics, so we read
  * them defensively from the raw payload the same way the parser does. */
@@ -145,10 +175,10 @@ export function cacheSnapshotFromRaw(raw: unknown): {
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
 } {
-  if (!raw || typeof raw !== "object") return {};
-  const root = raw as Record<string, unknown>;
-  const usage = root.usage as Record<string, unknown> | undefined;
-  const containers = [usage, root].filter(
+  const root = asRecord(raw);
+  const usage = asRecord(root?.usage);
+  const tokens = asRecord(root?.tokens);
+  const containers = [usage, tokens, root].filter(
     (c): c is Record<string, unknown> => c !== null && c !== undefined,
   );
 
@@ -189,42 +219,29 @@ export function cacheSnapshotFromRaw(raw: unknown): {
  * are left undefined rather than showing cumulative absolute values. */
 export function computeTurnDiagnostics(
   timing: TurnTimingState,
-  usageBefore: TurnUsageSnapshot,
+  usageBefore: TurnUsageSnapshot | undefined,
   usageAfter: TurnUsageSnapshot,
 ): TurnDiagnostics | undefined {
   if (timing.terminalAt === undefined) return undefined;
 
-  const totalDurationMs = timing.terminalAt - timing.submitAt;
+  const totalDurationMs = timing.terminalAt - timing.startAt;
   if (totalDurationMs <= 0) return undefined;
 
   const firstTokenAt = timing.firstTokenAt ?? timing.terminalAt;
   const lastCompleteAt = timing.lastMessageCompleteAt ?? timing.terminalAt;
 
-  const ttftMs = Math.max(0, firstTokenAt - timing.submitAt);
+  const ttftMs = Math.max(0, firstTokenAt - timing.startAt);
   const responseSpanMs = Math.max(0, lastCompleteAt - firstTokenAt);
   const tailMs = Math.max(0, timing.terminalAt - lastCompleteAt);
 
-  const hasBaseline = usageBefore.promptTokens !== undefined;
-  const outputTokens = delta(
-    usageBefore.completionTokens,
-    usageAfter.completionTokens,
-    hasBaseline,
-  );
-  const inputTokens = delta(usageBefore.promptTokens, usageAfter.promptTokens, hasBaseline);
-  const totalTokens = delta(usageBefore.totalTokens, usageAfter.totalTokens, hasBaseline);
-  const cacheReadTokens = delta(
-    usageBefore.cacheReadTokens,
-    usageAfter.cacheReadTokens,
-    hasBaseline,
-  );
-  const cacheWriteTokens = delta(
-    usageBefore.cacheWriteTokens,
-    usageAfter.cacheWriteTokens,
-    hasBaseline,
-  );
+  const outputTokens = delta(usageBefore?.completionTokens, usageAfter.completionTokens);
+  const inputTokens = delta(usageBefore?.promptTokens, usageAfter.promptTokens);
+  const totalTokens = delta(usageBefore?.totalTokens, usageAfter.totalTokens);
+  const cacheReadTokens = delta(usageBefore?.cacheReadTokens, usageAfter.cacheReadTokens);
+  const cacheWriteTokens = delta(usageBefore?.cacheWriteTokens, usageAfter.cacheWriteTokens);
 
   const responseSpanSeconds = responseSpanMs / 1000;
-  const tps =
+  const responseSpanTokensPerSecond =
     outputTokens !== undefined && responseSpanSeconds > 0
       ? outputTokens / responseSpanSeconds
       : undefined;
@@ -239,7 +256,7 @@ export function computeTurnDiagnostics(
     totalTokens,
     cacheReadTokens,
     cacheWriteTokens,
-    tps,
+    responseSpanTokensPerSecond,
     model: usageAfter.model,
     provider: usageAfter.provider,
     finalizedAt: new Date().toISOString(),
@@ -248,13 +265,8 @@ export function computeTurnDiagnostics(
 
 /** Compute a per-turn token delta. When the baseline snapshot is unavailable,
  * returns undefined instead of the cumulative absolute value. */
-function delta(
-  before: number | undefined,
-  after: number | undefined,
-  hasBaseline: boolean,
-): number | undefined {
-  if (after === undefined) return undefined;
-  if (!hasBaseline || before === undefined) return undefined;
+function delta(before: number | undefined, after: number | undefined): number | undefined {
+  if (before === undefined || after === undefined) return undefined;
   return Math.max(0, after - before);
 }
 
@@ -281,8 +293,8 @@ export function formatTurnDiagnostics(d: TurnDiagnostics): string {
     `tail ${fmtMs(d.tailMs)}`,
   ];
 
-  if (d.tps !== undefined) {
-    parts.push(`TPS ${d.tps.toFixed(1)} tok/s`);
+  if (d.responseSpanTokensPerSecond !== undefined) {
+    parts.push(`response avg ${d.responseSpanTokensPerSecond.toFixed(1)} tok/s`);
   }
 
   const tokenParts: string[] = [];

--- a/src/lib/turn-diagnostics.ts
+++ b/src/lib/turn-diagnostics.ts
@@ -1,0 +1,304 @@
+/**
+ * Per-turn development diagnostics for agent latency (JUN-436).
+ *
+ * Captures timing boundaries across one agent run (prompt submit through
+ * terminal event) and token usage deltas, then formats a concise diagnostic
+ * line that the chat UI renders when the experimental `turn_diagnostics` flag
+ * is on.
+ *
+ * The store is framework-agnostic (no React) so the session event listener can
+ * write to it outside React's render cycle. The UI adapts it with a small
+ * `useSyncExternalStore` wrapper.
+ *
+ * Safety: diagnostics carry only timing, token counts, and model/provider
+ * names. No prompt contents, credentials, or raw payloads are retained.
+ */
+
+import type { SessionUsage } from "./hermes-session-usage";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Mutable timing state captured during one agent run. Uses `performance.now()`
+ * for monotonic elapsed measurement. */
+export type TurnTimingState = {
+  /** `performance.now()` at listener attach (just before `prompt.submit`). */
+  submitAt: number;
+  /** First non-empty assistant transcript delta (time to first token). */
+  firstTokenAt?: number;
+  /** Last successful `message.complete` (end of the last assistant segment). */
+  lastMessageCompleteAt?: number;
+  /** Terminal lifecycle event (end of the agent run). */
+  terminalAt?: number;
+};
+
+/** Token usage snapshot for delta computation. */
+export type TurnUsageSnapshot = {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  model?: string;
+  provider?: string;
+};
+
+/** Computed diagnostics ready for display. */
+export type TurnDiagnostics = {
+  /** Monotonic milliseconds from submit to terminal. */
+  totalDurationMs: number;
+  /** Submit to first token (end-to-end time to first token). */
+  ttftMs: number;
+  /** First token to last message.complete (active streaming + tool calls +
+   * inter-segment orchestration). Not pure provider time. */
+  responseSpanMs: number;
+  /** Last message.complete to terminal (tail: post-response runtime work). */
+  tailMs: number;
+  /** Output tokens (delta of completion tokens, or undefined if baseline
+   * was unavailable). */
+  outputTokens?: number;
+  /** Input tokens (delta of prompt tokens, or undefined if baseline
+   * was unavailable). */
+  inputTokens?: number;
+  /** Total tokens (delta, or undefined if baseline was unavailable). */
+  totalTokens?: number;
+  /** Cache read tokens (delta, or undefined if baseline was unavailable). */
+  cacheReadTokens?: number;
+  /** Cache write tokens (delta, or undefined if baseline was unavailable). */
+  cacheWriteTokens?: number;
+  /** Output throughput: output tokens / response span seconds. */
+  tps?: number;
+  /** Model name from usage snapshot. */
+  model?: string;
+  /** Provider name from usage snapshot. */
+  provider?: string;
+  /** ISO timestamp when diagnostics were finalized. */
+  finalizedAt: string;
+};
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const listeners = new Set<() => void>();
+const diagnosticsBySession = new Map<string, TurnDiagnostics>();
+let version = 0;
+
+function emit(): void {
+  version += 1;
+  for (const listener of listeners) listener();
+}
+
+/** Publish diagnostics for a session. Called from the session event listener
+ * at the terminal event. Overwrites any previous diagnostics for this session. */
+export function publishTurnDiagnostics(sessionId: string, diagnostics: TurnDiagnostics): void {
+  diagnosticsBySession.set(sessionId, diagnostics);
+  emit();
+}
+
+/** Clear diagnostics for a session. Called when a new run begins so stale
+ * diagnostics from a prior run do not reappear. */
+export function clearTurnDiagnostics(sessionId: string): void {
+  if (diagnosticsBySession.delete(sessionId)) emit();
+}
+
+/** Read the latest diagnostics for a session, or undefined. */
+export function getTurnDiagnostics(sessionId: string | undefined): TurnDiagnostics | undefined {
+  if (!sessionId) return undefined;
+  return diagnosticsBySession.get(sessionId);
+}
+
+/** Subscribe to store changes for `useSyncExternalStore`. Returns unsubscribe. */
+export function subscribeTurnDiagnostics(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Monotonic version for `useSyncExternalStore` snapshot. */
+export function getTurnDiagnosticsVersion(): number {
+  return version;
+}
+
+// ---------------------------------------------------------------------------
+// Computation
+// ---------------------------------------------------------------------------
+
+/** Extract a usage snapshot from a parsed `SessionUsage`. */
+export function snapshotFromUsage(usage: SessionUsage | undefined): TurnUsageSnapshot {
+  if (!usage) return {};
+  return {
+    promptTokens: usage.promptTokens,
+    completionTokens: usage.completionTokens,
+    totalTokens: usage.totalTokens,
+    model: usage.model,
+    provider: usage.provider,
+  };
+}
+
+/** Extract cache token fields from a raw `session.usage` result. The normalized
+ * `SessionUsage` parser does not currently surface cache metrics, so we read
+ * them defensively from the raw payload the same way the parser does. */
+export function cacheSnapshotFromRaw(raw: unknown): {
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+} {
+  if (!raw || typeof raw !== "object") return {};
+  const root = raw as Record<string, unknown>;
+  const usage = root.usage as Record<string, unknown> | undefined;
+  const containers = [usage, root].filter(
+    (c): c is Record<string, unknown> => c !== null && c !== undefined,
+  );
+
+  function pickNum(keys: string[]): number | undefined {
+    for (const container of containers) {
+      for (const key of keys) {
+        const val = container[key];
+        if (typeof val === "number" && Number.isFinite(val)) return val;
+      }
+    }
+    return undefined;
+  }
+
+  return {
+    cacheReadTokens: pickNum([
+      "cache_read_input_tokens",
+      "cacheReadInputTokens",
+      "cache_read_tokens",
+      "cacheReadTokens",
+      "cached_tokens",
+      "cachedTokens",
+    ]),
+    cacheWriteTokens: pickNum([
+      "cache_creation_input_tokens",
+      "cacheCreationInputTokens",
+      "cache_write_tokens",
+      "cacheWriteTokens",
+      "cache_creation_tokens",
+      "cacheCreationTokens",
+    ]),
+  };
+}
+
+/** Compute per-turn diagnostics from timing state and usage deltas.
+ *
+ * Token deltas require both a before and after snapshot. If the before
+ * snapshot is unavailable (the baseline RPC raced or failed), token fields
+ * are left undefined rather than showing cumulative absolute values. */
+export function computeTurnDiagnostics(
+  timing: TurnTimingState,
+  usageBefore: TurnUsageSnapshot,
+  usageAfter: TurnUsageSnapshot,
+): TurnDiagnostics | undefined {
+  if (timing.terminalAt === undefined) return undefined;
+
+  const totalDurationMs = timing.terminalAt - timing.submitAt;
+  if (totalDurationMs <= 0) return undefined;
+
+  const firstTokenAt = timing.firstTokenAt ?? timing.terminalAt;
+  const lastCompleteAt = timing.lastMessageCompleteAt ?? timing.terminalAt;
+
+  const ttftMs = Math.max(0, firstTokenAt - timing.submitAt);
+  const responseSpanMs = Math.max(0, lastCompleteAt - firstTokenAt);
+  const tailMs = Math.max(0, timing.terminalAt - lastCompleteAt);
+
+  const hasBaseline = usageBefore.promptTokens !== undefined;
+  const outputTokens = delta(
+    usageBefore.completionTokens,
+    usageAfter.completionTokens,
+    hasBaseline,
+  );
+  const inputTokens = delta(usageBefore.promptTokens, usageAfter.promptTokens, hasBaseline);
+  const totalTokens = delta(usageBefore.totalTokens, usageAfter.totalTokens, hasBaseline);
+  const cacheReadTokens = delta(
+    usageBefore.cacheReadTokens,
+    usageAfter.cacheReadTokens,
+    hasBaseline,
+  );
+  const cacheWriteTokens = delta(
+    usageBefore.cacheWriteTokens,
+    usageAfter.cacheWriteTokens,
+    hasBaseline,
+  );
+
+  const responseSpanSeconds = responseSpanMs / 1000;
+  const tps =
+    outputTokens !== undefined && responseSpanSeconds > 0
+      ? outputTokens / responseSpanSeconds
+      : undefined;
+
+  return {
+    totalDurationMs,
+    ttftMs,
+    responseSpanMs,
+    tailMs,
+    outputTokens,
+    inputTokens,
+    totalTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    tps,
+    model: usageAfter.model,
+    provider: usageAfter.provider,
+    finalizedAt: new Date().toISOString(),
+  };
+}
+
+/** Compute a per-turn token delta. When the baseline snapshot is unavailable,
+ * returns undefined instead of the cumulative absolute value. */
+function delta(
+  before: number | undefined,
+  after: number | undefined,
+  hasBaseline: boolean,
+): number | undefined {
+  if (after === undefined) return undefined;
+  if (!hasBaseline || before === undefined) return undefined;
+  return Math.max(0, after - before);
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+function fmtMs(ms: number): string {
+  if (ms < 100) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function fmtTokens(n: number | undefined): string {
+  if (n === undefined) return "?";
+  return n.toLocaleString();
+}
+
+/** Format the diagnostics as a concise single-line summary. */
+export function formatTurnDiagnostics(d: TurnDiagnostics): string {
+  const parts: string[] = [
+    `turn ${fmtMs(d.totalDurationMs)}`,
+    `TTFT ${fmtMs(d.ttftMs)}`,
+    `stream ${fmtMs(d.responseSpanMs)}`,
+    `tail ${fmtMs(d.tailMs)}`,
+  ];
+
+  if (d.tps !== undefined) {
+    parts.push(`TPS ${d.tps.toFixed(1)} tok/s`);
+  }
+
+  const tokenParts: string[] = [];
+  if (d.outputTokens !== undefined) tokenParts.push(`out ${fmtTokens(d.outputTokens)}`);
+  if (d.inputTokens !== undefined) tokenParts.push(`in ${fmtTokens(d.inputTokens)}`);
+  if (d.cacheReadTokens !== undefined || d.cacheWriteTokens !== undefined) {
+    tokenParts.push(`cache r/w ${fmtTokens(d.cacheReadTokens)}/${fmtTokens(d.cacheWriteTokens)}`);
+  }
+  if (d.totalTokens !== undefined) tokenParts.push(`total ${fmtTokens(d.totalTokens)}`);
+  if (tokenParts.length > 0) {
+    parts.push(tokenParts.join(", "));
+  }
+
+  if (d.model) {
+    parts.push(d.model);
+  }
+
+  return parts.join(" \u00b7 ");
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -755,6 +755,17 @@ input:focus-visible,
     calc(var(--agent-turn-actions-h) + var(--sp-2));
 }
 
+/* Dev-only per-turn diagnostics line (JUN-436). A quiet monospace summary
+ * shown after the last completed turn when the experimental flag is on. */
+.agent-turn-diagnostics {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  line-height: 1.35;
+  color: var(--muted-foreground);
+  padding-inline: var(--sp-1);
+  user-select: text;
+}
+
 /* Dev-tools response gallery (window.__agentGallery): a labeled catalog of every
  * agent response part type, rendered through the real turn components. */
 .agent-gallery {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -665,7 +665,7 @@ describe("AppSettings", () => {
 
   it("shows the experimental restart action under React Strict Mode", async () => {
     const user = userEvent.setup();
-    await setExperimentalFlags({ unlocked: false, browser_use: false });
+    await setExperimentalFlags({ unlocked: false, browser_use: false, turn_diagnostics: false });
     render(
       <StrictMode>
         <AppSettings
@@ -690,12 +690,12 @@ describe("AppSettings", () => {
     await user.click(screen.getByRole("switch", { name: "Enable experimental Browser use" }));
 
     expect(await screen.findByRole("button", { name: "Restart agent" })).toBeInTheDocument();
-    await setExperimentalFlags({ unlocked: false, browser_use: false });
+    await setExperimentalFlags({ unlocked: false, browser_use: false, turn_diagnostics: false });
   });
 
   it("shows the experimental restart action when Browser use is turned off", async () => {
     const user = userEvent.setup();
-    await setExperimentalFlags({ unlocked: true, browser_use: true });
+    await setExperimentalFlags({ unlocked: true, browser_use: true, turn_diagnostics: false });
     render(
       <AppSettings
         account={signedInAccount}
@@ -721,7 +721,7 @@ describe("AppSettings", () => {
     expect(
       screen.getByText("Turning it off applies fully after June restarts.", { exact: false }),
     ).toBeInTheDocument();
-    await setExperimentalFlags({ unlocked: false, browser_use: false });
+    await setExperimentalFlags({ unlocked: false, browser_use: false, turn_diagnostics: false });
   });
 
   it("locks experimental controls while an operation is in progress", async () => {
@@ -733,7 +733,7 @@ describe("AppSettings", () => {
           finishUnpack = resolve;
         }),
     );
-    await setExperimentalFlags({ unlocked: true, browser_use: false });
+    await setExperimentalFlags({ unlocked: true, browser_use: false, turn_diagnostics: false });
     render(
       <AppSettings
         account={signedInAccount}
@@ -761,7 +761,7 @@ describe("AppSettings", () => {
     await act(async () => finishUnpack?.("/tmp/extension-unpacked"));
     await waitFor(() => expect(hide).toBeEnabled());
     expect(browserUse).toBeEnabled();
-    await setExperimentalFlags({ unlocked: false, browser_use: false });
+    await setExperimentalFlags({ unlocked: false, browser_use: false, turn_diagnostics: false });
   });
 
   it("opens checkout from Upgrade in billing settings", async () => {

--- a/src/test/experimental-flags.test.ts
+++ b/src/test/experimental-flags.test.ts
@@ -30,12 +30,16 @@ describe("experimental flags", () => {
   beforeEach(async () => {
     mocks.invoke.mockImplementation(async (command: string, input?: unknown) => {
       if (command === "experimental_flags_set") {
-        return (input as { request: { unlocked: boolean; browser_use: boolean } }).request;
+        return (
+          input as {
+            request: { unlocked: boolean; browser_use: boolean; turn_diagnostics: boolean };
+          }
+        ).request;
       }
-      return { unlocked: false, browser_use: false };
+      return { unlocked: false, browser_use: false, turn_diagnostics: false };
     });
     mocks.listen.mockResolvedValue(() => {});
-    await setExperimentalFlags({ unlocked: false, browser_use: false });
+    await setExperimentalFlags({ unlocked: false, browser_use: false, turn_diagnostics: false });
   });
 
   it("unlocks on the seventh click inside the time window", () => {
@@ -68,7 +72,7 @@ describe("experimental flags", () => {
   it("renders Browser access requests when the cached override is enabled", async () => {
     expect(hasBrowserAccessRequest(BROWSER_ACCESS_REQUEST_TOKEN)).toBe(false);
 
-    await setExperimentalFlags({ unlocked: true, browser_use: true });
+    await setExperimentalFlags({ unlocked: true, browser_use: true, turn_diagnostics: false });
 
     expect(hasBrowserAccessRequest(BROWSER_ACCESS_REQUEST_TOKEN)).toBe(true);
   });
@@ -89,7 +93,7 @@ describe("experimental flags", () => {
     mocks.listen.mockReset();
     mocks.invoke
       .mockRejectedValueOnce(new Error("bridge unavailable"))
-      .mockResolvedValueOnce({ unlocked: true, browser_use: true });
+      .mockResolvedValueOnce({ unlocked: true, browser_use: true, turn_diagnostics: false });
     mocks.listen.mockResolvedValue(() => {});
     const flags = await import("../lib/experimental-flags");
 
@@ -97,6 +101,7 @@ describe("experimental flags", () => {
     expect(flags.getCachedExperimentalFlags()).toEqual({
       unlocked: false,
       browser_use: false,
+      turn_diagnostics: false,
     });
 
     const { result, unmount } = renderHook(() => flags.useExperimentalFlags());

--- a/src/test/session-event-listener.test.ts
+++ b/src/test/session-event-listener.test.ts
@@ -4,6 +4,11 @@ import type { HermesGatewayClient, HermesGatewayEvent } from "../lib/hermes-gate
 import type { JuneHermesEvent } from "../lib/hermes-control-plane";
 import { createSessionEventListener } from "../components/agent/session-event-listener";
 import { agentStatusFromHermesEvent } from "../components/agent/session-state-helpers";
+import {
+  type TurnDiagnosticsContext,
+  clearTurnDiagnostics,
+  getTurnDiagnostics,
+} from "../lib/turn-diagnostics";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -103,5 +108,187 @@ describe("createSessionEventListener activity publications", () => {
     expect(statuses).toHaveLength(3);
 
     window.removeEventListener(AGENT_SESSION_STATUS_EVENT, onStatus);
+  });
+});
+
+describe("createSessionEventListener turn diagnostics", () => {
+  const diagnosticSessionIds = [
+    "diag-session",
+    "usage-diag-session",
+    "no-diag-session",
+    "duplicate-diag-session",
+  ];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const sessionId of diagnosticSessionIds) clearTurnDiagnostics(sessionId);
+  });
+
+  function attachListener({
+    request,
+    storedSessionId,
+    turnDiagnostics,
+  }: {
+    request: ReturnType<typeof vi.fn>;
+    storedSessionId: string;
+    turnDiagnostics?: TurnDiagnosticsContext;
+  }) {
+    let eventHandler: ((event: HermesGatewayEvent) => void) | undefined;
+    const gateway = {
+      onEvent(handler: (event: HermesGatewayEvent) => void) {
+        eventHandler = handler;
+        return () => {
+          eventHandler = undefined;
+        };
+      },
+      request,
+    } as unknown as HermesGatewayClient;
+    const { attachHermesSessionEventListener } = createSessionEventListener({
+      cancelAgentRunSettlement: vi.fn(),
+      clearSessionActivity: vi.fn(() => ({ activeCount: 0, needsUserCount: 0 })),
+      clearSubmittedSteers: vi.fn(),
+      continueAfterCompletedAgentRun: vi.fn(),
+      liveEventsRef: { current: {} as Record<string, JuneHermesEvent[]> },
+      onArtifactFilesystemChange: vi.fn(),
+      pendingSteerBySessionIdRef: { current: {} },
+      promotePendingIssueReportToReview: vi.fn(() => true),
+      recordHermesActivityAndDeriveStatus: (event) => agentStatusFromHermesEvent(event),
+      refreshHermesSession: vi.fn().mockResolvedValue(undefined),
+      releaseAllComputerUseRuns: vi.fn().mockResolvedValue(undefined),
+      releaseComputerUseRun: vi.fn().mockResolvedValue(undefined),
+      sessionGatewayUnlistenRef: { current: new Map<string, () => void>() },
+      sessionThinkingAppliedRef: { current: {} },
+      sessionThinkingEfforts: () => ({}),
+      sessionThinkingEffortsRef: { current: {} },
+      setLiveEvents: vi.fn(),
+      withStoredHermesSessionId: (event, sessionId) => ({ ...event, sessionId }) as JuneHermesEvent,
+    });
+
+    attachHermesSessionEventListener({
+      gateway,
+      runtimeSessionId: "runtime-session",
+      sessionDisplayTitle: "Diagnostic response",
+      storedSessionId,
+      turnDiagnostics,
+    });
+
+    return {
+      emit(event: HermesGatewayEvent) {
+        eventHandler?.(event);
+      },
+      request,
+    };
+  }
+
+  it("publishes timing-only diagnostics when post-turn usage rejects", async () => {
+    vi.spyOn(performance, "now").mockReturnValue(1_100);
+    const listener = attachListener({
+      request: vi.fn().mockRejectedValue(new Error("gateway unavailable")),
+      storedSessionId: "diag-session",
+      turnDiagnostics: { startAt: 1_000 },
+    });
+
+    listener.emit({
+      type: "message.delta",
+      session_id: "runtime-session",
+      payload: { delta: "hello" },
+    });
+    listener.emit({
+      type: "session.info",
+      session_id: "runtime-session",
+      payload: { running: false },
+    });
+
+    await vi.waitFor(() => expect(getTurnDiagnostics("diag-session")).toBeDefined());
+    const diagnostics = getTurnDiagnostics("diag-session");
+    expect(diagnostics?.totalDurationMs).toBeGreaterThan(0);
+    expect(diagnostics?.ttftMs).toBeGreaterThanOrEqual(0);
+    expect(diagnostics?.outputTokens).toBeUndefined();
+    clearTurnDiagnostics("diag-session");
+  });
+
+  it("publishes diagnostics with token deltas when post-turn usage succeeds", async () => {
+    vi.spyOn(performance, "now").mockReturnValue(1_100);
+    const listener = attachListener({
+      request: vi.fn().mockResolvedValue({
+        usage: {
+          prompt_tokens: 200,
+          completion_tokens: 110,
+          total_tokens: 310,
+          cache_read_input_tokens: 20,
+          cache_creation_input_tokens: 10,
+        },
+      }),
+      storedSessionId: "usage-diag-session",
+      turnDiagnostics: {
+        startAt: 1_000,
+        usageBefore: {
+          promptTokens: 100,
+          completionTokens: 100,
+          totalTokens: 200,
+          cacheReadTokens: 10,
+          cacheWriteTokens: 5,
+        },
+      },
+    });
+
+    listener.emit({
+      type: "message.delta",
+      session_id: "runtime-session",
+      payload: { delta: "hello" },
+    });
+    listener.emit({
+      type: "session.info",
+      session_id: "runtime-session",
+      payload: { running: false },
+    });
+
+    await vi.waitFor(() => expect(getTurnDiagnostics("usage-diag-session")).toBeDefined());
+    expect(getTurnDiagnostics("usage-diag-session")).toMatchObject({
+      outputTokens: 10,
+      inputTokens: 100,
+      totalTokens: 110,
+      cacheReadTokens: 10,
+      cacheWriteTokens: 5,
+    });
+    clearTurnDiagnostics("usage-diag-session");
+  });
+
+  it("does not capture diagnostics when turnDiagnostics is not provided", () => {
+    const listener = attachListener({
+      request: vi.fn(),
+      storedSessionId: "no-diag-session",
+    });
+
+    listener.emit({
+      type: "session.info",
+      session_id: "runtime-session",
+      payload: { running: false },
+    });
+
+    expect(listener.request).not.toHaveBeenCalled();
+    expect(getTurnDiagnostics("no-diag-session")).toBeUndefined();
+    clearTurnDiagnostics("no-diag-session");
+  });
+
+  it("does not publish diagnostics for duplicate terminal frames", async () => {
+    vi.spyOn(performance, "now").mockReturnValue(1_100);
+    const listener = attachListener({
+      request: vi.fn().mockResolvedValue({ usage: { prompt_tokens: 200 } }),
+      storedSessionId: "duplicate-diag-session",
+      turnDiagnostics: { startAt: 1_000 },
+    });
+    const terminalEvent: HermesGatewayEvent = {
+      type: "session.info",
+      session_id: "runtime-session",
+      payload: { running: false },
+    };
+
+    listener.emit(terminalEvent);
+    listener.emit(terminalEvent);
+
+    await vi.waitFor(() => expect(getTurnDiagnostics("duplicate-diag-session")).toBeDefined());
+    expect(listener.request).toHaveBeenCalledTimes(1);
+    clearTurnDiagnostics("duplicate-diag-session");
   });
 });

--- a/src/test/turn-diagnostics.test.ts
+++ b/src/test/turn-diagnostics.test.ts
@@ -1,0 +1,413 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cacheSnapshotFromRaw,
+  clearTurnDiagnostics,
+  computeTurnDiagnostics,
+  formatTurnDiagnostics,
+  getTurnDiagnostics,
+  getTurnDiagnosticsVersion,
+  publishTurnDiagnostics,
+  snapshotFromRawUsage,
+  subscribeTurnDiagnostics,
+  type TurnDiagnostics,
+  type TurnTimingState,
+  type TurnUsageSnapshot,
+} from "../lib/turn-diagnostics";
+
+const finalizedAt = "2026-07-24T12:00:00.000Z";
+
+function diagnostics(overrides: Partial<TurnDiagnostics> = {}): TurnDiagnostics {
+  return {
+    totalDurationMs: 6_500,
+    ttftMs: 1_200,
+    responseSpanMs: 4_800,
+    tailMs: 500,
+    finalizedAt,
+    ...overrides,
+  };
+}
+
+describe("computeTurnDiagnostics", () => {
+  it("computes normal timing and token deltas", () => {
+    const timing: TurnTimingState = {
+      startAt: 1_000,
+      firstTokenAt: 2_200,
+      lastMessageCompleteAt: 7_000,
+      terminalAt: 7_500,
+    };
+    const usageBefore: TurnUsageSnapshot = {
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 150,
+      cacheReadTokens: 10,
+      cacheWriteTokens: 5,
+    };
+    const usageAfter: TurnUsageSnapshot = {
+      promptTokens: 16_000,
+      completionTokens: 61,
+      totalTokens: 16_061,
+      cacheReadTokens: 20,
+      cacheWriteTokens: 8,
+      model: "test-model",
+      provider: "test-provider",
+    };
+
+    const result = computeTurnDiagnostics(timing, usageBefore, usageAfter);
+
+    expect(result).toBeDefined();
+    expect(result).toMatchObject({
+      totalDurationMs: 6_500,
+      ttftMs: 1_200,
+      responseSpanMs: 4_800,
+      tailMs: 500,
+      outputTokens: 11,
+      inputTokens: 15_900,
+      totalTokens: 15_911,
+      cacheReadTokens: 10,
+      cacheWriteTokens: 3,
+      model: "test-model",
+      provider: "test-provider",
+    });
+    expect(result?.responseSpanTokensPerSecond).toBeCloseTo(11 / 4.8);
+    expect(typeof result?.finalizedAt).toBe("string");
+    expect(new Date(result?.finalizedAt ?? "").toISOString()).toBe(result?.finalizedAt);
+  });
+
+  it("returns undefined when terminalAt is missing", () => {
+    expect(computeTurnDiagnostics({ startAt: 1_000 }, {}, {})).toBeUndefined();
+  });
+
+  it("returns undefined for zero duration", () => {
+    expect(computeTurnDiagnostics({ startAt: 1_000, terminalAt: 1_000 }, {}, {})).toBeUndefined();
+  });
+
+  it("returns undefined for negative duration", () => {
+    expect(computeTurnDiagnostics({ startAt: 1_000, terminalAt: 999 }, {}, {})).toBeUndefined();
+  });
+
+  it("falls back to terminal when first token and completion are missing", () => {
+    expect(computeTurnDiagnostics({ startAt: 1_000, terminalAt: 2_500 }, {}, {})).toMatchObject({
+      totalDurationMs: 1_500,
+      ttftMs: 1_500,
+      responseSpanMs: 0,
+      tailMs: 0,
+    });
+  });
+
+  it("clamps out-of-order boundaries to zero", () => {
+    const result = computeTurnDiagnostics(
+      {
+        startAt: 1_000,
+        firstTokenAt: 3_500,
+        lastMessageCompleteAt: 3_000,
+        terminalAt: 3_200,
+      },
+      {},
+      {},
+    );
+
+    expect(result?.responseSpanMs).toBe(0);
+    expect(result?.tailMs).toBe(200);
+
+    const firstTokenAfterTerminal = computeTurnDiagnostics(
+      { startAt: 1_000, firstTokenAt: 3_500, terminalAt: 3_200 },
+      {},
+      {},
+    );
+    expect(firstTokenAfterTerminal?.responseSpanMs).toBe(0);
+    expect(firstTokenAfterTerminal?.tailMs).toBe(0);
+  });
+
+  it("leaves all token deltas undefined when the whole baseline is missing", () => {
+    const result = computeTurnDiagnostics(
+      { startAt: 1_000, firstTokenAt: 1_500, lastMessageCompleteAt: 2_000, terminalAt: 2_100 },
+      undefined,
+      {
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 150,
+        cacheReadTokens: 10,
+        cacheWriteTokens: 5,
+      },
+    );
+
+    expect(result).toMatchObject({
+      outputTokens: undefined,
+      inputTokens: undefined,
+      totalTokens: undefined,
+      cacheReadTokens: undefined,
+      cacheWriteTokens: undefined,
+      responseSpanTokensPerSecond: undefined,
+    });
+  });
+
+  it("computes only fields present in both partial snapshots", () => {
+    const result = computeTurnDiagnostics(
+      { startAt: 1_000, firstTokenAt: 1_500, lastMessageCompleteAt: 2_000, terminalAt: 2_100 },
+      { completionTokens: 50 },
+      { completionTokens: 61, promptTokens: 100 },
+    );
+
+    expect(result).toMatchObject({
+      outputTokens: 11,
+      inputTokens: undefined,
+      totalTokens: undefined,
+      cacheReadTokens: undefined,
+      cacheWriteTokens: undefined,
+    });
+  });
+
+  it("clamps negative token movement to zero", () => {
+    const result = computeTurnDiagnostics(
+      { startAt: 1_000, terminalAt: 2_000 },
+      { completionTokens: 100 },
+      { completionTokens: 50 },
+    );
+    expect(result?.outputTokens).toBe(0);
+  });
+
+  it("leaves throughput undefined for a zero response span", () => {
+    const result = computeTurnDiagnostics(
+      {
+        startAt: 1_000,
+        firstTokenAt: 1_500,
+        lastMessageCompleteAt: 1_500,
+        terminalAt: 2_000,
+      },
+      { completionTokens: 10 },
+      { completionTokens: 20 },
+    );
+    expect(result?.responseSpanTokensPerSecond).toBeUndefined();
+  });
+});
+
+describe("cacheSnapshotFromRaw", () => {
+  it("reads nested usage snake_case fields", () => {
+    expect(
+      cacheSnapshotFromRaw({
+        usage: { cache_read_input_tokens: 100, cache_creation_input_tokens: 50 },
+      }),
+    ).toEqual({ cacheReadTokens: 100, cacheWriteTokens: 50 });
+  });
+
+  it("reads nested tokens camelCase fields", () => {
+    expect(
+      cacheSnapshotFromRaw({ tokens: { cacheReadTokens: 200, cacheWriteTokens: 75 } }),
+    ).toEqual({ cacheReadTokens: 200, cacheWriteTokens: 75 });
+  });
+
+  it("reads root-level aliases", () => {
+    expect(cacheSnapshotFromRaw({ cache_read_tokens: 300, cache_write_tokens: 90 })).toEqual({
+      cacheReadTokens: 300,
+      cacheWriteTokens: 90,
+    });
+  });
+
+  it("leaves the absent cache side undefined", () => {
+    expect(cacheSnapshotFromRaw({ usage: { cache_read_input_tokens: 100 } })).toEqual({
+      cacheReadTokens: 100,
+      cacheWriteTokens: undefined,
+    });
+  });
+
+  it.each([
+    ["null input", null],
+    ["array input", [1, 2, 3]],
+    ["string input", "hello"],
+    ["malformed nested object", { usage: "not-an-object" }],
+  ])("returns empty values for %s", (_label, raw) => {
+    expect(cacheSnapshotFromRaw(raw)).toEqual({});
+  });
+
+  it("ignores NaN and infinities", () => {
+    expect(cacheSnapshotFromRaw({ cache_read_tokens: Number.NaN })).toEqual({
+      cacheReadTokens: undefined,
+    });
+    expect(cacheSnapshotFromRaw({ cache_read_tokens: Number.POSITIVE_INFINITY })).toEqual({
+      cacheReadTokens: undefined,
+    });
+  });
+});
+
+describe("snapshotFromRawUsage", () => {
+  it("parses a full payload", () => {
+    expect(
+      snapshotFromRawUsage("test-full", {
+        model: "test-model",
+        provider: "test-provider",
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 5,
+        },
+      }),
+    ).toEqual({
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 150,
+      cacheReadTokens: 10,
+      cacheWriteTokens: 5,
+      model: "test-model",
+      provider: "test-provider",
+    });
+  });
+
+  it("returns an empty snapshot for an empty object", () => {
+    expect(snapshotFromRawUsage("test-empty", {})).toEqual({});
+  });
+
+  it("returns an empty snapshot for null", () => {
+    expect(snapshotFromRawUsage("test-null", null)).toEqual({});
+  });
+});
+
+describe("formatTurnDiagnostics", () => {
+  it("produces timing-only output when all token fields are undefined", () => {
+    const output = formatTurnDiagnostics(diagnostics());
+
+    expect(output).toContain("turn");
+    expect(output).toContain("TTFT");
+    expect(output).toContain("stream");
+    expect(output).toContain("tail");
+    expect(output).not.toContain("response avg");
+    expect(output).not.toContain("out ");
+    expect(output).not.toContain("in ");
+    expect(output).not.toContain("cache");
+    expect(output).not.toContain("total");
+    expect(output).not.toMatch(/ · $/);
+  });
+
+  it("formats full data", () => {
+    const output = formatTurnDiagnostics(
+      diagnostics({
+        outputTokens: 11,
+        inputTokens: 15_900,
+        totalTokens: 15_911,
+        cacheReadTokens: 10,
+        cacheWriteTokens: 3,
+        responseSpanTokensPerSecond: 2.3,
+        model: "test-model",
+        provider: "test-provider",
+      }),
+    );
+
+    expect(output).toContain("response avg");
+    expect(output).toContain("out 11");
+    expect(output).toContain("in 15,900");
+    expect(output).toContain("cache r/w 10/3");
+    expect(output).toContain("total 15,911");
+    expect(output).toContain("test-model");
+  });
+
+  it("formats a missing cache side as a question mark", () => {
+    expect(formatTurnDiagnostics(diagnostics({ cacheWriteTokens: 5 }))).toContain("cache r/w ?/5");
+  });
+
+  it("uses the response avg label", () => {
+    expect(formatTurnDiagnostics(diagnostics({ responseSpanTokensPerSecond: 2.3 }))).toContain(
+      "response avg 2.3 tok/s",
+    );
+  });
+
+  it("omits the model when absent", () => {
+    const output = formatTurnDiagnostics(diagnostics({ model: undefined }));
+    expect(output).toBe("turn 6.5s · TTFT 1.2s · stream 4.8s · tail 0.5s");
+  });
+
+  it("formats milliseconds and seconds", () => {
+    expect(formatTurnDiagnostics(diagnostics({ ttftMs: 50 }))).toContain("TTFT 50ms");
+    expect(formatTurnDiagnostics(diagnostics({ ttftMs: 1_500 }))).toContain("TTFT 1.5s");
+  });
+});
+
+describe("turn diagnostics store lifecycle", () => {
+  const sessionIds = [
+    "test-session-initial",
+    "test-session-publish",
+    "test-session-overwrite",
+    "session-a",
+    "session-b",
+    "test-session-clear",
+    "test-session-absent",
+    "test-session-unsubscribe",
+  ];
+
+  beforeEach(() => {
+    for (const sessionId of sessionIds) clearTurnDiagnostics(sessionId);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("initial get returns undefined", () => {
+    expect(getTurnDiagnostics("test-session-initial")).toBeUndefined();
+  });
+
+  it("publish stores data and increments version", () => {
+    const value = diagnostics();
+    const before = getTurnDiagnosticsVersion();
+
+    publishTurnDiagnostics("test-session-publish", value);
+
+    expect(getTurnDiagnosticsVersion()).toBeGreaterThan(before);
+    expect(getTurnDiagnostics("test-session-publish")).toBe(value);
+  });
+
+  it("publishing again overwrites the same session", () => {
+    const first = diagnostics({ outputTokens: 1 });
+    const second = diagnostics({ outputTokens: 2 });
+    publishTurnDiagnostics("test-session-overwrite", first);
+    publishTurnDiagnostics("test-session-overwrite", second);
+    expect(getTurnDiagnostics("test-session-overwrite")).toBe(second);
+  });
+
+  it("keeps sessions isolated", () => {
+    const first = diagnostics({ model: "model-a" });
+    const second = diagnostics({ model: "model-b" });
+    publishTurnDiagnostics("session-a", first);
+    publishTurnDiagnostics("session-b", second);
+    expect(getTurnDiagnostics("session-a")).toBe(first);
+    expect(getTurnDiagnostics("session-b")).toBe(second);
+  });
+
+  it("clear removes data and notifies listeners", () => {
+    publishTurnDiagnostics("test-session-clear", diagnostics());
+    const listener = vi.fn();
+    const unsubscribe = subscribeTurnDiagnostics(listener);
+
+    clearTurnDiagnostics("test-session-clear");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(getTurnDiagnostics("test-session-clear")).toBeUndefined();
+    unsubscribe();
+  });
+
+  it("clearing an absent session does not notify", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeTurnDiagnostics(listener);
+    const before = getTurnDiagnosticsVersion();
+
+    clearTurnDiagnostics("test-session-absent");
+
+    expect(getTurnDiagnosticsVersion()).toBe(before);
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it("does not call unsubscribed listeners", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeTurnDiagnostics(listener);
+    unsubscribe();
+
+    publishTurnDiagnostics("test-session-unsubscribe", diagnostics());
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for an undefined session", () => {
+    expect(getTurnDiagnostics(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a development-only experimental flag (`turn_diagnostics`) that appends concise timing and token diagnostics after each completed agent turn.
- The flag is toggled in Settings → About → Experiments (unlocked by clicking the version 7 times).
- Diagnostics show: total turn duration, time to first token, streaming span, tail processing, response-average throughput, input/output/cache token deltas, and model name.
- Timing always publishes even when the post-turn usage RPC fails or times out; token fields are omitted in that case.
- Baseline usage is captured with a bounded (500ms) pre-submit RPC in `beforePrompt`, guaranteeing it reflects pre-turn state rather than racing with the first events.
- Only the real send path provides the diagnostics context — recovery/restoration listeners do not, preventing partial-turn diagnostics.
- Settings description honestly states that timing spans are end to end and do not isolate upstream provider latency.
- 36 unit tests for the diagnostics module and 4 session-event-listener tests covering failure, success, no-context, and duplicate-terminal paths.

Closes JUN-436.

## Validation

- `pnpm typecheck` — passed
- `pnpm check` (Biome) — 0 errors (warnings are pre-existing)
- `pnpm vitest` — 147/147 tests passed (36 new turn-diagnostics, 4 new listener, 107 existing)

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- check if yes; say which change -->

## Out of scope

- True provider-vs-June overhead separation: the three timing spans (TTFT, stream, tail) are end-to-end composites. Separating provider time from June runtime overhead requires Hermes to expose per-model-call timestamps or safe request/trace identifiers — a future wire-contract change.
- Per-turn history: only the latest completed diagnostic is retained per session. Associating diagnostics with durable transcript turn IDs and showing history is deferred.
- `submitAt` (`startAt`) is captured in `beforePrompt` after the baseline attempt, immediately before `prompt.submit` dispatch. It includes gateway invocation and transport in TTFT/total duration. This is documented as an accepted limitation.

## Followups

- Future Hermes wire-contract extension for per-model-call telemetry would enable true provider/agent timing separation.
- Per-turn diagnostics history if developer feedback indicates it's useful.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary (diagnostics carry only timing, token counts, and model/provider names — no prompt contents or credentials).
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787490794&installation_model_id=425925&pr_number=959&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F959&signature=98d3f9343e06cb7d9c036b66bc6123dae8969d816fa9fff3b5453b1ca46088e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->