### PR TITLE
Fix horizontal overflow in sidebar dropdown menus

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -10303,11 +10303,14 @@ button.agent-user-attachment:hover {
 .sidebar-context-menu {
   --scroll-fade-size: var(--sp-6);
 
+  padding-inline: 0;
   max-height: calc(100vh - var(--sp-6));
   overflow: hidden;
 }
 
 .sidebar-context-menu-scroll {
+  /* Full-bleed separators expand into this padding without widening the scrollport. */
+  padding-inline: var(--sp-1);
   max-height: calc(100vh - var(--sp-6) - 2 * var(--sp-1) - 2 * var(--border-width));
   overflow-y: auto;
 }

--- a/src/test/sidebar-overflow.test.ts
+++ b/src/test/sidebar-overflow.test.ts
@@ -11,8 +11,15 @@ function cssRuleFor(selector: string) {
   const match = new RegExp(`(?:^|\\n)${escaped}\\s*\\{`).exec(appCss);
   if (!match) throw new Error(`Missing CSS rule for ${selector}`);
   const openIndex = match.index + match[0].length - 1;
-  const closeIndex = appCss.indexOf("}", openIndex);
-  return appCss.slice(openIndex + 1, closeIndex);
+  let depth = 0;
+  for (let index = openIndex; index < appCss.length; index += 1) {
+    if (appCss[index] === "{") depth += 1;
+    if (appCss[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return appCss.slice(openIndex + 1, index);
+    }
+  }
+  throw new Error(`Unclosed CSS rule for ${selector}`);
 }
 
 describe("sidebar overflow containment", () => {

--- a/src/test/sidebar-overflow.test.ts
+++ b/src/test/sidebar-overflow.test.ts
@@ -4,8 +4,28 @@ import {
   sidebarContextMenuAnchorIsVisible,
   sidebarContextMenuGeometryFromStyles,
 } from "../components/sidebar/sidebar-context-menu";
+import appCss from "../styles/app.css?raw";
+
+function cssRuleFor(selector: string) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`(?:^|\\n)${escaped}\\s*\\{`).exec(appCss);
+  if (!match) throw new Error(`Missing CSS rule for ${selector}`);
+  const openIndex = match.index + match[0].length - 1;
+  const closeIndex = appCss.indexOf("}", openIndex);
+  return appCss.slice(openIndex + 1, closeIndex);
+}
+
 describe("sidebar overflow containment", () => {
   const menuGeometry = { viewportInset: 8, anchorGap: 4 };
+
+  it("keeps full-bleed dividers inside the vertical menu scrollport", () => {
+    expect(cssRuleFor(".sidebar-context-menu")).toContain("padding-inline: 0;");
+    expect(cssRuleFor(".sidebar-context-menu-scroll")).toContain("padding-inline: var(--sp-1);");
+    expect(cssRuleFor(".sidebar-context-menu-scroll")).toContain("overflow-y: auto;");
+    expect(cssRuleFor(".context-menu-separator")).toContain(
+      "margin: var(--sp-1) calc(var(--sp-1) * -1);",
+    );
+  });
 
   it("keeps a menu below its trigger when it fits", () => {
     expect(


### PR DESCRIPTION
## Summary

- Move the sidebar context menu's inline gutter into its vertical scrollport so full-bleed separators no longer create horizontal overflow.
- Add a CSS contract regression test that keeps the popover padding, scrollport padding, separator bleed, and vertical overflow behavior coupled.
- Fix [JUN-457](https://app.opensoftware.co/june/issues/JUN-457).

## Root cause

The scrollable menu introduced an inner element with `overflow-y: auto`, while the existing full-bleed separator retained negative inline margins. Because the inner scrollport had no matching inline padding, the separator extended beyond its scroll width. The browser then computed horizontal overflow as scrollable too, producing the unwanted scrollbar.

## Validation

- `make check typecheck test-web`
- 150 frontend test files and 1,608 tests passed.
- Verified the real session menu in light and dark themes: the scrollport's client and scroll widths match and the divider remains full-bleed.
- Verified a constrained-height menu still scrolls vertically and updates the shared top and bottom scroll fades without horizontal overflow.
- Reviewed in the attached Herdr reviewer pane; no actionable findings remain.

- [x] Tested visually where it matters. Screenshots were captured during local verification.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is required; this is CSS and frontend-test only.

## Out of scope

- Changes to menu actions, positioning, anchoring, or dismissal behavior.
- June API or native-shell changes.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. None are present.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow files changed.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. No such files changed.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. No backend files changed.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787836658&installation_model_id=425925&pr_number=1002&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1002&signature=e9624470371452964024ad5ca48bc0977cb567705b9f6e933c28d3bf869e49e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->