### PR TITLE
Fix compaction usage and duplicate resume cleanup

### DIFF
--- a/agent-runtime/src/rpc-model-provider.ts
+++ b/agent-runtime/src/rpc-model-provider.ts
@@ -3,7 +3,7 @@ import {
   type Model,
   type ModelProvider,
 } from "@openai/agents";
-import type { JsonObject, JsonValue } from "./types.js";
+import type { JsonObject, JsonValue, RuntimeUsage } from "./types.js";
 import type { SteeringMessage } from "./types.js";
 
 export const MODEL_CHAT_COMPLETIONS_TOOL = "__june_model_chat_completions";
@@ -27,6 +27,8 @@ export class RpcChatCompletionsModelProvider implements ModelProvider {
   latestRoute: ModelRoute | undefined;
   resolvedModel: string | undefined;
   reasoningWireFormat: ReasoningWireFormat | undefined;
+  latestUsage: RuntimeUsage | undefined;
+  totalUsage: RuntimeUsage = {};
 
   constructor(
     invoke: ModelRpcInvoker,
@@ -101,6 +103,11 @@ export class RpcChatCompletionsModelProvider implements ModelProvider {
     while (true) {
       if (page.route) this.latestRoute = page.route;
       for (const chunk of page.chunks) {
+        const usage = chatCompletionUsage(chunk.usage);
+        if (usage) {
+          this.latestUsage = usage;
+          this.totalUsage = addUsage(this.totalUsage, usage);
+        }
         if (autoRequested) {
           const chunkModel = autoResponseModel(chunk.model);
           if (chunkModel && this.resolvedModel && chunkModel !== this.resolvedModel) {
@@ -389,4 +396,49 @@ function stringValue(value: unknown): string | undefined {
 
 function numberValue(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function chatCompletionUsage(value: unknown): RuntimeUsage | undefined {
+  if (!isRecord(value)) return undefined;
+  const inputTokens = numberValue(value.inputTokens ?? value.input_tokens ?? value.prompt_tokens);
+  const outputTokens = numberValue(
+    value.outputTokens ?? value.output_tokens ?? value.completion_tokens,
+  );
+  const totalTokens = numberValue(value.totalTokens ?? value.total_tokens);
+  if (
+    inputTokens === undefined &&
+    outputTokens === undefined &&
+    totalTokens === undefined
+  ) {
+    return undefined;
+  }
+  return compactUsage({
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    requests: numberValue(value.requests) ?? 1,
+  });
+}
+
+function addUsage(left: RuntimeUsage, right: RuntimeUsage): RuntimeUsage {
+  return compactUsage({
+    inputTokens: addDefined(left.inputTokens, right.inputTokens),
+    outputTokens: addDefined(left.outputTokens, right.outputTokens),
+    totalTokens: addDefined(left.totalTokens, right.totalTokens),
+    requests: addDefined(left.requests, right.requests),
+  });
+}
+
+function addDefined(left?: number, right?: number): number | undefined {
+  return left === undefined && right === undefined ? undefined : (left ?? 0) + (right ?? 0);
+}
+
+function compactUsage(
+  value: Record<string, number | string | undefined>,
+): RuntimeUsage {
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, number | string] => entry[1] !== undefined,
+    ),
+  ) as RuntimeUsage;
 }

--- a/agent-runtime/src/rpc-model-provider.ts
+++ b/agent-runtime/src/rpc-model-provider.ts
@@ -404,7 +404,11 @@ function chatCompletionUsage(value: unknown): RuntimeUsage | undefined {
   const outputTokens = numberValue(
     value.outputTokens ?? value.output_tokens ?? value.completion_tokens,
   );
-  const totalTokens = numberValue(value.totalTokens ?? value.total_tokens);
+  const totalTokens =
+    numberValue(value.totalTokens ?? value.total_tokens) ??
+    (inputTokens !== undefined && outputTokens !== undefined
+      ? inputTokens + outputTokens
+      : undefined);
   if (
     inputTokens === undefined &&
     outputTokens === undefined &&

--- a/agent-runtime/src/sdk-engine.ts
+++ b/agent-runtime/src/sdk-engine.ts
@@ -105,11 +105,18 @@ export class OpenAIAgentsEngine implements AgentEngine {
       ...(input.signal === undefined ? {} : { signal: input.signal }),
     });
     let summary = "";
-    for await (const event of response) {
-      if (event.type === "output_text_delta") summary += event.delta;
+    try {
+      for await (const event of response) {
+        if (event.type === "output_text_delta") summary += event.delta;
+      }
+    } catch (cause) {
+      const error = new Error(errorMessage(cause), { cause }) as Error & {
+        usage?: RuntimeUsage;
+      };
+      error.usage = modelProvider.totalUsage;
+      throw error;
     }
     summary = summary.trim();
-    if (!summary) throw new Error("June model route returned an empty context summary");
     return { text: summary, usage: modelProvider.totalUsage };
   }
 

--- a/agent-runtime/src/sdk-engine.ts
+++ b/agent-runtime/src/sdk-engine.ts
@@ -22,6 +22,7 @@ import type {
   EngineResumeInput,
   EngineRunInput,
   EngineSummaryInput,
+  EngineSummaryResult,
   HostToolInvoker,
   RunResumeParams,
   RunStartParams,
@@ -67,7 +68,7 @@ export class OpenAIAgentsEngine implements AgentEngine {
     this.initialized = true;
   }
 
-  async summarize(input: EngineSummaryInput): Promise<string> {
+  async summarize(input: EngineSummaryInput): Promise<EngineSummaryResult> {
     const modelProvider = this.createModelProvider(input.sessionId, input.runId);
     const contextWindow = Math.max(1_024, Math.floor(input.contextWindow));
     const configuredOutputTokens = Math.max(
@@ -109,7 +110,7 @@ export class OpenAIAgentsEngine implements AgentEngine {
     }
     summary = summary.trim();
     if (!summary) throw new Error("June model route returned an empty context summary");
-    return summary;
+    return { text: summary, usage: modelProvider.totalUsage };
   }
 
   async start(input: EngineRunInput): Promise<EngineResult> {
@@ -330,11 +331,15 @@ export class OpenAIAgentsEngine implements AgentEngine {
         ? serializeState(stream.state.toString(), modelProvider.reasoningWireFormat)
         : undefined;
     const history = sdkHistoryToRuntime(stream.history);
+    const usage = normalizeUsage(stream.usage);
+    const latestInputTokens =
+      modelProvider.latestUsage?.inputTokens ?? usage.inputTokens;
     return {
       ...(typeof stream.finalOutput === "string" ? { finalOutput: stream.finalOutput } : {}),
       history,
       usage: {
-        ...normalizeUsage(stream.usage),
+        ...usage,
+        ...(latestInputTokens === undefined ? {} : { latestInputTokens }),
         ...modelProvider.latestRoute,
         ...(modelProvider.resolvedModel ? { resolvedModel: modelProvider.resolvedModel } : {}),
       },

--- a/agent-runtime/src/service.ts
+++ b/agent-runtime/src/service.ts
@@ -113,19 +113,24 @@ export class RuntimeService {
       onFallback: (error) =>
         this.logCompactionFallback(error, sessionId, runId),
       summarize: async (history) => {
-        const summary = await this.engine.summarize({
-          sessionId,
-          runId,
-          model: parsed.model,
-          history,
-          contextWindow: parsed.contextWindow,
-          ...(parsed.maxOutputTokens === undefined
-            ? {}
-            : { maxOutputTokens: parsed.maxOutputTokens }),
-          signal: active.controller.signal,
-        });
-        compactionUsage = mergeUsage(compactionUsage, summary.usage);
-        return summary.text;
+        try {
+          const summary = await this.engine.summarize({
+            sessionId,
+            runId,
+            model: parsed.model,
+            history,
+            contextWindow: parsed.contextWindow,
+            ...(parsed.maxOutputTokens === undefined
+              ? {}
+              : { maxOutputTokens: parsed.maxOutputTokens }),
+            signal: active.controller.signal,
+          });
+          compactionUsage = mergeUsage(compactionUsage, summary.usage);
+          return summary.text;
+        } catch (error) {
+          compactionUsage = mergeUsage(compactionUsage, summaryErrorUsage(error));
+          throw error;
+        }
       },
     });
     throwIfAborted(active.controller.signal);
@@ -224,19 +229,24 @@ export class RuntimeService {
       ...(model
         ? {
             summarize: async (items) => {
-              const summary = await this.engine.summarize({
-                sessionId,
-                runId,
-                model,
-                history: items,
-                contextWindow:
-                  typeof params.contextWindow === "number"
-                    ? params.contextWindow
-                    : 128_000,
-                ...(maxOutputTokens === undefined ? {} : { maxOutputTokens }),
-              });
-              compactionUsage = mergeUsage(compactionUsage, summary.usage);
-              return summary.text;
+              try {
+                const summary = await this.engine.summarize({
+                  sessionId,
+                  runId,
+                  model,
+                  history: items,
+                  contextWindow:
+                    typeof params.contextWindow === "number"
+                      ? params.contextWindow
+                      : 128_000,
+                  ...(maxOutputTokens === undefined ? {} : { maxOutputTokens }),
+                });
+                compactionUsage = mergeUsage(compactionUsage, summary.usage);
+                return summary.text;
+              } catch (error) {
+                compactionUsage = mergeUsage(compactionUsage, summaryErrorUsage(error));
+                throw error;
+              }
             },
           }
         : {}),
@@ -369,6 +379,12 @@ function mergeUsage(earlier: RuntimeUsage, later: RuntimeUsage): RuntimeUsage {
     privacyLevel: later.privacyLevel ?? earlier.privacyLevel,
     endpoint: later.endpoint ?? earlier.endpoint,
   });
+}
+
+function summaryErrorUsage(error: unknown): RuntimeUsage {
+  if (typeof error !== "object" || error === null || !("usage" in error)) return {};
+  const usage = error.usage;
+  return typeof usage === "object" && usage !== null ? (usage as RuntimeUsage) : {};
 }
 
 function addDefined(left?: number, right?: number): number | undefined {

--- a/agent-runtime/src/service.ts
+++ b/agent-runtime/src/service.ts
@@ -133,8 +133,9 @@ export class RuntimeService {
         }
       },
     });
-    throwIfAborted(active.controller.signal);
-    this.emit("run.started", {
+    try {
+      throwIfAborted(active.controller.signal);
+      this.emit("run.started", {
       model: parsed.model,
       compacted: compaction.compacted,
       history: compaction.history as unknown as JsonValue,
@@ -142,20 +143,23 @@ export class RuntimeService {
       ...(compaction.summary === undefined
         ? {}
         : { contextSummary: compaction.summary as unknown as JsonValue }),
-    }, sessionId, runId);
-    const runParams: RunStartParams = { ...parsed, history: compaction.history };
-    const result = await this.engine.start({
+      }, sessionId, runId);
+      const runParams: RunStartParams = { ...parsed, history: compaction.history };
+      const result = await this.engine.start({
       sessionId,
       runId,
       params: runParams,
       signal: active.controller.signal,
       emit: (event) => this.forwardEngineEvent(event, sessionId, runId),
       takeSteering: () => active.steering.splice(0),
-    });
-    return {
-      ...result,
-      usage: mergeUsage(compactionUsage, result.usage),
-    };
+      });
+      return {
+        ...result,
+        usage: mergeUsage(compactionUsage, result.usage),
+      };
+    } catch (error) {
+      throw attachUsageToError(error, compactionUsage);
+    }
   }
 
   private resume(sessionId: string, runId: string, params: JsonObject): JsonValue {
@@ -287,6 +291,7 @@ export class RuntimeService {
     try {
       const result = await resultPromise;
       if (this.activeRuns.get(runKey(sessionId, runId))?.controller.signal.aborted) {
+        this.emitUsage(result.usage, sessionId, runId);
         this.emit("run.cancelled", { history: result.history as unknown as JsonValue }, sessionId, runId);
         return;
       }
@@ -309,6 +314,8 @@ export class RuntimeService {
       this.emitUsage(result.usage, sessionId, runId);
       this.emit("run.completed", { history: result.history as unknown as JsonValue }, sessionId, runId);
     } catch (error) {
+      const usage = summaryErrorUsage(error);
+      if (Object.keys(usage).length > 0) this.emitUsage(usage, sessionId, runId);
       const active = this.activeRuns.get(runKey(sessionId, runId));
       if (active?.controller.signal.aborted || isAbortError(error)) {
         this.emit("run.cancelled", {}, sessionId, runId);
@@ -385,6 +392,16 @@ function summaryErrorUsage(error: unknown): RuntimeUsage {
   if (typeof error !== "object" || error === null || !("usage" in error)) return {};
   const usage = error.usage;
   return typeof usage === "object" && usage !== null ? (usage as RuntimeUsage) : {};
+}
+
+function attachUsageToError(error: unknown, usage: RuntimeUsage): unknown {
+  if (Object.keys(usage).length === 0) return error;
+  const target = error instanceof Error ? error : new Error(errorMessage(error));
+  (target as Error & { usage?: RuntimeUsage }).usage = mergeUsage(
+    summaryErrorUsage(error),
+    usage,
+  );
+  return target;
 }
 
 function addDefined(left?: number, right?: number): number | undefined {

--- a/agent-runtime/src/service.ts
+++ b/agent-runtime/src/service.ts
@@ -105,14 +105,15 @@ export class RuntimeService {
     active: ActiveRun,
   ): Promise<EngineResult> {
     throwIfAborted(active.controller.signal);
+    let compactionUsage: RuntimeUsage = {};
     const compaction = await compactHistory({
       history: parsed.history,
       contextWindow: parsed.contextWindow,
       ...(parsed.maxOutputTokens === undefined ? {} : { maxOutputTokens: parsed.maxOutputTokens }),
       onFallback: (error) =>
         this.logCompactionFallback(error, sessionId, runId),
-      summarize: (history) =>
-        this.engine.summarize({
+      summarize: async (history) => {
+        const summary = await this.engine.summarize({
           sessionId,
           runId,
           model: parsed.model,
@@ -122,7 +123,10 @@ export class RuntimeService {
             ? {}
             : { maxOutputTokens: parsed.maxOutputTokens }),
           signal: active.controller.signal,
-        }),
+        });
+        compactionUsage = mergeUsage(compactionUsage, summary.usage);
+        return summary.text;
+      },
     });
     throwIfAborted(active.controller.signal);
     this.emit("run.started", {
@@ -135,7 +139,7 @@ export class RuntimeService {
         : { contextSummary: compaction.summary as unknown as JsonValue }),
     }, sessionId, runId);
     const runParams: RunStartParams = { ...parsed, history: compaction.history };
-    return this.engine.start({
+    const result = await this.engine.start({
       sessionId,
       runId,
       params: runParams,
@@ -143,6 +147,10 @@ export class RuntimeService {
       emit: (event) => this.forwardEngineEvent(event, sessionId, runId),
       takeSteering: () => active.steering.splice(0),
     });
+    return {
+      ...result,
+      usage: mergeUsage(compactionUsage, result.usage),
+    };
   }
 
   private resume(sessionId: string, runId: string, params: JsonObject): JsonValue {
@@ -205,6 +213,7 @@ export class RuntimeService {
     const model = typeof params.model === "string" ? params.model.trim() : "";
     const maxOutputTokens =
       typeof params.maxOutputTokens === "number" ? params.maxOutputTokens : undefined;
+    let compactionUsage: RuntimeUsage = {};
     const result = await compactHistory({
       history: history as RunStartParams["history"],
       contextWindow:
@@ -214,8 +223,8 @@ export class RuntimeService {
         this.logCompactionFallback(error, sessionId, runId),
       ...(model
         ? {
-            summarize: (items) =>
-              this.engine.summarize({
+            summarize: async (items) => {
+              const summary = await this.engine.summarize({
                 sessionId,
                 runId,
                 model,
@@ -225,12 +234,18 @@ export class RuntimeService {
                     ? params.contextWindow
                     : 128_000,
                 ...(maxOutputTokens === undefined ? {} : { maxOutputTokens }),
-              }),
+              });
+              compactionUsage = mergeUsage(compactionUsage, summary.usage);
+              return summary.text;
+            },
           }
         : {}),
       force: true,
     });
-    return result as unknown as JsonValue;
+    return {
+      ...result,
+      usage: compactionUsage,
+    } as unknown as JsonValue;
   }
 
   private logCompactionFallback(
@@ -337,6 +352,35 @@ export class RuntimeService {
     if (!this.peer) throw new ProtocolError(-32603, "Runtime transport is not attached");
     return this.peer;
   }
+}
+
+function mergeUsage(earlier: RuntimeUsage, later: RuntimeUsage): RuntimeUsage {
+  return compactUsage({
+    inputTokens: addDefined(earlier.inputTokens, later.inputTokens),
+    outputTokens: addDefined(earlier.outputTokens, later.outputTokens),
+    totalTokens: addDefined(earlier.totalTokens, later.totalTokens),
+    requests: addDefined(earlier.requests, later.requests),
+    latestInputTokens:
+      later.latestInputTokens ??
+      later.inputTokens ??
+      earlier.latestInputTokens ??
+      earlier.inputTokens,
+    provider: later.provider ?? earlier.provider,
+    privacyLevel: later.privacyLevel ?? earlier.privacyLevel,
+    endpoint: later.endpoint ?? earlier.endpoint,
+  });
+}
+
+function addDefined(left?: number, right?: number): number | undefined {
+  return left === undefined && right === undefined ? undefined : (left ?? 0) + (right ?? 0);
+}
+
+function compactUsage(
+  value: Record<string, number | string | undefined>,
+): RuntimeUsage {
+  return Object.fromEntries(
+    Object.entries(value).filter((entry) => entry[1] !== undefined),
+  ) as RuntimeUsage;
 }
 
 function validateRunStart(params: RunStartParams): void {

--- a/agent-runtime/src/service.ts
+++ b/agent-runtime/src/service.ts
@@ -385,6 +385,7 @@ function mergeUsage(earlier: RuntimeUsage, later: RuntimeUsage): RuntimeUsage {
     provider: later.provider ?? earlier.provider,
     privacyLevel: later.privacyLevel ?? earlier.privacyLevel,
     endpoint: later.endpoint ?? earlier.endpoint,
+    resolvedModel: later.resolvedModel ?? earlier.resolvedModel,
   });
 }
 

--- a/agent-runtime/src/types.ts
+++ b/agent-runtime/src/types.ts
@@ -90,6 +90,7 @@ export type RuntimeUsage = {
   outputTokens?: number;
   totalTokens?: number;
   requests?: number;
+  latestInputTokens?: number;
   provider?: string;
   privacyLevel?: string;
   endpoint?: string;
@@ -197,6 +198,11 @@ export type EngineSummaryInput = {
   signal?: AbortSignal;
 };
 
+export type EngineSummaryResult = {
+  text: string;
+  usage: RuntimeUsage;
+};
+
 export type SteeringMessage = {
   messageId: string;
   text: string;
@@ -212,7 +218,7 @@ export type EngineResult = {
 
 export interface AgentEngine {
   initialize(params: RuntimeInitializeParams): Promise<void>;
-  summarize(input: EngineSummaryInput): Promise<string>;
+  summarize(input: EngineSummaryInput): Promise<EngineSummaryResult>;
   start(input: EngineRunInput): Promise<EngineResult>;
   resume(input: EngineResumeInput): Promise<EngineResult>;
   shutdown(): Promise<void>;

--- a/agent-runtime/test/rpc-model-provider.test.ts
+++ b/agent-runtime/test/rpc-model-provider.test.ts
@@ -100,6 +100,31 @@ test("retains the actual host route from the latest stream page", async () => {
   });
 });
 
+test("derives total usage when Venice omits total_tokens", async () => {
+  const provider = new RpcChatCompletionsModelProvider(async () => ({
+    streamId: "stream-usage-without-total",
+    chunks: [
+      {
+        ...finalChunk,
+        usage: { prompt_tokens: 4, completion_tokens: 3 },
+      },
+    ],
+    done: true,
+  }));
+  for await (const _event of provider
+    .getModel("private-auto")
+    .getStreamedResponse(modelRequest())) {
+    // Drain the model response.
+  }
+  assert.deepEqual(provider.latestUsage, {
+    inputTokens: 4,
+    outputTokens: 3,
+    totalTokens: 7,
+    requests: 1,
+  });
+  assert.deepEqual(provider.totalUsage, provider.latestUsage);
+});
+
 test("rejects an Auto response without a canonical selected model", async () => {
   const provider = new RpcChatCompletionsModelProvider(async () => ({
     streamId: "stream-auto-missing-model",

--- a/agent-runtime/test/service.test.ts
+++ b/agent-runtime/test/service.test.ts
@@ -81,6 +81,37 @@ test("emits the visible context summary and exact removed ids after compaction",
   assert.equal(engine.summaryInputs[0]?.maxOutputTokens, 1_024);
 });
 
+test("includes automatic compaction usage while preserving latest request context", async () => {
+  const engine = new SummaryUsageEngine();
+  const { service, frames } = harness(engine);
+  await initialize(service);
+  const history = Array.from({ length: 9 }, (_, index) => ({
+    id: `message-${index}`,
+    kind: "message",
+    role: index % 2 === 0 ? "user" : "assistant",
+    text: `${index}:${"x".repeat(4_000)}`,
+  }));
+
+  await service.handle(
+    request("run.start", {
+      ...runParams,
+      history,
+      contextWindow: 7_000,
+      maxOutputTokens: 1_024,
+    }),
+  );
+  await nextTurn();
+
+  const usage = frames().find((frame) => frame.method === "usage.updated")?.params;
+  assert.deepEqual(usage, {
+    inputTokens: 23,
+    outputTokens: 4,
+    totalTokens: 27,
+    requests: 2,
+    latestInputTokens: 3,
+  });
+});
+
 test("serializes an approval interruption for durable host persistence", async () => {
   const engine = new FakeEngine({
     history: [],
@@ -370,6 +401,13 @@ test("routes manual compaction through the reserved metered model host tool", as
     typeof summaryInput.content === "string" &&
       summaryInput.content.length <= 8_100,
   );
+  assert.deepEqual((result as { usage?: JsonObject }).usage, {
+    inputTokens: 20,
+    outputTokens: 3,
+    totalTokens: 23,
+    requests: 1,
+    latestInputTokens: 20,
+  });
 });
 
 test("keeps manual compaction available when model summarization fails", async () => {
@@ -429,9 +467,9 @@ class FakeEngine implements AgentEngine {
   }
 
   async initialize(_params: RuntimeInitializeParams): Promise<void> {}
-  async summarize(input: EngineSummaryInput): Promise<string> {
+  async summarize(input: EngineSummaryInput) {
     this.summaryInputs.push(input);
-    return "Model-generated context summary";
+    return { text: "Model-generated context summary", usage: {} };
   }
   async start(input: EngineRunInput): Promise<EngineResult> {
     this.starts += 1;
@@ -445,7 +483,7 @@ class FakeEngine implements AgentEngine {
 }
 
 class FailingSummaryEngine extends FakeEngine {
-  override async summarize(input: EngineSummaryInput): Promise<string> {
+  override async summarize(input: EngineSummaryInput) {
     this.summaryInputs.push(input);
     throw new Error("model request timed out");
   }
@@ -454,7 +492,7 @@ class FailingSummaryEngine extends FakeEngine {
 class BlockingSummaryEngine extends FakeEngine {
   summaryStarted = false;
 
-  override async summarize(input: EngineSummaryInput): Promise<string> {
+  override async summarize(input: EngineSummaryInput) {
     this.summaryInputs.push(input);
     this.summaryStarted = true;
     return new Promise((_, reject) => {
@@ -466,6 +504,23 @@ class BlockingSummaryEngine extends FakeEngine {
       if (input.signal?.aborted) rejectAborted();
       else input.signal?.addEventListener("abort", rejectAborted, { once: true });
     });
+  }
+}
+
+class SummaryUsageEngine extends FakeEngine {
+  override readonly result: EngineResult = {
+    finalOutput: "Hi",
+    history: [{ id: "assistant", kind: "message", role: "assistant", text: "Hi" }],
+    usage: { inputTokens: 3, outputTokens: 1, totalTokens: 4, requests: 1 },
+    interruptions: [],
+  };
+
+  override async summarize(input: EngineSummaryInput) {
+    this.summaryInputs.push(input);
+    return {
+      text: "Model-generated context summary",
+      usage: { inputTokens: 20, outputTokens: 3, totalTokens: 23, requests: 1 },
+    };
   }
 }
 

--- a/agent-runtime/test/service.test.ts
+++ b/agent-runtime/test/service.test.ts
@@ -112,6 +112,37 @@ test("includes automatic compaction usage while preserving latest request contex
   });
 });
 
+test("counts failed automatic summary usage once", async () => {
+  const engine = new FailingSummaryWithUsageEngine();
+  const { service, frames } = harness(engine);
+  await initialize(service);
+  const history = Array.from({ length: 9 }, (_, index) => ({
+    id: `message-${index}`,
+    kind: "message",
+    role: index % 2 === 0 ? "user" : "assistant",
+    text: `${index}:${"x".repeat(4_000)}`,
+  }));
+
+  await service.handle(
+    request("run.start", {
+      ...runParams,
+      history,
+      contextWindow: 7_000,
+      maxOutputTokens: 1_024,
+    }),
+  );
+  await nextTurn();
+
+  const usage = frames().find((frame) => frame.method === "usage.updated")?.params;
+  assert.deepEqual(usage, {
+    inputTokens: 23,
+    outputTokens: 4,
+    totalTokens: 27,
+    requests: 1,
+    latestInputTokens: 3,
+  });
+});
+
 test("serializes an approval interruption for durable host persistence", async () => {
   const engine = new FakeEngine({
     history: [],

--- a/agent-runtime/test/service.test.ts
+++ b/agent-runtime/test/service.test.ts
@@ -452,6 +452,34 @@ test("keeps manual compaction available when model summarization fails", async (
   );
 });
 
+test("retains billable summary usage when model summarization falls back", async () => {
+  const engine = new FailingSummaryWithUsageEngine();
+  const { service } = harness(engine);
+  await initialize(service);
+  const history = Array.from({ length: 8 }, (_, index) => ({
+    id: `item-${index}`,
+    kind: "message",
+    role: index % 2 === 0 ? "user" : "assistant",
+    text: `Message ${index}`,
+  }));
+
+  const result = await service.handle(
+    request("history.compact", {
+      history,
+      model: "private-auto",
+      contextWindow: 128_000,
+    }),
+  );
+
+  assert.deepEqual((result as { usage?: JsonObject }).usage, {
+    inputTokens: 20,
+    outputTokens: 3,
+    totalTokens: 23,
+    requests: 1,
+    latestInputTokens: 20,
+  });
+});
+
 class FakeEngine implements AgentEngine {
   readonly result: EngineResult;
   readonly summaryInputs: EngineSummaryInput[] = [];
@@ -486,6 +514,17 @@ class FailingSummaryEngine extends FakeEngine {
   override async summarize(input: EngineSummaryInput) {
     this.summaryInputs.push(input);
     throw new Error("model request timed out");
+  }
+}
+
+class FailingSummaryWithUsageEngine extends FakeEngine {
+  override async summarize(input: EngineSummaryInput) {
+    this.summaryInputs.push(input);
+    const error = new Error("model request failed after usage") as Error & {
+      usage?: RuntimeUsage;
+    };
+    error.usage = { inputTokens: 20, outputTokens: 3, totalTokens: 23, requests: 1 };
+    throw error;
   }
 }
 

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -1343,6 +1343,13 @@ async fn resolve_agent_interruption_inner(
         .request("run.resume", &session.id, &run.id, params)
         .await
     {
+        if is_duplicate_resume_error(&error) {
+            return Ok(run_json(
+                repository
+                    .update_run_status(&run.id, "running", None, None, None)
+                    .await?,
+            ));
+        }
         let restore_result: Result<bool, sqlx::Error> = async {
             let mut transaction = repository.pool.begin_with("BEGIN IMMEDIATE").await?;
             let run_restored = sqlx::query::query(
@@ -1444,6 +1451,10 @@ fn resolved_model_from_usage(usage: Option<&Value>) -> Option<&str> {
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|model| crate::june_api::is_canonical_agent_model(model))
+}
+
+fn is_duplicate_resume_error(error: &AppError) -> bool {
+    error.code == "agent_runtime_request_failed" && error.message == "Run is already active"
 }
 
 async fn mark_dispatch_failed(repository: &AgentRepository, run_id: &str, error: &AppError) {
@@ -2427,6 +2438,22 @@ mod tests {
             None
         );
         assert_eq!(resolved_model_from_usage(None), None);
+    }
+
+    #[test]
+    fn only_the_sidecar_duplicate_resume_error_is_idempotent() {
+        assert!(is_duplicate_resume_error(&AppError::new(
+            "agent_runtime_request_failed",
+            "Run is already active",
+        )));
+        assert!(!is_duplicate_resume_error(&AppError::new(
+            "agent_runtime_request_failed",
+            "Run is already active after a worker crash",
+        )));
+        assert!(!is_duplicate_resume_error(&AppError::new(
+            "agent_runtime_request_timed_out",
+            "Run is already active",
+        )));
     }
 
     #[test]

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -183,6 +183,12 @@ pub async fn compact_agent_session(
         .await;
     host.cancel_run_streams(&stream_scope_id).await;
     let response = response?;
+    if let Some(usage) = response
+        .get("usage")
+        .filter(|usage| usage.as_object().is_some_and(|usage| !usage.is_empty()))
+    {
+        repository.add_run_usage(&run_id, usage).await?;
+    }
     let removed_item_ids = response
         .get("removedItemIds")
         .and_then(Value::as_array)

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -1431,7 +1431,7 @@ async fn resolve_agent_interruption_inner(
             if let Some(secret_ref) = created_secret_ref.as_deref() {
                 let _ = super::secrets::delete(secret_ref).await;
             }
-            return Err(error.into());
+            return Err(error);
         }
     };
     if !claimed {

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -1349,13 +1349,6 @@ async fn resolve_agent_interruption_inner(
         .request("run.resume", &session.id, &run.id, params)
         .await
     {
-        if is_duplicate_resume_error(&error) {
-            return Ok(run_json(
-                repository
-                    .update_run_status(&run.id, "running", None, None, None)
-                    .await?,
-            ));
-        }
         let restore_result: Result<bool, sqlx::Error> = async {
             let mut transaction = repository.pool.begin_with("BEGIN IMMEDIATE").await?;
             let run_restored = sqlx::query::query(
@@ -1424,6 +1417,13 @@ async fn resolve_agent_interruption_inner(
             );
         }
         restore_result?;
+        if is_duplicate_resume_error(&error) {
+            return Ok(run_json(
+                repository
+                    .update_run_status(&run.id, "running", None, None, None)
+                    .await?,
+            ));
+        }
         return Err(error);
     }
     if origin == InterruptionResolutionOrigin::Desktop {

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -1431,7 +1431,7 @@ async fn resolve_agent_interruption_inner(
             if let Some(secret_ref) = created_secret_ref.as_deref() {
                 let _ = super::secrets::delete(secret_ref).await;
             }
-            return Err(error);
+            return Err(error.into());
         }
     };
     if !claimed {

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -1349,6 +1349,16 @@ async fn resolve_agent_interruption_inner(
         .request("run.resume", &session.id, &run.id, params)
         .await
     {
+        // The sidecar may have accepted this exact resume before the host
+        // observed the duplicate-active response. Keep the resolved payload
+        // (including any answer or secret ref) for that already-running tool.
+        if duplicate_resume_preserves_resolved_interruption(&error) {
+            return Ok(run_json(
+                repository
+                    .update_run_status(&run.id, "running", None, None, None)
+                    .await?,
+            ));
+        }
         let restore_result: Result<bool, sqlx::Error> = async {
             let mut transaction = repository.pool.begin_with("BEGIN IMMEDIATE").await?;
             let run_restored = sqlx::query::query(
@@ -1417,13 +1427,6 @@ async fn resolve_agent_interruption_inner(
             );
         }
         restore_result?;
-        if is_duplicate_resume_error(&error) {
-            return Ok(run_json(
-                repository
-                    .update_run_status(&run.id, "running", None, None, None)
-                    .await?,
-            ));
-        }
         return Err(error);
     }
     if origin == InterruptionResolutionOrigin::Desktop {
@@ -1459,7 +1462,7 @@ fn resolved_model_from_usage(usage: Option<&Value>) -> Option<&str> {
         .filter(|model| crate::june_api::is_canonical_agent_model(model))
 }
 
-fn is_duplicate_resume_error(error: &AppError) -> bool {
+fn duplicate_resume_preserves_resolved_interruption(error: &AppError) -> bool {
     error.code == "agent_runtime_request_failed" && error.message == "Run is already active"
 }
 
@@ -2447,19 +2450,19 @@ mod tests {
     }
 
     #[test]
-    fn only_the_sidecar_duplicate_resume_error_is_idempotent() {
-        assert!(is_duplicate_resume_error(&AppError::new(
-            "agent_runtime_request_failed",
-            "Run is already active",
-        )));
-        assert!(!is_duplicate_resume_error(&AppError::new(
-            "agent_runtime_request_failed",
-            "Run is already active after a worker crash",
-        )));
-        assert!(!is_duplicate_resume_error(&AppError::new(
-            "agent_runtime_request_timed_out",
-            "Run is already active",
-        )));
+    fn only_the_sidecar_duplicate_resume_error_preserves_the_resolution() {
+        assert!(duplicate_resume_preserves_resolved_interruption(
+            &AppError::new("agent_runtime_request_failed", "Run is already active",)
+        ));
+        assert!(!duplicate_resume_preserves_resolved_interruption(
+            &AppError::new(
+                "agent_runtime_request_failed",
+                "Run is already active after a worker crash",
+            )
+        ));
+        assert!(!duplicate_resume_preserves_resolved_interruption(
+            &AppError::new("agent_runtime_request_timed_out", "Run is already active",)
+        ));
     }
 
     #[test]

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -947,6 +947,63 @@ async fn claim_interruption_resume(
     Ok(true)
 }
 
+async fn claim_resolved_interruption_redispatch(
+    repository: &AgentRepository,
+    record: &InterruptionRecord,
+    resolved_payload_json: &str,
+    updated_at: &str,
+) -> Result<bool, sqlx::Error> {
+    let mut transaction = repository.pool.begin_with("BEGIN IMMEDIATE").await?;
+    let run_updated = sqlx::query::query(
+        "UPDATE agent_runs
+         SET status = 'queued', last_sequence = 0, updated_at = ?
+         WHERE id = ? AND status = 'waiting_for_user'",
+    )
+    .bind(updated_at)
+    .bind(&record.run_id)
+    .execute(&mut *transaction)
+    .await?
+    .rows_affected();
+    if run_updated != 1 {
+        transaction.rollback().await?;
+        return Ok(false);
+    }
+    let resolved_item_exists = sqlx::query::query(
+        "SELECT 1
+         FROM agent_items
+         WHERE id = ?
+           AND run_id = ?
+           AND payload_json = ?
+           AND json_extract(payload_json, '$.status') = 'resolved'",
+    )
+    .bind(&record.item_id)
+    .bind(&record.run_id)
+    .bind(resolved_payload_json)
+    .fetch_optional(&mut *transaction)
+    .await?
+    .is_some();
+    if !resolved_item_exists {
+        transaction.rollback().await?;
+        return Ok(false);
+    }
+    let session_updated = sqlx::query::query(
+        "UPDATE agent_sessions
+         SET status = 'running', updated_at = ?, last_error = NULL
+         WHERE id = ? AND status = 'waiting_for_user'",
+    )
+    .bind(updated_at)
+    .bind(&record.session_id)
+    .execute(&mut *transaction)
+    .await?
+    .rows_affected();
+    if session_updated != 1 {
+        transaction.rollback().await?;
+        return Ok(false);
+    }
+    transaction.commit().await?;
+    Ok(true)
+}
+
 fn settle_interruption_payload(
     interruption: &mut Value,
     interruption_kind: &str,
@@ -1111,6 +1168,14 @@ async fn resolve_agent_interruption_inner(
             "This interruption can no longer be resumed.",
         ));
     }
+    let interruption_status = interruption
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("pending");
+    let redispatching_resolved = interruption_status == "resolved";
+    if !matches!(interruption_status, "pending" | "resolved") {
+        return Ok(run_json(run));
+    }
     let session = repository.get_session(&record.session_id).await?;
     let serialized_state = run
         .interrupted_state
@@ -1127,46 +1192,71 @@ async fn resolve_agent_interruption_inner(
         .and_then(Value::as_str)
         .unwrap_or("approval")
         .to_string();
-    let resolution_kind = request
-        .resolution
-        .get("kind")
-        .and_then(Value::as_str)
-        .ok_or_else(|| {
-            AppError::new(
-                "agent_interruption_resolution_invalid",
-                "The interruption response kind is required.",
-            )
-        })?;
-    if resolution_kind != interruption_kind {
-        return Err(AppError::new(
-            "agent_interruption_resolution_invalid",
-            "The interruption response does not match the pending request.",
-        ));
-    }
-    let clarification_answer = request
-        .resolution
-        .get("answer")
-        .and_then(Value::as_str)
-        .map(str::to_string);
-    let secret_value = request
-        .resolution
-        .get("secret")
-        .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string);
-    let choice = request.resolution.get("choice").and_then(Value::as_str);
-    let approved = match interruption_kind.as_str() {
-        "clarification" if clarification_answer.is_some() => true,
-        "secret" if secret_value.is_some() && choice == Some("once") => true,
-        "secret" if secret_value.is_none() && choice == Some("deny") => false,
-        "approval" if matches!(choice, Some("once" | "session" | "always")) => true,
-        "approval" if choice == Some("deny") => false,
-        _ => {
+    let (clarification_answer, secret_value, approved) = if redispatching_resolved {
+        let clarification_answer = interruption
+            .get("answer")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let approved = interruption
+            .get("approved")
+            .and_then(Value::as_bool)
+            .or_else(|| {
+                interruption
+                    .get("decision")
+                    .and_then(Value::as_str)
+                    .map(|decision| decision == "approve")
+            })
+            .unwrap_or_else(|| {
+                clarification_answer.is_some()
+                    || interruption
+                        .get("secretRef")
+                        .and_then(Value::as_str)
+                        .is_some()
+            });
+        (clarification_answer, None, approved)
+    } else {
+        let resolution_kind = request
+            .resolution
+            .get("kind")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                AppError::new(
+                    "agent_interruption_resolution_invalid",
+                    "The interruption response kind is required.",
+                )
+            })?;
+        if resolution_kind != interruption_kind {
             return Err(AppError::new(
                 "agent_interruption_resolution_invalid",
-                "The interruption response is invalid.",
+                "The interruption response does not match the pending request.",
             ));
         }
+        let clarification_answer = request
+            .resolution
+            .get("answer")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let secret_value = request
+            .resolution
+            .get("secret")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let choice = request.resolution.get("choice").and_then(Value::as_str);
+        let approved = match interruption_kind.as_str() {
+            "clarification" if clarification_answer.is_some() => true,
+            "secret" if secret_value.is_some() && choice == Some("once") => true,
+            "secret" if secret_value.is_none() && choice == Some("deny") => false,
+            "approval" if matches!(choice, Some("once" | "session" | "always")) => true,
+            "approval" if choice == Some("deny") => false,
+            _ => {
+                return Err(AppError::new(
+                    "agent_interruption_resolution_invalid",
+                    "The interruption response is invalid.",
+                ));
+            }
+        };
+        (clarification_answer, secret_value, approved)
     };
     let approval_choice = approval_choice_from_resolution(&interruption_kind, &request.resolution)
         .map(str::to_string);
@@ -1242,7 +1332,7 @@ async fn resolve_agent_interruption_inner(
     } else {
         json!([{ "interruptionId": request.interruption_id, "kind": "approval", "decision": if approved { "approve" } else { "reject" } }])
     };
-    let secret_ref = if interruption_kind == "secret" {
+    let created_secret_ref = if interruption_kind == "secret" && !redispatching_resolved {
         match secret_value {
             Some(value) => {
                 let secret_ref = format!("agent-secret-{}", uuid::Uuid::new_v4());
@@ -1254,74 +1344,98 @@ async fn resolve_agent_interruption_inner(
     } else {
         None
     };
-    let resolution_nonce = uuid::Uuid::new_v4().to_string();
     let resolution_time = chrono::Utc::now().to_rfc3339();
-    settle_interruption_payload(
-        &mut interruption,
-        &interruption_kind,
-        approval_choice.as_deref(),
-        clarification_answer.as_deref(),
-        secret_ref.as_deref(),
-        &resolution_time,
-    );
-    interruption["approved"] = json!(approved);
-    interruption["resolutionNonce"] = json!(resolution_nonce);
-    if interruption_kind == "approval" {
-        interruption["resolvedBy"] = json!(match &origin {
-            InterruptionResolutionOrigin::Desktop => "desktop",
-            InterruptionResolutionOrigin::Companion(
-                crate::companion::ComputerUseApprovalOrigin::Companion { .. },
-            ) => "linkedDevice",
-            InterruptionResolutionOrigin::Companion(
-                crate::companion::ComputerUseApprovalOrigin::Timeout,
-            ) => "timeout",
-        });
-        if let InterruptionResolutionOrigin::Companion(
-            crate::companion::ComputerUseApprovalOrigin::Companion { device_id },
-        ) = &origin
-        {
-            interruption["resolvedByDeviceId"] = json!(device_id);
+    let resolution_nonce = if redispatching_resolved {
+        interruption
+            .get("resolutionNonce")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
+    } else {
+        uuid::Uuid::new_v4().to_string()
+    };
+    if !redispatching_resolved {
+        settle_interruption_payload(
+            &mut interruption,
+            &interruption_kind,
+            approval_choice.as_deref(),
+            clarification_answer.as_deref(),
+            created_secret_ref.as_deref(),
+            &resolution_time,
+        );
+        interruption["approved"] = json!(approved);
+        interruption["resolutionNonce"] = json!(resolution_nonce);
+        if interruption_kind == "approval" {
+            interruption["resolvedBy"] = json!(match &origin {
+                InterruptionResolutionOrigin::Desktop => "desktop",
+                InterruptionResolutionOrigin::Companion(
+                    crate::companion::ComputerUseApprovalOrigin::Companion { .. },
+                ) => "linkedDevice",
+                InterruptionResolutionOrigin::Companion(
+                    crate::companion::ComputerUseApprovalOrigin::Timeout,
+                ) => "timeout",
+            });
+            if let InterruptionResolutionOrigin::Companion(
+                crate::companion::ComputerUseApprovalOrigin::Companion { device_id },
+            ) = &origin
+            {
+                interruption["resolvedByDeviceId"] = json!(device_id);
+            }
         }
     }
     let resolved_interruption_json = interruption.to_string();
-    let companion_audit = match &origin {
-        InterruptionResolutionOrigin::Companion(
-            crate::companion::ComputerUseApprovalOrigin::Companion { device_id },
-        ) => Some((
-            device_id.as_str(),
-            request.interruption_id.as_str(),
-            companion_session_id
-                .as_deref()
-                .unwrap_or(record.session_id.as_str()),
-            if approved { "approve" } else { "deny" },
-            resolution_time.as_str(),
-        )),
-        _ => None,
+    let companion_audit = if redispatching_resolved {
+        None
+    } else {
+        match &origin {
+            InterruptionResolutionOrigin::Companion(
+                crate::companion::ComputerUseApprovalOrigin::Companion { device_id },
+            ) => Some((
+                device_id.as_str(),
+                request.interruption_id.as_str(),
+                companion_session_id
+                    .as_deref()
+                    .unwrap_or(record.session_id.as_str()),
+                if approved { "approve" } else { "deny" },
+                resolution_time.as_str(),
+            )),
+            _ => None,
+        }
     };
     // Persist the visible resolution and reset sequencing as one unit. The
     // sidecar can emit resumed events immediately after accepting the request,
     // so both must be in place before dispatch, but neither may be left behind
     // when preparation or persistence fails.
-    let claimed = match claim_interruption_resume(
-        &repository,
-        &record,
-        &original_interruption_json,
-        &resolved_interruption_json,
-        &resolution_time,
-        companion_audit,
-    )
-    .await
-    {
+    let persist_result = if redispatching_resolved {
+        claim_resolved_interruption_redispatch(
+            &repository,
+            &record,
+            &resolved_interruption_json,
+            &resolution_time,
+        )
+        .await
+    } else {
+        claim_interruption_resume(
+            &repository,
+            &record,
+            &original_interruption_json,
+            &resolved_interruption_json,
+            &resolution_time,
+            companion_audit,
+        )
+        .await
+    };
+    let claimed = match persist_result {
         Ok(claimed) => claimed,
         Err(error) => {
-            if let Some(secret_ref) = secret_ref.as_deref() {
+            if let Some(secret_ref) = created_secret_ref.as_deref() {
                 let _ = super::secrets::delete(secret_ref).await;
             }
             return Err(error.into());
         }
     };
     if !claimed {
-        if let Some(secret_ref) = secret_ref.as_deref() {
+        if let Some(secret_ref) = created_secret_ref.as_deref() {
             let _ = super::secrets::delete(secret_ref).await;
         }
         return Err(AppError::new(
@@ -1376,6 +1490,24 @@ async fn resolve_agent_interruption_inner(
                 transaction.rollback().await?;
                 return Ok(false);
             }
+            if redispatching_resolved {
+                let session_restored = sqlx::query::query(
+                    "UPDATE agent_sessions
+                     SET status = 'waiting_for_user', updated_at = ?
+                     WHERE id = ? AND status = 'running'",
+                )
+                .bind(chrono::Utc::now().to_rfc3339())
+                .bind(&session.id)
+                .execute(&mut *transaction)
+                .await?
+                .rows_affected();
+                if session_restored != 1 {
+                    transaction.rollback().await?;
+                    return Ok(false);
+                }
+                transaction.commit().await?;
+                return Ok(true);
+            }
             let item_restored = sqlx::query::query(
                 "UPDATE agent_items
                  SET payload_json = ?
@@ -1410,7 +1542,7 @@ async fn resolve_agent_interruption_inner(
         }
         .await;
         if restore_result.as_ref().is_ok_and(|restored| *restored) {
-            if let Some(secret_ref) = secret_ref.as_deref() {
+            if let Some(secret_ref) = created_secret_ref.as_deref() {
                 if let Err(cleanup_error) = super::secrets::delete(secret_ref).await {
                     tracing::warn!(
                         error_code = %cleanup_error.code,

--- a/src-tauri/src/agent_runtime/host.rs
+++ b/src-tauri/src/agent_runtime/host.rs
@@ -209,13 +209,13 @@ impl AgentRuntimeHost {
         );
         let (send, receive) = oneshot::channel();
         let pending = runtime.pending.clone();
-        if opens_model_scope(method) {
-            self.model_scopes.lock().await.insert(run_id.to_string());
-        }
+        let opens_scope = opens_model_scope(method);
+        let owns_model_scope =
+            opens_scope && self.model_scopes.lock().await.insert(run_id.to_string());
         pending.lock().await.insert(id.clone(), send);
         if let Err(error) = write_frame(&runtime.stdin, &frame).await {
             pending.lock().await.remove(&id);
-            if opens_model_scope(method) {
+            if owns_model_scope {
                 self.cancel_run_streams(run_id).await;
             }
             return Err(error);
@@ -227,7 +227,8 @@ impl AgentRuntimeHost {
             receive,
             runtime_request_timeout(method),
             run_id,
-            opens_model_scope(method),
+            owns_model_scope,
+            !opens_scope,
         )
         .await
     }
@@ -239,14 +240,16 @@ impl AgentRuntimeHost {
         receive: oneshot::Receiver<Result<Value, AppError>>,
         timeout: std::time::Duration,
         run_id: &str,
-        cancel_scope_on_error: bool,
+        owns_model_scope: bool,
+        cancel_existing_scope_on_timeout: bool,
     ) -> Result<Value, AppError> {
         let response = await_runtime_response(pending, id, receive, timeout).await;
         if response.is_err()
-            && (cancel_scope_on_error
-                || response
-                    .as_ref()
-                    .is_err_and(|error| error.code == "agent_runtime_request_timed_out"))
+            && (owns_model_scope
+                || (cancel_existing_scope_on_timeout
+                    && response
+                        .as_ref()
+                        .is_err_and(|error| error.code == "agent_runtime_request_timed_out")))
         {
             self.cancel_run_streams(run_id).await;
         }
@@ -1313,6 +1316,7 @@ mod tests {
                 std::time::Duration::ZERO,
                 scope,
                 false,
+                true,
             )
             .await
             .expect_err("the pending response must time out");
@@ -1321,6 +1325,45 @@ mod tests {
         assert!(!pending.lock().await.contains_key(id));
         assert!(!host.model_scopes.lock().await.contains(scope));
         assert_eq!(host.cancellations.registration_count(scope), 0);
+    }
+
+    #[tokio::test]
+    async fn failed_duplicate_resume_keeps_the_preexisting_model_scope_active() {
+        let host = AgentRuntimeHost::default();
+        let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
+        let id = "duplicate-resume";
+        let scope = "run-resume";
+        host.model_scopes.lock().await.insert(scope.into());
+        let _registration = host.cancellations.register(scope).await;
+        let (send, receive) = oneshot::channel();
+        pending.lock().await.insert(id.into(), send);
+        pending
+            .lock()
+            .await
+            .remove(id)
+            .expect("pending duplicate resume")
+            .send(Err(AppError::new(
+                "agent_runtime_request_failed",
+                "Run is already active",
+            )))
+            .expect("duplicate response receiver");
+
+        let error = host
+            .await_request_response(
+                &pending,
+                id,
+                receive,
+                std::time::Duration::from_secs(1),
+                scope,
+                false,
+                false,
+            )
+            .await
+            .expect_err("the duplicate resume must be rejected");
+
+        assert_eq!(error.code, "agent_runtime_request_failed");
+        assert!(host.model_scopes.lock().await.contains(scope));
+        assert_eq!(host.cancellations.registration_count(scope), 1);
     }
 
     #[tokio::test]

--- a/src-tauri/src/agent_runtime/host.rs
+++ b/src-tauri/src/agent_runtime/host.rs
@@ -228,7 +228,7 @@ impl AgentRuntimeHost {
             runtime_request_timeout(method),
             run_id,
             owns_model_scope,
-            !opens_scope,
+            cancels_existing_scope_on_timeout(method),
         )
         .await
     }
@@ -290,6 +290,10 @@ impl AgentRuntimeHost {
 
 fn opens_model_scope(method: &str) -> bool {
     matches!(method, "run.start" | "run.resume" | "history.compact")
+}
+
+fn cancels_existing_scope_on_timeout(method: &str) -> bool {
+    !opens_model_scope(method) || method == "run.resume"
 }
 
 fn runtime_request_timeout(method: &str) -> std::time::Duration {
@@ -1295,6 +1299,14 @@ mod tests {
             runtime_request_timeout("run.start"),
             std::time::Duration::from_secs(15)
         );
+    }
+
+    #[test]
+    fn resume_timeouts_cancel_preexisting_model_scopes() {
+        assert!(cancels_existing_scope_on_timeout("run.resume"));
+        assert!(!cancels_existing_scope_on_timeout("run.start"));
+        assert!(!cancels_existing_scope_on_timeout("history.compact"));
+        assert!(cancels_existing_scope_on_timeout("run.cancel"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/agent_runtime/repository.rs
+++ b/src-tauri/src/agent_runtime/repository.rs
@@ -979,6 +979,31 @@ impl AgentRepository {
         self.get_run(run_id).await.map(Some).map_err(Into::into)
     }
 
+    pub async fn add_run_usage(
+        &self,
+        run_id: &str,
+        usage: &serde_json::Value,
+    ) -> Result<AgentRunDto, sqlx::Error> {
+        let mut transaction = self.pool.begin().await?;
+        let existing = query("SELECT usage_json FROM agent_runs WHERE id = ?")
+            .bind(run_id)
+            .fetch_one(&mut *transaction)
+            .await?
+            .get::<Option<String>, _>("usage_json")
+            .map(|value| serde_json::from_str::<serde_json::Value>(&value))
+            .transpose()
+            .map_err(decode_error)?;
+        let merged = merge_usage(existing.as_ref(), usage);
+        query("UPDATE agent_runs SET usage_json = ?, updated_at = ? WHERE id = ?")
+            .bind(merged.to_string())
+            .bind(now())
+            .bind(run_id)
+            .execute(&mut *transaction)
+            .await?;
+        transaction.commit().await?;
+        self.get_run(run_id).await
+    }
+
     pub async fn mark_active_runs_interrupted(&self, message: &str) -> Result<u64, sqlx::Error> {
         let now = now();
         let result = query("UPDATE agent_runs SET status = 'interrupted', updated_at = ?, completed_at = ?, error_code = 'runtime_crashed', error_message = ? WHERE status IN ('queued', 'running')")
@@ -1177,6 +1202,39 @@ fn json_column(row: &SqliteRow, column: &str) -> Option<serde_json::Value> {
 
 fn decode_error(error: serde_json::Error) -> sqlx::Error {
     sqlx::Error::Decode(Box::new(error))
+}
+
+fn merge_usage(
+    earlier: Option<&serde_json::Value>,
+    later: &serde_json::Value,
+) -> serde_json::Value {
+    let mut merged = earlier
+        .and_then(serde_json::Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let Some(later) = later.as_object() else {
+        return serde_json::Value::Object(merged);
+    };
+    merged.extend(later.clone());
+    for key in ["inputTokens", "outputTokens", "totalTokens", "requests"] {
+        let left = earlier
+            .and_then(|usage| usage.get(key))
+            .and_then(serde_json::Value::as_u64);
+        let right = later.get(key).and_then(serde_json::Value::as_u64);
+        if left.is_some() || right.is_some() {
+            merged.insert(
+                key.to_string(),
+                serde_json::json!(left.unwrap_or(0) + right.unwrap_or(0)),
+            );
+        }
+    }
+    if let Some(latest) = later
+        .get("latestInputTokens")
+        .or_else(|| later.get("inputTokens"))
+    {
+        merged.insert("latestInputTokens".to_string(), latest.clone());
+    }
+    serde_json::Value::Object(merged)
 }
 
 #[cfg(test)]
@@ -1511,6 +1569,63 @@ mod tests {
                 .expect("routine claim")
                 .get("claim_token");
         assert_eq!(claim_token.as_deref(), Some(claim.token.as_str()));
+    }
+
+    #[tokio::test]
+    async fn manual_usage_is_added_to_a_terminal_run() {
+        let repository = repository().await;
+        let session = repository
+            .create_session("Completed", "auto", AgentSafetyMode::Sandboxed, None)
+            .await
+            .expect("session");
+        let run = repository
+            .create_run(&session.id, "auto", None)
+            .await
+            .expect("run");
+        repository
+            .update_run_status(
+                &run.id,
+                "completed",
+                Some(&serde_json::json!({
+                    "inputTokens": 10,
+                    "outputTokens": 4,
+                    "totalTokens": 14,
+                    "requests": 1,
+                    "latestInputTokens": 10,
+                    "provider": "initial"
+                })),
+                None,
+                None,
+            )
+            .await
+            .expect("completed run");
+
+        let updated = repository
+            .add_run_usage(
+                &run.id,
+                &serde_json::json!({
+                    "inputTokens": 6,
+                    "outputTokens": 2,
+                    "totalTokens": 8,
+                    "requests": 1,
+                    "provider": "summary"
+                }),
+            )
+            .await
+            .expect("usage update");
+
+        assert_eq!(updated.status, "completed");
+        assert_eq!(
+            updated.usage,
+            Some(serde_json::json!({
+                "inputTokens": 16,
+                "outputTokens": 6,
+                "totalTokens": 22,
+                "requests": 2,
+                "latestInputTokens": 6,
+                "provider": "summary"
+            }))
+        );
     }
 
     #[tokio::test]

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2111,7 +2111,7 @@ export function AgentWorkspace({
   );
   const runUsage = projection.run?.usage;
   const contextLimit = usageModel?.contextTokens;
-  const contextUsed = runUsage?.inputTokens;
+  const contextUsed = runUsage?.latestInputTokens ?? runUsage?.inputTokens;
   const contextPercent =
     contextUsed !== undefined && contextLimit !== undefined && contextLimit > 0
       ? Math.min(100, (contextUsed / contextLimit) * 100)

--- a/src/lib/agent-runtime-contract.ts
+++ b/src/lib/agent-runtime-contract.ts
@@ -38,6 +38,7 @@ export type AgentUsageDto = {
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
+  requests?: number;
   latestInputTokens?: number;
   provider?: string;
   privacyLevel?: string;

--- a/src/lib/agent-runtime-contract.ts
+++ b/src/lib/agent-runtime-contract.ts
@@ -38,6 +38,7 @@ export type AgentUsageDto = {
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
+  latestInputTokens?: number;
   provider?: string;
   privacyLevel?: string;
   endpoint?: string;


### PR DESCRIPTION
## What changed

- include automatic context-compaction token usage in the persisted and displayed run totals
- keep `latestInputTokens` separate so the context meter describes the latest model request rather than the full billable run
- make model-scope cleanup ownership-aware so a rejected duplicate `run.resume` cannot cancel the already active resume
- preserve strict interruption-response validation while safely redispatching a persisted resolved answer after crash-before-acceptance
- derive `totalTokens` from prompt/completion counts when Venice omits `total_tokens`
- add focused TypeScript and Rust regressions

## Why

Two post-merge PR #979 review findings exposed user-visible billing-reporting drift and a concurrency failure during duplicate interruption resolution. The summary request is already metered by June API, but its usage was discarded before `usage.updated`. Separately, every `run.resume` request treated a shared run scope as its own and cancelled that scope on rejection.

## Validation

- agent-runtime TypeScript typecheck: pass
- agent-runtime tests: 58/58 pass
- focused provider tests: 12/12 pass
- focused Rust API tests: 18/18 pass
- focused repository tests: 8/8 pass, including current-main waiting-run cancellation
- root and extension TypeScript typechecks: pass
- `cargo fmt --check`: pass
- `git diff --check`: pass
- hosted final-head workflows: pending on `e3a34f79` after the current-main rebase
- independent adversarial review: pass, no actionable findings
- Biome on the two frontend files: pass with eight pre-existing hook-dependency warnings

The local GitHub CLI session remains unauthenticated. Deterministic focused gates pass after rebasing onto current main `08e9891f` at final head `e3a34f79`; hosted final-head signoff is pending. The reconciliation preserves #1012's atomic waiting-run cancellation and PR #980's manual-usage persistence and crash-safe redispatch.

## Walkthrough

Skipped: this is a low-level protocol, accounting, and concurrency repair with no new interaction surface. The focused regressions directly exercise both failure modes.

## Scope

Review-only. No production merge, release, deployment, billing action, or public product change was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787756552&installation_model_id=425925&pr_number=980&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F980&signature=70cc7cbae071fa90e5d55a08cf94c553380795274a8354b59d2409dac9613ace"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->