### PR TITLE
fix(agent): restore session feedback and model picker parity

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -259,6 +259,12 @@ export function AgentWorkspace({
     prompt: string;
     attachments: string[];
   }>();
+  const [pendingInitialTurn, setPendingInitialTurn] = useState<{
+    prompt: string;
+    sessionId?: string;
+    title: string;
+    turn: AgentChatTurn;
+  }>();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string>();
   const [approvalSubmitting, setApprovalSubmitting] = useState<
@@ -304,6 +310,7 @@ export function AgentWorkspace({
       setDraft(request?.prompt ?? "");
       setAttachments([]);
       setQueuedFollowUp(undefined);
+      setPendingInitialTurn(undefined);
       setSubmitting(false);
       setError(undefined);
       onSessionSelected?.(undefined);
@@ -316,6 +323,23 @@ export function AgentWorkspace({
   const running = projection.run?.status === "running" || projection.run?.status === "queued";
   const waiting = projection.run?.status === "waiting_for_user";
   const turns = useMemo(() => agentItemsToChatTurns(projection.items), [projection.items]);
+  const visibleTurns = useMemo(() => {
+    if (!pendingInitialTurn) return turns;
+    if (turns.some((turn) => turn.id === pendingInitialTurn.turn.id)) return turns;
+    return [pendingInitialTurn.turn, ...turns];
+  }, [pendingInitialTurn, turns]);
+
+  useEffect(() => {
+    if (!pendingInitialTurn) return;
+    const persisted = projection.items.some(
+      (item) =>
+        item.kind === "message" &&
+        item.role === "user" &&
+        !item.id.startsWith("optimistic:") &&
+        stripProjectContext(item.text).trim() === pendingInitialTurn.prompt,
+    );
+    if (persisted) setPendingInitialTurn(undefined);
+  }, [pendingInitialTurn, projection.items]);
   const activeModel = selectedModel(models, model);
   const textActionsDisabledReason = shouldBlockTextOnFunding(Boolean(creditActionsDisabledReason), {
     activeModelId: model || undefined,
@@ -431,6 +455,9 @@ export function AgentWorkspace({
   useEffect(() => {
     const nextId = initialSession?.id ?? initialSessionId;
     if (!nextId) return;
+    setPendingInitialTurn((current) =>
+      current?.sessionId && current.sessionId !== nextId ? undefined : current,
+    );
     setSelectedId(nextId);
     selectedIdRef.current = nextId;
     if (initialSession) {
@@ -580,6 +607,33 @@ export function AgentWorkspace({
     }
     setSubmitting(true);
     setError(undefined);
+    const creatingSession = !selectedSession || newSessionMode;
+    const optimisticId = `optimistic:${crypto.randomUUID()}`;
+    const optimisticCreatedAt = new Date().toISOString();
+    const attachedPaths = attachments;
+    if (creatingSession) {
+      setPendingInitialTurn({
+        prompt,
+        title: titleFromPrompt(prompt),
+        turn: {
+          id: optimisticId,
+          createdAt: optimisticCreatedAt,
+          role: "user",
+          status: "complete",
+          parts: [
+            ...attachedPaths.map((path): AgentChatTurn["parts"][number] => ({
+              type: "attachment",
+              name: path.split(/[\\/]/).pop() || path,
+              path,
+              kind: /\.(?:avif|gif|jpe?g|png|webp)$/i.test(path) ? "image" : "file",
+            })),
+            { type: "text", text: prompt, status: "complete" },
+          ],
+        },
+      });
+      setDraft("");
+      setAttachments([]);
+    }
     try {
       let session = selectedSession;
       if (!session || newSessionMode) {
@@ -597,20 +651,23 @@ export function AgentWorkspace({
           createdSession,
           ...current.filter((item) => item.id !== createdSession.id),
         ]);
+        setPendingInitialTurn((current) =>
+          current ? { ...current, sessionId: createdSession.id } : current,
+        );
         onSessionSelected?.(createdSession);
         writeLastOpenSessionId(createdSession.id);
       }
       const activeSession = session;
       const optimistic: AgentItemDto = {
-        id: `optimistic:${crypto.randomUUID()}`,
+        id: optimisticId,
         sessionId: activeSession.id,
         sequence: Math.max(0, ...projection.items.map((item) => item.sequence)) + 1,
-        createdAt: new Date().toISOString(),
+        createdAt: optimisticCreatedAt,
         kind: "message",
         role: "user",
         text: prompt,
         status: "complete",
-        attachments: attachments.map((path, index) => ({
+        attachments: attachedPaths.map((path, index) => ({
           id: `attachment:${index}:${path}`,
           sessionId: activeSession.id,
           name: path.split(/[\\/]/).pop() || path,
@@ -626,7 +683,6 @@ export function AgentWorkspace({
         items: [...current.items, optimistic],
       }));
       setDraft("");
-      const attachedPaths = attachments;
       setAttachments([]);
       const enabledSkillIds = (await agentRuntimeBindings.listSkills())
         .filter((skill) => skill.enabled)
@@ -658,7 +714,12 @@ export function AgentWorkspace({
       await refreshSessions();
     } catch (cause) {
       setSubmitting(false);
+      if (creatingSession && !selectedIdRef.current) {
+        setPendingInitialTurn(undefined);
+        setNewSessionMode(true);
+      }
       setDraft((current) => current || prompt);
+      setAttachments((current) => (current.length > 0 ? current : attachedPaths));
       setError(messageFromError(cause));
     }
   }
@@ -1160,7 +1221,7 @@ export function AgentWorkspace({
     await refreshSessions();
   }
 
-  const heroMode = !homeMode && newSessionMode && !selectedSession;
+  const heroMode = !homeMode && newSessionMode && !selectedSession && !pendingInitialTurn;
   const homeConversationTurns = useMemo(
     () =>
       [
@@ -1308,7 +1369,7 @@ export function AgentWorkspace({
         {!heroMode && !homeMode ? (
           <AgentSessionBar
             origin={origin}
-            title={selectedSession?.title ?? ""}
+            title={selectedSession?.title ?? pendingInitialTurn?.title ?? ""}
             fullMode={selectedSession?.safetyMode === "unrestricted"}
             artifactCount={renderedArtifacts.length}
             artifactsOpen={artifactPanel !== null}
@@ -1478,7 +1539,7 @@ export function AgentWorkspace({
                 </div>
               ) : null}
               <div className="agent-timeline">
-                {turns.map((turn) => (
+                {visibleTurns.map((turn) => (
                   <AgentChatTurnRow
                     key={turn.id}
                     turn={turn}
@@ -1506,7 +1567,9 @@ export function AgentWorkspace({
                   onOpen={openArtifact}
                   onDownload={(artifact) => void downloadArtifact(artifact)}
                 />
-                <AgentThinking visible={running && turns.at(-1)?.role === "user"} />
+                <AgentThinking
+                  visible={(running || submitting) && visibleTurns.at(-1)?.role === "user"}
+                />
               </div>
               {queuedFollowUp ? (
                 <div className="agent-follow-up-row" role="status">

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -271,6 +271,7 @@ export function AgentWorkspace({
     title: string;
     turn: AgentChatTurn;
   }>();
+  const pendingSessionCreationRef = useRef<string>();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string>();
   const [approvalSubmitting, setApprovalSubmitting] = useState<
@@ -305,6 +306,7 @@ export function AgentWorkspace({
 
   const startNewSession = useCallback(
     (request?: AgentNewSessionDetail) => {
+      pendingSessionCreationRef.current = undefined;
       setSelectedId(undefined);
       selectedIdRef.current = undefined;
       setNewSessionMode(true);
@@ -461,8 +463,12 @@ export function AgentWorkspace({
   useEffect(() => {
     const nextId = initialSession?.id ?? initialSessionId;
     if (!nextId) return;
+    if (selectedIdRef.current !== nextId) {
+      pendingSessionCreationRef.current = undefined;
+      setSubmitting(false);
+    }
     setPendingInitialTurn((current) =>
-      current?.storedSessionId && current.storedSessionId !== nextId ? undefined : current,
+      current && current.storedSessionId !== nextId ? undefined : current,
     );
     setSelectedId(nextId);
     selectedIdRef.current = nextId;
@@ -614,10 +620,12 @@ export function AgentWorkspace({
     setSubmitting(true);
     setError(undefined);
     const creatingSession = !selectedSession || newSessionMode;
+    const creationRequestId = creatingSession ? crypto.randomUUID() : undefined;
     const optimisticId = `optimistic:${crypto.randomUUID()}`;
     const optimisticCreatedAt = new Date().toISOString();
     const attachedPaths = attachments;
     if (creatingSession) {
+      pendingSessionCreationRef.current = creationRequestId;
       setPendingInitialTurn({
         prompt,
         title: titleFromPrompt(prompt),
@@ -650,18 +658,23 @@ export function AgentWorkspace({
           profile: getCurrentDataPartitionName(),
         });
         session = createdSession;
-        setSelectedId(createdSession.id);
-        selectedIdRef.current = createdSession.id;
-        setNewSessionMode(false);
         setSessions((current) => [
           createdSession,
           ...current.filter((item) => item.id !== createdSession.id),
         ]);
-        setPendingInitialTurn((current) =>
-          current ? { ...current, storedSessionId: createdSession.id } : current,
-        );
-        onSessionSelected?.(createdSession);
-        writeLastOpenSessionId(createdSession.id);
+        const shouldPresentCreatedSession =
+          pendingSessionCreationRef.current === creationRequestId &&
+          selectedIdRef.current === undefined;
+        if (shouldPresentCreatedSession) {
+          setSelectedId(createdSession.id);
+          selectedIdRef.current = createdSession.id;
+          setNewSessionMode(false);
+          setPendingInitialTurn((current) =>
+            current ? { ...current, storedSessionId: createdSession.id } : current,
+          );
+          onSessionSelected?.(createdSession);
+          writeLastOpenSessionId(createdSession.id);
+        }
       }
       const activeSession = session;
       const optimistic: AgentItemDto = {
@@ -683,11 +696,13 @@ export function AgentWorkspace({
           createdAt: new Date().toISOString(),
         })),
       };
-      setProjection((current) => ({
-        ...current,
-        session: activeSession,
-        items: [...current.items, optimistic],
-      }));
+      if (selectedIdRef.current === activeSession.id) {
+        setProjection((current) => ({
+          ...current,
+          session: activeSession,
+          items: [...current.items, optimistic],
+        }));
+      }
       setDraft("");
       setAttachments([]);
       const enabledSkillIds = (await agentRuntimeBindings.listSkills())
@@ -710,7 +725,12 @@ export function AgentWorkspace({
       });
       projectContextSignaturesBySessionId.set(activeSession.id, preparedPrompt.contextSignature);
       rememberSessionThinkingLevel(activeSession.id, thinkingLevel);
-      setProjection((current) => ({ ...current, run }));
+      if (selectedIdRef.current === activeSession.id) {
+        setProjection((current) => ({ ...current, run }));
+      }
+      if (pendingSessionCreationRef.current === creationRequestId) {
+        pendingSessionCreationRef.current = undefined;
+      }
       setSubmitting(false);
       dispatchAgentSessionStatus({
         sessionId: activeSession.id,
@@ -720,7 +740,12 @@ export function AgentWorkspace({
       await refreshSessions();
     } catch (cause) {
       setSubmitting(false);
+      const operationIsVisible = creationRequestId
+        ? pendingSessionCreationRef.current === creationRequestId
+        : selectedIdRef.current === selectedSession?.id;
+      if (!operationIsVisible) return;
       if (creatingSession && !selectedIdRef.current) {
+        pendingSessionCreationRef.current = undefined;
         setPendingInitialTurn(undefined);
         setNewSessionMode(true);
       }
@@ -1902,6 +1927,39 @@ function AgentComposer({
     return () => window.removeEventListener("mousedown", close);
   }, [attachOpen, modelOpen, safetyOpen]);
 
+  useEffect(() => {
+    if (!modelOpen && !safetyOpen && !attachOpen) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.defaultPrevented) return;
+      event.preventDefault();
+      if (modelOpen) {
+        if (modelFlyout) {
+          if (modelFlyout.kind === "all") setModelSearch("");
+          setModelFlyout(null);
+          requestAnimationFrame(() => modelRootSearchRef.current?.focus());
+          return;
+        }
+        if (modelRootSearch) {
+          setModelRootSearch("");
+          requestAnimationFrame(() => modelRootSearchRef.current?.focus());
+          return;
+        }
+        setModelOpen(false);
+        requestAnimationFrame(() => modelTriggerRef.current?.focus());
+        return;
+      }
+      if (safetyOpen) {
+        setSafetyOpen(false);
+        requestAnimationFrame(() => safetyTriggerRef.current?.focus());
+        return;
+      }
+      setAttachOpen(false);
+      requestAnimationFrame(() => attachTriggerRef.current?.focus());
+    };
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
+  }, [attachOpen, modelFlyout, modelOpen, modelRootSearch, safetyOpen]);
+
   useLayoutEffect(() => {
     if (modelOpen && modelFlyout === null) modelRootSearchRef.current?.focus();
   }, [modelFlyout, modelOpen]);
@@ -2151,12 +2209,16 @@ function AgentComposer({
           onSearchChange={setModelSearch}
           onSelect={(nextModel, _costQuality, options) => {
             setModel(nextModel);
-            if (!options?.keepOpen) setModelOpen(false);
+            if (!options?.keepOpen) {
+              setModelOpen(false);
+              requestAnimationFrame(() => modelTriggerRef.current?.focus());
+            }
           }}
           onSelectThinking={(level) => {
             setThinkingLevel(level);
             setModelFlyout(null);
             setModelOpen(false);
+            requestAnimationFrame(() => modelTriggerRef.current?.focus());
           }}
         />
       ) : null}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1,6 +1,7 @@
 import { listen } from "@tauri-apps/api/event";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { IconArrowDown } from "central-icons/IconArrowDown";
+import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
 import { IconArrowUp } from "central-icons/IconArrowUp";
 import { IconCheckmark2Small } from "central-icons/IconCheckmark2Small";
 import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
@@ -240,9 +241,7 @@ export function AgentWorkspace({
   const [projection, setProjection] = useState<AgentRuntimeProjection>(() =>
     createAgentRuntimeProjection({ session: initialAgentSession }),
   );
-  const [hydratedSessionIds, setHydratedSessionIds] = useState<ReadonlySet<string>>(
-    () => new Set(),
-  );
+  const [hydratedSelectionId, setHydratedSelectionId] = useState<string>();
   const [artifacts, setArtifacts] = useState<AgentArtifactDto[]>([]);
   const [artifactPanel, setArtifactPanel] = useState<AgentArtifactPanelState | null>(null);
   const [shareOpen, setShareOpen] = useState(false);
@@ -280,8 +279,14 @@ export function AgentWorkspace({
     setDraft(value);
   }, []);
   const [attachments, setAttachments] = useState<string[]>([]);
+  const attachmentsRef = useRef(attachments);
+  attachmentsRef.current = attachments;
   const [queuedFollowUps, setQueuedFollowUpsState] =
     useState<QueuedAgentFollowUps>(loadQueuedAgentFollowUps);
+  const attemptedQueuedMessageIdsRef = useRef(new Set<string>());
+  const [failedQueuedMessageIds, setFailedQueuedMessageIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const updateQueuedFollowUps = useCallback(
     (update: (current: QueuedAgentFollowUps) => QueuedAgentFollowUps) => {
       setQueuedFollowUpsState((current) => {
@@ -301,6 +306,14 @@ export function AgentWorkspace({
     model: string;
     thinkingLevel: ThinkingLevel;
   }>();
+  const [recoverableSubmission, setRecoverableSubmission] = useState<{
+    id: string;
+    prompt: string;
+    attachments: string[];
+    model: string;
+    thinkingLevel: ThinkingLevel;
+  }>();
+  const recoverableSubmissionSnapshotRef = useRef<typeof recoverableSubmission>();
   const [pendingInitialTurn, setPendingInitialTurn] = useState<{
     prompt: string;
     storedSessionId?: string;
@@ -308,6 +321,7 @@ export function AgentWorkspace({
     turn: AgentChatTurn;
   }>();
   const pendingSessionCreationRef = useRef<string>();
+  const hydrationRequestRef = useRef<string>();
   const submissionOwnerRef = useRef<string>();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string>();
@@ -343,6 +357,8 @@ export function AgentWorkspace({
 
   const startNewSession = useCallback(
     (request?: AgentNewSessionDetail) => {
+      hydrationRequestRef.current = undefined;
+      setHydratedSelectionId(undefined);
       pendingSessionCreationRef.current = undefined;
       submissionOwnerRef.current = undefined;
       setSelectedId(undefined);
@@ -441,13 +457,18 @@ export function AgentWorkspace({
 
   const hydrate = useCallback(
     async (sessionId: string) => {
+      const requestId = crypto.randomUUID();
+      hydrationRequestRef.current = requestId;
+      if (selectedIdRef.current === sessionId) setHydratedSelectionId(undefined);
       const [session, items, files, latestRun] = await Promise.all([
         agentRuntimeBindings.getSession(sessionId),
         agentRuntimeBindings.listItems(sessionId),
         agentRuntimeBindings.listArtifacts(sessionId),
         agentRuntimeBindings.getLatestRun?.(sessionId) ?? Promise.resolve(null),
       ]);
-      if (selectedIdRef.current !== sessionId) return;
+      if (selectedIdRef.current !== sessionId || hydrationRequestRef.current !== requestId) {
+        return;
+      }
       setProjection({
         ...createAgentRuntimeProjection({ session, items }),
         run: latestRun ?? undefined,
@@ -459,10 +480,7 @@ export function AgentWorkspace({
           items.map((item) => item.id),
         ),
       );
-      setHydratedSessionIds((current) => {
-        if (current.has(sessionId)) return current;
-        return new Set([...current, sessionId]);
-      });
+      setHydratedSelectionId(sessionId);
       setArtifacts(files);
       setModel(homeMode ? AUTO_MODEL_ID : (loadSessionModels()[session.id] ?? session.model));
       setThinkingLevel(
@@ -552,6 +570,13 @@ export function AgentWorkspace({
     let unlisten: (() => void) | undefined;
     void listen<AgentRuntimeEvent>(AGENT_RUNTIME_EVENT, ({ payload }) => {
       if (payload.method === "steering.consumed") {
+        attemptedQueuedMessageIdsRef.current.delete(payload.data.messageId);
+        setFailedQueuedMessageIds((current) => {
+          if (!current.has(payload.data.messageId)) return current;
+          const next = new Set(current);
+          next.delete(payload.data.messageId);
+          return next;
+        });
         updateQueuedFollowUps((current) => {
           const queued = current[payload.sessionId];
           if (queued?.messageId !== payload.data.messageId) return current;
@@ -611,12 +636,15 @@ export function AgentWorkspace({
       textActionsDisabledReason ||
       !queuedFollowUp ||
       !selectedId ||
-      !hydratedSessionIds.has(selectedId)
+      hydratedSelectionId !== selectedId ||
+      failedQueuedMessageIds.has(queuedFollowUp.messageId) ||
+      attemptedQueuedMessageIdsRef.current.has(queuedFollowUp.messageId)
     ) {
       return;
     }
     const queued = queuedFollowUp;
     const ownerSessionId = selectedId;
+    attemptedQueuedMessageIdsRef.current.add(queued.messageId);
     queuedSubmissionSnapshotRef.current = {
       sessionId: ownerSessionId,
       messageId: queued.messageId,
@@ -628,12 +656,14 @@ export function AgentWorkspace({
     requestAnimationFrame(() => {
       if (selectedIdRef.current !== ownerSessionId) {
         queuedSubmissionSnapshotRef.current = undefined;
+        attemptedQueuedMessageIdsRef.current.delete(queued.messageId);
         return;
       }
       composerRef.current?.requestSubmit();
     });
   }, [
-    hydratedSessionIds,
+    failedQueuedMessageIds,
+    hydratedSelectionId,
     queuedFollowUp,
     running,
     selectedId,
@@ -691,7 +721,8 @@ export function AgentWorkspace({
       queuedSubmissionSnapshotRef.current = undefined;
       return;
     }
-    const prompt = (queuedSubmission?.prompt ?? draft).trim();
+    const recoveredSubmission = recoverableSubmissionSnapshotRef.current;
+    const prompt = (queuedSubmission?.prompt ?? recoveredSubmission?.prompt ?? draft).trim();
     if (!prompt || waiting || submitting || textActionsDisabledReason) return;
     if (running) {
       const ownerSessionId = selectedIdRef.current;
@@ -711,9 +742,12 @@ export function AgentWorkspace({
       return;
     }
     queuedSubmissionSnapshotRef.current = undefined;
+    recoverableSubmissionSnapshotRef.current = undefined;
     const queuedSnapshot = queuedSubmission;
-    const submittedModel = queuedSnapshot?.model ?? model;
-    const submittedThinkingLevel = queuedSnapshot?.thinkingLevel ?? thinkingLevel;
+    const recoveredSnapshot = recoveredSubmission;
+    const submittedModel = queuedSnapshot?.model ?? recoveredSnapshot?.model ?? model;
+    const submittedThinkingLevel =
+      queuedSnapshot?.thinkingLevel ?? recoveredSnapshot?.thinkingLevel ?? thinkingLevel;
     const submissionId = crypto.randomUUID();
     submissionOwnerRef.current = submissionId;
     setSubmitting(true);
@@ -722,7 +756,8 @@ export function AgentWorkspace({
     const creationRequestId = creatingSession ? crypto.randomUUID() : undefined;
     const optimisticId = `optimistic:${crypto.randomUUID()}`;
     const optimisticCreatedAt = new Date().toISOString();
-    const attachedPaths = queuedSnapshot?.attachments ?? attachments;
+    const attachedPaths =
+      queuedSnapshot?.attachments ?? recoveredSnapshot?.attachments ?? attachments;
     if (creatingSession) {
       pendingSessionCreationRef.current = creationRequestId;
       setPendingInitialTurn({
@@ -744,7 +779,7 @@ export function AgentWorkspace({
           ],
         },
       });
-      if (submissionOwnerRef.current === submissionId) {
+      if (submissionOwnerRef.current === submissionId && !recoveredSnapshot) {
         setDraft("");
         setAttachments([]);
       }
@@ -812,7 +847,12 @@ export function AgentWorkspace({
           items: [...current.items, optimistic],
         }));
       }
-      if (!queuedSnapshot && !creatingSession && submissionOwnerRef.current === submissionId) {
+      if (
+        !queuedSnapshot &&
+        !recoveredSnapshot &&
+        !creatingSession &&
+        submissionOwnerRef.current === submissionId
+      ) {
         setDraft("");
         setAttachments([]);
       }
@@ -838,6 +878,13 @@ export function AgentWorkspace({
         attachments: attachedPaths,
       });
       if (queuedSnapshot) {
+        attemptedQueuedMessageIdsRef.current.delete(queuedSnapshot.messageId);
+        setFailedQueuedMessageIds((current) => {
+          if (!current.has(queuedSnapshot.messageId)) return current;
+          const next = new Set(current);
+          next.delete(queuedSnapshot.messageId);
+          return next;
+        });
         updateQueuedFollowUps((current) => {
           if (current[queuedSnapshot.sessionId]?.messageId !== queuedSnapshot.messageId) {
             return current;
@@ -846,6 +893,11 @@ export function AgentWorkspace({
           delete next[queuedSnapshot.sessionId];
           return next;
         });
+      }
+      if (recoveredSnapshot) {
+        setRecoverableSubmission((current) =>
+          current?.id === recoveredSnapshot.id ? undefined : current,
+        );
       }
       clearSessionModelIfApplied(activeSession.id, submittedModel);
       projectContextSignaturesBySessionId.set(activeSession.id, preparedPrompt.contextSignature);
@@ -870,6 +922,9 @@ export function AgentWorkspace({
       });
       await refreshSessions();
     } catch (cause) {
+      if (queuedSnapshot) {
+        setFailedQueuedMessageIds((current) => new Set([...current, queuedSnapshot.messageId]));
+      }
       if (submissionOwnerRef.current !== submissionId) return;
       submissionOwnerRef.current = undefined;
       setSubmitting(false);
@@ -882,8 +937,21 @@ export function AgentWorkspace({
         setPendingInitialTurn(undefined);
         setNewSessionMode(true);
       }
-      setDraft((current) => current || prompt);
-      setAttachments((current) => (current.length > 0 ? current : attachedPaths));
+      if (!queuedSnapshot) {
+        const failedSubmission = {
+          id: recoveredSnapshot?.id ?? crypto.randomUUID(),
+          prompt,
+          attachments: attachedPaths,
+          model: submittedModel,
+          thinkingLevel: submittedThinkingLevel,
+        };
+        if (recoveredSnapshot || draftRef.current.trim() || attachmentsRef.current.length > 0) {
+          setRecoverableSubmission(failedSubmission);
+        } else {
+          setDraft(prompt);
+          setAttachments(attachedPaths);
+        }
+      }
       setError(messageFromError(cause));
     }
   }
@@ -1501,6 +1569,35 @@ export function AgentWorkspace({
       summary.set(item.name, current);
       return summary;
     }, new Map());
+  const recoverableSubmissionRow = recoverableSubmission ? (
+    <div className="agent-follow-up-row" role="status">
+      <span className="agent-follow-up-copy">
+        <span className="agent-follow-up-announcement">Unsent message</span>
+        <span className="agent-follow-up-text">{recoverableSubmission.prompt}</span>
+      </span>
+      <span className="agent-follow-up-actions">
+        <button
+          type="button"
+          aria-label="Retry unsent message"
+          disabled={running || waiting || submitting || Boolean(textActionsDisabledReason)}
+          onClick={() => {
+            recoverableSubmissionSnapshotRef.current = recoverableSubmission;
+            setError(undefined);
+            requestAnimationFrame(() => composerRef.current?.requestSubmit());
+          }}
+        >
+          <IconArrowRotateClockwise size={12} aria-hidden />
+        </button>
+        <button
+          type="button"
+          aria-label="Discard unsent message"
+          onClick={() => setRecoverableSubmission(undefined)}
+        >
+          <IconCrossSmall size={12} aria-hidden />
+        </button>
+      </span>
+    </div>
+  ) : null;
   const composer = (
     <AgentComposer
       formRef={composerRef}
@@ -1514,6 +1611,7 @@ export function AgentWorkspace({
           rememberSessionModel(selectedId, nextModel);
           return;
         }
+        if (pendingSessionCreationRef.current) return;
         void persistAgentDefaultModel(nextModel).catch((cause) => {
           if (modelRef.current === nextModel) setError(messageFromError(cause));
         });
@@ -1682,6 +1780,7 @@ export function AgentWorkspace({
             <div className="agent-hero-heading">
               <h2 className="agent-hero-title">{heroGreeting}</h2>
             </div>
+            {recoverableSubmissionRow}
             {composer}
             <div className="agent-hero-suggestions">
               <div className="agent-hero-chips" data-hidden={draft.trim() ? "true" : undefined}>
@@ -1755,6 +1854,7 @@ export function AgentWorkspace({
                   visible={(running || submitting) && visibleTurns.at(-1)?.role === "user"}
                 />
               </div>
+              {recoverableSubmissionRow}
               {queuedFollowUp ? (
                 <div className="agent-follow-up-row" role="status">
                   <span className="agent-follow-up-copy">
@@ -1762,11 +1862,39 @@ export function AgentWorkspace({
                     <span className="agent-follow-up-text">{queuedFollowUp.prompt}</span>
                   </span>
                   <span className="agent-follow-up-actions">
+                    {failedQueuedMessageIds.has(queuedFollowUp.messageId) ? (
+                      <button
+                        type="button"
+                        aria-label="Retry queued follow-up"
+                        disabled={
+                          running || waiting || submitting || Boolean(textActionsDisabledReason)
+                        }
+                        onClick={() => {
+                          attemptedQueuedMessageIdsRef.current.delete(queuedFollowUp.messageId);
+                          setFailedQueuedMessageIds((current) => {
+                            if (!current.has(queuedFollowUp.messageId)) return current;
+                            const next = new Set(current);
+                            next.delete(queuedFollowUp.messageId);
+                            return next;
+                          });
+                          setError(undefined);
+                        }}
+                      >
+                        <IconArrowRotateClockwise size={12} aria-hidden />
+                      </button>
+                    ) : null}
                     <button
                       type="button"
                       aria-label="Remove queued follow-up"
                       onClick={() => {
                         if (!selectedId) return;
+                        attemptedQueuedMessageIdsRef.current.delete(queuedFollowUp.messageId);
+                        setFailedQueuedMessageIds((current) => {
+                          if (!current.has(queuedFollowUp.messageId)) return current;
+                          const next = new Set(current);
+                          next.delete(queuedFollowUp.messageId);
+                          return next;
+                        });
                         updateQueuedFollowUps((current) => {
                           if (!(selectedId in current)) return current;
                           const next = { ...current };

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -146,13 +146,13 @@ export const AGENT_RUNTIME_EVENT = "june://agent-runtime-event";
 const DEFAULT_MODEL = AUTO_MODEL_ID;
 const AGENT_SUGGESTED_MODEL_IDS = [AUTO_MODEL_ID] as const;
 const AGENT_AUTO_MODEL: VeniceModelDto = {
-  provider: "june",
+  provider: "",
   id: AUTO_MODEL_ID,
   name: "Auto",
   description: "Chooses the best available model for each request.",
   modelType: "text",
   traits: [],
-  capabilities: ["tool-calling"],
+  capabilities: [],
 };
 const projectContextSignaturesBySessionId = new ProjectContextSignatureStore();
 
@@ -267,7 +267,7 @@ export function AgentWorkspace({
   }>();
   const [pendingInitialTurn, setPendingInitialTurn] = useState<{
     prompt: string;
-    sessionId?: string;
+    storedSessionId?: string;
     title: string;
     turn: AgentChatTurn;
   }>();
@@ -462,7 +462,7 @@ export function AgentWorkspace({
     const nextId = initialSession?.id ?? initialSessionId;
     if (!nextId) return;
     setPendingInitialTurn((current) =>
-      current?.sessionId && current.sessionId !== nextId ? undefined : current,
+      current?.storedSessionId && current.storedSessionId !== nextId ? undefined : current,
     );
     setSelectedId(nextId);
     selectedIdRef.current = nextId;
@@ -658,7 +658,7 @@ export function AgentWorkspace({
           ...current.filter((item) => item.id !== createdSession.id),
         ]);
         setPendingInitialTurn((current) =>
-          current ? { ...current, sessionId: createdSession.id } : current,
+          current ? { ...current, storedSessionId: createdSession.id } : current,
         );
         onSessionSelected?.(createdSession);
         writeLastOpenSessionId(createdSession.id);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -84,15 +84,11 @@ import {
 } from "./agent-workspace-config";
 import { ComposerEditor, type ComposerEditorHandle } from "./composer/ComposerEditor";
 import { agentComposerClearance } from "./composer/layout";
-import {
-  ComposerModelPicker,
-  ComposerModelPopover,
-  heroPrivacyFootnote,
-  type ComposerModelFlyout,
-} from "./composer/ModelPicker";
+import { ComposerModelPicker, heroPrivacyFootnote } from "./composer/ModelPicker";
 import { modelPrivacyBadge } from "../../lib/model-privacy";
 import { getCurrentDataPartitionName } from "../../lib/data-partition";
 import { AUTO_MODEL_ID, modelOptions, selectedModel } from "../settings/ModelPickerDialog";
+import { ModelPickerPopover, type ModelPickerFlyout } from "../settings/ModelPickerPopover";
 import { Dialog } from "../ui/Dialog";
 import { Spinner } from "../ui/Spinner";
 import { JuneBloom } from "../brand/JuneBloom";
@@ -148,6 +144,16 @@ export {
 
 export const AGENT_RUNTIME_EVENT = "june://agent-runtime-event";
 const DEFAULT_MODEL = AUTO_MODEL_ID;
+const AGENT_SUGGESTED_MODEL_IDS = [AUTO_MODEL_ID] as const;
+const AGENT_AUTO_MODEL: VeniceModelDto = {
+  provider: "june",
+  id: AUTO_MODEL_ID,
+  name: "Auto",
+  description: "Chooses the best available model for each request.",
+  modelType: "text",
+  traits: [],
+  capabilities: ["tool-calling"],
+};
 const projectContextSignaturesBySessionId = new ProjectContextSignatureStore();
 
 export function composerInSteerStateFor(input: {
@@ -1849,11 +1855,13 @@ function AgentComposer({
   const editorRef = useRef<ComposerEditorHandle>(null);
   const publishedDraftRef = useRef(draft);
   const [modelOpen, setModelOpen] = useState(false);
-  const [modelFlyout, setModelFlyout] = useState<ComposerModelFlyout>(null);
+  const [modelFlyout, setModelFlyout] = useState<ModelPickerFlyout>(null);
   const [modelSearch, setModelSearch] = useState("");
+  const [modelRootSearch, setModelRootSearch] = useState("");
   const modelTriggerRef = useRef<HTMLButtonElement>(null);
   const modelPopoverRef = useRef<HTMLDivElement>(null);
   const modelSearchRef = useRef<HTMLInputElement>(null);
+  const modelRootSearchRef = useRef<HTMLInputElement>(null);
   const [safetyOpen, setSafetyOpen] = useState(false);
   const [attachOpen, setAttachOpen] = useState(false);
   const [confirmUnrestricted, setConfirmUnrestricted] = useState(false);
@@ -1862,6 +1870,9 @@ function AgentComposer({
   const safetyTriggerRef = useRef<HTMLButtonElement>(null);
   const safetyMenuRef = useRef<HTMLDivElement>(null);
   const activeModel = selectedModel(models, model);
+  const pickerModels = models.some((option) => option.id === AUTO_MODEL_ID)
+    ? models
+    : [AGENT_AUTO_MODEL, ...models];
   const working = running || submitting;
 
   useEffect(() => {
@@ -1890,6 +1901,10 @@ function AgentComposer({
     window.addEventListener("mousedown", close);
     return () => window.removeEventListener("mousedown", close);
   }, [attachOpen, modelOpen, safetyOpen]);
+
+  useLayoutEffect(() => {
+    if (modelOpen && modelFlyout === null) modelRootSearchRef.current?.focus();
+  }, [modelFlyout, modelOpen]);
 
   function referenceNote() {
     const prefix = draft && !/\s$/.test(draft) ? " @" : "@";
@@ -1982,7 +1997,16 @@ function AgentComposer({
               effort={thinkingLevel}
               readOnly={working}
               triggerRef={modelTriggerRef}
-              onToggleOpen={() => setModelOpen((open) => !open)}
+              onToggleOpen={() => {
+                if (modelOpen) {
+                  setModelOpen(false);
+                  return;
+                }
+                setModelFlyout(null);
+                setModelSearch("");
+                setModelRootSearch("");
+                setModelOpen(true);
+              }}
             />
             <button
               type="button"
@@ -2109,23 +2133,30 @@ function AgentComposer({
         </div>
       ) : null}
       {modelOpen ? (
-        <ComposerModelPopover
+        <ModelPickerPopover
+          mode="generation"
           flyout={modelFlyout}
           model={activeModel}
-          options={modelOptions(models, model)}
+          options={modelOptions(pickerModels, model)}
           search={modelSearch}
           popoverRef={modelPopoverRef}
           searchRef={modelSearchRef}
+          rootSearchRef={modelRootSearchRef}
+          rootSearch={modelRootSearch}
+          onRootSearchChange={setModelRootSearch}
+          catalogLoaded={models.length > 0}
+          suggestedModelIds={AGENT_SUGGESTED_MODEL_IDS}
           thinkingLevel={thinkingLevel}
           onFlyoutChange={setModelFlyout}
           onSearchChange={setModelSearch}
-          onSelect={(nextModel) => {
+          onSelect={(nextModel, _costQuality, options) => {
             setModel(nextModel);
-            setModelOpen(false);
+            if (!options?.keepOpen) setModelOpen(false);
           }}
           onSelectThinking={(level) => {
             setThinkingLevel(level);
             setModelFlyout(null);
+            setModelOpen(false);
           }}
         />
       ) : null}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -272,6 +272,7 @@ export function AgentWorkspace({
     turn: AgentChatTurn;
   }>();
   const pendingSessionCreationRef = useRef<string>();
+  const submissionOwnerRef = useRef<string>();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string>();
   const [approvalSubmitting, setApprovalSubmitting] = useState<
@@ -307,6 +308,7 @@ export function AgentWorkspace({
   const startNewSession = useCallback(
     (request?: AgentNewSessionDetail) => {
       pendingSessionCreationRef.current = undefined;
+      submissionOwnerRef.current = undefined;
       setSelectedId(undefined);
       selectedIdRef.current = undefined;
       setNewSessionMode(true);
@@ -465,6 +467,7 @@ export function AgentWorkspace({
     if (!nextId) return;
     if (selectedIdRef.current !== nextId) {
       pendingSessionCreationRef.current = undefined;
+      submissionOwnerRef.current = undefined;
       setSubmitting(false);
     }
     setPendingInitialTurn((current) =>
@@ -617,6 +620,8 @@ export function AgentWorkspace({
       }
       return;
     }
+    const submissionId = crypto.randomUUID();
+    submissionOwnerRef.current = submissionId;
     setSubmitting(true);
     setError(undefined);
     const creatingSession = !selectedSession || newSessionMode;
@@ -645,8 +650,10 @@ export function AgentWorkspace({
           ],
         },
       });
-      setDraft("");
-      setAttachments([]);
+      if (submissionOwnerRef.current === submissionId) {
+        setDraft("");
+        setAttachments([]);
+      }
     }
     try {
       let session = selectedSession;
@@ -703,8 +710,10 @@ export function AgentWorkspace({
           items: [...current.items, optimistic],
         }));
       }
-      setDraft("");
-      setAttachments([]);
+      if (submissionOwnerRef.current === submissionId) {
+        setDraft("");
+        setAttachments([]);
+      }
       const enabledSkillIds = (await agentRuntimeBindings.listSkills())
         .filter((skill) => skill.enabled)
         .map((skill) => skill.id);
@@ -731,7 +740,10 @@ export function AgentWorkspace({
       if (pendingSessionCreationRef.current === creationRequestId) {
         pendingSessionCreationRef.current = undefined;
       }
-      setSubmitting(false);
+      if (submissionOwnerRef.current === submissionId) {
+        submissionOwnerRef.current = undefined;
+        setSubmitting(false);
+      }
       dispatchAgentSessionStatus({
         sessionId: activeSession.id,
         title: activeSession.title,
@@ -739,6 +751,8 @@ export function AgentWorkspace({
       });
       await refreshSessions();
     } catch (cause) {
+      if (submissionOwnerRef.current !== submissionId) return;
+      submissionOwnerRef.current = undefined;
       setSubmitting(false);
       const operationIsVisible = creationRequestId
         ? pendingSessionCreationRef.current === creationRequestId

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -51,6 +51,19 @@ import {
 import { shouldBlockTextOnFunding } from "../../lib/account-gate";
 import { dispatchAgentSessionStatus, dispatchAgentSessionsChanged } from "../../lib/agent-events";
 import { messageFromError } from "../../lib/errors";
+import { persistAgentDefaultModel } from "../../lib/agent-default-model";
+import {
+  loadQueuedAgentFollowUps,
+  reconcileConsumedAgentFollowUp,
+  saveQueuedAgentFollowUps,
+  type QueuedAgentFollowUps,
+} from "../../lib/agent-follow-up-queue";
+import {
+  clearSessionModelIfApplied,
+  forgetSessionModel,
+  loadSessionModels,
+  rememberSessionModel,
+} from "../../lib/agent-session-models";
 import {
   forgetSessionThinkingLevel,
   loadSessionThinkingLevels,
@@ -227,6 +240,9 @@ export function AgentWorkspace({
   const [projection, setProjection] = useState<AgentRuntimeProjection>(() =>
     createAgentRuntimeProjection({ session: initialAgentSession }),
   );
+  const [hydratedSessionIds, setHydratedSessionIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const [artifacts, setArtifacts] = useState<AgentArtifactDto[]>([]);
   const [artifactPanel, setArtifactPanel] = useState<AgentArtifactPanelState | null>(null);
   const [shareOpen, setShareOpen] = useState(false);
@@ -242,6 +258,8 @@ export function AgentWorkspace({
   const [model, setModel] = useState(
     homeMode ? AUTO_MODEL_ID : initialAgentSession?.model || DEFAULT_MODEL,
   );
+  const modelRef = useRef(model);
+  modelRef.current = model;
   const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(() => {
     if (homeMode) return "instant";
     const sessionLevel = initialAgentSession?.id
@@ -249,6 +267,8 @@ export function AgentWorkspace({
       : undefined;
     return sessionLevel ?? loadThinkingLevel();
   });
+  const thinkingLevelRef = useRef(thinkingLevel);
+  thinkingLevelRef.current = thinkingLevel;
   const [safetyMode, setSafetyMode] = useState<AgentSafetyMode>(
     initialAgentSession?.safetyMode ?? "sandboxed",
   );
@@ -260,10 +280,26 @@ export function AgentWorkspace({
     setDraft(value);
   }, []);
   const [attachments, setAttachments] = useState<string[]>([]);
-  const [queuedFollowUp, setQueuedFollowUp] = useState<{
+  const [queuedFollowUps, setQueuedFollowUpsState] =
+    useState<QueuedAgentFollowUps>(loadQueuedAgentFollowUps);
+  const updateQueuedFollowUps = useCallback(
+    (update: (current: QueuedAgentFollowUps) => QueuedAgentFollowUps) => {
+      setQueuedFollowUpsState((current) => {
+        const next = update(current);
+        if (next !== current) saveQueuedAgentFollowUps(next);
+        return next;
+      });
+    },
+    [],
+  );
+  const queuedFollowUp = selectedId ? queuedFollowUps[selectedId] : undefined;
+  const queuedSubmissionSnapshotRef = useRef<{
+    sessionId: string;
     messageId: string;
     prompt: string;
     attachments: string[];
+    model: string;
+    thinkingLevel: ThinkingLevel;
   }>();
   const [pendingInitialTurn, setPendingInitialTurn] = useState<{
     prompt: string;
@@ -319,7 +355,6 @@ export function AgentWorkspace({
       setThinkingLevel(loadThinkingLevel());
       setDraft(request?.prompt ?? "");
       setAttachments([]);
-      setQueuedFollowUp(undefined);
       setPendingInitialTurn(undefined);
       setSubmitting(false);
       setError(undefined);
@@ -417,8 +452,19 @@ export function AgentWorkspace({
         ...createAgentRuntimeProjection({ session, items }),
         run: latestRun ?? undefined,
       });
+      updateQueuedFollowUps((current) =>
+        reconcileConsumedAgentFollowUp(
+          current,
+          sessionId,
+          items.map((item) => item.id),
+        ),
+      );
+      setHydratedSessionIds((current) => {
+        if (current.has(sessionId)) return current;
+        return new Set([...current, sessionId]);
+      });
       setArtifacts(files);
-      setModel(homeMode ? AUTO_MODEL_ID : session.model);
+      setModel(homeMode ? AUTO_MODEL_ID : (loadSessionModels()[session.id] ?? session.model));
       setThinkingLevel(
         homeMode ? "instant" : (loadSessionThinkingLevels()[session.id] ?? loadThinkingLevel()),
       );
@@ -427,7 +473,7 @@ export function AgentWorkspace({
       if (!homeMode) writeLastOpenSessionId(sessionId);
       onSessionSelected?.(session);
     },
-    [homeMode, onSessionSelected],
+    [homeMode, onSessionSelected, updateQueuedFollowUps],
   );
 
   useEffect(() => {
@@ -450,7 +496,7 @@ export function AgentWorkspace({
         if (homeMode) {
           focusedHomeModelRef.current = response.selectedModel || DEFAULT_MODEL;
         }
-        if (!homeMode && !initialAgentSession?.model && response.selectedModel) {
+        if (!homeMode && !initialAgentSession && !initialSessionId && response.selectedModel) {
           setModel(response.selectedModel);
         }
       })
@@ -460,7 +506,7 @@ export function AgentWorkspace({
         setVeniceApiKeyConfigured(response.effectiveSettings.veniceApiKeyConfigured),
       )
       .catch(() => setVeniceApiKeyConfigured(false));
-  }, [homeMode, initialAgentSession?.model, refreshSessions]);
+  }, [homeMode, initialAgentSession, initialSessionId, refreshSessions]);
 
   useEffect(() => {
     const nextId = initialSession?.id ?? initialSessionId;
@@ -481,7 +527,7 @@ export function AgentWorkspace({
         ...current.filter((session) => session.id !== initialSession.id),
       ]);
       setProjection((current) => ({ ...current, session: initialSession }));
-      setModel(initialSession.model || DEFAULT_MODEL);
+      setModel(loadSessionModels()[initialSession.id] ?? (initialSession.model || DEFAULT_MODEL));
       setSafetyMode(initialSession.safetyMode);
       setNewSessionMode(false);
     }
@@ -505,16 +551,20 @@ export function AgentWorkspace({
     let disposed = false;
     let unlisten: (() => void) | undefined;
     void listen<AgentRuntimeEvent>(AGENT_RUNTIME_EVENT, ({ payload }) => {
+      if (payload.method === "steering.consumed") {
+        updateQueuedFollowUps((current) => {
+          const queued = current[payload.sessionId];
+          if (queued?.messageId !== payload.data.messageId) return current;
+          const next = { ...current };
+          delete next[payload.sessionId];
+          return next;
+        });
+      }
       if (payload.sessionId !== selectedIdRef.current) {
         void refreshSessions().catch(() => undefined);
         return;
       }
       setProjection((current) => applyAgentRuntimeEvent(current, payload));
-      if (payload.method === "steering.consumed") {
-        setQueuedFollowUp((current) =>
-          current?.messageId === payload.data.messageId ? undefined : current,
-        );
-      }
       dispatchAgentSessionStatus({
         sessionId: payload.sessionId,
         status:
@@ -544,7 +594,7 @@ export function AgentWorkspace({
       disposed = true;
       unlisten?.();
     };
-  }, [hydrate, refreshSessions]);
+  }, [hydrate, refreshSessions, updateQueuedFollowUps]);
 
   useEffect(() => {
     const scroller = scrollRef.current;
@@ -554,13 +604,43 @@ export function AgentWorkspace({
   }, [projection.items]);
 
   useEffect(() => {
-    if (running || waiting || submitting || !queuedFollowUp) return;
+    if (
+      running ||
+      waiting ||
+      submitting ||
+      textActionsDisabledReason ||
+      !queuedFollowUp ||
+      !selectedId ||
+      !hydratedSessionIds.has(selectedId)
+    ) {
+      return;
+    }
     const queued = queuedFollowUp;
-    setQueuedFollowUp(undefined);
-    setDraft(queued.prompt);
-    setAttachments(queued.attachments);
-    requestAnimationFrame(() => composerRef.current?.requestSubmit());
-  }, [queuedFollowUp, running, submitting, waiting]);
+    const ownerSessionId = selectedId;
+    queuedSubmissionSnapshotRef.current = {
+      sessionId: ownerSessionId,
+      messageId: queued.messageId,
+      prompt: queued.prompt,
+      attachments: queued.attachments,
+      model: queued.model,
+      thinkingLevel: queued.thinkingLevel,
+    };
+    requestAnimationFrame(() => {
+      if (selectedIdRef.current !== ownerSessionId) {
+        queuedSubmissionSnapshotRef.current = undefined;
+        return;
+      }
+      composerRef.current?.requestSubmit();
+    });
+  }, [
+    hydratedSessionIds,
+    queuedFollowUp,
+    running,
+    selectedId,
+    submitting,
+    textActionsDisabledReason,
+    waiting,
+  ]);
 
   useLayoutEffect(() => {
     const scroller = scrollRef.current;
@@ -606,11 +686,21 @@ export function AgentWorkspace({
 
   async function submit(event?: FormEvent) {
     event?.preventDefault();
-    const prompt = draft.trim();
+    const queuedSubmission = queuedSubmissionSnapshotRef.current;
+    if (queuedSubmission && queuedSubmission.sessionId !== selectedIdRef.current) {
+      queuedSubmissionSnapshotRef.current = undefined;
+      return;
+    }
+    const prompt = (queuedSubmission?.prompt ?? draft).trim();
     if (!prompt || waiting || submitting || textActionsDisabledReason) return;
     if (running) {
+      const ownerSessionId = selectedIdRef.current;
+      if (!ownerSessionId) return;
       const messageId = crypto.randomUUID();
-      setQueuedFollowUp({ messageId, prompt, attachments });
+      updateQueuedFollowUps((current) => ({
+        ...current,
+        [ownerSessionId]: { messageId, prompt, attachments, model, thinkingLevel },
+      }));
       setDraft("");
       setAttachments([]);
       if (attachments.length === 0 && projection.run) {
@@ -620,6 +710,10 @@ export function AgentWorkspace({
       }
       return;
     }
+    queuedSubmissionSnapshotRef.current = undefined;
+    const queuedSnapshot = queuedSubmission;
+    const submittedModel = queuedSnapshot?.model ?? model;
+    const submittedThinkingLevel = queuedSnapshot?.thinkingLevel ?? thinkingLevel;
     const submissionId = crypto.randomUUID();
     submissionOwnerRef.current = submissionId;
     setSubmitting(true);
@@ -628,7 +722,7 @@ export function AgentWorkspace({
     const creationRequestId = creatingSession ? crypto.randomUUID() : undefined;
     const optimisticId = `optimistic:${crypto.randomUUID()}`;
     const optimisticCreatedAt = new Date().toISOString();
-    const attachedPaths = attachments;
+    const attachedPaths = queuedSnapshot?.attachments ?? attachments;
     if (creatingSession) {
       pendingSessionCreationRef.current = creationRequestId;
       setPendingInitialTurn({
@@ -660,11 +754,19 @@ export function AgentWorkspace({
       if (!session || newSessionMode) {
         const createdSession = await agentRuntimeBindings.createSession({
           title: titleFromPrompt(prompt),
-          model,
+          model: submittedModel,
           safetyMode,
           profile: getCurrentDataPartitionName(),
         });
         session = createdSession;
+        const latestModel = modelRef.current;
+        if (latestModel !== submittedModel) {
+          rememberSessionModel(createdSession.id, latestModel);
+        }
+        const latestThinkingLevel = thinkingLevelRef.current;
+        if (latestThinkingLevel !== submittedThinkingLevel) {
+          rememberSessionThinkingLevel(createdSession.id, latestThinkingLevel);
+        }
         setSessions((current) => [
           createdSession,
           ...current.filter((item) => item.id !== createdSession.id),
@@ -710,7 +812,7 @@ export function AgentWorkspace({
           items: [...current.items, optimistic],
         }));
       }
-      if (submissionOwnerRef.current === submissionId) {
+      if (!queuedSnapshot && !creatingSession && submissionOwnerRef.current === submissionId) {
         setDraft("");
         setAttachments([]);
       }
@@ -725,15 +827,32 @@ export function AgentWorkspace({
       const run = await agentRuntimeBindings.startRun({
         sessionId: activeSession.id,
         prompt: preparedPrompt.text,
-        model,
-        reasoningEffort: thinkingEffortForLevel(thinkingLevel) as "minimal" | "medium" | "high",
+        model: submittedModel,
+        reasoningEffort: thinkingEffortForLevel(submittedThinkingLevel) as
+          | "minimal"
+          | "medium"
+          | "high",
         safetyMode,
         workspacePath: activeSession.workspacePath,
         enabledSkillIds,
         attachments: attachedPaths,
       });
+      if (queuedSnapshot) {
+        updateQueuedFollowUps((current) => {
+          if (current[queuedSnapshot.sessionId]?.messageId !== queuedSnapshot.messageId) {
+            return current;
+          }
+          const next = { ...current };
+          delete next[queuedSnapshot.sessionId];
+          return next;
+        });
+      }
+      clearSessionModelIfApplied(activeSession.id, submittedModel);
       projectContextSignaturesBySessionId.set(activeSession.id, preparedPrompt.contextSignature);
-      rememberSessionThinkingLevel(activeSession.id, thinkingLevel);
+      const storedThinkingLevel = loadSessionThinkingLevels()[activeSession.id];
+      if (!storedThinkingLevel || storedThinkingLevel === submittedThinkingLevel) {
+        rememberSessionThinkingLevel(activeSession.id, submittedThinkingLevel);
+      }
       if (selectedIdRef.current === activeSession.id) {
         setProjection((current) => ({ ...current, run }));
       }
@@ -1257,7 +1376,14 @@ export function AgentWorkspace({
     await agentRuntimeBindings.deleteSession(selectedId);
     projectContextSignaturesBySessionId.delete(selectedId);
     forgetSessionThinkingLevel(selectedId);
+    forgetSessionModel(selectedId);
     forgetLastOpenSessionId(selectedId);
+    updateQueuedFollowUps((current) => {
+      if (!(selectedId in current)) return current;
+      const next = { ...current };
+      delete next[selectedId];
+      return next;
+    });
     setSelectedId(undefined);
     setProjection(createAgentRuntimeProjection());
     setArtifacts([]);
@@ -1382,7 +1508,16 @@ export function AgentWorkspace({
       draft={draft}
       setDraft={setComposerDraft}
       model={model}
-      setModel={setModel}
+      setModel={(nextModel) => {
+        setModel(nextModel);
+        if (selectedId) {
+          rememberSessionModel(selectedId, nextModel);
+          return;
+        }
+        void persistAgentDefaultModel(nextModel).catch((cause) => {
+          if (modelRef.current === nextModel) setError(messageFromError(cause));
+        });
+      }}
       thinkingLevel={thinkingLevel}
       setThinkingLevel={(level) => {
         setThinkingLevel(level);
@@ -1402,6 +1537,7 @@ export function AgentWorkspace({
       submitting={submitting}
       disabledReason={textActionsDisabledReason}
       hero={heroMode}
+      showModelPicker={!homeMode}
     />
   );
   return (
@@ -1629,7 +1765,15 @@ export function AgentWorkspace({
                     <button
                       type="button"
                       aria-label="Remove queued follow-up"
-                      onClick={() => setQueuedFollowUp(undefined)}
+                      onClick={() => {
+                        if (!selectedId) return;
+                        updateQueuedFollowUps((current) => {
+                          if (!(selectedId in current)) return current;
+                          const next = { ...current };
+                          delete next[selectedId];
+                          return next;
+                        });
+                      }}
                     >
                       <IconCrossSmall size={12} aria-hidden />
                     </button>
@@ -1871,6 +2015,7 @@ function AgentComposer({
   submitting,
   disabledReason,
   hero = false,
+  showModelPicker = true,
 }: {
   formRef: RefObject<HTMLFormElement>;
   scrollRef: RefObject<HTMLDivElement>;
@@ -1893,6 +2038,7 @@ function AgentComposer({
   submitting: boolean;
   disabledReason?: string;
   hero?: boolean;
+  showModelPicker?: boolean;
 }) {
   const editorRef = useRef<ComposerEditorHandle>(null);
   const publishedDraftRef = useRef(draft);
@@ -1915,7 +2061,6 @@ function AgentComposer({
   const pickerModels = models.some((option) => option.id === AUTO_MODEL_ID)
     ? models
     : [AGENT_AUTO_MODEL, ...models];
-  const working = running || submitting;
 
   useEffect(() => {
     if (draft === publishedDraftRef.current) return;
@@ -2066,23 +2211,24 @@ function AgentComposer({
             </button>
           ) : null}
           <div className="agent-composer-actions">
-            <ComposerModelPicker
-              open={modelOpen}
-              model={activeModel}
-              effort={thinkingLevel}
-              readOnly={working}
-              triggerRef={modelTriggerRef}
-              onToggleOpen={() => {
-                if (modelOpen) {
-                  setModelOpen(false);
-                  return;
-                }
-                setModelFlyout(null);
-                setModelSearch("");
-                setModelRootSearch("");
-                setModelOpen(true);
-              }}
-            />
+            {showModelPicker ? (
+              <ComposerModelPicker
+                open={modelOpen}
+                model={activeModel}
+                effort={thinkingLevel}
+                triggerRef={modelTriggerRef}
+                onToggleOpen={() => {
+                  if (modelOpen) {
+                    setModelOpen(false);
+                    return;
+                  }
+                  setModelFlyout(null);
+                  setModelSearch("");
+                  setModelRootSearch("");
+                  setModelOpen(true);
+                }}
+              />
+            ) : null}
             <button
               type="button"
               className="agent-composer-mic"
@@ -2207,7 +2353,7 @@ function AgentComposer({
           })}
         </div>
       ) : null}
-      {modelOpen ? (
+      {showModelPicker && modelOpen ? (
         <ModelPickerPopover
           mode="generation"
           flyout={modelFlyout}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1267,6 +1267,7 @@ export function AgentWorkspace({
   }
 
   const heroMode = !homeMode && newSessionMode && !selectedSession && !pendingInitialTurn;
+  const sessionActionsAvailable = Boolean(selectedId && selectedSession);
   const homeConversationTurns = useMemo(
     () =>
       [
@@ -1418,8 +1419,10 @@ export function AgentWorkspace({
             fullMode={selectedSession?.safetyMode === "unrestricted"}
             artifactCount={renderedArtifacts.length}
             artifactsOpen={artifactPanel !== null}
-            onToggleArtifacts={() =>
-              setArtifactPanel((current) => (current ? null : { view: "list" }))
+            onToggleArtifacts={
+              sessionActionsAvailable
+                ? () => setArtifactPanel((current) => (current ? null : { view: "list" }))
+                : undefined
             }
             inProject={sessionInProject}
             projectContext={projectContext}
@@ -1435,22 +1438,22 @@ export function AgentWorkspace({
                 ? () => setShareOpen(true)
                 : undefined
             }
-            onUsage={() => setUsageOpen(true)}
+            onUsage={sessionActionsAvailable ? () => setUsageOpen(true) : undefined}
             onCompact={
-              agentRuntimeBindings.compactSession && !running && !waiting
+              sessionActionsAvailable && agentRuntimeBindings.compactSession && !running && !waiting
                 ? () => {
                     setCompactResult(undefined);
                     setCompactOpen(true);
                   }
                 : undefined
             }
-            onRename={rename}
+            onRename={sessionActionsAvailable ? rename : undefined}
             onMoveToProject={
-              selectedId && onMoveSessionToProject
+              sessionActionsAvailable && selectedId && onMoveSessionToProject
                 ? () => onMoveSessionToProject(selectedId)
                 : undefined
             }
-            onDelete={remove}
+            onDelete={sessionActionsAvailable ? remove : undefined}
           />
         ) : null}
         {homeMode ? (

--- a/src/components/agent/SmoothedStreamingMarkdown.tsx
+++ b/src/components/agent/SmoothedStreamingMarkdown.tsx
@@ -3,13 +3,12 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 
 import { createInlineMarkdownPattern, MarkdownContent } from "./MarkdownContent";
 
-// Deltas gather for one beat, then the whole backlog mounts in a single
-// commit — every word in the batch shares one fade timeline, so a chunk
-// surfaces as a unit instead of a mask sweeping left to right. The interval
-// is the batch width: long enough that a fast token stream groups into
-// visible chunks (and markdown parsing stays off the display refresh), short
-// enough that the response never feels laggy.
-const STREAM_REVEAL_INTERVAL_MS = 80;
+// Providers can deliver anything from a token to a paragraph in one delta.
+// Reveal a tiny, word-bounded slice on each beat so those transport chunks do
+// not become visible presentation chunks. Two words per 32 ms stays well ahead
+// of reading speed while still feeling like prose is arriving continuously.
+const STREAM_REVEAL_INTERVAL_MS = 32;
+const STREAM_WORDS_PER_REVEAL = 2;
 
 // Longest ambiguous markdown tail we will stall the reveal on. Past this,
 // revealing beats freezing the stream on syntax that may never close. That
@@ -309,12 +308,53 @@ export function holdbackSafeEnd(text: string): number {
   return holdbackDecision(text).safeEnd;
 }
 
+function wordBoundedEnd(text: string, start: number, limit: number): number {
+  let cursor = start;
+  let words = 0;
+  let inWord = false;
+  while (cursor < limit) {
+    if (/\s/.test(text[cursor])) {
+      if (inWord) {
+        words += 1;
+        inWord = false;
+      }
+      cursor += 1;
+      if (words >= STREAM_WORDS_PER_REVEAL) {
+        while (cursor < limit && /\s/.test(text[cursor])) cursor += 1;
+        return cursor;
+      }
+      continue;
+    }
+    inWord = true;
+    cursor += 1;
+  }
+  return limit;
+}
+
+// A word boundary can still land inside markdown (`**two words`). Advance to
+// the first word-bounded prefix whose own parse is safe, which keeps existing
+// rendered words mounted while allowing a complete inline construct to arrive
+// together when necessary.
+function nextRevealEnd(text: string, currentEnd: number, safeEnd: number): number {
+  let scanFrom = currentEnd;
+  while (scanFrom < safeEnd) {
+    const candidateEnd = wordBoundedEnd(text, scanFrom, safeEnd);
+    const candidateSafeEnd = Math.min(
+      holdbackDecision(text.slice(0, candidateEnd)).safeEnd,
+      safeEnd,
+    );
+    if (candidateSafeEnd > currentEnd) return candidateSafeEnd;
+    if (candidateEnd <= scanFrom) break;
+    scanFrom = candidateEnd;
+  }
+  return safeEnd;
+}
+
 /**
- * Presents append-only assistant text as chunk-batched reveals: deltas are
- * held for one short beat and released together, so each batch fades in as a
- * unit (see agent-stream-word-in). The authoritative text remains the raw
- * stream in AgentWorkspace; this component only trails it by at most one
- * batch interval.
+ * Presents append-only assistant text as word-paced reveals. Provider deltas
+ * are transport details and may contain whole paragraphs, so the visible
+ * stream advances in small word-bounded steps instead. The authoritative text
+ * remains the raw stream in AgentWorkspace.
  */
 export function SmoothedStreamingMarkdown({
   markdown,
@@ -334,8 +374,12 @@ export function SmoothedStreamingMarkdown({
       !running || reducedMotion || document.hidden
         ? { safeEnd: markdown.length, disableWordFade: false }
         : holdbackDecision(markdown);
+    const initialEnd =
+      !running || reducedMotion || document.hidden
+        ? decision.safeEnd
+        : nextRevealEnd(markdown, 0, decision.safeEnd);
     initialPresentationRef.current = {
-      visible: markdown.slice(0, decision.safeEnd),
+      visible: markdown.slice(0, initialEnd),
       fadeDisabled: decision.disableWordFade,
     };
   }
@@ -365,19 +409,19 @@ export function SmoothedStreamingMarkdown({
 
   const scheduleReveal = useCallback(() => {
     if (timerRef.current !== null) return;
-    timerRef.current = window.setTimeout(() => {
+    const tick = () => {
       timerRef.current = null;
-      // Everything that arrived during the batch interval mounts at once, in
-      // one commit, so the whole batch starts its fade on the same frame.
-      // Reveal only up to the safe holdback so an incomplete trailing
-      // construct does not surface and then re-parse under the next delta.
       const decision = holdbackDecision(targetRef.current);
       if (decision.disableWordFade) setFadeDisabled(true);
-      const safe = targetRef.current.slice(0, decision.safeEnd);
-      if (safe !== visibleRef.current) {
-        reveal(safe);
+      const end = nextRevealEnd(targetRef.current, visibleRef.current.length, decision.safeEnd);
+      if (end > visibleRef.current.length) {
+        reveal(targetRef.current.slice(0, end));
       }
-    }, STREAM_REVEAL_INTERVAL_MS);
+      if (end < decision.safeEnd) {
+        timerRef.current = window.setTimeout(tick, STREAM_REVEAL_INTERVAL_MS);
+      }
+    };
+    timerRef.current = window.setTimeout(tick, STREAM_REVEAL_INTERVAL_MS);
   }, [reveal]);
 
   useLayoutEffect(() => {
@@ -390,14 +434,25 @@ export function SmoothedStreamingMarkdown({
       reveal(markdown);
       return;
     }
-    // First chunk, or a reconciled (non-prefix) replacement: reveal instantly
-    // rather than waiting a beat, but still only up to the safe holdback.
-    if (visibleRef.current.length === 0 || !markdown.startsWith(visibleRef.current)) {
+    // A reconciled (non-prefix) replacement is a correction, not an append.
+    // Reveal it immediately rather than animating through text being replaced.
+    if (!markdown.startsWith(visibleRef.current)) {
       stopTimer();
       const decision = holdbackDecision(markdown);
       if (decision.disableWordFade) setFadeDisabled(true);
       const safe = markdown.slice(0, decision.safeEnd);
       if (safe !== visibleRef.current) reveal(safe);
+      return;
+    }
+    // The first provider delta is visible immediately, but only as the first
+    // word-sized step. Continue draining the rest even if no new delta arrives.
+    if (visibleRef.current.length === 0) {
+      stopTimer();
+      const decision = holdbackDecision(markdown);
+      if (decision.disableWordFade) setFadeDisabled(true);
+      const end = nextRevealEnd(markdown, 0, decision.safeEnd);
+      if (end > 0) reveal(markdown.slice(0, end));
+      if (end < decision.safeEnd) scheduleReveal();
       return;
     }
     scheduleReveal();

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -268,6 +268,15 @@ export function ModelPickerPopover({
     }
   }, [flyout]);
 
+  useLayoutEffect(() => {
+    if (flyout?.kind !== "effort") return;
+    window.requestAnimationFrame(() => {
+      flyoutRef.current
+        ?.querySelector<HTMLButtonElement>('[role="menuitemradio"][aria-checked="true"]')
+        ?.focus();
+    });
+  }, [flyout]);
+
   // The detail card opens beside the popover, its top pinned to the active
   // row's top. It's portaled to the body (see render), so `offsetTop` is
   // meaningless — compute viewport-fixed coords here, the same math as
@@ -928,6 +937,28 @@ export function ModelPickerPopover({
                   className="agent-composer-model-flyout agent-composer-model-effort-panel"
                   role="group"
                   aria-label="Thinking level"
+                  onKeyDown={(event) => {
+                    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+                    const choices = Array.from(
+                      event.currentTarget.querySelectorAll<HTMLButtonElement>(
+                        '[role="menuitemradio"]',
+                      ),
+                    );
+                    if (!choices.length) return;
+                    event.preventDefault();
+                    const currentIndex = Math.max(
+                      0,
+                      choices.indexOf(document.activeElement as HTMLButtonElement),
+                    );
+                    const nextIndex =
+                      event.key === "Home"
+                        ? 0
+                        : event.key === "End"
+                          ? choices.length - 1
+                          : (currentIndex + (event.key === "ArrowDown" ? 1 : -1) + choices.length) %
+                            choices.length;
+                    choices[nextIndex]?.focus();
+                  }}
                   onPointerLeave={() => {
                     cancelHoverIntent();
                     setBridging(false);
@@ -941,6 +972,7 @@ export function ModelPickerPopover({
                         className="agent-composer-model-row agent-composer-model-choice-option"
                         role="menuitemradio"
                         aria-checked={option.id === thinkingLevel}
+                        tabIndex={option.id === thinkingLevel ? 0 : -1}
                         onClick={() => onSelectThinking(option.id)}
                       >
                         <span className="agent-composer-model-choice-copy">

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -9,6 +9,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import type { RefObject } from "react";
 import { createPortal } from "react-dom";
@@ -480,12 +481,13 @@ export function ModelPickerPopover({
     : [];
   const resolvedRootActive = Math.min(rootActive, Math.max(rootResults.length - 1, 0));
   const rootStatusId = `${rootListId}-status`;
-  const rootSearchStatus = rootControlsMatch
-    ? `${rootVisibleControlCount} ${rootVisibleControlCount === 1 ? "setting" : "settings"} shown. Press Tab to review ${rootVisibleControlCount === 1 ? "it" : "settings"}.${
-        rootResults.length
-          ? ` ${rootResults.length} matching ${rootResults.length === 1 ? "model" : "models"}. Use the arrow keys to review ${rootResults.length === 1 ? "it" : "models"}.`
-          : ""
-      }`
+  const matchingModelsStatus = rootResults.length
+    ? `${rootResults.length} matching ${rootResults.length === 1 ? "model" : "models"}. Use the arrow keys to review ${rootResults.length === 1 ? "it" : "models"}.`
+    : "No results match your search.";
+  const rootSearchStatus = rootQueryActive
+    ? rootControlsMatch
+      ? `${rootVisibleControlCount} ${rootVisibleControlCount === 1 ? "setting" : "settings"} shown. Press Tab to review ${rootVisibleControlCount === 1 ? "it" : "settings"}. ${matchingModelsStatus}`
+      : matchingModelsStatus
     : undefined;
   useEffect(() => {
     setRootActive(0);
@@ -504,6 +506,16 @@ export function ModelPickerPopover({
           ?.scrollIntoView?.({ block: "nearest" });
       });
       return nextIndex;
+    });
+  }
+  function moveRootActiveTo(index: number) {
+    if (!rootResults.length) return;
+    const nextIndex = Math.max(0, Math.min(index, rootResults.length - 1));
+    setRootActive(nextIndex);
+    window.requestAnimationFrame(() => {
+      document
+        .getElementById(`${rootListId}-option-${nextIndex}`)
+        ?.scrollIntoView?.({ block: "nearest" });
     });
   }
   const detail =
@@ -590,6 +602,24 @@ export function ModelPickerPopover({
     setBridging,
   });
 
+  function handleListboxNavigation(event: ReactKeyboardEvent<HTMLDivElement>) {
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+    const options = Array.from(
+      event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="option"]'),
+    );
+    if (!options.length) return;
+    event.preventDefault();
+    const focusedIndex = options.indexOf(document.activeElement as HTMLButtonElement);
+    const currentIndex = focusedIndex >= 0 ? focusedIndex : 0;
+    const nextIndex =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? options.length - 1
+          : (currentIndex + (event.key === "ArrowDown" ? 1 : -1) + options.length) % options.length;
+    options[nextIndex]?.focus();
+  }
+
   function catalogList(label: string) {
     return (
       <>
@@ -616,6 +646,7 @@ export function ModelPickerPopover({
             className="agent-composer-model-list"
             role="listbox"
             aria-label={label}
+            onKeyDown={handleListboxNavigation}
             onScroll={() => {
               fade.update();
               cancelHoverIntent();
@@ -645,7 +676,7 @@ export function ModelPickerPopover({
                 />
               ))
             ) : (
-              <p className="agent-composer-model-empty">
+              <p className="agent-composer-model-empty" role="status" aria-live="polite">
                 {privateOnly
                   ? query
                     ? "No private models match your search."
@@ -760,6 +791,16 @@ export function ModelPickerPopover({
               if (event.key === "ArrowUp" && rootResults.length) {
                 event.preventDefault();
                 moveRootActive(-1);
+                return;
+              }
+              if (event.key === "Home" && rootResults.length) {
+                event.preventDefault();
+                moveRootActiveTo(0);
+                return;
+              }
+              if (event.key === "End" && rootResults.length) {
+                event.preventDefault();
+                moveRootActiveTo(rootResults.length - 1);
                 return;
               }
             }}
@@ -1016,6 +1057,7 @@ export function ModelPickerPopover({
                 className="agent-composer-model-menu"
                 role="listbox"
                 aria-label={suggestedListLabel}
+                onKeyDown={handleListboxNavigation}
               >
                 {suggested.length ? (
                   suggested.map(({ key, model: option, costQuality: presetCostQuality }) => (

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -176,6 +176,7 @@ export function ModelPickerPopover({
   onSelectThinking?: (level: ThinkingLevel) => void;
 }) {
   const flyoutRef = useRef<HTMLDivElement | null>(null);
+  const focusEffortChoiceRef = useRef(false);
   const listRef = useRef<HTMLDivElement | null>(null);
   const hovercardRef = useRef<HTMLDivElement | null>(null);
   // "Private" catalog filter. Local to the popover on purpose: it resets when
@@ -269,12 +270,14 @@ export function ModelPickerPopover({
   }, [flyout]);
 
   useLayoutEffect(() => {
-    if (flyout?.kind !== "effort") return;
-    window.requestAnimationFrame(() => {
+    if (flyout?.kind !== "effort" || !focusEffortChoiceRef.current) return;
+    const frame = window.requestAnimationFrame(() => {
+      focusEffortChoiceRef.current = false;
       flyoutRef.current
         ?.querySelector<HTMLButtonElement>('[role="menuitemradio"][aria-checked="true"]')
         ?.focus();
     });
+    return () => window.cancelAnimationFrame(frame);
   }, [flyout]);
 
   // The detail card opens beside the popover, its top pinned to the active
@@ -902,7 +905,10 @@ export function ModelPickerPopover({
                     if (modelBridge.isActive()) {
                       return;
                     }
-                    const open = () => onFlyoutChange({ kind: "effort" });
+                    const open = () => {
+                      focusEffortChoiceRef.current = false;
+                      onFlyoutChange({ kind: "effort" });
+                    };
                     if (flyout) {
                       cancelHoverIntent();
                       open();
@@ -912,10 +918,12 @@ export function ModelPickerPopover({
                   }}
                   onFocus={() => {
                     cancelHoverIntent();
+                    focusEffortChoiceRef.current = true;
                     onFlyoutChange({ kind: "effort" });
                   }}
                   onClick={() => {
                     cancelHoverIntent();
+                    focusEffortChoiceRef.current = true;
                     onFlyoutChange({ kind: "effort" });
                   }}
                 >

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -108,6 +108,7 @@ export function ModelPickerPopover({
   allModelsLabel = `All ${modelModeLabel(mode)} models`,
   veniceApiKeyConfigured = false,
   catalogLoaded,
+  suggestedModelIds,
   rootSearchRef,
   rootSearch,
   onRootSearchChange,
@@ -143,6 +144,9 @@ export function ModelPickerPopover({
    * catalog should pass this; without it the popover falls back to treating
    * "any concrete entry present" as loaded. */
   catalogLoaded?: boolean;
+  /** Optional host-owned suggestion order. Agent sessions use this to keep
+   * Auto as the single quick pick while the full catalog remains searchable. */
+  suggestedModelIds?: readonly string[];
   /** Enables the root-layer search (the /model + composer trigger surface):
    * a field above the pinned controls whose query searches across BOTH
    * layers, suggested picks and the full catalog, as one flat result list.
@@ -365,7 +369,21 @@ export function ModelPickerPopover({
       ),
     [mode, onCostQualityChange, options],
   );
-  const suggested = useMemo(() => suggestedModelsForMode(mode, selectable), [mode, selectable]);
+  const suggested = useMemo(() => {
+    if (!suggestedModelIds) return suggestedModelsForMode(mode, selectable);
+    return suggestedModelIds.flatMap((id, index) => {
+      const option = selectable.find((candidate) => candidate.id === id);
+      if (!option) return [];
+      return [
+        {
+          key: `${id}:host:${index}`,
+          model: option,
+          reason: option.description ?? "Suggested for this surface.",
+          costQuality: undefined,
+        },
+      ];
+    });
+  }, [mode, selectable, suggestedModelIds]);
   const autoEnabled = onCostQualityChange !== undefined && model?.id === AUTO_MODEL_ID;
   const autoPreference = autoPreferenceFromCostQuality(costQuality ?? 100);
   // Toggling stays inside the popover: turning Auto off lands on the leading

--- a/src/lib/agent-default-model.ts
+++ b/src/lib/agent-default-model.ts
@@ -1,0 +1,21 @@
+import { setVeniceModel, type ProviderModelSettingsDto } from "./tauri";
+
+type ModelWriter = (modelId: string) => Promise<ProviderModelSettingsDto | void>;
+
+let writeTail: Promise<void> = Promise.resolve();
+
+/** Serialize app-wide model writes so a slower earlier IPC response cannot
+ * persist over a newer picker choice. Each write still runs after a previous
+ * failure, leaving the most recent selection with the final word. */
+export function persistAgentDefaultModel(
+  modelId: string,
+  writer: ModelWriter = (nextModelId) => setVeniceModel("generation", nextModelId),
+): Promise<void> {
+  const write = writeTail.catch(() => undefined).then(() => writer(modelId));
+  writeTail = write.then(() => undefined);
+  return writeTail;
+}
+
+export function resetAgentDefaultModelPersistenceForTests() {
+  writeTail = Promise.resolve();
+}

--- a/src/lib/agent-follow-up-queue.ts
+++ b/src/lib/agent-follow-up-queue.ts
@@ -1,0 +1,82 @@
+import type { ThinkingLevel } from "./thinking-level";
+
+export type QueuedAgentFollowUp = {
+  messageId: string;
+  prompt: string;
+  attachments: string[];
+  model: string;
+  thinkingLevel: ThinkingLevel;
+};
+
+export type QueuedAgentFollowUps = Record<string, QueuedAgentFollowUp>;
+
+const STORAGE_KEY = "june.agent.queuedFollowUps";
+
+function isThinkingLevel(value: unknown): value is ThinkingLevel {
+  return value === "instant" || value === "medium" || value === "hard";
+}
+
+function queuedFollowUp(value: unknown): QueuedAgentFollowUp | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.messageId !== "string" ||
+    typeof record.prompt !== "string" ||
+    typeof record.model !== "string" ||
+    !Array.isArray(record.attachments) ||
+    !record.attachments.every((path) => typeof path === "string") ||
+    !isThinkingLevel(record.thinkingLevel)
+  ) {
+    return undefined;
+  }
+  return {
+    messageId: record.messageId,
+    prompt: record.prompt,
+    attachments: record.attachments,
+    model: record.model,
+    thinkingLevel: record.thinkingLevel,
+  };
+}
+
+export function loadQueuedAgentFollowUps(): QueuedAgentFollowUps {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const result: QueuedAgentFollowUps = {};
+    for (const [sessionId, value] of Object.entries(parsed)) {
+      const queued = queuedFollowUp(value);
+      if (sessionId && queued) result[sessionId] = queued;
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+export function saveQueuedAgentFollowUps(queued: QueuedAgentFollowUps) {
+  try {
+    if (Object.keys(queued).length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(queued));
+  } catch {
+    // The current mounted workspace still owns the in-memory queue.
+  }
+}
+
+/** Steering items are persisted as `steering:<messageId>`. Drop a restored
+ * fallback once native history proves the active run consumed it. */
+export function reconcileConsumedAgentFollowUp(
+  queued: QueuedAgentFollowUps,
+  sessionId: string,
+  itemIds: readonly string[],
+): QueuedAgentFollowUps {
+  const current = queued[sessionId];
+  if (!current || !itemIds.includes(`steering:${current.messageId}`)) return queued;
+  const next = { ...queued };
+  delete next[sessionId];
+  return next;
+}

--- a/src/lib/agent-session-models.ts
+++ b/src/lib/agent-session-models.ts
@@ -1,0 +1,66 @@
+/**
+ * Session-local model choices that have not reached an agent run boundary yet.
+ *
+ * The runtime persists a session's model when the next run starts. Until then,
+ * keep the user's staged choice locally so navigation, hydration, and app
+ * restart cannot snap the picker back to the model used by the previous run.
+ */
+
+const STORAGE_KEY = "june.agent.sessionModels";
+
+function readStore(): Record<string, string> {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const store: Record<string, string> = {};
+    for (const [sessionId, model] of Object.entries(parsed)) {
+      if (typeof model === "string" && model.trim()) store[sessionId] = model;
+    }
+    return store;
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: Record<string, string>) {
+  try {
+    if (Object.keys(store).length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // The persisted session model remains the safe fallback.
+  }
+}
+
+export function loadSessionModels(): Record<string, string> {
+  return readStore();
+}
+
+export function rememberSessionModel(sessionId: string, model: string) {
+  const normalized = model.trim();
+  if (!sessionId || !normalized) return;
+  const store = readStore();
+  store[sessionId] = normalized;
+  writeStore(store);
+}
+
+export function forgetSessionModel(sessionId: string) {
+  const store = readStore();
+  if (!(sessionId in store)) return;
+  delete store[sessionId];
+  writeStore(store);
+}
+
+/** Clear the staged choice acknowledged by a completed run start without
+ * deleting a newer choice made while that start was still awaiting native
+ * work. */
+export function clearSessionModelIfApplied(sessionId: string, appliedModel: string) {
+  const store = readStore();
+  if (store[sessionId] !== appliedModel) return;
+  delete store[sessionId];
+  writeStore(store);
+}

--- a/src/lib/model-privacy.ts
+++ b/src/lib/model-privacy.ts
@@ -1,3 +1,4 @@
+import { AUTO_MODEL_ID } from "./agent-model-selection";
 import type { ProviderModelMode, VeniceModelDto } from "./tauri";
 
 export type ModelPrivacyMode = "e2ee" | "private" | "anonymous";
@@ -63,8 +64,12 @@ export function modelSupportsTools(
 
 export function modelAvailableForMode(
   mode: ProviderModelMode,
-  model: Partial<Pick<VeniceModelDto, "capabilities" | "provider">>,
+  model: Partial<Pick<VeniceModelDto, "id" | "capabilities" | "provider">>,
 ) {
+  // Auto is June's first-party router, not a concrete provider model. Its
+  // catalog row therefore does not need to duplicate every capability of the
+  // concrete model selected at request time.
+  if (mode === "generation" && model.id === AUTO_MODEL_ID) return true;
   if (mode === "generation" && model.provider && !modelSupportsTools(model)) {
     return false;
   }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3116,10 +3116,10 @@ button.agent-user-attachment:hover {
 /* While a turn streams, each newly revealed word mounts as a span and fades
  * in over a deliberately long window: a quick rise to ~30% ink so new words
  * are readable at once, then a slow linear crawl to full. Because the crawl
- * far outlasts the gap between chunks, the last second-or-so of prose reads
+ * far outlasts the gap between word-paced steps, the last second-or-so of prose reads
  * as a soft ink gradient trailing the reveal — SmoothedStreamingMarkdown
- * batches deltas so words that arrived together mount together and settle
- * together. Opacity-only on purpose: batches land several times a second and
+ * decouples the visible cadence from provider delta sizes. Opacity-only on
+ * purpose: new words land several times a second and
  * blur/transform here would churn compositor layers in WKWebView. The
  * settle clock below derives from the same duration token and keeps the spans
  * mounted after completion so the tail finishes settling instead of popping

--- a/src/test/agent-default-model.test.ts
+++ b/src/test/agent-default-model.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  persistAgentDefaultModel,
+  resetAgentDefaultModelPersistenceForTests,
+} from "../lib/agent-default-model";
+
+describe("agent default model persistence", () => {
+  beforeEach(resetAgentDefaultModelPersistenceForTests);
+
+  it("persists rapid choices in selection order even when the first write is slow", async () => {
+    let resolveFirst: (() => void) | undefined;
+    const firstWrite = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const writer = vi
+      .fn<(modelId: string) => Promise<void>>()
+      .mockImplementationOnce(() => firstWrite)
+      .mockResolvedValueOnce();
+
+    const first = persistAgentDefaultModel("fast", writer);
+    const second = persistAgentDefaultModel("open-software/auto", writer);
+    await vi.waitFor(() => expect(writer).toHaveBeenCalledTimes(1));
+    expect(writer).toHaveBeenNthCalledWith(1, "fast");
+
+    resolveFirst?.();
+    await Promise.all([first, second]);
+    expect(writer).toHaveBeenNthCalledWith(2, "open-software/auto");
+  });
+
+  it("continues with the latest choice after an earlier write fails", async () => {
+    const writer = vi
+      .fn<(modelId: string) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("first failed"))
+      .mockResolvedValueOnce();
+    const first = persistAgentDefaultModel("fast", writer);
+    const second = persistAgentDefaultModel("open-software/auto", writer);
+
+    await expect(first).rejects.toThrow("first failed");
+    await expect(second).resolves.toBeUndefined();
+    expect(writer).toHaveBeenNthCalledWith(2, "open-software/auto");
+  });
+});

--- a/src/test/agent-follow-up-queue.test.ts
+++ b/src/test/agent-follow-up-queue.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  loadQueuedAgentFollowUps,
+  reconcileConsumedAgentFollowUp,
+  saveQueuedAgentFollowUps,
+} from "../lib/agent-follow-up-queue";
+
+const queued = {
+  "session-1": {
+    messageId: "message-1",
+    prompt: "Continue with the attachment",
+    attachments: ["/tmp/brief.pdf"],
+    model: "open-software/auto",
+    thinkingLevel: "medium" as const,
+  },
+};
+
+describe("agent follow-up queue", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("survives a workspace remount", () => {
+    saveQueuedAgentFollowUps(queued);
+    expect(loadQueuedAgentFollowUps()).toEqual(queued);
+  });
+
+  it("drops a fallback once persisted history proves steering consumed it", () => {
+    expect(reconcileConsumedAgentFollowUp(queued, "session-1", ["steering:message-1"])).toEqual({});
+    expect(reconcileConsumedAgentFollowUp(queued, "session-1", ["steering:other"])).toBe(queued);
+  });
+
+  it("ignores malformed stored entries", () => {
+    window.localStorage.setItem(
+      "june.agent.queuedFollowUps",
+      JSON.stringify({ valid: queued["session-1"], invalid: { prompt: 42 } }),
+    );
+    expect(loadQueuedAgentFollowUps()).toEqual({ valid: queued["session-1"] });
+  });
+});

--- a/src/test/agent-session-models.test.ts
+++ b/src/test/agent-session-models.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearSessionModelIfApplied,
+  forgetSessionModel,
+  loadSessionModels,
+  rememberSessionModel,
+} from "../lib/agent-session-models";
+
+describe("agent session model drafts", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("retains staged choices independently by session", () => {
+    rememberSessionModel("one", "open-software/auto");
+    rememberSessionModel("two", "fast");
+    expect(loadSessionModels()).toEqual({ one: "open-software/auto", two: "fast" });
+
+    forgetSessionModel("one");
+    expect(loadSessionModels()).toEqual({ two: "fast" });
+  });
+
+  it("ignores corrupt and empty values", () => {
+    window.localStorage.setItem(
+      "june.agent.sessionModels",
+      JSON.stringify({ valid: "fast", empty: "", invalid: 42 }),
+    );
+    expect(loadSessionModels()).toEqual({ valid: "fast" });
+  });
+
+  it("does not let an older run acknowledgement erase a newer choice", () => {
+    rememberSessionModel("one", "kimi");
+    rememberSessionModel("one", "open-software/auto");
+    clearSessionModelIfApplied("one", "kimi");
+    expect(loadSessionModels()).toEqual({ one: "open-software/auto" });
+
+    clearSessionModelIfApplied("one", "open-software/auto");
+    expect(loadSessionModels()).toEqual({});
+  });
+});

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -390,16 +390,41 @@ describe("AgentWorkspace runtime wiring", () => {
       }),
     ).toBeVisible();
 
-    await user.clear(search);
+    await user.keyboard("{Escape}");
+    expect(search).toHaveValue("");
+    expect(search).toHaveFocus();
+    await user.click(screen.getByRole("button", { name: "All models" }));
+    expect(screen.getByRole("group", { name: "All text models" })).toBeVisible();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("group", { name: "All text models" })).not.toBeInTheDocument();
+    expect(search).toHaveFocus();
+
     await user.click(screen.getByRole("button", { name: /Effort.*Medium/ }));
     const effort = screen.getByRole("group", { name: "Thinking level" });
     expect(effort).toHaveClass("agent-composer-model-effort-panel");
-    expect(
-      within(effort).getByRole("menuitemradio", { name: /Low.*Faster responses/ }),
-    ).toBeVisible();
-    expect(
-      within(effort).getByRole("menuitemradio", { name: /High.*Deeper reasoning/ }),
-    ).toBeVisible();
+    const lowEffort = within(effort).getByRole("menuitemradio", {
+      name: /Low.*Faster responses/,
+    });
+    const mediumEffort = within(effort).getByRole("menuitemradio", {
+      name: /Medium.*Balances speed/,
+    });
+    const highEffort = within(effort).getByRole("menuitemradio", {
+      name: /High.*Deeper reasoning/,
+    });
+    expect(lowEffort).toBeVisible();
+    expect(highEffort).toBeVisible();
+    await waitFor(() => expect(mediumEffort).toHaveFocus());
+    await user.keyboard("{ArrowDown}");
+    expect(highEffort).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(screen.queryByRole("group", { name: "Thinking level" })).not.toBeInTheDocument();
+    const trigger = screen.getByRole("button", { name: "Model: Fast" });
+    await waitFor(() => expect(trigger).toHaveFocus());
+
+    await user.click(trigger);
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("combobox", { name: "Search models" })).not.toBeInTheDocument();
+    await waitFor(() => expect(trigger).toHaveFocus());
   });
 
   it("shows context, estimated charge, and per-tool usage for the latest run", async () => {
@@ -777,6 +802,44 @@ describe("AgentWorkspace runtime wiring", () => {
     await waitFor(() =>
       expect(container.querySelector(".agent-user-turn")).toHaveTextContent("Fresh request"),
     );
+  });
+
+  it("does not take over the workspace when a delayed fresh session finishes after navigation", async () => {
+    const user = userEvent.setup();
+    let resolveCreate: ((value: AgentSessionDto) => void) | undefined;
+    const pendingCreate = new Promise<AgentSessionDto>((resolve) => {
+      resolveCreate = resolve;
+    });
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "create_agent_session") return pendingCreate;
+      return defaultInvoke?.(command, args);
+    });
+
+    const onSessionSelected = vi.fn();
+    const { container, rerender } = render(
+      <AgentWorkspace onSessionSelected={onSessionSelected} />,
+    );
+    const composer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(composer, "Fresh request");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(container.querySelector(".agent-user-turn")).toHaveTextContent("Fresh request"),
+    );
+
+    rerender(<AgentWorkspace initialSession={session} onSessionSelected={onSessionSelected} />);
+    expect(await screen.findByText("Earlier answer")).toBeVisible();
+    await waitFor(() => expect(screen.queryByText("Fresh request")).not.toBeInTheDocument());
+
+    await act(async () => resolveCreate?.(newSession));
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", {
+        request: expect.objectContaining({ sessionId: newSession.id }),
+      }),
+    );
+    expect(screen.getByText("Earlier answer")).toBeVisible();
+    expect(screen.queryByText("Fresh request")).not.toBeInTheDocument();
+    expect(onSessionSelected).not.toHaveBeenCalledWith(newSession);
   });
 
   it("uses the priced June Auto model id for a fresh workspace", async () => {

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -399,7 +399,15 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(screen.queryByRole("group", { name: "All text models" })).not.toBeInTheDocument();
     expect(search).toHaveFocus();
 
-    await user.click(screen.getByRole("button", { name: /Effort.*Medium/ }));
+    const effortTrigger = screen.getByRole("button", { name: /Effort.*Medium/ });
+    fireEvent.mouseEnter(effortTrigger);
+    expect(await screen.findByRole("group", { name: "Thinking level" })).toBeVisible();
+    expect(search).toHaveFocus();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("group", { name: "Thinking level" })).not.toBeInTheDocument();
+    expect(search).toHaveFocus();
+
+    await user.click(effortTrigger);
     const effort = screen.getByRole("group", { name: "Thinking level" });
     expect(effort).toHaveClass("agent-composer-model-effort-panel");
     const lowEffort = within(effort).getByRole("menuitemradio", {
@@ -830,6 +838,9 @@ describe("AgentWorkspace runtime wiring", () => {
     rerender(<AgentWorkspace initialSession={session} onSessionSelected={onSessionSelected} />);
     expect(await screen.findByText("Earlier answer")).toBeVisible();
     await waitFor(() => expect(screen.queryByText("Fresh request")).not.toBeInTheDocument());
+    const activeComposer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(activeComposer, "Keep this draft");
+    await waitFor(() => expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled());
 
     await act(async () => resolveCreate?.(newSession));
     await waitFor(() =>
@@ -839,6 +850,8 @@ describe("AgentWorkspace runtime wiring", () => {
     );
     expect(screen.getByText("Earlier answer")).toBeVisible();
     expect(screen.queryByText("Fresh request")).not.toBeInTheDocument();
+    expect(activeComposer).toHaveTextContent("Keep this draft");
+    expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
     expect(onSessionSelected).not.toHaveBeenCalledWith(newSession);
   });
 

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -660,6 +660,48 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(onSessionSelected).toHaveBeenLastCalledWith(newSession);
   });
 
+  it("shows the first message and thinking before fresh session creation finishes", async () => {
+    const user = userEvent.setup();
+    let resolveCreate: ((value: AgentSessionDto) => void) | undefined;
+    const pendingCreate = new Promise<AgentSessionDto>((resolve) => {
+      resolveCreate = resolve;
+    });
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "create_agent_session") return pendingCreate;
+      if (
+        command === "list_agent_items" &&
+        (args as { sessionId?: string } | undefined)?.sessionId === newSession.id
+      ) {
+        return Promise.resolve([]);
+      }
+      return defaultInvoke?.(command, args);
+    });
+
+    const onSessionSelected = vi.fn();
+    const { container, rerender } = render(
+      <AgentWorkspace onSessionSelected={onSessionSelected} />,
+    );
+    const composer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(composer, "Fresh request");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(container.querySelector(".agent-user-turn")).toHaveTextContent("Fresh request"),
+    );
+    expect(screen.getByText("Thinking…")).toBeVisible();
+    expect(container.querySelector(".agent-workspace[data-hero='true']")).toBeNull();
+
+    await act(async () => resolveCreate?.(newSession));
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", expect.anything()),
+    );
+    rerender(<AgentWorkspace initialSession={newSession} onSessionSelected={onSessionSelected} />);
+    await waitFor(() =>
+      expect(container.querySelector(".agent-user-turn")).toHaveTextContent("Fresh request"),
+    );
+  });
+
   it("uses the priced June Auto model id for a fresh workspace", async () => {
     setCurrentDataPartitionName("private");
     const user = userEvent.setup();

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -111,6 +111,14 @@ describe("AgentWorkspace runtime wiring", () => {
           models: [
             {
               provider: "june",
+              id: "open-software/auto",
+              name: "Auto",
+              modelType: "text",
+              traits: [],
+              capabilities: [],
+            },
+            {
+              provider: "june",
               id: "fast",
               name: "Fast",
               modelType: "text",

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -801,11 +801,13 @@ describe("AgentWorkspace runtime wiring", () => {
     );
     expect(screen.getByText("Thinking…")).toBeVisible();
     expect(container.querySelector(".agent-workspace[data-hero='true']")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Session actions" })).not.toBeInTheDocument();
 
     await act(async () => resolveCreate?.(newSession));
     await waitFor(() =>
       expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", expect.anything()),
     );
+    expect(screen.getByRole("button", { name: "Session actions" })).toBeVisible();
     rerender(<AgentWorkspace initialSession={newSession} onSessionSelected={onSessionSelected} />);
     await waitFor(() =>
       expect(container.querySelector(".agent-user-turn")).toHaveTextContent("Fresh request"),

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -687,9 +687,18 @@ describe("AgentWorkspace runtime wiring", () => {
 
   it("keeps a queued follow-up owned by its running session across navigation", async () => {
     const defaultInvoke = mocks.invoke.getMockImplementation();
+    let resolveRevisitItems: ((items: unknown[]) => void) | undefined;
+    const revisitItems = new Promise<unknown[]>((resolve) => {
+      resolveRevisitItems = resolve;
+    });
+    let sessionAItemsCalls = 0;
     mocks.invoke.mockImplementation((command: string, args?: unknown) => {
       const sessionId = (args as { sessionId?: string } | undefined)?.sessionId;
       if (command === "list_agent_sessions") return Promise.resolve([session, newSession]);
+      if (command === "list_agent_items" && sessionId === session.id) {
+        sessionAItemsCalls += 1;
+        if (sessionAItemsCalls > 1) return revisitItems;
+      }
       if (command === "get_agent_session" && sessionId === newSession.id) {
         return Promise.resolve(newSession);
       }
@@ -742,6 +751,24 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(screen.queryByText("Only send this in session A")).not.toBeInTheDocument();
 
     rerender(<AgentWorkspace initialSession={session} />);
+    await act(async () => Promise.resolve());
+    expect(
+      mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run"),
+    ).toHaveLength(1);
+    await act(async () =>
+      resolveRevisitItems?.([
+        {
+          id: "message-1",
+          sessionId: session.id,
+          sequence: 1,
+          createdAt: session.createdAt,
+          kind: "message",
+          role: "assistant",
+          text: "Earlier answer",
+          status: "complete",
+        },
+      ]),
+    );
     await waitFor(() => {
       const starts = mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run");
       expect(starts).toHaveLength(2);
@@ -823,6 +850,12 @@ describe("AgentWorkspace runtime wiring", () => {
     await act(async () => rejectFirstStart?.(new Error("runtime unavailable")));
 
     rerender(<AgentWorkspace initialSession={session} />);
+    expect(await screen.findByRole("button", { name: "Retry queued follow-up" })).toBeVisible();
+    expect(
+      mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run"),
+    ).toHaveLength(1);
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "Retry queued follow-up" }));
     await waitFor(() => {
       const starts = mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run");
       expect(starts).toHaveLength(2);
@@ -1129,6 +1162,55 @@ describe("AgentWorkspace runtime wiring", () => {
     );
   });
 
+  it("keeps a failed first submission recoverable without replacing a newer draft", async () => {
+    const user = userEvent.setup();
+    let rejectCreate: ((error: Error) => void) | undefined;
+    const firstCreate = new Promise<AgentSessionDto>((_, reject) => {
+      rejectCreate = reject;
+    });
+    let createCount = 0;
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "create_agent_session" && createCount++ === 0) return firstCreate;
+      return defaultInvoke?.(command, args);
+    });
+    mocks.openDialog
+      .mockResolvedValueOnce(["/tmp/first.pdf"])
+      .mockResolvedValueOnce(["/tmp/later.pdf"]);
+
+    render(<AgentWorkspace />);
+    await user.click(screen.getByRole("button", { name: "Add files or notes" }));
+    await user.click(screen.getByRole("menuitem", { name: "Attach files" }));
+    const composer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(composer, "First submission");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await screen.findByText("Thinking…");
+
+    const laterComposer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(laterComposer, "Later draft");
+    await user.click(screen.getByRole("button", { name: "Add files or notes" }));
+    await user.click(screen.getByRole("menuitem", { name: "Attach files" }));
+    await act(async () => rejectCreate?.(new Error("session creation failed")));
+
+    expect(await screen.findByText("Unsent message")).toBeVisible();
+    expect(screen.getByText("First submission")).toBeVisible();
+    expect(laterComposer).toHaveTextContent("Later draft");
+    expect(screen.getByText("later.pdf")).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Retry unsent message" }));
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", {
+        request: expect.objectContaining({
+          prompt: "First submission",
+          attachments: ["/tmp/first.pdf"],
+        }),
+      }),
+    );
+    expect(laterComposer).toHaveTextContent("Later draft");
+    expect(screen.getByText("later.pdf")).toBeVisible();
+    expect(screen.queryByText("Unsent message")).not.toBeInTheDocument();
+  });
+
   it("stages model and effort changes made while a fresh session is still being created", async () => {
     const user = userEvent.setup();
     let resolveCreate: ((value: AgentSessionDto) => void) | undefined;
@@ -1190,6 +1272,9 @@ describe("AgentWorkspace runtime wiring", () => {
       "title",
       expect.stringContaining("Effort: High"),
     );
+    expect(
+      mocks.invoke.mock.calls.filter(([command]) => command === "set_venice_model"),
+    ).toHaveLength(1);
 
     rerender(<AgentWorkspace initialSession={session} />);
     expect(await screen.findByRole("button", { name: "Model: Fast" })).toBeEnabled();

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -38,6 +38,7 @@ import {
   setCurrentDataPartitionName,
 } from "../lib/data-partition";
 import { readJuneHomeStoredSessionId, writeJuneHomeStoredSessionId } from "../lib/june-home";
+import { saveQueuedAgentFollowUps } from "../lib/agent-follow-up-queue";
 
 const session: AgentSessionDto = {
   id: "session-1",
@@ -123,7 +124,7 @@ describe("AgentWorkspace runtime wiring", () => {
               name: "Fast",
               modelType: "text",
               traits: [],
-              capabilities: ["tools"],
+              capabilities: ["tool-calling"],
               privacy: "private",
               contextTokens: 200_000,
               inputCreditsPerMillionTokens: 2_000,
@@ -188,6 +189,7 @@ describe("AgentWorkspace runtime wiring", () => {
 
     render(<AgentWorkspace homeMode initialSession={homeSession} />);
     const composer = await screen.findByRole("textbox", { name: "Message June" });
+    expect(screen.queryByRole("button", { name: /Model:/ })).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Add files or notes" }));
     await user.click(screen.getByRole("menuitem", { name: "Attach files" }));
     await waitFor(() => expect(screen.getByText("brief.pdf")).toBeVisible());
@@ -308,8 +310,15 @@ describe("AgentWorkspace runtime wiring", () => {
         }),
       }),
     );
-    expect(screen.queryByRole("button", { name: "Model: Fast" })).not.toBeInTheDocument();
-    expect(screen.getByText("Fast")).toBeInTheDocument();
+    const activeRunPicker = screen.getByRole("button", { name: "Model: Fast" });
+    expect(activeRunPicker).toBeEnabled();
+    await user.click(activeRunPicker);
+    await user.click(
+      within(screen.getByRole("listbox", { name: "Suggested text models" })).getByRole("option", {
+        name: /Auto/,
+      }),
+    );
+    expect(screen.getByRole("button", { name: "Model: Auto" })).toBeEnabled();
 
     fireEvent.click(screen.getByRole("button", { name: "Stop June" }));
     await waitFor(() =>
@@ -330,7 +339,19 @@ describe("AgentWorkspace runtime wiring", () => {
       });
     });
 
-    await waitFor(() => expect(screen.getByRole("button", { name: "Model: Fast" })).toBeEnabled());
+    const nextRunPicker = await screen.findByRole("button", { name: "Model: Auto" });
+    expect(nextRunPicker).toBeEnabled();
+    const nextComposer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(nextComposer, "Use the staged model");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", {
+        request: expect.objectContaining({
+          prompt: "Use the staged model",
+          model: "open-software/auto",
+        }),
+      }),
+    );
   });
 
   it("restores Auto-only suggestions, root model search, and compact effort choices", async () => {
@@ -390,11 +411,27 @@ describe("AgentWorkspace runtime wiring", () => {
       }),
     ).toBeVisible();
 
+    await user.clear(search);
+    await user.type(search, "no-such-model");
+    const pickerDialog = screen.getByRole("dialog", { name: "Choose text model" });
+    expect(within(pickerDialog).getByRole("status")).toHaveTextContent(
+      "No results match your search.",
+    );
+    await user.clear(search);
+    await user.type(search, "Kimi");
+
     await user.keyboard("{Escape}");
     expect(search).toHaveValue("");
     expect(search).toHaveFocus();
     await user.click(screen.getByRole("button", { name: "All models" }));
     expect(screen.getByRole("group", { name: "All text models" })).toBeVisible();
+    const allModelsList = screen.getByRole("listbox", { name: "All text models" });
+    const allModelOptions = within(allModelsList).getAllByRole("option");
+    allModelOptions[0]?.focus();
+    fireEvent.keyDown(allModelsList, { key: "End" });
+    expect(allModelOptions.at(-1)).toHaveFocus();
+    fireEvent.keyDown(allModelsList, { key: "Home" });
+    expect(allModelOptions[0]).toHaveFocus();
     await user.keyboard("{Escape}");
     expect(screen.queryByRole("group", { name: "All text models" })).not.toBeInTheDocument();
     expect(search).toHaveFocus();
@@ -601,10 +638,25 @@ describe("AgentWorkspace runtime wiring", () => {
     await user.click(screen.getByRole("button", { name: "Send message" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Stop June" })).toBeVisible());
 
+    await user.click(screen.getByRole("button", { name: "Model: Fast" }));
+    await user.click(
+      within(screen.getByRole("listbox", { name: "Suggested text models" })).getByRole("option", {
+        name: /Auto/,
+      }),
+    );
+
     composer = screen.getByRole("textbox", { name: "Message June" });
     composer.textContent = "Send this next";
     fireEvent.input(composer);
     await user.click(await screen.findByRole("button", { name: "Queue follow-up" }));
+
+    await user.click(screen.getByRole("button", { name: "Model: Auto" }));
+    await user.click(screen.getByRole("button", { name: "All models" }));
+    await user.click(
+      within(screen.getByRole("group", { name: "All text models" })).getByRole("option", {
+        name: /Fast/,
+      }),
+    );
 
     act(() => {
       mocks.runtimeListener?.({
@@ -624,9 +676,269 @@ describe("AgentWorkspace runtime wiring", () => {
       const starts = mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run");
       expect(starts).toHaveLength(2);
       expect(starts[1]?.[1]).toMatchObject({
-        request: expect.objectContaining({ prompt: "Send this next" }),
+        request: expect.objectContaining({
+          prompt: "Send this next",
+          model: "open-software/auto",
+        }),
       });
     });
+    expect(screen.getByRole("button", { name: "Model: Fast" })).toBeEnabled();
+  });
+
+  it("keeps a queued follow-up owned by its running session across navigation", async () => {
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      const sessionId = (args as { sessionId?: string } | undefined)?.sessionId;
+      if (command === "list_agent_sessions") return Promise.resolve([session, newSession]);
+      if (command === "get_agent_session" && sessionId === newSession.id) {
+        return Promise.resolve(newSession);
+      }
+      if (command === "list_agent_items" && sessionId === newSession.id) {
+        return Promise.resolve([]);
+      }
+      return defaultInvoke?.(command, args);
+    });
+
+    const user = userEvent.setup();
+    mocks.openDialog.mockResolvedValue(["/tmp/follow-up.pdf"]);
+    const { rerender } = render(<AgentWorkspace initialSession={session} />);
+    await screen.findByText("Earlier answer");
+    let composer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(composer, "Start in session A");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await screen.findByRole("button", { name: "Stop June" });
+
+    composer = screen.getByRole("textbox", { name: "Message June" });
+    await user.click(screen.getByRole("button", { name: "Add files or notes" }));
+    await user.click(screen.getByRole("menuitem", { name: "Attach files" }));
+    expect(await screen.findByText("follow-up.pdf")).toBeVisible();
+    composer.textContent = "Only send this in session A";
+    fireEvent.input(composer);
+    await user.click(await screen.findByRole("button", { name: "Queue follow-up" }));
+    expect(screen.getByText("Queued follow-up")).toBeVisible();
+
+    rerender(<AgentWorkspace initialSession={newSession} />);
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Stop June" })).toBeNull());
+    expect(screen.queryByText("Queued follow-up")).not.toBeInTheDocument();
+
+    act(() => {
+      mocks.runtimeListener?.({
+        payload: {
+          protocolVersion: 1,
+          eventId: "event-session-a-completed",
+          sessionId: session.id,
+          runId: "run-1",
+          sequence: 3,
+          method: "run.completed",
+          data: { completedAt: "2026-07-22T12:01:00Z" },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      const starts = mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run");
+      expect(starts).toHaveLength(1);
+    });
+    expect(screen.queryByText("Only send this in session A")).not.toBeInTheDocument();
+
+    rerender(<AgentWorkspace initialSession={session} />);
+    await waitFor(() => {
+      const starts = mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run");
+      expect(starts).toHaveLength(2);
+      expect(starts[1]?.[1]).toMatchObject({
+        request: expect.objectContaining({
+          sessionId: session.id,
+          prompt: "Only send this in session A",
+          model: "fast",
+          attachments: ["/tmp/follow-up.pdf"],
+        }),
+      });
+    });
+  });
+
+  it("restores an attachment follow-up after the workspace remounts", async () => {
+    saveQueuedAgentFollowUps({
+      [session.id]: {
+        messageId: "restored-message",
+        prompt: "Resume with this file",
+        attachments: ["/tmp/restored.pdf"],
+        model: "open-software/auto",
+        thinkingLevel: "hard",
+      },
+    });
+
+    render(<AgentWorkspace initialSession={session} />);
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", {
+        request: expect.objectContaining({
+          sessionId: session.id,
+          prompt: "Resume with this file",
+          attachments: ["/tmp/restored.pdf"],
+          model: "open-software/auto",
+          reasoningEffort: "high",
+        }),
+      }),
+    );
+    expect(await screen.findByText("Resume with this file")).toBeVisible();
+  });
+
+  it("keeps a restored follow-up when its run start fails after navigation", async () => {
+    saveQueuedAgentFollowUps({
+      [session.id]: {
+        messageId: "retry-after-navigation",
+        prompt: "Retry this in session A",
+        attachments: ["/tmp/retry.pdf"],
+        model: "fast",
+        thinkingLevel: "medium",
+      },
+    });
+    let rejectFirstStart: ((error: Error) => void) | undefined;
+    const firstStart = new Promise((_, reject) => {
+      rejectFirstStart = reject;
+    });
+    let startCount = 0;
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      const sessionId = (args as { sessionId?: string } | undefined)?.sessionId;
+      if (command === "list_agent_sessions") return Promise.resolve([session, newSession]);
+      if (command === "get_agent_session" && sessionId === newSession.id) {
+        return Promise.resolve(newSession);
+      }
+      if (command === "list_agent_items" && sessionId === newSession.id) {
+        return Promise.resolve([]);
+      }
+      if (command === "start_agent_run" && startCount++ === 0) return firstStart;
+      return defaultInvoke?.(command, args);
+    });
+
+    const { rerender } = render(<AgentWorkspace initialSession={session} />);
+    await waitFor(() =>
+      expect(
+        mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run"),
+      ).toHaveLength(1),
+    );
+
+    rerender(<AgentWorkspace initialSession={newSession} />);
+    await waitFor(() => expect(screen.queryByText("Retry this in session A")).toBeNull());
+    await act(async () => rejectFirstStart?.(new Error("runtime unavailable")));
+
+    rerender(<AgentWorkspace initialSession={session} />);
+    await waitFor(() => {
+      const starts = mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run");
+      expect(starts).toHaveLength(2);
+      expect(starts[1]?.[1]).toMatchObject({
+        request: expect.objectContaining({
+          sessionId: session.id,
+          prompt: "Retry this in session A",
+          attachments: ["/tmp/retry.pdf"],
+        }),
+      });
+    });
+  });
+
+  it("does not replay a restored follow-up that persisted history already consumed", async () => {
+    saveQueuedAgentFollowUps({
+      [session.id]: {
+        messageId: "already-consumed",
+        prompt: "Do not send this twice",
+        attachments: [],
+        model: "fast",
+        thinkingLevel: "medium",
+      },
+    });
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "list_agent_items") {
+        return Promise.resolve([
+          {
+            id: "steering:already-consumed",
+            sessionId: session.id,
+            runId: "run-consumed",
+            sequence: 1,
+            createdAt: session.createdAt,
+            kind: "steering",
+            text: "Do not send this twice",
+          },
+        ]);
+      }
+      return defaultInvoke?.(command, args);
+    });
+
+    render(<AgentWorkspace initialSession={session} />);
+    expect(await screen.findByText("Steering: Do not send this twice")).toBeVisible();
+    await waitFor(() =>
+      expect(
+        mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run"),
+      ).toHaveLength(0),
+    );
+  });
+
+  it("does not let a slow global catalog overwrite a restored session model", async () => {
+    let resolveCatalog:
+      | ((value: {
+          mode: "generation";
+          selectedModel: string;
+          modelType: string;
+          models: Array<{
+            provider: string;
+            id: string;
+            name: string;
+            modelType: string;
+            traits: string[];
+            capabilities: string[];
+          }>;
+        }) => void)
+      | undefined;
+    const pendingCatalog = new Promise<{
+      mode: "generation";
+      selectedModel: string;
+      modelType: string;
+      models: Array<{
+        provider: string;
+        id: string;
+        name: string;
+        modelType: string;
+        traits: string[];
+        capabilities: string[];
+      }>;
+    }>((resolve) => {
+      resolveCatalog = resolve;
+    });
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "list_venice_models") return pendingCatalog;
+      return defaultInvoke?.(command, args);
+    });
+
+    render(<AgentWorkspace initialSessionId={session.id} />);
+    await screen.findByText("Earlier answer");
+
+    await act(async () =>
+      resolveCatalog?.({
+        mode: "generation",
+        selectedModel: "open-software/auto",
+        modelType: "text",
+        models: [
+          {
+            provider: "june",
+            id: "open-software/auto",
+            name: "Auto",
+            modelType: "text",
+            traits: [],
+            capabilities: [],
+          },
+          {
+            provider: "june",
+            id: "fast",
+            name: "Fast",
+            modelType: "text",
+            traits: [],
+            capabilities: ["tool-calling"],
+          },
+        ],
+      }),
+    );
+    expect(screen.getByRole("button", { name: "Model: Fast" })).toBeEnabled();
   });
 
   it("resolves clarification interruptions through the typed host command", async () => {
@@ -802,15 +1114,89 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(screen.getByText("Thinking…")).toBeVisible();
     expect(container.querySelector(".agent-workspace[data-hero='true']")).toBeNull();
     expect(screen.queryByRole("button", { name: "Session actions" })).not.toBeInTheDocument();
+    const followUpComposer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(followUpComposer, "Follow-up draft");
 
     await act(async () => resolveCreate?.(newSession));
     await waitFor(() =>
       expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", expect.anything()),
     );
     expect(screen.getByRole("button", { name: "Session actions" })).toBeVisible();
+    expect(followUpComposer).toHaveTextContent("Follow-up draft");
     rerender(<AgentWorkspace initialSession={newSession} onSessionSelected={onSessionSelected} />);
     await waitFor(() =>
       expect(container.querySelector(".agent-user-turn")).toHaveTextContent("Fresh request"),
+    );
+  });
+
+  it("stages model and effort changes made while a fresh session is still being created", async () => {
+    const user = userEvent.setup();
+    let resolveCreate: ((value: AgentSessionDto) => void) | undefined;
+    const pendingCreate = new Promise<AgentSessionDto>((resolve) => {
+      resolveCreate = resolve;
+    });
+    const createdSession = { ...newSession, model: "fast" };
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      const sessionId = (args as { sessionId?: string } | undefined)?.sessionId;
+      if (command === "create_agent_session") return pendingCreate;
+      if (command === "get_agent_session" && sessionId === createdSession.id) {
+        return Promise.resolve(createdSession);
+      }
+      if (command === "list_agent_items" && sessionId === createdSession.id) {
+        return Promise.resolve([]);
+      }
+      return defaultInvoke?.(command, args);
+    });
+
+    const { rerender } = render(<AgentWorkspace />);
+    await user.click(await screen.findByRole("button", { name: "Model: Auto" }));
+    await user.click(screen.getByRole("button", { name: "All models" }));
+    await user.click(
+      within(screen.getByRole("group", { name: "All text models" })).getByRole("option", {
+        name: /Fast/,
+      }),
+    );
+    const composer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(composer, "Create this slowly");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await screen.findByText("Thinking…");
+
+    await user.click(screen.getByRole("button", { name: "Model: Fast" }));
+    await user.click(
+      within(screen.getByRole("listbox", { name: "Suggested text models" })).getByRole("option", {
+        name: /Auto/,
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "Model: Auto" }));
+    await user.click(screen.getByRole("button", { name: /Effort.*Medium/ }));
+    await user.click(
+      within(screen.getByRole("group", { name: "Thinking level" })).getByRole("menuitemradio", {
+        name: /High.*Deeper reasoning/,
+      }),
+    );
+
+    await act(async () => resolveCreate?.(createdSession));
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", {
+        request: expect.objectContaining({
+          sessionId: createdSession.id,
+          model: "fast",
+          reasoningEffort: "medium",
+        }),
+      }),
+    );
+    expect(screen.getByRole("button", { name: "Model: Auto" })).toHaveAttribute(
+      "title",
+      expect.stringContaining("Effort: High"),
+    );
+
+    rerender(<AgentWorkspace initialSession={session} />);
+    expect(await screen.findByRole("button", { name: "Model: Fast" })).toBeEnabled();
+    rerender(<AgentWorkspace initialSession={createdSession} />);
+    expect(await screen.findByRole("button", { name: "Model: Auto" })).toHaveAttribute(
+      "title",
+      expect.stringContaining("Effort: High"),
     );
   });
 

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentRuntimeEvent, AgentSessionDto } from "../lib/agent-runtime-contract";
@@ -323,6 +323,75 @@ describe("AgentWorkspace runtime wiring", () => {
     });
 
     await waitFor(() => expect(screen.getByRole("button", { name: "Model: Fast" })).toBeEnabled());
+  });
+
+  it("restores Auto-only suggestions, root model search, and compact effort choices", async () => {
+    const user = userEvent.setup();
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "list_venice_models") {
+        return Promise.resolve({
+          mode: "generation",
+          selectedModel: "fast",
+          modelType: "text",
+          models: [
+            {
+              provider: "june",
+              id: "fast",
+              name: "Fast",
+              modelType: "text",
+              traits: [],
+              capabilities: ["tool-calling"],
+            },
+            {
+              provider: "venice",
+              id: "kimi-k3",
+              name: "Kimi K3",
+              modelType: "text",
+              traits: [],
+              capabilities: ["tool-calling"],
+            },
+            {
+              provider: "venice",
+              id: "zai-org-glm-5-2",
+              name: "GLM 5.2",
+              modelType: "text",
+              traits: [],
+              capabilities: ["tool-calling"],
+            },
+          ],
+        });
+      }
+      return defaultInvoke?.(command, args);
+    });
+
+    render(<AgentWorkspace initialSession={session} />);
+    await screen.findByText("Earlier answer");
+    await user.click(await screen.findByRole("button", { name: "Model: Fast" }));
+
+    const suggested = screen.getByRole("listbox", { name: "Suggested text models" });
+    expect(within(suggested).getByRole("option", { name: /Auto/ })).toBeVisible();
+    expect(within(suggested).queryByText("GLM 5.2")).not.toBeInTheDocument();
+    expect(within(suggested).queryByText("Kimi K3")).not.toBeInTheDocument();
+
+    const search = screen.getByRole("combobox", { name: "Search models" });
+    await user.type(search, "Kimi");
+    expect(
+      within(screen.getByRole("listbox", { name: "Matching models" })).getByRole("option", {
+        name: /Kimi K3/,
+      }),
+    ).toBeVisible();
+
+    await user.clear(search);
+    await user.click(screen.getByRole("button", { name: /Effort.*Medium/ }));
+    const effort = screen.getByRole("group", { name: "Thinking level" });
+    expect(effort).toHaveClass("agent-composer-model-effort-panel");
+    expect(
+      within(effort).getByRole("menuitemradio", { name: /Low.*Faster responses/ }),
+    ).toBeVisible();
+    expect(
+      within(effort).getByRole("menuitemradio", { name: /High.*Deeper reasoning/ }),
+    ).toBeVisible();
   });
 
   it("shows context, estimated charge, and per-tool usage for the latest run", async () => {

--- a/src/test/model-privacy.test.ts
+++ b/src/test/model-privacy.test.ts
@@ -4,6 +4,7 @@ import {
   E2EE_MODEL_DESCRIPTION,
   PRIVATE_MODEL_DESCRIPTION,
   modelIsPrivate,
+  modelAvailableForMode,
   modelPrivacyBadge,
   modelSupportsImageInput,
 } from "../lib/model-privacy";
@@ -71,6 +72,18 @@ describe("private catalog filter", () => {
     // A non-loopback custom endpoint reports "external" — no privacy claim.
     expect(modelIsPrivate({ privacy: "external", traits: [] })).toBe(false);
     expect(modelIsPrivate({ privacy: "", traits: [] })).toBe(false);
+  });
+});
+
+describe("model mode availability", () => {
+  it("keeps June Auto available without pretending it is a concrete tool model", () => {
+    expect(
+      modelAvailableForMode("generation", {
+        id: "open-software/auto",
+        provider: "june",
+        capabilities: [],
+      }),
+    ).toBe(true);
   });
 });
 

--- a/src/test/smoothed-streaming-markdown.test.tsx
+++ b/src/test/smoothed-streaming-markdown.test.tsx
@@ -75,7 +75,7 @@ describe("SmoothedStreamingMarkdown", () => {
     expect(view.container.textContent).not.toContain("1.");
   });
 
-  it("batches appended stream text into one whole-chunk reveal per beat", () => {
+  it("paces a large provider chunk into word-sized reveals", () => {
     vi.useFakeTimers();
     const view = render(<SmoothedStreamingMarkdown markdown="Hello" running repairProse />);
     view.rerender(
@@ -86,11 +86,32 @@ describe("SmoothedStreamingMarkdown", () => {
       />,
     );
 
-    // The delta holds for one batch interval, then mounts all at once — a
-    // chunk fading in as a unit, never a partial left-to-right dribble.
+    // A provider delta can contain a paragraph. Its transport boundary must
+    // not become one giant visible animation batch.
     expect(view.container.textContent).toBe("Hello");
-    act(() => vi.advanceTimersByTime(80));
+    act(() => vi.advanceTimersByTime(32));
+    expect(view.container.textContent).toBe("Hello from a");
+    act(() => vi.advanceTimersByTime(32));
+    expect(view.container.textContent).toBe("Hello from a larger provider");
+    act(() => vi.advanceTimersByTime(32));
     expect(view.container.textContent).toBe("Hello from a larger provider chunk");
+  });
+
+  it("limits the first non-empty provider delta without delaying its first words", () => {
+    vi.useFakeTimers();
+    const view = render(<SmoothedStreamingMarkdown markdown="" running />);
+
+    view.rerender(
+      <SmoothedStreamingMarkdown
+        markdown="Two visible words followed by the rest of a paragraph"
+        running
+      />,
+    );
+
+    expect(view.container.textContent).toBe("Two visible");
+    act(() => vi.advanceTimersByTime(32));
+    expect(view.container.textContent).toBe("Two visible words followed");
+    expect(view.container.textContent).not.toContain("paragraph");
   });
 
   it("flushes immediately when the turn completes", () => {
@@ -200,18 +221,22 @@ describe("SmoothedStreamingMarkdown", () => {
   });
 
   it("still renders valid emphasis after tightening literal-star handling", () => {
+    vi.useFakeTimers();
     const view = render(<SmoothedStreamingMarkdown markdown="before *valid words*" running />);
+    act(() => vi.runAllTimers());
 
     expect(view.container.querySelector("em")?.textContent).toBe("valid words");
   });
 
   it("excludes inline and fenced code from word-fade spans", () => {
+    vi.useFakeTimers();
     const view = render(
       <SmoothedStreamingMarkdown
         markdown={"Fade prose around `inline code`.\n\n```ts\nconst value = 1;\n```"}
         running
       />,
     );
+    act(() => vi.runAllTimers());
 
     expect(view.container.querySelector("p .agent-stream-word")).not.toBeNull();
     expect(view.container.querySelector("code .agent-stream-word")).toBeNull();
@@ -227,7 +252,7 @@ describe("SmoothedStreamingMarkdown", () => {
         running
       />,
     );
-    act(() => vi.advanceTimersByTime(80));
+    act(() => vi.runAllTimers());
 
     expect(view.container.querySelector("pre code")?.textContent).toBe("const value = 1;");
     expect(view.container.querySelector("p")?.textContent).toBe("Following prose");
@@ -239,6 +264,7 @@ describe("SmoothedStreamingMarkdown", () => {
     const view = render(
       <SmoothedStreamingMarkdown markdown={"> ```ts\n> const value = 1;"} running />,
     );
+    act(() => vi.runAllTimers());
 
     expect(view.container.querySelector("blockquote pre code")?.textContent).toBe(
       "const value = 1;",
@@ -250,7 +276,7 @@ describe("SmoothedStreamingMarkdown", () => {
         running
       />,
     );
-    act(() => vi.advanceTimersByTime(80));
+    act(() => vi.runAllTimers());
 
     expect(view.container.querySelector("blockquote pre code")?.textContent).toBe(
       "const value = 1;",
@@ -259,17 +285,21 @@ describe("SmoothedStreamingMarkdown", () => {
   });
 
   it("does not stall on a thematic break inside a blockquote", () => {
+    vi.useFakeTimers();
     const view = render(
       <SmoothedStreamingMarkdown markdown={"> ***\n> Following prose"} running />,
     );
+    act(() => vi.runAllTimers());
 
     expect(view.container.querySelector("blockquote hr")).not.toBeNull();
     expect(view.container.querySelector("blockquote p")?.textContent).toBe("Following prose");
   });
 
   it("reveals later paragraphs across renderer-recognized blank lines", () => {
+    vi.useFakeTimers();
     const markdown = "before *open\r\n \t\r\nNext paragraph";
     const view = render(<SmoothedStreamingMarkdown markdown={markdown} running />);
+    act(() => vi.runAllTimers());
 
     expect(
       [...view.container.querySelectorAll("p")].map((paragraph) => paragraph.textContent),
@@ -323,6 +353,7 @@ describe("SmoothedStreamingMarkdown", () => {
     const view = render(<SmoothedStreamingMarkdown markdown="" running />);
 
     view.rerender(<SmoothedStreamingMarkdown markdown={text} running />);
+    act(() => vi.runAllTimers());
 
     expect(view.container.textContent).toBe(text);
   });
@@ -331,12 +362,13 @@ describe("SmoothedStreamingMarkdown", () => {
     vi.useFakeTimers();
     const view = render(<SmoothedStreamingMarkdown markdown="" running />);
     view.rerender(<SmoothedStreamingMarkdown markdown="2 * 3" running />);
+    act(() => vi.runAllTimers());
     const three = [...view.container.querySelectorAll(".agent-stream-word")].find(
       (word) => word.textContent === "3",
     );
 
     view.rerender(<SmoothedStreamingMarkdown markdown="2 * 3 * 4" running />);
-    act(() => vi.advanceTimersByTime(80));
+    act(() => vi.runAllTimers());
 
     expect(view.container.textContent).toBe("2 * 3 * 4");
     expect(view.container.querySelector("em")).toBeNull();
@@ -366,7 +398,7 @@ describe("SmoothedStreamingMarkdown", () => {
         running
       />,
     );
-    act(() => vi.advanceTimersByTime(80));
+    act(() => vi.runAllTimers());
 
     expect(view.container.querySelector("th")?.textContent).toBe("Metric");
     expect(view.container.textContent).toBe("MetricQ1Revenue1.2M");
@@ -385,7 +417,7 @@ describe("SmoothedStreamingMarkdown", () => {
         running
       />,
     );
-    act(() => vi.advanceTimersByTime(80));
+    act(() => vi.runAllTimers());
 
     expect(view.container.querySelector("blockquote th")?.textContent).toBe("Metric");
     expect(view.container.textContent).toBe("MetricQ1Revenue1.2M");
@@ -397,12 +429,12 @@ describe("SmoothedStreamingMarkdown", () => {
     const view = render(<SmoothedStreamingMarkdown markdown="" running />);
 
     view.rerender(<SmoothedStreamingMarkdown markdown={table} running />);
-    act(() => vi.advanceTimersByTime(80));
+    act(() => vi.runAllTimers());
     expect(view.container.querySelector("table")).not.toBeNull();
 
     const afterTable = `${table}\nThe response continues after the table.`;
     view.rerender(<SmoothedStreamingMarkdown markdown={afterTable} running />);
-    act(() => vi.advanceTimersByTime(80));
+    act(() => vi.runAllTimers());
     expect(view.container.textContent).toContain("The response continues after the table.");
     expect(
       [...view.container.querySelectorAll(".agent-stream-word")].some(
@@ -413,7 +445,7 @@ describe("SmoothedStreamingMarkdown", () => {
     view.rerender(
       <SmoothedStreamingMarkdown markdown={`${afterTable} More streamed text.`} running />,
     );
-    act(() => vi.advanceTimersByTime(80));
+    act(() => vi.runAllTimers());
     expect(view.container.textContent).toContain(
       "The response continues after the table. More streamed text.",
     );


### PR DESCRIPTION
## What changed

- keep the first optimistic user turn and Thinking visible while a fresh session is created
- reveal streamed responses in word-sized steps instead of provider-sized paragraph chunks
- restore the pre-migration searchable model picker in focused agent sessions
- show Auto as the sole suggested model while keeping the full catalog searchable
- restore the compact effort panel with complete descriptions and keyboard navigation
- prevent delayed session creation from overriding a session the user navigated to

## Why

RC9 regressed startup feedback, streaming presentation, and model-picker parity during the Hermes replacement. Fresh sessions could appear blank, oversized provider deltas animated as paragraphs, model search disappeared, and the effort flyout became cramped.

## Validation

- 1,485 frontend tests passed
- TypeScript compilation passed
- Biome check passed with existing repository warnings only
- production frontend build passed
- focused model-picker and delayed-session regression coverage passed
- visual component QA passed for Auto-only suggestions, root catalog search, compact effort layout, and searched-model selection
- native macOS streaming walkthrough passed with a deterministic Chat Completions SSE provider

Follow-up to #920.
