### PR TITLE
docs: address PR #976 post-merge review followups

### DIFF
--- a/.reviews/jun-976-followup-summary.md
+++ b/.reviews/jun-976-followup-summary.md
@@ -1,0 +1,31 @@
+# JUN-976 followup summary
+
+## Finding 1
+
+Corrected the P3A implementation plan so `agent.sessions` is recorded only
+after successful `create_agent_session` completion. The plan now explicitly
+excludes `start_agent_run`, which runs for every user turn.
+
+## Finding 2
+
+Added a dated append-only addendum to ADR-0040 that supersedes the
+June-managed MCP-server integration portions of ADR-0017, ADR-0028, and
+ADR-0034 while preserving their product scope. ADR-0028's brokered-helper
+isolation pattern also remains binding. Added matching dated notes to the end
+of each earlier ADR and annotated their entries in `docs/index.md`.
+
+The ADR-0040 addendum cites the current Rust host-tool dispatch for
+`computer_use` and `get_obsidian_vault` as the implemented shape.
+
+## Finding 3
+
+Added the standard stale-integration banner to all 14 named implementation
+plans: Asana, Azure Boards, Box, Canva, ClickUp, Dropbox, GitHub, GitLab,
+Google Workspace, HubSpot, Linear, Pipedrive, Salesforce, and Slack.
+
+No plans were skipped. Each plan still prescribes a `june_*` server or
+otherwise explicitly describes the retired MCP-server shape.
+
+## Validation
+
+`pnpm check` exited 0. Biome reported existing warnings but no errors.

--- a/.reviews/jun-976-followup-summary.md
+++ b/.reviews/jun-976-followup-summary.md
@@ -29,3 +29,15 @@ otherwise explicitly describes the retired MCP-server shape.
 ## Validation
 
 `pnpm check` exited 0. Biome reported existing warnings but no errors.
+
+## Greptile round 1
+
+Addressed the P2 naming-spec finding. `spec/mcp-tool-naming.md` now governs
+June-owned in-loop host tools, keeps the `verb_object` rule and
+contract-before-code requirement, points to ADR-0040, and treats the
+June-managed `june_*` MCP-server framing and `june_browser` example as
+historical. It now directs readers to the current Rust host-tool catalog and
+dispatch files instead of the removed Hermes Python servers.
+
+Updated the matching one-line descriptions in `spec/index.md` and `AGENTS.md`.
+`pnpm check` exited 0 with the existing warnings and no errors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ distinct from the `specs/` Spec Kit feature specs.)
 - [control-sizes](spec/control-sizes.md) — control heights from `--control-*`, no raw min/max-heights
 - [scroll-fade](spec/scroll-fade.md) — clipped scrollers use the shared `useScrollFade` + `.scroll-fade` / `.scroll-fade-mask` primitive
 - [package-install-security](spec/package-install-security.md) — pnpm-only; new package installs go through `sfw`; 7-day `minimumReleaseAge` cooldown
-- [mcp-tool-naming](spec/mcp-tool-naming.md) — internal MCP tools are `verb_object`; the owning PRD names them before the code is written
+- [mcp-tool-naming](spec/mcp-tool-naming.md) — June-owned in-loop host tools are `verb_object`; the owning PRD or contract names them before the code is written
 
 ## PR and description conventions
 

--- a/docs/adr/0017-browser-use-via-june-extension.md
+++ b/docs/adr/0017-browser-use-via-june-extension.md
@@ -136,3 +136,5 @@ the opt-in retains the credential only for authentication and refusal, removes
 the server from rendered configuration, and makes the broker return
 `browser_routine_not_opted_in`. Attended credentials remain a separate class
 and never consult routine opt-ins.
+
+2026-07-27 addendum: ADR-0040 supersedes this ADR's `june_browser` MCP-server integration shape; the Browser use and Computer use product scope and broker policies remain binding.

--- a/docs/adr/0028-private-stdio-broker-for-computer-use.md
+++ b/docs/adr/0028-private-stdio-broker-for-computer-use.md
@@ -313,3 +313,5 @@ retains the initialized no-authority driver as the next attended task's prewarm.
 Explicit Stop, grant revocation, readiness loss, and shutdown still invalidate
 its epoch and terminate it. Authorization, target validation, rollout, plan,
 model, billing, and approval behavior remain unchanged.
+
+2026-07-27 addendum: ADR-0040 supersedes this ADR's public `june_computer_use` MCP-server integration shape; the brokered-helper isolation pattern and Computer use product scope remain binding.

--- a/docs/adr/0034-obsidian-vault-discovery-mcp.md
+++ b/docs/adr/0034-obsidian-vault-discovery-mcp.md
@@ -74,3 +74,5 @@ validate and persist or delete the selected vault, then refresh UI state.
   validation and leaks configuration ownership across the sandbox boundary.
 - **Register the server only while connected.** Rejected: stable registration
   lets a running runtime discover current state without a restart.
+
+2026-07-27 addendum: ADR-0040 supersedes this ADR's `june_obsidian` MCP-server integration shape; the Obsidian vault-discovery product scope remains binding.

--- a/docs/adr/0040-plugin-capabilities-as-host-tools.md
+++ b/docs/adr/0040-plugin-capabilities-as-host-tools.md
@@ -67,3 +67,24 @@ decision.
   gain when both ends are June.
 - In-process engines without a broker. Rejected for untrusted-input parsers;
   loses the isolation the original plans placed behind the artifact broker.
+
+## Addendum - earlier MCP-server decisions (2026-07-27)
+
+This addendum explicitly supersedes only the June-managed MCP-server
+integration portions of ADR-0017, ADR-0028, and ADR-0034:
+
+- ADR-0017's app-owned `june_browser` MCP contract is retired. Its Browser use
+  and Computer use product scope and Rust broker policy remain binding.
+- ADR-0028's public `june_computer_use` MCP server and Hermes-facing wiring are
+  retired. Its Computer use product scope and brokered-helper isolation pattern
+  remain binding, including the signed private stdio helper, provenance checks,
+  grants, rollout control, and broker policy.
+- ADR-0034's `june_obsidian` MCP registration and loopback adapter are retired.
+  Its Obsidian vault-discovery product scope, June-owned configuration, and
+  current-state discovery semantics remain binding.
+
+The current implementation already records this shape in
+`src-tauri/src/agent_runtime/tools.rs`: `computer_use` dispatches through the
+Rust Computer use broker, and `get_obsidian_vault` dispatches directly to
+June-owned Obsidian discovery. These capabilities stay in the agent loop as
+host tools. They are not exposed through June-managed MCP servers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ decision. See "When to add an ADR" in [AGENTS.md](../AGENTS.md).
 - [adr/0014](adr/0014-pinned-dictation-paste-target.md) — the dictation paste target is pinned when the recording stops, never re-resolved at paste time
 - [adr/0015](adr/0015-video-generation-tools.md) — video generation: `/video` fast path + LLM tools, async job + poll, quote-priced, via Venice
 - [adr/0016](adr/0016-private-connectors-local-mode.md) — private connectors (local mode): Keychain-only token custody, app-proxied MCP calls straight to Google, trust modes enforced in the Rust proxy, earned autonomy, event-trigger daemon
-- [adr/0017](adr/0017-browser-use-via-june-extension.md) — browser use in the user's own browser via the June extension, two tracks behind one broker; computer use productizes the pinned toolset
+- [adr/0017](adr/0017-browser-use-via-june-extension.md) — browser use in the user's own browser via the June extension, two tracks behind one broker; computer use productizes the pinned toolset (MCP-server shape superseded by ADR-0040)
 - [adr/0018](adr/0018-session-model-changes-apply-at-agent-run-boundaries.md) — session model changes are staged at Send and applied only at the next idle agent-run boundary
 - [adr/0019](adr/0019-windows-dictation-helper.md) — Windows dictation uses a platform-native helper process
 - [adr/0020](adr/0020-windows-dictation-keyboard-hook.md) — Windows shortcuts combine `RegisterHotKey` with a narrow keyboard hook
@@ -37,13 +37,13 @@ decision. See "When to add an ADR" in [AGENTS.md](../AGENTS.md).
 - [adr/0025](adr/0025-targeted-hermes-approval-protocol.md) - MCP approvals use stable request identity, targeted resolution, bounded queues, and fail-closed retirement (superseded by ADR-0038)
 - [adr/0026](adr/0026-durable-note-transcription-jobs.md) - saved-audio Source spans use durable, fingerprinted, idempotent note-transcription jobs
 - [adr/0027](adr/0027-june-owned-project-memory-store.md) — memory entries live in June's SQLite (not the Hermes memory toolset), scoped by project, agent writes via the loopback proxy, project context by prompt injection
-- [adr/0028](adr/0028-private-stdio-broker-for-computer-use.md) - Computer use runs through a June-owned private stdio driver broker with signed-helper TCC identity, task-scoped app authorization, and exact-window Stage Manager restoration
+- [adr/0028](adr/0028-private-stdio-broker-for-computer-use.md) - Computer use runs through a June-owned private stdio driver broker with signed-helper TCC identity, task-scoped app authorization, and exact-window Stage Manager restoration (MCP-server shape superseded by ADR-0040)
 - [adr/0029](adr/0029-dual-architecture-hermes-runtime.md) - the universal macOS app carries complete arm64 and x86_64 Hermes runtime trees and executes both before release (superseded by ADR-0038)
 - [adr/0030](adr/0030-explicit-per-session-profile-targeting.md) — profile switching writes the sticky active profile AND threads it explicitly on session.create; no per-profile Hermes process
 - [adr/0031](adr/0031-per-profile-data-isolation.md) — profiles isolate user data (notes/dictation/projects via a `profile` column, chat sessions via a `session_profiles` map); profile is the first data-partition key; delete prompts move-to-default vs delete
 - [adr/0032](adr/0032-session-completion-june-owned-local-state.md) — marking a session complete is June-owned local SQLite state keyed by the stored Hermes session id, orthogonal to Hermes' archive flag; mirrors the `session_folders` stack
 - [adr/0033](adr/0033-notion-hosted-mcp-connect-preview.md) - Notion hosted MCP connector preview with read-only `june_notion`, approved page creation and updates, and no selected-resource claim
-- [adr/0034](adr/0034-obsidian-vault-discovery-mcp.md) - Obsidian vault discovery uses a June-owned MCP server, not an ambient environment variable
+- [adr/0034](adr/0034-obsidian-vault-discovery-mcp.md) - Obsidian vault discovery uses a June-owned MCP server, not an ambient environment variable (MCP-server shape superseded by ADR-0040)
 - [adr/0035](adr/0035-extension-releases-follow-desktop-rc-promotion.md) - Chrome Web Store packages are reviewed during desktop RC and the exact staged bytes publish after stable desktop promotion
 - [adr/0036](adr/0036-github-connector-app-user-tokens.md) - GitHub connector uses GitHub App user access tokens only (no app private key on device or backend), local-mode custody per ADR-0016, June-side read/write gating, approval-only writes
 - [adr/0037](adr/0037-versioned-local-sqlite-migrations.md) - June's local SQLite schema uses an append-only release-ordered catalog, introspection-based legacy stamping, and one transaction for all pending migrations

--- a/docs/plugins/asana-implementation-plan.md
+++ b/docs/plugins/asana-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: Asana plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-14
 - **Status:** Proposed; auth spike required

--- a/docs/plugins/azure-boards-implementation-plan.md
+++ b/docs/plugins/azure-boards-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: Azure Boards plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-14
 - **Status:** Proposed; Entra migration spike required

--- a/docs/plugins/box-implementation-plan.md
+++ b/docs/plugins/box-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: Box plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-14
 - **Status:** Proposed; auth and enterprise spike required

--- a/docs/plugins/canva-implementation-plan.md
+++ b/docs/plugins/canva-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: Canva plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-14
 - **Status:** Proposed; credential and API review gates

--- a/docs/plugins/clickup-implementation-plan.md
+++ b/docs/plugins/clickup-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: ClickUp plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-14
 - **Status:** Proposed; blocked on auth posture

--- a/docs/plugins/dropbox-implementation-plan.md
+++ b/docs/plugins/dropbox-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: Dropbox plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-14
 - **Status:** Proposed; public-client path documented

--- a/docs/plugins/github-implementation-plan.md
+++ b/docs/plugins/github-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: GitHub plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-13
 - **Status:** Proposed

--- a/docs/plugins/gitlab-implementation-plan.md
+++ b/docs/plugins/gitlab-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: GitLab Issues plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-14
 - **Status:** Proposed; GitLab.com-first

--- a/docs/plugins/google-workspace-implementation-plan.md
+++ b/docs/plugins/google-workspace-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: Google Workspace plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-13
 - **Status:** Proposed expansion of shipped local mode

--- a/docs/plugins/hubspot-implementation-plan.md
+++ b/docs/plugins/hubspot-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: HubSpot plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-14
 - **Status:** Proposed; auth and permission spike required

--- a/docs/plugins/linear-implementation-plan.md
+++ b/docs/plugins/linear-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: Linear plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-13
 - **Status:** Proposed; Phase 0 documentation spike complete, see

--- a/docs/plugins/pipedrive-implementation-plan.md
+++ b/docs/plugins/pipedrive-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: Pipedrive plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-14
 - **Status:** Proposed; auth and demand gate

--- a/docs/plugins/salesforce-implementation-plan.md
+++ b/docs/plugins/salesforce-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: Salesforce plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-14
 - **Status:** Proposed; auth, packaging, and schema spike required

--- a/docs/plugins/slack-implementation-plan.md
+++ b/docs/plugins/slack-implementation-plan.md
@@ -1,5 +1,16 @@
 # Implementation plan: Slack plugin
 
+> **Stale integration point.** This plan predates the runtime migration:
+> "Hermes" (and any Hermes bridge commands such as
+> `import_hermes_bridge_file`) refer to the removed embedded Hermes runtime.
+> Agent-facing MCP registration is now June-owned per
+> [ADR-0038](../adr/0038-june-owned-openai-agents-runtime.md) and
+> [ADR-0039](../adr/0039-june-owned-routines-and-mcp.md); read "Hermes" below
+> as "the June agent runtime" and route MCP registration through the ADR-0039
+> mechanism. The MCP-server integration shape itself is superseded: June-owned
+> capabilities are built as in-loop host tools per
+> [ADR-0040](../adr/0040-plugin-capabilities-as-host-tools.md).
+
 - **Mode:** CTO
 - **Date:** 2026-07-13
 - **Status:** Proposed; auth spike required

--- a/docs/telemetry-p3a-implementation-plan.md
+++ b/docs/telemetry-p3a-implementation-plan.md
@@ -125,9 +125,12 @@ catalog CI test green.
   - dictation session completed → `dictation.rs`
   - recording completed + audio source mode → recording finalize path in
     `commands.rs` / `audio/`
-  - agent session started → `agent_runtime/api.rs` (session creation /
-    `start_agent_run`; the plan predates the ADR-0038 runtime migration and
-    originally named the removed `hermes_bridge.rs`)
+  - agent session started → `agent_runtime/api.rs`: record `agent.sessions`
+    only after `create_agent_session` successfully creates and returns the
+    stored session (lines 202-230). Do not record it from `start_agent_run`
+    (lines 498-550), which runs for every user turn. The plan predates the
+    ADR-0038 runtime migration and originally named the removed
+    `hermes_bridge.rs`.
   - model/privacy-mode selection → `providers/mod.rs`
   - app foreground day → `lib.rs` setup / focus handler
   - Frontend-originated signals (onboarding completed) go through one

--- a/spec/index.md
+++ b/spec/index.md
@@ -31,9 +31,9 @@ authoritative, reviewable version.
 
 - [control-sizes](control-sizes.md) — control heights from `--control-*`, no raw min/max-heights
 
-## Agent surface — MCP
+## Agent surface - tools
 
-- [mcp-tool-naming](mcp-tool-naming.md) — internal MCP tools are `verb_object`; the owning PRD names them before the code is written
+- [mcp-tool-naming](mcp-tool-naming.md) - June-owned in-loop host tools are `verb_object`; the owning PRD or contract names them before the code is written
 
 ## Tooling — dependencies
 

--- a/spec/mcp-tool-naming.md
+++ b/spec/mcp-tool-naming.md
@@ -1,28 +1,30 @@
-# Internal MCP tool naming
+# Internal agent tool naming
 
-**Rule.** Tools exposed by June's own internal MCP servers (`june_context`,
-`june_web`, `june_image`, `june_video`, `june_recorder`, `june_browser`,
-`june_gmail*`, `june_gcal*`, and any future `june_*` server) are named
-**`verb_object`**: the verb first, in `snake_case`, with no server-name prefix
-repeated inside the tool name.
+**Rule.** June-owned tools exposed to the agent as in-loop host tools are named
+**`verb_object`**: the verb first, in `snake_case`, with no capability or
+provider prefix repeated inside the tool name.
+
+[ADR-0040](../docs/adr/0040-plugin-capabilities-as-host-tools.md) defines the
+integration shape. June-managed `june_*` MCP servers are retired; they are
+historical architecture, not the namespace or template for a new internal
+tool surface.
 
 Good: `start_recording`, `stop_recording`, `generate_image`, `edit_image`,
 `search_threads`, `read_thread`, `get_meeting_note`, `start_session`,
 `accept_shared_tab`, `list_tabs`.
 
 Not: `session_start`, `tab_accept_shared`, `recording_start`,
-`june_browser_navigate`.
+`june_browser_navigate`, `june_gmail_search_threads`.
 
-Two carve-outs, both pre-existing and deliberate: a server may use a
+Two carve-outs, both pre-existing and deliberate: a host-tool surface may use a
 `namespace_verb` form when the namespace disambiguates an otherwise generic
 verb (`web_search`, `web_fetch`), and a status reader may be named for what it
 returns (`recording_status`, `status`).
 
 **And: the name of every tool in a contract is fixed in exactly one document,
-before the code is written.** For an internal MCP server that document is the
-subsystem PRD that owns the server (for `june_browser`,
-`docs/browser-computer-use-prd.md`). Other documents reference those names;
-they never coin them.
+before the code is written.** For a June-owned host-tool surface that document
+is the subsystem PRD or contract that owns the capability. Other documents
+reference those names; they never coin them.
 
 **Why.** Two reasons, one aesthetic and one that cost real work.
 
@@ -32,24 +34,28 @@ like it was assembled by different people who never spoke, and the model has to
 guess the shape of a name it has not seen.
 
 The one that cost real work: in JUN-278 the canonical PRD described the
-`june_browser` surface in prose ("session start and close ... accept a
-user-shared tab") without naming the tools. The portfolio implementation plan
-then coined `start_session` / `accept_shared_tab`; the implementing slice
-independently coined `session_start` / `tab_accept_shared`. Both were
-reasonable. Both were merged into different documents. Neither was wrong, which
-is exactly why nobody caught it. A contract described but not *named* will be
-named twice.
+Browser use surface in prose ("session start and close ... accept a user-shared
+tab") without naming the tools. The portfolio implementation plan then coined
+`start_session` / `accept_shared_tab`; the implementing slice independently
+coined `session_start` / `tab_accept_shared`. Both were reasonable. Both were
+merged into different documents. Neither was wrong, which is exactly why
+nobody caught it. A contract described but not *named* will be named twice.
+That incident happened while Browser use was framed as the `june_browser` MCP
+server. ADR-0040 retired that server shape, but the naming lesson remains.
 
-**How to apply.** Before implementing a tool surface, put the names in the
-owning PRD as a table, then implement against that table. When adding a tool to
-an existing server, match the server's established convention and add the name
-to the owning document in the same change. When a name in a document and a name
-in code disagree, the document that *owns* the contract wins and the code is
-the bug; if no document owns it, that is the defect to fix first.
+**How to apply.** Before implementing a June-owned host-tool surface, put the
+names in the owning PRD or contract as a table, then implement against that
+table. When adding a tool to an existing surface, match its established
+convention and add the name to the owning document in the same change. When a
+name in a document and a name in code disagree, the document that *owns* the
+contract wins and the code is the bug; if no document owns it, that is the
+defect to fix first.
 
-Grep the existing servers before coining anything:
-`src-tauri/src/hermes/june_*_mcp.py`.
+Inspect the current host-tool catalog and dispatch before coining anything:
+`src-tauri/src/agent_runtime/api.rs`,
+`src-tauri/src/agent_runtime/native_connectors.rs`, and
+`src-tauri/src/agent_runtime/tools.rs`.
 
-**Exceptions.** Tools of the *upstream* runtime and third-party MCP servers are
-not ours to name; use them as they come. This rule binds June's own `june_*`
-servers only.
+**Exceptions.** Tools supplied by external MCP servers, including
+user-connected and provider-hosted servers, are not ours to name; use them as
+they come. This rule binds June-owned in-loop host tools only.


### PR DESCRIPTION
## Summary

- Pin the P3A plan's `agent.sessions` counter to successful `create_agent_session` completion (not `start_agent_run`, which fires every turn and would inflate the aggregate).
- Add a dated append-only addendum to ADR-0040 superseding the June-managed MCP-server integration portions of ADR-0017, ADR-0028, and ADR-0034 (product scope and ADR-0028's brokered-helper isolation pattern stay binding), with matching dated notes at the end of those ADRs and `docs/index.md` annotations.
- Roll the stale-integration banner out to the 14 remaining plugin implementation plans that still prescribe the retired `june_*` MCP-server shape (Asana, Azure Boards, Box, Canva, ClickUp, Dropbox, GitHub, GitLab, Google Workspace, HubSpot, Linear, Pipedrive, Salesforce, Slack).

## Root cause

PR #976's sweep fixed the P3A hook location imprecisely (pointed at the per-turn entry point) and added ADR-0040 without reconciling three still-accepted ADRs that prescribe June-managed MCP servers; the banner rollout covered only the plans named in the original audit.

## Validation

- `pnpm check` exit 0; docs-only diff.

- [ ] Tested visually where it matters (n/a: docs only).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Code changes; rewriting any ADR or plan body (append-only edits throughout).

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [ ] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787730306&installation_model_id=425925&pr_number=977&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F977&signature=d0df70c1cbcec15fad215f455f8afc16173fccbc1b89b2ba534a0ca195f73bc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->