### PR TITLE
Fence composer draft resets

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -234,6 +234,7 @@ export function AgentWorkspace({
   sessionInProject = false,
   projectContext,
   creditActionsDisabledReason,
+  testOnlyComposerReady,
 }: AgentWorkspaceProps = {}) {
   const initialAgentSession = initialSession;
   const pendingRequestRef = useRef(pendingNewSessionRequest());
@@ -284,15 +285,25 @@ export function AgentWorkspace({
   );
   const [draft, setDraft] = useState(pendingRequestRef.current?.prompt ?? "");
   const [draftRevision, setDraftRevision] = useState(0);
+  const draftRevisionRef = useRef(0);
   const draftRef = useRef(draft);
   draftRef.current = draft;
   const draftHasContentRef = useRef(Boolean(draft.trim()));
-  const setComposerDraft = useCallback((value: string) => {
+  const publishComposerDraft = useCallback((value: string, sourceRevision?: number) => {
+    if (sourceRevision !== undefined && sourceRevision !== draftRevisionRef.current) return false;
     draftRef.current = value;
     draftHasContentRef.current = Boolean(value.trim());
     setDraft(value);
-    setDraftRevision((revision) => revision + 1);
+    return true;
   }, []);
+  const setComposerDraft = useCallback(
+    (value: string) => {
+      draftRevisionRef.current += 1;
+      publishComposerDraft(value);
+      setDraftRevision(draftRevisionRef.current);
+    },
+    [publishComposerDraft],
+  );
   const [attachments, setAttachments] = useState<string[]>([]);
   const attachmentsRef = useRef(attachments);
   attachmentsRef.current = attachments;
@@ -1707,10 +1718,11 @@ export function AgentWorkspace({
       scrollRef={scrollRef}
       draft={draft}
       draftRevision={draftRevision}
-      setDraft={setComposerDraft}
+      setDraft={publishComposerDraft}
       onDraftContentChange={(hasContent) => {
         draftHasContentRef.current = hasContent;
       }}
+      testOnlyComposerReady={testOnlyComposerReady}
       model={model}
       setModel={(nextModel, nextCostQuality) => {
         const selectedCostQuality =
@@ -2243,6 +2255,7 @@ function AgentComposer({
   draftRevision,
   setDraft,
   onDraftContentChange,
+  testOnlyComposerReady,
   model,
   setModel,
   costQuality,
@@ -2268,8 +2281,9 @@ function AgentComposer({
   scrollRef: RefObject<HTMLDivElement>;
   draft: string;
   draftRevision: number;
-  setDraft: (value: string) => void;
+  setDraft: (value: string, sourceRevision?: number) => boolean;
   onDraftContentChange: (hasContent: boolean) => void;
+  testOnlyComposerReady?: AgentWorkspaceProps["testOnlyComposerReady"];
   model: string;
   setModel: (value: string, costQuality?: number) => void;
   costQuality: number;
@@ -2320,8 +2334,8 @@ function AgentComposer({
       return;
     }
     appliedDraftRevisionRef.current = draftRevision;
-    if (draft === publishedDraftRef.current) return;
     publishedDraftRef.current = draft;
+    setHasEditorContent(Boolean(draft.trim()));
     editorRef.current?.setContent(draft, null, { focus: false });
   }, [draft, draftRevision]);
 
@@ -2430,15 +2444,19 @@ function AgentComposer({
         ) : null}
         <ComposerEditor
           ref={editorRef}
+          changeKey={String(draftRevision)}
           placeholder={hero ? "Ask June anything, run / commands" : "Send a message"}
-          onChange={(text) => {
+          onChange={(text, _category, changeKey) => {
+            const sourceRevision =
+              typeof changeKey === "string" ? Number.parseInt(changeKey, 10) : draftRevision;
+            if (!setDraft(text, sourceRevision)) return;
             publishedDraftRef.current = text;
-            setDraft(text);
           }}
           onContentChange={(hasContent) => {
             setHasEditorContent(hasContent);
             onDraftContentChange(hasContent);
           }}
+          onReady={testOnlyComposerReady}
           onSubmit={() => void onSubmit()}
         />
         <div className="agent-composer-toolbar">

--- a/src/components/agent/agent-workspace-types.ts
+++ b/src/components/agent/agent-workspace-types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { Editor } from "@tiptap/react";
 import type { FundingTier, TextFundingNoticeContext } from "../account/FundingNotice";
 import type { AgentProjectContext } from "../../lib/agent-project-context";
 import type { AgentSessionDto } from "../../lib/agent-runtime-contract";
@@ -50,4 +51,6 @@ export type AgentWorkspaceProps = {
       runVideoSlashCommand: (argument: string, commandText: string) => Promise<void>;
     } | null;
   };
+  /** Test seam for asserting editor selection across parent draft synchronization. */
+  testOnlyComposerReady?: (editor: Editor) => void;
 };

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { Editor } from "@tiptap/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentRuntimeEvent, AgentSessionDto } from "../lib/agent-runtime-contract";
 
@@ -1391,6 +1392,60 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(onSessionSelected).toHaveBeenLastCalledWith(newSession);
   });
 
+  it("clears an unpublished draft when an already-fresh session is reset", async () => {
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+    const composer = screen.getByRole("textbox", { name: "Message June" });
+    await user.click(composer);
+    await user.type(composer, "Do not leak this draft");
+    await waitFor(() => expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled());
+
+    act(() => {
+      markAgentNewSessionPending();
+      window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Message June" }).textContent).toBe(""),
+    );
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 100));
+    });
+    expect(screen.getByRole("textbox", { name: "Message June" }).textContent).toBe("");
+    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+  });
+
+  it("preserves the caret when a trailing editor publication catches up", async () => {
+    const user = userEvent.setup();
+    let editor: Editor | undefined;
+    render(<AgentWorkspace testOnlyComposerReady={(next) => (editor = next)} />);
+    const composer = screen.getByRole("textbox", { name: "Message June" });
+    await user.click(composer);
+    await user.type(composer, "abcdef");
+    await waitFor(() => expect(editor).toBeDefined());
+    act(() => {
+      editor?.commands.setTextSelection(4);
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 100));
+    });
+
+    expect(editor?.state.selection.from).toBe(4);
+    act(() => {
+      editor?.commands.insertContent("X");
+    });
+    expect(composer.textContent).toBe("abcXdef");
+    act(() => {
+      expect(editor?.commands.undo()).toBe(true);
+    });
+    expect(composer.textContent).toBe("abcdef");
+    act(() => {
+      expect(editor?.commands.redo()).toBe(true);
+    });
+    expect(composer.textContent).toBe("abcXdef");
+  });
+
   it("shows the first message and thinking before fresh session creation finishes", async () => {
     const user = userEvent.setup();
     let resolveCreate: ((value: AgentSessionDto) => void) | undefined;
@@ -1525,6 +1580,9 @@ describe("AgentWorkspace runtime wiring", () => {
       () =>
         expect(container.querySelector(".agent-user-turn")).toHaveTextContent("Create this slowly"),
       { timeout: 3_000 },
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Message June" }).textContent).toBe(""),
     );
     expect(screen.getByText("Thinking…")).toBeVisible();
 


### PR DESCRIPTION
## What changed

- separate editor-originated draft publication from programmatic composer revisions
- tag delayed editor publications with the revision that produced them and reject stale callbacks after a session reset
- synchronize Send state when a programmatic replacement clears the editor
- add regressions for an unpublished draft surviving a fresh-session reset and for caret plus undo/redo preservation after the 75 ms trailing publish

## Why

PR #969 left an unresolved P1: a same-value draft reset could be skipped, allowing a pending draft to reappear in a new session. A naive removal of the equality guard fixed that leak but caused identical `setContent` transactions after ordinary typing pauses, moving the caret to the end and disturbing edit history. The revision fence distinguishes those two paths.

## User impact

Starting a new session now clears pending unsent content and leaves Send disabled, while ordinary mid-string editing retains its caret and undo/redo behavior.

## Validation

- `make check typecheck test-web` — passed; 144 files / 1,511 tests
- `pnpm vitest run src/test/agent-workspace-runtime.test.tsx` — 31/31 passed
- `pnpm typecheck` — passed
- changed-file Biome — passed with eight pre-existing hook warnings
- `git diff --check` — passed
- live Chrome keyboard walkthrough — immediate Cmd+N cleared a pending typed draft and disabled Send after 250 ms; pausing mid-string preserved `abcXdef`; undo/redo remained functional
- repo-review battery — standards clean, spec clean after adding automated undo/redo assertions, two adversarial product-engineering rounds clean

## Known gap

`make local-ci` stopped at its GitHub CLI authentication preflight because both local `gh` tokens are invalid. The underlying local check/type/test gates passed, and PR/CI state is being inspected through the authenticated GitHub connector. No production merge or release is included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787680470&installation_model_id=425925&pr_number=972&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F972&signature=2ba9e406ebe15af1580df546cf6198fb160804781befd6ca32eb00c9eea53a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->