### PR TITLE
feat(dictation): stop dictation from meeting notes with Escape (JUN-351)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -106,6 +106,7 @@ import {
   isCreateNoteShortcut,
   isMicrophoneRecordingBlocked,
   isNewSessionShortcut,
+  isStopDictationShortcut,
 } from "./app-helpers";
 export { isAccessibilityBlocked, isMicrophoneRecordingBlocked } from "./app-helpers";
 import {
@@ -297,6 +298,8 @@ export function App() {
     recordingTelemetryStore,
     recordingStatusRef,
     dictationWorkflowActiveRef,
+    dictationActive,
+    setDictationActive,
     recordingInactivityTrackerRef,
     recordingInactivityPrompt,
     setRecordingInactivityPrompt,
@@ -1134,6 +1137,7 @@ export function App() {
 
   useDictationEvents({
     dictationWorkflowActiveRef,
+    setDictationActive,
     setAccessibilityStatus,
     setActiveView,
     setMicrophoneStatus,
@@ -1529,6 +1533,21 @@ export function App() {
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
       if (document.querySelector('[role="dialog"]')) return;
+      // Escape stops an active dictation from the meeting-notes view and keeps
+      // the captured text (stop_and_paste, never discard). Gated on live
+      // dictation so Escape keeps its other meanings (dropdown close) when
+      // nothing is listening — hence no preventDefault on the inactive path.
+      // activeViewRef.current, not the captured value: this effect never
+      // re-subscribes on view change (see deps below).
+      if (
+        isStopDictationShortcut(event) &&
+        activeViewRef.current === "meetings" &&
+        dictationWorkflowActiveRef.current
+      ) {
+        event.preventDefault();
+        void dictationHelperCommand({ type: "stop_and_paste" });
+        return;
+      }
       if (isNewSessionShortcut(event)) {
         event.preventDefault();
         handleNewAgentSession();
@@ -2045,6 +2064,7 @@ export function App() {
     appMaxGrantWaitRef,
     billingNotice,
     captureActive,
+    dictationActive,
     changeSettingsTab,
     checkingUpdate,
     closeOtherTabs,

--- a/src/app/app-helpers.tsx
+++ b/src/app/app-helpers.tsx
@@ -102,6 +102,16 @@ export function isCreateNoteShortcut(event: KeyboardEvent) {
   );
 }
 
+export function isStopDictationShortcut(event: KeyboardEvent) {
+  // Bare Escape, no modifiers. Callers gate this on active dictation so Escape
+  // keeps its other meanings (e.g. closing a dropdown) when nothing is
+  // listening. A modifier would collide with nothing today, but Escape is the
+  // universal "stop the transient thing" affordance and needs no chord.
+  return (
+    event.key === "Escape" && !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
+  );
+}
+
 export function stringPayloadValue(value: unknown) {
   return typeof value === "string" ? value : undefined;
 }

--- a/src/app/app-layout-types.ts
+++ b/src/app/app-layout-types.ts
@@ -38,6 +38,7 @@ export type RenderAppLayoutDependencies = {
   appMaxGrantWaitRef: React.MutableRefObject<MaxGrantWait | undefined>;
   billingNotice: string | null;
   captureActive: boolean;
+  dictationActive: boolean;
   changeSettingsTab: (tab: SettingsTab) => void;
   checkingUpdate: boolean;
   closeOtherTabs: (id: string) => void;

--- a/src/app/app-layout.tsx
+++ b/src/app/app-layout.tsx
@@ -54,6 +54,7 @@ export function renderAppLayout(dependencies: RenderAppLayoutDependencies) {
     appMaxGrantWaitRef,
     billingNotice,
     captureActive,
+    dictationActive,
     changeSettingsTab,
     checkingUpdate,
     closeOtherTabs,
@@ -405,6 +406,7 @@ export function renderAppLayout(dependencies: RenderAppLayoutDependencies) {
             note={{ id: selectedNote.id, title: selectedNote.title }}
             chat={noteChat}
             recordingActive={captureActive}
+            dictationActive={dictationActive}
             creditActionsDisabledReason={
               fundingRequired ? COMPOSER_FUNDING_DISABLED_REASON : undefined
             }

--- a/src/app/use-app-state.ts
+++ b/src/app/use-app-state.ts
@@ -245,6 +245,11 @@ export function useAppState() {
   }
   const recordingTelemetryStore = recordingTelemetryStoreRef.current;
   const dictationWorkflowActiveRef = useRef(false);
+  // Reactive mirror of dictationWorkflowActiveRef. The ref serves the
+  // synchronous keydown gate (stop-dictation shortcut); this state drives
+  // render decisions — the Dictate button's stop hint. Updated together in
+  // useDictationEvents so they can't drift.
+  const [dictationActive, setDictationActive] = useState(false);
   const recordingInactivityTrackerRef = useRef<RecordingInactivityTracker>({});
   const [recordingInactivityPrompt, setRecordingInactivityPrompt] =
     useState<RecordingInactivityPrompt | null>(null);
@@ -383,6 +388,8 @@ export function useAppState() {
     recordingTelemetryStore,
     recordingStatusRef,
     dictationWorkflowActiveRef,
+    dictationActive,
+    setDictationActive,
     recordingInactivityTrackerRef,
     recordingInactivityPrompt,
     setRecordingInactivityPrompt,

--- a/src/app/use-dictation-events-types.ts
+++ b/src/app/use-dictation-events-types.ts
@@ -3,6 +3,7 @@ import type * as React from "react";
 
 export type UseDictationEventsDependencies = {
   dictationWorkflowActiveRef: React.MutableRefObject<boolean>;
+  setDictationActive: React.Dispatch<React.SetStateAction<boolean>>;
   setAccessibilityStatus: React.Dispatch<React.SetStateAction<string | undefined>>;
   setActiveView: React.Dispatch<React.SetStateAction<SidebarView>>;
   setMicrophoneStatus: React.Dispatch<React.SetStateAction<string | undefined>>;

--- a/src/app/use-dictation-events.ts
+++ b/src/app/use-dictation-events.ts
@@ -12,8 +12,13 @@ import { stringPayloadValue } from "./app-helpers";
 import type { UseDictationEventsDependencies } from "./use-dictation-events-types";
 
 export function useDictationEvents(dependencies: UseDictationEventsDependencies) {
-  const { dictationWorkflowActiveRef, setAccessibilityStatus, setActiveView, setMicrophoneStatus } =
-    dependencies;
+  const {
+    dictationWorkflowActiveRef,
+    setDictationActive,
+    setAccessibilityStatus,
+    setActiveView,
+    setMicrophoneStatus,
+  } = dependencies;
 
   useEffect(() => {
     let aborted = false;
@@ -21,10 +26,14 @@ export function useDictationEvents(dependencies: UseDictationEventsDependencies)
     void listen<string>("dictation-event", (event) => {
       const helperEvent = parseDictationHelperEvent(event.payload);
       if (!helperEvent) return;
-      dictationWorkflowActiveRef.current = nextDictationWorkflowActive(
+      const nextActive = nextDictationWorkflowActive(
         dictationWorkflowActiveRef.current,
         helperEvent.type,
       );
+      // Keep the synchronous ref (keydown gate) and the reactive state (Dictate
+      // button stop hint) in lockstep from the single source of truth.
+      dictationWorkflowActiveRef.current = nextActive;
+      setDictationActive(nextActive);
       if (helperEvent.type === "final_transcript") {
         // T3 of the referral delight nudge: a dictation landed (often while
         // June is backgrounded; the card waits to be found).

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -39,6 +39,7 @@ import {
   withLocalGenerationOption,
 } from "../../lib/local-generation";
 import { useScrollFade } from "../../lib/use-scroll-fade";
+import { KeycapShortcut } from "../shortcuts/KeycapShortcut";
 import { dispatchProviderModelSettingsChanged } from "../../lib/model-privacy";
 import {
   dictationHelperCommand,
@@ -209,6 +210,7 @@ export function NoteChatPanel({
   note,
   chat,
   recordingActive,
+  dictationActive,
   creditActionsDisabledReason,
   renderFundingNotice,
   onClose,
@@ -222,6 +224,10 @@ export function NoteChatPanel({
    * ducks the recording's mic while dictation listens (so a dictated question
    * never lands in the note); this only tunes the tooltip to say so. */
   recordingActive?: boolean;
+  /** True while a dictation take is live (JUN-383 workflow state, mirrored
+   * reactively). Surfaces the "press Esc to stop" hint on the Dictate button
+   * so the meeting-notes-scoped stop shortcut is discoverable (JUN-351). */
+  dictationActive?: boolean;
   creditActionsDisabledReason?: string;
   /** App owns the account and billing action; the composer owns the active
    * session model and picker. */
@@ -829,15 +835,23 @@ export function NoteChatPanel({
                   aria-label="Dictate"
                   title={
                     creditActionsDisabledReason ??
-                    (recordingActive
-                      ? "Dictate a question (kept out of the recording)"
-                      : "Start dictation")
+                    (dictationActive
+                      ? "Stop dictation (press Esc)"
+                      : recordingActive
+                        ? "Dictate a question (kept out of the recording)"
+                        : "Start dictation")
                   }
                   disabled={Boolean(creditActionsDisabledReason)}
                   onClick={() => void startDictation()}
                 >
                   <IconMicrophone size={18} />
                 </button>
+                {dictationActive ? (
+                  // Discoverable stop affordance: the meeting-notes-scoped Esc
+                  // shortcut (App.tsx keydown) only exists while a take is live,
+                  // so the chip only shows then (JUN-351 AC #3).
+                  <KeycapShortcut label="Esc" />
+                ) : null}
                 {working ? (
                   <button
                     type="button"

--- a/src/test/app-helpers-shortcut.test.ts
+++ b/src/test/app-helpers-shortcut.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  isCreateNoteShortcut,
+  isNewSessionShortcut,
+  isStopDictationShortcut,
+} from "../app/app-helpers";
+
+function key(init: Partial<KeyboardEventInit> & { key: string }) {
+  return new KeyboardEvent("keydown", init);
+}
+
+describe("isStopDictationShortcut", () => {
+  it("matches bare Escape", () => {
+    expect(isStopDictationShortcut(key({ key: "Escape" }))).toBe(true);
+  });
+
+  it("rejects Escape with any modifier", () => {
+    expect(isStopDictationShortcut(key({ key: "Escape", metaKey: true }))).toBe(false);
+    expect(isStopDictationShortcut(key({ key: "Escape", ctrlKey: true }))).toBe(false);
+    expect(isStopDictationShortcut(key({ key: "Escape", altKey: true }))).toBe(false);
+    expect(isStopDictationShortcut(key({ key: "Escape", shiftKey: true }))).toBe(false);
+  });
+
+  it("does not shadow the existing new-session / create-note chords or bare n", () => {
+    const newSession = key({ key: "n", metaKey: true });
+    const createNote = key({ key: "n", metaKey: true, shiftKey: true });
+    const bareN = key({ key: "n" });
+    for (const event of [newSession, createNote, bareN]) {
+      expect(isStopDictationShortcut(event)).toBe(false);
+    }
+    // Sanity: those chords still match their own predicates, so nothing regressed.
+    expect(isNewSessionShortcut(newSession)).toBe(true);
+    expect(isCreateNoteShortcut(createNote)).toBe(true);
+  });
+
+  it("rejects other stop-adjacent keys (Cmd+T, W)", () => {
+    expect(isStopDictationShortcut(key({ key: "t", metaKey: true }))).toBe(false);
+    expect(isStopDictationShortcut(key({ key: "w", metaKey: true }))).toBe(false);
+  });
+});

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -786,6 +786,73 @@ describe("App shortcuts", () => {
     }
   });
 
+  // The stop-dictation shortcut is gated on the meetings view, which is only
+  // active once a note is open (the sidebar "Meeting notes" button lands on the
+  // notes list). Open the note first, then flip dictation state.
+  async function openNoteInMeetingsView(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(await screen.findByRole("button", { name: "Meeting notes" }));
+    await user.click(await screen.findByText("First note"));
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+  }
+
+  function flipDictationActive() {
+    // listening_started is in DICTATION_ACTIVE_EVENTS, so this sets the ref +
+    // reactive mirror true through useDictationEvents.
+    return act(async () => {
+      mocks.listeners.get("dictation-event")?.({
+        payload: JSON.stringify({ type: "listening_started" }),
+      });
+    });
+  }
+
+  it("stops an active dictation from the meeting notes view with Escape, keeping the text", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await waitFor(() => expect(mocks.listeners.has("dictation-event")).toBe(true));
+    await openNoteInMeetingsView(user);
+    await flipDictationActive();
+
+    mocks.dictationHelperCommand.mockClear();
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    // stop_and_paste keeps the captured text (AC #2); never discard_recording.
+    expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({ type: "stop_and_paste" });
+    expect(mocks.dictationHelperCommand).not.toHaveBeenCalledWith({ type: "discard_recording" });
+  });
+
+  it("leaves Escape alone in the meeting notes view when no dictation is active", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await waitFor(() => expect(mocks.listeners.has("dictation-event")).toBe(true));
+    await openNoteInMeetingsView(user);
+
+    mocks.dictationHelperCommand.mockClear();
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(mocks.dictationHelperCommand).not.toHaveBeenCalledWith({ type: "stop_and_paste" });
+  });
+
+  it("ignores the Escape stop shortcut while a dialog is open", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await waitFor(() => expect(mocks.listeners.has("dictation-event")).toBe(true));
+    await openNoteInMeetingsView(user);
+    await flipDictationActive();
+
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    document.body.appendChild(dialog);
+
+    mocks.dictationHelperCommand.mockClear();
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(mocks.dictationHelperCommand).not.toHaveBeenCalledWith({ type: "stop_and_paste" });
+    dialog.remove();
+  });
+
   it("opens a report draft from the account menu while a session is active", async () => {
     const user = userEvent.setup();
     const activeSession = {


### PR DESCRIPTION
Adds a meeting-notes-scoped keyboard shortcut to **stop an active dictation and keep the captured text**. Resolves JUN-351.

## What changed
- **Escape** stops dictation from the meeting-notes view, gated on: `activeViewRef.current === "meetings"` **and** a live dictation take (`dictationWorkflowActiveRef.current`) **and** no open dialog. It sends `stop_and_paste` (never `discard_recording`) through the existing `dictation_helper_command` path — the same payload the HUD stop button uses.
- **Discoverability (AC #3):** the Ask June Dictate button shows a `Stop dictation (press Esc)` title and an `Esc` keycap chip while a take is live, driven by a new reactive `dictationActive` mirror of the JUN-383 workflow ref (kept in lockstep inside `useDictationEvents`).
- No `preventDefault` on the inactive path, so Escape keeps closing the note-header dropdown when nothing is listening.
- Reads `activeViewRef.current` inside the existing keydown effect to avoid a stale closure (effect deps unchanged).

## Acceptance criteria
- **#1** stops an active dictation from the meeting notes view — ✅ (Escape → `stop_and_paste`)
- **#2** does not discard captured text — ✅ (`stop_and_paste`; test asserts `discard_recording` is never sent)
- **#3** discoverable in the relevant controls — ✅ (Dictate button title + Esc keycap chip, shown only while dictating)

## Tested visually
Unit + integration tests (below). The actual helper stop + paste round trip is not unit-testable — **needs a manual / `agent-e2e-qa` pass**: start dictation into a note, press Esc, confirm the text is kept and pasted (not discarded).

- `pnpm typecheck`, `pnpm check`: green
- `pnpm test`: **210 files, 3427 passed, 2 skipped, 0 failed**
  - `app-shortcut.test.tsx` (43/43): active → `stop_and_paste` and **not** `discard_recording`; inactive → no-op; dialog open → no-op
  - `app-helpers-shortcut.test.ts` (4/4): `isStopDictationShortcut` matches bare Escape and can't shadow Cmd/Ctrl+T/W/N or bare `n`

## Needs a June API (backend) deploy
**No.** Desktop-only, frontend-only change (all `src/**`). The `stop_and_paste` capability already exists in the helper.

## Root cause
Not a bug — a missing capability. The stop-and-keep mechanism and a global toggle/PTT hotkey already existed, but there was no meeting-notes-view-scoped, discoverable stop shortcut (AC #3, and AC #1 read strictly).

## Out of scope
- A **system-global configurable stop hotkey** (that's the larger helper + `DictationSettings` change; the existing global toggle already covers "stop from anywhere").
- The RecorderBar **"Done"** button, which stops the meeting *recording*, not dictation — left untouched.

## Followups
- Manual / `agent-e2e-qa` verification of the live helper stop+paste round trip before merge.
- Optional: expose the binding in Settings alongside PTT/toggle if it should become user-configurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787491695&installation_model_id=425925&pr_number=960&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F960&signature=596f590d852629cb37b22e0b3f9403125c496078c5126ac6174500149880dfc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->