### PR TITLE
fix(app): make dictation helper follow owner lifetime

### DIFF
--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -4,6 +4,7 @@ import AppKit
 import Carbon
 import CoreMedia
 import CoreGraphics
+import Darwin
 import SoundAnalysis
 
 struct HelperEvent: Encodable {
@@ -156,6 +157,55 @@ final class AccessibilityTrustMonitor {
         }
         lastTrusted = trusted
         emit("permission_status", permissionPayload())
+    }
+}
+
+/// Makes the helper self-terminating if the June process that spawned it dies.
+///
+/// The Rust shutdown coordinator normally sends an explicit shutdown command,
+/// but macOS can finalize an application through paths where only stdio closure
+/// reaches the helper. A pipe write descriptor inherited by another child can
+/// delay that EOF indefinitely, leaving the global event tap alive after June
+/// has exited. Rust passes the owning pid explicitly so the helper still knows
+/// what to watch even if June dies before Swift finishes initializing.
+final class ParentProcessMonitor {
+    static let shared = ParentProcessMonitor()
+
+    private let ownerPID: pid_t = {
+        guard
+            let raw = ProcessInfo.processInfo.environment["JUNE_OWNER_PID"],
+            let parsed = Int32(raw),
+            parsed > 1
+        else {
+            return getppid()
+        }
+        return parsed
+    }()
+    private var timer: DispatchSourceTimer?
+    private var didObserveOwnerExit = false
+
+    private init() {}
+
+    func start(onOwnerExit: @escaping () -> Void) {
+        guard ownerPID > 1 else {
+            return
+        }
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.main)
+        timer.schedule(deadline: .now() + 0.25, repeating: 0.25)
+        timer.setEventHandler { [weak self] in
+            guard let self, !self.didObserveOwnerExit else {
+                return
+            }
+            guard getppid() != self.ownerPID || kill(self.ownerPID, 0) != 0 else {
+                return
+            }
+            self.didObserveOwnerExit = true
+            self.timer?.cancel()
+            self.timer = nil
+            onOwnerExit()
+        }
+        self.timer = timer
+        timer.resume()
     }
 }
 
@@ -2499,6 +2549,9 @@ emit("ready")
 ShortcutKeyMonitor.shared.start()
 FocusTargetController.shared.start()
 AccessibilityTrustMonitor.shared.start()
+ParentProcessMonitor.shared.start {
+    dictation.shutdown()
+}
 dictation.emitDiagnostics()
 
 Thread.detachNewThread {

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1764,29 +1764,28 @@ pub fn stop_helper(app: &AppHandle) {
                 timeout_ms = HELPER_SHUTDOWN_MUTEX_TIMEOUT.as_millis(),
                 "dictation helper shutdown timed out acquiring the process lock"
             );
-            // A command thread can be blocked writing to a wedged helper while
-            // it owns `state.process`. Dropping the app in that state detaches
-            // the child and leaves its global event tap alive. On macOS the
-            // per-instance ownership record gives us a second, lock-independent
-            // handle to the exact helper this process spawned. Validate the
-            // complete (pid, start time) identities before killing it so a
-            // concurrently running June instance is never touched.
-            #[cfg(target_os = "macos")]
-            if !reap_current_owned_helper_without_process_lock(app) {
-                tracing::warn!(
-                    "dictation helper shutdown fallback could not confirm the helper exited"
-                );
-            }
             None
         }
     };
     if let Some(helper) = helper {
         abandon_helper(helper);
     }
+    // A command thread can be blocked writing to a wedged helper while it owns
+    // `state.process`, or the child handle can race out of the slot before the
+    // bounded reaper confirms exit. Dropping the app in either state detaches
+    // the child and leaves its global event tap alive. On macOS the per-instance
+    // ownership record gives us a lock-independent handle to the exact helper
+    // this process spawned. Always verify that record after the normal path so
+    // shutdown does not return until the helper is gone (or ownership fails
+    // closed). This also removes the now-stale record after a clean exit.
+    #[cfg(target_os = "macos")]
+    if !reap_current_owned_helper_without_process_lock(app) {
+        tracing::warn!("dictation helper shutdown fallback could not confirm the helper exited");
+    }
 }
 
 #[cfg(target_os = "macos")]
-fn decide_owned_lock_timeout_action(
+fn decide_owned_shutdown_action(
     recorded_app_pid: u32,
     current_app_pid: u32,
     owner: OwnerLiveness,
@@ -1810,10 +1809,11 @@ fn decide_owned_lock_timeout_action(
 #[cfg(target_os = "macos")]
 fn reap_current_owned_helper_without_process_lock(app: &AppHandle) -> bool {
     let Some(path) = helper_ownership_path(app) else {
-        return false;
+        return true;
     };
     let raw = match fs::read_to_string(&path) {
         Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return true,
         Err(error) => {
             tracing::warn!(
                 path = %path.display(),
@@ -1840,7 +1840,7 @@ fn reap_current_owned_helper_without_process_lock(app: &AppHandle) -> bool {
         &record.helper_start,
         &inspect_helper_identity(record.helper_pid),
     );
-    match decide_owned_lock_timeout_action(record.app_pid, std::process::id(), owner, helper) {
+    match decide_owned_shutdown_action(record.app_pid, std::process::id(), owner, helper) {
         RecordAction::Reap => {
             kill_pid(record.helper_pid);
             if !wait_for_pid_exit(record.helper_pid, HELPER_ORPHAN_EXIT_TIMEOUT) {
@@ -3181,7 +3181,10 @@ fn spawn_helper(app: &AppHandle) -> Result<HelperProcess, AppError> {
             )
         })?;
 
-    let mut child = Command::new(&helper_path)
+    let mut command = Command::new(&helper_path);
+    #[cfg(target_os = "macos")]
+    command.env("JUNE_OWNER_PID", std::process::id().to_string());
+    let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -6234,48 +6237,28 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn lock_timeout_fallback_reaps_only_the_current_instances_helper() {
+    fn shutdown_fallback_reaps_only_the_current_instances_helper() {
         assert_eq!(
-            decide_owned_lock_timeout_action(
-                42,
-                42,
-                OwnerLiveness::Alive,
-                HelperMatch::MatchesRecord,
-            ),
+            decide_owned_shutdown_action(42, 42, OwnerLiveness::Alive, HelperMatch::MatchesRecord,),
             RecordAction::Reap
         );
         assert_eq!(
-            decide_owned_lock_timeout_action(
-                42,
-                42,
-                OwnerLiveness::Alive,
-                HelperMatch::GoneOrReused,
-            ),
+            decide_owned_shutdown_action(42, 42, OwnerLiveness::Alive, HelperMatch::GoneOrReused,),
             RecordAction::DeleteStale
         );
         // A sibling instance's ownership record is never a shutdown target.
         assert_eq!(
-            decide_owned_lock_timeout_action(
-                41,
-                42,
-                OwnerLiveness::Alive,
-                HelperMatch::MatchesRecord,
-            ),
+            decide_owned_shutdown_action(41, 42, OwnerLiveness::Alive, HelperMatch::MatchesRecord,),
             RecordAction::Abort
         );
         // Pid reuse, an already-dead owner, or any uncertain helper identity
         // fails closed instead of signalling an unverified process.
         assert_eq!(
-            decide_owned_lock_timeout_action(
-                42,
-                42,
-                OwnerLiveness::Dead,
-                HelperMatch::MatchesRecord,
-            ),
+            decide_owned_shutdown_action(42, 42, OwnerLiveness::Dead, HelperMatch::MatchesRecord,),
             RecordAction::Abort
         );
         assert_eq!(
-            decide_owned_lock_timeout_action(42, 42, OwnerLiveness::Alive, HelperMatch::Unknown,),
+            decide_owned_shutdown_action(42, 42, OwnerLiveness::Alive, HelperMatch::Unknown,),
             RecordAction::Abort
         );
     }


### PR DESCRIPTION
## Summary
- pass June's owner PID to the macOS dictation helper
- add an independent 250 ms helper watchdog that exits if the owning app disappears
- verify the ownership-record fallback after every normal shutdown path

## Why
Signed RC14 stress testing reproduced a dictation helper orphan on the third rapid launch/quit cycle. The Rust coordinator path is not guaranteed on every macOS finalization path, while stdio EOF can be delayed. The helper now has a kernel-backed owner-lifetime guarantee independent of both.

## Verification
- direct orphan probe: helper exited after explicit owner PID disappeared
- bundled debug app: six consecutive Command-Q launch/quit cycles clean
- bundled debug app: forced parent SIGKILL cleaned helper through watchdog
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib dictation::tests:: -q` (125 passed)
- signed RC15 will repeat the installed-app stress test before acceptance.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787679454&installation_model_id=425925&pr_number=971&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F971&signature=28b46a67653ef93fe712860a44ecdc745a50932856c75fdcd31c8105a6034e9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->