### PR TITLE
ci: verify June API production source identity

### DIFF
--- a/.github/workflows/promote-june-api.yml
+++ b/.github/workflows/promote-june-api.yml
@@ -33,6 +33,10 @@ jobs:
     env:
       FROM_TAG: ${{ inputs.from-tag }}
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
       - name: Validate source tag
         id: validate
         run: |
@@ -88,6 +92,15 @@ jobs:
             echo "::error::Could not resolve the source commit for $source. Use an image built by this repository, or pass a SHA tag directly."
             exit 1
           fi
+          # Canonicalize even a short fallback tag to one exact repository
+          # commit. The public post-deploy receipt must never compare prefixes.
+          reported_rev="$rev"
+          if ! resolved_rev=$(git rev-parse "${reported_rev}^{commit}" 2>/dev/null) \
+            || [[ ! "$resolved_rev" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Image $source reports source revision '${reported_rev}', which does not resolve to one full repository commit."
+            exit 1
+          fi
+          rev="$resolved_rev"
 
           {
             echo "digest=${digest}"
@@ -193,32 +206,51 @@ jobs:
           api-key: ${{ secrets.PHALA_CLOUD_API_KEY }}
 
       # Staging exercises the same ingress stack before promote, but production
-      # must still pass its own public endpoint check before accepting the
-      # promote: a broken production ingress boot would otherwise surface via
-      # the 30-minute watchdog. Runs before the retag/record steps so a
-      # failure fails the promotion and leaves :production on the last-good
-      # digest. Deeper checks (e.g. body-size probes after an ingress change)
-      # are run manually against the public endpoint.
+      # must still prove both availability and the build-stamped source commit
+      # before accepting the promote. A 200 from the old container is not
+      # evidence that the new source reached production. This does not replace
+      # the separate tag-to-digest and attestation checks documented in
+      # reproducible-builds.md. Runs before the retag/record steps so a failure
+      # leaves :production and the immutable deploy record on the last-good
+      # digest.
       - name: Verify public endpoint after deploy
         if: steps.phala.outputs.deployed == 'true'
         run: |
           set -euo pipefail
           base="https://june-api.opensoftware.co"
+          expected_sha="${{ needs.verify.outputs.source-sha }}"
           # The CVM restarts its containers on update; give the ingress up to
-          # 10 minutes to come back before judging the deploy.
+          # 10 minutes to come back with the promoted identity before judging
+          # the deploy. The old container may stay healthy during the rollout.
           code=""
+          identity_verified=false
+          verify_body=""
+          observed_sha=""
           for _ in $(seq 1 60); do
             # `|| true`, not `|| echo`: curl prints its own %{http_code} (000)
             # on transport failure, so a fallback echo would corrupt the value.
             code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$base/healthz" || true)
-            [[ "$code" == "200" ]] && break
+            if [[ "$code" == "200" ]]; then
+              verify_body=$(curl -fsS --max-time 10 "$base/verify" || true)
+              observed_sha=$(printf '%s' "$verify_body" \
+                | sed -nE 's#.*href="[^"]*/commit/([0-9a-f]{40})".*#\1#p' \
+                | head -n 1)
+              if [[ "$observed_sha" == "$expected_sha" ]]; then
+                identity_verified=true
+                break
+              fi
+            fi
             sleep 10
           done
           if [[ "$code" != "200" ]]; then
             echo "::error::$base/healthz did not return 200 within 10 minutes of the promote (last: $code)."
             exit 1
           fi
-          echo "healthz OK"
+          if [[ "$identity_verified" != "true" ]]; then
+            echo "::error::$base/verify did not report promoted source commit ${expected_sha} within 10 minutes (observed: ${observed_sha:-unknown})."
+            exit 1
+          fi
+          echo "healthz and build-stamped source commit OK (${expected_sha})"
 
       - name: Retag digest as :production
         if: steps.phala.outputs.deployed == 'true'

--- a/docs/june-api-prd.md
+++ b/docs/june-api-prd.md
@@ -329,8 +329,14 @@ Three workflows under `.github/workflows/`:
 - `build-june-api.yml` — push to `main` touching `june-api/**`, or
   manual dispatch. Builds and pushes `ghcr.io/open-software-network/june-api:<short-sha>`
   + updates `:staging`. Stops at GHCR.
-- `promote-june-api.yml` — manual dispatch. Verifies an existing image,
-  re-tags `:<short-sha>` to `:production`. Never rebuilds.
+- `promote-june-api.yml` — manual dispatch. Resolves an existing image once,
+  replays the stable-client contract suite against its source commit, deploys
+  through a per-commit tag pinned to the resolved digest, and waits for both
+  public health and `/verify` to report the promoted build-stamped source
+  commit before re-tagging the resolved digest as `:production` and recording
+  the immutable deploy tag. This verifies source identity, not the runtime
+  image digest; the separate mutable-tag, tag-to-digest, and attestation limits
+  are documented in `reproducible-builds.md`. Never rebuilds.
 
 The two composite actions (`setup-rust`, `changed-paths`) from the skill
 get added under `.github/actions/`, with `setup-rust` pointed at


### PR DESCRIPTION
## Summary

- canonicalize the promoted image revision to one exact repository commit
- require the public `/healthz` and `/verify` receipts to report that exact build-stamped commit before retagging or recording the promotion
- document the proof boundary: this verifies source identity, not the runtime image digest

## Why

Five consecutive production promotions failed while the incumbent API stayed healthy. A health-only gate could therefore accept an old healthy container and record the intended digest as promoted even when the new source never reached production.

## Verification

- YAML parsed successfully
- `git diff --check` passed
- shell syntax and exact 40-character SHA extraction/equality predicates exercised locally
- short-SHA canonicalization exercised against a repository commit
- two adversarial review rounds fixed prefix matching and digest-guarantee overstatement; final convergence review reported no material findings

## Known limitation

Phala still pulls a per-commit tag rather than an `@digest` reference. The workflow pins that tag before deployment, but `/verify` independently proves only the build-stamped source commit. Existing tag-to-digest and attestation limits remain documented in `reproducible-builds.md`.

No production workflow was run and no deployment was attempted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787588534&installation_model_id=425925&pr_number=963&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F963&signature=823b232efd28ef863446405bbb9673fb4654bc70f5ff250aea564af198332ce6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->