### PR TITLE
fix(agent): live steering with attachments and honest steer feedback

### DIFF
--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -1618,7 +1618,14 @@ fn item_json_with_active_run(
         .filter(|external_id| {
             external_id.starts_with("assistant:") || external_id.starts_with("reasoning:")
         });
-    let public_item_id = stable_stream_id.unwrap_or(&item.id).to_string();
+    let stable_steering_id = item
+        .external_id
+        .as_deref()
+        .filter(|external_id| external_id.starts_with("steering:"));
+    let public_item_id = stable_steering_id
+        .or(stable_stream_id)
+        .unwrap_or(&item.id)
+        .to_string();
     let stream_status =
         if stable_stream_id.is_some_and(|external_id| external_id.starts_with("assistant:")) {
             "streaming"
@@ -2149,25 +2156,31 @@ mod tests {
     #[test]
     fn consumed_steering_is_visible_and_replayed_as_user_context() {
         let item = AgentItemDto {
-            id: "steering-1".into(),
+            id: "c896c2a5-7cd1-4695-870d-707fdbcb4abf".into(),
             session_id: "session-1".into(),
             run_id: Some("run-1".into()),
             sequence: 3,
             payload: AgentItemPayload::Steering(super::super::TextPayload {
                 text: "Use the launch plan".into(),
             }),
-            external_id: Some("steering-event-1".into()),
+            external_id: Some("steering:message-1".into()),
             created_at: "2026-07-24T12:00:02Z".into(),
         };
 
         let history = history_item(item.clone()).expect("runtime history");
-        let value = item_json_with_active_run(item, None).expect("public item");
+        let active =
+            item_json_with_active_run(item.clone(), Some("run-1")).expect("active public item");
+        let completed = item_json_with_active_run(item, None).expect("completed public item");
 
         assert_eq!(history["kind"], "message");
         assert_eq!(history["role"], "user");
         assert_eq!(history["text"], "Use the launch plan");
-        assert_eq!(value["kind"], "steering");
-        assert_eq!(value["text"], "Use the launch plan");
+        assert_eq!(active["id"], "steering:message-1");
+        assert_eq!(active["kind"], "steering");
+        assert_eq!(active["text"], "Use the launch plan");
+        assert_eq!(completed["id"], "steering:message-1");
+        assert_eq!(completed["kind"], "steering");
+        assert_eq!(completed["text"], "Use the launch plan");
     }
 
     #[test]

--- a/src-tauri/src/agent_runtime/host.rs
+++ b/src-tauri/src/agent_runtime/host.rs
@@ -561,11 +561,8 @@ async fn persist_and_emit_event(
             None
         }
         "steering.consumed" => {
-            let message_id = params
-                .get("messageId")
-                .and_then(Value::as_str)
-                .unwrap_or(&event_id);
-            data["itemId"] = json!(format!("steering:{message_id}"));
+            persistence_external_id = steering_stable_id(&params, &event_id);
+            data["itemId"] = json!(persistence_external_id.clone());
             data["createdAt"] = json!(created_at);
             Some(AgentItemPayload::Steering(TextPayload {
                 text: params
@@ -846,6 +843,16 @@ fn interruption_stable_id(params: &Value, event_id: &str) -> String {
         .to_string()
 }
 
+fn steering_stable_id(params: &Value, event_id: &str) -> String {
+    format!(
+        "steering:{}",
+        params
+            .get("messageId")
+            .and_then(Value::as_str)
+            .unwrap_or(event_id)
+    )
+}
+
 fn sanitize_log(value: &str) -> String {
     let value = redact_bearer_tokens(value);
     let value = redact_key_tokens(&value);
@@ -935,6 +942,18 @@ fn redact_key_tokens(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn consumed_steering_uses_message_id_as_its_persisted_external_id() {
+        assert_eq!(
+            steering_stable_id(&json!({ "messageId": "message-1" }), "event-1"),
+            "steering:message-1"
+        );
+        assert_eq!(
+            steering_stable_id(&json!({}), "event-1"),
+            "steering:event-1"
+        );
+    }
 
     #[test]
     fn model_gateway_errors_preserve_top_level_messages() {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -57,7 +57,9 @@ import { messageFromError } from "../../lib/errors";
 import { persistAgentDefaultModel } from "../../lib/agent-default-model";
 import { agentModelSelection, agentRunModelId } from "../../lib/agent-model-selection";
 import {
+  clearQueuedAgentFollowUpSteering,
   loadQueuedAgentFollowUps,
+  mergeQueuedAgentFollowUp,
   reconcileConsumedAgentFollowUp,
   saveQueuedAgentFollowUps,
   type QueuedAgentFollowUp,
@@ -225,10 +227,14 @@ function queuedAttachmentStatus(attachments: readonly string[]) {
 }
 
 function queuedFollowUpStatus(queued: QueuedAgentFollowUp, failed: boolean) {
+  const withAttachmentStatus = (status: string) =>
+    queued.attachments.length ? `${status}. ${queuedAttachmentStatus(queued.attachments)}` : status;
   if (failed) {
-    return queued.delivery === "attachments"
-      ? "Couldn't send queued attachments"
-      : "Couldn't send queued follow-up";
+    return withAttachmentStatus(
+      queued.delivery === "attachments"
+        ? "Couldn't send queued attachments"
+        : "Couldn't send queued follow-up",
+    );
   }
   if (queued.delivery === "attachments") {
     return queuedAttachmentStatus(queued.attachments);
@@ -236,11 +242,9 @@ function queuedFollowUpStatus(queued: QueuedAgentFollowUp, failed: boolean) {
   if (queued.steering) {
     const steeringStatus =
       queued.steering === "accepted" ? "Steering active run" : "Sending to active run";
-    return queued.attachments.length
-      ? `${steeringStatus}. ${queuedAttachmentStatus(queued.attachments)}`
-      : steeringStatus;
+    return withAttachmentStatus(steeringStatus);
   }
-  return "Queued follow-up";
+  return withAttachmentStatus("Queued follow-up");
 }
 
 function queuedFollowUpText(queued: QueuedAgentFollowUp) {
@@ -726,6 +730,15 @@ export function AgentWorkspace({
           ]),
         );
       }
+      const terminal =
+        payload.method === "run.completed" ||
+        payload.method === "run.cancelled" ||
+        payload.method === "run.failed";
+      if (terminal) {
+        updateQueuedFollowUps((current) =>
+          clearQueuedAgentFollowUpSteering(current, payload.sessionId),
+        );
+      }
       if (payload.sessionId !== selectedIdRef.current) {
         void refreshSessions().catch(() => undefined);
         return;
@@ -744,11 +757,7 @@ export function AgentWorkspace({
                   ? "failed"
                   : "running",
       });
-      if (
-        payload.method === "run.completed" ||
-        payload.method === "run.cancelled" ||
-        payload.method === "run.failed"
-      ) {
+      if (terminal) {
         setSubmitting(false);
         void Promise.all([hydrate(payload.sessionId), refreshSessions()]);
       }
@@ -863,8 +872,14 @@ export function AgentWorkspace({
   async function submit(event?: FormEvent) {
     event?.preventDefault();
     const queuedSubmission = queuedSubmissionSnapshotRef.current;
-    if (queuedSubmission && queuedSubmission.sessionId !== selectedIdRef.current) {
+    const clearQueuedSubmissionAttempt = () => {
       queuedSubmissionSnapshotRef.current = undefined;
+      if (queuedSubmission) {
+        attemptedQueuedMessageIdsRef.current.delete(queuedSubmission.messageId);
+      }
+    };
+    if (queuedSubmission && queuedSubmission.sessionId !== selectedIdRef.current) {
+      clearQueuedSubmissionAttempt();
       return;
     }
     const recoveredSubmission = recoverableSubmissionSnapshotRef.current;
@@ -873,22 +888,29 @@ export function AgentWorkspace({
       recoveredSubmission?.prompt ??
       draftRef.current
     ).trim();
-    if (!prompt || waiting || submitting || textActionsDisabledReason) return;
+    if (!prompt || waiting || submitting || textActionsDisabledReason) {
+      clearQueuedSubmissionAttempt();
+      return;
+    }
     if (running) {
+      const submittedAttachments = queuedSubmission?.attachments ?? attachments;
+      const submittedModel = queuedSubmission?.model ?? agentRunModelId(model, costQuality);
+      const submittedThinkingLevel = queuedSubmission?.thinkingLevel ?? thinkingLevel;
+      clearQueuedSubmissionAttempt();
       const ownerSessionId = selectedIdRef.current;
       if (!ownerSessionId) return;
       const messageId = crypto.randomUUID();
       updateQueuedFollowUps((current) => ({
         ...current,
-        [ownerSessionId]: {
+        [ownerSessionId]: mergeQueuedAgentFollowUp(current[ownerSessionId], {
           messageId,
           prompt,
-          attachments,
-          model: agentRunModelId(model, costQuality),
-          thinkingLevel,
+          attachments: submittedAttachments,
+          model: submittedModel,
+          thinkingLevel: submittedThinkingLevel,
           delivery: "follow_up",
           steering: "pending",
-        },
+        }),
       }));
       setComposerDraft("");
       setAttachments([]);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -60,6 +60,7 @@ import {
   loadQueuedAgentFollowUps,
   reconcileConsumedAgentFollowUp,
   saveQueuedAgentFollowUps,
+  type QueuedAgentFollowUp,
   type QueuedAgentFollowUps,
 } from "../../lib/agent-follow-up-queue";
 import {
@@ -216,6 +217,56 @@ export function canShareAgentSession(input: {
 function titleFromPrompt(prompt: string) {
   const normalized = prompt.replace(/\s+/g, " ").trim();
   return normalized.length > 52 ? `${normalized.slice(0, 51).trimEnd()}…` : normalized;
+}
+
+function queuedAttachmentStatus(attachments: readonly string[]) {
+  const count = attachments.length;
+  return `${count} attachment${count === 1 ? "" : "s"} queued for next turn`;
+}
+
+function queuedFollowUpStatus(queued: QueuedAgentFollowUp, failed: boolean) {
+  if (failed) {
+    return queued.delivery === "attachments"
+      ? "Couldn't send queued attachments"
+      : "Couldn't send queued follow-up";
+  }
+  if (queued.delivery === "attachments") {
+    return queuedAttachmentStatus(queued.attachments);
+  }
+  if (queued.steering) {
+    const steeringStatus =
+      queued.steering === "accepted" ? "Steering active run" : "Sending to active run";
+    return queued.attachments.length
+      ? `${steeringStatus}. ${queuedAttachmentStatus(queued.attachments)}`
+      : steeringStatus;
+  }
+  return "Queued follow-up";
+}
+
+function queuedFollowUpText(queued: QueuedAgentFollowUp) {
+  if (queued.delivery !== "attachments") return queued.prompt;
+  return queued.attachments.map((path) => path.split(/[\\/]/).pop() || path).join(", ");
+}
+
+function withQueuedSteering(
+  queued: QueuedAgentFollowUps,
+  sessionId: string,
+  messageId: string,
+  steering: QueuedAgentFollowUp["steering"],
+) {
+  const current = queued[sessionId];
+  if (
+    !current ||
+    current.messageId !== messageId ||
+    current.delivery === "attachments" ||
+    current.steering === steering
+  ) {
+    return queued;
+  }
+  const nextFollowUp = { ...current };
+  if (steering) nextFollowUp.steering = steering;
+  else delete nextFollowUp.steering;
+  return { ...queued, [sessionId]: nextFollowUp };
 }
 
 function artifactView(artifact: AgentArtifactDto): AgentArtifact {
@@ -669,13 +720,11 @@ export function AgentWorkspace({
           next.delete(payload.data.messageId);
           return next;
         });
-        updateQueuedFollowUps((current) => {
-          const queued = current[payload.sessionId];
-          if (queued?.messageId !== payload.data.messageId) return current;
-          const next = { ...current };
-          delete next[payload.sessionId];
-          return next;
-        });
+        updateQueuedFollowUps((current) =>
+          reconcileConsumedAgentFollowUp(current, payload.sessionId, [
+            `steering:${payload.data.messageId}`,
+          ]),
+        );
       }
       if (payload.sessionId !== selectedIdRef.current) {
         void refreshSessions().catch(() => undefined);
@@ -837,14 +886,44 @@ export function AgentWorkspace({
           attachments,
           model: agentRunModelId(model, costQuality),
           thinkingLevel,
+          delivery: "follow_up",
+          steering: "pending",
         },
       }));
       setComposerDraft("");
       setAttachments([]);
-      if (attachments.length === 0 && projection.run) {
+      if (projection.run) {
+        const activeRunId = projection.run.id;
         void agentRuntimeBindings
-          .steerRun(projection.run.id, messageId, prompt)
-          .catch(() => undefined);
+          .steerRun(activeRunId, messageId, prompt)
+          .then((result) => {
+            if (result.accepted) {
+              updateQueuedFollowUps((current) =>
+                withQueuedSteering(current, ownerSessionId, messageId, "accepted"),
+              );
+              return;
+            }
+            // biome-ignore lint/suspicious/noConsole: steering fallback needs a non-sensitive diagnostic
+            console.warn("Live steering was rejected; queued the full follow-up instead.", {
+              reason: result.reason ?? "unknown",
+              runId: activeRunId,
+              messageId,
+            });
+            updateQueuedFollowUps((current) =>
+              withQueuedSteering(current, ownerSessionId, messageId, undefined),
+            );
+          })
+          .catch((cause: unknown) => {
+            // biome-ignore lint/suspicious/noConsole: steering fallback needs a non-sensitive diagnostic
+            console.warn("Live steering failed; queued the full follow-up instead.", {
+              reason: messageFromError(cause),
+              runId: activeRunId,
+              messageId,
+            });
+            updateQueuedFollowUps((current) =>
+              withQueuedSteering(current, ownerSessionId, messageId, undefined),
+            );
+          });
       }
       return;
     }
@@ -2014,14 +2093,25 @@ export function AgentWorkspace({
               {queuedFollowUp ? (
                 <div className="agent-follow-up-row" role="status">
                   <span className="agent-follow-up-copy">
-                    <span className="agent-follow-up-announcement">Queued follow-up</span>
-                    <span className="agent-follow-up-text">{queuedFollowUp.prompt}</span>
+                    <span className="agent-follow-up-text">
+                      {queuedFollowUpText(queuedFollowUp)}
+                    </span>
+                    <span className="agent-follow-up-status">
+                      {queuedFollowUpStatus(
+                        queuedFollowUp,
+                        failedQueuedMessageIds.has(queuedFollowUp.messageId),
+                      )}
+                    </span>
                   </span>
                   <span className="agent-follow-up-actions">
                     {failedQueuedMessageIds.has(queuedFollowUp.messageId) ? (
                       <button
                         type="button"
-                        aria-label="Retry queued follow-up"
+                        aria-label={
+                          queuedFollowUp.delivery === "attachments"
+                            ? "Retry queued attachments"
+                            : "Retry queued follow-up"
+                        }
                         disabled={
                           running || waiting || submitting || Boolean(textActionsDisabledReason)
                         }
@@ -2041,7 +2131,11 @@ export function AgentWorkspace({
                     ) : null}
                     <button
                       type="button"
-                      aria-label="Remove queued follow-up"
+                      aria-label={
+                        queuedFollowUp.delivery === "attachments"
+                          ? "Remove queued attachments"
+                          : "Remove queued follow-up"
+                      }
                       onClick={() => {
                         if (!selectedId) return;
                         attemptedQueuedMessageIdsRef.current.delete(queuedFollowUp.messageId);
@@ -2553,7 +2647,7 @@ function AgentComposer({
                   <button
                     type="submit"
                     className="agent-composer-send"
-                    aria-label="Queue follow-up"
+                    aria-label="Steer active run"
                   >
                     <IconArrowUp size={18} />
                   </button>

--- a/src/lib/agent-follow-up-queue.ts
+++ b/src/lib/agent-follow-up-queue.ts
@@ -6,9 +6,13 @@ export type QueuedAgentFollowUp = {
   attachments: string[];
   model: string;
   thinkingLevel: ThinkingLevel;
+  delivery?: "follow_up" | "attachments";
+  steering?: "pending" | "accepted";
 };
 
 export type QueuedAgentFollowUps = Record<string, QueuedAgentFollowUp>;
+
+export const ATTACHMENT_FOLLOW_UP_PROMPT = "Use these attachments with my previous instruction.";
 
 const STORAGE_KEY = "june.agent.queuedFollowUps";
 
@@ -25,7 +29,13 @@ function queuedFollowUp(value: unknown): QueuedAgentFollowUp | undefined {
     typeof record.model !== "string" ||
     !Array.isArray(record.attachments) ||
     !record.attachments.every((path) => typeof path === "string") ||
-    !isThinkingLevel(record.thinkingLevel)
+    !isThinkingLevel(record.thinkingLevel) ||
+    (record.delivery !== undefined &&
+      record.delivery !== "follow_up" &&
+      record.delivery !== "attachments") ||
+    (record.steering !== undefined &&
+      record.steering !== "pending" &&
+      record.steering !== "accepted")
   ) {
     return undefined;
   }
@@ -35,6 +45,8 @@ function queuedFollowUp(value: unknown): QueuedAgentFollowUp | undefined {
     attachments: record.attachments,
     model: record.model,
     thinkingLevel: record.thinkingLevel,
+    ...(record.delivery ? { delivery: record.delivery } : {}),
+    ...(record.steering ? { steering: record.steering } : {}),
   };
 }
 
@@ -67,16 +79,33 @@ export function saveQueuedAgentFollowUps(queued: QueuedAgentFollowUps) {
   }
 }
 
-/** Steering items are persisted as `steering:<messageId>`. Drop a restored
- * fallback once native history proves the active run consumed it. */
+/** Steering items are persisted as `steering:<messageId>`. Once native
+ * history proves the active run consumed the text, retire its full fallback
+ * while preserving any attachments as a contextual next turn. */
 export function reconcileConsumedAgentFollowUp(
   queued: QueuedAgentFollowUps,
   sessionId: string,
   itemIds: readonly string[],
 ): QueuedAgentFollowUps {
   const current = queued[sessionId];
-  if (!current || !itemIds.includes(`steering:${current.messageId}`)) return queued;
+  if (
+    !current ||
+    current.delivery === "attachments" ||
+    !itemIds.includes(`steering:${current.messageId}`)
+  ) {
+    return queued;
+  }
   const next = { ...queued };
-  delete next[sessionId];
+  if (current.attachments.length === 0) {
+    delete next[sessionId];
+    return next;
+  }
+  const attachmentsOnly: QueuedAgentFollowUp = {
+    ...current,
+    prompt: ATTACHMENT_FOLLOW_UP_PROMPT,
+    delivery: "attachments",
+  };
+  delete attachmentsOnly.steering;
+  next[sessionId] = attachmentsOnly;
   return next;
 }

--- a/src/lib/agent-follow-up-queue.ts
+++ b/src/lib/agent-follow-up-queue.ts
@@ -12,7 +12,7 @@ export type QueuedAgentFollowUp = {
 
 export type QueuedAgentFollowUps = Record<string, QueuedAgentFollowUp>;
 
-export const ATTACHMENT_FOLLOW_UP_PROMPT = "Use these attachments with my previous instruction.";
+export const ATTACHMENT_FOLLOW_UP_NOTE = "The files are attached to this message.";
 
 const STORAGE_KEY = "june.agent.queuedFollowUps";
 
@@ -46,7 +46,6 @@ function queuedFollowUp(value: unknown): QueuedAgentFollowUp | undefined {
     model: record.model,
     thinkingLevel: record.thinkingLevel,
     ...(record.delivery ? { delivery: record.delivery } : {}),
-    ...(record.steering ? { steering: record.steering } : {}),
   };
 }
 
@@ -79,6 +78,27 @@ export function saveQueuedAgentFollowUps(queued: QueuedAgentFollowUps) {
   }
 }
 
+export function mergeQueuedAgentFollowUp(
+  current: QueuedAgentFollowUp | undefined,
+  incoming: QueuedAgentFollowUp,
+): QueuedAgentFollowUp {
+  const attachments = Array.from(
+    new Set([...(current?.attachments ?? []), ...incoming.attachments]),
+  );
+  return { ...incoming, attachments };
+}
+
+export function clearQueuedAgentFollowUpSteering(
+  queued: QueuedAgentFollowUps,
+  sessionId: string,
+): QueuedAgentFollowUps {
+  const current = queued[sessionId];
+  if (!current?.steering) return queued;
+  const nextItem = { ...current };
+  delete nextItem.steering;
+  return { ...queued, [sessionId]: nextItem };
+}
+
 /** Steering items are persisted as `steering:<messageId>`. Once native
  * history proves the active run consumed the text, retire its full fallback
  * while preserving any attachments as a contextual next turn. */
@@ -102,7 +122,9 @@ export function reconcileConsumedAgentFollowUp(
   }
   const attachmentsOnly: QueuedAgentFollowUp = {
     ...current,
-    prompt: ATTACHMENT_FOLLOW_UP_PROMPT,
+    prompt: current.prompt.trim()
+      ? `${current.prompt.trim()}\n\n${ATTACHMENT_FOLLOW_UP_NOTE}`
+      : ATTACHMENT_FOLLOW_UP_NOTE,
     delivery: "attachments",
   };
   delete attachmentsOnly.steering;

--- a/src/lib/agent-runtime-contract.ts
+++ b/src/lib/agent-runtime-contract.ts
@@ -305,7 +305,11 @@ export type AgentRuntimeBindings = {
   deleteSession(sessionId: string): Promise<void>;
   listItems(sessionId: string): Promise<AgentItemDto[]>;
   startRun(input: StartAgentRunRequest): Promise<AgentRunDto>;
-  steerRun(runId: string, messageId: string, text: string): Promise<{ accepted: boolean }>;
+  steerRun(
+    runId: string,
+    messageId: string,
+    text: string,
+  ): Promise<{ accepted: boolean; reason?: string }>;
   cancelRun(runId: string): Promise<void>;
   retryRun(runId: string): Promise<AgentRunDto>;
   resolveInterruption(input: ResolveAgentInterruptionRequest): Promise<AgentRunDto>;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -82,7 +82,11 @@ export const agentRuntimeBindings: AgentRuntimeBindings = {
   listItems: (sessionId) => invoke<AgentItemDto[]>("list_agent_items", { sessionId }),
   startRun: (request) => invoke<AgentRunDto>("start_agent_run", { request }),
   steerRun: (runId, messageId, text) =>
-    invoke<{ accepted: boolean }>("steer_agent_run", { runId, messageId, text }),
+    invoke<{ accepted: boolean; reason?: string }>("steer_agent_run", {
+      runId,
+      messageId,
+      text,
+    }),
   cancelRun: (runId) => invoke<void>("cancel_agent_run", { runId }),
   retryRun: (runId) => invoke<AgentRunDto>("retry_agent_run", { runId }),
   resolveInterruption: (request) => invoke<AgentRunDto>("resolve_agent_interruption", { request }),

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6683,6 +6683,16 @@ button.agent-user-attachment:hover {
   white-space: nowrap;
 }
 
+.agent-follow-up-status {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .agent-follow-up-announcement {
   position: absolute;
   width: 1px;

--- a/src/test/agent-follow-up-queue.test.ts
+++ b/src/test/agent-follow-up-queue.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  ATTACHMENT_FOLLOW_UP_PROMPT,
   loadQueuedAgentFollowUps,
   reconcileConsumedAgentFollowUp,
   saveQueuedAgentFollowUps,
@@ -12,6 +13,8 @@ const queued = {
     attachments: ["/tmp/brief.pdf"],
     model: "open-software/auto",
     thinkingLevel: "medium" as const,
+    delivery: "follow_up" as const,
+    steering: "accepted" as const,
   },
 };
 
@@ -24,7 +27,31 @@ describe("agent follow-up queue", () => {
   });
 
   it("drops a fallback once persisted history proves steering consumed it", () => {
-    expect(reconcileConsumedAgentFollowUp(queued, "session-1", ["steering:message-1"])).toEqual({});
+    const textOnly = {
+      "session-1": {
+        ...queued["session-1"],
+        attachments: [],
+      },
+    };
+    expect(reconcileConsumedAgentFollowUp(textOnly, "session-1", ["steering:message-1"])).toEqual(
+      {},
+    );
+    expect(reconcileConsumedAgentFollowUp(textOnly, "session-1", ["steering:other"])).toBe(
+      textOnly,
+    );
+  });
+
+  it("keeps pending attachments after steering consumes the text", () => {
+    expect(reconcileConsumedAgentFollowUp(queued, "session-1", ["steering:message-1"])).toEqual({
+      "session-1": {
+        messageId: "message-1",
+        prompt: ATTACHMENT_FOLLOW_UP_PROMPT,
+        attachments: ["/tmp/brief.pdf"],
+        model: "open-software/auto",
+        thinkingLevel: "medium",
+        delivery: "attachments",
+      },
+    });
     expect(reconcileConsumedAgentFollowUp(queued, "session-1", ["steering:other"])).toBe(queued);
   });
 

--- a/src/test/agent-follow-up-queue.test.ts
+++ b/src/test/agent-follow-up-queue.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
-  ATTACHMENT_FOLLOW_UP_PROMPT,
+  ATTACHMENT_FOLLOW_UP_NOTE,
+  clearQueuedAgentFollowUpSteering,
   loadQueuedAgentFollowUps,
+  mergeQueuedAgentFollowUp,
   reconcileConsumedAgentFollowUp,
   saveQueuedAgentFollowUps,
 } from "../lib/agent-follow-up-queue";
@@ -23,7 +25,58 @@ describe("agent follow-up queue", () => {
 
   it("survives a workspace remount", () => {
     saveQueuedAgentFollowUps(queued);
-    expect(loadQueuedAgentFollowUps()).toEqual(queued);
+    expect(loadQueuedAgentFollowUps()).toEqual({
+      "session-1": {
+        ...queued["session-1"],
+        steering: undefined,
+      },
+    });
+  });
+
+  it.each([
+    "pending",
+    "accepted",
+  ] as const)("restores persisted %s steering as a plain queued follow-up", (steering) => {
+    saveQueuedAgentFollowUps({
+      "session-1": { ...queued["session-1"], steering },
+    });
+    expect(loadQueuedAgentFollowUps()["session-1"]).not.toHaveProperty("steering");
+  });
+
+  it("merges attachments into the latest queued submission by path", () => {
+    expect(
+      mergeQueuedAgentFollowUp(
+        {
+          ...queued["session-1"],
+          prompt: "Earlier prompt",
+          attachments: ["/tmp/brief.pdf"],
+          delivery: "attachments",
+          steering: undefined,
+        },
+        {
+          ...queued["session-1"],
+          messageId: "message-2",
+          prompt: "Latest prompt",
+          attachments: ["/tmp/brief.pdf", "/tmp/notes.md"],
+          steering: "pending",
+        },
+      ),
+    ).toEqual({
+      ...queued["session-1"],
+      messageId: "message-2",
+      prompt: "Latest prompt",
+      attachments: ["/tmp/brief.pdf", "/tmp/notes.md"],
+      steering: "pending",
+    });
+  });
+
+  it("downgrades an unconsumed steering attempt to a plain queued follow-up", () => {
+    expect(clearQueuedAgentFollowUpSteering(queued, "session-1")).toEqual({
+      "session-1": {
+        ...queued["session-1"],
+        steering: undefined,
+      },
+    });
   });
 
   it("drops a fallback once persisted history proves steering consumed it", () => {
@@ -45,7 +98,7 @@ describe("agent follow-up queue", () => {
     expect(reconcileConsumedAgentFollowUp(queued, "session-1", ["steering:message-1"])).toEqual({
       "session-1": {
         messageId: "message-1",
-        prompt: ATTACHMENT_FOLLOW_UP_PROMPT,
+        prompt: `Continue with the attachment\n\n${ATTACHMENT_FOLLOW_UP_NOTE}`,
         attachments: ["/tmp/brief.pdf"],
         model: "open-software/auto",
         thinkingLevel: "medium",
@@ -60,6 +113,8 @@ describe("agent follow-up queue", () => {
       "june.agent.queuedFollowUps",
       JSON.stringify({ valid: queued["session-1"], invalid: { prompt: 42 } }),
     );
-    expect(loadQueuedAgentFollowUps()).toEqual({ valid: queued["session-1"] });
+    expect(loadQueuedAgentFollowUps()).toEqual({
+      valid: { ...queued["session-1"], steering: undefined },
+    });
   });
 });

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -38,7 +38,10 @@ import {
   setCurrentDataPartitionName,
 } from "../lib/data-partition";
 import { readJuneHomeStoredSessionId, writeJuneHomeStoredSessionId } from "../lib/june-home";
-import { saveQueuedAgentFollowUps } from "../lib/agent-follow-up-queue";
+import {
+  ATTACHMENT_FOLLOW_UP_PROMPT,
+  saveQueuedAgentFollowUps,
+} from "../lib/agent-follow-up-queue";
 
 const session: AgentSessionDto = {
   id: "session-1",
@@ -151,6 +154,9 @@ describe("AgentWorkspace runtime wiring", () => {
           status: "running",
           model: "auto",
         });
+      }
+      if (command === "steer_agent_run") {
+        return Promise.resolve({ accepted: true });
       }
       return Promise.resolve(undefined);
     });
@@ -950,7 +956,7 @@ describe("AgentWorkspace runtime wiring", () => {
     const activeComposer = screen.getByRole("textbox", { name: "Message June" });
     activeComposer.textContent = "Use the launch plan";
     fireEvent.input(activeComposer);
-    await user.click(await screen.findByRole("button", { name: "Queue follow-up" }));
+    await user.click(await screen.findByRole("button", { name: "Steer active run" }));
 
     const steerCall = mocks.invoke.mock.calls.find(([command]) => command === "steer_agent_run");
     expect(steerCall?.[1]).toMatchObject({
@@ -958,7 +964,7 @@ describe("AgentWorkspace runtime wiring", () => {
       text: "Use the launch plan",
       messageId: expect.any(String),
     });
-    expect(screen.getByText("Queued follow-up")).toBeVisible();
+    expect(await screen.findByText("Steering active run")).toBeVisible();
 
     act(() => {
       mocks.runtimeListener?.({
@@ -980,7 +986,151 @@ describe("AgentWorkspace runtime wiring", () => {
     });
 
     expect(await screen.findByText("Steering: Use the launch plan")).toBeVisible();
-    expect(screen.queryByText("Queued follow-up")).not.toBeInTheDocument();
+    expect(screen.queryByText("Steering active run")).not.toBeInTheDocument();
+  });
+
+  it("steers text with attachments and submits the attachments once after consumption", async () => {
+    const user = userEvent.setup();
+    mocks.openDialog.mockResolvedValue(["/tmp/brief.pdf"]);
+    render(<AgentWorkspace initialSession={session} />);
+    await screen.findByText("Earlier answer");
+
+    let composer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(composer, "Start the analysis");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await screen.findByRole("button", { name: "Stop June" });
+
+    await user.click(screen.getByRole("button", { name: "Add files or notes" }));
+    await user.click(screen.getByRole("menuitem", { name: "Attach files" }));
+    composer = screen.getByRole("textbox", { name: "Message June" });
+    composer.textContent = "Use the attached brief";
+    fireEvent.input(composer);
+    await user.click(await screen.findByRole("button", { name: "Steer active run" }));
+
+    const steerCall = mocks.invoke.mock.calls.find(([command]) => command === "steer_agent_run");
+    expect(steerCall?.[1]).toMatchObject({
+      runId: "run-1",
+      text: "Use the attached brief",
+      messageId: expect.any(String),
+    });
+    expect(
+      await screen.findByText("Steering active run. 1 attachment queued for next turn"),
+    ).toBeVisible();
+
+    act(() => {
+      mocks.runtimeListener?.({
+        payload: {
+          protocolVersion: 1,
+          eventId: "event-steering-with-attachment",
+          sessionId: session.id,
+          runId: "run-1",
+          sequence: 3,
+          method: "steering.consumed",
+          data: {
+            itemId: "steering-with-attachment",
+            messageId: String((steerCall?.[1] as { messageId?: string })?.messageId),
+            text: "Use the attached brief",
+            createdAt: "2026-07-22T12:01:00Z",
+          },
+        },
+      });
+    });
+
+    expect(await screen.findByText("Steering: Use the attached brief")).toBeVisible();
+    expect(screen.getByText("1 attachment queued for next turn")).toBeVisible();
+    expect(screen.getByText("brief.pdf")).toBeVisible();
+
+    act(() => {
+      mocks.runtimeListener?.({
+        payload: {
+          protocolVersion: 1,
+          eventId: "event-completed-after-attachment-steer",
+          sessionId: session.id,
+          runId: "run-1",
+          sequence: 4,
+          method: "run.completed",
+          data: { completedAt: "2026-07-22T12:02:00Z" },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      const starts = mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run");
+      expect(starts).toHaveLength(2);
+      expect(starts[1]?.[1]).toMatchObject({
+        request: expect.objectContaining({
+          prompt: ATTACHMENT_FOLLOW_UP_PROMPT,
+          attachments: ["/tmp/brief.pdf"],
+        }),
+      });
+    });
+    await act(async () => new Promise((resolve) => window.setTimeout(resolve, 0)));
+    expect(
+      mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run"),
+    ).toHaveLength(2);
+  });
+
+  it("falls back to the full queued follow-up when steering is rejected", async () => {
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "steer_agent_run") {
+        return Promise.resolve({ accepted: false, reason: "not_active" });
+      }
+      return defaultInvoke?.(command, args);
+    });
+    mocks.openDialog.mockResolvedValue(["/tmp/brief.pdf"]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    try {
+      const user = userEvent.setup();
+      render(<AgentWorkspace initialSession={session} />);
+      await screen.findByText("Earlier answer");
+
+      let composer = screen.getByRole("textbox", { name: "Message June" });
+      await user.type(composer, "Start the analysis");
+      await user.click(screen.getByRole("button", { name: "Send message" }));
+      await screen.findByRole("button", { name: "Stop June" });
+
+      await user.click(screen.getByRole("button", { name: "Add files or notes" }));
+      await user.click(screen.getByRole("menuitem", { name: "Attach files" }));
+      composer = screen.getByRole("textbox", { name: "Message June" });
+      composer.textContent = "Use the attached brief";
+      fireEvent.input(composer);
+      await user.click(await screen.findByRole("button", { name: "Steer active run" }));
+
+      expect(await screen.findByText("Queued follow-up")).toBeVisible();
+      expect(warn).toHaveBeenCalledWith(
+        "Live steering was rejected; queued the full follow-up instead.",
+        expect.objectContaining({ reason: "not_active", messageId: expect.any(String) }),
+      );
+
+      act(() => {
+        mocks.runtimeListener?.({
+          payload: {
+            protocolVersion: 1,
+            eventId: "event-completed-after-rejected-steer",
+            sessionId: session.id,
+            runId: "run-1",
+            sequence: 3,
+            method: "run.completed",
+            data: { completedAt: "2026-07-22T12:02:00Z" },
+          },
+        });
+      });
+
+      await waitFor(() => {
+        const starts = mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run");
+        expect(starts).toHaveLength(2);
+        expect(starts[1]?.[1]).toMatchObject({
+          request: expect.objectContaining({
+            prompt: "Use the attached brief",
+            attachments: ["/tmp/brief.pdf"],
+          }),
+        });
+      });
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("submits an unconsumed live instruction as the next run after settlement", async () => {
@@ -1003,7 +1153,7 @@ describe("AgentWorkspace runtime wiring", () => {
     composer = screen.getByRole("textbox", { name: "Message June" });
     composer.textContent = "Send this next";
     fireEvent.input(composer);
-    await user.click(await screen.findByRole("button", { name: "Queue follow-up" }));
+    await user.click(await screen.findByRole("button", { name: "Steer active run" }));
 
     await user.click(screen.getByRole("button", { name: "Model: Auto" }));
     await user.click(screen.getByRole("button", { name: "All models" }));
@@ -1078,12 +1228,16 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(await screen.findByText("follow-up.pdf")).toBeVisible();
     composer.textContent = "Only send this in session A";
     fireEvent.input(composer);
-    await user.click(await screen.findByRole("button", { name: "Queue follow-up" }));
-    expect(screen.getByText("Queued follow-up")).toBeVisible();
+    await user.click(await screen.findByRole("button", { name: "Steer active run" }));
+    expect(
+      await screen.findByText("Steering active run. 1 attachment queued for next turn"),
+    ).toBeVisible();
 
     rerender(<AgentWorkspace initialSession={newSession} />);
     await waitFor(() => expect(screen.queryByRole("button", { name: "Stop June" })).toBeNull());
-    expect(screen.queryByText("Queued follow-up")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Steering active run. 1 attachment queued for next turn"),
+    ).not.toBeInTheDocument();
 
     act(() => {
       mocks.runtimeListener?.({

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -38,10 +38,7 @@ import {
   setCurrentDataPartitionName,
 } from "../lib/data-partition";
 import { readJuneHomeStoredSessionId, writeJuneHomeStoredSessionId } from "../lib/june-home";
-import {
-  ATTACHMENT_FOLLOW_UP_PROMPT,
-  saveQueuedAgentFollowUps,
-} from "../lib/agent-follow-up-queue";
+import { ATTACHMENT_FOLLOW_UP_NOTE, saveQueuedAgentFollowUps } from "../lib/agent-follow-up-queue";
 
 const session: AgentSessionDto = {
   id: "session-1",
@@ -1059,7 +1056,7 @@ describe("AgentWorkspace runtime wiring", () => {
       expect(starts).toHaveLength(2);
       expect(starts[1]?.[1]).toMatchObject({
         request: expect.objectContaining({
-          prompt: ATTACHMENT_FOLLOW_UP_PROMPT,
+          prompt: `Use the attached brief\n\n${ATTACHMENT_FOLLOW_UP_NOTE}`,
           attachments: ["/tmp/brief.pdf"],
         }),
       });
@@ -1068,6 +1065,117 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(
       mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run"),
     ).toHaveLength(2);
+  });
+
+  it("merges a later steer into an attachments-only queue without dropping files", async () => {
+    const user = userEvent.setup();
+    mocks.openDialog
+      .mockResolvedValueOnce(["/tmp/brief.pdf"])
+      .mockResolvedValueOnce(["/tmp/notes.md"]);
+    render(<AgentWorkspace initialSession={session} />);
+    await screen.findByText("Earlier answer");
+
+    let composer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(composer, "Start the analysis");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await screen.findByRole("button", { name: "Stop June" });
+
+    await user.click(screen.getByRole("button", { name: "Add files or notes" }));
+    await user.click(screen.getByRole("menuitem", { name: "Attach files" }));
+    composer = screen.getByRole("textbox", { name: "Message June" });
+    composer.textContent = "Use the first brief";
+    fireEvent.input(composer);
+    await user.click(await screen.findByRole("button", { name: "Steer active run" }));
+
+    let steerCalls = mocks.invoke.mock.calls.filter(([command]) => command === "steer_agent_run");
+    const firstMessageId = String(
+      (steerCalls[0]?.[1] as { messageId?: string } | undefined)?.messageId,
+    );
+    act(() => {
+      mocks.runtimeListener?.({
+        payload: {
+          protocolVersion: 1,
+          eventId: "event-consumed-first-brief",
+          sessionId: session.id,
+          runId: "run-1",
+          sequence: 3,
+          method: "steering.consumed",
+          data: {
+            itemId: `steering:${firstMessageId}`,
+            messageId: firstMessageId,
+            text: "Use the first brief",
+            createdAt: "2026-07-22T12:01:00Z",
+          },
+        },
+      });
+    });
+    expect(await screen.findByText("1 attachment queued for next turn")).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Add files or notes" }));
+    await user.click(screen.getByRole("menuitem", { name: "Attach files" }));
+    composer = screen.getByRole("textbox", { name: "Message June" });
+    composer.textContent = "Use the latest plan";
+    fireEvent.input(composer);
+    await user.click(await screen.findByRole("button", { name: "Steer active run" }));
+
+    steerCalls = mocks.invoke.mock.calls.filter(([command]) => command === "steer_agent_run");
+    expect(steerCalls).toHaveLength(2);
+    const secondMessageId = String(
+      (steerCalls[1]?.[1] as { messageId?: string } | undefined)?.messageId,
+    );
+    await waitFor(() => {
+      const stored = JSON.parse(
+        window.localStorage.getItem("june.agent.queuedFollowUps") ?? "{}",
+      ) as Record<string, { messageId?: string; prompt?: string; attachments?: string[] }>;
+      expect(stored[session.id]).toMatchObject({
+        messageId: secondMessageId,
+        prompt: "Use the latest plan",
+        attachments: ["/tmp/brief.pdf", "/tmp/notes.md"],
+      });
+    });
+
+    act(() => {
+      mocks.runtimeListener?.({
+        payload: {
+          protocolVersion: 1,
+          eventId: "event-consumed-latest-plan",
+          sessionId: session.id,
+          runId: "run-1",
+          sequence: 4,
+          method: "steering.consumed",
+          data: {
+            itemId: `steering:${secondMessageId}`,
+            messageId: secondMessageId,
+            text: "Use the latest plan",
+            createdAt: "2026-07-22T12:01:30Z",
+          },
+        },
+      });
+    });
+    act(() => {
+      mocks.runtimeListener?.({
+        payload: {
+          protocolVersion: 1,
+          eventId: "event-completed-after-merged-steer",
+          sessionId: session.id,
+          runId: "run-1",
+          sequence: 5,
+          method: "run.completed",
+          data: { completedAt: "2026-07-22T12:02:00Z" },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      const starts = mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run");
+      expect(starts).toHaveLength(2);
+      expect(starts[1]?.[1]).toMatchObject({
+        request: expect.objectContaining({
+          prompt: `Use the latest plan\n\n${ATTACHMENT_FOLLOW_UP_NOTE}`,
+          attachments: ["/tmp/brief.pdf", "/tmp/notes.md"],
+        }),
+      });
+    });
   });
 
   it("falls back to the full queued follow-up when steering is rejected", async () => {
@@ -1098,7 +1206,9 @@ describe("AgentWorkspace runtime wiring", () => {
       fireEvent.input(composer);
       await user.click(await screen.findByRole("button", { name: "Steer active run" }));
 
-      expect(await screen.findByText("Queued follow-up")).toBeVisible();
+      expect(
+        await screen.findByText("Queued follow-up. 1 attachment queued for next turn"),
+      ).toBeVisible();
       expect(warn).toHaveBeenCalledWith(
         "Live steering was rejected; queued the full follow-up instead.",
         expect.objectContaining({ reason: "not_active", messageId: expect.any(String) }),
@@ -1188,6 +1298,113 @@ describe("AgentWorkspace runtime wiring", () => {
       });
     });
     expect(screen.getByRole("button", { name: "Model: Fast" })).toBeEnabled();
+  });
+
+  it("downgrades terminal steering and clears the queued snapshot when delivery races a new run", async () => {
+    const user = userEvent.setup();
+    mocks.openDialog.mockResolvedValue(["/tmp/brief.pdf"]);
+    render(<AgentWorkspace initialSession={session} />);
+    await screen.findByText("Earlier answer");
+
+    let composer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(composer, "Start the analysis");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await screen.findByRole("button", { name: "Stop June" });
+
+    await user.click(screen.getByRole("button", { name: "Add files or notes" }));
+    await user.click(screen.getByRole("menuitem", { name: "Attach files" }));
+    composer = screen.getByRole("textbox", { name: "Message June" });
+    composer.textContent = "Deliver this after settlement";
+    fireEvent.input(composer);
+    await user.click(await screen.findByRole("button", { name: "Steer active run" }));
+    expect(
+      await screen.findByText("Steering active run. 1 attachment queued for next turn"),
+    ).toBeVisible();
+
+    const frameCallbacks: FrameRequestCallback[] = [];
+    const animationFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        frameCallbacks.push(callback);
+        return frameCallbacks.length;
+      });
+    try {
+      act(() => {
+        mocks.runtimeListener?.({
+          payload: {
+            protocolVersion: 1,
+            eventId: "event-terminal-before-queued-delivery",
+            sessionId: session.id,
+            runId: "run-1",
+            sequence: 3,
+            method: "run.completed",
+            data: { completedAt: "2026-07-22T12:01:00Z" },
+          },
+        });
+      });
+
+      expect(
+        await screen.findByText("Queued follow-up. 1 attachment queued for next turn"),
+      ).toBeVisible();
+      await waitFor(() => expect(frameCallbacks.length).toBeGreaterThan(0));
+
+      act(() => {
+        mocks.runtimeListener?.({
+          payload: {
+            protocolVersion: 1,
+            eventId: "event-new-run-before-queued-delivery",
+            sessionId: session.id,
+            runId: "run-2",
+            sequence: 0,
+            method: "run.started",
+            data: {
+              startedAt: "2026-07-22T12:01:01Z",
+              model: "fast",
+            },
+          },
+        });
+      });
+      const queuedFrames = frameCallbacks.splice(0);
+      act(() => {
+        for (const callback of queuedFrames) callback(0);
+      });
+
+      await waitFor(() => {
+        const steerCalls = mocks.invoke.mock.calls.filter(
+          ([command]) => command === "steer_agent_run",
+        );
+        expect(steerCalls).toHaveLength(2);
+        expect(steerCalls[1]?.[1]).toMatchObject({
+          runId: "run-2",
+          text: "Deliver this after settlement",
+        });
+      });
+
+      composer = screen.getByRole("textbox", { name: "Message June" });
+      composer.textContent = "Latest live correction";
+      fireEvent.input(composer);
+      await user.click(await screen.findByRole("button", { name: "Steer active run" }));
+
+      await waitFor(() => {
+        const steerCalls = mocks.invoke.mock.calls.filter(
+          ([command]) => command === "steer_agent_run",
+        );
+        expect(steerCalls).toHaveLength(3);
+        expect(steerCalls[2]?.[1]).toMatchObject({
+          runId: "run-2",
+          text: "Latest live correction",
+        });
+        const stored = JSON.parse(
+          window.localStorage.getItem("june.agent.queuedFollowUps") ?? "{}",
+        ) as Record<string, { prompt?: string; attachments?: string[] }>;
+        expect(stored[session.id]).toMatchObject({
+          prompt: "Latest live correction",
+          attachments: ["/tmp/brief.pdf"],
+        });
+      });
+    } finally {
+      animationFrame.mockRestore();
+    }
   });
 
   it("keeps a queued follow-up owned by its running session across navigation", async () => {
@@ -1318,6 +1535,56 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(await screen.findByText("Resume with this file")).toBeVisible();
   });
 
+  it("releases a queued attempt when submit becomes blocked before its frame", async () => {
+    saveQueuedAgentFollowUps({
+      [session.id]: {
+        messageId: "blocked-frame",
+        prompt: "Retry after funding refresh",
+        attachments: ["/tmp/retry.pdf"],
+        model: "fast",
+        thinkingLevel: "medium",
+      },
+    });
+    const frameCallbacks: FrameRequestCallback[] = [];
+    const animationFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        frameCallbacks.push(callback);
+        return frameCallbacks.length;
+      });
+    try {
+      const view = render(<AgentWorkspace initialSession={session} />);
+      await waitFor(() => expect(frameCallbacks).toHaveLength(1));
+
+      view.rerender(
+        <AgentWorkspace
+          initialSession={session}
+          creditActionsDisabledReason="Add credits to continue"
+        />,
+      );
+      act(() => frameCallbacks.shift()?.(0));
+      await waitFor(() =>
+        expect(
+          mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run"),
+        ).toHaveLength(0),
+      );
+
+      view.rerender(<AgentWorkspace initialSession={session} />);
+      await waitFor(() => expect(frameCallbacks).toHaveLength(1));
+      act(() => frameCallbacks.shift()?.(0));
+      await waitFor(() =>
+        expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", {
+          request: expect.objectContaining({
+            prompt: "Retry after funding refresh",
+            attachments: ["/tmp/retry.pdf"],
+          }),
+        }),
+      );
+    } finally {
+      animationFrame.mockRestore();
+    }
+  });
+
   it("keeps a restored follow-up when its run start fails after navigation", async () => {
     saveQueuedAgentFollowUps({
       [session.id]: {
@@ -1378,14 +1645,16 @@ describe("AgentWorkspace runtime wiring", () => {
     });
   });
 
-  it("does not replay a restored follow-up that persisted history already consumed", async () => {
+  it("hydrates a public steering item and submits only its pending attachments", async () => {
     saveQueuedAgentFollowUps({
       [session.id]: {
         messageId: "already-consumed",
-        prompt: "Do not send this twice",
-        attachments: [],
+        prompt: "Use this restored brief",
+        attachments: ["/tmp/restored-brief.pdf"],
         model: "fast",
         thinkingLevel: "medium",
+        delivery: "follow_up",
+        steering: "accepted",
       },
     });
     const defaultInvoke = mocks.invoke.getMockImplementation();
@@ -1399,7 +1668,7 @@ describe("AgentWorkspace runtime wiring", () => {
             sequence: 1,
             createdAt: session.createdAt,
             kind: "steering",
-            text: "Do not send this twice",
+            text: "Use this restored brief",
           },
         ]);
       }
@@ -1407,12 +1676,17 @@ describe("AgentWorkspace runtime wiring", () => {
     });
 
     render(<AgentWorkspace initialSession={session} />);
-    expect(await screen.findByText("Steering: Do not send this twice")).toBeVisible();
-    await waitFor(() =>
-      expect(
-        mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run"),
-      ).toHaveLength(0),
-    );
+    expect(await screen.findByText("Steering: Use this restored brief")).toBeVisible();
+    await waitFor(() => {
+      const starts = mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run");
+      expect(starts).toHaveLength(1);
+      expect(starts[0]?.[1]).toMatchObject({
+        request: expect.objectContaining({
+          prompt: `Use this restored brief\n\n${ATTACHMENT_FOLLOW_UP_NOTE}`,
+          attachments: ["/tmp/restored-brief.pdf"],
+        }),
+      });
+    });
   });
 
   it("does not let a slow global catalog overwrite a restored session model", async () => {


### PR DESCRIPTION
## Summary

Fixes JUN-441 and JUN-442 (initiative: Restore/complete post-runtime-migration functionality).

- Submitting during an active run now steers the text live even when files are attached; the attachments are held and submitted as the next turn with the user's original prompt preserved (JUN-441).
- The `steerRun` result is consumed: on `accepted: false` or transport failure the full follow-up is deliberately restored to the queue, with the reason logged and the state visible (JUN-442).
- Hardening from a two-model adversarial review round: `steering.consumed` items now persist `steering:<messageId>` as their public external id (Rust) so hydration reconciles against real payloads; submit-while-running merges the queue slot (attachment union, dedup by path) instead of silently replacing it; queued-submission snapshots are released on all early-return paths; persisted steering markers downgrade honestly on reload; queued attachment counts stay visible in every state.

## Root cause

The original submit path skipped `steerRun` entirely whenever attachments were present (`attachments.length === 0` guard) and discarded the steer result, so live steering silently degraded to a queued next turn with no user-visible distinction.

## Validation

- 1,524 frontend tests, `pnpm typecheck`, `pnpm check`, `pnpm test:rust` all green (run independently by the orchestrator, not only by the implementer).
- Adversarial reviews (Grok 4.5 and Opus) ran before this PR; all 6 surviving findings (2 P1, 2 P2, 2 P3) fixed in `e189b11d` with regression tests each.

- [ ] Tested visually where it matters (no visual walkthrough; queue status copy and transitions covered by component tests).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Steering consumption timing (still the next model boundary per ADR-0038).
- Multi-slot follow-up queues; the queue stays one merged slot per session.

## Followups

- None planned.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [ ] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787731960&installation_model_id=425925&pr_number=978&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F978&signature=f8e83a8388b04ce350d0ffe1aad0f75c27e38d69c32e8fa756fbce63d0a91f08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->