### PR TITLE
Fix recording HUD demo lifecycle isolation

### DIFF
--- a/src/lib/recording-hud-demo.ts
+++ b/src/lib/recording-hud-demo.ts
@@ -63,12 +63,12 @@ const HELP = [
   "seconds arg works.",
 ].join("\n");
 
-let timers: number[] = [];
-let statusTimer: number | undefined;
-let levelPhase = 0;
-
 export function registerRecordingHudDemo({ local }: RecordingHudDemoOptions) {
-  if (typeof window === "undefined") return;
+  if (typeof window === "undefined") return { dispose() {} };
+
+  let timers: number[] = [];
+  let statusTimer: number | undefined;
+  let levelPhase = 0;
 
   function emitStatus(status: RecordingStatusDto) {
     if (local) {
@@ -223,20 +223,21 @@ export function registerRecordingHudDemo({ local }: RecordingHudDemoOptions) {
   // Standalone page only: the card's buttons invoke Tauri commands that don't
   // exist without the bridge, so mirror their outcome locally — either action
   // collapses the card back to the live pill.
-  if (local) {
-    for (const id of ["mhud-end-keep", "mhud-end-stop"]) {
-      document.getElementById(id)?.addEventListener("click", () => {
-        cancelTimers();
-        emitMeetingEnd(null);
-        recording();
-      });
-    }
+  const localMeetingEndButtons = local
+    ? ["mhud-end-keep", "mhud-end-stop"]
+        .map((id) => document.getElementById(id))
+        .filter((button): button is HTMLElement => button !== null)
+    : [];
+  const collapseLocalMeetingEnd = () => {
+    cancelTimers();
+    emitMeetingEnd(null);
+    recording();
+  };
+  for (const button of localMeetingEndButtons) {
+    button.addEventListener("click", collapseLocalMeetingEnd);
   }
 
-  (window as unknown as Record<string, unknown>).__recordingHud = (
-    state?: DemoState,
-    seconds?: number,
-  ) => {
+  const hook = (state?: DemoState, seconds?: number) => {
     switch (state) {
       case "recording":
         recording();
@@ -262,4 +263,19 @@ export function registerRecordingHudDemo({ local }: RecordingHudDemoOptions) {
         return HELP;
     }
   };
+
+  const demoWindow = window as unknown as Record<string, unknown>;
+  demoWindow.__recordingHud = hook;
+
+  function dispose() {
+    cancelTimers();
+    for (const button of localMeetingEndButtons) {
+      button.removeEventListener("click", collapseLocalMeetingEnd);
+    }
+    if (demoWindow.__recordingHud === hook) {
+      delete demoWindow.__recordingHud;
+    }
+  }
+
+  return { dispose };
 }

--- a/src/meeting-hud.ts
+++ b/src/meeting-hud.ts
@@ -28,6 +28,8 @@ const lifecycle = createHudLifecycle();
 // Recolor this HUD window to the selected accent and keep it live-synced.
 lifecycle.trackUnlisten(subscribeBrand());
 
+const HAS_TAURI_BRIDGE = "__TAURI_INTERNALS__" in window;
+
 // Absent on the standalone browser page (no Tauri bridge), where the demo
 // driver exercises the pill — getCurrentWindow() throws there. Same guard as
 // hud.ts.
@@ -351,9 +353,10 @@ startBarLoop();
 // Console driver for this page when served standalone in a browser:
 // __recordingHud("recording") etc. See lib/recording-hud-demo.ts.
 if (import.meta.env.DEV) {
-  void import("./lib/recording-hud-demo").then(({ registerRecordingHudDemo }) =>
-    registerRecordingHudDemo({ local: true }),
-  );
+  void import("./lib/recording-hud-demo").then(({ registerRecordingHudDemo }) => {
+    const demo = registerRecordingHudDemo({ local: !HAS_TAURI_BRIDGE });
+    lifecycle.addCleanup(demo.dispose);
+  });
 }
 
 // Paint immediately if a recording is already live when this view appears.

--- a/src/test/hud-listener-lifecycle.test.ts
+++ b/src/test/hud-listener-lifecycle.test.ts
@@ -14,6 +14,10 @@ const mocks = vi.hoisted(() => ({
   }),
   hide: vi.fn().mockResolvedValue(undefined),
   startDragging: vi.fn().mockResolvedValue(undefined),
+  getCurrentWindow: vi.fn(() => ({
+    hide: mocks.hide,
+    startDragging: mocks.startDragging,
+  })),
 }));
 
 function deferred<T>() {
@@ -33,10 +37,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 }));
 
 vi.mock("@tauri-apps/api/window", () => ({
-  getCurrentWindow: () => ({
-    hide: mocks.hide,
-    startDragging: mocks.startDragging,
-  }),
+  getCurrentWindow: mocks.getCurrentWindow,
 }));
 
 describe("HUD listener lifecycle", () => {
@@ -46,6 +47,10 @@ describe("HUD listener lifecycle", () => {
     mocks.listeners.clear();
     mocks.unlistenHandles.length = 0;
     mocks.invoke.mockResolvedValue(undefined);
+    mocks.getCurrentWindow.mockImplementation(() => ({
+      hide: mocks.hide,
+      startDragging: mocks.startDragging,
+    }));
     Object.defineProperty(window, "__TAURI_INTERNALS__", {
       configurable: true,
       value: {},
@@ -97,9 +102,13 @@ describe("HUD listener lifecycle", () => {
   });
 
   it("shows the meeting-end countdown and wires both safety actions", async () => {
+    mocks.getCurrentWindow.mockImplementationOnce(() => {
+      throw new Error("Mocked Tauri bridge has no window metadata");
+    });
     await import("../meeting-hud");
     await vi.waitFor(() => {
       expect(mocks.listeners.has("meeting-end-state-event")).toBe(true);
+      expect((window as unknown as Record<string, unknown>).__recordingHud).toBeTypeOf("function");
     });
 
     const countdown = {
@@ -130,6 +139,7 @@ describe("HUD listener lifecycle", () => {
         sessionId: "meeting-session",
       });
     });
+    expect(pill?.dataset.mode).toBe("meeting-end");
 
     mocks.listeners.get("meeting-end-state-event")?.({ payload: countdown });
     stop?.click();
@@ -138,11 +148,41 @@ describe("HUD listener lifecycle", () => {
         sessionId: "meeting-session",
       });
     });
+    expect(pill?.dataset.mode).toBe("meeting-end");
 
     mocks.listeners.get("meeting-end-state-event")?.({
       payload: { sessionId: "meeting-session", phase: "tracking" },
     });
     expect(pill?.dataset.mode).toBeUndefined();
+
+    window.dispatchEvent(new Event("pagehide"));
+    expect((window as unknown as Record<string, unknown>).__recordingHud).toBeUndefined();
+  });
+
+  it("disposes recording demo timers, local buttons, and its console hook", async () => {
+    const setInterval = vi.spyOn(window, "setInterval");
+    const clearInterval = vi.spyOn(window, "clearInterval");
+    const { registerRecordingHudDemo } = await import("../lib/recording-hud-demo");
+    const demo = registerRecordingHudDemo({ local: true });
+    const hook = (window as unknown as Record<string, unknown>).__recordingHud as (
+      state: "recording",
+    ) => string;
+
+    hook("recording");
+    expect(setInterval).toHaveBeenCalled();
+    clearInterval.mockClear();
+
+    demo.dispose();
+
+    expect(clearInterval).toHaveBeenCalled();
+    expect((window as unknown as Record<string, unknown>).__recordingHud).toBeUndefined();
+    setInterval.mockClear();
+    document.querySelector<HTMLButtonElement>("#mhud-end-keep")?.click();
+    document.querySelector<HTMLButtonElement>("#mhud-end-stop")?.click();
+    expect(setInterval).not.toHaveBeenCalled();
+
+    setInterval.mockRestore();
+    clearInterval.mockRestore();
   });
 
   it("does not let the initial meeting-end read overwrite a newer HUD event", async () => {


### PR DESCRIPTION
## Summary

- Keep real and mocked Tauri recording HUD actions isolated from the standalone browser demo behavior.
- Dispose demo timers, local button listeners, and the console hook with the HUD window lifecycle.
- Cover bridge detection without window metadata and verify teardown releases demo-owned resources.

## Root cause

The recording HUD always registered its developer demo with local browser behavior, including inside real and mocked Tauri contexts. The synthetic Keep and Stop listeners could therefore clear native meeting-end state before the real command path completed, and the synthetic waveform interval was not connected to window teardown. Under the frontend suite this caused the native action assertion to fail and left a timer accessing `window` after jsdom teardown.

## Validation

- `pnpm typecheck`
- `pnpm vitest run src/test/hud-listener-lifecycle.test.ts src/test/hud-meeting.test.ts --maxWorkers=2 --minWorkers=1` - 62 passed
- `pnpm biome check src/lib/recording-hud-demo.ts src/meeting-hud.ts src/test/hud-listener-lifecycle.test.ts` - completed with the existing demo-only `console.warn` warning
- Focused HUD lifecycle suite passed repeatedly with no leaked timer.
- Oracle review completed; bridge-detection and regression-coverage findings were addressed.
- `june-signoff-frontend` no longer reports the HUD failure or post-teardown `window` error. The full suite remains non-green because two unrelated tests fail under suite load: generated append handling in `note-editor.test.tsx` and project navigation in `app-shortcut.test.tsx`. The latter passes in isolation; neither file is changed here.

- [ ] Tested visually where it matters (not run: this changes developer-demo routing and teardown, covered by focused tests).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- The unrelated note editor and project navigation test failures seen under full-suite load.
- Product meeting-end behavior and visual styling.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary (none).
- [x] Workflow action references are pinned to full-length commit SHAs (no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable).
- [x] User-facing copy follows the repo UI conventions (no user-facing copy changes).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787812897&installation_model_id=425925&pr_number=996&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F996&signature=bc860a370f3ac78e669dbf2a7b692377457cb8cc933ef87877f9739d5dacee1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->