### PR TITLE
docs: retire stale Hermes references after ADR-0038 cutover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ CLAUDE.local.md
 # Ephemeral Phala CVM state (holds a per-run bearer token; mode 600).
 # The glob also covers write_state's atomic-rename temps (.json.XXXXXX).
 .ephemeral-june-api.json*
+
+# Local agent working files: task briefs and review/report scratch
+.briefs/
+.reviews/

--- a/docs/adr/0006-embed-hermes-sandboxed-runtime.md
+++ b/docs/adr/0006-embed-hermes-sandboxed-runtime.md
@@ -1,5 +1,5 @@
 ---
-status: accepted
+status: superseded by ADR-0038
 date: 2026-07-01
 ---
 

--- a/docs/adr/0009-hermes-config-shared-ownership-merge.md
+++ b/docs/adr/0009-hermes-config-shared-ownership-merge.md
@@ -1,7 +1,7 @@
 # ADR 0009: config.yaml is shared with the Hermes dashboard; June merges, never overwrites
 
 Date: 2026-07-03
-Status: accepted
+Status: superseded by ADR-0038
 
 ## Context
 

--- a/docs/adr/0011-bundled-hermes-skills.md
+++ b/docs/adr/0011-bundled-hermes-skills.md
@@ -1,7 +1,7 @@
 # ADR 0011: Bundle selected Hermes skills as read-only resources
 
 Date: 2026-07-03
-Status: accepted
+Status: superseded by ADR-0038
 
 ## Context
 

--- a/docs/adr/0025-targeted-hermes-approval-protocol.md
+++ b/docs/adr/0025-targeted-hermes-approval-protocol.md
@@ -1,7 +1,7 @@
 # ADR 0025: Targeted Hermes approval protocol
 
 Date: 2026-07-16
-Status: accepted
+Status: superseded by ADR-0038
 
 ## Context
 

--- a/docs/adr/0029-dual-architecture-hermes-runtime.md
+++ b/docs/adr/0029-dual-architecture-hermes-runtime.md
@@ -1,5 +1,5 @@
 ---
-status: accepted
+status: superseded by ADR-0038
 date: 2026-07-17
 ---
 

--- a/docs/adr/0040-plugin-capabilities-as-host-tools.md
+++ b/docs/adr/0040-plugin-capabilities-as-host-tools.md
@@ -1,0 +1,69 @@
+---
+status: accepted
+date: 2026-07-27
+---
+
+# June-owned plugin capabilities are host tools, not MCP servers
+
+## Context
+
+The plugin implementation plans (documents, spreadsheets, browser use,
+computer use, Notion, Microsoft 365, private connectors) were written against
+the embedded Hermes runtime and describe each capability as a June-managed
+`june_*` MCP server, following the pattern of the Hermes-era Python bridges.
+
+ADR-0038 replaced that runtime with a June-owned harness, and the migration
+deliberately filters June-managed Python bridges instead of importing them
+(`src-tauri/src/agent_runtime/migration.rs`). Their functionality already runs
+as native host tools dispatched directly in the trusted Rust host
+(`src-tauri/src/agent_runtime/tools.rs`): context search, web search and
+fetch, memory, files, shell, skills, routines, Notion actions, computer use.
+The MCP machinery kept by ADR-0039 exists for user-supplied external servers,
+which reach the loop through the `mcp_` dispatch prefix and host-owned policy.
+
+The open question was whether future June-owned plugin capabilities should
+return to the MCP-server shape their plans describe.
+
+## Decision
+
+June-owned plugin capabilities are implemented as host tools inside the agent
+loop, never as June-managed MCP servers.
+
+- A new capability adds tools to the host dispatch table in
+  `agent_runtime/tools.rs`, named per `spec/mcp-tool-naming.md` (`verb_object`,
+  named by the owning PRD before code is written).
+- Safety machinery attaches where it already lives: approvals, safety-mode
+  gating, output bounds, and the Seatbelt write-jail are host-tool properties;
+  no policy bridging through the MCP layer.
+- Engines that parse untrusted input (document and spreadsheet engines) do not
+  run in the main process. They follow the ADR-0028 pattern: a host-tool
+  front-end in the loop and a sandboxed, brokered child process for the risky
+  engine. The process boundary, not MCP, is the isolation mechanism.
+- The ADR-0039 MCP path remains reserved for genuinely external servers the
+  user connects. June ships no MCP server of its own.
+
+The plugin implementation plans remain valid for scope and product behavior
+but their `june_*` MCP-server integration shape is superseded by this
+decision.
+
+## Consequences
+
+- No subprocess lifecycle, packaging, signing, protocol versioning, or
+  health-checking for capabilities June owns end to end; that overhead was the
+  motivation for removing the embedded runtime and would return with each
+  June-managed MCP server.
+- Host tools are testable in the existing Rust test suites and get the safety
+  policy for free.
+- June-only reach: an in-loop tool cannot be reused by third-party MCP
+  clients. Accepted; no such reuse is planned, and a standard surface could be
+  added later without changing the internal shape.
+- Risky-parser isolation costs a brokered helper per engine (as computer use
+  already pays), rather than being a side effect of an MCP process boundary.
+
+## Alternatives considered
+
+- June-managed MCP servers per the original plans. Rejected: reintroduces the
+  ownership and packaging costs ADR-0038 removed, for no interoperability
+  gain when both ends are June.
+- In-process engines without a broker. Rejected for untrusted-input parsers;
+  loses the isolation the original plans placed behind the artifact broker.

--- a/docs/computer-use-cua-driver-spike.md
+++ b/docs/computer-use-cua-driver-spike.md
@@ -1,5 +1,15 @@
 # Computer use cua-driver sandbox spike (JUN-288)
 
+> **Historical — findings predate the runtime migration.** This spike was
+> written against the embedded Hermes runtime architecture, which has been
+> replaced by the June-owned OpenAI Agents runtime
+> ([ADR-0038](adr/0038-june-owned-openai-agents-runtime.md)). The Seatbelt
+> findings and spawn-topology recommendation may still inform computer use,
+> but the broker/runtime integration points described below no longer exist
+> as written; see ADR-0038 and
+> [ADR-0028](adr/0028-private-stdio-broker-for-computer-use.md) for the
+> current architecture. Kept unrewritten as a findings record.
+
 A timeboxed spike answering one phase-2 question for **Computer use** (see
 [browser-computer-use-prd.md](browser-computer-use-prd.md) "Computer use (phase
 2)" and [ADR-0017](adr/0017-browser-use-via-june-extension.md)): when June

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,8 +36,7 @@ built-in fallback ← `config.toml` ← the **live Venice catalog at boot**.
 | `OS_NOTETAKER_TRANSCRIPTION_LANGUAGE` | Optional ISO-639-1 language hint | unset |
 
 Dev-only toggles also read in code: `OS_JUNE_ENABLE_DEV_SINGLE_INSTANCE`,
-`OS_JUNE_USE_PROD_ACCOUNTS_TOKENS`, `OS_JUNE_USE_PROD_DATA_DIR`,
-`JUNE_HERMES_DISABLE_SANDBOX`.
+`OS_JUNE_USE_PROD_ACCOUNTS_TOKENS`, `OS_JUNE_USE_PROD_DATA_DIR`.
 
 When set to `1`, `true`, `yes`, or `on`, `OS_JUNE_USE_PROD_DATA_DIR` opts a
 debug build into the production app data directory and the production

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,12 +15,12 @@ decision. See "When to add an ADR" in [AGENTS.md](../AGENTS.md).
 - [adr/0003](adr/0003-release-candidate-channel-and-promotion.md) — rc channel + promote-to-stable (every stable release starts as an RC)
 - [adr/0004](adr/0004-out-of-process-system-audio-helper.md) — macOS system audio via an out-of-process helper (file IPC + Unix signals)
 - [adr/0005](adr/0005-source-separated-audio-capture.md) — one WAV per source, re-interleaved as turns
-- [adr/0006](adr/0006-embed-hermes-sandboxed-runtime.md) — embed the pinned Hermes runtime as sandboxed child processes
+- [adr/0006](adr/0006-embed-hermes-sandboxed-runtime.md) — embed the pinned Hermes runtime as sandboxed child processes (superseded by ADR-0038)
 - [adr/0007](adr/0007-model-capability-source-of-truth.md) — model capabilities come from the live Venice catalog, not marketing traits
 - [adr/0008](adr/0008-image-generation-and-editing-tools.md) — image generation/editing: `/image` fast path + LLM tools, via Venice
-- [adr/0009](adr/0009-hermes-config-shared-ownership-merge.md) — config.yaml is shared with the Hermes dashboard; June deep-merges on spawn, never overwrites
+- [adr/0009](adr/0009-hermes-config-shared-ownership-merge.md) — config.yaml is shared with the Hermes dashboard; June deep-merges on spawn, never overwrites (superseded by ADR-0038)
 - [adr/0010](adr/0010-note-references-in-agent-chat.md) — note references in agent chat: `@note:<id>` text token + `get_meeting_note` fetch-by-id
-- [adr/0011](adr/0011-bundled-hermes-skills.md) — selected Hermes skills ship as read-only app resources when the runtime pin cannot move
+- [adr/0011](adr/0011-bundled-hermes-skills.md) — selected Hermes skills ship as read-only app resources when the runtime pin cannot move (superseded by ADR-0038)
 - [adr/0012](adr/0012-direct-issue-report-submission.md) — issue reports submit directly (no client model turn, nothing to charge); June API generates the team-facing diagnosis
 - [adr/0013](adr/0013-stream-inference-responses-through-june-api.md) — inference responses stream through June API (SSE pass-through + keep-alive heartbeats); charges settle after the stream ends
 - [adr/0014](adr/0014-pinned-dictation-paste-target.md) — the dictation paste target is pinned when the recording stops, never re-resolved at paste time
@@ -34,11 +34,11 @@ decision. See "When to add an ADR" in [AGENTS.md](../AGENTS.md).
 - [adr/0022](adr/0022-venice-private-first-model-routing.md) — service-managed text uses Venice private zero-retention first with Phala TEE fallback; existing `/v1` provider semantics stay compatible and pricing is fallback-safe
 - [adr/0023](adr/0023-attested-os-api-service-chain.md) - superseded by ADR-0024
 - [adr/0024](adr/0024-independent-product-verification.md) - June, Open Software API, and Chat publish independent verification evidence without cross-product release pinning
-- [adr/0025](adr/0025-targeted-hermes-approval-protocol.md) - MCP approvals use stable request identity, targeted resolution, bounded queues, and fail-closed retirement
+- [adr/0025](adr/0025-targeted-hermes-approval-protocol.md) - MCP approvals use stable request identity, targeted resolution, bounded queues, and fail-closed retirement (superseded by ADR-0038)
 - [adr/0026](adr/0026-durable-note-transcription-jobs.md) - saved-audio Source spans use durable, fingerprinted, idempotent note-transcription jobs
 - [adr/0027](adr/0027-june-owned-project-memory-store.md) — memory entries live in June's SQLite (not the Hermes memory toolset), scoped by project, agent writes via the loopback proxy, project context by prompt injection
 - [adr/0028](adr/0028-private-stdio-broker-for-computer-use.md) - Computer use runs through a June-owned private stdio driver broker with signed-helper TCC identity, task-scoped app authorization, and exact-window Stage Manager restoration
-- [adr/0029](adr/0029-dual-architecture-hermes-runtime.md) - the universal macOS app carries complete arm64 and x86_64 Hermes runtime trees and executes both before release
+- [adr/0029](adr/0029-dual-architecture-hermes-runtime.md) - the universal macOS app carries complete arm64 and x86_64 Hermes runtime trees and executes both before release (superseded by ADR-0038)
 - [adr/0030](adr/0030-explicit-per-session-profile-targeting.md) — profile switching writes the sticky active profile AND threads it explicitly on session.create; no per-profile Hermes process
 - [adr/0031](adr/0031-per-profile-data-isolation.md) — profiles isolate user data (notes/dictation/projects via a `profile` column, chat sessions via a `session_profiles` map); profile is the first data-partition key; delete prompts move-to-default vs delete
 - [adr/0032](adr/0032-session-completion-june-owned-local-state.md) — marking a session complete is June-owned local SQLite state keyed by the stored Hermes session id, orthogonal to Hermes' archive flag; mirrors the `session_folders` stack

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ decision. See "When to add an ADR" in [AGENTS.md](../AGENTS.md).
 - [adr/0037](adr/0037-versioned-local-sqlite-migrations.md) - June's local SQLite schema uses an append-only release-ordered catalog, introspection-based legacy stamping, and one transaction for all pending migrations
 - [adr/0038](adr/0038-june-owned-openai-agents-runtime.md) - June owns the local agent harness, persistence, tools, approvals, and stdio protocol on top of the OpenAI Agents SDK
 - [adr/0039](adr/0039-june-owned-routines-and-mcp.md) - June owns routine scheduling and user-configured MCP transport, persistence, safety, and migration
+- [adr/0040](adr/0040-plugin-capabilities-as-host-tools.md) - June-owned plugin capabilities are in-loop host tools (brokered helpers for risky engines), never June-managed MCP servers
 
 ## Enforceable rules (spec/)
 

--- a/docs/plugins/browser-use-implementation-plan.md
+++ b/docs/plugins/browser-use-implementation-plan.md
@@ -7,7 +7,9 @@
 > [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
 > [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
 > as "the June agent runtime" and route MCP registration through the ADR-0039
-> mechanism.
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
 
 - **Mode:** CTO
 - **Date:** 2026-07-13

--- a/docs/plugins/browser-use-implementation-plan.md
+++ b/docs/plugins/browser-use-implementation-plan.md
@@ -1,5 +1,14 @@
 # Implementation plan: Browser use plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism.
+
 - **Mode:** CTO
 - **Date:** 2026-07-13
 - **Status:** Accepted workstream; implementation active

--- a/docs/plugins/computer-use-implementation-plan.md
+++ b/docs/plugins/computer-use-implementation-plan.md
@@ -7,7 +7,9 @@
 > [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
 > [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
 > as "the June agent runtime" and route MCP registration through the ADR-0039
-> mechanism.
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
 
 - **Mode:** CTO
 - **Date:** 2026-07-13

--- a/docs/plugins/computer-use-implementation-plan.md
+++ b/docs/plugins/computer-use-implementation-plan.md
@@ -1,5 +1,14 @@
 # Implementation plan: Computer use plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism.
+
 - **Mode:** CTO
 - **Date:** 2026-07-13
 - **Status:** Implemented for review

--- a/docs/plugins/documents-implementation-plan.md
+++ b/docs/plugins/documents-implementation-plan.md
@@ -1,5 +1,14 @@
 # Implementation plan: Documents plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism.
+
 - **Mode:** CTO
 - **Date:** 2026-07-13
 - **Status:** Proposed; artifact-engine spike required

--- a/docs/plugins/documents-implementation-plan.md
+++ b/docs/plugins/documents-implementation-plan.md
@@ -7,7 +7,9 @@
 > [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
 > [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
 > as "the June agent runtime" and route MCP registration through the ADR-0039
-> mechanism.
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
 
 - **Mode:** CTO
 - **Date:** 2026-07-13

--- a/docs/plugins/microsoft-365-implementation-plan.md
+++ b/docs/plugins/microsoft-365-implementation-plan.md
@@ -7,7 +7,9 @@
 > [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
 > [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
 > as "the June agent runtime" and route MCP registration through the ADR-0039
-> mechanism.
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
 
 - **Mode:** CTO
 - **Date:** 2026-07-13

--- a/docs/plugins/microsoft-365-implementation-plan.md
+++ b/docs/plugins/microsoft-365-implementation-plan.md
@@ -1,5 +1,14 @@
 # Implementation plan: Microsoft 365 plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism.
+
 - **Mode:** CTO
 - **Date:** 2026-07-13
 - **Status:** Proposed; API and tenant spike required

--- a/docs/plugins/notion-implementation-plan.md
+++ b/docs/plugins/notion-implementation-plan.md
@@ -1,5 +1,14 @@
 # Implementation plan: Notion plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism.
+
 - **Mode:** CTO
 - **Date:** 2026-07-13
 - **Status:** Proposed; hosted MCP connector preview in implementation, selected-resource scoping intentionally out of scope for this pass

--- a/docs/plugins/notion-implementation-plan.md
+++ b/docs/plugins/notion-implementation-plan.md
@@ -7,7 +7,9 @@
 > [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
 > [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
 > as "the June agent runtime" and route MCP registration through the ADR-0039
-> mechanism.
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
 
 - **Mode:** CTO
 - **Date:** 2026-07-13

--- a/docs/plugins/spreadsheets-implementation-plan.md
+++ b/docs/plugins/spreadsheets-implementation-plan.md
@@ -1,5 +1,14 @@
 # Implementation plan: Spreadsheets plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism.
+
 - **Mode:** CTO
 - **Date:** 2026-07-13
 - **Status:** Proposed; depends on the artifact broker

--- a/docs/plugins/spreadsheets-implementation-plan.md
+++ b/docs/plugins/spreadsheets-implementation-plan.md
@@ -7,7 +7,9 @@
 > [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
 > [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
 > as "the June agent runtime" and route MCP registration through the ADR-0039
-> mechanism.
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
 
 - **Mode:** CTO
 - **Date:** 2026-07-13

--- a/docs/private-connectors-implementation-plan.md
+++ b/docs/private-connectors-implementation-plan.md
@@ -3,6 +3,14 @@
 **Owner:** CTO · **Date:** 2026-07-09 · **Status:** Draft for review · **PRD:** [private-connectors-prd.md](private-connectors-prd.md)
 **Repos:** `os-june` (app + June API), `os-accounts` (metering/action slugs), `os-marketing-page` (verify page, comparison copy)
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" and "the Hermes bridge" refer to the removed embedded Hermes
+> runtime. Agent-facing MCP registration is now June-owned per
+> [ADR-0038](adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below as
+> "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism.
+
 > File-level references were re-verified against `origin/main` on 2026-07-09
 > when this doc was ported into the repo (confirmed: `june_context`/`june_web`
 > MCP registration in the Hermes bridge, the agent approval surface, cron

--- a/docs/private-connectors-implementation-plan.md
+++ b/docs/private-connectors-implementation-plan.md
@@ -9,7 +9,9 @@
 > [ADR-0038](adr/0038-june-owned-openai-agents-runtime.md) and
 > [ADR-0039](adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below as
 > "the June agent runtime" and route MCP registration through the ADR-0039
-> mechanism.
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](adr/0040-plugin-capabilities-as-host-tools.md).
 
 > File-level references were re-verified against `origin/main` on 2026-07-09
 > when this doc was ported into the repo (confirmed: `june_context`/`june_web`

--- a/docs/telemetry-p3a-implementation-plan.md
+++ b/docs/telemetry-p3a-implementation-plan.md
@@ -125,7 +125,9 @@ catalog CI test green.
   - dictation session completed → `dictation.rs`
   - recording completed + audio source mode → recording finalize path in
     `commands.rs` / `audio/`
-  - agent session started → `hermes_bridge.rs`
+  - agent session started → `agent_runtime/api.rs` (session creation /
+    `start_agent_run`; the plan predates the ADR-0038 runtime migration and
+    originally named the removed `hermes_bridge.rs`)
   - model/privacy-mode selection → `providers/mod.rs`
   - app foreground day → `lib.rs` setup / focus handler
   - Frontend-originated signals (onboarding completed) go through one


### PR DESCRIPTION
## Summary

- Remove `JUNE_HERMES_DISABLE_SANDBOX` from the dev-toggle list in `docs/configuration.md` (the env var no longer exists in code).
- Add a historical/obsolete banner to `docs/computer-use-cua-driver-spike.md` pointing at ADR-0038/0028; body kept unrewritten as a findings record.
- Fix the P3A plan's "agent session started" hook point: `hermes_bridge.rs` (removed) -> `agent_runtime/api.rs`.
- Add a stale-integration-point banner to the six plugin implementation plans and `docs/private-connectors-implementation-plan.md`: "Hermes" / `import_hermes_bridge_file` refer to the removed embedded runtime; MCP registration is now June-owned per ADR-0038/0039.
- Mark ADRs 0006, 0009, 0011, 0025, 0029 `superseded by ADR-0038` (status line only, append-only convention) and annotate the same in `docs/index.md`.
- Add ADR-0040: June-owned plugin capabilities are in-loop host tools (brokered helpers for untrusted-input engines, ADR-0028 pattern), never June-managed MCP servers; plan banners and `docs/index.md` point at it.
- Gitignore the local `.briefs/` and `.reviews/` agent working directories.

## Root cause

Docs lagged the ADR-0038 runtime cutover: the code migration off the embedded Hermes runtime landed 2026-07-22 but the referencing docs were never swept. Dead symbols verified gone from code before editing (`JUNE_HERMES_DISABLE_SANDBOX`, `import_hermes_bridge_file`, `sync_hermes_config`, `apply_isolated_hermes_env`, `hermes_bridge.rs`).

## Validation

- `pnpm check` clean (exit 0; docs are outside Biome's scope, confirmed no new diagnostics).
- Docs-only change; no code touched.

- [ ] Tested visually where it matters (n/a: docs only).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Code changes of any kind.
- Intentional Hermes remnants left untouched: `agent_runtime/migration.rs`, `stop_legacy_hermes_runtime`, the `hermes_session_id` column, Hermes-era table imports in `routines.rs`, the negative payload check in `scripts/build-signed-dmg.sh`, `.gitignore` `.tauri-hermes/`, CONTEXT.md glossary mentions, `docs/release-windows.md`.
- Rewriting the spike doc or plugin plans; banners only.

## Followups

- Companion os-platform initiative filing verified post-migration functionality gaps (tracked separately).

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [ ] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787725729&installation_model_id=425925&pr_number=976&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F976&signature=554c7f1e8dececfd8c22997829eb03f6f86a62c8c9054e9a22f2106d9d950401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
