### PR TITLE
Fix Home error notice overlap

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -532,6 +532,7 @@ export function AgentWorkspace({
 
   const selectedSession =
     sessions.find((session) => session.id === selectedId) ?? projection.session;
+  const heroMode = !homeMode && newSessionMode && !selectedSession && !pendingInitialTurn;
   const running = projection.run?.status === "running" || projection.run?.status === "queued";
   const waiting = projection.run?.status === "waiting_for_user";
   const turns = useMemo(() => agentItemsToChatTurns(projection.items), [projection.items]);
@@ -1031,7 +1032,7 @@ export function AgentWorkspace({
     // state lets the greeting and suggestions settle underneath the input.
     // The focused new-session hero is inline and remains the only mode that
     // intentionally needs no fixed-composer clearance.
-    if ((!homeMode && (newSessionMode || !selectedSession)) || !scroller || !composer) {
+    if (heroMode || !scroller || !composer) {
       setComposerClearance(0);
       return;
     }
@@ -1051,7 +1052,7 @@ export function AgentWorkspace({
       observer?.disconnect();
       window.removeEventListener("resize", measure);
     };
-  }, [homeMode, newSessionMode, selectedSession]);
+  }, [heroMode, homeMode, selectedSession]);
 
   useLayoutEffect(() => {
     const shell = document.querySelector(".app-shell");
@@ -1901,7 +1902,6 @@ export function AgentWorkspace({
     await refreshSessions();
   }
 
-  const heroMode = !homeMode && newSessionMode && !selectedSession && !pendingInitialTurn;
   const sessionActionsAvailable = Boolean(selectedId && selectedSession);
   const homeConversationTurns = useMemo(
     () =>

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1052,7 +1052,7 @@ export function AgentWorkspace({
       observer?.disconnect();
       window.removeEventListener("resize", measure);
     };
-  }, [heroMode, homeMode, selectedSession]);
+  }, [heroMode]);
 
   useLayoutEffect(() => {
     const shell = document.querySelector(".app-shell");

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2088,6 +2088,7 @@ export function AgentWorkspace({
       running={running}
       submitting={submitting}
       disabledReason={textActionsDisabledReason}
+      notice={!heroMode ? error : undefined}
       hero={heroMode}
       showModelPicker={!homeMode}
     />
@@ -2151,11 +2152,6 @@ export function AgentWorkspace({
             style={{ "--agent-composer-clearance": `${composerClearance}px` } as CSSProperties}
           >
             <main className="agent-main" aria-label="Home conversation">
-              {error ? (
-                <div className="agent-composer-notice" role="alert">
-                  {error}
-                </div>
-              ) : null}
               <div className="agent-timeline" data-home="true">
                 {homeConversationTurns.map((turn, index) => {
                   const previous = index > 0 ? homeConversationTurns[index - 1] : undefined;
@@ -2270,11 +2266,6 @@ export function AgentWorkspace({
             style={{ "--agent-composer-clearance": `${composerClearance}px` } as CSSProperties}
           >
             <main className="agent-main" aria-label="Agent task details">
-              {error ? (
-                <div className="agent-composer-notice" role="alert">
-                  {error}
-                </div>
-              ) : null}
               <div className="agent-timeline">
                 {visibleTurns.map((turn) => (
                   <AgentChatTurnRow
@@ -2613,6 +2604,7 @@ function AgentComposer({
   running,
   submitting,
   disabledReason,
+  notice,
   hero = false,
   showModelPicker = true,
 }: {
@@ -2640,6 +2632,7 @@ function AgentComposer({
   running: boolean;
   submitting: boolean;
   disabledReason?: string;
+  notice?: string;
   hero?: boolean;
   showModelPicker?: boolean;
 }) {
@@ -2762,6 +2755,11 @@ function AgentComposer({
           }
         />
       )}
+      {notice ? (
+        <div className="agent-composer-notice" role="alert">
+          {notice}
+        </div>
+      ) : null}
       <div className="agent-composer-box">
         {attachments.length ? (
           <div className="agent-composer-attachments">

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -60,23 +60,23 @@ const newSession: AgentSessionDto = {
 };
 
 function mockAgentLayoutBounds() {
-  return vi
-    .spyOn(HTMLElement.prototype, "getBoundingClientRect")
-    .mockImplementation(function (this: HTMLElement) {
-      const top = this.classList.contains("agent-composer") ? 520 : 0;
-      const bottom = this.classList.contains("agent-scroll") ? 640 : top;
-      return {
-        x: 0,
-        y: top,
-        top,
-        right: 0,
-        bottom,
-        left: 0,
-        width: 0,
-        height: Math.max(0, bottom - top),
-        toJSON: () => ({}),
-      } as DOMRect;
-    });
+  return vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (
+    this: HTMLElement,
+  ) {
+    const top = this.classList.contains("agent-composer") ? 520 : 0;
+    const bottom = this.classList.contains("agent-scroll") ? 640 : top;
+    return {
+      x: 0,
+      y: top,
+      top,
+      right: 0,
+      bottom,
+      left: 0,
+      width: 0,
+      height: Math.max(0, bottom - top),
+      toJSON: () => ({}),
+    } as DOMRect;
+  });
 }
 
 describe("AgentWorkspace runtime wiring", () => {

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -428,6 +428,9 @@ describe("AgentWorkspace runtime wiring", () => {
     rejectHome?.(new Error("Home is temporarily unavailable"));
 
     expect(await screen.findByText("First message")).toBeVisible();
+    const errorNotice = await screen.findByRole("alert");
+    expect(errorNotice).toHaveTextContent("Home is temporarily unavailable");
+    expect(errorNotice.closest(".agent-composer")).not.toBeNull();
     await waitFor(() =>
       expect(screen.getByRole("textbox", { name: "Message June" })).toHaveTextContent("New draft"),
     );

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -59,6 +59,26 @@ const newSession: AgentSessionDto = {
   workspacePath: "/tmp/session-2",
 };
 
+function mockAgentLayoutBounds() {
+  return vi
+    .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+    .mockImplementation(function (this: HTMLElement) {
+      const top = this.classList.contains("agent-composer") ? 520 : 0;
+      const bottom = this.classList.contains("agent-scroll") ? 640 : top;
+      return {
+        x: 0,
+        y: top,
+        top,
+        right: 0,
+        bottom,
+        left: 0,
+        width: 0,
+        height: Math.max(0, bottom - top),
+        toJSON: () => ({}),
+      } as DOMRect;
+    });
+}
+
 describe("AgentWorkspace runtime wiring", () => {
   beforeEach(() => {
     resetCurrentDataPartitionForTests();
@@ -177,23 +197,7 @@ describe("AgentWorkspace runtime wiring", () => {
       }
       return Promise.resolve(undefined);
     });
-    const bounds = vi
-      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
-      .mockImplementation(function (this: HTMLElement) {
-        const top = this.classList.contains("agent-composer") ? 520 : 0;
-        const bottom = this.classList.contains("agent-scroll") ? 640 : top;
-        return {
-          x: 0,
-          y: top,
-          top,
-          right: 0,
-          bottom,
-          left: 0,
-          width: 0,
-          height: Math.max(0, bottom - top),
-          toJSON: () => ({}),
-        } as DOMRect;
-      });
+    const bounds = mockAgentLayoutBounds();
 
     try {
       const { container } = render(<AgentWorkspace homeMode />);
@@ -201,6 +205,42 @@ describe("AgentWorkspace runtime wiring", () => {
 
       await waitFor(() =>
         expect(scroller?.style.getPropertyValue("--agent-composer-clearance")).toBe("120px"),
+      );
+    } finally {
+      bounds.mockRestore();
+    }
+  });
+
+  it("reserves the fixed composer while a focused session is being created", async () => {
+    const user = userEvent.setup();
+    const pendingSession = new Promise<AgentSessionDto>(() => {});
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "list_agent_sessions") return Promise.resolve([]);
+      if (command === "list_venice_models") {
+        return Promise.resolve({
+          mode: "generation",
+          selectedModel: "open-software/auto",
+          modelType: "text",
+          models: [],
+        });
+      }
+      if (command === "create_agent_session") return pendingSession;
+      return Promise.resolve(undefined);
+    });
+    const bounds = mockAgentLayoutBounds();
+
+    try {
+      const { container } = render(<AgentWorkspace />);
+      await user.type(await screen.findByRole("textbox", { name: "Message June" }), "New task");
+      await user.click(screen.getByRole("button", { name: "Send message" }));
+      const scroller = await waitFor(() => {
+        const element = container.querySelector<HTMLElement>(".agent-scroll");
+        expect(element).not.toBeNull();
+        return element as HTMLElement;
+      });
+
+      await waitFor(() =>
+        expect(scroller.style.getPropertyValue("--agent-composer-clearance")).toBe("120px"),
       );
     } finally {
       bounds.mockRestore();


### PR DESCRIPTION
## Summary

- Keep Home and focused-session error notices attached to the fixed composer.
- Reserve the notice height as part of composer clearance so conversation turns cannot paint through or settle underneath it.
- Cover the failed Home-send path with a regression assertion.

## Root cause

Error notices were rendered as children of the scrolling conversation column even though their styling and behavior were composer-owned. Home message bubbles create their own paint layers, and the fixed composer clearance did not include the separately rendered notice, allowing scrolling content to overlap it.

## Validation

- `make check typecheck test-web`
- 1,547 frontend tests passed.
- Browser walkthrough of a failed Home send with a tall, scrolling conversation.
- Verified in light and dark themes with no page or console errors.
- At the live edge, the last conversation turn remained about 45 px above the error notice and the composer reserved 88 px of clearance.

- [x] Tested visually where it matters. A recording will be attached in a PR comment.
- [ ] Needs a June API (backend) deploy before it works end to end. No June API changes are required.

## Out of scope

- Changing error copy, styling, dismissal behavior, or duration.
- Changing the inline new-session hero error placement.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. This change is not security-sensitive.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow actions changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. None changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. None changed.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787773325&installation_model_id=425925&pr_number=987&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F987&signature=cd6e8faef272b447db7ab1cfd781b406037fefaba7ae3889c538bef20b6c9931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->