### PR TITLE
fix: restore responsive recording waveform

### DIFF
--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -46,11 +46,11 @@ preview).
    replace that Source's partial rows only after the replacement succeeds.
 
 While capture is active, the native meeting-HUD supervisor samples capture at
-10 Hz and emits the additive `recording-telemetry` Tauri event. Its narrow
+20 Hz and emits the additive `recording-telemetry` Tauri event. Its narrow
 payload carries the recording session id, state, elapsed time, audio levels,
 and live warnings; both the main renderer and meeting HUD subscribe to that
 single stream. In the main renderer, the latest sample stays in a narrow
-external store: waveform subscribers receive level samples at 10 Hz, elapsed
+external store: waveform subscribers receive level samples at 20 Hz, elapsed
 time subscribers publish only on whole-second boundaries, and the root App
 reducer receives only lifecycle, Source-health, and actionable-warning changes.
 Stable metadata still comes from the recording commands, and

--- a/src-tauri/src/meeting_hud.rs
+++ b/src-tauri/src/meeting_hud.rs
@@ -49,10 +49,10 @@ use objc2::runtime::{AnyClass, AnyObject};
 const WINDOW_LABEL: &str = "meeting-hud";
 pub const RECORDING_TELEMETRY_EVENT: &str = "recording-telemetry";
 
-/// One native sample feeds both renderer surfaces. Their animation loops smooth
-/// between samples, so 10 Hz stays responsive without contending with the audio
-/// callback at the old combined 45 Hz status-read rate.
-const ACTIVE_TICK: Duration = Duration::from_millis(100);
+/// One native sample feeds both renderer surfaces. Twenty hertz matches the
+/// waveform's peak window and ballistics while remaining below half the old
+/// combined 45 Hz status-read rate.
+const ACTIVE_TICK: Duration = Duration::from_millis(50);
 const IDLE_TICK: Duration = Duration::from_millis(220);
 
 /// Logical pill size — must agree with `.mhud` in meeting-hud.css.
@@ -205,7 +205,7 @@ struct ZoneTracker {
     show_armed: bool,
 }
 
-/// Edge-tracks the menu-bar recording dot so the supervisor's 10 Hz poll only
+/// Edge-tracks the menu-bar recording dot so the supervisor's 20 Hz poll only
 /// notifies the tray when capture actually starts or stops, not every tick.
 static RECORDING_INDICATOR_ACTIVE: AtomicBool = AtomicBool::new(false);
 
@@ -820,11 +820,21 @@ fn make_nonactivating(hud: &WebviewWindow) {
 
 #[cfg(test)]
 mod tests {
-    use super::{PILL_SIZE, VERTICAL_PILL_LENGTH, WINDOW_SIZE};
+    use super::{ACTIVE_TICK, PILL_SIZE, VERTICAL_PILL_LENGTH, WINDOW_SIZE};
     use crate::domain::types::{
         AudioLevelDto, RecordingSource, RecordingSourceMode, RecordingState, RecordingStatusDto,
         RecordingTelemetryDto, SourceState, SourceStatusDto,
     };
+    use std::time::Duration;
+
+    #[test]
+    fn active_telemetry_cadence_keeps_waveform_responsive() {
+        assert_eq!(
+            ACTIVE_TICK,
+            Duration::from_millis(50),
+            "the waveform peak window and ballistics are tuned for 20 Hz level targets"
+        );
+    }
 
     /// First `prop: <n>px` declaration inside the rule whose selector line
     /// contains `selector`. Good enough for the flat declarations this test

--- a/src/lib/global-recorder-demo.ts
+++ b/src/lib/global-recorder-demo.ts
@@ -23,9 +23,9 @@ export type GlobalRecorderDemoApi = {
   stop: () => void;
 };
 
-// Push cadence: a fresh synthetic level a touch faster than the real 50ms-ish
-// poll, enough to keep the coalescing waveform alive without pinning a core.
-const TICK_MS = 90;
+// Match the real active telemetry cadence so visual review reflects the
+// production waveform's peak window and ballistics.
+const TICK_MS = 50;
 
 const HELP = [
   "Global recorder presence demo (sidebar header or floating fallback):",

--- a/src/lib/record-notices-demo.ts
+++ b/src/lib/record-notices-demo.ts
@@ -38,9 +38,9 @@ const DEMO_NOTE_ID = "dev-record-notices-demo-note";
 const DEFAULT_WARNING_MESSAGE =
   "Microphone input stopped unexpectedly. Audio after this point may be missing.";
 
-// Push cadence for the waveform + elapsed clock, matching global-recorder-demo:
-// fast enough to keep the recorder bar looking alive without pinning a core.
-const TICK_MS = 90;
+// Match the real active telemetry cadence so the parked in-note recorder has
+// production waveform timing during visual review.
+const TICK_MS = 50;
 
 type Variant = "consent" | "warning";
 

--- a/src/lib/recording-hud-demo.ts
+++ b/src/lib/recording-hud-demo.ts
@@ -33,9 +33,9 @@ type DemoState = "recording" | "paused" | "vertical" | "horizontal" | "demo" | "
 const STATUS_EVENT = "meeting-hud-status";
 const ZONE_EVENT = "meeting-hud-zone";
 
-// Status pushes carry fresh peaks; ~90ms keeps the waveform alive without
-// pinning the loop.
-const STATUS_TICK_MS = 90;
+// Match the real active telemetry cadence so the standalone HUD has production
+// waveform timing during visual review.
+const STATUS_TICK_MS = 50;
 
 const HELP = [
   "Recording pill demo states (meeting-hud window):",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12659,10 +12659,19 @@ button.agent-user-attachment:hover {
    * meter drives --level per frame; the 24ms transition smooths sub-frame steps
    * (sharpened from 40ms to match the HUD so the carrier shimmer reads crisp). */
   height: 100%;
-  border-radius: 999px;
+  border-radius: var(--r-pill);
   background: var(--foreground);
   transform: translateY(50%) scaleY(calc(0.1 + var(--level, 0) * 0.8));
   transition: transform 18ms linear;
+}
+
+/* Scaling the whole pill also flattens its corner radius, so the in-note bars
+ * read nearly square. A rounded inset clip changes the visible height while
+ * preserving the 3px capsule caps and the same 10%-to-90% level range. */
+.recorder-bar .waveform span::before {
+  clip-path: inset(calc(45% - var(--level, 0) * 40%) 0 round var(--r-pill));
+  transform: translateY(50%);
+  transition: clip-path 18ms linear;
 }
 
 .recorder-bar[data-state="paused"] .waveform span {

--- a/src/test/css-stabilization.test.tsx
+++ b/src/test/css-stabilization.test.tsx
@@ -11,6 +11,7 @@ describe("CSS stabilization state selectors", () => {
 
   it("uses composited properties for waveform and progress animation", () => {
     expect(appCss).toContain("transition: transform 18ms linear;");
+    expect(appCss).toContain("transition: clip-path 18ms linear;");
     expect(appCss).toContain("transition: clip-path var(--t-fast) var(--ease-out);");
     expect(appCss).not.toMatch(/transition:[ \t]*(?:height|width)\b/);
   });


### PR DESCRIPTION
## Summary

- Restore active recording telemetry to 20 Hz so the in-note waveform and meeting HUD respond smoothly without returning to separate native polling loops.
- Preserve rounded capsule caps as the in-note waveform bars change height.
- Match the visual demo drivers and audio-pipeline documentation to production cadence.

## Root cause

The shared recording telemetry stream reduced the main waveform's level targets from about 20 Hz to 10 Hz, while its six-sample peak window and animation ballistics remained tuned for 50 ms samples. The UI therefore received visible targets at only 10 frames per second and could miss short transients. Separately, scaling the complete 3 px pill flattened its corner radius as bars became short, which made the waveform read as square.

## Validation

- `make check typecheck test-web` (147 test files, 1,547 tests passed)
- `make tauri-fmt-check tauri-lint tauri-test`
- Focused recorder, telemetry-rendering, meeting-HUD, and CSS-stabilization tests
- Native cadence regression test pins active telemetry to 50 ms
- Visually tested the live recording UI and light/dark rounded-cap previews; approved by the requester

- [x] Tested visually where it matters.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

Audio capture, transcription, recording recovery, and the idle telemetry cadence are unchanged.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [ ] Security-sensitive changes were called out in the summary. Not applicable.
- [ ] Workflow action references are pinned to full-length commit SHAs. Not applicable.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787772367&installation_model_id=425925&pr_number=986&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F986&signature=8b30e321efeee464dfcf2c4fe2f80ecba74dd1f3c26cf54c82717f8423d9a22d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->