### PR TITLE
test(frontend): stabilize signoff synchronization

### DIFF
--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -1,6 +1,9 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+// This suite verifies native meeting event orchestration, not workspace chunk loading.
+// Preload the lazy editor module so transform latency cannot consume assertion timeouts.
+import "../components/note-editor/NoteEditor";
 import { App } from "../app/App";
 import {
   AGENT_RECORDER_REQUEST_EVENT,
@@ -341,7 +344,7 @@ describe("meeting start transcription event", () => {
     }));
   });
 
-  async function fireMeetingStart(expired = false, waitForAcknowledgement = false) {
+  async function fireMeetingStart(expired = false) {
     mocks.pendingMeetingStartRequest = {
       requestId: "meeting-request-1",
       noteId: "note-2",
@@ -352,11 +355,6 @@ describe("meeting start transcription event", () => {
       await mocks.listeners.get(MEETING_START_TRANSCRIPTION_EVENT)?.({
         payload: undefined,
       });
-      if (waitForAcknowledgement) {
-        await vi.waitFor(() =>
-          expect(mocks.acknowledgeMeetingStartRequest).toHaveBeenCalledWith("meeting-request-1"),
-        );
-      }
     });
   }
 
@@ -378,11 +376,14 @@ describe("meeting start transcription event", () => {
     await waitFor(() => expect(mocks.listeners.has(MEETING_START_TRANSCRIPTION_EVENT)).toBe(true));
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
 
-    await fireMeetingStart(false, true);
-    expect(mocks.startMeetingRecording).toHaveBeenCalledWith(
-      "meeting-request-1",
-      "microphonePlusSystem",
-    );
+    await fireMeetingStart();
+    await waitFor(() => {
+      expect(mocks.startMeetingRecording).toHaveBeenCalledWith(
+        "meeting-request-1",
+        "microphonePlusSystem",
+      );
+      expect(mocks.acknowledgeMeetingStartRequest).toHaveBeenCalledWith("meeting-request-1");
+    });
     expect(mocks.playRecordingSound).toHaveBeenCalledWith("start");
     expect(await screen.findByLabelText("Note title")).toHaveValue("New meeting");
   });

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -379,8 +379,8 @@ describe("meeting start transcription event", () => {
         "meeting-request-1",
         "microphonePlusSystem",
       );
+      expect(mocks.acknowledgeMeetingStartRequest).toHaveBeenCalledWith("meeting-request-1");
     });
-    expect(mocks.acknowledgeMeetingStartRequest).toHaveBeenCalledWith("meeting-request-1");
     expect(mocks.playRecordingSound).toHaveBeenCalledWith("start");
     expect(await screen.findByLabelText("Note title")).toHaveValue("New meeting");
   });

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -341,7 +341,7 @@ describe("meeting start transcription event", () => {
     }));
   });
 
-  async function fireMeetingStart(expired = false) {
+  async function fireMeetingStart(expired = false, waitForAcknowledgement = false) {
     mocks.pendingMeetingStartRequest = {
       requestId: "meeting-request-1",
       noteId: "note-2",
@@ -352,6 +352,11 @@ describe("meeting start transcription event", () => {
       await mocks.listeners.get(MEETING_START_TRANSCRIPTION_EVENT)?.({
         payload: undefined,
       });
+      if (waitForAcknowledgement) {
+        await vi.waitFor(() =>
+          expect(mocks.acknowledgeMeetingStartRequest).toHaveBeenCalledWith("meeting-request-1"),
+        );
+      }
     });
   }
 
@@ -373,14 +378,11 @@ describe("meeting start transcription event", () => {
     await waitFor(() => expect(mocks.listeners.has(MEETING_START_TRANSCRIPTION_EVENT)).toBe(true));
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
 
-    await fireMeetingStart();
-    await waitFor(() => {
-      expect(mocks.startMeetingRecording).toHaveBeenCalledWith(
-        "meeting-request-1",
-        "microphonePlusSystem",
-      );
-      expect(mocks.acknowledgeMeetingStartRequest).toHaveBeenCalledWith("meeting-request-1");
-    });
+    await fireMeetingStart(false, true);
+    expect(mocks.startMeetingRecording).toHaveBeenCalledWith(
+      "meeting-request-1",
+      "microphonePlusSystem",
+    );
     expect(mocks.playRecordingSound).toHaveBeenCalledWith("start");
     expect(await screen.findByLabelText("Note title")).toHaveValue("New meeting");
   });

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Editor } from "@tiptap/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { NoteEditor } from "../components/note-editor/NoteEditor";
@@ -1102,14 +1103,12 @@ describe("NoteEditor", () => {
         })}
       />,
     );
-    const manualText = editor.querySelector("p")?.firstChild;
-    if (!manualText) throw new Error("Expected the focused manual note text");
-    const caret = document.createRange();
-    caret.setStart(manualText, manualText.textContent?.length ?? 0);
-    caret.collapse(true);
-    window.getSelection()?.removeAllRanges();
-    window.getSelection()?.addRange(caret);
-    await user.type(editor, " written live", { skipClick: true });
+    // Move ProseMirror's state selection, not only the DOM range. In jsdom,
+    // installing a browser Range does not update the editor transaction.
+    const tiptapEditor = (editor as HTMLElement & { editor?: Editor }).editor;
+    if (!tiptapEditor) throw new Error("Expected the mounted Tiptap editor");
+    tiptapEditor.commands.focus("end");
+    await user.keyboard(" written live");
     fireEvent.blur(editor);
 
     expect(onContentChange).toHaveBeenLastCalledWith(


### PR DESCRIPTION
## Summary

- Preload the lazy note-editor workspace in the meeting-event suite so chunk transform latency cannot consume UI assertion timeouts.
- Wait for the retained meeting-start request to reach terminal acknowledgement before checking the resulting note.
- Move the Tiptap/ProseMirror selection through the mounted editor before typing, rather than installing a disconnected DOM range.

## Root cause

The meeting-start test mixed two concerns: native event orchestration and lazy workspace loading. Under full-suite load, transforming the note-editor chunk could exceed the query timeout even after recording startup had completed. The test also observed the start command invocation before the retained request reached terminal acknowledgement.

The note-editor test changed `window.getSelection()`, but ProseMirror owns a separate transactional selection. The simulated input therefore used ProseMirror's stale offset at the start of the document, producing `written liveManual notes` even though the DOM range appeared to be at the end.

## Validation

- Five consecutive focused runs of each repaired scenario passed.
- Both complete touched test files passed: 72/72 tests.
- `pnpm typecheck` passed.
- `pnpm check` passed with the existing warning baseline.
- Stressed full frontend run passed while typecheck and Biome ran concurrently: 1,611/1,611 tests.
- `make local-ci` passed on the clean pushed commit and posted `signoff/frontend` plus the not-applicable `signoff/rust-macos` status. The first attempt hit an unrelated load-sensitive `app-shortcut.test.tsx` lazy-workspace timeout; that test passed immediately in isolation and the complete retry passed.
- Standard review battery passed: Standards, Spec, and Adversarial all approved with no remaining findings.

- [ ] Tested visually where it matters. Not applicable: test-only synchronization changes with no product UI behavior change.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend change.

## Out of scope

- Product behavior and production workspace-loading behavior.
- Unrelated lazy-workspace timing in `app-shortcut.test.tsx`.
- Timeout increases or weaker behavioral assertions.

## Followups

None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [ ] Security-sensitive changes were called out in the summary. Not applicable.
- [ ] Workflow action references are pinned to full-length commit SHAs. Not applicable.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions. No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787837405&installation_model_id=425925&pr_number=1003&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1003&signature=1b09079522624b85a7762a58280c9824d68da3399767d7ea09c0d498d2ed339d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->