### PR TITLE
Refresh Venice model catalog automatically

### DIFF
--- a/june-api/.env.example
+++ b/june-api/.env.example
@@ -18,6 +18,9 @@
 # June API refuses to start in that combination. Set a random token instead,
 # e.g. `openssl rand -hex 32`, and keep it in sync with the root .env.
 JUNE__SERVER__HOST=127.0.0.1
+# June refreshes Venice's model catalog in-process at this interval, so new
+# upstream models become selectable without restarting the API. Default: 300.
+# JUNE__SERVER__MODEL_CATALOG_REFRESH_SECS=300
 JUNE__LOCAL_DEV__ENABLED=true
 JUNE__LOCAL_DEV__BEARER_TOKEN=local-dev-token
 JUNE__LOCAL_DEV__USER_ID=usr_local_dev

--- a/june-api/config.toml
+++ b/june-api/config.toml
@@ -2,6 +2,9 @@
 host = "0.0.0.0"
 port = 8080
 request_timeout_secs = 600
+# Refresh Venice pricing and model metadata in-process so newly released
+# models appear without restarting the production CVM.
+model_catalog_refresh_secs = 300
 max_audio_bytes = 26214400
 max_json_bytes = 524288
 # os-platform accepts 300 MiB attachments. The extra 1 MiB covers multipart

--- a/june-api/crates/api/src/handlers/agent.rs
+++ b/june-api/crates/api/src/handlers/agent.rs
@@ -12,8 +12,9 @@ use axum::{
     http::{HeaderMap, HeaderValue, StatusCode, header::CONTENT_TYPE},
     response::{IntoResponse, Response},
 };
+use june_config::ModelPriceConfig;
 use june_domain::{ModelId, ModelKind, UpstreamRouteMetadata};
-use june_services::{AgentChatParams, AgentChatStreamOutput, PricingTable};
+use june_services::{AgentChatParams, AgentChatStreamOutput};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 const PREFERRED_VISION_TEXT_MODEL: &str = "kimi-k2-6";
@@ -161,35 +162,27 @@ fn resolve_priced_agent_text_model(
     if resolved_model_id == AUTO_TEXT_MODEL
         || resolved_model_id == requested_model_id
         || requirements.is_empty()
-        || model_supports_requirements(state.pricing(), &resolved_model_id, requirements)
+        || state
+            .pricing()
+            .priced_model(&resolved_model_id, ModelKind::Text)
+            .is_ok_and(|model| model_supports_requirements(&model, requirements))
     {
         return Ok(resolved_model_id);
     }
 
-    let compatible_model = [PREFERRED_VISION_TEXT_MODEL]
-        .into_iter()
-        .filter(|model_id| {
-            state
-                .pricing()
-                .ensure_model_kind(model_id, ModelKind::Text)
-                .is_ok()
-        })
-        .find(|model_id| model_supports_requirements(state.pricing(), model_id, requirements))
-        .map(str::to_string)
+    let compatible_model = state
+        .pricing()
+        .priced_model(PREFERRED_VISION_TEXT_MODEL, ModelKind::Text)
+        .ok()
+        .filter(|model| model_supports_requirements(model, requirements))
+        .map(|_| PREFERRED_VISION_TEXT_MODEL.to_string())
         .or_else(|| {
             state
                 .pricing()
-                .priced_models(Some(ModelKind::Text))
-                .into_iter()
-                .map(|(model_id, _)| model_id)
-                .filter(|model_id| *model_id != AUTO_TEXT_MODEL)
-                .find(|model_id| {
-                    state
-                        .pricing()
-                        .ensure_model_kind(model_id, ModelKind::Text)
-                        .is_ok()
-                        && model_supports_requirements(state.pricing(), model_id, requirements)
+                .find_priced_model(ModelKind::Text, |model_id, model| {
+                    model_id != AUTO_TEXT_MODEL && model_supports_requirements(model, requirements)
                 })
+                .map(|(model_id, _)| model_id)
         });
 
     if compatible_model.is_none() {
@@ -218,16 +211,13 @@ fn chat_items_contain_image(value: &serde_json::Value) -> bool {
 }
 
 fn model_supports_requirements(
-    pricing: &PricingTable,
-    model_id: &str,
+    model: &ModelPriceConfig,
     requirements: AgentModelRequirements,
 ) -> bool {
-    pricing.model(model_id).is_some_and(|model| {
-        (!requirements.vision || has_capability(&model.capabilities, "supportsvision"))
-            && (!requirements.tools
-                || has_capability(&model.capabilities, "functioncalling")
-                || has_capability(&model.capabilities, "toolcalling"))
-    })
+    (!requirements.vision || has_capability(&model.capabilities, "supportsvision"))
+        && (!requirements.tools
+            || has_capability(&model.capabilities, "functioncalling")
+            || has_capability(&model.capabilities, "toolcalling"))
 }
 
 fn has_capability(capabilities: &[String], expected: &str) -> bool {

--- a/june-api/crates/api/src/handlers/agent.rs
+++ b/june-api/crates/api/src/handlers/agent.rs
@@ -190,7 +190,6 @@ fn resolve_priced_agent_text_model(
                         .is_ok()
                         && model_supports_requirements(state.pricing(), model_id, requirements)
                 })
-                .cloned()
         });
 
     if compatible_model.is_none() {
@@ -223,15 +222,12 @@ fn model_supports_requirements(
     model_id: &str,
     requirements: AgentModelRequirements,
 ) -> bool {
-    pricing
-        .iter()
-        .find(|(candidate_id, _)| candidate_id.as_str() == model_id)
-        .is_some_and(|(_, model)| {
-            (!requirements.vision || has_capability(&model.capabilities, "supportsvision"))
-                && (!requirements.tools
-                    || has_capability(&model.capabilities, "functioncalling")
-                    || has_capability(&model.capabilities, "toolcalling"))
-        })
+    pricing.model(model_id).is_some_and(|model| {
+        (!requirements.vision || has_capability(&model.capabilities, "supportsvision"))
+            && (!requirements.tools
+                || has_capability(&model.capabilities, "functioncalling")
+                || has_capability(&model.capabilities, "toolcalling"))
+    })
 }
 
 fn has_capability(capabilities: &[String], expected: &str) -> bool {

--- a/june-api/crates/api/src/handlers/models.rs
+++ b/june-api/crates/api/src/handlers/models.rs
@@ -46,7 +46,7 @@ pub(crate) async fn list_models(
         .pricing()
         .priced_models(kind)
         .into_iter()
-        .map(|(id, model)| to_dto(id, model))
+        .map(|(id, model)| to_dto(&id, &model))
         .collect();
     Ok(Json(ApiResponse::ok(models)))
 }

--- a/june-api/crates/api/src/handlers/notes.rs
+++ b/june-api/crates/api/src/handlers/notes.rs
@@ -449,7 +449,6 @@ fn resolve_priced_text_model_kind(
                 .into_iter()
                 .map(|(model_id, _)| model_id)
                 .find(|model_id| pricing.ensure_model_kind(model_id, ModelKind::Text).is_ok())
-                .cloned()
                 .ok_or_else(|| ApiError::unprocessable("model_not_priced"))
         }
         Err(PricingError::WrongUnit) => Err(ApiError::unprocessable("model_type_invalid")),
@@ -485,7 +484,6 @@ fn resolve_priced_asr_model_kind(
                 .into_iter()
                 .map(|(model_id, _)| model_id)
                 .find(|model_id| pricing.ensure_model_kind(model_id, ModelKind::Asr).is_ok())
-                .cloned()
                 .ok_or_else(|| ApiError::unprocessable("model_not_priced"))
         }
         Err(PricingError::WrongUnit) => Err(ApiError::unprocessable("model_type_invalid")),
@@ -579,8 +577,8 @@ mod tests {
     #[test]
     fn auto_falls_back_to_the_concrete_default_when_auto_is_not_priced() {
         let mut models = pricing_table()
-            .iter()
-            .map(|(model_id, model)| (model_id.clone(), model.clone()))
+            .priced_models(None)
+            .into_iter()
             .collect::<BTreeMap<_, _>>();
         models.remove(AUTO_TEXT_MODEL);
         let text_model = models
@@ -598,8 +596,8 @@ mod tests {
     #[test]
     fn non_local_auto_without_auto_pricing_fails_loudly() {
         let mut models = pricing_table()
-            .iter()
-            .map(|(model_id, model)| (model_id.clone(), model.clone()))
+            .priced_models(None)
+            .into_iter()
             .collect::<BTreeMap<_, _>>();
         models.remove(AUTO_TEXT_MODEL);
 
@@ -616,8 +614,8 @@ mod tests {
     #[test]
     fn unpriced_text_falls_back_to_another_priced_text_model_without_auto_or_default() {
         let mut models = pricing_table()
-            .iter()
-            .map(|(model_id, model)| (model_id.clone(), model.clone()))
+            .priced_models(None)
+            .into_iter()
             .collect::<BTreeMap<_, _>>();
         models.remove(AUTO_TEXT_MODEL);
 

--- a/june-api/crates/api/src/handlers/notes.rs
+++ b/june-api/crates/api/src/handlers/notes.rs
@@ -445,10 +445,8 @@ fn resolve_priced_text_model_kind(
                 return Ok(DEFAULT_TEXT_MODEL.to_string());
             }
             pricing
-                .priced_models(Some(ModelKind::Text))
-                .into_iter()
+                .find_priced_model(ModelKind::Text, |_, _| true)
                 .map(|(model_id, _)| model_id)
-                .find(|model_id| pricing.ensure_model_kind(model_id, ModelKind::Text).is_ok())
                 .ok_or_else(|| ApiError::unprocessable("model_not_priced"))
         }
         Err(PricingError::WrongUnit) => Err(ApiError::unprocessable("model_type_invalid")),
@@ -480,10 +478,8 @@ fn resolve_priced_asr_model_kind(
                 return Ok(DEFAULT_ASR_MODEL.to_string());
             }
             pricing
-                .priced_models(Some(ModelKind::Asr))
-                .into_iter()
+                .find_priced_model(ModelKind::Asr, |_, _| true)
                 .map(|(model_id, _)| model_id)
-                .find(|model_id| pricing.ensure_model_kind(model_id, ModelKind::Asr).is_ok())
                 .ok_or_else(|| ApiError::unprocessable("model_not_priced"))
         }
         Err(PricingError::WrongUnit) => Err(ApiError::unprocessable("model_type_invalid")),

--- a/june-api/crates/app/src/main.rs
+++ b/june-api/crates/app/src/main.rs
@@ -227,18 +227,16 @@ fn build_router(
     pricing: Arc<PricingTable>,
     share_store: Option<Arc<dyn june_domain::ShareStore>>,
 ) -> axum::Router {
-    let openai_model_ids = pricing
-        .priced_models(None)
-        .into_iter()
-        .filter(|(_, model)| model.provider == ModelProvider::Openai)
-        .map(|(model_id, _)| model_id)
-        .collect::<Vec<_>>();
-
     let os_accounts = build_os_accounts_client(config, clients.default);
+    let routing_pricing = pricing.clone();
     let transcriber: Arc<dyn june_domain::Transcriber> = Arc::new(RoutingTranscriber::from_config(
         clients.upstream.clone(),
         &config.upstreams,
-        openai_model_ids,
+        Arc::new(move |model_id| {
+            routing_pricing
+                .priced_model(model_id, june_domain::ModelKind::Asr)
+                .is_ok_and(|model| model.provider == ModelProvider::Openai)
+        }),
     ));
     // Note generation and agent chat can now run long (streamed/kept-alive
     // responses), so their upstream window must leave the settlement budget

--- a/june-api/crates/app/src/main.rs
+++ b/june-api/crates/app/src/main.rs
@@ -62,7 +62,15 @@ async fn serve() -> anyhow::Result<()> {
     // file and Issue creation POSTs are not idempotent.
     let issue_report_http =
         issue_report_client(Duration::from_secs(config.server.request_timeout_secs))?;
-    let pricing = load_pricing(&config, upstream_http.clone()).await;
+    let initial_pricing = try_load_pricing(&config, upstream_http.clone())
+        .await
+        .unwrap_or_else(|| configured_pricing(&config));
+    tracing::info!(
+        count = initial_pricing.len(),
+        "loaded initial model catalog"
+    );
+    let pricing = Arc::new(PricingTable::new(initial_pricing));
+    spawn_model_catalog_refresh(&config, upstream_http.clone(), pricing.clone());
     let clients = HttpClients {
         default: &http,
         upstream: &upstream_http,
@@ -110,30 +118,72 @@ async fn serve() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn load_pricing(
+async fn try_load_pricing(
     config: &AppConfig,
     http: reqwest::Client,
-) -> BTreeMap<String, ModelPriceConfig> {
-    let mut pricing = config.pricing.clone();
+) -> Option<BTreeMap<String, ModelPriceConfig>> {
     if !provider_is_configured(config, ModelProvider::Venice) {
         tracing::info!("Venice API key is not configured; skipping Venice model catalog");
-        return pricing;
+        return Some(configured_pricing(config));
     }
     match VeniceModelCatalog::from_config(http, &config.upstreams.venice)
         .priced_models()
         .await
     {
         Ok(models) => {
-            let count = models.len();
+            let mut pricing = config.pricing.clone();
             pricing.extend(models);
             apply_private_route_price_floors(&mut pricing);
-            tracing::info!(count, "loaded Venice model catalog");
+            Some(filter_pricing_for_environment(config, pricing))
         }
         Err(error) => {
-            tracing::warn!(%error, "failed to load Venice model catalog; using configured model pricing only");
+            tracing::warn!(%error, "failed to refresh Venice model catalog; keeping the last known catalog");
+            None
         }
     }
-    pricing
+}
+
+fn configured_pricing(config: &AppConfig) -> BTreeMap<String, ModelPriceConfig> {
+    filter_pricing_for_environment(config, config.pricing.clone())
+}
+
+fn filter_pricing_for_environment(
+    config: &AppConfig,
+    pricing: BTreeMap<String, ModelPriceConfig>,
+) -> BTreeMap<String, ModelPriceConfig> {
+    if config.local_dev.enabled {
+        filter_unconfigured_provider_models(config, pricing)
+    } else {
+        pricing
+    }
+}
+
+fn spawn_model_catalog_refresh(
+    config: &AppConfig,
+    http: reqwest::Client,
+    pricing: Arc<PricingTable>,
+) {
+    if !provider_is_configured(config, ModelProvider::Venice) {
+        return;
+    }
+    let config = config.clone();
+    let refresh_every = Duration::from_secs(config.server.model_catalog_refresh_secs);
+    let task = tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(refresh_every).await;
+            if let Some(models) = try_load_pricing(&config, http.clone()).await {
+                let count = models.len();
+                pricing.replace(models);
+                tracing::info!(
+                    count,
+                    refresh_secs = refresh_every.as_secs(),
+                    "refreshed model catalog"
+                );
+            }
+        }
+    });
+    // Dropping a Tokio join handle detaches the long-lived refresh task.
+    drop(task);
 }
 
 /// The routed catalog currently reports the cheapest eligible endpoint, while
@@ -174,20 +224,16 @@ fn apply_private_route_price_floors(pricing: &mut BTreeMap<String, ModelPriceCon
 fn build_router(
     config: &AppConfig,
     clients: HttpClients<'_>,
-    mut pricing_config: BTreeMap<String, ModelPriceConfig>,
+    pricing: Arc<PricingTable>,
     share_store: Option<Arc<dyn june_domain::ShareStore>>,
 ) -> axum::Router {
-    if config.local_dev.enabled {
-        pricing_config = filter_unconfigured_provider_models(config, pricing_config);
-    }
-
-    let openai_model_ids = pricing_config
-        .iter()
+    let openai_model_ids = pricing
+        .priced_models(None)
+        .into_iter()
         .filter(|(_, model)| model.provider == ModelProvider::Openai)
-        .map(|(model_id, _)| model_id.clone())
+        .map(|(model_id, _)| model_id)
         .collect::<Vec<_>>();
 
-    let pricing = Arc::new(PricingTable::new(pricing_config));
     let os_accounts = build_os_accounts_client(config, clients.default);
     let transcriber: Arc<dyn june_domain::Transcriber> = Arc::new(RoutingTranscriber::from_config(
         clients.upstream.clone(),

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -435,6 +435,7 @@ pub struct ServerConfig {
     pub host: String,
     pub port: u16,
     pub request_timeout_secs: u64,
+    pub model_catalog_refresh_secs: u64,
     pub max_audio_bytes: usize,
     pub max_json_bytes: usize,
     /// Total multipart body cap for `/v1/issue-reports`.
@@ -1086,6 +1087,7 @@ impl Default for AppConfig {
                 host: "127.0.0.1".to_string(),
                 port: 8080,
                 request_timeout_secs: DEFAULT_REQUEST_TIMEOUT_SECS,
+                model_catalog_refresh_secs: 300,
                 max_audio_bytes: 26_214_400,
                 max_json_bytes: 524_288,
                 max_issue_report_bytes: DEFAULT_MAX_ISSUE_REPORT_BYTES,
@@ -1198,6 +1200,7 @@ fn validate(config: &AppConfig) -> Result<(), ConfigError> {
         return validate_viewer_only(config);
     }
 
+    validate_server_config(config)?;
     if config.local_dev.enabled {
         validate_local_dev_bearer_token(config)?;
         validate_required_text("local_dev.user_id", &config.local_dev.user_id)?;
@@ -1297,6 +1300,13 @@ fn validate(config: &AppConfig) -> Result<(), ConfigError> {
     validate_image_pricing(config)?;
     validate_video_pricing(config)?;
     Ok(())
+}
+
+fn validate_server_config(config: &AppConfig) -> Result<(), ConfigError> {
+    validate_positive_config(
+        "server.model_catalog_refresh_secs",
+        config.server.model_catalog_refresh_secs,
+    )
 }
 
 /// The isolated short-link process does not expose product routes and must not
@@ -2544,6 +2554,16 @@ mod tests {
         let result = validate(&config);
 
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_zero_model_catalog_refresh_interval() {
+        let mut config = valid_config();
+        config.server.model_catalog_refresh_secs = 0;
+
+        let result = validate(&config);
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/june-api/crates/providers/src/routing.rs
+++ b/june-api/crates/providers/src/routing.rs
@@ -2,24 +2,24 @@ use crate::{openai::OpenAiTranscriber, venice::VeniceTranscriber};
 use async_trait::async_trait;
 use june_config::UpstreamsConfig;
 use june_domain::{DomainError, Transcriber, Transcript, TranscriptionRequest};
-use std::collections::BTreeSet;
+use std::sync::Arc;
 
 pub struct RoutingTranscriber {
     openai: OpenAiTranscriber,
     venice: VeniceTranscriber,
-    openai_model_ids: BTreeSet<String>,
+    is_openai_model: Arc<dyn Fn(&str) -> bool + Send + Sync>,
 }
 
 impl RoutingTranscriber {
     pub fn from_config(
         http: reqwest::Client,
         config: &UpstreamsConfig,
-        openai_model_ids: impl IntoIterator<Item = String>,
+        is_openai_model: Arc<dyn Fn(&str) -> bool + Send + Sync>,
     ) -> Self {
         Self {
             openai: OpenAiTranscriber::from_config(http.clone(), &config.openai),
             venice: VeniceTranscriber::from_config(http, &config.venice),
-            openai_model_ids: openai_model_ids.into_iter().collect(),
+            is_openai_model,
         }
     }
 }
@@ -27,7 +27,7 @@ impl RoutingTranscriber {
 #[async_trait]
 impl Transcriber for RoutingTranscriber {
     async fn transcribe(&self, request: TranscriptionRequest) -> Result<Transcript, DomainError> {
-        if self.openai_model_ids.contains(&request.model.0) {
+        if (self.is_openai_model)(&request.model.0) {
             self.openai.transcribe(request).await
         } else {
             self.venice.transcribe(request).await
@@ -43,14 +43,18 @@ mod tests {
     use june_domain::{ModelId, ProviderCredentials, Transcriber, TranscriptionRequest};
     use pretty_assertions::assert_eq;
     use serde_json::json;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
         matchers::{body_string_contains, header, method, path},
     };
 
     #[tokio::test]
-    async fn calls_openai_for_configured_openai_model() {
-        let server = MockServer::start().await;
+    async fn consults_the_live_catalog_for_each_request() {
+        let openai_server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/audio/transcriptions"))
             .and(header("authorization", "Bearer openai_key"))
@@ -59,26 +63,48 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "text": "Transcribed text"
             })))
-            .mount(&server)
+            .mount(&openai_server)
             .await;
+        let venice_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/audio/transcriptions"))
+            .and(header("authorization", "Bearer venice_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "text": "Venice text"
+            })))
+            .mount(&venice_server)
+            .await;
+        let route_to_openai = Arc::new(AtomicBool::new(false));
+        let live_route = route_to_openai.clone();
         let transcriber = RoutingTranscriber::from_config(
             http::default_client(),
             &UpstreamsConfig {
                 openai: UpstreamConfig {
                     api_key: "openai_key".to_string(),
-                    base_url: server.uri(),
+                    base_url: openai_server.uri(),
                     byok_base_url: None,
                 },
                 venice: UpstreamConfig {
                     api_key: "venice_key".to_string(),
-                    base_url: server.uri(),
+                    base_url: venice_server.uri(),
                     byok_base_url: None,
                 },
             },
-            ["gpt-4o-mini-transcribe".to_string()],
+            Arc::new(move |_| live_route.load(Ordering::Relaxed)),
         );
 
-        let transcript = transcriber
+        let venice_transcript = transcriber
+            .transcribe(TranscriptionRequest {
+                audio: b"fake wav".to_vec(),
+                format: june_domain::AudioFormat::Wav,
+                context: Some("Prompt context".to_string()),
+                language: Some("es".to_string()),
+                model: ModelId("gpt-4o-mini-transcribe".to_string()),
+                provider_credentials: ProviderCredentials::default(),
+            })
+            .await;
+        route_to_openai.store(true, Ordering::Relaxed);
+        let openai_transcript = transcriber
             .transcribe(TranscriptionRequest {
                 audio: b"fake wav".to_vec(),
                 format: june_domain::AudioFormat::Wav,
@@ -90,7 +116,11 @@ mod tests {
             .await;
 
         assert_eq!(
-            transcript.map(|value| (value.text, value.provider)),
+            venice_transcript.map(|value| (value.text, value.provider)),
+            Ok(("Venice text".to_string(), "venice".to_string()))
+        );
+        assert_eq!(
+            openai_transcript.map(|value| (value.text, value.provider)),
             Ok(("Transcribed text".to_string(), "openai".to_string()))
         );
     }

--- a/june-api/crates/services/src/pricing.rs
+++ b/june-api/crates/services/src/pricing.rs
@@ -1,18 +1,34 @@
 use june_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
 use june_domain::{Credits, InferencePrivacy, ModelKind, TokenUsage};
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    sync::{RwLock, RwLockReadGuard},
+};
 use thiserror::Error;
 
 const RATE_SCALE: u64 = 1_000_000;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct PricingTable {
-    models: BTreeMap<String, ModelPriceConfig>,
+    models: RwLock<BTreeMap<String, ModelPriceConfig>>,
 }
 
 impl PricingTable {
     pub fn new(models: BTreeMap<String, ModelPriceConfig>) -> Self {
-        Self { models }
+        Self {
+            models: RwLock::new(models),
+        }
+    }
+
+    /// Atomically swaps the complete model catalog used by both discovery and
+    /// request pricing. In-flight pricing calls finish against either the old
+    /// or new snapshot, never a partially updated table.
+    pub fn replace(&self, models: BTreeMap<String, ModelPriceConfig>) {
+        let mut current = self
+            .models
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *current = models;
     }
 
     pub fn price_audio_seconds(
@@ -20,7 +36,8 @@ impl PricingTable {
         model_id: &str,
         seconds: u64,
     ) -> Result<Credits, PricingError> {
-        let model = self.models.get(model_id).ok_or(PricingError::NotPriced)?;
+        let models = self.read_models();
+        let model = models.get(model_id).ok_or(PricingError::NotPriced)?;
         if model.unit != PriceUnit::Seconds {
             return Err(PricingError::WrongUnit);
         }
@@ -35,7 +52,8 @@ impl PricingTable {
         model_id: &str,
         usage: TokenUsage,
     ) -> Result<Credits, PricingError> {
-        let model = self.models.get(model_id).ok_or(PricingError::NotPriced)?;
+        let models = self.read_models();
+        let model = models.get(model_id).ok_or(PricingError::NotPriced)?;
         if model.unit != PriceUnit::Tokens {
             return Err(PricingError::WrongUnit);
         }
@@ -52,17 +70,21 @@ impl PricingTable {
     }
 
     pub fn has_model(&self, model_id: &str) -> bool {
-        self.models.contains_key(model_id)
+        self.read_models().contains_key(model_id)
+    }
+
+    pub fn model(&self, model_id: &str) -> Option<ModelPriceConfig> {
+        self.read_models().get(model_id).cloned()
     }
 
     pub fn is_venice_model(&self, model_id: &str) -> bool {
-        self.models
+        self.read_models()
             .get(model_id)
             .is_some_and(|model| model.provider == ModelProvider::Venice)
     }
 
     pub fn inference_privacy(&self, model_id: &str) -> InferencePrivacy {
-        self.models
+        self.read_models()
             .get(model_id)
             .and_then(|model| model.privacy.as_deref())
             .filter(|privacy| privacy.eq_ignore_ascii_case("anonymized"))
@@ -70,7 +92,8 @@ impl PricingTable {
     }
 
     pub fn ensure_model_kind(&self, model_id: &str, kind: ModelKind) -> Result<(), PricingError> {
-        let model = self.models.get(model_id).ok_or(PricingError::NotPriced)?;
+        let models = self.read_models();
+        let model = models.get(model_id).ok_or(PricingError::NotPriced)?;
         if !model_type_matches_kind(model.model_type, kind) {
             return Err(PricingError::WrongUnit);
         }
@@ -98,17 +121,20 @@ impl PricingTable {
         Ok(())
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &ModelPriceConfig)> {
-        self.models.iter()
-    }
-
-    pub fn priced_models(&self, kind: Option<ModelKind>) -> Vec<(&String, &ModelPriceConfig)> {
-        self.models
+    pub fn priced_models(&self, kind: Option<ModelKind>) -> Vec<(String, ModelPriceConfig)> {
+        self.read_models()
             .iter()
             .filter(|(_, model)| {
                 kind.is_none_or(|kind| model_type_matches_kind(model.model_type, kind))
             })
+            .map(|(id, model)| (id.clone(), model.clone()))
             .collect()
+    }
+
+    fn read_models(&self) -> RwLockReadGuard<'_, BTreeMap<String, ModelPriceConfig>> {
+        self.models
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     fn price_scaled<const N: usize>(components: [(u64, u64); N]) -> Result<Credits, PricingError> {
@@ -356,5 +382,27 @@ mod tests {
         assert!(!table.is_venice_model("openai-asr"));
         assert!(table.is_venice_model("venice-text"));
         assert!(!table.is_venice_model("missing"));
+    }
+
+    #[test]
+    fn replaces_the_catalog_atomically() {
+        let table = PricingTable::new(models([("old", PriceUnit::Tokens, 1, 1, ModelType::Text)]));
+
+        table.replace(models([("new", PriceUnit::Tokens, 2, 3, ModelType::Text)]));
+
+        assert!(!table.has_model("old"));
+        assert!(table.has_model("new"));
+        assert_eq!(
+            table
+                .price_token_usage(
+                    "new",
+                    TokenUsage {
+                        prompt_tokens: 1_000_000,
+                        completion_tokens: 1_000_000,
+                    },
+                )
+                .map(|credits| credits.0),
+            Ok(5)
+        );
     }
 }

--- a/june-api/crates/services/src/pricing.rs
+++ b/june-api/crates/services/src/pricing.rs
@@ -73,10 +73,6 @@ impl PricingTable {
         self.read_models().contains_key(model_id)
     }
 
-    pub fn model(&self, model_id: &str) -> Option<ModelPriceConfig> {
-        self.read_models().get(model_id).cloned()
-    }
-
     pub fn is_venice_model(&self, model_id: &str) -> bool {
         self.read_models()
             .get(model_id)
@@ -92,33 +88,29 @@ impl PricingTable {
     }
 
     pub fn ensure_model_kind(&self, model_id: &str, kind: ModelKind) -> Result<(), PricingError> {
+        self.priced_model(model_id, kind).map(drop)
+    }
+
+    pub fn priced_model(
+        &self,
+        model_id: &str,
+        kind: ModelKind,
+    ) -> Result<ModelPriceConfig, PricingError> {
         let models = self.read_models();
         let model = models.get(model_id).ok_or(PricingError::NotPriced)?;
-        if !model_type_matches_kind(model.model_type, kind) {
-            return Err(PricingError::WrongUnit);
-        }
-        match kind {
-            ModelKind::Asr => {
-                if model.unit != PriceUnit::Seconds {
-                    return Err(PricingError::WrongUnit);
-                }
-                model
-                    .credits_per_million_seconds
-                    .ok_or(PricingError::MissingRate)?;
-            }
-            ModelKind::Text => {
-                if model.unit != PriceUnit::Tokens {
-                    return Err(PricingError::WrongUnit);
-                }
-                model
-                    .input_credits_per_million_tokens
-                    .ok_or(PricingError::MissingRate)?;
-                model
-                    .output_credits_per_million_tokens
-                    .ok_or(PricingError::MissingRate)?;
-            }
-        }
-        Ok(())
+        validate_model_kind(model, kind)?;
+        Ok(model.clone())
+    }
+
+    pub fn find_priced_model(
+        &self,
+        kind: ModelKind,
+        mut predicate: impl FnMut(&str, &ModelPriceConfig) -> bool,
+    ) -> Option<(String, ModelPriceConfig)> {
+        let models = self.read_models().clone();
+        models.into_iter().find(|(model_id, model)| {
+            validate_model_kind(model, kind).is_ok() && predicate(model_id, model)
+        })
     }
 
     pub fn priced_models(&self, kind: Option<ModelKind>) -> Vec<(String, ModelPriceConfig)> {
@@ -161,6 +153,34 @@ fn model_type_matches_kind(model_type: ModelType, kind: ModelKind) -> bool {
         (model_type, kind),
         (ModelType::Asr, ModelKind::Asr) | (ModelType::Text, ModelKind::Text)
     )
+}
+
+fn validate_model_kind(model: &ModelPriceConfig, kind: ModelKind) -> Result<(), PricingError> {
+    if !model_type_matches_kind(model.model_type, kind) {
+        return Err(PricingError::WrongUnit);
+    }
+    match kind {
+        ModelKind::Asr => {
+            if model.unit != PriceUnit::Seconds {
+                return Err(PricingError::WrongUnit);
+            }
+            model
+                .credits_per_million_seconds
+                .ok_or(PricingError::MissingRate)?;
+        }
+        ModelKind::Text => {
+            if model.unit != PriceUnit::Tokens {
+                return Err(PricingError::WrongUnit);
+            }
+            model
+                .input_credits_per_million_tokens
+                .ok_or(PricingError::MissingRate)?;
+            model
+                .output_credits_per_million_tokens
+                .ok_or(PricingError::MissingRate)?;
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Error, Eq, PartialEq)]


### PR DESCRIPTION
## What

- Refresh Venice model metadata and pricing in-process every five minutes by default.
- Keep a shared, atomically replaced catalog for both model discovery and request pricing.
- Preserve the last known-good catalog when Venice refreshes fail.
- Make the refresh interval configurable with `JUNE__SERVER__MODEL_CATALOG_REFRESH_SECS`.
- Update catalog consumers to use owned snapshots safely while refreshes can occur.

## Why

The API loaded Venice's catalog only during process startup, so newly released models required a production CVM restart before they appeared. With this change, new models become available within the configured refresh interval without restarting the production API.

## Checks

- `cargo fmt --all -- --check`
- `cargo test --workspace --locked`
- `cargo test -p june-config --locked`
- `cargo clippy --workspace --all-targets --locked`

`cargo clippy --workspace --all-targets --locked -- -D warnings` reaches three pre-existing `unreachable_pub` warnings in `crates/api/src/share_rate_limit.rs` on current `main`; this PR does not modify that file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787510562&installation_model_id=425925&pr_number=961&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F961&signature=874d6dcf7363199685b207adb46b92a28a8e2e4a344f6e7d3c0d8b7e3fd56a6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->