### PR TITLE
Fence active transcript hydration races

### DIFF
--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -97,6 +97,30 @@ pub async fn get_agent_session(app: AppHandle, session_id: String) -> Result<Val
 }
 
 #[tauri::command]
+pub async fn get_agent_session_snapshot(
+    app: AppHandle,
+    session_id: String,
+) -> Result<Value, AppError> {
+    let (session, run, items) = repository(&app)
+        .await?
+        .session_snapshot(&session_id)
+        .await?;
+    let active_run_id = run
+        .as_ref()
+        .filter(|run| matches!(run.status.as_str(), "running" | "waiting_for_user"))
+        .map(|run| run.id.as_str());
+    let items = items
+        .into_iter()
+        .map(|item| item_json_with_active_run(item, active_run_id))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(json!({
+        "session": session_json(session),
+        "run": run.map(run_json),
+        "items": items,
+    }))
+}
+
+#[tauri::command]
 pub async fn get_latest_agent_run(
     app: AppHandle,
     session_id: String,
@@ -1957,6 +1981,57 @@ mod tests {
             .expect("branch profile")
             .get("profile");
         assert_eq!(profile, "private");
+    }
+
+    #[tokio::test]
+    async fn session_snapshots_include_the_matching_run_watermark_and_items() {
+        use sqlx_sqlite::SqlitePoolOptions;
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("memory database");
+        crate::db::migrations::run_migrations(&pool)
+            .await
+            .expect("migrations");
+        let repository = AgentRepository::new(pool);
+        let session = repository
+            .create_session("Snapshot", "auto", AgentSafetyMode::Sandboxed, None)
+            .await
+            .expect("session");
+        let run = repository
+            .create_run(&session.id, "auto", None)
+            .await
+            .expect("run");
+        repository
+            .append_assistant_message_delta(
+                &session.id,
+                &run.id,
+                7,
+                "Current response",
+                "assistant:run-1",
+            )
+            .await
+            .expect("assistant delta");
+
+        let (snapshot_session, snapshot_run, snapshot_items) = repository
+            .session_snapshot(&session.id)
+            .await
+            .expect("snapshot");
+
+        assert_eq!(snapshot_session.id, session.id);
+        assert_eq!(
+            snapshot_run.as_ref().map(|run| run.id.as_str()),
+            Some(run.id.as_str())
+        );
+        assert_eq!(snapshot_run.map(|run| run.last_sequence), Some(7));
+        assert_eq!(snapshot_items.len(), 1);
+        assert_eq!(snapshot_items[0].run_id.as_deref(), Some(run.id.as_str()));
+        assert!(matches!(
+            &snapshot_items[0].payload,
+            AgentItemPayload::AssistantMessage(message) if message.content == "Current response"
+        ));
     }
 
     #[test]

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -1604,7 +1604,7 @@ fn session_json(session: super::AgentSessionDto) -> Value {
     json!({ "id": session.id, "title": session.title, "status": session.status, "model": session.model, "safetyMode": session.safety_mode, "workspacePath": session.workspace_path.unwrap_or_default(), "source": match session.source.as_str() { "legacy_routine" => "legacy_routine", "routine" => "routine", "user" => "user", _ => "legacy_task" }, "createdAt": session.created_at, "updatedAt": session.updated_at, "error": session.last_error })
 }
 fn run_json(run: super::AgentRunDto) -> Value {
-    json!({ "id": run.id, "sessionId": run.session_id, "status": run.status, "model": run.model, "reasoningEffort": run.reasoning_effort, "startedAt": run.started_at, "completedAt": run.completed_at, "usage": run.usage, "error": run.error_message })
+    json!({ "id": run.id, "sessionId": run.session_id, "status": run.status, "model": run.model, "reasoningEffort": run.reasoning_effort, "startedAt": run.started_at, "completedAt": run.completed_at, "usage": run.usage, "lastSequence": run.last_sequence, "error": run.error_message })
 }
 
 fn item_json_with_active_run(
@@ -1868,6 +1868,27 @@ fn attachment_mime_type(path: &std::path::Path) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn run_json_carries_the_persisted_event_watermark() {
+        let value = run_json(super::super::AgentRunDto {
+            id: "run-1".into(),
+            session_id: "session-1".into(),
+            status: "running".into(),
+            model: "auto".into(),
+            reasoning_effort: None,
+            started_at: "2026-07-26T12:00:00Z".into(),
+            updated_at: "2026-07-26T12:00:01Z".into(),
+            completed_at: None,
+            usage: None,
+            interrupted_state: None,
+            last_sequence: 7,
+            error_code: None,
+            error_message: None,
+        });
+
+        assert_eq!(value["lastSequence"], 7);
+    }
 
     #[test]
     fn retry_uses_the_prompt_owned_by_the_selected_run() {

--- a/src-tauri/src/agent_runtime/repository.rs
+++ b/src-tauri/src/agent_runtime/repository.rs
@@ -100,6 +100,44 @@ impl AgentRepository {
         .map(session_from_row)
     }
 
+    pub async fn session_snapshot(
+        &self,
+        session_id: &str,
+    ) -> Result<(AgentSessionDto, Option<AgentRunDto>, Vec<AgentItemDto>), sqlx::Error> {
+        let mut transaction = self.pool.begin().await?;
+        let session = query(
+            "SELECT id, title, status, model, safety_mode, workspace_path, source,
+                    created_at, updated_at, completed_at, last_error
+             FROM agent_sessions WHERE id = ?",
+        )
+        .bind(session_id)
+        .fetch_one(&mut *transaction)
+        .await
+        .map(session_from_row)?;
+        let run = query(
+            "SELECT id, session_id, status, model, reasoning_effort, started_at, updated_at, completed_at,
+                    usage_json, interrupted_state_json, last_sequence, error_code, error_message
+             FROM agent_runs WHERE session_id = ? ORDER BY started_at DESC LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .map(run_from_row);
+        let rows = query(
+            "SELECT id, session_id, run_id, sequence, kind, payload_json, external_id, created_at
+             FROM agent_items WHERE session_id = ? ORDER BY sequence ASC",
+        )
+        .bind(session_id)
+        .fetch_all(&mut *transaction)
+        .await?;
+        let items = rows
+            .into_iter()
+            .map(item_from_row)
+            .collect::<Result<_, _>>()?;
+        transaction.commit().await?;
+        Ok((session, run, items))
+    }
+
     pub async fn list_sessions(&self) -> Result<Vec<AgentSessionDto>, sqlx::Error> {
         query(
             "SELECT id, title, status, model, safety_mode, workspace_path, source,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -173,6 +173,7 @@ pub fn run() {
             commands::bootstrap_app,
             agent_runtime::api::list_agent_sessions,
             agent_runtime::api::get_agent_session,
+            agent_runtime::api::get_agent_session_snapshot,
             agent_runtime::api::get_latest_agent_run,
             agent_runtime::api::compact_agent_session,
             agent_runtime::api::create_agent_session,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -530,27 +530,31 @@ export function AgentWorkspace({
       const requestId = crypto.randomUUID();
       hydrationRequestRef.current = requestId;
       if (selectedIdRef.current === sessionId) setHydratedSelectionId(undefined);
-      const [session, items, files, latestRun] = await Promise.all([
-        agentRuntimeBindings.getSession(sessionId),
-        agentRuntimeBindings.listItems(sessionId),
+      const [snapshot, files] = await Promise.all([
+        agentRuntimeBindings.getSnapshot
+          ? agentRuntimeBindings.getSnapshot(sessionId)
+          : Promise.all([
+              agentRuntimeBindings.getSession(sessionId),
+              agentRuntimeBindings.listItems(sessionId),
+              agentRuntimeBindings.getLatestRun?.(sessionId) ?? Promise.resolve(null),
+            ]).then(([session, items, run]) => ({ session, items, run: run ?? undefined })),
         agentRuntimeBindings.listArtifacts(sessionId),
-        agentRuntimeBindings.getLatestRun?.(sessionId) ?? Promise.resolve(null),
       ]);
       if (selectedIdRef.current !== sessionId || hydrationRequestRef.current !== requestId) {
         return;
       }
       setProjection((current) =>
         mergeAgentRuntimeSnapshot(current, {
-          session,
-          items,
-          run: latestRun ?? undefined,
+          session: snapshot.session,
+          items: snapshot.items,
+          run: snapshot.run,
         }),
       );
       updateQueuedFollowUps((current) =>
         reconcileConsumedAgentFollowUp(
           current,
           sessionId,
-          items.map((item) => item.id),
+          snapshot.items.map((item) => item.id),
         ),
       );
       setHydratedSelectionId(sessionId);
@@ -558,15 +562,17 @@ export function AgentWorkspace({
       if (homeMode) {
         setModel(AUTO_MODEL_ID);
       } else {
-        applySessionModel(loadSessionModels()[session.id] ?? session.model);
+        applySessionModel(loadSessionModels()[snapshot.session.id] ?? snapshot.session.model);
       }
       setThinkingLevel(
-        homeMode ? "instant" : (loadSessionThinkingLevels()[session.id] ?? loadThinkingLevel()),
+        homeMode
+          ? "instant"
+          : (loadSessionThinkingLevels()[snapshot.session.id] ?? loadThinkingLevel()),
       );
-      setSafetyMode(homeMode ? "sandboxed" : session.safetyMode);
+      setSafetyMode(homeMode ? "sandboxed" : snapshot.session.safetyMode);
       setNewSessionMode(false);
       if (!homeMode) writeLastOpenSessionId(sessionId);
-      onSessionSelected?.(session);
+      onSessionSelected?.(snapshot.session);
     },
     [applySessionModel, homeMode, onSessionSelected, updateQueuedFollowUps],
   );

--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -76,6 +76,9 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
   const generationRef = useRef(0);
   const sessionIdRef = useRef<string>();
   const activeSubmitRef = useRef<symbol>();
+  const sessionTitleRef = useRef<string>();
+  const runtimeListenerReadyRef = useRef<Promise<boolean>>(Promise.resolve(false));
+  sessionTitleRef.current = projection.session?.title;
 
   const working = runIsActive(projection);
   const turns = useMemo(() => agentItemsToChatTurns(projection.items), [projection.items]);
@@ -94,6 +97,55 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
   }, []);
 
   useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    runtimeListenerReadyRef.current = listen<AgentRuntimeEvent>(
+      AGENT_RUNTIME_EVENT,
+      ({ payload }) => {
+        if (payload.sessionId !== sessionIdRef.current) return;
+        setProjection((current) => applyAgentRuntimeEvent(current, payload));
+        const terminal =
+          payload.method === "run.completed" ||
+          payload.method === "run.cancelled" ||
+          payload.method === "run.failed";
+        dispatchAgentSessionStatus({
+          sessionId: payload.sessionId,
+          title: sessionTitleRef.current ?? "Note chat",
+          status:
+            payload.method === "run.completed"
+              ? "completed"
+              : payload.method === "run.cancelled"
+                ? "cancelled"
+                : payload.method === "run.failed"
+                  ? "failed"
+                  : "running",
+          ...(payload.method === "run.failed" ? { summary: payload.data.message } : {}),
+        });
+        if (terminal) void hydrate(payload.sessionId).catch(() => undefined);
+      },
+    )
+      .then((dispose) => {
+        if (disposed) {
+          dispose();
+          return false;
+        }
+        unlisten = dispose;
+        return true;
+      })
+      .catch((cause) => {
+        if (!disposed) {
+          setError(messageFromError(cause));
+          setLoading(false);
+        }
+        return false;
+      });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [hydrate]);
+
+  useEffect(() => {
     const generation = ++generationRef.current;
     const rememberedSessionId = noteId ? noteChatSessionIdFor(noteId) : undefined;
     sessionIdRef.current = rememberedSessionId;
@@ -108,7 +160,8 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
     }
 
     setLoading(true);
-    void hydrate(rememberedSessionId)
+    void runtimeListenerReadyRef.current
+      .then((ready) => (ready ? hydrate(rememberedSessionId) : undefined))
       .catch(() => {
         if (generation !== generationRef.current) return;
         forgetNoteChatSession(noteId!);
@@ -119,40 +172,6 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
         if (generation === generationRef.current) setLoading(false);
       });
   }, [hydrate, noteId]);
-
-  useEffect(() => {
-    let disposed = false;
-    let unlisten: (() => void) | undefined;
-    void listen<AgentRuntimeEvent>(AGENT_RUNTIME_EVENT, ({ payload }) => {
-      if (payload.sessionId !== sessionIdRef.current) return;
-      setProjection((current) => applyAgentRuntimeEvent(current, payload));
-      const terminal =
-        payload.method === "run.completed" ||
-        payload.method === "run.cancelled" ||
-        payload.method === "run.failed";
-      dispatchAgentSessionStatus({
-        sessionId: payload.sessionId,
-        title: projection.session?.title ?? "Note chat",
-        status:
-          payload.method === "run.completed"
-            ? "completed"
-            : payload.method === "run.cancelled"
-              ? "cancelled"
-              : payload.method === "run.failed"
-                ? "failed"
-                : "running",
-        ...(payload.method === "run.failed" ? { summary: payload.data.message } : {}),
-      });
-      if (terminal) void hydrate(payload.sessionId).catch(() => undefined);
-    }).then((dispose) => {
-      if (disposed) dispose();
-      else unlisten = dispose;
-    });
-    return () => {
-      disposed = true;
-      unlisten?.();
-    };
-  }, [hydrate, projection.session?.title]);
 
   const submit = useCallback(
     async (

--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -5,6 +5,7 @@ import {
   agentItemsToChatTurns,
   applyAgentRuntimeEvent,
   createAgentRuntimeProjection,
+  mergeAgentRuntimeSnapshot,
   type AgentRuntimeProjection,
 } from "../../lib/agent-runtime-adapter";
 import type { AgentItemDto, AgentRuntimeEvent } from "../../lib/agent-runtime-contract";
@@ -86,10 +87,13 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
       agentRuntimeBindings.getLatestRun?.(sessionId) ?? Promise.resolve(null),
     ]);
     if (sessionIdRef.current !== sessionId) return;
-    setProjection({
-      ...createAgentRuntimeProjection({ session, items }),
-      run: latestRun ?? undefined,
-    });
+    setProjection((current) =>
+      mergeAgentRuntimeSnapshot(current, {
+        session,
+        items,
+        run: latestRun ?? undefined,
+      }),
+    );
     setModel(session.model || DEFAULT_MODEL);
   }, []);
 

--- a/src/components/note-chat/useNoteChat.ts
+++ b/src/components/note-chat/useNoteChat.ts
@@ -81,20 +81,16 @@ export function useNoteChat(note: NoteReferenceInput | null): NoteChat {
   const turns = useMemo(() => agentItemsToChatTurns(projection.items), [projection.items]);
 
   const hydrate = useCallback(async (sessionId: string) => {
-    const [session, items, latestRun] = await Promise.all([
-      agentRuntimeBindings.getSession(sessionId),
-      agentRuntimeBindings.listItems(sessionId),
-      agentRuntimeBindings.getLatestRun?.(sessionId) ?? Promise.resolve(null),
-    ]);
+    const snapshot = agentRuntimeBindings.getSnapshot
+      ? await agentRuntimeBindings.getSnapshot(sessionId)
+      : await Promise.all([
+          agentRuntimeBindings.getSession(sessionId),
+          agentRuntimeBindings.listItems(sessionId),
+          agentRuntimeBindings.getLatestRun?.(sessionId) ?? Promise.resolve(null),
+        ]).then(([session, items, run]) => ({ session, items, run: run ?? undefined }));
     if (sessionIdRef.current !== sessionId) return;
-    setProjection((current) =>
-      mergeAgentRuntimeSnapshot(current, {
-        session,
-        items,
-        run: latestRun ?? undefined,
-      }),
-    );
-    setModel(session.model || DEFAULT_MODEL);
+    setProjection((current) => mergeAgentRuntimeSnapshot(current, snapshot));
+    setModel(snapshot.session.model || DEFAULT_MODEL);
   }, []);
 
   useEffect(() => {

--- a/src/lib/agent-runtime-adapter.ts
+++ b/src/lib/agent-runtime-adapter.ts
@@ -49,6 +49,9 @@ export function mergeAgentRuntimeSnapshot(
   const snapshot = createAgentRuntimeProjection(input);
   const run = input.run;
   if (!run || run.lastSequence === undefined) return snapshot;
+  if (current.run && current.run.id !== run.id && currentRunIsNewer(current.run, run)) {
+    return current;
+  }
   const snapshotSequence = run.lastSequence;
   let merged: AgentRuntimeProjection = {
     ...snapshot,
@@ -61,6 +64,19 @@ export function mergeAgentRuntimeSnapshot(
     .sort((left, right) => left.sequence - right.sequence);
   for (const event of pendingEvents) merged = applyAgentRuntimeEvent(merged, event);
   return merged;
+}
+
+function currentRunIsNewer(current: AgentRunDto, snapshot: AgentRunDto) {
+  const currentStartedAt = current.startedAt ? Date.parse(current.startedAt) : Number.NaN;
+  const snapshotStartedAt = snapshot.startedAt ? Date.parse(snapshot.startedAt) : Number.NaN;
+  if (Number.isFinite(currentStartedAt) && Number.isFinite(snapshotStartedAt)) {
+    return currentStartedAt >= snapshotStartedAt;
+  }
+  return (
+    current.status === "queued" ||
+    current.status === "running" ||
+    current.status === "waiting_for_user"
+  );
 }
 
 export function applyAgentRuntimeEvent(

--- a/src/lib/agent-runtime-adapter.ts
+++ b/src/lib/agent-runtime-adapter.ts
@@ -18,6 +18,7 @@ export type AgentRuntimeProjection = {
   items: AgentItemDto[];
   lastSequenceByRun: Record<string, number>;
   processedEventIds: Set<string>;
+  textDeltasByItem: Record<string, Array<{ sequence: number; delta: string }>>;
 };
 
 export function createAgentRuntimeProjection(
@@ -29,6 +30,7 @@ export function createAgentRuntimeProjection(
     items: [...(input.items ?? [])].sort(compareAgentItems),
     lastSequenceByRun: {},
     processedEventIds: new Set(),
+    textDeltasByItem: {},
   };
 }
 
@@ -46,25 +48,39 @@ export function mergeAgentRuntimeSnapshot(
   const run = input.run;
   if (!run || (run.status !== "running" && run.status !== "waiting_for_user")) return snapshot;
 
-  const liveItems = current.items.filter(
+  const snapshotSequence =
+    run.lastSequence ??
+    snapshot.items.reduce((latest, item) => Math.max(latest, item.sequence), -1);
+  const textDeltasByItem: AgentRuntimeProjection["textDeltasByItem"] = {};
+  for (const [key, deltas] of Object.entries(current.textDeltasByItem)) {
+    if (!key.startsWith(`${run.id}:`)) continue;
+    const pending = deltas
+      .filter((delta) => delta.sequence > snapshotSequence)
+      .sort((a, b) => a.sequence - b.sequence);
+    if (pending.length > 0) textDeltasByItem[key] = pending;
+  }
+  const newerItems = current.items.filter(
     (item) =>
       item.sessionId === input.session.id &&
       item.runId === run.id &&
-      (item.kind === "message" || item.kind === "reasoning") &&
-      item.status === "streaming",
+      item.sequence > snapshotSequence,
   );
   let items = snapshot.items;
-  for (const liveItem of liveItems) {
-    const persisted = items.find((item) => item.id === liveItem.id);
+  for (const newerItem of newerItems) {
+    const persisted = items.find((item) => item.id === newerItem.id);
     if (
       persisted &&
       (persisted.kind === "message" || persisted.kind === "reasoning") &&
-      persisted.kind === liveItem.kind
+      persisted.kind === newerItem.kind &&
+      newerItem.status === "streaming"
     ) {
-      const text = mergeStreamText(persisted.text, liveItem.text);
-      items = upsertItem(items, { ...persisted, text, status: "streaming" });
+      const deltas = textDeltasByItem[textDeltaKey(run.id, newerItem.id)] ?? [];
+      items = upsertItem(items, {
+        ...newerItem,
+        text: persisted.text + deltas.map((delta) => delta.delta).join(""),
+      });
     } else {
-      items = upsertItem(items, liveItem);
+      items = upsertItem(items, newerItem);
     }
   }
 
@@ -80,24 +96,11 @@ export function mergeAgentRuntimeSnapshot(
     items,
     lastSequenceByRun: {
       ...snapshot.lastSequenceByRun,
-      ...(current.lastSequenceByRun[run.id] === undefined
-        ? {}
-        : { [run.id]: current.lastSequenceByRun[run.id] }),
+      [run.id]: Math.max(snapshotSequence, current.lastSequenceByRun[run.id] ?? -1),
     },
     processedEventIds: new Set(current.processedEventIds),
+    textDeltasByItem,
   };
-}
-
-function mergeStreamText(persisted: string, live: string) {
-  if (live.startsWith(persisted)) return live;
-  if (persisted.startsWith(live)) return persisted;
-  const maxOverlap = Math.min(persisted.length, live.length);
-  for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
-    if (persisted.endsWith(live.slice(0, overlap))) {
-      return persisted + live.slice(overlap);
-    }
-  }
-  return persisted + live;
 }
 
 export function applyAgentRuntimeEvent(
@@ -115,6 +118,7 @@ export function applyAgentRuntimeEvent(
     items: [...projection.items],
     lastSequenceByRun: { ...projection.lastSequenceByRun, [event.runId]: event.sequence },
     processedEventIds: new Set(projection.processedEventIds).add(event.eventId),
+    textDeltasByItem: { ...projection.textDeltasByItem },
   };
 
   switch (event.method) {
@@ -135,6 +139,10 @@ export function applyAgentRuntimeEvent(
       }
       break;
     case "message.delta":
+      next.textDeltasByItem[textDeltaKey(event.runId, event.data.itemId)] = [
+        ...(next.textDeltasByItem[textDeltaKey(event.runId, event.data.itemId)] ?? []),
+        { sequence: event.sequence, delta: event.data.delta },
+      ];
       next.items = appendTextDelta(next.items, event, "message");
       break;
     case "message.completed":
@@ -151,6 +159,10 @@ export function applyAgentRuntimeEvent(
       });
       break;
     case "reasoning.delta":
+      next.textDeltasByItem[textDeltaKey(event.runId, event.data.itemId)] = [
+        ...(next.textDeltasByItem[textDeltaKey(event.runId, event.data.itemId)] ?? []),
+        { sequence: event.sequence, delta: event.data.delta },
+      ];
       next.items = appendTextDelta(next.items, event, "reasoning");
       break;
     case "steering.consumed":
@@ -439,6 +451,10 @@ function generatedVideoPart(output: unknown): AgentChatPart | undefined {
 
 function toolCallKey(runId: string | undefined, callId: string) {
   return `${runId ?? ""}:${callId}`;
+}
+
+function textDeltaKey(runId: string, itemId: string) {
+  return `${runId}:${itemId}`;
 }
 
 function interruptionToPart(

--- a/src/lib/agent-runtime-adapter.ts
+++ b/src/lib/agent-runtime-adapter.ts
@@ -19,6 +19,7 @@ export type AgentRuntimeProjection = {
   lastSequenceByRun: Record<string, number>;
   processedEventIds: Set<string>;
   textDeltasByItem: Record<string, Array<{ sequence: number; delta: string }>>;
+  eventsByRun: Record<string, AgentRuntimeEvent[]>;
 };
 
 export function createAgentRuntimeProjection(
@@ -31,6 +32,7 @@ export function createAgentRuntimeProjection(
     lastSequenceByRun: {},
     processedEventIds: new Set(),
     textDeltasByItem: {},
+    eventsByRun: {},
   };
 }
 
@@ -46,62 +48,19 @@ export function mergeAgentRuntimeSnapshot(
 ): AgentRuntimeProjection {
   const snapshot = createAgentRuntimeProjection(input);
   const run = input.run;
-  if (!run) return snapshot;
-  const activeRun = run.status === "running" || run.status === "waiting_for_user";
-
-  const snapshotSequence =
-    run.lastSequence ??
-    snapshot.items.reduce((latest, item) => Math.max(latest, item.sequence), -1);
-  const textDeltasByItem: AgentRuntimeProjection["textDeltasByItem"] = {};
-  for (const [key, deltas] of Object.entries(current.textDeltasByItem)) {
-    if (!key.startsWith(`${run.id}:`)) continue;
-    const pending = deltas
-      .filter((delta) => activeRun && delta.sequence > snapshotSequence)
-      .sort((a, b) => a.sequence - b.sequence);
-    if (pending.length > 0) textDeltasByItem[key] = pending;
-  }
-  const newerItems = current.items.filter((item) => {
-    if (item.sessionId !== input.session.id || item.runId !== run.id) return false;
-    if (activeRun) return item.sequence > snapshotSequence;
-    const persisted = snapshot.items.find((candidate) => candidate.id === item.id);
-    return !persisted || item.sequence > persisted.sequence;
-  });
-  let items = snapshot.items;
-  for (const newerItem of newerItems) {
-    const persisted = items.find((item) => item.id === newerItem.id);
-    if (
-      persisted &&
-      (persisted.kind === "message" || persisted.kind === "reasoning") &&
-      persisted.kind === newerItem.kind &&
-      newerItem.status === "streaming"
-    ) {
-      const deltas = textDeltasByItem[textDeltaKey(run.id, newerItem.id)] ?? [];
-      items = upsertItem(items, {
-        ...newerItem,
-        text: persisted.text + deltas.map((delta) => delta.delta).join(""),
-      });
-    } else {
-      items = upsertItem(items, newerItem);
-    }
-  }
-
-  const currentRun = current.run?.id === run.id ? current.run : undefined;
-  const currentRunFinished =
-    currentRun &&
-    (currentRun.status === "completed" ||
-      currentRun.status === "cancelled" ||
-      currentRun.status === "failed");
-  return {
+  if (!run || run.lastSequence === undefined) return snapshot;
+  const snapshotSequence = run.lastSequence;
+  let merged: AgentRuntimeProjection = {
     ...snapshot,
-    run: currentRunFinished ? currentRun : run,
-    items,
     lastSequenceByRun: {
-      ...snapshot.lastSequenceByRun,
-      [run.id]: Math.max(snapshotSequence, current.lastSequenceByRun[run.id] ?? -1),
+      [run.id]: snapshotSequence,
     },
-    processedEventIds: new Set(current.processedEventIds),
-    textDeltasByItem,
   };
+  const pendingEvents = (current.eventsByRun[run.id] ?? [])
+    .filter((event) => event.sequence > snapshotSequence)
+    .sort((left, right) => left.sequence - right.sequence);
+  for (const event of pendingEvents) merged = applyAgentRuntimeEvent(merged, event);
+  return merged;
 }
 
 export function applyAgentRuntimeEvent(
@@ -120,6 +79,10 @@ export function applyAgentRuntimeEvent(
     lastSequenceByRun: { ...projection.lastSequenceByRun, [event.runId]: event.sequence },
     processedEventIds: new Set(projection.processedEventIds).add(event.eventId),
     textDeltasByItem: { ...projection.textDeltasByItem },
+    eventsByRun: {
+      ...projection.eventsByRun,
+      [event.runId]: [...(projection.eventsByRun[event.runId] ?? []), event],
+    },
   };
 
   switch (event.method) {

--- a/src/lib/agent-runtime-adapter.ts
+++ b/src/lib/agent-runtime-adapter.ts
@@ -46,7 +46,8 @@ export function mergeAgentRuntimeSnapshot(
 ): AgentRuntimeProjection {
   const snapshot = createAgentRuntimeProjection(input);
   const run = input.run;
-  if (!run || (run.status !== "running" && run.status !== "waiting_for_user")) return snapshot;
+  if (!run) return snapshot;
+  const activeRun = run.status === "running" || run.status === "waiting_for_user";
 
   const snapshotSequence =
     run.lastSequence ??
@@ -55,16 +56,16 @@ export function mergeAgentRuntimeSnapshot(
   for (const [key, deltas] of Object.entries(current.textDeltasByItem)) {
     if (!key.startsWith(`${run.id}:`)) continue;
     const pending = deltas
-      .filter((delta) => delta.sequence > snapshotSequence)
+      .filter((delta) => activeRun && delta.sequence > snapshotSequence)
       .sort((a, b) => a.sequence - b.sequence);
     if (pending.length > 0) textDeltasByItem[key] = pending;
   }
-  const newerItems = current.items.filter(
-    (item) =>
-      item.sessionId === input.session.id &&
-      item.runId === run.id &&
-      item.sequence > snapshotSequence,
-  );
+  const newerItems = current.items.filter((item) => {
+    if (item.sessionId !== input.session.id || item.runId !== run.id) return false;
+    if (activeRun) return item.sequence > snapshotSequence;
+    const persisted = snapshot.items.find((candidate) => candidate.id === item.id);
+    return !persisted || item.sequence > persisted.sequence;
+  });
   let items = snapshot.items;
   for (const newerItem of newerItems) {
     const persisted = items.find((item) => item.id === newerItem.id);

--- a/src/lib/agent-runtime-contract.ts
+++ b/src/lib/agent-runtime-contract.ts
@@ -48,6 +48,7 @@ export type AgentRunDto = {
   sessionId: string;
   status: AgentRunStatus;
   model: string;
+  lastSequence?: number;
   reasoningEffort?: "minimal" | "medium" | "high";
   startedAt?: string;
   completedAt?: string;

--- a/src/lib/agent-runtime-contract.ts
+++ b/src/lib/agent-runtime-contract.ts
@@ -289,6 +289,11 @@ export type ResolveAgentInterruptionRequest = {
 export type AgentRuntimeBindings = {
   listSessions(): Promise<AgentSessionDto[]>;
   getSession(sessionId: string): Promise<AgentSessionDto>;
+  getSnapshot?(sessionId: string): Promise<{
+    session: AgentSessionDto;
+    run?: AgentRunDto;
+    items: AgentItemDto[];
+  }>;
   getLatestRun?(sessionId: string): Promise<AgentRunDto | null>;
   compactSession?(sessionId: string): Promise<{
     compacted: boolean;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -67,6 +67,11 @@ export async function juneHomeChat(
 export const agentRuntimeBindings: AgentRuntimeBindings = {
   listSessions: () => invoke<AgentSessionDto[]>("list_agent_sessions"),
   getSession: (sessionId) => invoke<AgentSessionDto>("get_agent_session", { sessionId }),
+  getSnapshot: (sessionId) =>
+    invoke<{ session: AgentSessionDto; run?: AgentRunDto; items: AgentItemDto[] }>(
+      "get_agent_session_snapshot",
+      { sessionId },
+    ),
   getLatestRun: (sessionId) => invoke<AgentRunDto | null>("get_latest_agent_run", { sessionId }),
   compactSession: (sessionId) =>
     invoke<{ compacted: boolean; removedItems: number; estimatedTokens?: number }>(

--- a/src/test/agent-runtime-adapter.test.ts
+++ b/src/test/agent-runtime-adapter.test.ts
@@ -265,6 +265,60 @@ describe("agent runtime adapter", () => {
     expect(hydrated.lastSequenceByRun[run.id]).toBe(5);
   });
 
+  it("does not replace a newer active run with a stale terminal snapshot", () => {
+    const session = {
+      id: "session-1",
+      title: "Active session",
+      status: "running" as const,
+      model: "auto",
+      safetyMode: "sandboxed" as const,
+      workspacePath: "/tmp/session-1",
+      source: "user" as const,
+      createdAt: "2026-07-22T12:00:00Z",
+      updatedAt: "2026-07-22T12:01:00Z",
+    };
+    const current = createAgentRuntimeProjection({
+      session,
+      run: {
+        id: "run-new",
+        sessionId: session.id,
+        status: "running",
+        model: "auto",
+        startedAt: "2026-07-22T12:01:00Z",
+      },
+      items: [
+        {
+          id: "new-question",
+          sessionId: session.id,
+          runId: "run-new",
+          sequence: 6,
+          createdAt: "2026-07-22T12:01:00Z",
+          kind: "message",
+          role: "user",
+          text: "New question",
+          status: "complete",
+        },
+      ],
+    });
+
+    const hydrated = mergeAgentRuntimeSnapshot(current, {
+      session: { ...session, status: "idle" },
+      run: {
+        id: "run-old",
+        sessionId: session.id,
+        status: "completed",
+        model: "auto",
+        startedAt: "2026-07-22T12:00:00Z",
+        lastSequence: 5,
+      },
+      items: [],
+    });
+
+    expect(hydrated).toBe(current);
+    expect(hydrated.run?.id).toBe("run-new");
+    expect(hydrated.items[0]).toMatchObject({ id: "new-question", text: "New question" });
+  });
+
   it("uses the persisted run watermark to ignore delayed duplicate deltas", () => {
     const session = {
       id: "session-1",

--- a/src/test/agent-runtime-adapter.test.ts
+++ b/src/test/agent-runtime-adapter.test.ts
@@ -135,6 +135,7 @@ describe("agent runtime adapter", () => {
       status: "running" as const,
       model: "auto",
       startedAt: "2026-07-22T12:00:00Z",
+      lastSequence: 3,
     };
     let current = createAgentRuntimeProjection({ session, run });
     current = applyAgentRuntimeEvent(current, {
@@ -262,66 +263,6 @@ describe("agent runtime adapter", () => {
       { id: "assistant:run-1", text: "final answer", status: "complete", sequence: 5 },
     ]);
     expect(hydrated.lastSequenceByRun[run.id]).toBe(5);
-  });
-
-  it("keeps newer renderer items when a parallel run fetch is already terminal", () => {
-    const session = {
-      id: "session-1",
-      title: "Active session",
-      status: "completed" as const,
-      model: "auto",
-      safetyMode: "sandboxed" as const,
-      workspacePath: "/tmp/session-1",
-      source: "user" as const,
-      createdAt: "2026-07-22T12:00:00Z",
-      updatedAt: "2026-07-22T12:00:03Z",
-    };
-    const run = {
-      id: "run-1",
-      sessionId: session.id,
-      status: "completed" as const,
-      model: "auto",
-      lastSequence: 6,
-    };
-    const current = createAgentRuntimeProjection({
-      session,
-      run,
-      items: [
-        {
-          id: "assistant:run-1",
-          sessionId: session.id,
-          runId: run.id,
-          sequence: 5,
-          createdAt: "2026-07-22T12:00:03Z",
-          kind: "message",
-          role: "assistant",
-          text: "final answer",
-          status: "complete",
-        },
-      ],
-    });
-
-    const hydrated = mergeAgentRuntimeSnapshot(current, {
-      session,
-      run,
-      items: [
-        {
-          id: "assistant:run-1",
-          sessionId: session.id,
-          runId: run.id,
-          sequence: 3,
-          createdAt: "2026-07-22T12:00:01Z",
-          kind: "message",
-          role: "assistant",
-          text: "part",
-          status: "streaming",
-        },
-      ],
-    });
-
-    expect(hydrated.items).toMatchObject([
-      { id: "assistant:run-1", text: "final answer", status: "complete", sequence: 5 },
-    ]);
   });
 
   it("uses the persisted run watermark to ignore delayed duplicate deltas", () => {

--- a/src/test/agent-runtime-adapter.test.ts
+++ b/src/test/agent-runtime-adapter.test.ts
@@ -194,6 +194,186 @@ describe("agent runtime adapter", () => {
     });
   });
 
+  it("keeps a completion received while an older active snapshot is loading", () => {
+    const session = {
+      id: "session-1",
+      title: "Active session",
+      status: "running" as const,
+      model: "auto",
+      safetyMode: "sandboxed" as const,
+      workspacePath: "/tmp/session-1",
+      source: "user" as const,
+      createdAt: "2026-07-22T12:00:00Z",
+      updatedAt: "2026-07-22T12:00:01Z",
+    };
+    const run = {
+      id: "run-1",
+      sessionId: session.id,
+      status: "running" as const,
+      model: "auto",
+      startedAt: "2026-07-22T12:00:00Z",
+      lastSequence: 3,
+    };
+    let current = createAgentRuntimeProjection({ session, run });
+    current = applyAgentRuntimeEvent(current, {
+      ...frame,
+      eventId: "event-live-delta",
+      sequence: 4,
+      method: "message.delta",
+      data: {
+        itemId: "assistant:run-1",
+        role: "assistant",
+        delta: "partial",
+        createdAt: "2026-07-22T12:00:02Z",
+      },
+    });
+    current = applyAgentRuntimeEvent(current, {
+      ...frame,
+      eventId: "event-live-completion",
+      sequence: 5,
+      method: "message.completed",
+      data: {
+        itemId: "assistant:run-1",
+        role: "assistant",
+        text: "final answer",
+        createdAt: "2026-07-22T12:00:03Z",
+      },
+    });
+
+    const hydrated = mergeAgentRuntimeSnapshot(current, {
+      session,
+      run,
+      items: [
+        {
+          id: "assistant:run-1",
+          sessionId: session.id,
+          runId: run.id,
+          sequence: 3,
+          createdAt: "2026-07-22T12:00:01Z",
+          kind: "message",
+          role: "assistant",
+          text: "part",
+          status: "streaming",
+        },
+      ],
+    });
+
+    expect(hydrated.items).toMatchObject([
+      { id: "assistant:run-1", text: "final answer", status: "complete", sequence: 5 },
+    ]);
+    expect(hydrated.lastSequenceByRun[run.id]).toBe(5);
+  });
+
+  it("uses the persisted run watermark to ignore delayed duplicate deltas", () => {
+    const session = {
+      id: "session-1",
+      title: "Active session",
+      status: "running" as const,
+      model: "auto",
+      safetyMode: "sandboxed" as const,
+      workspacePath: "/tmp/session-1",
+      source: "user" as const,
+      createdAt: "2026-07-22T12:00:00Z",
+      updatedAt: "2026-07-22T12:00:01Z",
+    };
+    const run = {
+      id: "run-1",
+      sessionId: session.id,
+      status: "running" as const,
+      model: "auto",
+      startedAt: "2026-07-22T12:00:00Z",
+      lastSequence: 4,
+    };
+    const hydrated = mergeAgentRuntimeSnapshot(createAgentRuntimeProjection({ session, run }), {
+      session,
+      run,
+      items: [
+        {
+          id: "assistant:run-1",
+          sessionId: session.id,
+          runId: run.id,
+          sequence: 4,
+          createdAt: "2026-07-22T12:00:01Z",
+          kind: "message",
+          role: "assistant",
+          text: "persisted once",
+          status: "streaming",
+        },
+      ],
+    });
+
+    const delayed = applyAgentRuntimeEvent(hydrated, {
+      ...frame,
+      eventId: "event-delayed",
+      sequence: 4,
+      method: "message.delta",
+      data: {
+        itemId: "assistant:run-1",
+        role: "assistant",
+        delta: "persisted once",
+        createdAt: "2026-07-22T12:00:01Z",
+      },
+    });
+
+    expect(delayed).toBe(hydrated);
+    expect(delayed.items[0]).toMatchObject({ text: "persisted once" });
+  });
+
+  it("preserves intentional repeated text across an active hydration race", () => {
+    const session = {
+      id: "session-1",
+      title: "Active session",
+      status: "running" as const,
+      model: "auto",
+      safetyMode: "sandboxed" as const,
+      workspacePath: "/tmp/session-1",
+      source: "user" as const,
+      createdAt: "2026-07-22T12:00:00Z",
+      updatedAt: "2026-07-22T12:00:01Z",
+    };
+    const run = {
+      id: "run-1",
+      sessionId: session.id,
+      status: "running" as const,
+      model: "auto",
+      startedAt: "2026-07-22T12:00:00Z",
+      lastSequence: 3,
+    };
+    let current = createAgentRuntimeProjection({ session, run });
+    current = applyAgentRuntimeEvent(current, {
+      ...frame,
+      eventId: "event-repeated-delta",
+      sequence: 4,
+      method: "message.delta",
+      data: {
+        itemId: "assistant:run-1",
+        role: "assistant",
+        delta: "ha!",
+        createdAt: "2026-07-22T12:00:02Z",
+      },
+    });
+
+    const hydrated = mergeAgentRuntimeSnapshot(current, {
+      session,
+      run,
+      items: [
+        {
+          id: "assistant:run-1",
+          sessionId: session.id,
+          runId: run.id,
+          sequence: 3,
+          createdAt: "2026-07-22T12:00:01Z",
+          kind: "message",
+          role: "assistant",
+          text: "ha",
+          status: "streaming",
+        },
+      ],
+    });
+
+    expect(hydrated.items[0]).toMatchObject({ text: "haha!", status: "streaming" });
+  });
+
   it("replaces compacted transcript items with the visible context summary", () => {
     const projection = createAgentRuntimeProjection({
       items: [

--- a/src/test/agent-runtime-adapter.test.ts
+++ b/src/test/agent-runtime-adapter.test.ts
@@ -264,6 +264,66 @@ describe("agent runtime adapter", () => {
     expect(hydrated.lastSequenceByRun[run.id]).toBe(5);
   });
 
+  it("keeps newer renderer items when a parallel run fetch is already terminal", () => {
+    const session = {
+      id: "session-1",
+      title: "Active session",
+      status: "completed" as const,
+      model: "auto",
+      safetyMode: "sandboxed" as const,
+      workspacePath: "/tmp/session-1",
+      source: "user" as const,
+      createdAt: "2026-07-22T12:00:00Z",
+      updatedAt: "2026-07-22T12:00:03Z",
+    };
+    const run = {
+      id: "run-1",
+      sessionId: session.id,
+      status: "completed" as const,
+      model: "auto",
+      lastSequence: 6,
+    };
+    const current = createAgentRuntimeProjection({
+      session,
+      run,
+      items: [
+        {
+          id: "assistant:run-1",
+          sessionId: session.id,
+          runId: run.id,
+          sequence: 5,
+          createdAt: "2026-07-22T12:00:03Z",
+          kind: "message",
+          role: "assistant",
+          text: "final answer",
+          status: "complete",
+        },
+      ],
+    });
+
+    const hydrated = mergeAgentRuntimeSnapshot(current, {
+      session,
+      run,
+      items: [
+        {
+          id: "assistant:run-1",
+          sessionId: session.id,
+          runId: run.id,
+          sequence: 3,
+          createdAt: "2026-07-22T12:00:01Z",
+          kind: "message",
+          role: "assistant",
+          text: "part",
+          status: "streaming",
+        },
+      ],
+    });
+
+    expect(hydrated.items).toMatchObject([
+      { id: "assistant:run-1", text: "final answer", status: "complete", sequence: 5 },
+    ]);
+  });
+
   it("uses the persisted run watermark to ignore delayed duplicate deltas", () => {
     const session = {
       id: "session-1",

--- a/src/test/note-chat-sessions.test.ts
+++ b/src/test/note-chat-sessions.test.ts
@@ -154,6 +154,25 @@ describe("note chat sessions", () => {
     });
   });
 
+  it("installs the runtime listener before hydrating a saved session", async () => {
+    rememberNoteChatSession("note-1", "note-session");
+    mocks.getSession.mockResolvedValue(session());
+    mocks.listItems.mockResolvedValue([]);
+    let finishListening: ((dispose: () => void) => void) | undefined;
+    mocks.listen.mockReturnValue(
+      new Promise<() => void>((resolve) => {
+        finishListening = resolve;
+      }),
+    );
+
+    renderHook(() => useNoteChat({ id: "note-1", title: "Planning" }));
+
+    await waitFor(() => expect(mocks.listen).toHaveBeenCalledOnce());
+    expect(mocks.getSession).not.toHaveBeenCalled();
+    await act(async () => finishListening?.(() => undefined));
+    await waitFor(() => expect(mocks.getSession).toHaveBeenCalledWith("note-session"));
+  });
+
   it("cancels the active runtime run", async () => {
     mocks.createSession.mockResolvedValue(session());
     mocks.startRun.mockResolvedValue(run());


### PR DESCRIPTION
## What changed

- carry the persisted run sequence watermark into active transcript hydration
- serialize that backend watermark through the public run DTO
- retain post-snapshot text deltas by sequence instead of guessing from text prefixes
- preserve newer completion and other item state that lands while a snapshot is in flight
- add regressions for completion loss, delayed duplicate events, repeated text, and watermark serialization

## Why

PR #973 merged with three unresolved hydration-race findings: a P1 completion rollback and two P2 cases that could duplicate or drop streamed text. This follow-up uses sequence provenance to reconcile the persisted snapshot with renderer-local events.

## Validation

- `vitest run` — 144 files / 1,513 tests passed
- focused adapter suite — 13/13 passed
- root and extension TypeScript checks passed
- production Vite build passed
- targeted Rust watermark test passed; 1/1
- `cargo fmt --check` passed
- changed-file Biome passed with two pre-existing non-null-assertion warnings
- `git diff --check` passed

No production merge or release is included.