### PR TITLE
Fix June API image dependency cook layer

### DIFF
--- a/june-api/Dockerfile
+++ b/june-api/Dockerfile
@@ -19,9 +19,9 @@ FROM chef AS builder
 ENV CARGO_INCREMENTAL=0 \
     RUSTFLAGS="--remap-path-prefix=/app=. --remap-path-prefix=/usr/local/cargo=/cargo"
 COPY --from=planner /app/recipe.json recipe.json
+COPY crates/june-companion-protocol /crates/june-companion-protocol
 RUN cargo chef cook --release --locked --recipe-path recipe.json
 COPY june-api/ .
-COPY crates/june-companion-protocol /crates/june-companion-protocol
 RUN cargo build --release --locked --bin june
 
 FROM debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb AS runtime


### PR DESCRIPTION
## Summary

- Make the June API image builder copy the shared companion protocol crate before `cargo chef cook`.
- Preserve the repository-root build context, reproducible-build flags, pinned images, and published image tags and labels.

## Root cause

PR #981 made the companion protocol crate available to the planner and final source build, but the builder stage received only `recipe.json` before `cargo chef cook`. The recipe retained the path dependency at `/crates/june-companion-protocol`, so cook failed because that crate was copied only after the failing layer.

## Validation

- `docker build -f june-api/Dockerfile .` - passed the previously failing cook layer, built the release binary, and exported the runtime image.
- `CI=true pnpm test:june-api` - passed all targets and features (526 tests plus the share rate limiter benchmark target).
- `git diff --check` - passed.

- [ ] Tested visually where it matters. Not a UI change, so visual testing was skipped.
- [ ] Needs a June API (backend) deploy before it works end to end. This is build infrastructure only; merging reruns the main image build and staging deploy.

## Out of scope

- June API crate or API contract changes.
- Changes to workflow triggers, published image tags, labels, or deployment behavior.
- Broader cargo-chef or container-layer refactoring.

## Followups

- The hosted `build-june-api` workflow runs only on pushes to `main`; the full local image build is the pre-merge image-build evidence.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. Not applicable; this only reorders an existing Docker `COPY`.
- [x] Workflow action references are pinned to full-length commit SHAs. No action references changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787760498&installation_model_id=425925&pr_number=982&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F982&signature=acd17d841b4e07c4c3dc89d85d165def775ddbd354d65748c505148d789bf5ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->