### PR TITLE
fix(home): keep composer from covering prompts

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -675,7 +675,12 @@ export function AgentWorkspace({
   useLayoutEffect(() => {
     const scroller = scrollRef.current;
     const composer = composerRef.current;
-    if (newSessionMode || !selectedSession || !scroller || !composer) {
+    // Home renders its composer before it has a persisted backing session.
+    // It is still fixed over the scroller, so skipping clearance in that
+    // state lets the greeting and suggestions settle underneath the input.
+    // The focused new-session hero is inline and remains the only mode that
+    // intentionally needs no fixed-composer clearance.
+    if ((!homeMode && (newSessionMode || !selectedSession)) || !scroller || !composer) {
       setComposerClearance(0);
       return;
     }
@@ -695,7 +700,7 @@ export function AgentWorkspace({
       observer?.disconnect();
       window.removeEventListener("resize", measure);
     };
-  }, [newSessionMode, selectedSession]);
+  }, [homeMode, newSessionMode, selectedSession]);
 
   useLayoutEffect(() => {
     const shell = document.querySelector(".app-shell");

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -151,6 +151,49 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(agentComposerClearance(600, 620)).toBe(0);
   });
 
+  it("reserves the fixed composer before Home has a persisted session", async () => {
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "list_agent_sessions") return Promise.resolve([]);
+      if (command === "list_venice_models") {
+        return Promise.resolve({
+          mode: "generation",
+          selectedModel: "open-software/auto",
+          modelType: "text",
+          models: [],
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+    const bounds = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        const top = this.classList.contains("agent-composer") ? 520 : 0;
+        const bottom = this.classList.contains("agent-scroll") ? 640 : top;
+        return {
+          x: 0,
+          y: top,
+          top,
+          right: 0,
+          bottom,
+          left: 0,
+          width: 0,
+          height: Math.max(0, bottom - top),
+          toJSON: () => ({}),
+        } as DOMRect;
+      });
+
+    try {
+      const { container } = render(<AgentWorkspace homeMode />);
+      const scroller = container.querySelector<HTMLElement>(".agent-scroll");
+
+      await waitFor(() =>
+        expect(scroller?.style.getPropertyValue("--agent-composer-clearance")).toBe("120px"),
+      );
+    } finally {
+      bounds.mockRestore();
+    }
+  });
+
   it("hands Home attachments to a focused June runtime session with send-time profile", async () => {
     const user = userEvent.setup();
     const homeSession: AgentSessionDto = {


### PR DESCRIPTION
## Summary
- measure the fixed Home composer before the first session is persisted
- reserve dynamic timeline clearance for fresh Home profiles
- cover the fresh-profile regression with an exact layout test

## QA
- 
 RUN  v2.1.9 /Users/junhohong/code/open-software/os-june-home-composer-layout

 ✓ src/test/agent-notifications.test.ts (22 tests) 8ms
 ✓ src/test/hover-tip.test.tsx (12 tests) 70ms
 ✓ src/test/approval-card-css.test.ts (16 tests) 13ms
 ✓ src/test/app-state.test.ts (17 tests) 12ms
 ✓ src/test/agent-runtime-adapter.test.ts (9 tests) 6ms
 ✓ src/test/connectors.test.ts (18 tests) 7ms
 ✓ src/test/june-home.test.ts (12 tests) 19ms
 ✓ src/test/smoothed-streaming-markdown.test.tsx (48 tests) 63ms
 ✓ src/test/extension-release.test.mjs (23 tests) 82ms
 ✓ src/test/max-upgrade.test.ts (32 tests) 194ms
 ✓ src/test/tab-bar.test.tsx (23 tests) 122ms
 ✓ src/test/dictation-history.test.tsx (7 tests) 247ms
 ✓ src/test/billing-actions.test.ts (17 tests) 8ms
 ✓ src/test/account-gate.test.ts (29 tests) 5ms
 ✓ src/test/funding-notice.test.tsx (25 tests) 699ms
 ✓ src/test/share-dialog.test.tsx (14 tests) 777ms
 ✓ src/test/agent-project-context.test.ts (16 tests) 34ms
 ✓ src/test/june-spinner-grid.test.ts (4 tests) 5ms
 ✓ src/test/live-transcript-preview.test.ts (16 tests) 301ms
 ✓ src/test/recorder.test.tsx (13 tests) 126ms
 ✓ src/test/record-notices-demo.test.tsx (10 tests) 113ms
 ✓ src/test/computer-use-control.test.tsx (18 tests) 578ms
 ✓ src/test/composer-note-reference.test.ts (20 tests) 102ms
 ✓ src/test/sidebar-resize.test.ts (6 tests) 366ms
   ✓ handleSidebarResizeStart > keeps hero composer offsets auto under sidebar preview CSS 341ms
 ✓ src/test/hud-meeting.test.ts (35 tests) 1660ms
   ✓ meeting detection HUD > shows the take notes prompt when a meeting is detected 375ms
 ✓ src/test/agent-hud.test.ts (37 tests) 1679ms
   ✓ agent HUD > stays a collapsed pill with a running count when work starts 332ms
 ✓ src/test/note-save-controller.test.ts (8 tests) 21ms
 ✓ src/test/update-decision.test.ts (13 tests) 30ms
 ✓ src/test/computer-use-dev.test.mjs (7 tests) 15ms
 ✓ src/test/memory-settings-section.test.tsx (11 tests) 921ms
 ✓ src/test/routine-schedule.test.ts (16 tests) 17ms
 ✓ src/test/agent-note-entry-points.test.ts (13 tests) 377ms
 ✓ src/test/chat-image-generation.test.ts (10 tests) 6ms
 ✓ src/test/note-editor.test.tsx (50 tests) 1709ms
 ✓ src/test/connector-approvals-tray.test.tsx (7 tests) 239ms
 ✓ src/test/referral-nudge.test.ts (13 tests) 7ms
 ✓ src/test/onboarding.test.tsx (28 tests) 1933ms
 ✓ src/test/share-crypto.test.ts (14 tests) 150ms
 ✓ src/test/agent-mcp-servers.test.tsx (6 tests) 840ms
 ✓ src/test/use-follow-latest-scroll.test.tsx (10 tests) 21ms
 ✓ src/test/folders.test.tsx (30 tests) 1488ms
 ✓ src/test/autostart.test.ts (11 tests) 6ms
 ✓ src/test/font-scale.test.ts (8 tests) 8ms
 ✓ src/test/folders-workspace.test.tsx (34 tests) 1978ms
 ✓ src/test/note-failure-banner.test.tsx (13 tests) 141ms
 ✓ src/test/note-chat-sessions.test.ts (5 tests) 129ms
 ✓ src/test/recording-telemetry-rendering.test.tsx (2 tests) 41ms
 ✓ src/test/tabs.test.ts (13 tests) 4ms
 ✓ src/test/skill-slash-commands.test.ts (12 tests) 12ms
 ✓ src/test/source-readiness.test.ts (12 tests) 5ms
 ✓ src/test/scroll-thumb-fade.test.ts (7 tests) 17ms
 ✓ src/test/composer-editor-change-publishing.test.tsx (6 tests) 225ms
 ✓ src/test/thinking-level.test.ts (13 tests) 5ms
 ✓ src/test/composer-editor-lifecycle.test.tsx (2 tests) 10ms
 ✓ src/test/model-privacy.test.ts (13 tests) 4ms
 ✓ src/test/chat-video-generation.test.ts (5 tests) 4ms
 ✓ src/test/recording-inactivity.test.ts (8 tests) 3ms
 ✓ src/test/hover-bridge.test.ts (9 tests) 6ms
 ✓ src/test/workspace-lazy.test.tsx (3 tests) 113ms
 ✓ src/test/import-claude-projects-dialog.test.tsx (4 tests) 126ms
 ✓ src/test/updater.test.ts (8 tests) 11ms
 ✓ src/test/recording-telemetry.test.ts (4 tests) 4ms
 ✓ src/test/computer-use-approvals-tray.test.tsx (6 tests) 277ms
 ✓ src/test/home-polish-css.test.ts (8 tests) 15ms
 ✓ src/test/account-status.test.tsx (4 tests) 39ms
 ✓ src/test/tauri-contract.test.ts (6 tests) 5ms
 ✓ src/test/menu-bar.test.ts (4 tests) 10ms
 ✓ src/test/trust-mode-picker.test.tsx (6 tests) 186ms
 ✓ src/test/connectors-section.test.tsx (53 tests) 3275ms
 ✓ src/test/category-suggestion-list.test.tsx (3 tests) 93ms
 ✓ src/test/agent-composer-slash-commands.test.ts (7 tests) 15ms
 ✓ src/test/release-changelog.test.mjs (9 tests) 5ms
 ✓ src/test/experimental-flags.test.ts (5 tests) 67ms
 ✓ src/test/app-meeting-start.test.tsx (17 tests) 2652ms
   ✓ meeting start transcription event > drains the newer generation when an expired request loses the acknowledgement race 544ms
   ✓ meeting start transcription event > retains a meeting request while a competing start is provisional and retries after failure 666ms
 ✓ src/test/suggested-models.test.ts (7 tests) 4ms
 ✓ src/test/composer-editor-slash-menu.test.tsx (2 tests) 254ms
 ✓ src/test/agent-tool-labels.test.ts (8 tests) 4ms
 ✓ src/test/app-permissions.test.ts (10 tests) 3ms
 ✓ src/test/agent-turn-actions-css.test.ts (3 tests) 3ms
 ✓ src/test/list-render-hygiene.test.ts (3 tests) 23ms
 ✓ src/test/app-domain-actions.test.ts (2 tests) 3ms
 ✓ src/test/routines-view.test.tsx (58 tests) 4426ms
   ✓ RoutinesView templates and creation > creates a routine from the editor and opens its detail page 311ms
 ✓ src/test/spinner-demo.test.ts (3 tests) 127ms
 ✓ src/test/note-actions.test.ts (2 tests) 5ms
 ✓ src/test/dictionary-settings.test.tsx (2 tests) 351ms
   ✓ DictionarySettingsSection > loads, creates, edits, and deletes dictionary entries 340ms
 ✓ src/test/upstream-provider-recovery.test.ts (3 tests) 3ms
 ✓ src/test/folder-chip.test.tsx (4 tests) 330ms
 ✓ src/test/qa-tracker.test.mjs (5 tests) 27ms
 ✓ src/test/agent-sounds.test.ts (5 tests) 9ms
 ✓ src/test/dictation-events.test.ts (18 tests) 4ms
 ✓ src/test/set-build-version.test.mjs (10 tests) 4ms
 ✓ src/test/category-chip.test.ts (6 tests) 62ms
 ✓ src/test/version-bump.test.mjs (9 tests) 5ms
 ✓ src/test/agent-scroll-to-latest-css.test.ts (4 tests) 3ms
 ✓ src/test/trailing-microbatch.test.ts (6 tests) 5ms
 ✓ src/test/recording-sounds.test.ts (4 tests) 10ms
 ✓ src/test/local-storage-spec.test.ts (4 tests) 34ms
 ✓ src/test/use-scroll-fade.test.ts (4 tests) 16ms
 ✓ src/test/native-context-menu.test.ts (7 tests) 5ms
 ✓ src/test/dialog-close-lock.test.tsx (1 test) 51ms
 ✓ src/test/june-sounds-demo.test.ts (4 tests) 8ms
 ✓ src/test/share-link-copy-action.test.tsx (1 test) 55ms
 ✓ src/test/issue-report-prompt.test.ts (6 tests) 5ms
 ✓ src/test/account-avatar.test.ts (5 tests) 4ms
 ✓ src/test/model-spec-entries.test.ts (4 tests) 3ms
 ✓ src/test/interface-sounds.test.ts (2 tests) 4ms
 ✓ src/test/agent-runtime-bindings.test.ts (2 tests) 3ms
 ✓ src/test/shimmer-system.test.ts (2 tests) 3ms
 ✓ src/test/style-settings.test.tsx (1 test) 90ms
 ✓ src/test/hud-listener-lifecycle.test.ts (2 tests) 202ms
 ✓ src/test/css-stabilization.test.tsx (4 tests) 12ms
 ❯ src/test/agent-workspace-runtime.test.tsx (25 tests | 1 failed) 5574ms
   ✓ AgentWorkspace runtime wiring > hydrates history, shows an optimistic turn, and cancels 414ms
   ✓ AgentWorkspace runtime wiring > restores Auto-only suggestions, root model search, and compact effort choices 626ms
   ✓ AgentWorkspace runtime wiring > submits an unconsumed live instruction as the next run after settlement 396ms
   ✓ AgentWorkspace runtime wiring > keeps a failed first submission recoverable without replacing a newer draft 350ms
   × AgentWorkspace runtime wiring > stages model and effort changes made while a fresh session is still being created 1209ms
     → Unable to find an element with the text: Thinking…. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.

Ignored nodes: comments, script, style
[36m<body[39m
  [33mstyle[39m=[32m""[39m
[36m>[39m
  [36m<div>[39m
    [36m<section[39m
      [33maria-atomic[39m=[32m"false"[39m
      [33maria-label[39m=[32m"June notifications alt+T"[39m
      [33maria-live[39m=[32m"polite"[39m
      [33maria-relevant[39m=[32m"additions text"[39m
      [33mtabindex[39m=[32m"-1"[39m
    [36m/>[39m
  [36m</div>[39m
  [36m<div>[39m
    [36m<section[39m
      [33maria-label[39m=[32m"Session"[39m
      [33mclass[39m=[32m"agent-workspace"[39m
      [33mdata-hero[39m=[32m"true"[39m
    [36m>[39m
      [36m<main[39m
        [33maria-label[39m=[32m"Agent task details"[39m
        [33mclass[39m=[32m"agent-main"[39m
        [33mdata-hero[39m=[32m"true"[39m
      [36m>[39m
        [36m<div[39m
          [33mclass[39m=[32m"agent-hero-heading"[39m
        [36m>[39m
          [36m<h2[39m
            [33mclass[39m=[32m"agent-hero-title"[39m
          [36m>[39m
            [0mWhat can June do for you?[0m
          [36m</h2>[39m
        [36m</div>[39m
        [36m<form[39m
          [33mclass[39m=[32m"agent-composer"[39m
          [33mdata-hero[39m=[32m"true"[39m
        [36m>[39m
          [36m<div[39m
            [33mclass[39m=[32m"agent-composer-box"[39m
          [36m>[39m
            [36m<div[39m
              [33mclass[39m=[32m"agent-composer-editor-root scroll-fade"[39m
              [33mdata-caret-edge[39m=[32m"start"[39m
            [36m>[39m
              [36m<div>[39m
                [36m<div[39m
                  [33maria-label[39m=[32m"Message June"[39m
                  [33maria-multiline[39m=[32m"true"[39m
                  [33mclass[39m=[32m"tiptap ProseMirror agent-composer-editor"[39m
                  [33mcontenteditable[39m=[32m"true"[39m
                  [33mrole[39m=[32m"textbox"[39m
                  [33mtabindex[39m=[32m"0"[39m
                  [33mtranslate[39m=[32m"no"[39m
                [36m>[39m
                  [36m<p[39m
                    [33mclass[39m=[32m"is-empty is-editor-empty"[39m
                    [33mdata-placeholder[39m=[32m"Ask June anything, run / commands"[39m
                  [36m>[39m
                    [36m<br[39m
                      [33mclass[39m=[32m"ProseMirror-trailingBreak"[39m
                    [36m/>[39m
                  [36m</p>[39m
                [36m</div>[39m
              [36m</div>[39m
            [36m</div>[39m
            [36m<div[39m
              [33mclass[39m=[32m"agent-composer-toolbar"[39m
            [36m>[39m
              [36m<button[39m
                [33maria-expanded[39m=[32m"false"[39m
                [33maria-haspopup[39m=[32m"menu"[39m
                [33maria-label[39m=[32m"Add files or notes"[39m
                [33mclass[39m=[32m"agent-composer-attach"[39m
                [33mtitle[39m=[32m"Add"[39m
                [33mtype[39m=[32m"button"[39m
              [36m>[39m
                [36m<svg[39m
                  [33maria-hidden[39m=[32m"true"[39m
                  [33mfill[39m=[32m"none"[39m
                  [33mheight[39m=[32m"18px"[39m
                  [33mviewBox[39m=[32m"0 0 24 24"[39m
                  [33mwidth[39m=[32m"18px"[39m
                  [33mxmlns[39m=[32m"http://www.w3.org/2000/svg"[39m
                [36m>[39m
                  [36m<path[39m
                    [33md[39m=[32m"M12 5.5V12M12 12V18.5M12 12H5.5M12 12H18.5"[39m
                    [33mstroke[39m=[32m"currentColor"[39m
                    [33mstroke-linecap[39m=[32m"round"[39m
                    [33mstroke-width[39m=[32m"2"[39m
                  [36m/>[39m
                [36m</svg>[39m
              [36m</button>[39m
              [36m<button[39m
                [33maria-expanded[39m=[32m"false"[39m
                [33maria-haspopup[39m=[32m"menu"[39m
                [33mclass[39m=[32m"agent-sandbox-trigger"[39m
                [33mtitle[39m=[32m"Change what June can touch"[39m
                [33mtype[39m=[32m"button"[39m
              [36m>[39m
                [36m<svg[39m
                  [33maria-hidden[39m=[32m"true"[39m
                  [33mfill[39m=[32m"none"[39m
                  [33mheight[39m=[32m"14px"[39m
                  [33mviewBox[39m=[32m"0 0 24 24"[39m
                  [33mwidth[39m=[32m"14px"[39m
                  [33mxmlns[39m=[32m"http://www.w3.org/2000/svg"[39m
                [36m>[39m
                  [36m<path[39m
                    [33md[39m=[32m"M9.5 11.75L11 13.25L14.5 9.75M20 11.9123V7.17737C20 6.32338 19.4578 5.56361 18.6502 5.286L12.9752 3.33524C12.3432 3.11799 11.6568 3.11799 11.0248 3.33524L5.34984 5.286C4.54224 5.56361 4 6.32338 4 7.17737V11.9123C4 16.8848 8 19 12 21.1579C16 19 20 16.8848 20 11.9123Z"[39m
                    [33mstroke[39m=[32m"currentColor"[39m
                    [33mstroke-linecap[39m=[32m"round"[39m
                    [33mstroke-linejoin[39m=[32m"round"[39m
                    [33mstroke-width[39m=[32m"2"[39m
                  [36m/>[39m
                [36m</svg>[39m
                [0mSandboxed[0m
                [36m<svg[39m
                  [33maria-hidden[39m=[32m"true"[39m
                  [33mfill[39m=[32m"none"[39m
                  [33mheight[39m=[32m"12px"[39m
                  [33mviewBox[39m=[32m"0 0 24 24"[39m
                  [33mwidth[39m=[32m"12px"[39m
                  [33mxmlns[39m=[32m"http://www.w3.org/2000/svg"[39m
                [36m>[39m
                  [36m<path[39m
                    [33md[39m=[32m"M8 10L10.9393 12.9393C11.5251 13.5251 12.4749 13.5251 13.0607 12.9393L16 10"[39m
                    [33mstroke[39m=[32m"currentColor"[39m
                    [33mstroke-linecap[39m=[32m"round"[39m
                    [33mstroke-linejoin[39m=[32m"round"[39m
                    [33mstroke-width[39m=[32m"2"[39m
                  [36m/>[39m
                [36m</svg>[39m
              [36m</button>[39m
              [36m<div[39m
                [33mclass[39m=[32m"agent-composer-actions"[39m
              [36m>[39m
                [36m<div[39m
                  [33mclass[39m=[32m"agent-composer-model"[39m
                  [33mdata-open[39m=[32m"true"[39m
                [36m>[39m
                  [36m<button[39m
                    [33maria-describedby[39m=[32m":rc6:"[39m
                    [33maria-expanded[39m=[32m"true"[39m
                    [33maria-haspopup[39m=[32m"dialog"[39m
                    [33maria-label[39m=[32m"Model: Fast"[39m
                    [33mclass[39m=[32m"agent-composer-model-trigger"[39m
                    [33mtitle[39m=[32m"Model: Fast. Effort: Medium."[39m
                    [33mtype[39m=[32m"button"[39m...

Ignored nodes: comments, script, style
[36m<body[39m
  [33mstyle[39m=[32m""[39m
[36m>[39m
  [36m<div>[39m
    [36m<section[39m
      [33maria-atomic[39m=[32m"false"[39m
      [33maria-label[39m=[32m"June notifications alt+T"[39m
      [33maria-live[39m=[32m"polite"[39m
      [33maria-relevant[39m=[32m"additions text"[39m
      [33mtabindex[39m=[32m"-1"[39m
    [36m/>[39m
  [36m</div>[39m
  [36m<div>[39m
    [36m<section[39m
      [33maria-label[39m=[32m"Session"[39m
      [33mclass[39m=[32m"agent-workspace"[39m
      [33mdata-hero[39m=[32m"true"[39m
    [36m>[39m
      [36m<main[39m
        [33maria-label[39m=[32m"Agent task details"[39m
        [33mclass[39m=[32m"agent-main"[39m
        [33mdata-hero[39m=[32m"true"[39m
      [36m>[39m
        [36m<div[39m
          [33mclass[39m=[32m"agent-hero-heading"[39m
        [36m>[39m
          [36m<h2[39m
            [33mclass[39m=[32m"agent-hero-title"[39m
          [36m>[39m
            [0mWhat can June do for you?[0m
          [36m</h2>[39m
        [36m</div>[39m
        [36m<form[39m
          [33mclass[39m=[32m"agent-composer"[39m
          [33mdata-hero[39m=[32m"true"[39m
        [36m>[39m
          [36m<div[39m
            [33mclass[39m=[32m"agent-composer-box"[39m
          [36m>[39m
            [36m<div[39m
              [33mclass[39m=[32m"agent-composer-editor-root scroll-fade"[39m
              [33mdata-caret-edge[39m=[32m"start"[39m
            [36m>[39m
              [36m<div>[39m
                [36m<div[39m
                  [33maria-label[39m=[32m"Message June"[39m
                  [33maria-multiline[39m=[32m"true"[39m
                  [33mclass[39m=[32m"tiptap ProseMirror agent-composer-editor"[39m
                  [33mcontenteditable[39m=[32m"true"[39m
                  [33mrole[39m=[32m"textbox"[39m
                  [33mtabindex[39m=[32m"0"[39m
                  [33mtranslate[39m=[32m"no"[39m
                [36m>[39m
                  [36m<p[39m
                    [33mclass[39m=[32m"is-empty is-editor-empty"[39m
                    [33mdata-placeholder[39m=[32m"Ask June anything, run / commands"[39m
                  [36m>[39m
                    [36m<br[39m
                      [33mclass[39m=[32m"ProseMirror-trailingBreak"[39m
                    [36m/>[39m
                  [36m</p>[39m
                [36m</div>[39m
              [36m</div>[39m
            [36m</div>[39m
            [36m<div[39m
              [33mclass[39m=[32m"agent-composer-toolbar"[39m
            [36m>[39m
              [36m<button[39m
                [33maria-expanded[39m=[32m"false"[39m
                [33maria-haspopup[39m=[32m"menu"[39m
                [33maria-label[39m=[32m"Add files or notes"[39m
                [33mclass[39m=[32m"agent-composer-attach"[39m
                [33mtitle[39m=[32m"Add"[39m
                [33mtype[39m=[32m"button"[39m
              [36m>[39m
                [36m<svg[39m
                  [33maria-hidden[39m=[32m"true"[39m
                  [33mfill[39m=[32m"none"[39m
                  [33mheight[39m=[32m"18px"[39m
                  [33mviewBox[39m=[32m"0 0 24 24"[39m
                  [33mwidth[39m=[32m"18px"[39m
                  [33mxmlns[39m=[32m"http://www.w3.org/2000/svg"[39m
                [36m>[39m
                  [36m<path[39m
                    [33md[39m=[32m"M12 5.5V12M12 12V18.5M12 12H5.5M12 12H18.5"[39m
                    [33mstroke[39m=[32m"currentColor"[39m
                    [33mstroke-linecap[39m=[32m"round"[39m
                    [33mstroke-width[39m=[32m"2"[39m
                  [36m/>[39m
                [36m</svg>[39m
              [36m</button>[39m
              [36m<button[39m
                [33maria-expanded[39m=[32m"false"[39m
                [33maria-haspopup[39m=[32m"menu"[39m
                [33mclass[39m=[32m"agent-sandbox-trigger"[39m
                [33mtitle[39m=[32m"Change what June can touch"[39m
                [33mtype[39m=[32m"button"[39m
              [36m>[39m
                [36m<svg[39m
                  [33maria-hidden[39m=[32m"true"[39m
                  [33mfill[39m=[32m"none"[39m
                  [33mheight[39m=[32m"14px"[39m
                  [33mviewBox[39m=[32m"0 0 24 24"[39m
                  [33mwidth[39m=[32m"14px"[39m
                  [33mxmlns[39m=[32m"http://www.w3.org/2000/svg"[39m
                [36m>[39m
                  [36m<path[39m
                    [33md[39m=[32m"M9.5 11.75L11 13.25L14.5 9.75M20 11.9123V7.17737C20 6.32338 19.4578 5.56361 18.6502 5.286L12.9752 3.33524C12.3432 3.11799 11.6568 3.11799 11.0248 3.33524L5.34984 5.286C4.54224 5.56361 4 6.32338 4 7.17737V11.9123C4 16.8848 8 19 12 21.1579C16 19 20 16.8848 20 11.9123Z"[39m
                    [33mstroke[39m=[32m"currentColor"[39m
                    [33mstroke-linecap[39m=[32m"round"[39m
                    [33mstroke-linejoin[39m=[32m"round"[39m
                    [33mstroke-width[39m=[32m"2"[39m
                  [36m/>[39m
                [36m</svg>[39m
                [0mSandboxed[0m
                [36m<svg[39m
                  [33maria-hidden[39m=[32m"true"[39m
                  [33mfill[39m=[32m"none"[39m
                  [33mheight[39m=[32m"12px"[39m
                  [33mviewBox[39m=[32m"0 0 24 24"[39m
                  [33mwidth[39m=[32m"12px"[39m
                  [33mxmlns[39m=[32m"http://www.w3.org/2000/svg"[39m
                [36m>[39m
                  [36m<path[39m
                    [33md[39m=[32m"M8 10L10.9393 12.9393C11.5251 13.5251 12.4749 13.5251 13.0607 12.9393L16 10"[39m
                    [33mstroke[39m=[32m"currentColor"[39m
                    [33mstroke-linecap[39m=[32m"round"[39m
                    [33mstroke-linejoin[39m=[32m"round"[39m
                    [33mstroke-width[39m=[32m"2"[39m
                  [36m/>[39m
                [36m</svg>[39m
              [36m</button>[39m
              [36m<div[39m
                [33mclass[39m=[32m"agent-composer-actions"[39m
              [36m>[39m
                [36m<div[39m
                  [33mclass[39m=[32m"agent-composer-model"[39m
                  [33mdata-open[39m=[32m"true"[39m
                [36m>[39m
                  [36m<button[39m
                    [33maria-describedby[39m=[32m":rc6:"[39m
                    [33maria-expanded[39m=[32m"true"[39m
                    [33maria-haspopup[39m=[32m"dialog"[39m
                    [33maria-label[39m=[32m"Model: Fast"[39m
                    [33mclass[39m=[32m"agent-composer-model-trigger"[39m
                    [33mtitle[39m=[32m"Model: Fast. Effort: Medium."[39m
                    [33mtype[39m=[32m"button"[39m...
 ✓ src/test/computer-use-agent-run.test.ts (19 tests) 10ms
 ✓ src/test/report-category.test.ts (5 tests) 15ms
 ✓ src/test/select-popover.test.ts (4 tests) 3ms
 ✓ src/test/agent-thinking.test.tsx (2 tests) 26ms
 ✓ src/test/app-shell-layout.test.ts (2 tests) 4ms
 ✓ src/test/agent-default-model.test.ts (2 tests) 55ms
 ✓ src/test/model-picker-dialog.test.tsx (2 tests) 28ms
 ✓ src/test/download-toast-css.test.ts (1 test) 2ms
 ✓ src/test/date-format.test.ts (4 tests) 18ms
 ✓ src/test/agent-session-models.test.ts (3 tests) 3ms
 ✓ |june-extension| src/test/protocol.test.ts (6 tests) 3ms
 ✓ |june-extension| src/test/pairing.test.ts (8 tests) 2ms
 ✓ src/test/dev-app-identity.test.mjs (7 tests) 4ms
 ✓ src/test/agent-follow-up-queue.test.ts (3 tests) 5ms
 ✓ src/test/connector-policy.test.tsx (2 tests) 112ms
 ✓ src/test/session-partition-filter.test.ts (1 test) 2ms
 ✓ src/test/recovery.test.tsx (1 test) 45ms
 ✓ src/test/hud-css.test.ts (1 test) 2ms
 ✓ src/test/agent-session-bar.test.tsx (1 test) 47ms
 ✓ src/test/note-pdf.test.ts (3 tests) 4ms
 ✓ src/test/provider-logo.test.tsx (3 tests) 14ms
 ✓ src/test/select.test.tsx (1 test) 20ms
 ✓ src/test/agent-runtime-signing.test.ts (2 tests) 3ms
 ✓ src/test/june-glass-mark.test.tsx (1 test) 8ms
 ✓ src/test/agent-sound-settings.test.ts (2 tests) 3ms
 ✓ src/test/thinking-level-meter.test.tsx (3 tests) 11ms
 ✓ src/test/app-shortcut.test.tsx (35 tests) 5711ms
   ✓ App shortcuts > keeps notes, session history, and sign out available while funding is required 305ms
   ✓ App shortcuts > does not overlap system audio readiness polls while a probe is pending 1272ms
   ✓ App shortcuts > pauses system audio readiness polling while recording is active 1273ms
 ✓ src/test/dev-ports.test.mjs (2 tests) 3ms
 ✓ src/test/dialog-layering.test.ts (3 tests) 4ms
 ✓ |june-extension| src/test/browser.test.ts (26 tests) 957ms
   ✓ native payload chunking > keeps chunks well below the native frame limit and roundtrips bytes 945ms
 ✓ src/test/app-notes-reliability.test.tsx (44 tests) 6854ms
   ✓ notes recording reliability > shows calendar context as soon as the backend matches the open note 307ms
   ✓ notes recording reliability > retains and retries a request after an IPC failure 556ms
   ✓ notes recording reliability > clears the recorder presence and disables retry when a recovery is discarded 309ms

 Test Files  1 failed | 142 passed (143)
      Tests  1 failed | 1501 passed (1502)
   Start at  06:12:34
   Duration  10.70s (transform 10.56s, setup 72.27s, collect 32.20s, tests 50.27s, environment 66.63s, prepare 6.34s)

[ELIFECYCLE] Test failed. See above for more details. (1,502 tests)
- vite v6.4.2 building for production...
transforming...
✓ 1522 modules transformed.
rendering chunks...
computing gzip size...
dist/meeting-hud.html                            1.52 kB │ gzip:   0.54 kB
dist/agent-hud.html                              2.40 kB │ gzip:   0.73 kB
dist/hud.html                                    3.28 kB │ gzip:   0.90 kB
dist/index.html                                  3.51 kB │ gzip:   1.25 kB
dist/assets/meeting-hud-DRaQXno7.css            15.53 kB │ gzip:   4.14 kB
dist/assets/hud-DP2eMcHK.css                    23.56 kB │ gzip:   5.59 kB
dist/assets/agent-hud-CgTS_h7t.css              24.10 kB │ gzip:   5.79 kB
dist/assets/main-GwC9A89E.css                  471.90 kB │ gzip:  65.81 kB
dist/assets/index-cyyxFyH3.js                    0.31 kB │ gzip:   0.20 kB
dist/assets/index-DPZGnfX_.js                    0.60 kB │ gzip:   0.41 kB
dist/assets/hud-lifecycle-DPiRqdZd.js            0.67 kB │ gzip:   0.36 kB
dist/assets/recorder-levels-Bg5mLGjy.js          0.79 kB │ gzip:   0.42 kB
dist/assets/index-BthsmLbj.js                    1.22 kB │ gzip:   0.67 kB
dist/assets/meeting-hud-DkxWARop.js              2.20 kB │ gzip:   1.07 kB
dist/assets/NoteFailureBanner-2tNPjUKV.js        2.26 kB │ gzip:   1.18 kB
dist/assets/onboarding-CbxemzYR.js               2.90 kB │ gzip:   1.26 kB
dist/assets/session-title-rzSTGQ5E.js            6.23 kB │ gzip:   2.32 kB
dist/assets/native-context-menu-j6j_djcD.js      7.72 kB │ gzip:   3.28 kB
dist/assets/vendor-react-JmLSyO4Y.js             7.91 kB │ gzip:   3.02 kB
dist/assets/tauri-9KQyu4F-.js                   13.52 kB │ gzip:   3.59 kB
dist/assets/audio-meter-BFWM_SXM.js             14.72 kB │ gzip:   4.11 kB
dist/assets/agent-hud-BYJ4Ly41.js               15.84 kB │ gzip:   5.24 kB
dist/assets/hud-A4IXv2i6.js                     16.91 kB │ gzip:   5.51 kB
dist/assets/NoteEditor-DkKQwk9n.js              36.99 kB │ gzip:  11.02 kB
dist/assets/FoldersWorkspace-BhXrGBuv.js        44.44 kB │ gzip:  11.30 kB
dist/assets/RoutinesView-DRQMiNzZ.js            62.93 kB │ gzip:  18.96 kB
dist/assets/vendor-react-server-q2t3vez9.js     70.20 kB │ gzip:  22.95 kB
dist/assets/vendor-react-dom-CbDobrz2.js       134.86 kB │ gzip:  43.31 kB
dist/assets/vendor-editor-CN4n5TVq.js          447.34 kB │ gzip: 142.74 kB
dist/assets/glass-mark-canvas-D5g-iO2s.js      977.00 kB │ gzip: 270.43 kB
dist/assets/main-zlJHzcdT.js                 1,032.33 kB │ gzip: 299.53 kB
✓ built in 3.67s
- The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 673.
Checked 518 files in 453ms. No fixes applied.
Found 691 warnings.
Found 2 infos. (passes with existing warnings)
- visual at 1818x598 dark mode: 44px prompt-to-composer gap
- expanded three-line composer at 1200x500: 44.5px gap, no overlap

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787652781&installation_model_id=425925&pr_number=967&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F967&signature=48159552624bdda179a64ceca25d034369977e5e02881b4620fefa388986287b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->