### PR TITLE
fix(app): reap wedged dictation helper on quit

### DIFF
--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1764,11 +1764,107 @@ pub fn stop_helper(app: &AppHandle) {
                 timeout_ms = HELPER_SHUTDOWN_MUTEX_TIMEOUT.as_millis(),
                 "dictation helper shutdown timed out acquiring the process lock"
             );
+            // A command thread can be blocked writing to a wedged helper while
+            // it owns `state.process`. Dropping the app in that state detaches
+            // the child and leaves its global event tap alive. On macOS the
+            // per-instance ownership record gives us a second, lock-independent
+            // handle to the exact helper this process spawned. Validate the
+            // complete (pid, start time) identities before killing it so a
+            // concurrently running June instance is never touched.
+            #[cfg(target_os = "macos")]
+            if !reap_current_owned_helper_without_process_lock(app) {
+                tracing::warn!(
+                    "dictation helper shutdown fallback could not confirm the helper exited"
+                );
+            }
             None
         }
     };
     if let Some(helper) = helper {
         abandon_helper(helper);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn decide_owned_lock_timeout_action(
+    recorded_app_pid: u32,
+    current_app_pid: u32,
+    owner: OwnerLiveness,
+    helper: HelperMatch,
+) -> RecordAction {
+    if recorded_app_pid != current_app_pid || owner != OwnerLiveness::Alive {
+        return RecordAction::Abort;
+    }
+    match helper {
+        HelperMatch::MatchesRecord => RecordAction::Reap,
+        HelperMatch::GoneOrReused => RecordAction::DeleteStale,
+        HelperMatch::Unknown => RecordAction::Abort,
+    }
+}
+
+/// Reaps this app instance's helper without acquiring [`HelperState::process`].
+///
+/// This is only a shutdown fallback for a process lock held by a blocked helper
+/// write. The ownership record is keyed to the current app pid, and both the app
+/// and helper start times are revalidated before the helper is signalled.
+#[cfg(target_os = "macos")]
+fn reap_current_owned_helper_without_process_lock(app: &AppHandle) -> bool {
+    let Some(path) = helper_ownership_path(app) else {
+        return false;
+    };
+    let raw = match fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                %error,
+                "dictation shutdown fallback could not read its ownership record"
+            );
+            return false;
+        }
+    };
+    let record = match serde_json::from_str::<HelperOwnershipRecord>(&raw) {
+        Ok(record) => record,
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                %error,
+                "dictation shutdown fallback found an invalid ownership record"
+            );
+            return false;
+        }
+    };
+    let owner = owner_liveness(&probe_start_time(record.app_pid), &record.app_start);
+    let helper = helper_match(
+        &probe_start_time(record.helper_pid),
+        &record.helper_start,
+        &inspect_helper_identity(record.helper_pid),
+    );
+    match decide_owned_lock_timeout_action(record.app_pid, std::process::id(), owner, helper) {
+        RecordAction::Reap => {
+            kill_pid(record.helper_pid);
+            if !wait_for_pid_exit(record.helper_pid, HELPER_ORPHAN_EXIT_TIMEOUT) {
+                tracing::warn!(
+                    helper_pid = record.helper_pid,
+                    "dictation shutdown fallback helper would not exit"
+                );
+                return false;
+            }
+            let _ = fs::remove_file(path);
+            true
+        }
+        RecordAction::DeleteStale => {
+            let _ = fs::remove_file(path);
+            true
+        }
+        RecordAction::Skip | RecordAction::Abort => {
+            tracing::warn!(
+                app_pid = record.app_pid,
+                helper_pid = record.helper_pid,
+                "dictation shutdown fallback could not validate helper ownership"
+            );
+            false
+        }
     }
 }
 
@@ -6132,6 +6228,54 @@ mod tests {
         );
         assert_eq!(
             decide_record_action(OwnerLiveness::Dead, HelperMatch::Unknown),
+            RecordAction::Abort
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn lock_timeout_fallback_reaps_only_the_current_instances_helper() {
+        assert_eq!(
+            decide_owned_lock_timeout_action(
+                42,
+                42,
+                OwnerLiveness::Alive,
+                HelperMatch::MatchesRecord,
+            ),
+            RecordAction::Reap
+        );
+        assert_eq!(
+            decide_owned_lock_timeout_action(
+                42,
+                42,
+                OwnerLiveness::Alive,
+                HelperMatch::GoneOrReused,
+            ),
+            RecordAction::DeleteStale
+        );
+        // A sibling instance's ownership record is never a shutdown target.
+        assert_eq!(
+            decide_owned_lock_timeout_action(
+                41,
+                42,
+                OwnerLiveness::Alive,
+                HelperMatch::MatchesRecord,
+            ),
+            RecordAction::Abort
+        );
+        // Pid reuse, an already-dead owner, or any uncertain helper identity
+        // fails closed instead of signalling an unverified process.
+        assert_eq!(
+            decide_owned_lock_timeout_action(
+                42,
+                42,
+                OwnerLiveness::Dead,
+                HelperMatch::MatchesRecord,
+            ),
+            RecordAction::Abort
+        );
+        assert_eq!(
+            decide_owned_lock_timeout_action(42, 42, OwnerLiveness::Alive, HelperMatch::Unknown,),
             RecordAction::Abort
         );
     }


### PR DESCRIPTION
## Summary
- fall back to the per-instance ownership record when the dictation helper process mutex is wedged during shutdown
- revalidate app and helper pid/start-time identities before signalling anything
- remove a confirmed stale ownership record when the helper is already gone

## Why
RC13 installed-app stress testing reproduced a helper leak: the main app and agent runtime exited, but `june-dictation-helper` remained after a rapid second launch/quit cycle. The existing 250 ms process-lock timeout deliberately let shutdown continue but had no lock-independent reap path.

## Verification
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib dictation::tests:: -q` (125 passed)
- RC13 baseline reproduced before this patch; a signed RC will repeat the native multi-cycle shutdown stress test after merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787677121&installation_model_id=425925&pr_number=970&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F970&signature=e74aa4b2923026b96bea6a1e85bd33d972fa5cd0a5f16a62796ab56a7eb568a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->