### PR TITLE
fix(agent): move completed assistant text behind its tool rows on hydration

### DIFF
--- a/src-tauri/src/agent_runtime/repository.rs
+++ b/src-tauri/src/agent_runtime/repository.rs
@@ -408,9 +408,13 @@ impl AgentRepository {
 
         if let Some(row) = query(
             "SELECT id, sequence, payload_json, created_at
-             FROM agent_items WHERE external_id = ?",
+             FROM agent_items
+             WHERE external_id = ? AND session_id = ? AND run_id = ?
+               AND kind = 'assistant_message'",
         )
         .bind(external_id)
+        .bind(session_id)
+        .bind(run_id)
         .fetch_optional(&mut *transaction)
         .await?
         {
@@ -530,16 +534,26 @@ impl AgentRepository {
         let payload_json = serde_json::to_string(&payload)
             .map_err(|error| sqlx::Error::Encode(Box::new(error)))?;
         let item = if let Some(row) =
-            query("SELECT id, sequence, created_at FROM agent_items WHERE external_id = ?")
+            query("SELECT id FROM agent_items WHERE external_id = ? AND session_id = ? AND run_id = ? AND kind = 'assistant_message'")
                 .bind(external_id)
+                .bind(session_id)
+                .bind(run_id)
                 .fetch_optional(&mut *transaction)
                 .await?
         {
             let id: String = row.get("id");
-            let display_sequence: i64 = row.get("sequence");
-            let created_at: String = row.get("created_at");
-            query("UPDATE agent_items SET payload_json = ?, external_id = NULL WHERE id = ?")
+            let display_sequence: i64 = query(
+                "SELECT COALESCE(MAX(sequence), -1) + 1 AS next_sequence
+                 FROM agent_items WHERE session_id = ?",
+            )
+            .bind(session_id)
+            .fetch_one(&mut *transaction)
+            .await?
+            .get("next_sequence");
+            query("UPDATE agent_items SET sequence = ?, payload_json = ?, external_id = NULL, created_at = ? WHERE id = ?")
+                .bind(display_sequence)
                 .bind(&payload_json)
+                .bind(&now)
                 .bind(&id)
                 .execute(&mut *transaction)
                 .await?;
@@ -550,7 +564,7 @@ impl AgentRepository {
                 sequence: display_sequence,
                 payload: AgentItemPayload::AssistantMessage(payload),
                 external_id: None,
-                created_at,
+                created_at: now.clone(),
             }
         } else {
             let id = Uuid::new_v4().to_string();

--- a/src-tauri/tests/agent_runtime_persistence.rs
+++ b/src-tauri/tests/agent_runtime_persistence.rs
@@ -1,6 +1,6 @@
 use os_june_lib::agent_runtime::{
     import_legacy_agent_state, legacy_import_completed, AgentItemPayload, AgentRepository,
-    LegacyImportOptions, MessagePayload,
+    LegacyImportOptions, MessagePayload, ToolPayload,
 };
 use os_june_lib::db::migrations::run_migrations;
 use sqlx::{query::query, row::Row};
@@ -158,6 +158,117 @@ async fn streamed_assistant_text_survives_mid_run_hydration_without_duplicates()
             if message.content == "What was already said, plus the ending."
     ));
     assert_eq!(repository.get_run(&run.id).await.unwrap().last_sequence, 3);
+}
+
+#[tokio::test]
+async fn completed_assistant_text_moves_behind_the_tools_that_produced_it() {
+    let pool = memory_database().await;
+    let repository = AgentRepository::new(pool);
+    let session = repository
+        .create_session(
+            "Tool ordering",
+            "private-auto",
+            os_june_lib::agent_runtime::AgentSafetyMode::Sandboxed,
+            None,
+        )
+        .await
+        .expect("session");
+    let run = repository
+        .create_run(&session.id, "private-auto", Some("medium"))
+        .await
+        .expect("run");
+    let stream_id = format!("assistant:{}", run.id);
+
+    // Stream the start of the assistant response — this allocates the first
+    // display sequence (0) and a low created_at.
+    repository
+        .append_assistant_message_delta(&session.id, &run.id, 1, "Here is ", &stream_id)
+        .await
+        .expect("streamed delta");
+
+    let streamed = repository
+        .items(&session.id)
+        .await
+        .expect("items after delta");
+    assert_eq!(streamed.len(), 1);
+    let assistant_row_id = streamed[0].id.clone();
+
+    // Simulate back-dating: the delta row was created early, but tool call and
+    // tool result arrive afterward and get higher display sequences.
+    repository
+        .append_item(
+            &session.id,
+            Some(&run.id),
+            2,
+            &AgentItemPayload::ToolCall(ToolPayload {
+                tool_name: Some("read_file".into()),
+                tool_call_id: Some("call-1".into()),
+                arguments: Some(serde_json::json!({ "path": "notes.md" })),
+                result: None,
+                status: None,
+            }),
+            None,
+        )
+        .await
+        .expect("tool call item")
+        .expect("tool call inserted");
+
+    repository
+        .append_item(
+            &session.id,
+            Some(&run.id),
+            3,
+            &AgentItemPayload::ToolResult(ToolPayload {
+                tool_name: Some("read_file".into()),
+                tool_call_id: Some("call-1".into()),
+                arguments: None,
+                result: Some(serde_json::json!("file contents")),
+                status: Some("ok".into()),
+            }),
+            None,
+        )
+        .await
+        .expect("tool result item")
+        .expect("tool result inserted");
+
+    // Complete the assistant message — the fix moves the coalesced row to the
+    // session-global tail so hydration places it after the tool rows.
+    repository
+        .complete_assistant_message(
+            &session.id,
+            &run.id,
+            4,
+            "Here is the final answer based on the file.",
+            &stream_id,
+        )
+        .await
+        .expect("completed message");
+
+    let hydrated = repository.items(&session.id).await.expect("hydrated items");
+    assert_eq!(
+        hydrated.len(),
+        3,
+        "should have exactly one assistant row (reused) plus two tool rows"
+    );
+
+    // The assistant row must reuse the original id, not create a duplicate.
+    assert_eq!(hydrated[2].id, assistant_row_id);
+
+    // Order must be: tool call, tool result, final assistant response.
+    assert!(matches!(
+        &hydrated[0].payload,
+        AgentItemPayload::ToolCall(tool) if tool.tool_name.as_deref() == Some("read_file")
+    ));
+    assert!(matches!(
+        &hydrated[1].payload,
+        AgentItemPayload::ToolResult(tool) if tool.tool_name.as_deref() == Some("read_file")
+    ));
+    assert!(matches!(
+        &hydrated[2].payload,
+        AgentItemPayload::AssistantMessage(msg)
+            if msg.content == "Here is the final answer based on the file."
+    ));
+    assert_eq!(hydrated[2].external_id, None);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- On conversation reload (hydration), the final assistant response rendered above the tool calls and tool results that produced it, even though live ordering was correct.
- complete_assistant_message in the agent runtime repository now moves the coalesced assistant row to the next session-global tail sequence and updates its timestamp on completion, so hydration (which sorts by sequence ASC) places it after the tool rows.
- The coalescing lookups in both ppend_assistant_message_delta and complete_assistant_message are tightened to match on external_id AND session_id AND run_id AND kind = 'assistant_message' instead of just external_id, preventing cross-run collisions.

## Root cause

complete_assistant_message overwrote the coalesced assistant row's content with the SDK's authoritative final text but preserved the row's stale, early sequence and created_at (allocated when the first streaming delta arrived, before any tool calls). Since hydration sorts persisted rows by sequence ASC, the completed assistant message appeared before the tool rows that were persisted after the first delta. Live ordering was unaffected because the React adapter replaces the item using the later runtime event sequence, not the persisted display sequence.

## Validation

- All 13 agent runtime persistence tests pass (cargo test --test agent_runtime_persistence), including the new regression test completed_assistant_text_moves_behind_the_tools_that_produced_it and the existing streamed_assistant_text_survives_mid_run_hydration_without_duplicates.
- cargo fmt clean.
- Code review: Standards axis clean, Adversarial axis approve (no material findings).

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- no backend changes -->

## Out of scope

- Multi-approval parallel execution / sequencing fix (Issue B from the planning thread) — that is a separate effort.
- Rewriting historical conversations already persisted with old ordering — only new completions get the tail-sequence move.
- Frontend projection reordering — the fix is at the persistence layer so live events and hydration share the same ordering.

## Followups

- The multi-approval batch fix remains uncommitted and will be addressed separately.

## Security and release checklist

- [x] No secrets, local .env values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787808420&installation_model_id=425925&pr_number=995&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F995&signature=cc225b80bd6ca4aa4d493c6960d35671fb6bf4172ee1527d642659f8e9db49de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->