### PR TITLE
fix(agent): hydrate active stream history

### DIFF
--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -479,12 +479,18 @@ pub async fn delete_agent_session(app: AppHandle, session_id: String) -> Result<
 
 #[tauri::command]
 pub async fn list_agent_items(app: AppHandle, session_id: String) -> Result<Vec<Value>, AppError> {
-    repository(&app)
-        .await?
+    let repository = repository(&app).await?;
+    let active_run_id = repository
+        .latest_run(&session_id)
+        .await
+        .ok()
+        .filter(|run| matches!(run.status.as_str(), "running" | "waiting_for_user"))
+        .map(|run| run.id);
+    repository
         .items(&session_id)
         .await?
         .into_iter()
-        .map(item_json)
+        .map(|item| item_json_with_active_run(item, active_run_id.as_deref()))
         .collect()
 }
 
@@ -1601,8 +1607,25 @@ fn run_json(run: super::AgentRunDto) -> Value {
     json!({ "id": run.id, "sessionId": run.session_id, "status": run.status, "model": run.model, "reasoningEffort": run.reasoning_effort, "startedAt": run.started_at, "completedAt": run.completed_at, "usage": run.usage, "error": run.error_message })
 }
 
-fn item_json(item: AgentItemDto) -> Result<Value, AppError> {
-    let base = json!({ "id": item.id, "sessionId": item.session_id, "runId": item.run_id, "sequence": item.sequence, "createdAt": item.created_at });
+fn item_json_with_active_run(
+    item: AgentItemDto,
+    active_run_id: Option<&str>,
+) -> Result<Value, AppError> {
+    let is_active_run = item.run_id.as_deref() == active_run_id;
+    let stable_stream_id = is_active_run
+        .then_some(item.external_id.as_deref())
+        .flatten()
+        .filter(|external_id| {
+            external_id.starts_with("assistant:") || external_id.starts_with("reasoning:")
+        });
+    let public_item_id = stable_stream_id.unwrap_or(&item.id).to_string();
+    let stream_status =
+        if stable_stream_id.is_some_and(|external_id| external_id.starts_with("assistant:")) {
+            "streaming"
+        } else {
+            "complete"
+        };
+    let base = json!({ "id": public_item_id, "sessionId": item.session_id, "runId": item.run_id, "sequence": item.sequence, "createdAt": item.created_at });
     let mut object = base.as_object().cloned().expect("base object");
     let fields = match item.payload {
         AgentItemPayload::UserMessage(v)
@@ -1627,10 +1650,10 @@ fn item_json(item: AgentItemDto) -> Result<Value, AppError> {
                     })
                 })
                 .collect::<Vec<_>>();
-            json!({ "kind": "message", "role": v.role, "text": v.content, "status": "complete", "attachments": attachments })
+            json!({ "kind": "message", "role": v.role, "text": v.content, "status": stream_status, "attachments": attachments })
         }
         AgentItemPayload::Reasoning(v) => {
-            json!({ "kind": "reasoning", "text": v.text, "status": "complete" })
+            json!({ "kind": "reasoning", "text": v.text, "status": stream_status })
         }
         AgentItemPayload::Steering(v) => json!({ "kind": "steering", "text": v.text }),
         AgentItemPayload::ContextSummary(v) => json!({ "kind": "context_summary", "text": v.text }),
@@ -2017,7 +2040,7 @@ mod tests {
         };
 
         let history = history_item(item.clone()).expect("runtime history");
-        let value = item_json(item).expect("public item");
+        let value = item_json_with_active_run(item, None).expect("public item");
         assert_eq!(value["attachments"][0]["sessionId"], "session-1");
         assert_eq!(value["attachments"][0]["runId"], "run-1");
         assert_eq!(value["attachments"][0]["itemId"], "message-1");
@@ -2028,6 +2051,53 @@ mod tests {
         );
         assert_eq!(history["attachments"][0]["mimeType"], "text/markdown");
         assert_eq!(history["attachments"][0]["sizeBytes"], 42);
+    }
+
+    #[test]
+    fn active_stream_items_keep_runtime_identity_and_streaming_status() {
+        let item = AgentItemDto {
+            id: "database-item-1".into(),
+            session_id: "session-1".into(),
+            run_id: Some("run-1".into()),
+            sequence: 1,
+            payload: AgentItemPayload::AssistantMessage(super::super::MessagePayload {
+                role: "assistant".into(),
+                content: "Everything emitted so far".into(),
+                attachments: vec![],
+            }),
+            external_id: Some("assistant:run-1".into()),
+            created_at: "2026-07-24T12:00:00Z".into(),
+        };
+
+        let active =
+            item_json_with_active_run(item.clone(), Some("run-1")).expect("active public item");
+        assert_eq!(active["id"], "assistant:run-1");
+        assert_eq!(active["status"], "streaming");
+        assert_eq!(active["text"], "Everything emitted so far");
+
+        let completed = item_json_with_active_run(item, None).expect("completed public item");
+        assert_eq!(completed["id"], "database-item-1");
+        assert_eq!(completed["status"], "complete");
+
+        let user = item_json_with_active_run(
+            AgentItemDto {
+                id: "user-item-1".into(),
+                session_id: "session-1".into(),
+                run_id: Some("run-1".into()),
+                sequence: 0,
+                payload: AgentItemPayload::UserMessage(super::super::MessagePayload {
+                    role: "user".into(),
+                    content: "Keep this complete".into(),
+                    attachments: vec![],
+                }),
+                external_id: Some("user:run-1".into()),
+                created_at: "2026-07-24T11:59:59Z".into(),
+            },
+            Some("run-1"),
+        )
+        .expect("active user item");
+        assert_eq!(user["id"], "user-item-1");
+        assert_eq!(user["status"], "complete");
     }
 
     #[test]
@@ -2091,7 +2161,7 @@ mod tests {
         };
 
         let history = history_item(item.clone()).expect("runtime history");
-        let value = item_json(item).expect("public item");
+        let value = item_json_with_active_run(item, None).expect("public item");
 
         assert_eq!(history["kind"], "message");
         assert_eq!(history["role"], "user");

--- a/src-tauri/src/agent_runtime/host.rs
+++ b/src-tauri/src/agent_runtime/host.rs
@@ -1,7 +1,7 @@
 use super::{
     protocol::{RpcFrame, PROTOCOL_VERSION},
     tools::{dispatch_tool, ToolCancellationRegistry, ToolContext},
-    AgentItemPayload, AgentRepository, MessagePayload, TextPayload, ToolPayload,
+    AgentItemPayload, AgentRepository, TextPayload, ToolPayload,
 };
 use crate::domain::types::AppError;
 use serde_json::{json, Value};
@@ -510,6 +510,18 @@ async fn persist_and_emit_event(
             data["itemId"] = json!(assistant_id);
             data["role"] = json!("assistant");
             data["createdAt"] = json!(created_at);
+            repository
+                .append_assistant_message_delta(
+                    &frame.session_id,
+                    &frame.run_id,
+                    frame.sequence,
+                    params
+                        .get("delta")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default(),
+                    &assistant_id,
+                )
+                .await?;
             None
         }
         "message.completed" => {
@@ -520,11 +532,16 @@ async fn persist_and_emit_event(
             data["itemId"] = json!(assistant_id);
             data["role"] = json!("assistant");
             data["createdAt"] = json!(created_at);
-            Some(AgentItemPayload::AssistantMessage(MessagePayload {
-                role: "assistant".into(),
-                content: text.into(),
-                attachments: Vec::new(),
-            }))
+            repository
+                .complete_assistant_message(
+                    &frame.session_id,
+                    &frame.run_id,
+                    frame.sequence,
+                    text,
+                    &assistant_id,
+                )
+                .await?;
+            None
         }
         "reasoning.delta" => {
             data["itemId"] = json!(reasoning_id);

--- a/src-tauri/src/agent_runtime/repository.rs
+++ b/src-tauri/src/agent_runtime/repository.rs
@@ -370,6 +370,223 @@ impl AgentRepository {
         }))
     }
 
+    /// Coalesces streamed assistant output into one durable row. Persisting
+    /// partial output lets another window hydrate the full response-so-far
+    /// instead of only receiving deltas emitted after it subscribed.
+    pub async fn append_assistant_message_delta(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        sequence: i64,
+        delta: &str,
+        external_id: &str,
+    ) -> Result<Option<AgentItemDto>, sqlx::Error> {
+        let now = now();
+        let mut transaction = self.pool.begin().await?;
+        let updated = query(
+            "UPDATE agent_runs SET last_sequence = ?, updated_at = ?
+             WHERE id = ? AND last_sequence < ?",
+        )
+        .bind(sequence)
+        .bind(&now)
+        .bind(run_id)
+        .bind(sequence)
+        .execute(&mut *transaction)
+        .await?
+        .rows_affected();
+        if updated == 0 {
+            transaction.rollback().await?;
+            return Ok(None);
+        }
+
+        if let Some(row) = query(
+            "SELECT id, sequence, payload_json, created_at
+             FROM agent_items WHERE external_id = ?",
+        )
+        .bind(external_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        {
+            let id: String = row.get("id");
+            let display_sequence: i64 = row.get("sequence");
+            let created_at: String = row.get("created_at");
+            let mut payload: super::domain::MessagePayload =
+                serde_json::from_str(&row.get::<String, _>("payload_json"))
+                    .map_err(|error| sqlx::Error::Decode(Box::new(error)))?;
+            payload.content.push_str(delta);
+            query("UPDATE agent_items SET payload_json = ? WHERE id = ?")
+                .bind(
+                    serde_json::to_string(&payload)
+                        .map_err(|error| sqlx::Error::Encode(Box::new(error)))?,
+                )
+                .bind(&id)
+                .execute(&mut *transaction)
+                .await?;
+            query("UPDATE agent_sessions SET updated_at = ? WHERE id = ?")
+                .bind(&now)
+                .bind(session_id)
+                .execute(&mut *transaction)
+                .await?;
+            transaction.commit().await?;
+            return Ok(Some(AgentItemDto {
+                id,
+                session_id: session_id.to_string(),
+                run_id: Some(run_id.to_string()),
+                sequence: display_sequence,
+                payload: AgentItemPayload::AssistantMessage(payload),
+                external_id: Some(external_id.to_string()),
+                created_at,
+            }));
+        }
+
+        let id = Uuid::new_v4().to_string();
+        let display_sequence: i64 = query(
+            "SELECT COALESCE(MAX(sequence), -1) + 1 AS next_sequence
+             FROM agent_items WHERE session_id = ?",
+        )
+        .bind(session_id)
+        .fetch_one(&mut *transaction)
+        .await?
+        .get("next_sequence");
+        let payload = super::domain::MessagePayload {
+            role: "assistant".into(),
+            content: delta.to_string(),
+            attachments: Vec::new(),
+        };
+        query(
+            "INSERT INTO agent_items
+             (id, session_id, run_id, sequence, kind, payload_json, external_id, created_at)
+             VALUES (?, ?, ?, ?, 'assistant_message', ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(session_id)
+        .bind(run_id)
+        .bind(display_sequence)
+        .bind(
+            serde_json::to_string(&payload)
+                .map_err(|error| sqlx::Error::Encode(Box::new(error)))?,
+        )
+        .bind(external_id)
+        .bind(&now)
+        .execute(&mut *transaction)
+        .await?;
+        query("UPDATE agent_sessions SET updated_at = ? WHERE id = ?")
+            .bind(&now)
+            .bind(session_id)
+            .execute(&mut *transaction)
+            .await?;
+        transaction.commit().await?;
+        Ok(Some(AgentItemDto {
+            id,
+            session_id: session_id.to_string(),
+            run_id: Some(run_id.to_string()),
+            sequence: display_sequence,
+            payload: AgentItemPayload::AssistantMessage(payload),
+            external_id: Some(external_id.to_string()),
+            created_at: now,
+        }))
+    }
+
+    /// Replaces the coalesced response-so-far with the SDK's authoritative
+    /// completed text without creating a duplicate assistant message.
+    pub async fn complete_assistant_message(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        sequence: i64,
+        text: &str,
+        external_id: &str,
+    ) -> Result<Option<AgentItemDto>, sqlx::Error> {
+        let now = now();
+        let mut transaction = self.pool.begin().await?;
+        let updated = query(
+            "UPDATE agent_runs SET last_sequence = ?, updated_at = ?
+             WHERE id = ? AND last_sequence < ?",
+        )
+        .bind(sequence)
+        .bind(&now)
+        .bind(run_id)
+        .bind(sequence)
+        .execute(&mut *transaction)
+        .await?
+        .rows_affected();
+        if updated == 0 {
+            transaction.rollback().await?;
+            return Ok(None);
+        }
+
+        let payload = super::domain::MessagePayload {
+            role: "assistant".into(),
+            content: text.to_string(),
+            attachments: Vec::new(),
+        };
+        let payload_json = serde_json::to_string(&payload)
+            .map_err(|error| sqlx::Error::Encode(Box::new(error)))?;
+        let item = if let Some(row) =
+            query("SELECT id, sequence, created_at FROM agent_items WHERE external_id = ?")
+                .bind(external_id)
+                .fetch_optional(&mut *transaction)
+                .await?
+        {
+            let id: String = row.get("id");
+            let display_sequence: i64 = row.get("sequence");
+            let created_at: String = row.get("created_at");
+            query("UPDATE agent_items SET payload_json = ?, external_id = NULL WHERE id = ?")
+                .bind(&payload_json)
+                .bind(&id)
+                .execute(&mut *transaction)
+                .await?;
+            AgentItemDto {
+                id,
+                session_id: session_id.to_string(),
+                run_id: Some(run_id.to_string()),
+                sequence: display_sequence,
+                payload: AgentItemPayload::AssistantMessage(payload),
+                external_id: None,
+                created_at,
+            }
+        } else {
+            let id = Uuid::new_v4().to_string();
+            let display_sequence: i64 = query(
+                "SELECT COALESCE(MAX(sequence), -1) + 1 AS next_sequence
+                 FROM agent_items WHERE session_id = ?",
+            )
+            .bind(session_id)
+            .fetch_one(&mut *transaction)
+            .await?
+            .get("next_sequence");
+            query(
+                "INSERT INTO agent_items
+                 (id, session_id, run_id, sequence, kind, payload_json, external_id, created_at)
+                 VALUES (?, ?, ?, ?, 'assistant_message', ?, NULL, ?)",
+            )
+            .bind(&id)
+            .bind(session_id)
+            .bind(run_id)
+            .bind(display_sequence)
+            .bind(&payload_json)
+            .bind(&now)
+            .execute(&mut *transaction)
+            .await?;
+            AgentItemDto {
+                id,
+                session_id: session_id.to_string(),
+                run_id: Some(run_id.to_string()),
+                sequence: display_sequence,
+                payload: AgentItemPayload::AssistantMessage(payload),
+                external_id: None,
+                created_at: now.clone(),
+            }
+        };
+        query("UPDATE agent_sessions SET updated_at = ? WHERE id = ?")
+            .bind(&now)
+            .bind(session_id)
+            .execute(&mut *transaction)
+            .await?;
+        transaction.commit().await?;
+        Ok(Some(item))
+    }
+
     /// Persists one runtime event. Duplicate or out-of-order sequence numbers
     /// are ignored so reconnect/replay cannot duplicate transcript items.
     pub async fn append_item(

--- a/src-tauri/tests/agent_runtime_persistence.rs
+++ b/src-tauri/tests/agent_runtime_persistence.rs
@@ -98,6 +98,69 @@ async fn run_configuration_and_streamed_reasoning_survive_resume_and_hydration()
 }
 
 #[tokio::test]
+async fn streamed_assistant_text_survives_mid_run_hydration_without_duplicates() {
+    let pool = memory_database().await;
+    let repository = AgentRepository::new(pool);
+    let session = repository
+        .create_session(
+            "Visible active run",
+            "private-auto",
+            os_june_lib::agent_runtime::AgentSafetyMode::Sandboxed,
+            None,
+        )
+        .await
+        .expect("session");
+    let run = repository
+        .create_run(&session.id, "private-auto", Some("medium"))
+        .await
+        .expect("run");
+    let stream_id = format!("assistant:{}", run.id);
+
+    repository
+        .append_assistant_message_delta(&session.id, &run.id, 1, "What was ", &stream_id)
+        .await
+        .expect("first message delta");
+    repository
+        .append_assistant_message_delta(&session.id, &run.id, 2, "already said", &stream_id)
+        .await
+        .expect("second message delta");
+
+    let partial = repository.items(&session.id).await.expect("partial items");
+    assert_eq!(partial.len(), 1);
+    assert_eq!(partial[0].external_id.as_deref(), Some(stream_id.as_str()));
+    assert!(matches!(
+        &partial[0].payload,
+        AgentItemPayload::AssistantMessage(message)
+            if message.content == "What was already said"
+    ));
+
+    repository
+        .complete_assistant_message(
+            &session.id,
+            &run.id,
+            3,
+            "What was already said, plus the ending.",
+            &stream_id,
+        )
+        .await
+        .expect("completed message");
+
+    let completed = repository
+        .items(&session.id)
+        .await
+        .expect("completed items");
+    assert_eq!(completed.len(), 1);
+    assert_eq!(completed[0].id, partial[0].id);
+    assert_eq!(completed[0].external_id, None);
+    assert!(matches!(
+        &completed[0].payload,
+        AgentItemPayload::AssistantMessage(message)
+            if message.content == "What was already said, plus the ending."
+    ));
+    assert_eq!(repository.get_run(&run.id).await.unwrap().last_sequence, 3);
+}
+
+#[tokio::test]
 async fn compaction_replaces_old_items_with_one_ordered_visible_summary() {
     let pool = memory_database().await;
     let repository = AgentRepository::new(pool.clone());

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -29,6 +29,7 @@ import {
   agentItemsToChatTurns,
   applyAgentRuntimeEvent,
   createAgentRuntimeProjection,
+  mergeAgentRuntimeSnapshot,
   type AgentRuntimeProjection,
 } from "../../lib/agent-runtime-adapter";
 import type {
@@ -538,10 +539,13 @@ export function AgentWorkspace({
       if (selectedIdRef.current !== sessionId || hydrationRequestRef.current !== requestId) {
         return;
       }
-      setProjection({
-        ...createAgentRuntimeProjection({ session, items }),
-        run: latestRun ?? undefined,
-      });
+      setProjection((current) =>
+        mergeAgentRuntimeSnapshot(current, {
+          session,
+          items,
+          run: latestRun ?? undefined,
+        }),
+      );
       updateQueuedFollowUps((current) =>
         reconcileConsumedAgentFollowUp(
           current,

--- a/src/lib/agent-runtime-adapter.ts
+++ b/src/lib/agent-runtime-adapter.ts
@@ -32,6 +32,74 @@ export function createAgentRuntimeProjection(
   };
 }
 
+/**
+ * Hydrates a persisted transcript without dropping deltas that arrived while
+ * the snapshot request was in flight. Only streamed text from the active run
+ * is carried across, so switching sessions cannot leak items from the previous
+ * transcript.
+ */
+export function mergeAgentRuntimeSnapshot(
+  current: AgentRuntimeProjection,
+  input: { session: AgentSessionDto; run?: AgentRunDto; items: AgentItemDto[] },
+): AgentRuntimeProjection {
+  const snapshot = createAgentRuntimeProjection(input);
+  const run = input.run;
+  if (!run || (run.status !== "running" && run.status !== "waiting_for_user")) return snapshot;
+
+  const liveItems = current.items.filter(
+    (item) =>
+      item.sessionId === input.session.id &&
+      item.runId === run.id &&
+      (item.kind === "message" || item.kind === "reasoning") &&
+      item.status === "streaming",
+  );
+  let items = snapshot.items;
+  for (const liveItem of liveItems) {
+    const persisted = items.find((item) => item.id === liveItem.id);
+    if (
+      persisted &&
+      (persisted.kind === "message" || persisted.kind === "reasoning") &&
+      persisted.kind === liveItem.kind
+    ) {
+      const text = mergeStreamText(persisted.text, liveItem.text);
+      items = upsertItem(items, { ...persisted, text, status: "streaming" });
+    } else {
+      items = upsertItem(items, liveItem);
+    }
+  }
+
+  const currentRun = current.run?.id === run.id ? current.run : undefined;
+  const currentRunFinished =
+    currentRun &&
+    (currentRun.status === "completed" ||
+      currentRun.status === "cancelled" ||
+      currentRun.status === "failed");
+  return {
+    ...snapshot,
+    run: currentRunFinished ? currentRun : run,
+    items,
+    lastSequenceByRun: {
+      ...snapshot.lastSequenceByRun,
+      ...(current.lastSequenceByRun[run.id] === undefined
+        ? {}
+        : { [run.id]: current.lastSequenceByRun[run.id] }),
+    },
+    processedEventIds: new Set(current.processedEventIds),
+  };
+}
+
+function mergeStreamText(persisted: string, live: string) {
+  if (live.startsWith(persisted)) return live;
+  if (persisted.startsWith(live)) return persisted;
+  const maxOverlap = Math.min(persisted.length, live.length);
+  for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
+    if (persisted.endsWith(live.slice(0, overlap))) {
+      return persisted + live.slice(overlap);
+    }
+  }
+  return persisted + live;
+}
+
 export function applyAgentRuntimeEvent(
   projection: AgentRuntimeProjection,
   event: AgentRuntimeEvent,

--- a/src/test/agent-runtime-adapter.test.ts
+++ b/src/test/agent-runtime-adapter.test.ts
@@ -3,6 +3,7 @@ import {
   agentItemsToChatTurns,
   applyAgentRuntimeEvent,
   createAgentRuntimeProjection,
+  mergeAgentRuntimeSnapshot,
 } from "../lib/agent-runtime-adapter";
 import {
   AGENT_RUNTIME_PROTOCOL_VERSION,
@@ -114,6 +115,83 @@ describe("agent runtime adapter", () => {
         parts: [{ type: "text", text: "Hello there", status: "running" }],
       },
     ]);
+  });
+
+  it("keeps deltas received while an active-session snapshot is loading", () => {
+    const session = {
+      id: "session-1",
+      title: "Active session",
+      status: "running" as const,
+      model: "auto",
+      safetyMode: "sandboxed" as const,
+      workspacePath: "/tmp/session-1",
+      source: "user" as const,
+      createdAt: "2026-07-22T12:00:00Z",
+      updatedAt: "2026-07-22T12:00:01Z",
+    };
+    const run = {
+      id: "run-1",
+      sessionId: session.id,
+      status: "running" as const,
+      model: "auto",
+      startedAt: "2026-07-22T12:00:00Z",
+    };
+    let current = createAgentRuntimeProjection({ session, run });
+    current = applyAgentRuntimeEvent(current, {
+      ...frame,
+      eventId: "event-after-snapshot",
+      sequence: 4,
+      method: "message.delta",
+      data: {
+        itemId: "assistant:run-1",
+        role: "assistant",
+        delta: " plus the newest words",
+        createdAt: "2026-07-22T12:00:02Z",
+      },
+    });
+
+    const hydrated = mergeAgentRuntimeSnapshot(current, {
+      session,
+      run,
+      items: [
+        {
+          id: "assistant:run-1",
+          sessionId: session.id,
+          runId: run.id,
+          sequence: 1,
+          createdAt: "2026-07-22T12:00:01Z",
+          kind: "message",
+          role: "assistant",
+          text: "Everything said before opening",
+          status: "streaming",
+        },
+      ],
+    });
+
+    expect(hydrated.items).toMatchObject([
+      {
+        id: "assistant:run-1",
+        text: "Everything said before opening plus the newest words",
+        status: "streaming",
+      },
+    ]);
+    expect(hydrated.lastSequenceByRun[run.id]).toBe(4);
+
+    const continued = applyAgentRuntimeEvent(hydrated, {
+      ...frame,
+      eventId: "event-after-hydration",
+      sequence: 5,
+      method: "message.delta",
+      data: {
+        itemId: "assistant:run-1",
+        role: "assistant",
+        delta: " and the continuation",
+        createdAt: "2026-07-22T12:00:03Z",
+      },
+    });
+    expect(continued.items[0]).toMatchObject({
+      text: "Everything said before opening plus the newest words and the continuation",
+    });
   });
 
   it("replaces compacted transcript items with the visible context summary", () => {


### PR DESCRIPTION
## Summary
- persist assistant deltas while a run is active so opening the session shows the response-so-far
- keep stable runtime item IDs during active hydration and merge deltas that race the snapshot request
- coalesce final assistant output into the same row and avoid marking user messages as streaming

## Verification
- `pnpm typecheck`
- `pnpm test` (1,510 tests)
- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml --locked`
- `cargo test --manifest-path src-tauri/Cargo.toml --test agent_runtime_persistence --locked`
- focused Rust API active-stream identity test

## Native QA
The development app compiled and launched. The isolated native QA account bootstrap was blocked by missing local OS Accounts configuration, so no visual pass is claimed; the Rust persistence and React hydration boundary are covered deterministically.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787681637&installation_model_id=425925&pr_number=973&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F973&signature=ff6f99ca24ae445f85e6aeb5942d63ba2736d7ae20a84e95cc9addd4f7b8a491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->