### PR TITLE
Fix recovery notice alignment

### DIFF
--- a/src/components/recorder/NoteRecoveryPrompt.tsx
+++ b/src/components/recorder/NoteRecoveryPrompt.tsx
@@ -17,9 +17,11 @@ export function NoteRecoveryPrompt({
   disabled,
   recoverBlockedReason,
 }: NoteRecoveryPromptProps) {
+  const isRecoveryBlocked = Boolean(recoverBlockedReason);
+
   return (
     <InlineNotice
-      className="note-recovery-prompt"
+      className={`note-recovery-prompt${isRecoveryBlocked ? " note-recovery-prompt-blocked" : ""}`}
       aria-label="Recoverable recording"
       icon={<IconRecord size={14} aria-hidden />}
       body={
@@ -46,7 +48,7 @@ export function NoteRecoveryPrompt({
           <button
             type="button"
             className="btn btn-secondary"
-            disabled={disabled || Boolean(recoverBlockedReason)}
+            disabled={disabled || isRecoveryBlocked}
             title={recoverBlockedReason}
             onClick={() => onRecover(recovery.sessionId)}
           >

--- a/src/components/recorder/NoteRecoveryPrompt.tsx
+++ b/src/components/recorder/NoteRecoveryPrompt.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef, useState } from "react";
 import { IconRecord } from "central-icons/IconRecord";
 import { InlineNotice } from "../ui/InlineNotice";
 import type { RecoverableRecordingDto } from "../../lib/tauri";
@@ -18,12 +19,45 @@ export function NoteRecoveryPrompt({
   recoverBlockedReason,
 }: NoteRecoveryPromptProps) {
   const isRecoveryBlocked = Boolean(recoverBlockedReason);
+  const bodyRef = useRef<HTMLSpanElement>(null);
+  const [bodyIsSingleLine, setBodyIsSingleLine] = useState(false);
+
+  useLayoutEffect(() => {
+    if (isRecoveryBlocked) {
+      setBodyIsSingleLine(false);
+      return;
+    }
+
+    const body = bodyRef.current;
+    if (!body) return;
+
+    const measure = () => setBodyIsSingleLine(hasOneRenderedLine(body));
+    measure();
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", measure);
+      return () => window.removeEventListener("resize", measure);
+    }
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(body);
+    return () => observer.disconnect();
+  }, [isRecoveryBlocked]);
+
+  const isCentered = !isRecoveryBlocked && bodyIsSingleLine;
 
   return (
     <InlineNotice
-      className={`note-recovery-prompt${isRecoveryBlocked ? " note-recovery-prompt-blocked" : ""}`}
+      className={[
+        "note-recovery-prompt",
+        isRecoveryBlocked && "note-recovery-prompt-blocked",
+        isCentered && "note-recovery-prompt-single-line",
+      ]
+        .filter(Boolean)
+        .join(" ")}
       aria-label="Recoverable recording"
       icon={<IconRecord size={14} aria-hidden />}
+      bodyRef={bodyRef}
       body={
         <>
           This recording was interrupted. We saved {formatBytes(recovery.bytesFound)} of audio.
@@ -58,6 +92,21 @@ export function NoteRecoveryPrompt({
       }
     />
   );
+}
+
+function hasOneRenderedLine(element: HTMLElement): boolean {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+
+  const lineTops: number[] = [];
+  for (const rect of range.getClientRects()) {
+    if (rect.width === 0 && rect.height === 0) continue;
+    if (lineTops.every((top) => Math.abs(top - rect.top) >= 1)) {
+      lineTops.push(rect.top);
+    }
+  }
+
+  return lineTops.length === 1;
 }
 
 function formatBytes(bytes: number): string {

--- a/src/components/ui/InlineNotice.tsx
+++ b/src/components/ui/InlineNotice.tsx
@@ -5,6 +5,7 @@ export type InlineNoticeTone = "info" | "warning" | "destructive";
 type InlineNoticeProps = {
   eyebrow?: ReactNode;
   body: ReactNode;
+  bodyRef?: React.Ref<HTMLSpanElement>;
   actions?: ReactNode;
   icon?: ReactNode;
   tone?: InlineNoticeTone;
@@ -16,6 +17,7 @@ type InlineNoticeProps = {
 export function InlineNotice({
   eyebrow,
   body,
+  bodyRef,
   actions,
   icon,
   tone = "warning",
@@ -29,7 +31,9 @@ export function InlineNotice({
       {icon ? <span className="inline-notice-icon">{icon}</span> : null}
       <div className="inline-notice-message">
         {eyebrow ? <span className="inline-notice-eyebrow">{eyebrow}</span> : null}
-        <span className="inline-notice-body">{body}</span>
+        <span ref={bodyRef} className="inline-notice-body">
+          {body}
+        </span>
       </div>
       {actions ? <div className="inline-notice-actions">{actions}</div> : null}
     </section>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -13088,16 +13088,21 @@ button.agent-user-attachment:hover {
   flex-shrink: 0;
 }
 
-/* The recovery prompt is a single message/action row, so center the whole
- * composition rather than inheriting the first-line alignment used by longer
- * shared notices. The compound selector keeps this consumer decision attached
- * to the InlineNotice primitive if the flat stylesheet is reordered. */
-.inline-notice.note-recovery-prompt {
-  align-items: center;
+/* Layout slot for the recovery prompt — sits in editor-content with spacing
+ * below it before the editor body begins. */
+.note-recovery-prompt {
   margin: 0 0 var(--sp-5);
 }
 
-.note-recovery-prompt .inline-notice-icon {
+/* The normal recovery prompt is a single message/action row, so center the
+ * whole composition. A funding-blocked prompt carries extra copy that can wrap;
+ * its explicit modifier excludes it from these overrides so it retains the
+ * shared notice's first-line alignment and top-aligned icon. */
+.inline-notice.note-recovery-prompt:not(.note-recovery-prompt-blocked) {
+  align-items: center;
+}
+
+.note-recovery-prompt:not(.note-recovery-prompt-blocked) .inline-notice-icon {
   align-self: center;
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11428,8 +11428,6 @@ button.agent-user-attachment:hover {
 
 .editor-content {
   min-height: 0;
-  container-name: note-editor;
-  container-type: inline-size;
 }
 
 .note-body,
@@ -13096,18 +13094,15 @@ button.agent-user-attachment:hover {
   margin: 0 0 var(--sp-5);
 }
 
-/* At wider editor sizes the normal recovery prompt fits on one line, so center
- * the whole composition. Below this font-relative threshold it keeps the
- * shared notice's first-line alignment and top-aligned icon as the copy wraps.
- * Funding-blocked prompts always keep that shared wrapped layout. */
-@container note-editor (min-width: 43em) {
-  .inline-notice.note-recovery-prompt:not(.note-recovery-prompt-blocked) {
-    align-items: center;
-  }
+/* NoteRecoveryPrompt adds this class only after measuring one rendered body
+ * line. Wrapped and funding-blocked prompts retain the shared first-line and
+ * top alignment above. */
+.inline-notice.note-recovery-prompt-single-line {
+  align-items: center;
+}
 
-  .note-recovery-prompt:not(.note-recovery-prompt-blocked) .inline-notice-icon {
-    align-self: center;
-  }
+.note-recovery-prompt-single-line .inline-notice-icon {
+  align-self: center;
 }
 
 .note-transcription-warning {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -13088,10 +13088,17 @@ button.agent-user-attachment:hover {
   flex-shrink: 0;
 }
 
-/* Layout slot for the recovery prompt — sits in editor-content with
- * spacing below it before the editor body begins. */
-.note-recovery-prompt {
+/* The recovery prompt is a single message/action row, so center the whole
+ * composition rather than inheriting the first-line alignment used by longer
+ * shared notices. The compound selector keeps this consumer decision attached
+ * to the InlineNotice primitive if the flat stylesheet is reordered. */
+.inline-notice.note-recovery-prompt {
+  align-items: center;
   margin: 0 0 var(--sp-5);
+}
+
+.note-recovery-prompt .inline-notice-icon {
+  align-self: center;
 }
 
 .note-transcription-warning {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11428,6 +11428,8 @@ button.agent-user-attachment:hover {
 
 .editor-content {
   min-height: 0;
+  container-name: note-editor;
+  container-type: inline-size;
 }
 
 .note-body,
@@ -13094,16 +13096,18 @@ button.agent-user-attachment:hover {
   margin: 0 0 var(--sp-5);
 }
 
-/* The normal recovery prompt is a single message/action row, so center the
- * whole composition. A funding-blocked prompt carries extra copy that can wrap;
- * its explicit modifier excludes it from these overrides so it retains the
- * shared notice's first-line alignment and top-aligned icon. */
-.inline-notice.note-recovery-prompt:not(.note-recovery-prompt-blocked) {
-  align-items: center;
-}
+/* At wider editor sizes the normal recovery prompt fits on one line, so center
+ * the whole composition. Below this font-relative threshold it keeps the
+ * shared notice's first-line alignment and top-aligned icon as the copy wraps.
+ * Funding-blocked prompts always keep that shared wrapped layout. */
+@container note-editor (min-width: 43em) {
+  .inline-notice.note-recovery-prompt:not(.note-recovery-prompt-blocked) {
+    align-items: center;
+  }
 
-.note-recovery-prompt:not(.note-recovery-prompt-blocked) .inline-notice-icon {
-  align-self: center;
+  .note-recovery-prompt:not(.note-recovery-prompt-blocked) .inline-notice-icon {
+    align-self: center;
+  }
 }
 
 .note-transcription-warning {

--- a/src/test/approval-card-css.test.ts
+++ b/src/test/approval-card-css.test.ts
@@ -3,7 +3,7 @@ import appCss from "../styles/app.css?raw";
 
 function cssRuleFor(selector: string) {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = new RegExp(`${escaped}\\s*\\{`).exec(appCss);
+  const match = new RegExp(`(?:^|\\n)${escaped}\\s*\\{`).exec(appCss);
   if (!match) throw new Error(`Missing CSS rule for ${selector}`);
   const openIndex = match.index + match[0].length - 1;
   let depth = 0;
@@ -241,12 +241,21 @@ describe("inline notice centering", () => {
     expect(baseIndex).toBeGreaterThan(overrideIndex);
   });
 
-  it("centers the meeting-note recovery row without changing the shared notice default", () => {
+  it("centers only the one-line meeting-note recovery row", () => {
     expect(cssRuleFor(".inline-notice")).toContain("align-items: first baseline;");
-    expect(cssRuleFor(".inline-notice.note-recovery-prompt")).toContain("align-items: center;");
-    expect(cssRuleFor(".note-recovery-prompt .inline-notice-icon")).toContain(
-      "align-self: center;",
-    );
+    expect(
+      cssRuleFor(".inline-notice.note-recovery-prompt:not(.note-recovery-prompt-blocked)"),
+    ).toContain("align-items: center;");
+    expect(
+      cssRuleFor(".note-recovery-prompt:not(.note-recovery-prompt-blocked) .inline-notice-icon"),
+    ).toContain("align-self: center;");
+  });
+
+  it("keeps the blocked recovery variant on the shared first-line alignment", () => {
+    const blockedSelector = ".inline-notice.note-recovery-prompt-blocked";
+    expect(appCss).not.toContain(`${blockedSelector} {`);
+    expect(cssRuleFor(".inline-notice")).toContain("align-items: first baseline;");
+    expect(cssRuleFor(".inline-notice-icon")).toContain("align-self: flex-start;");
   });
 });
 

--- a/src/test/approval-card-css.test.ts
+++ b/src/test/approval-card-css.test.ts
@@ -240,23 +240,6 @@ describe("inline notice centering", () => {
     // specificity would lose — the compound override is what makes it hold.
     expect(baseIndex).toBeGreaterThan(overrideIndex);
   });
-
-  it("centers only the one-line meeting-note recovery row", () => {
-    expect(cssRuleFor(".inline-notice")).toContain("align-items: first baseline;");
-    expect(
-      cssRuleFor(".inline-notice.note-recovery-prompt:not(.note-recovery-prompt-blocked)"),
-    ).toContain("align-items: center;");
-    expect(
-      cssRuleFor(".note-recovery-prompt:not(.note-recovery-prompt-blocked) .inline-notice-icon"),
-    ).toContain("align-self: center;");
-  });
-
-  it("keeps the blocked recovery variant on the shared first-line alignment", () => {
-    const blockedSelector = ".inline-notice.note-recovery-prompt-blocked";
-    expect(appCss).not.toContain(`${blockedSelector} {`);
-    expect(cssRuleFor(".inline-notice")).toContain("align-items: first baseline;");
-    expect(cssRuleFor(".inline-notice-icon")).toContain("align-self: flex-start;");
-  });
 });
 
 describe("resolved action row styles", () => {

--- a/src/test/approval-card-css.test.ts
+++ b/src/test/approval-card-css.test.ts
@@ -223,7 +223,7 @@ describe("pending action card styles", () => {
   });
 });
 
-describe("credits notice centering", () => {
+describe("inline notice centering", () => {
   it("centers the tier-card credits notice via an override that outranks the base rule", () => {
     // The base rule aligns notice copy with action-label baselines while
     // wrapped copy grows downward from the first line.
@@ -239,6 +239,14 @@ describe("credits notice centering", () => {
     // Guard the diagnosis: the base really is later in the file, so equal
     // specificity would lose — the compound override is what makes it hold.
     expect(baseIndex).toBeGreaterThan(overrideIndex);
+  });
+
+  it("centers the meeting-note recovery row without changing the shared notice default", () => {
+    expect(cssRuleFor(".inline-notice")).toContain("align-items: first baseline;");
+    expect(cssRuleFor(".inline-notice.note-recovery-prompt")).toContain("align-items: center;");
+    expect(cssRuleFor(".note-recovery-prompt .inline-notice-icon")).toContain(
+      "align-self: center;",
+    );
   });
 });
 

--- a/src/test/note-recovery-css.test.ts
+++ b/src/test/note-recovery-css.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import appCss from "../styles/app.css?raw";
+
+function cssRuleFor(selector: string) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`(?:^|\\n)${escaped}\\s*\\{`).exec(appCss);
+  if (!match) throw new Error(`Missing CSS rule for ${selector}`);
+  const openIndex = match.index + match[0].length - 1;
+  let depth = 0;
+  for (let index = openIndex; index < appCss.length; index += 1) {
+    if (appCss[index] === "{") depth += 1;
+    if (appCss[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return appCss.slice(openIndex + 1, index);
+    }
+  }
+  throw new Error(`Unclosed CSS rule for ${selector}`);
+}
+
+describe("note recovery prompt alignment", () => {
+  it("centers an unblocked prompt only when the editor is wide enough for one line", () => {
+    const editor = cssRuleFor(".editor-content");
+    expect(editor).toContain("container-name: note-editor;");
+    expect(editor).toContain("container-type: inline-size;");
+
+    const centeredPrompt = ".inline-notice.note-recovery-prompt:not(.note-recovery-prompt-blocked)";
+    const centeredIcon =
+      ".note-recovery-prompt:not(.note-recovery-prompt-blocked) .inline-notice-icon";
+    const wideEditor = cssRuleFor("@container note-editor (min-width: 43em)");
+
+    expect(wideEditor).toContain(`${centeredPrompt} {`);
+    expect(wideEditor).toContain("align-items: center;");
+    expect(wideEditor).toContain(`${centeredIcon} {`);
+    expect(wideEditor).toContain("align-self: center;");
+    expect(appCss.split(centeredPrompt)).toHaveLength(2);
+    expect(appCss.split(centeredIcon)).toHaveLength(2);
+  });
+
+  it("keeps narrow and funding-blocked prompts on the shared first-line alignment", () => {
+    expect(cssRuleFor(".inline-notice")).toContain("align-items: first baseline;");
+    expect(cssRuleFor(".inline-notice-icon")).toContain("align-self: flex-start;");
+    expect(appCss).not.toContain(".inline-notice.note-recovery-prompt-blocked {");
+  });
+});

--- a/src/test/note-recovery-css.test.ts
+++ b/src/test/note-recovery-css.test.ts
@@ -18,27 +18,20 @@ function cssRuleFor(selector: string) {
 }
 
 describe("note recovery prompt alignment", () => {
-  it("centers an unblocked prompt only when the editor is wide enough for one line", () => {
-    const editor = cssRuleFor(".editor-content");
-    expect(editor).toContain("container-name: note-editor;");
-    expect(editor).toContain("container-type: inline-size;");
-
-    const centeredPrompt = ".inline-notice.note-recovery-prompt:not(.note-recovery-prompt-blocked)";
-    const centeredIcon =
-      ".note-recovery-prompt:not(.note-recovery-prompt-blocked) .inline-notice-icon";
-    const wideEditor = cssRuleFor("@container note-editor (min-width: 43em)");
-
-    expect(wideEditor).toContain(`${centeredPrompt} {`);
-    expect(wideEditor).toContain("align-items: center;");
-    expect(wideEditor).toContain(`${centeredIcon} {`);
-    expect(wideEditor).toContain("align-self: center;");
-    expect(appCss.split(centeredPrompt)).toHaveLength(2);
-    expect(appCss.split(centeredIcon)).toHaveLength(2);
+  it("centers only the explicit measured single-line variant", () => {
+    expect(cssRuleFor(".inline-notice.note-recovery-prompt-single-line")).toContain(
+      "align-items: center;",
+    );
+    expect(cssRuleFor(".note-recovery-prompt-single-line .inline-notice-icon")).toContain(
+      "align-self: center;",
+    );
   });
 
-  it("keeps narrow and funding-blocked prompts on the shared first-line alignment", () => {
+  it("keeps wrapped and funding-blocked prompts on the shared first-line alignment", () => {
     expect(cssRuleFor(".inline-notice")).toContain("align-items: first baseline;");
     expect(cssRuleFor(".inline-notice-icon")).toContain("align-self: flex-start;");
     expect(appCss).not.toContain(".inline-notice.note-recovery-prompt-blocked {");
+    expect(appCss).not.toContain("container-name: note-editor;");
+    expect(appCss).not.toContain("@container note-editor");
   });
 });

--- a/src/test/recovery.test.tsx
+++ b/src/test/recovery.test.tsx
@@ -20,6 +20,9 @@ describe("NoteRecoveryPrompt", () => {
     const onDiscard = vi.fn();
     render(<NoteRecoveryPrompt recovery={recovery} onRecover={onRecover} onDiscard={onDiscard} />);
 
+    expect(screen.getByLabelText("Recoverable recording")).not.toHaveClass(
+      "note-recovery-prompt-blocked",
+    );
     expect(screen.getByText(/recording was interrupted/i)).toBeInTheDocument();
     expect(screen.getByText(/4\.0 KB/)).toBeInTheDocument();
 
@@ -28,5 +31,24 @@ describe("NoteRecoveryPrompt", () => {
 
     expect(onRecover).toHaveBeenCalledWith("session-1");
     expect(onDiscard).toHaveBeenCalledWith("session-1");
+  });
+
+  it("marks a funding-blocked recovery prompt as the wrapped layout variant", () => {
+    const recoverBlockedReason =
+      "Add credits before recovering this recording. Your saved audio will stay available.";
+
+    render(
+      <NoteRecoveryPrompt
+        recovery={recovery}
+        onRecover={vi.fn()}
+        onDiscard={vi.fn()}
+        recoverBlockedReason={recoverBlockedReason}
+      />,
+    );
+
+    const prompt = screen.getByLabelText("Recoverable recording");
+    expect(prompt).toHaveClass("note-recovery-prompt", "note-recovery-prompt-blocked");
+    expect(screen.getByRole("button", { name: "Recover" })).toBeDisabled();
+    expect(screen.getByText(recoverBlockedReason)).toBeInTheDocument();
   });
 });

--- a/src/test/recovery.test.tsx
+++ b/src/test/recovery.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { NoteRecoveryPrompt } from "../components/recorder/NoteRecoveryPrompt";
@@ -12,6 +12,13 @@ const recovery: RecoverableRecordingDto = {
   finalPathPresent: false,
   bytesFound: 4096,
 };
+
+function rectList(lineTops: number[]): DOMRectList {
+  const rects = lineTops.map((top) => ({ height: 24, top, width: 200 }));
+  return Object.assign(rects, {
+    item: (index: number) => rects[index] ?? null,
+  }) as unknown as DOMRectList;
+}
 
 describe("NoteRecoveryPrompt", () => {
   it("surfaces recoverable recordings with recover and discard actions", async () => {
@@ -48,7 +55,45 @@ describe("NoteRecoveryPrompt", () => {
 
     const prompt = screen.getByLabelText("Recoverable recording");
     expect(prompt).toHaveClass("note-recovery-prompt", "note-recovery-prompt-blocked");
+    expect(prompt).not.toHaveClass("note-recovery-prompt-single-line");
     expect(screen.getByRole("button", { name: "Recover" })).toBeDisabled();
     expect(screen.getByText(recoverBlockedReason)).toBeInTheDocument();
+  });
+
+  it("centers only while the unblocked body occupies one rendered line", () => {
+    let lineTops = [10];
+    let resizeCallback: ResizeObserverCallback | undefined;
+    const disconnect = vi.fn();
+    vi.spyOn(Range.prototype, "getClientRects").mockImplementation(() => rectList(lineTops));
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallback = callback;
+        }
+        observe() {}
+        disconnect() {
+          disconnect();
+        }
+      },
+    );
+
+    const { unmount } = render(
+      <NoteRecoveryPrompt recovery={recovery} onRecover={vi.fn()} onDiscard={vi.fn()} />,
+    );
+
+    const prompt = screen.getByLabelText("Recoverable recording");
+    expect(prompt).toHaveClass("note-recovery-prompt-single-line");
+
+    lineTops = [10, 34];
+    act(() => resizeCallback?.([], {} as ResizeObserver));
+    expect(prompt).not.toHaveClass("note-recovery-prompt-single-line");
+
+    lineTops = [10];
+    act(() => resizeCallback?.([], {} as ResizeObserver));
+    expect(prompt).toHaveClass("note-recovery-prompt-single-line");
+
+    unmount();
+    expect(disconnect).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- Vertically center the interrupted-recording notice only when its message occupies one rendered line.
- Measure rendered line fragments and update alignment as the meeting-note panel resizes.
- Keep wrapped and funding-blocked recovery copy on the shared first-line/top alignment.
- Add component and CSS regression coverage for centered, wrapped, and blocked states.

## Root cause

The shared inline-notice layout aligns text and actions by their first baseline while pinning its icon to the top of the first text line. That is correct for multiline notices, but it puts the icon above the visual center of the normal one-line recovery row. A fixed width or blocked-state heuristic cannot guarantee that dynamic recovery copy stays on one line, so the final implementation centers only after measuring the actual rendered line count.

## Validation

- `make local-ci` (149 test files and 1,584 tests passed)
- `signoff/frontend` passed on `46604b3706e911fccacf510aa1491f1285921039`
- `signoff/rust-macos` passed as not applicable on the same commit
- Focused Vitest coverage: 3 files and 21 tests passed
- `pnpm typecheck`
- `pnpm check` (passed with the repository's existing warnings)
- Browser preview verified the centered wide state, wrapped narrow state, funding-blocked state, and both wide-to-narrow and narrow-to-wide resize transitions
- `git diff --check`
- Greptile confidence 5/5 on the final commit

- [x] Tested visually where it matters (local screenshots and geometry captured for wide, narrow, and funding-blocked states).
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is needed.

## Out of scope

- Standalone funding notices, agent credit notices, transcription warnings, microphone notices, note failure banners, and other `InlineNotice` consumers remain behaviorally unchanged.
- The shared multiline notice alignment remains first-baseline aligned.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. This PR has no security-sensitive changes.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow references changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. None changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. None changed.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787804810&installation_model_id=425925&pr_number=992&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F992&signature=5b15fdc045d912ca492d651076f6df5ee4367fbc7e044711fb22eb55a8c923cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
