### PR TITLE
Fix routine Run now execution and status refresh

### DIFF
--- a/src-tauri/src/agent_runtime/host.rs
+++ b/src-tauri/src/agent_runtime/host.rs
@@ -842,6 +842,11 @@ async fn persist_and_emit_event(
             repository
                 .update_run_status(&frame.run_id, "completed", None, None, None)
                 .await?;
+            if let Err(error) =
+                crate::routines::mark_agent_run_terminal(&repository.pool, &frame.run_id).await
+            {
+                tracing::warn!(agent_run_id = %frame.run_id, error_code = %error.code, "routine terminal projection failed");
+            }
             None
         }
         "run.cancelled" => {
@@ -849,6 +854,11 @@ async fn persist_and_emit_event(
             repository
                 .update_run_status(&frame.run_id, "cancelled", None, None, None)
                 .await?;
+            if let Err(error) =
+                crate::routines::mark_agent_run_terminal(&repository.pool, &frame.run_id).await
+            {
+                tracing::warn!(agent_run_id = %frame.run_id, error_code = %error.code, "routine terminal projection failed");
+            }
             None
         }
         "run.failed" => {
@@ -865,6 +875,11 @@ async fn persist_and_emit_event(
                     )),
                 )
                 .await?;
+            if let Err(error) =
+                crate::routines::mark_agent_run_terminal(&repository.pool, &frame.run_id).await
+            {
+                tracing::warn!(agent_run_id = %frame.run_id, error_code = %error.code, "routine terminal projection failed");
+            }
             Some(AgentItemPayload::Error(data.clone()))
         }
         _ => None,

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -369,6 +369,13 @@ pub fn generation_model() -> String {
     current_settings().generation_model
 }
 
+/// The saved service-managed generation model, independent of an explicitly
+/// enabled local provider. Unattended Routines use this accessor so they stay
+/// on June's metered remote route.
+pub fn remote_generation_model() -> String {
+    current_settings().remote_generation_model
+}
+
 pub fn cost_quality() -> f64 {
     // Keep the wire value safe even if a user manually edits the settings file
     // after it has been loaded but before a future accessor refactor.
@@ -2252,6 +2259,7 @@ mod tests {
 
         assert_eq!(sanitized.generation_provider, PROVIDER_LOCAL);
         assert_eq!(sanitized.generation_model, "llama3.1:8b");
+        assert_eq!(sanitized.remote_generation_model, "remote-model");
         assert_eq!(
             sanitized.local_generation.base_url,
             "http://192.168.1.5:11434/v1"

--- a/src-tauri/src/routines.rs
+++ b/src-tauri/src/routines.rs
@@ -175,8 +175,10 @@ fn resolve_routine_model(stored_model: &str, selected_model: &str) -> String {
         || stored_model == "auto"
         || stored_model == crate::providers::AUTO_GENERATION_MODEL
     {
-        // `open-software/auto` is itself a supported metered route. The shared
-        // agent proxy adds its cost-quality preference before calling June API.
+        // A Routine's stored Auto value resolves against the saved remote
+        // selection so unattended work stays on June's metered model route.
+        // `open-software/auto` is itself supported; the proxy adds its
+        // cost-quality preference before calling June API.
         let selected_model = selected_model.trim();
         if selected_model.is_empty() || selected_model == "auto" {
             crate::providers::AUTO_GENERATION_MODEL.to_string()
@@ -433,7 +435,7 @@ async fn claim_with_connector_guard(
     let run_id = Uuid::new_v4().to_string();
     let timestamp = now();
     let stored_model: String = routine.get("model");
-    let model = resolve_routine_model(&stored_model, &crate::providers::generation_model());
+    let model = resolve_routine_model(&stored_model, &crate::providers::remote_generation_model());
     let safety_mode = AgentSafetyMode::from(routine.get::<String, _>("safety_mode").as_str());
     let metadata = serde_json::from_str::<Value>(&routine.get::<String, _>("metadata_json"))
         .unwrap_or_else(|_| json!({}));
@@ -481,9 +483,18 @@ pub async fn claim_due(pool: &SqlitePool) -> Result<Vec<Claim>, AppError> {
     Ok(claims)
 }
 
-/// Reconciles terminal agent runs and releases abandoned queued claims after a
-/// restart. A still-running agent run remains claimed; an unstarted claim only
-/// becomes eligible again after a bounded lease expiry.
+async fn scheduler_tick(pool: &SqlitePool) -> Result<Vec<Claim>, AppError> {
+    // The terminal event path is best effort after the agent run is durable.
+    // Reconcile on every tick so a transient projection failure cannot retain
+    // a completed Routine's single-flight claim until the next app restart.
+    reconcile(pool).await?;
+    claim_due(pool).await
+}
+
+/// Reconciles terminal agent runs and releases abandoned queued claims during
+/// scheduler maintenance and restart recovery. A still-running agent run
+/// remains claimed; an unstarted claim only becomes eligible again after a
+/// bounded lease expiry.
 pub async fn reconcile(pool: &SqlitePool) -> Result<(), AppError> {
     let timestamp = now();
     let mut transaction = pool
@@ -697,7 +708,7 @@ pub fn start_scheduler(app: &AppHandle) {
             tracing::warn!(error_code = %error.code, "routine restart reconciliation failed");
         }
         loop {
-            match claim_due(&pool).await {
+            match scheduler_tick(&pool).await {
                 Ok(claims) => {
                     let host = app.state::<AgentRuntimeHost>();
                     for claim in claims {
@@ -1626,7 +1637,7 @@ mod tests {
     }
 
     #[test]
-    fn automatic_routine_model_resolves_to_the_selected_generation_model() {
+    fn automatic_routine_model_resolves_to_the_selected_remote_model() {
         for stored_model in ["", "auto", crate::providers::AUTO_GENERATION_MODEL] {
             assert_eq!(
                 resolve_routine_model(stored_model, "kimi-k2-6"),
@@ -1878,7 +1889,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn claimed_run_snapshots_the_resolved_model_and_safety_mode() {
+    async fn claimed_run_snapshots_the_resolved_remote_model_and_safety_mode() {
         let pool = pool().await;
         let mut request = create_request("every 1h");
         request.model = "auto".into();
@@ -1888,14 +1899,14 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(claim.model, crate::providers::generation_model());
+        assert_eq!(claim.model, crate::providers::remote_generation_model());
         assert_eq!(claim.safety_mode, AgentSafetyMode::Unrestricted);
         let run = list_runs(&pool, Some("routine-1"))
             .await
             .unwrap()
             .pop()
             .unwrap();
-        assert_eq!(run.model, crate::providers::generation_model());
+        assert_eq!(run.model, crate::providers::remote_generation_model());
         assert_eq!(run.safety_mode, AgentSafetyMode::Unrestricted);
         let tools = base_unattended_tools().to_string();
         assert!(!tools.contains("computer_use"));
@@ -2115,6 +2126,52 @@ mod tests {
                 .unwrap()
                 .get("claim_token");
         assert_eq!(claim_token.as_deref(), Some(claimed.token.as_str()));
+    }
+
+    #[tokio::test]
+    async fn scheduler_tick_retries_a_missed_terminal_projection() {
+        let pool = pool().await;
+        create(&pool, create_request("every 1h")).await.unwrap();
+        let claimed = claim(&pool, "routine-1", "manual", false)
+            .await
+            .unwrap()
+            .unwrap();
+        query("INSERT INTO agent_sessions (id) VALUES ('session-retry')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        query(
+            "INSERT INTO agent_runs
+             (id, status, completed_at)
+             VALUES ('run-retry', 'completed', '2026-07-28T08:00:00.000Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        attach_run_mapping(
+            &pool,
+            &claimed.routine_run_id,
+            &claimed.token,
+            "session-retry",
+            "run-retry",
+            &now(),
+        )
+        .await
+        .unwrap();
+
+        assert!(scheduler_tick(&pool).await.unwrap().is_empty());
+
+        let run = list_runs(&pool, Some("routine-1")).await.unwrap().remove(0);
+        assert_eq!(run.status, "completed");
+        let routine = get(&pool, "routine-1").await.unwrap();
+        assert_eq!(routine.last_status.as_deref(), Some("ok"));
+        let claim_token: Option<String> =
+            query("SELECT claim_token FROM routines WHERE id = 'routine-1'")
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+                .get("claim_token");
+        assert_eq!(claim_token, None);
     }
 
     #[tokio::test]

--- a/src-tauri/src/routines.rs
+++ b/src-tauri/src/routines.rs
@@ -19,8 +19,8 @@ use chrono::{DateTime, Datelike, Duration, TimeZone, Timelike, Utc};
 use chrono_tz::Tz;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use sqlx::{query::query, row::Row};
-use sqlx_sqlite::SqlitePool;
+use sqlx::{query::query, query_scalar::query_scalar, row::Row, transaction::Transaction};
+use sqlx_sqlite::{Sqlite, SqlitePool};
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager, State};
 use uuid::Uuid;
@@ -441,33 +441,31 @@ pub async fn claim_due(pool: &SqlitePool) -> Result<Vec<Claim>, AppError> {
 /// becomes eligible again after a bounded lease expiry.
 pub async fn reconcile(pool: &SqlitePool) -> Result<(), AppError> {
     let timestamp = now();
-    query("UPDATE routine_runs SET status = (SELECT status FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), completed_at = COALESCE((SELECT completed_at FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), completed_at), error_code = COALESCE((SELECT error_code FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), error_code), error_message = COALESCE((SELECT error_message FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), error_message), updated_at = ? WHERE agent_run_id IS NOT NULL AND status IN ('running', 'waiting_for_user') AND EXISTS (SELECT 1 FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id AND agent_runs.status IN ('completed', 'cancelled', 'interrupted', 'failed'))")
-        .bind(&timestamp).execute(pool).await.map_err(app_error)?;
-    let stale_before = format_time(Utc::now() - Duration::minutes(CLAIM_STALE_AFTER_MINUTES));
-    query("UPDATE routine_runs SET status = 'interrupted', completed_at = ?, error_code = 'routine_claim_expired', error_message = 'Routine dispatch did not start before its claim expired.', updated_at = ? WHERE status = 'queued' AND agent_run_id IS NULL AND updated_at < ?")
-        .bind(&timestamp).bind(&timestamp).bind(stale_before).execute(pool).await.map_err(app_error)?;
-    release_terminal_claims(pool, &timestamp, None).await
-}
-
-async fn release_terminal_claims(
-    pool: &SqlitePool,
-    timestamp: &str,
-    agent_run_id: Option<&str>,
-) -> Result<(), AppError> {
-    // Routine edits and terminal release both update schedule metadata. Hold a
-    // write reservation across the read/derive/write sequence so a concurrent
-    // edit either lands wholly before this snapshot or wholly after it.
     let mut transaction = pool
         .begin_with("BEGIN IMMEDIATE")
         .await
         .map_err(app_error)?;
+    query("UPDATE routine_runs SET status = (SELECT status FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), completed_at = COALESCE((SELECT completed_at FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), completed_at), error_code = COALESCE((SELECT error_code FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), error_code), error_message = COALESCE((SELECT error_message FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), error_message), updated_at = ? WHERE agent_run_id IS NOT NULL AND status IN ('running', 'waiting_for_user') AND EXISTS (SELECT 1 FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id AND agent_runs.status IN ('completed', 'cancelled', 'interrupted', 'failed'))")
+        .bind(&timestamp).execute(&mut *transaction).await.map_err(app_error)?;
+    let stale_before = format_time(Utc::now() - Duration::minutes(CLAIM_STALE_AFTER_MINUTES));
+    query("UPDATE routine_runs SET status = 'interrupted', completed_at = ?, error_code = 'routine_claim_expired', error_message = 'Routine dispatch did not start before its claim expired.', updated_at = ? WHERE status = 'queued' AND agent_run_id IS NULL AND updated_at < ?")
+        .bind(&timestamp).bind(&timestamp).bind(stale_before).execute(&mut *transaction).await.map_err(app_error)?;
+    release_terminal_claims(&mut transaction, &timestamp, None).await?;
+    transaction.commit().await.map_err(app_error)
+}
+
+async fn release_terminal_claims(
+    transaction: &mut Transaction<'_, Sqlite>,
+    timestamp: &str,
+    agent_run_id: Option<&str>,
+) -> Result<(), AppError> {
     // A terminal run releases exactly its matching routine claim. Advance the
     // schedule here rather than leaving a past `next_run_at`, which would
     // otherwise immediately re-run a completed routine on the next tick.
     let terminal = query("SELECT routines.id, routines.schedule, routines.timezone, routines.repeat, routines.metadata_json, routines.state, routines.enabled, routine_runs.claim_token, routine_runs.status, routine_runs.completed_at, routine_runs.error_message FROM routines JOIN routine_runs ON routine_runs.routine_id = routines.id AND routine_runs.claim_token = routines.claim_token WHERE routines.claim_token IS NOT NULL AND routine_runs.status IN ('completed', 'cancelled', 'interrupted', 'failed') AND (? IS NULL OR routine_runs.agent_run_id = ?)")
         .bind(agent_run_id)
         .bind(agent_run_id)
-        .fetch_all(&mut *transaction).await.map_err(app_error)?;
+        .fetch_all(&mut **transaction).await.map_err(app_error)?;
     for row in terminal {
         let state: String = row.get("state");
         let enabled = row.get::<i64, _>("enabled") != 0;
@@ -496,9 +494,9 @@ async fn release_terminal_claims(
             .bind(timestamp)
             .bind(row.get::<String, _>("id"))
             .bind(row.get::<String, _>("claim_token"))
-            .execute(&mut *transaction).await.map_err(app_error)?;
+            .execute(&mut **transaction).await.map_err(app_error)?;
     }
-    transaction.commit().await.map_err(app_error)
+    Ok(())
 }
 
 fn advance_repeat(repeat: &str, metadata: &mut Value) -> bool {
@@ -600,17 +598,40 @@ pub async fn mark_agent_run_terminal(
     pool: &SqlitePool,
     agent_run_id: &str,
 ) -> Result<(), AppError> {
+    // Most terminal agent events are not Routine runs. Avoid taking SQLite's
+    // RESERVED write lock for those unrelated chat and dictation completions.
+    let is_routine_run: i64 = query_scalar(
+        "SELECT EXISTS(
+             SELECT 1 FROM routine_runs
+             WHERE agent_run_id = ? AND status IN ('running', 'waiting_for_user')
+         )",
+    )
+    .bind(agent_run_id)
+    .fetch_one(pool)
+    .await
+    .map_err(app_error)?;
+    if is_routine_run == 0 {
+        return Ok(());
+    }
+
     let timestamp = now();
+    // Project the terminal run and release its routine claim under one write
+    // reservation. A concurrent routine edit therefore lands wholly before or
+    // after both updates and cannot erase the matching claim between them.
+    let mut transaction = pool
+        .begin_with("BEGIN IMMEDIATE")
+        .await
+        .map_err(app_error)?;
     let changed = query("UPDATE routine_runs SET status = (SELECT status FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), completed_at = COALESCE((SELECT completed_at FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), completed_at), error_code = COALESCE((SELECT error_code FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), error_code), error_message = COALESCE((SELECT error_message FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), error_message), updated_at = ? WHERE agent_run_id = ? AND status IN ('running', 'waiting_for_user') AND EXISTS (SELECT 1 FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id AND agent_runs.status IN ('completed', 'cancelled', 'interrupted', 'failed'))")
         .bind(&timestamp)
         .bind(agent_run_id)
-        .execute(pool)
+        .execute(&mut *transaction)
         .await
         .map_err(app_error)?;
-    if changed.rows_affected() == 0 {
-        return Ok(());
+    if changed.rows_affected() != 0 {
+        release_terminal_claims(&mut transaction, &timestamp, Some(agent_run_id)).await?;
     }
-    release_terminal_claims(pool, &timestamp, Some(agent_run_id)).await
+    transaction.commit().await.map_err(app_error)
 }
 
 /// Start the single local scheduler for June-owned routines. Claims are stored
@@ -1893,6 +1914,61 @@ mod tests {
             .await
             .unwrap()
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn terminal_projection_rolls_back_when_claim_release_fails() {
+        let pool = pool().await;
+        create(&pool, create_request("every 1h")).await.unwrap();
+        let claimed = claim(&pool, "routine-1", "manual", false)
+            .await
+            .unwrap()
+            .unwrap();
+        query("INSERT INTO agent_sessions (id) VALUES ('session-atomic')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        query(
+            "INSERT INTO agent_runs
+             (id, status, completed_at, error_code, error_message)
+             VALUES ('run-atomic', 'failed', '2026-07-28T08:00:00.000Z',
+                     'model_not_priced', 'model_not_priced')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        attach_run_mapping(
+            &pool,
+            &claimed.routine_run_id,
+            &claimed.token,
+            "session-atomic",
+            "run-atomic",
+            &now(),
+        )
+        .await
+        .unwrap();
+        query("UPDATE routines SET schedule = 'not a schedule' WHERE id = 'routine-1'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let error = mark_agent_run_terminal(&pool, "run-atomic")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code, "routine_schedule_invalid");
+        let run = list_runs(&pool, Some("routine-1")).await.unwrap().remove(0);
+        assert_eq!(run.status, "running");
+        assert_eq!(run.error_code, None);
+        let routine = get(&pool, "routine-1").await.unwrap();
+        assert_eq!(routine.last_status, None);
+        let claim_token: Option<String> =
+            query("SELECT claim_token FROM routines WHERE id = 'routine-1'")
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+                .get("claim_token");
+        assert_eq!(claim_token.as_deref(), Some(claimed.token.as_str()));
     }
 
     #[tokio::test]

--- a/src-tauri/src/routines.rs
+++ b/src-tauri/src/routines.rs
@@ -67,7 +67,7 @@ pub struct AgentRoutineRunDto {
     pub scheduled_for: Option<String>,
     pub started_at: Option<String>,
     pub completed_at: Option<String>,
-    /// Concrete model resolved at claim time, never a moving `auto` alias.
+    /// Model snapshotted from the routine or current generation selection at claim time.
     pub model: String,
     pub safety_mode: AgentSafetyMode,
     pub error_code: Option<String>,
@@ -168,12 +168,20 @@ fn validate_state(state: &str) -> Result<(), AppError> {
     }
 }
 
-fn normalized_model(model: &str) -> String {
-    let model = model.trim();
-    if model.is_empty() || model == "auto" || model == "open-software/auto" {
-        crate::providers::AUTO_GENERATION_MODEL.to_string()
+fn resolve_routine_model(stored_model: &str, selected_model: &str) -> String {
+    let stored_model = stored_model.trim();
+    if stored_model.is_empty()
+        || stored_model == "auto"
+        || stored_model == crate::providers::AUTO_GENERATION_MODEL
+    {
+        let selected_model = selected_model.trim();
+        if selected_model.is_empty() || selected_model == "auto" {
+            crate::providers::AUTO_GENERATION_MODEL.to_string()
+        } else {
+            selected_model.to_string()
+        }
     } else {
-        model.to_string()
+        stored_model.to_string()
     }
 }
 
@@ -379,8 +387,8 @@ async fn claim_with_connector_guard(
     let token = Uuid::new_v4().to_string();
     let run_id = Uuid::new_v4().to_string();
     let timestamp = now();
-    let model: String = routine.get("model");
-    let model = normalized_model(&model);
+    let stored_model: String = routine.get("model");
+    let model = resolve_routine_model(&stored_model, &crate::providers::generation_model());
     let safety_mode = AgentSafetyMode::from(routine.get::<String, _>("safety_mode").as_str());
     let metadata = serde_json::from_str::<Value>(&routine.get::<String, _>("metadata_json"))
         .unwrap_or_else(|_| json!({}));
@@ -438,11 +446,28 @@ pub async fn reconcile(pool: &SqlitePool) -> Result<(), AppError> {
     let stale_before = format_time(Utc::now() - Duration::minutes(CLAIM_STALE_AFTER_MINUTES));
     query("UPDATE routine_runs SET status = 'interrupted', completed_at = ?, error_code = 'routine_claim_expired', error_message = 'Routine dispatch did not start before its claim expired.', updated_at = ? WHERE status = 'queued' AND agent_run_id IS NULL AND updated_at < ?")
         .bind(&timestamp).bind(&timestamp).bind(stale_before).execute(pool).await.map_err(app_error)?;
+    release_terminal_claims(pool, &timestamp, None).await
+}
+
+async fn release_terminal_claims(
+    pool: &SqlitePool,
+    timestamp: &str,
+    agent_run_id: Option<&str>,
+) -> Result<(), AppError> {
+    // Routine edits and terminal release both update schedule metadata. Hold a
+    // write reservation across the read/derive/write sequence so a concurrent
+    // edit either lands wholly before this snapshot or wholly after it.
+    let mut transaction = pool
+        .begin_with("BEGIN IMMEDIATE")
+        .await
+        .map_err(app_error)?;
     // A terminal run releases exactly its matching routine claim. Advance the
     // schedule here rather than leaving a past `next_run_at`, which would
     // otherwise immediately re-run a completed routine on the next tick.
-    let terminal = query("SELECT routines.id, routines.schedule, routines.timezone, routines.repeat, routines.metadata_json, routines.state, routines.enabled, routine_runs.claim_token, routine_runs.status, routine_runs.completed_at, routine_runs.error_message FROM routines JOIN routine_runs ON routine_runs.routine_id = routines.id AND routine_runs.claim_token = routines.claim_token WHERE routines.claim_token IS NOT NULL AND routine_runs.status IN ('completed', 'cancelled', 'interrupted', 'failed')")
-        .fetch_all(pool).await.map_err(app_error)?;
+    let terminal = query("SELECT routines.id, routines.schedule, routines.timezone, routines.repeat, routines.metadata_json, routines.state, routines.enabled, routine_runs.claim_token, routine_runs.status, routine_runs.completed_at, routine_runs.error_message FROM routines JOIN routine_runs ON routine_runs.routine_id = routines.id AND routine_runs.claim_token = routines.claim_token WHERE routines.claim_token IS NOT NULL AND routine_runs.status IN ('completed', 'cancelled', 'interrupted', 'failed') AND (? IS NULL OR routine_runs.agent_run_id = ?)")
+        .bind(agent_run_id)
+        .bind(agent_run_id)
+        .fetch_all(&mut *transaction).await.map_err(app_error)?;
     for row in terminal {
         let state: String = row.get("state");
         let enabled = row.get::<i64, _>("enabled") != 0;
@@ -465,15 +490,15 @@ pub async fn reconcile(pool: &SqlitePool) -> Result<(), AppError> {
             .bind(repeat_completed)
             .bind(metadata_json(metadata))
             .bind(row.get::<Option<String>, _>("completed_at"))
-            .bind(&timestamp)
+            .bind(timestamp)
             .bind(if status == "completed" { "ok" } else { "error" })
             .bind(row.get::<Option<String>, _>("error_message"))
-            .bind(&timestamp)
+            .bind(timestamp)
             .bind(row.get::<String, _>("id"))
             .bind(row.get::<String, _>("claim_token"))
-            .execute(pool).await.map_err(app_error)?;
+            .execute(&mut *transaction).await.map_err(app_error)?;
     }
-    Ok(())
+    transaction.commit().await.map_err(app_error)
 }
 
 fn advance_repeat(repeat: &str, metadata: &mut Value) -> bool {
@@ -569,6 +594,23 @@ pub async fn mark_agent_run_resumed(pool: &SqlitePool, agent_run_id: &str) -> Re
     .await
     .map_err(app_error)?;
     Ok(())
+}
+
+pub async fn mark_agent_run_terminal(
+    pool: &SqlitePool,
+    agent_run_id: &str,
+) -> Result<(), AppError> {
+    let timestamp = now();
+    let changed = query("UPDATE routine_runs SET status = (SELECT status FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), completed_at = COALESCE((SELECT completed_at FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), completed_at), error_code = COALESCE((SELECT error_code FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), error_code), error_message = COALESCE((SELECT error_message FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), error_message), updated_at = ? WHERE agent_run_id = ? AND status IN ('running', 'waiting_for_user') AND EXISTS (SELECT 1 FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id AND agent_runs.status IN ('completed', 'cancelled', 'interrupted', 'failed'))")
+        .bind(&timestamp)
+        .bind(agent_run_id)
+        .execute(pool)
+        .await
+        .map_err(app_error)?;
+    if changed.rows_affected() == 0 {
+        return Ok(());
+    }
+    release_terminal_claims(pool, &timestamp, Some(agent_run_id)).await
 }
 
 /// Start the single local scheduler for June-owned routines. Claims are stored
@@ -1497,6 +1539,20 @@ mod tests {
     }
 
     #[test]
+    fn automatic_routine_model_resolves_to_the_selected_generation_model() {
+        for stored_model in ["", "auto", crate::providers::AUTO_GENERATION_MODEL] {
+            assert_eq!(
+                resolve_routine_model(stored_model, "kimi-k2-6"),
+                "kimi-k2-6"
+            );
+        }
+        assert_eq!(
+            resolve_routine_model("explicit-model", "kimi-k2-6"),
+            "explicit-model"
+        );
+    }
+
+    #[test]
     fn scheduled_dispatch_failure_advances_instead_of_reclaiming_the_due_time() {
         let now = Utc.with_ymd_and_hms(2026, 7, 25, 12, 0, 0).unwrap();
         let claim = Claim {
@@ -1741,14 +1797,14 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(claim.model, crate::providers::AUTO_GENERATION_MODEL);
+        assert_eq!(claim.model, crate::providers::generation_model());
         assert_eq!(claim.safety_mode, AgentSafetyMode::Unrestricted);
         let run = list_runs(&pool, Some("routine-1"))
             .await
             .unwrap()
             .pop()
             .unwrap();
-        assert_eq!(run.model, crate::providers::AUTO_GENERATION_MODEL);
+        assert_eq!(run.model, crate::providers::generation_model());
         assert_eq!(run.safety_mode, AgentSafetyMode::Unrestricted);
         let tools = base_unattended_tools().to_string();
         assert!(!tools.contains("computer_use"));
@@ -1789,6 +1845,82 @@ mod tests {
         assert_eq!(run.agent_session_id.as_deref(), Some("session-1"));
         assert_eq!(run.agent_run_id.as_deref(), Some("run-1"));
         assert_eq!(run.status, "running");
+    }
+
+    #[tokio::test]
+    async fn terminal_agent_event_immediately_reconciles_the_routine_run() {
+        let pool = pool().await;
+        create(&pool, create_request("every 1h")).await.unwrap();
+        let claimed = claim(&pool, "routine-1", "manual", false)
+            .await
+            .unwrap()
+            .unwrap();
+        query("INSERT INTO agent_sessions (id) VALUES ('session-terminal')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        query(
+            "INSERT INTO agent_runs
+             (id, status, completed_at, error_code, error_message)
+             VALUES ('run-terminal', 'failed', '2026-07-28T08:00:00.000Z',
+                     'model_not_priced', 'model_not_priced')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        attach_run_mapping(
+            &pool,
+            &claimed.routine_run_id,
+            &claimed.token,
+            "session-terminal",
+            "run-terminal",
+            &now(),
+        )
+        .await
+        .unwrap();
+
+        mark_agent_run_terminal(&pool, "run-terminal")
+            .await
+            .unwrap();
+
+        let run = list_runs(&pool, Some("routine-1")).await.unwrap().remove(0);
+        assert_eq!(run.status, "failed");
+        assert_eq!(run.error_code.as_deref(), Some("model_not_priced"));
+        let routine = get(&pool, "routine-1").await.unwrap();
+        assert_eq!(routine.last_status.as_deref(), Some("error"));
+        assert_eq!(routine.last_error.as_deref(), Some("model_not_priced"));
+        assert!(claim(&pool, "routine-1", "manual", false)
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn non_routine_terminal_event_does_not_release_an_unrelated_routine_claim() {
+        let pool = pool().await;
+        create(&pool, create_request("every 1h")).await.unwrap();
+        let claimed = claim(&pool, "routine-1", "manual", false)
+            .await
+            .unwrap()
+            .unwrap();
+        query("UPDATE routine_runs SET status = 'failed' WHERE id = ?")
+            .bind(&claimed.routine_run_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        query("UPDATE routines SET schedule = 'not a schedule' WHERE id = 'routine-1'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        mark_agent_run_terminal(&pool, "unrelated-agent-run")
+            .await
+            .unwrap();
+
+        assert!(claim(&pool, "routine-1", "manual", false)
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]

--- a/src-tauri/src/routines.rs
+++ b/src-tauri/src/routines.rs
@@ -312,20 +312,23 @@ pub async fn update(
     let mut metadata = request.metadata.unwrap_or(current.metadata);
     let tool_catalog_updated = request.enabled_toolsets.is_some();
     set_enabled_toolsets(&mut metadata, request.enabled_toolsets);
-    query("UPDATE routines SET name = ?, prompt = ?, schedule = ?, timezone = ?, repeat = ?, deliver = ?, model = ?, safety_mode = ?, state = ?, enabled = ?, updated_at = ?, next_run_at = ?, metadata_json = ?, tool_catalog_version = CASE WHEN ? THEN 1 ELSE tool_catalog_version END, claim_token = CASE WHEN ? THEN NULL ELSE claim_token END, claimed_at = CASE WHEN ? THEN NULL ELSE claimed_at END WHERE id = ?")
+    query("UPDATE routines SET name = ?, prompt = ?, schedule = ?, timezone = ?, repeat = ?, deliver = ?, model = ?, safety_mode = ?, state = ?, enabled = ?, updated_at = ?, next_run_at = ?, metadata_json = ?, tool_catalog_version = CASE WHEN ? THEN 1 ELSE tool_catalog_version END WHERE id = ?")
         .bind(request.name.unwrap_or(current.name).trim()).bind(request.prompt.unwrap_or(current.prompt).trim())
         .bind(&schedule).bind(timezone).bind(request.repeat.unwrap_or(current.repeat))
         .bind(request.deliver.unwrap_or(current.deliver)).bind(request.model.unwrap_or(current.model))
         .bind(request.safety_mode.unwrap_or(current.safety_mode).as_db()).bind(&state).bind(enabled).bind(now())
         .bind(next_run_at).bind(metadata_json(metadata)).bind(tool_catalog_updated)
-        .bind(state != "scheduled" || !enabled).bind(state != "scheduled" || !enabled).bind(&routine_id)
+        .bind(&routine_id)
         .execute(&mut *transaction).await.map_err(app_error)?;
     transaction.commit().await.map_err(app_error)?;
     get(pool, &routine_id).await
 }
 
 pub async fn pause(pool: &SqlitePool, id: &str) -> Result<AgentRoutineDto, AppError> {
-    let changed = query("UPDATE routines SET state = 'paused', enabled = 0, next_run_at = NULL, claim_token = NULL, claimed_at = NULL, updated_at = ? WHERE id = ?")
+    // Pausing stops future scheduling but does not cancel a claimed run. Keep
+    // its claim association until terminal projection records status and
+    // repeat progress, then releases the claim transactionally.
+    let changed = query("UPDATE routines SET state = 'paused', enabled = 0, next_run_at = NULL, updated_at = ? WHERE id = ?")
         .bind(now()).bind(id).execute(pool).await.map_err(app_error)?;
     if changed.rows_affected() == 0 {
         return Err(AppError::new("routine_not_found", "Routine was not found."));
@@ -1608,6 +1611,48 @@ mod tests {
         }
     }
 
+    async fn claimed_terminal_run(
+        pool: &SqlitePool,
+        routine_id: &str,
+        session_id: &str,
+        agent_run_id: &str,
+    ) -> Claim {
+        let mut request = create_request("every 1h");
+        request.id = Some(routine_id.to_string());
+        request.legacy_job_id = Some(format!("legacy-{routine_id}"));
+        request.repeat = Some("3".into());
+        create(pool, request).await.unwrap();
+        let claimed = claim(pool, routine_id, "manual", false)
+            .await
+            .unwrap()
+            .unwrap();
+        query("INSERT INTO agent_sessions (id) VALUES (?)")
+            .bind(session_id)
+            .execute(pool)
+            .await
+            .unwrap();
+        query(
+            "INSERT INTO agent_runs
+             (id, status, completed_at)
+             VALUES (?, 'completed', '2026-07-28T08:00:00.000Z')",
+        )
+        .bind(agent_run_id)
+        .execute(pool)
+        .await
+        .unwrap();
+        attach_run_mapping(
+            pool,
+            &claimed.routine_run_id,
+            &claimed.token,
+            session_id,
+            agent_run_id,
+            &now(),
+        )
+        .await
+        .unwrap();
+        claimed
+    }
+
     #[test]
     fn cron_schedule_uses_the_routine_iana_timezone() {
         let summer = Utc.with_ymd_and_hms(2026, 7, 24, 12, 30, 0).unwrap();
@@ -2071,6 +2116,103 @@ mod tests {
             let run = list_runs(&pool, Some(&routine_id)).await.unwrap().remove(0);
             assert_eq!(run.status, "completed");
         }
+    }
+
+    #[tokio::test]
+    async fn pausing_before_terminal_projection_preserves_the_current_run() {
+        let pool = pool().await;
+        let claimed =
+            claimed_terminal_run(&pool, "routine-paused", "session-paused", "run-paused").await;
+
+        pause(&pool, "routine-paused").await.unwrap();
+        let retained_claim: Option<String> =
+            query("SELECT claim_token FROM routines WHERE id = 'routine-paused'")
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+                .get("claim_token");
+        assert_eq!(retained_claim.as_deref(), Some(claimed.token.as_str()));
+        mark_agent_run_terminal(&pool, "run-paused").await.unwrap();
+
+        let routine = get(&pool, "routine-paused").await.unwrap();
+        assert_eq!(routine.state, "paused");
+        assert!(!routine.enabled);
+        assert_eq!(routine.last_status.as_deref(), Some("ok"));
+        assert_eq!(
+            routine.metadata["repeatState"]["completed"].as_u64(),
+            Some(1)
+        );
+        let run = list_runs(&pool, Some("routine-paused"))
+            .await
+            .unwrap()
+            .remove(0);
+        assert_eq!(run.status, "completed");
+        let claim_token: Option<String> =
+            query("SELECT claim_token FROM routines WHERE id = 'routine-paused'")
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+                .get("claim_token");
+        assert_eq!(claim_token, None);
+    }
+
+    #[tokio::test]
+    async fn disabling_by_update_before_terminal_projection_preserves_the_current_run() {
+        let pool = pool().await;
+        let claimed = claimed_terminal_run(
+            &pool,
+            "routine-updated-paused",
+            "session-updated-paused",
+            "run-updated-paused",
+        )
+        .await;
+        update(
+            &pool,
+            UpdateAgentRoutineRequest {
+                routine_id: "routine-updated-paused".into(),
+                name: None,
+                prompt: None,
+                schedule: None,
+                timezone: None,
+                repeat: None,
+                deliver: None,
+                model: None,
+                safety_mode: None,
+                state: Some("paused".into()),
+                enabled: Some(false),
+                metadata: None,
+                enabled_toolsets: None,
+            },
+        )
+        .await
+        .unwrap();
+        let retained_claim: Option<String> =
+            query("SELECT claim_token FROM routines WHERE id = 'routine-updated-paused'")
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+                .get("claim_token");
+        assert_eq!(retained_claim.as_deref(), Some(claimed.token.as_str()));
+
+        mark_agent_run_terminal(&pool, "run-updated-paused")
+            .await
+            .unwrap();
+
+        let routine = get(&pool, "routine-updated-paused").await.unwrap();
+        assert_eq!(routine.state, "paused");
+        assert!(!routine.enabled);
+        assert_eq!(routine.last_status.as_deref(), Some("ok"));
+        assert_eq!(
+            routine.metadata["repeatState"]["completed"].as_u64(),
+            Some(1)
+        );
+        assert_eq!(
+            list_runs(&pool, Some("routine-updated-paused"))
+                .await
+                .unwrap()[0]
+                .status,
+            "completed"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/routines.rs
+++ b/src-tauri/src/routines.rs
@@ -27,6 +27,7 @@ use uuid::Uuid;
 
 const CLAIM_STALE_AFTER_MINUTES: i64 = 10;
 const SCHEDULER_TICK_SECONDS: u64 = 30;
+const ROUTINE_SELECT_BY_ID_SQL: &str = "SELECT id, legacy_job_id, name, prompt, schedule, timezone, repeat, deliver, model, safety_mode, state, enabled, created_at, updated_at, next_run_at, last_run_at, last_status, last_error, last_delivery_error, metadata_json FROM routines WHERE id = ?";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -174,6 +175,8 @@ fn resolve_routine_model(stored_model: &str, selected_model: &str) -> String {
         || stored_model == "auto"
         || stored_model == crate::providers::AUTO_GENERATION_MODEL
     {
+        // `open-software/auto` is itself a supported metered route. The shared
+        // agent proxy adds its cost-quality preference before calling June API.
         let selected_model = selected_model.trim();
         if selected_model.is_empty() || selected_model == "auto" {
             crate::providers::AUTO_GENERATION_MODEL.to_string()
@@ -237,15 +240,51 @@ pub async fn list(pool: &SqlitePool) -> Result<Vec<AgentRoutineDto>, AppError> {
 }
 
 pub async fn get(pool: &SqlitePool, id: &str) -> Result<AgentRoutineDto, AppError> {
-    query("SELECT id, legacy_job_id, name, prompt, schedule, timezone, repeat, deliver, model, safety_mode, state, enabled, created_at, updated_at, next_run_at, last_run_at, last_status, last_error, last_delivery_error, metadata_json FROM routines WHERE id = ?")
-        .bind(id).fetch_one(pool).await.map_err(|error| if matches!(error, sqlx::Error::RowNotFound) { AppError::new("routine_not_found", "Routine was not found.") } else { app_error(error) }).map(routine_from_row)
+    query(ROUTINE_SELECT_BY_ID_SQL)
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .map_err(|error| {
+            if matches!(error, sqlx::Error::RowNotFound) {
+                AppError::new("routine_not_found", "Routine was not found.")
+            } else {
+                app_error(error)
+            }
+        })
+        .map(routine_from_row)
+}
+
+async fn get_in_transaction(
+    transaction: &mut Transaction<'_, Sqlite>,
+    id: &str,
+) -> Result<AgentRoutineDto, AppError> {
+    query(ROUTINE_SELECT_BY_ID_SQL)
+        .bind(id)
+        .fetch_one(&mut **transaction)
+        .await
+        .map_err(|error| {
+            if matches!(error, sqlx::Error::RowNotFound) {
+                AppError::new("routine_not_found", "Routine was not found.")
+            } else {
+                app_error(error)
+            }
+        })
+        .map(routine_from_row)
 }
 
 pub async fn update(
     pool: &SqlitePool,
     request: UpdateAgentRoutineRequest,
 ) -> Result<AgentRoutineDto, AppError> {
-    let current = get(pool, &request.routine_id).await?;
+    // Routine edits derive state and metadata from the stored row. Serialize
+    // that read with terminal claim release so a stale edit cannot overwrite
+    // finite-repeat progress or re-enable a just-completed routine.
+    let mut transaction = pool
+        .begin_with("BEGIN IMMEDIATE")
+        .await
+        .map_err(app_error)?;
+    let current = get_in_transaction(&mut transaction, &request.routine_id).await?;
+    let routine_id = request.routine_id;
     let state = request.state.unwrap_or(current.state);
     validate_state(&state)?;
     let enabled = request.enabled.unwrap_or(current.enabled);
@@ -277,9 +316,10 @@ pub async fn update(
         .bind(request.deliver.unwrap_or(current.deliver)).bind(request.model.unwrap_or(current.model))
         .bind(request.safety_mode.unwrap_or(current.safety_mode).as_db()).bind(&state).bind(enabled).bind(now())
         .bind(next_run_at).bind(metadata_json(metadata)).bind(tool_catalog_updated)
-        .bind(state != "scheduled" || !enabled).bind(state != "scheduled" || !enabled).bind(&request.routine_id)
-        .execute(pool).await.map_err(app_error)?;
-    get(pool, &request.routine_id).await
+        .bind(state != "scheduled" || !enabled).bind(state != "scheduled" || !enabled).bind(&routine_id)
+        .execute(&mut *transaction).await.map_err(app_error)?;
+    transaction.commit().await.map_err(app_error)?;
+    get(pool, &routine_id).await
 }
 
 pub async fn pause(pool: &SqlitePool, id: &str) -> Result<AgentRoutineDto, AppError> {
@@ -292,7 +332,11 @@ pub async fn pause(pool: &SqlitePool, id: &str) -> Result<AgentRoutineDto, AppEr
 }
 
 pub async fn resume(pool: &SqlitePool, id: &str) -> Result<AgentRoutineDto, AppError> {
-    let current = get(pool, id).await?;
+    let mut transaction = pool
+        .begin_with("BEGIN IMMEDIATE")
+        .await
+        .map_err(app_error)?;
+    let current = get_in_transaction(&mut transaction, id).await?;
     if requires_legacy_execution_review(&current.metadata) {
         return Err(AppError::new(
             "routine_legacy_execution_review_required",
@@ -301,7 +345,8 @@ pub async fn resume(pool: &SqlitePool, id: &str) -> Result<AgentRoutineDto, AppE
     }
     let next = next_run_after(&current.schedule, &current.timezone, Utc::now())?.map(format_time);
     query("UPDATE routines SET state = 'scheduled', enabled = 1, next_run_at = ?, updated_at = ? WHERE id = ?")
-        .bind(next).bind(now()).bind(id).execute(pool).await.map_err(app_error)?;
+        .bind(next).bind(now()).bind(id).execute(&mut *transaction).await.map_err(app_error)?;
+    transaction.commit().await.map_err(app_error)?;
     get(pool, id).await
 }
 
@@ -1486,14 +1531,10 @@ fn cron_field(field: &str, value: i32, min: i32, max: i32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sqlx_sqlite::SqlitePoolOptions;
+    use sqlx_sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+    use std::time::Duration as StdDuration;
 
-    async fn pool() -> SqlitePool {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect("sqlite::memory:")
-            .await
-            .unwrap();
+    async fn initialize_pool(pool: &SqlitePool) {
         // The routine migration only needs these parent keys for FK coverage.
         // Running the full runtime migration in memory would also require the
         // retired Hermes tables it deliberately imports from.
@@ -1502,15 +1543,40 @@ mod tests {
             "CREATE TABLE agent_runs (id TEXT PRIMARY KEY, session_id TEXT, status TEXT, updated_at TEXT, completed_at TEXT, interrupted_state_json TEXT, error_code TEXT, error_message TEXT)",
             "CREATE TABLE connector_triggers (id TEXT PRIMARY KEY, job_id TEXT, kind TEXT, account_id TEXT)",
         ] {
-            query(statement).execute(&pool).await.unwrap();
+            query(statement).execute(pool).await.unwrap();
         }
         for statement in include_str!("../migrations/026_routines.sql")
             .split(';')
             .filter(|statement| !statement.trim().is_empty())
         {
-            query(statement).execute(&pool).await.unwrap();
+            query(statement).execute(pool).await.unwrap();
         }
+    }
+
+    async fn pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        initialize_pool(&pool).await;
         pool
+    }
+
+    async fn concurrent_pool() -> (tempfile::TempDir, SqlitePool) {
+        let directory = tempfile::tempdir().expect("temporary routine database directory");
+        let options = SqliteConnectOptions::new()
+            .filename(directory.path().join("routine-concurrency.sqlite3"))
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(StdDuration::from_secs(2));
+        let pool = SqlitePoolOptions::new()
+            .max_connections(2)
+            .connect_with(options)
+            .await
+            .expect("file-backed routine sqlite");
+        initialize_pool(&pool).await;
+        (directory, pool)
     }
     fn create_request(schedule: &str) -> CreateAgentRoutineRequest {
         CreateAgentRoutineRequest {
@@ -1570,6 +1636,10 @@ mod tests {
         assert_eq!(
             resolve_routine_model("explicit-model", "kimi-k2-6"),
             "explicit-model"
+        );
+        assert_eq!(
+            resolve_routine_model("auto", crate::providers::AUTO_GENERATION_MODEL),
+            crate::providers::AUTO_GENERATION_MODEL
         );
     }
 
@@ -1914,6 +1984,82 @@ mod tests {
             .await
             .unwrap()
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn concurrent_edit_cannot_resurrect_a_completed_finite_repeat() {
+        let (_directory, pool) = concurrent_pool().await;
+        for iteration in 0..12 {
+            let routine_id = format!("routine-concurrent-{iteration}");
+            let session_id = format!("session-concurrent-{iteration}");
+            let agent_run_id = format!("run-concurrent-{iteration}");
+            let mut request = create_request("every 1h");
+            request.id = Some(routine_id.clone());
+            request.legacy_job_id = Some(format!("legacy-concurrent-{iteration}"));
+            request.repeat = Some("once".into());
+            create(&pool, request).await.unwrap();
+            let claimed = claim(&pool, &routine_id, "manual", false)
+                .await
+                .unwrap()
+                .unwrap();
+            query("INSERT INTO agent_sessions (id) VALUES (?)")
+                .bind(&session_id)
+                .execute(&pool)
+                .await
+                .unwrap();
+            query(
+                "INSERT INTO agent_runs
+                 (id, status, completed_at)
+                 VALUES (?, 'completed', '2026-07-28T08:00:00.000Z')",
+            )
+            .bind(&agent_run_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+            attach_run_mapping(
+                &pool,
+                &claimed.routine_run_id,
+                &claimed.token,
+                &session_id,
+                &agent_run_id,
+                &now(),
+            )
+            .await
+            .unwrap();
+
+            let edit = UpdateAgentRoutineRequest {
+                routine_id: routine_id.clone(),
+                name: Some(format!("Edited routine {iteration}")),
+                prompt: None,
+                schedule: None,
+                timezone: None,
+                repeat: None,
+                deliver: None,
+                model: None,
+                safety_mode: None,
+                state: None,
+                enabled: None,
+                metadata: None,
+                enabled_toolsets: None,
+            };
+            let (edit_result, terminal_result) = tokio::join!(
+                update(&pool, edit),
+                mark_agent_run_terminal(&pool, &agent_run_id)
+            );
+            edit_result.unwrap();
+            terminal_result.unwrap();
+
+            let routine = get(&pool, &routine_id).await.unwrap();
+            assert_eq!(routine.state, "completed");
+            assert!(!routine.enabled);
+            assert_eq!(
+                routine.metadata["repeatState"]["completed"].as_u64(),
+                Some(1)
+            );
+            assert_eq!(routine.last_status.as_deref(), Some("ok"));
+            let run = list_runs(&pool, Some(&routine_id)).await.unwrap().remove(0);
+            assert_eq!(run.status, "completed");
+        }
     }
 
     #[tokio::test]

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -141,6 +141,7 @@ export function RoutinesView({
   const [runsUnavailableState, setRunsUnavailable] = useState(false);
   const routineLoadSequenceRef = useRef(0);
   const visibleRoutineLoadSequenceRef = useRef(0);
+  const visibleRoutineLoadsInFlightRef = useRef(0);
   const runLoadSequenceRef = useRef(0);
   // Run ids already reported for crediting this mount; the local store is the
   // durable idempotent ledger, this just avoids re-reporting on every refresh.
@@ -158,12 +159,16 @@ export function RoutinesView({
   // `refreshing` covers every fetch so reloads keep the list visible while
   // still signalling progress on the refresh control.
   const loadRoutines = useCallback(async (options: { silent?: boolean } = {}) => {
+    const silent = options.silent ?? false;
+    // A timer or terminal event is best-effort. Let an initial, manual, or
+    // mutation-triggered load retain foreground result and error semantics.
+    if (silent && visibleRoutineLoadsInFlightRef.current > 0) return null;
     const sequence = routineLoadSequenceRef.current + 1;
     routineLoadSequenceRef.current = sequence;
-    const silent = options.silent ?? false;
     const visibleSequence = silent ? null : visibleRoutineLoadSequenceRef.current + 1;
     if (visibleSequence !== null) {
       visibleRoutineLoadSequenceRef.current = visibleSequence;
+      visibleRoutineLoadsInFlightRef.current += 1;
       setRefreshing(true);
     }
     try {
@@ -181,8 +186,14 @@ export function RoutinesView({
       return message;
     } finally {
       if (routineLoadSequenceRef.current === sequence) setLoading(false);
-      if (visibleSequence !== null && visibleRoutineLoadSequenceRef.current === visibleSequence) {
-        setRefreshing(false);
+      if (visibleSequence !== null) {
+        visibleRoutineLoadsInFlightRef.current = Math.max(
+          0,
+          visibleRoutineLoadsInFlightRef.current - 1,
+        );
+        if (visibleRoutineLoadSequenceRef.current === visibleSequence) {
+          setRefreshing(false);
+        }
       }
     }
   }, []);

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -1,3 +1,4 @@
+import { listen } from "@tauri-apps/api/event";
 import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
 import { IconArrowUp } from "central-icons/IconArrowUp";
 import { IconCalendarRepeat } from "central-icons/IconCalendarRepeat";
@@ -15,6 +16,7 @@ import { IconZap } from "central-icons/IconZap";
 import { IconPause } from "central-icons/IconPause";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { messageFromError } from "../../lib/errors";
+import type { AgentRuntimeEvent } from "../../lib/agent-runtime-contract";
 import {
   TRUST_MODE_META,
   eventTriggerScheduleDraft,
@@ -63,6 +65,8 @@ import { ROUTINE_TEMPLATES, type RoutineTemplate } from "./routine-templates";
 const NO_ROUTINES: RoutineJob[] = [];
 const NO_RUNS: RoutineRunSession[] = [];
 const RUN_HISTORY_REFRESH_MS = 10000;
+// Must match the native event name in src-tauri/src/agent_runtime/host.rs.
+const AGENT_RUNTIME_EVENT = "june://agent-runtime-event";
 
 /**
  * Advances the earned-autonomy counter by reporting each finished run to the
@@ -135,6 +139,8 @@ export function RoutinesView({
   const [describeUnrestricted, setDescribeUnrestricted] = useState(false);
   const [allRuns, setRuns] = useState<RoutineRunSession[]>([]);
   const [runsUnavailableState, setRunsUnavailable] = useState(false);
+  const routineLoadSequenceRef = useRef(0);
+  const visibleRoutineLoadSequenceRef = useRef(0);
   const runLoadSequenceRef = useRef(0);
   // Run ids already reported for crediting this mount; the local store is the
   // durable idempotent ledger, this just avoids re-reporting on every refresh.
@@ -151,22 +157,33 @@ export function RoutinesView({
   // `loading` gates the whole list and only covers the first fetch;
   // `refreshing` covers every fetch so reloads keep the list visible while
   // still signalling progress on the refresh control.
-  const loadRoutines = useCallback(async () => {
-    setRefreshing(true);
+  const loadRoutines = useCallback(async (options: { silent?: boolean } = {}) => {
+    const sequence = routineLoadSequenceRef.current + 1;
+    routineLoadSequenceRef.current = sequence;
+    const silent = options.silent ?? false;
+    const visibleSequence = silent ? null : visibleRoutineLoadSequenceRef.current + 1;
+    if (visibleSequence !== null) {
+      visibleRoutineLoadSequenceRef.current = visibleSequence;
+      setRefreshing(true);
+    }
     try {
       const jobs = await listRoutines();
+      if (routineLoadSequenceRef.current !== sequence) return null;
       setRoutines(sortRoutines(jobs));
       setError(null);
       setErrorRetryable(false);
       return null;
     } catch (err) {
       const message = describeRoutineError(err);
+      if (routineLoadSequenceRef.current !== sequence || silent) return message;
       setError(message);
       setErrorRetryable(true);
       return message;
     } finally {
-      setLoading(false);
-      setRefreshing(false);
+      if (routineLoadSequenceRef.current === sequence) setLoading(false);
+      if (visibleSequence !== null && visibleRoutineLoadSequenceRef.current === visibleSequence) {
+        setRefreshing(false);
+      }
     }
   }, []);
 
@@ -192,16 +209,46 @@ export function RoutinesView({
     () => Promise.all([loadRoutines(), loadRuns()]),
     [loadRoutines, loadRuns],
   );
+  const refreshSilently = useCallback(
+    () => Promise.all([loadRoutines({ silent: true }), loadRuns()]),
+    [loadRoutines, loadRuns],
+  );
 
   useEffect(() => {
     void refresh();
   }, [refresh]);
 
   useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    void listen<AgentRuntimeEvent>(AGENT_RUNTIME_EVENT, ({ payload }) => {
+      if (
+        payload.method !== "run.completed" &&
+        payload.method !== "run.cancelled" &&
+        payload.method !== "run.failed"
+      ) {
+        return;
+      }
+      // The native runtime projects terminal agent state into both the
+      // routine and session stores before emitting this event. Refresh both
+      // projections now so an open detail page cannot keep showing the
+      // previous run's failure until the user navigates away.
+      void refreshSilently();
+    }).then((dispose) => {
+      if (disposed) dispose();
+      else unlisten = dispose;
+    });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [refreshSilently]);
+
+  useEffect(() => {
     if (forcedEmpty) return;
-    const timer = window.setInterval(() => void loadRuns(), RUN_HISTORY_REFRESH_MS);
+    const timer = window.setInterval(() => void refreshSilently(), RUN_HISTORY_REFRESH_MS);
     return () => window.clearInterval(timer);
-  }, [forcedEmpty, loadRuns]);
+  }, [forcedEmpty, refreshSilently]);
 
   const filtered = useMemo(() => {
     const normalized = query.trim().toLowerCase();

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -234,10 +234,15 @@ export function RoutinesView({
       // projections now so an open detail page cannot keep showing the
       // previous run's failure until the user navigates away.
       void refreshSilently();
-    }).then((dispose) => {
-      if (disposed) dispose();
-      else unlisten = dispose;
-    });
+    })
+      .then((dispose) => {
+        if (disposed) dispose();
+        else unlisten = dispose;
+      })
+      .catch(() => {
+        // The periodic refresh remains the fallback when event registration is
+        // unavailable, including outside a native Tauri event environment.
+      });
     return () => {
       disposed = true;
       unlisten?.();

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -1340,30 +1340,27 @@ describe("RoutinesView run history", () => {
     expect(screen.queryByText("Last run failed")).toBeNull();
   });
 
-  it("ignores stale routine responses after a newer background refresh", async () => {
+  it("does not let a background refresh supersede a visible load", async () => {
     vi.useFakeTimers();
     let resolveFirstLoad: (routines: RoutineJob[]) => void = () => {};
-    mocks.listRoutines
-      .mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolveFirstLoad = resolve;
-        }),
-      )
-      .mockResolvedValueOnce([job({ name: "Fresh routine" })]);
+    mocks.listRoutines.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFirstLoad = resolve;
+      }),
+    );
     renderView();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10000);
     });
-    expect(screen.getByText("Fresh routine")).toBeInTheDocument();
+    expect(mocks.listRoutines).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      resolveFirstLoad([job({ name: "Stale routine" })]);
+      resolveFirstLoad([job({ name: "Visible routine" })]);
       await Promise.resolve();
     });
 
-    expect(screen.getByText("Fresh routine")).toBeInTheDocument();
-    expect(screen.queryByText("Stale routine")).toBeNull();
+    expect(screen.getByText("Visible routine")).toBeInTheDocument();
   });
 
   it("keeps usable routine data when a background refresh fails", async () => {

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -1316,6 +1316,30 @@ describe("RoutinesView run history", () => {
     expect(screen.queryByText("Last run failed")).toBeNull();
   });
 
+  it("keeps polling when terminal event listener registration fails", async () => {
+    vi.useFakeTimers();
+    eventMocks.listen.mockRejectedValueOnce(new Error("event listener unavailable"));
+    mocks.listRoutines
+      .mockResolvedValueOnce([job({ last_status: "error" })])
+      .mockResolvedValueOnce([job({ last_status: "ok" })]);
+    adapterMocks.listScheduledRunSessions
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([run({ active: true, preview: "" })]);
+    renderView();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByText("Last run failed")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.queryByText("Last run failed")).toBeNull();
+  });
+
   it("ignores stale routine responses after a newer background refresh", async () => {
     vi.useFakeTimers();
     let resolveFirstLoad: (routines: RoutineJob[]) => void = () => {};

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -1054,6 +1054,51 @@ describe("RoutinesView detail", () => {
     expect(screen.getByRole("button", { name: "Queued" })).toBeDisabled();
   });
 
+  it("refreshes the open routine when an agent run finishes", async () => {
+    mocks.listRoutines
+      .mockResolvedValueOnce([
+        job({
+          last_status: "error",
+          last_error: "The previous run failed.",
+        }),
+      ])
+      .mockResolvedValueOnce([
+        job({
+          last_run_at: "2026-06-10T09:00:30Z",
+          last_status: "ok",
+          last_error: null,
+        }),
+      ]);
+    renderView();
+    await openDetail("Morning summary");
+
+    expect(screen.getByText("Last run failed.")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(eventMocks.listen).toHaveBeenCalledWith(
+        "june://agent-runtime-event",
+        expect.any(Function),
+      ),
+    );
+    const runtimeListener = eventMocks.listen.mock.calls.find(
+      ([eventName]) => eventName === "june://agent-runtime-event",
+    )?.[1] as ((event: { payload: { method: string } }) => void) | undefined;
+    expect(runtimeListener).toBeDefined();
+
+    await act(async () => {
+      runtimeListener?.({ payload: { method: "run.started" } });
+      await Promise.resolve();
+    });
+    expect(mocks.listRoutines).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      runtimeListener?.({ payload: { method: "run.completed" } });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.queryByText("Last run failed.")).toBeNull());
+    expect(mocks.listRoutines).toHaveBeenCalledTimes(2);
+  });
+
   it("disables run now with the funding explanation while credits are depleted", async () => {
     mocks.listRoutines.mockResolvedValue([job()]);
     renderView({ creditActionsDisabledReason: "Add credits before running a routine." });
@@ -1246,9 +1291,11 @@ describe("RoutinesView run history", () => {
     expect(within(history).getByText("Running now")).toBeInTheDocument();
   });
 
-  it("refreshes run history while the routines view stays open", async () => {
+  it("refreshes run history and routine status while the view stays open", async () => {
     vi.useFakeTimers();
-    mocks.listRoutines.mockResolvedValue([job()]);
+    mocks.listRoutines
+      .mockResolvedValueOnce([job({ last_status: "error" })])
+      .mockResolvedValueOnce([job({ last_status: "ok" })]);
     adapterMocks.listScheduledRunSessions
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([run({ active: true, preview: "" })]);
@@ -1259,12 +1306,59 @@ describe("RoutinesView run history", () => {
     });
     const history = screen.getByRole("region", { name: "Run history" });
     expect(within(history).getByText(/No runs yet/)).toBeInTheDocument();
+    expect(screen.getByText("Last run failed")).toBeInTheDocument();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10000);
     });
 
     expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.queryByText("Last run failed")).toBeNull();
+  });
+
+  it("ignores stale routine responses after a newer background refresh", async () => {
+    vi.useFakeTimers();
+    let resolveFirstLoad: (routines: RoutineJob[]) => void = () => {};
+    mocks.listRoutines
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirstLoad = resolve;
+        }),
+      )
+      .mockResolvedValueOnce([job({ name: "Fresh routine" })]);
+    renderView();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+    expect(screen.getByText("Fresh routine")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFirstLoad([job({ name: "Stale routine" })]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Fresh routine")).toBeInTheDocument();
+    expect(screen.queryByText("Stale routine")).toBeNull();
+  });
+
+  it("keeps usable routine data when a background refresh fails", async () => {
+    vi.useFakeTimers();
+    mocks.listRoutines
+      .mockResolvedValueOnce([job()])
+      .mockRejectedValueOnce(new Error("temporary refresh failure"));
+    renderView();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByText("Morning summary")).toBeInTheDocument();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+
+    expect(screen.getByText("Morning summary")).toBeInTheDocument();
+    expect(screen.queryByText("temporary refresh failure")).toBeNull();
   });
 
   it("ignores stale run history responses after a newer refresh", async () => {


### PR DESCRIPTION
## Summary

- Resolve automatic routine models to the current concrete generation model when a run is claimed, while preserving explicitly selected models.
- Project terminal agent events into the matching routine run immediately and release only that run's claim, with transactional protection against concurrent routine edits.
- Refresh routine details and history on terminal events, retain a 10-second fallback, and ignore stale or failed background refreshes.

## Root cause

Routine runs snapshotted the canonical `open-software/auto` alias instead of the concrete generation model selected by June. June API billing therefore rejected those runs with `model_not_priced`. Terminal agent state was also not projected immediately into `routine_runs`, and the Routines view refreshed session history without re-reading routine status, so an open detail page could continue showing an older failure after a later run completed.

## Validation

- Live Computer Use QA against the bundled debug app: an ordinary session and a manual routine run both completed with Kimi K2.6; the routine produced its web-search response and both `agent_runs` and `routine_runs` recorded `completed`.
- `pnpm agent-runtime:typecheck`
- `pnpm agent-runtime:test` (51 passed)
- `pnpm agent-runtime:build`
- `cargo test --manifest-path src-tauri/Cargo.toml routines::tests` (20 passed)
- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/test/routines-view.test.tsx` (61 passed)
- `pnpm typecheck`
- Independent backend and frontend reviewer-pane passes found no remaining correctness or race defects.

- [x] Tested visually where it matters. The Run now queued state, completed response, concrete model, run history, and status refresh were inspected in the bundled debug app; this PR does not change visual styling.
- [ ] Needs a June API (backend) deploy before it works end to end. No June API deploy is required; these are desktop runtime and frontend changes.

## Out of scope

- Changing existing routine schedules or their stored timezones.
- Redesigning routine trust, connector permissions, or delivery behavior.
- June API contract or deployment changes.

## Followups

- Make routine timezone behavior visible in the UI and decide whether newly created cron routines should default to the device's IANA timezone instead of UTC.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. No security boundary or permission behavior changed.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow files changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such files changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No June API files changed.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787830104&installation_model_id=425925&pr_number=999&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F999&signature=183f0202f7a76f4216b943ad840b5913310373f935da90b1fcc05a7f9cf3c7f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->