### PR TITLE
fix(agent): restore Auto Economy, Balanced, and Quality

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1123,7 +1123,7 @@ export function AgentWorkspace({
 
     let focusedSession: AgentSessionDto | undefined;
     try {
-      const focusedModel = focusedHomeModelRef.current;
+      const focusedModel = agentRunModelId(focusedHomeModelRef.current, costQualityRef.current);
       const focusedThinkingLevel = focusedHomeThinkingLevelRef.current;
       focusedSession = await agentRuntimeBindings.createSession({
         title: request.title,
@@ -1617,11 +1617,13 @@ export function AgentWorkspace({
       setError(messageFromError(cause));
     }
   };
+  const runDisplayModel = agentModelSelection(projection.run?.model ?? "").modelId;
+  const sessionDisplayModel = agentModelSelection(selectedSession?.model ?? model).modelId;
   const usageModel = selectedModel(
     models,
-    models.some((candidate) => candidate.id === projection.run?.model)
-      ? (projection.run?.model ?? model)
-      : (selectedSession?.model ?? model),
+    models.some((candidate) => candidate.id === runDisplayModel)
+      ? runDisplayModel
+      : sessionDisplayModel,
   );
   const runUsage = projection.run?.usage;
   const contextLimit = usageModel?.contextTokens;
@@ -2033,9 +2035,7 @@ export function AgentWorkspace({
           <div className="agent-usage-body">
             <div className="agent-usage-row">
               <span className="agent-usage-primary">Model</span>
-              <span className="agent-usage-value">
-                {usageModel?.name ?? projection.run?.model ?? selectedSession.model}
-              </span>
+              <span className="agent-usage-value">{usageModel?.name ?? sessionDisplayModel}</span>
             </div>
             {projection.run?.usage?.provider || usageModel?.provider ? (
               <div className="agent-usage-row">

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -47,12 +47,14 @@ import {
   type JuneHomeChatResponse,
   listVeniceModels,
   providerModelSettings,
+  setCostQuality as setProviderCostQuality,
   type VeniceModelDto,
 } from "../../lib/tauri";
 import { shouldBlockTextOnFunding } from "../../lib/account-gate";
 import { dispatchAgentSessionStatus, dispatchAgentSessionsChanged } from "../../lib/agent-events";
 import { messageFromError } from "../../lib/errors";
 import { persistAgentDefaultModel } from "../../lib/agent-default-model";
+import { agentModelSelection, agentRunModelId } from "../../lib/agent-model-selection";
 import {
   loadQueuedAgentFollowUps,
   reconcileConsumedAgentFollowUp,
@@ -100,6 +102,7 @@ import { ComposerEditor, type ComposerEditorHandle } from "./composer/ComposerEd
 import { agentComposerClearance } from "./composer/layout";
 import { ComposerModelPicker, heroPrivacyFootnote } from "./composer/ModelPicker";
 import { modelPrivacyBadge } from "../../lib/model-privacy";
+import { autoPillDesignation } from "../../lib/suggested-models";
 import { getCurrentDataPartitionName } from "../../lib/data-partition";
 import { AUTO_MODEL_ID, modelOptions, selectedModel } from "../settings/ModelPickerDialog";
 import { ModelPickerPopover, type ModelPickerFlyout } from "../settings/ModelPickerPopover";
@@ -254,11 +257,18 @@ export function AgentWorkspace({
   const [veniceApiKeyConfigured, setVeniceApiKeyConfigured] = useState(false);
   const focusedHomeModelRef = useRef(DEFAULT_MODEL);
   const focusedHomeThinkingLevelRef = useRef(loadThinkingLevel());
-  const [model, setModel] = useState(
-    homeMode ? AUTO_MODEL_ID : initialAgentSession?.model || DEFAULT_MODEL,
-  );
+  const initialModelSelection = agentModelSelection(initialAgentSession?.model || DEFAULT_MODEL);
+  const [model, setModel] = useState(homeMode ? AUTO_MODEL_ID : initialModelSelection.modelId);
   const modelRef = useRef(model);
   modelRef.current = model;
+  const [costQuality, setCostQuality] = useState(initialModelSelection.costQuality ?? 100);
+  const costQualityRef = useRef(costQuality);
+  costQualityRef.current = costQuality;
+  const confirmedCostQualityRef = useRef(costQuality);
+  const costQualitySaveChainRef = useRef<Promise<void>>(Promise.resolve());
+  const latestCostQualitySaveRef = useRef(0);
+  const costQualityIntentRevisionRef = useRef(0);
+  const sessionCostQualityExplicitRef = useRef(initialModelSelection.costQuality !== undefined);
   const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(() => {
     if (homeMode) return "instant";
     const sessionLevel = initialAgentSession?.id
@@ -379,6 +389,42 @@ export function AgentWorkspace({
     [onSessionSelected],
   );
 
+  const applyCostQuality = useCallback((value: number) => {
+    const normalized = Math.max(0, Math.min(100, Math.round(value)));
+    costQualityIntentRevisionRef.current += 1;
+    costQualityRef.current = normalized;
+    setCostQuality(normalized);
+    const sessionId = selectedIdRef.current;
+    if (sessionId) {
+      sessionCostQualityExplicitRef.current = true;
+      rememberSessionModel(sessionId, agentRunModelId(modelRef.current, normalized));
+      return;
+    }
+
+    sessionCostQualityExplicitRef.current = false;
+    const version = ++latestCostQualitySaveRef.current;
+    const save = costQualitySaveChainRef.current.then(() => setProviderCostQuality(normalized));
+    costQualitySaveChainRef.current = save.then(
+      () => undefined,
+      () => undefined,
+    );
+    void save.then(
+      (next) => {
+        confirmedCostQualityRef.current = next.costQuality;
+        if (version !== latestCostQualitySaveRef.current) return;
+        costQualityRef.current = next.costQuality;
+        setCostQuality(next.costQuality);
+        setError(undefined);
+      },
+      (cause) => {
+        if (version !== latestCostQualitySaveRef.current) return;
+        costQualityRef.current = confirmedCostQualityRef.current;
+        setCostQuality(confirmedCostQualityRef.current);
+        setError(messageFromError(cause));
+      },
+    );
+  }, []);
+
   const selectedSession =
     sessions.find((session) => session.id === selectedId) ?? projection.session;
   const running = projection.run?.status === "running" || projection.run?.status === "queued";
@@ -455,6 +501,19 @@ export function AgentWorkspace({
     return next;
   }, [publishSessions]);
 
+  const applySessionModel = useCallback((storedModel: string) => {
+    const selection = agentModelSelection(storedModel);
+    setModel(selection.modelId || DEFAULT_MODEL);
+    sessionCostQualityExplicitRef.current = selection.costQuality !== undefined;
+    if (selection.costQuality !== undefined) {
+      costQualityRef.current = selection.costQuality;
+      setCostQuality(selection.costQuality);
+    } else {
+      costQualityRef.current = confirmedCostQualityRef.current;
+      setCostQuality(confirmedCostQualityRef.current);
+    }
+  }, []);
+
   const hydrate = useCallback(
     async (sessionId: string) => {
       const requestId = crypto.randomUUID();
@@ -482,7 +541,11 @@ export function AgentWorkspace({
       );
       setHydratedSelectionId(sessionId);
       setArtifacts(files);
-      setModel(homeMode ? AUTO_MODEL_ID : (loadSessionModels()[session.id] ?? session.model));
+      if (homeMode) {
+        setModel(AUTO_MODEL_ID);
+      } else {
+        applySessionModel(loadSessionModels()[session.id] ?? session.model);
+      }
       setThinkingLevel(
         homeMode ? "instant" : (loadSessionThinkingLevels()[session.id] ?? loadThinkingLevel()),
       );
@@ -491,7 +554,7 @@ export function AgentWorkspace({
       if (!homeMode) writeLastOpenSessionId(sessionId);
       onSessionSelected?.(session);
     },
-    [homeMode, onSessionSelected, updateQueuedFollowUps],
+    [applySessionModel, homeMode, onSessionSelected, updateQueuedFollowUps],
   );
 
   useEffect(() => {
@@ -519,10 +582,17 @@ export function AgentWorkspace({
         }
       })
       .catch(() => undefined);
+    const costQualityRequestRevision = costQualityIntentRevisionRef.current;
     void providerModelSettings()
-      .then((response) =>
-        setVeniceApiKeyConfigured(response.effectiveSettings.veniceApiKeyConfigured),
-      )
+      .then((response) => {
+        setVeniceApiKeyConfigured(response.effectiveSettings.veniceApiKeyConfigured);
+        if (costQualityRequestRevision !== costQualityIntentRevisionRef.current) return;
+        confirmedCostQualityRef.current = response.settings.costQuality;
+        if (!sessionCostQualityExplicitRef.current) {
+          costQualityRef.current = response.settings.costQuality;
+          setCostQuality(response.settings.costQuality);
+        }
+      })
       .catch(() => setVeniceApiKeyConfigured(false));
   }, [homeMode, initialAgentSession, initialSessionId, refreshSessions]);
 
@@ -545,7 +615,9 @@ export function AgentWorkspace({
         ...current.filter((session) => session.id !== initialSession.id),
       ]);
       setProjection((current) => ({ ...current, session: initialSession }));
-      setModel(loadSessionModels()[initialSession.id] ?? (initialSession.model || DEFAULT_MODEL));
+      applySessionModel(
+        loadSessionModels()[initialSession.id] ?? (initialSession.model || DEFAULT_MODEL),
+      );
       setSafetyMode(initialSession.safetyMode);
       setNewSessionMode(false);
     }
@@ -553,7 +625,7 @@ export function AgentWorkspace({
       if (homeMode && selectedIdRef.current !== nextId) return;
       setError(messageFromError(cause));
     });
-  }, [homeMode, hydrate, initialSession?.id, initialSessionId]);
+  }, [applySessionModel, homeMode, hydrate, initialSession?.id, initialSessionId]);
 
   useEffect(() => {
     const handleNewSession = (event: Event) => {
@@ -735,7 +807,13 @@ export function AgentWorkspace({
       const messageId = crypto.randomUUID();
       updateQueuedFollowUps((current) => ({
         ...current,
-        [ownerSessionId]: { messageId, prompt, attachments, model, thinkingLevel },
+        [ownerSessionId]: {
+          messageId,
+          prompt,
+          attachments,
+          model: agentRunModelId(model, costQuality),
+          thinkingLevel,
+        },
       }));
       setDraft("");
       setAttachments([]);
@@ -750,7 +828,8 @@ export function AgentWorkspace({
     recoverableSubmissionSnapshotRef.current = undefined;
     const queuedSnapshot = queuedSubmission;
     const recoveredSnapshot = recoveredSubmission;
-    const submittedModel = queuedSnapshot?.model ?? recoveredSnapshot?.model ?? model;
+    const submittedModel =
+      queuedSnapshot?.model ?? recoveredSnapshot?.model ?? agentRunModelId(model, costQuality);
     const submittedThinkingLevel =
       queuedSnapshot?.thinkingLevel ?? recoveredSnapshot?.thinkingLevel ?? thinkingLevel;
     const submissionId = crypto.randomUUID();
@@ -799,7 +878,7 @@ export function AgentWorkspace({
           profile: getCurrentDataPartitionName(),
         });
         session = createdSession;
-        const latestModel = modelRef.current;
+        const latestModel = agentRunModelId(modelRef.current, costQualityRef.current);
         if (latestModel !== submittedModel) {
           rememberSessionModel(createdSession.id, latestModel);
         }
@@ -1610,17 +1689,27 @@ export function AgentWorkspace({
       draft={draft}
       setDraft={setComposerDraft}
       model={model}
-      setModel={(nextModel) => {
+      setModel={(nextModel, nextCostQuality) => {
+        const selectedCostQuality =
+          nextModel === AUTO_MODEL_ID ? (nextCostQuality ?? costQualityRef.current) : undefined;
         setModel(nextModel);
         if (selectedId) {
-          rememberSessionModel(selectedId, nextModel);
+          if (selectedCostQuality !== undefined) {
+            costQualityRef.current = selectedCostQuality;
+            setCostQuality(selectedCostQuality);
+          }
+          sessionCostQualityExplicitRef.current = selectedCostQuality !== undefined;
+          rememberSessionModel(selectedId, agentRunModelId(nextModel, selectedCostQuality));
           return;
         }
         if (pendingSessionCreationRef.current) return;
+        if (nextCostQuality !== undefined) applyCostQuality(nextCostQuality);
         void persistAgentDefaultModel(nextModel).catch((cause) => {
           if (modelRef.current === nextModel) setError(messageFromError(cause));
         });
       }}
+      costQuality={costQuality}
+      onCostQualityChange={applyCostQuality}
       thinkingLevel={thinkingLevel}
       setThinkingLevel={(level) => {
         setThinkingLevel(level);
@@ -2133,6 +2222,8 @@ function AgentComposer({
   setDraft,
   model,
   setModel,
+  costQuality,
+  onCostQualityChange,
   thinkingLevel,
   setThinkingLevel,
   models,
@@ -2155,7 +2246,9 @@ function AgentComposer({
   draft: string;
   setDraft: (value: string) => void;
   model: string;
-  setModel: (value: string) => void;
+  setModel: (value: string, costQuality?: number) => void;
+  costQuality: number;
+  onCostQualityChange: (value: number) => void;
   thinkingLevel: ThinkingLevel;
   setThinkingLevel: (value: ThinkingLevel) => void;
   models: VeniceModelDto[];
@@ -2348,6 +2441,7 @@ function AgentComposer({
               <ComposerModelPicker
                 open={modelOpen}
                 model={activeModel}
+                detail={model === AUTO_MODEL_ID ? autoPillDesignation(costQuality) : undefined}
                 effort={thinkingLevel}
                 triggerRef={modelTriggerRef}
                 onToggleOpen={() => {
@@ -2492,6 +2586,7 @@ function AgentComposer({
           flyout={modelFlyout}
           model={activeModel}
           options={modelOptions(pickerModels, model)}
+          costQuality={costQuality}
           search={modelSearch}
           popoverRef={modelPopoverRef}
           searchRef={modelSearchRef}
@@ -2500,16 +2595,18 @@ function AgentComposer({
           onRootSearchChange={setModelRootSearch}
           catalogLoaded={models.length > 0}
           suggestedModelIds={AGENT_SUGGESTED_MODEL_IDS}
+          showAutoToggle={false}
           thinkingLevel={thinkingLevel}
           onFlyoutChange={setModelFlyout}
           onSearchChange={setModelSearch}
-          onSelect={(nextModel, _costQuality, options) => {
-            setModel(nextModel);
+          onSelect={(nextModel, nextCostQuality, options) => {
+            setModel(nextModel, nextCostQuality);
             if (!options?.keepOpen) {
               setModelOpen(false);
               requestAnimationFrame(() => modelTriggerRef.current?.focus());
             }
           }}
+          onCostQualityChange={onCostQualityChange}
           onSelectThinking={(level) => {
             setThinkingLevel(level);
             setModelFlyout(null);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -402,6 +402,7 @@ export function AgentWorkspace({
     }
 
     sessionCostQualityExplicitRef.current = false;
+    const sessionIdAtSave = selectedIdRef.current;
     const version = ++latestCostQualitySaveRef.current;
     const save = costQualitySaveChainRef.current.then(() => setProviderCostQuality(normalized));
     costQualitySaveChainRef.current = save.then(
@@ -411,7 +412,12 @@ export function AgentWorkspace({
     void save.then(
       (next) => {
         confirmedCostQualityRef.current = next.costQuality;
-        if (version !== latestCostQualitySaveRef.current) return;
+        if (
+          version !== latestCostQualitySaveRef.current ||
+          selectedIdRef.current !== sessionIdAtSave
+        ) {
+          return;
+        }
         costQualityRef.current = next.costQuality;
         setCostQuality(next.costQuality);
         setError(undefined);

--- a/src/components/settings/ModelPickerPopover.tsx
+++ b/src/components/settings/ModelPickerPopover.tsx
@@ -117,6 +117,7 @@ export function ModelPickerPopover({
   onSearchChange,
   onSelect,
   onCostQualityChange,
+  showAutoToggle = true,
   showAutoPreference = true,
   thinkingLevel,
   onSelectThinking,
@@ -162,10 +163,12 @@ export function ModelPickerPopover({
   /** `keepOpen` asks the host to leave the popover mounted (used by the Auto
    * toggle, where switching is a mid-flow adjustment, not a final pick). */
   onSelect: (modelId: string, costQuality?: number, options?: { keepOpen?: boolean }) => void;
-  /** Enables the pinned Auto section (generation surfaces): a toggle that
-   * swaps the selection to/from the Auto router, plus the Preference
-   * drill-in writing through this callback while Auto is on. */
+  /** Enables the pinned Auto controls on generation surfaces. */
   onCostQualityChange?: (value: number) => void;
+  /** Whether Auto is a pinned toggle or remains in the host's suggestion
+   * list. Agent sessions keep Auto as their one quick pick and use the
+   * Preference row only after it is selected. */
+  showAutoToggle?: boolean;
   /** Whether Auto's Preference drill-in appears inside the popover. Settings
    * keeps that preference visible as its own segmented row, so its picker
    * omits the duplicate while retaining the Auto toggle. */
@@ -378,9 +381,9 @@ export function ModelPickerPopover({
           // With the Auto section shown, the toggle is the router's one home;
           // keep the catalog's Auto entry out of the lists so it doesn't
           // double up as a row.
-          !(onCostQualityChange && option.id === AUTO_MODEL_ID),
+          !(onCostQualityChange && showAutoToggle && option.id === AUTO_MODEL_ID),
       ),
-    [mode, onCostQualityChange, options],
+    [mode, onCostQualityChange, options, showAutoToggle],
   );
   const suggested = useMemo(() => {
     if (!suggestedModelIds) return suggestedModelsForMode(mode, selectable);
@@ -440,7 +443,7 @@ export function ModelPickerPopover({
   const rootQuery = (rootSearch ?? "").trim().toLowerCase();
   const rootQueryActive = Boolean(rootSearchRef) && Boolean(rootQuery);
   const rootControlTerms = [
-    ...(onCostQualityChange ? ["auto", "automatic"] : []),
+    ...(onCostQualityChange && showAutoToggle ? ["auto", "automatic"] : []),
     ...(onCostQualityChange && autoEnabled && showAutoPreference
       ? [
           "preference",
@@ -458,7 +461,7 @@ export function ModelPickerPopover({
       rootControlTerms.some((term) => term.toLowerCase().includes(queryTerm)),
     );
   const rootVisibleControlCount =
-    (onCostQualityChange ? 1 : 0) +
+    (onCostQualityChange && showAutoToggle ? 1 : 0) +
     (onCostQualityChange && autoEnabled && showAutoPreference ? 1 : 0) +
     (thinkingLevel && onSelectThinking ? 1 : 0);
   const rootMatchingSuggested = rootQueryActive
@@ -831,7 +834,7 @@ export function ModelPickerPopover({
                 .filter(Boolean)
                 .join(" ")}
             >
-              {onCostQualityChange ? (
+              {onCostQualityChange && showAutoToggle ? (
                 <>
                   <div className="agent-composer-model-filter agent-composer-model-auto-toggle">
                     <span>Auto</span>

--- a/src/lib/agent-model-selection.ts
+++ b/src/lib/agent-model-selection.ts
@@ -1,1 +1,29 @@
 export const AUTO_MODEL_ID = "open-software/auto";
+
+// Rust decodes this tagged model at the June API boundary and forwards the
+// selected Auto cost-to-quality value with the request. Keeping it in the
+// run model also makes a session's preference survive navigation, retries,
+// and app restarts without changing the public runtime protocol.
+export const AGENT_RUN_AUTO_MODEL_PREFIX = "__june_auto_generation__:";
+
+export type AgentModelSelection = {
+  modelId: string;
+  costQuality?: number;
+};
+
+export function agentRunModelId(modelId: string, costQuality?: number): string {
+  if (modelId !== AUTO_MODEL_ID || costQuality === undefined || !Number.isFinite(costQuality)) {
+    return modelId;
+  }
+  const normalized = Math.max(0, Math.min(100, Math.round(costQuality)));
+  return `${AGENT_RUN_AUTO_MODEL_PREFIX}${normalized}`;
+}
+
+export function agentModelSelection(modelId: string): AgentModelSelection {
+  if (!modelId.startsWith(AGENT_RUN_AUTO_MODEL_PREFIX)) return { modelId };
+  const encoded = modelId.slice(AGENT_RUN_AUTO_MODEL_PREFIX.length);
+  if (!/^\d{1,3}$/.test(encoded)) return { modelId: AUTO_MODEL_ID };
+  const parsed = Number(encoded);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 100) return { modelId: AUTO_MODEL_ID };
+  return { modelId: AUTO_MODEL_ID, costQuality: parsed };
+}

--- a/src/test/agent-model-selection.test.ts
+++ b/src/test/agent-model-selection.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentModelSelection,
+  agentRunModelId,
+  AGENT_RUN_AUTO_MODEL_PREFIX,
+  AUTO_MODEL_ID,
+} from "../lib/agent-model-selection";
+
+describe("agent Auto model selections", () => {
+  it("encodes the Auto preference for the June API run boundary", () => {
+    expect(agentRunModelId(AUTO_MODEL_ID, 20)).toBe(`${AGENT_RUN_AUTO_MODEL_PREFIX}20`);
+    expect(agentRunModelId(AUTO_MODEL_ID, 50)).toBe(`${AGENT_RUN_AUTO_MODEL_PREFIX}50`);
+    expect(agentRunModelId(AUTO_MODEL_ID, 100)).toBe(`${AGENT_RUN_AUTO_MODEL_PREFIX}100`);
+    expect(agentRunModelId("fast", 20)).toBe("fast");
+  });
+
+  it("decodes persisted Auto preferences without exposing the tagged model in the picker", () => {
+    expect(agentModelSelection(`${AGENT_RUN_AUTO_MODEL_PREFIX}20`)).toEqual({
+      modelId: AUTO_MODEL_ID,
+      costQuality: 20,
+    });
+    expect(agentModelSelection(`${AGENT_RUN_AUTO_MODEL_PREFIX}50`)).toEqual({
+      modelId: AUTO_MODEL_ID,
+      costQuality: 50,
+    });
+    expect(agentModelSelection(`${AGENT_RUN_AUTO_MODEL_PREFIX}100`)).toEqual({
+      modelId: AUTO_MODEL_ID,
+      costQuality: 100,
+    });
+  });
+
+  it("falls back safely for malformed preferences and preserves concrete models", () => {
+    expect(agentModelSelection(`${AGENT_RUN_AUTO_MODEL_PREFIX}101`)).toEqual({
+      modelId: AUTO_MODEL_ID,
+    });
+    expect(agentModelSelection(`${AGENT_RUN_AUTO_MODEL_PREFIX}wat`)).toEqual({
+      modelId: AUTO_MODEL_ID,
+    });
+    expect(agentModelSelection("fast")).toEqual({ modelId: "fast" });
+  });
+});

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -66,7 +66,7 @@ describe("AgentWorkspace runtime wiring", () => {
     mocks.runtimeListener = undefined;
     mocks.invoke.mockReset();
     mocks.openDialog.mockReset();
-    mocks.invoke.mockImplementation((command: string) => {
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
       if (command === "list_agent_sessions") return Promise.resolve([session]);
       if (command === "get_agent_session") return Promise.resolve(session);
       if (command === "list_agent_items") {
@@ -132,6 +132,16 @@ describe("AgentWorkspace runtime wiring", () => {
             },
           ],
         });
+      }
+      if (command === "provider_model_settings") {
+        return Promise.resolve({
+          settings: { costQuality: 100 },
+          effectiveSettings: { veniceApiKeyConfigured: false },
+        });
+      }
+      if (command === "set_cost_quality") {
+        const value = (args as { request?: { value?: number } } | undefined)?.request?.value ?? 100;
+        return Promise.resolve({ costQuality: value });
       }
       if (command === "create_agent_session") return Promise.resolve(newSession);
       if (command === "start_agent_run") {
@@ -391,7 +401,7 @@ describe("AgentWorkspace runtime wiring", () => {
       expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", {
         request: expect.objectContaining({
           prompt: "Use the staged model",
-          model: "open-software/auto",
+          model: "__june_auto_generation__:100",
         }),
       }),
     );
@@ -513,6 +523,165 @@ describe("AgentWorkspace runtime wiring", () => {
     await user.keyboard("{Escape}");
     expect(screen.queryByRole("combobox", { name: "Search models" })).not.toBeInTheDocument();
     await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it("restores Auto Economy, Balanced, and Quality with session-persistent routing", async () => {
+    const user = userEvent.setup();
+    const autoSession = {
+      ...session,
+      model: "__june_auto_generation__:50",
+    };
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "list_agent_sessions") return Promise.resolve([autoSession]);
+      if (command === "get_agent_session") return Promise.resolve(autoSession);
+      if (command === "provider_model_settings") {
+        return Promise.resolve({
+          settings: { costQuality: 100 },
+          effectiveSettings: { veniceApiKeyConfigured: false },
+        });
+      }
+      return defaultInvoke?.(command, args);
+    });
+
+    render(<AgentWorkspace initialSession={autoSession} />);
+    await screen.findByText("Earlier answer");
+    const trigger = await screen.findByRole("button", { name: "Model: Auto" });
+    expect(trigger).toHaveAttribute("title", expect.stringContaining("Preference: Balanced"));
+
+    await user.click(trigger);
+    await user.click(screen.getByRole("button", { name: /Preference.*Balanced/ }));
+    const preferences = screen.getByRole("group", { name: "Auto preference" });
+    expect(
+      within(preferences).getByRole("menuitemradio", {
+        name: /Economy.*Favors cheaper models/,
+      }),
+    ).toBeVisible();
+    expect(
+      within(preferences).getByRole("menuitemradio", {
+        name: /Balanced.*Weighs quality against cost/,
+      }),
+    ).toBeVisible();
+    expect(
+      within(preferences).getByRole("menuitemradio", {
+        name: /Quality.*Routes to the strongest model/,
+      }),
+    ).toBeVisible();
+
+    await user.click(within(preferences).getByRole("menuitemradio", { name: /Economy/ }));
+    expect(trigger).toHaveAttribute("title", expect.stringContaining("Preference: Economy"));
+    expect(mocks.invoke).not.toHaveBeenCalledWith("set_cost_quality", expect.anything());
+
+    await user.keyboard("{Escape}");
+    await waitFor(() =>
+      expect(screen.queryByRole("group", { name: "Auto preference" })).not.toBeInTheDocument(),
+    );
+    await user.keyboard("{Escape}");
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Choose text model" })).not.toBeInTheDocument(),
+    );
+    const composer = screen.getByRole("textbox", { name: "Message June" });
+    composer.textContent = "Use Economy";
+    fireEvent.input(composer);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled());
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", {
+        request: expect.objectContaining({
+          sessionId: autoSession.id,
+          prompt: "Use Economy",
+          model: "__june_auto_generation__:20",
+        }),
+      }),
+    );
+  });
+
+  it("persists a fresh Auto preference and applies it to the first run", async () => {
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+
+    const trigger = await screen.findByRole("button", { name: "Model: Auto" });
+    expect(trigger).toHaveAttribute("title", expect.stringContaining("Preference: Quality"));
+    await user.click(trigger);
+    await user.click(screen.getByRole("button", { name: /Preference.*Quality/ }));
+    await user.click(
+      within(screen.getByRole("group", { name: "Auto preference" })).getByRole("menuitemradio", {
+        name: /Economy/,
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("set_cost_quality", {
+        request: { value: 20 },
+      }),
+    );
+
+    await user.keyboard("{Escape}");
+    await waitFor(() =>
+      expect(screen.queryByRole("group", { name: "Auto preference" })).not.toBeInTheDocument(),
+    );
+    await user.keyboard("{Escape}");
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Choose text model" })).not.toBeInTheDocument(),
+    );
+    const composer = screen.getByRole("textbox", { name: "Message June" });
+    composer.textContent = "Fresh Economy request";
+    fireEvent.input(composer);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled());
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("create_agent_session", {
+        request: expect.objectContaining({
+          title: "Fresh Economy request",
+          model: "__june_auto_generation__:20",
+        }),
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", {
+        request: expect.objectContaining({
+          prompt: "Fresh Economy request",
+          model: "__june_auto_generation__:20",
+        }),
+      }),
+    );
+  });
+
+  it("keeps a freshly selected Auto preference when settings hydration finishes late", async () => {
+    const user = userEvent.setup();
+    let resolveSettings: ((value: unknown) => void) | undefined;
+    const pendingSettings = new Promise((resolve) => {
+      resolveSettings = resolve;
+    });
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "provider_model_settings") return pendingSettings;
+      return defaultInvoke?.(command, args);
+    });
+
+    render(<AgentWorkspace />);
+    const trigger = await screen.findByRole("button", { name: "Model: Auto" });
+    await user.click(trigger);
+    await user.click(screen.getByRole("button", { name: /Preference.*Quality/ }));
+    await user.click(
+      within(screen.getByRole("group", { name: "Auto preference" })).getByRole("menuitemradio", {
+        name: /Economy/,
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("set_cost_quality", {
+        request: { value: 20 },
+      }),
+    );
+
+    await act(async () => {
+      resolveSettings?.({
+        settings: { costQuality: 100 },
+        effectiveSettings: { veniceApiKeyConfigured: false },
+      });
+      await pendingSettings;
+    });
+
+    expect(trigger).toHaveAttribute("title", expect.stringContaining("Preference: Economy"));
   });
 
   it("shows context, estimated charge, and per-tool usage for the latest run", async () => {
@@ -721,7 +890,7 @@ describe("AgentWorkspace runtime wiring", () => {
       expect(starts[1]?.[1]).toMatchObject({
         request: expect.objectContaining({
           prompt: "Send this next",
-          model: "open-software/auto",
+          model: "__june_auto_generation__:100",
         }),
       });
     });
@@ -1384,7 +1553,7 @@ describe("AgentWorkspace runtime wiring", () => {
     await waitFor(() =>
       expect(mocks.invoke).toHaveBeenCalledWith("create_agent_session", {
         request: expect.objectContaining({
-          model: "open-software/auto",
+          model: "__june_auto_generation__:100",
           title: "Fresh request",
           profile: "private",
         }),
@@ -1419,7 +1588,10 @@ describe("AgentWorkspace runtime wiring", () => {
         });
       }
       if (command === "provider_model_settings") {
-        return Promise.resolve({ effectiveSettings: { veniceApiKeyConfigured: true } });
+        return Promise.resolve({
+          settings: { costQuality: 100 },
+          effectiveSettings: { veniceApiKeyConfigured: true },
+        });
       }
       return defaultInvoke?.(command, args);
     });

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -226,7 +226,18 @@ describe("AgentWorkspace runtime wiring", () => {
       if (command === "list_agent_items" || command === "list_agent_artifacts") return [];
       if (command === "list_agent_skills") return [];
       if (command === "list_venice_models") {
-        return { mode: "generation", selectedModel: "fast", modelType: "text", models: [] };
+        return {
+          mode: "generation",
+          selectedModel: "open-software/auto",
+          modelType: "text",
+          models: [],
+        };
+      }
+      if (command === "provider_model_settings") {
+        return {
+          settings: { costQuality: 20 },
+          effectiveSettings: { veniceApiKeyConfigured: false },
+        };
       }
       if (command === "create_agent_session") return focusedSession;
       if (command === "start_agent_run") {
@@ -253,7 +264,7 @@ describe("AgentWorkspace runtime wiring", () => {
       expect(mocks.invoke).toHaveBeenCalledWith("create_agent_session", {
         request: {
           title: "Summarize this file",
-          model: "fast",
+          model: "__june_auto_generation__:20",
           safetyMode: "sandboxed",
           profile: "work",
         },
@@ -264,7 +275,7 @@ describe("AgentWorkspace runtime wiring", () => {
         request: expect.objectContaining({
           sessionId: "focused-session",
           prompt: "Summarize this file",
-          model: "fast",
+          model: "__june_auto_generation__:20",
           reasoningEffort: "medium",
           safetyMode: "sandboxed",
           attachments: ["/tmp/brief.pdf"],
@@ -747,9 +758,10 @@ describe("AgentWorkspace runtime wiring", () => {
   });
 
   it("shows route-only persisted usage without crashing", async () => {
+    const autoSession = { ...session, model: "__june_auto_generation__:20" };
     mocks.invoke.mockImplementation(async (command: string) => {
-      if (command === "list_agent_sessions") return [session];
-      if (command === "get_agent_session") return session;
+      if (command === "list_agent_sessions") return [autoSession];
+      if (command === "get_agent_session") return autoSession;
       if (command === "list_agent_items") {
         return [
           {
@@ -770,7 +782,7 @@ describe("AgentWorkspace runtime wiring", () => {
           id: "run-route-only",
           sessionId: session.id,
           status: "completed",
-          model: "zai-org-glm-5-2",
+          model: "__june_auto_generation__:20",
           usage: {
             provider: "qa-fixture",
             privacyLevel: "isolated",
@@ -781,7 +793,7 @@ describe("AgentWorkspace runtime wiring", () => {
       return undefined;
     });
     const user = userEvent.setup();
-    render(<AgentWorkspace initialSession={session} />);
+    render(<AgentWorkspace initialSession={autoSession} />);
     await screen.findByText("Earlier answer");
 
     await user.click(screen.getByRole("button", { name: "Session actions" }));
@@ -791,6 +803,8 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(usagePanel).toHaveTextContent("qa-fixture");
     expect(usagePanel).toHaveTextContent("isolated");
     expect(usagePanel).toHaveTextContent("localhost");
+    expect(usagePanel).toHaveTextContent("Auto");
+    expect(usagePanel).not.toHaveTextContent("__june_auto_generation__");
     expect(usagePanel).toHaveTextContent("Token counts were not reported for this request.");
   });
 

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -695,6 +695,56 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(trigger).toHaveAttribute("title", expect.stringContaining("Preference: Economy"));
   });
 
+  it("does not overwrite a session preference when a global save finishes after navigation", async () => {
+    const user = userEvent.setup();
+    const balancedSession = { ...session, model: "__june_auto_generation__:50" };
+    let resolveSave: ((value: { costQuality: number }) => void) | undefined;
+    const pendingSave = new Promise<{ costQuality: number }>((resolve) => {
+      resolveSave = resolve;
+    });
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "list_agent_sessions") return Promise.resolve([balancedSession]);
+      if (command === "get_agent_session") return Promise.resolve(balancedSession);
+      if (command === "set_cost_quality") return pendingSave;
+      return defaultInvoke?.(command, args);
+    });
+
+    const { rerender } = render(<AgentWorkspace />);
+    const freshTrigger = await screen.findByRole("button", { name: "Model: Auto" });
+    await user.click(freshTrigger);
+    await user.click(screen.getByRole("button", { name: /Preference.*Quality/ }));
+    await user.click(
+      within(screen.getByRole("group", { name: "Auto preference" })).getByRole("menuitemradio", {
+        name: /Economy/,
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("set_cost_quality", {
+        request: { value: 20 },
+      }),
+    );
+
+    rerender(<AgentWorkspace initialSession={balancedSession} />);
+    const sessionTrigger = await screen.findByRole("button", { name: "Model: Auto" });
+    await waitFor(() =>
+      expect(sessionTrigger).toHaveAttribute(
+        "title",
+        expect.stringContaining("Preference: Balanced"),
+      ),
+    );
+
+    await act(async () => {
+      resolveSave?.({ costQuality: 20 });
+      await pendingSave;
+    });
+
+    expect(sessionTrigger).toHaveAttribute(
+      "title",
+      expect.stringContaining("Preference: Balanced"),
+    );
+  });
+
   it("shows context, estimated charge, and per-tool usage for the latest run", async () => {
     const user = userEvent.setup();
     render(<AgentWorkspace initialSession={session} />);


### PR DESCRIPTION
## Summary

- restore the three Auto routing preferences in the agent model picker
- keep Auto as the sole suggested model while retaining model search and compact effort controls
- persist per-session Auto routing through navigation, retries, restarts, queued follow-ups, and first-run session creation
- guard user selections from delayed provider-settings hydration

## Verification

- 1,507 frontend tests passed
- 34 focused agent model/session tests passed after the final race regression
- TypeScript passed
- production frontend build passed
- 21 Rust agent proxy routing tests passed
- repository lint passed with the existing warning baseline
- isolated live visual walkthrough passed for Auto suggestion, Economy/Balanced/Quality, selection labels, reopen persistence, and model search

## QA caveat

Native Tauri visual launch was blocked by an unrelated macOS Swift system-audio helper compiler process. Native routing and persistence are covered by the Rust and React integration suites; the visual interaction was exercised against the real branch UI with an isolated Tauri IPC fixture.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787672747&installation_model_id=425925&pr_number=968&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F968&signature=0e336f764266d5921ced29445110978509150c84dc6ee2a23a2aef999ed14e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->