### PR TITLE
Build and verify unsigned Windows installers locally

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -322,78 +322,16 @@ jobs:
           restore-keys: |
             tauri-cargo-target-${{ runner.os }}-
 
-      - name: Build and smoke test agent runtime
+      - name: Build and verify unsigned Windows installer
         shell: pwsh
-        run: |
-          pnpm agent-runtime:build
-          node scripts/build-agent-runtime.mjs
-          if ($LASTEXITCODE -ne 0) {
-            throw "Agent runtime SEA build failed."
-          }
-          $runtime = Get-Item ".tauri-agent-runtime/june-agent-runtime.exe" -ErrorAction Stop
-          $digest = (Get-FileHash -Algorithm SHA256 $runtime.FullName).Hash.ToLowerInvariant()
-          $expected = (Get-Content -Raw "$($runtime.FullName).sha256").Trim()
-          if ($digest -ne $expected) {
-            throw "Agent runtime checksum does not match."
-          }
-          $smokeDir = Join-Path $env:RUNNER_TEMP "June agent runtime smoke"
-          New-Item -ItemType Directory -Force -Path $smokeDir | Out-Null
-          $smokeRuntime = Join-Path $smokeDir "june-agent-runtime.exe"
-          Copy-Item -LiteralPath $runtime.FullName -Destination $smokeRuntime -Force
-          node scripts/build-agent-runtime.mjs --smoke $smokeRuntime
-          if ($LASTEXITCODE -ne 0) {
-            throw "Agent runtime path-with-spaces smoke test failed."
-          }
-
-      - name: Tauri Windows bundle
-        env:
-          JUNE_AGENT_RUNTIME_PREBUILT: "1"
-        run: node scripts/tauri-build.mjs --debug --no-sign
-
-      - name: Verify Windows bundle
-        shell: pwsh
-        run: |
-          $exe = Get-Item "src-tauri/target/debug/os-june.exe" -ErrorAction Stop
-          if ($exe.Length -le 0) {
-            throw "Windows app executable is empty."
-          }
-
-          $setup = Get-ChildItem "src-tauri/target/debug/bundle/nsis" -Filter "*-setup.exe" | Select-Object -First 1
-          if ($null -eq $setup) {
-            throw "NSIS setup.exe was not produced."
-          }
-          if ($setup.Length -le 0) {
-            throw "NSIS setup.exe is empty."
-          }
-
-          $sevenZip = "${env:ProgramFiles}\7-Zip\7z.exe"
-          if (!(Test-Path $sevenZip)) {
-            throw "7-Zip was not installed at $sevenZip."
-          }
-          $listing = & $sevenZip l $setup.FullName
-          if ($LASTEXITCODE -ne 0) {
-            throw "Could not inspect NSIS installer payload."
-          }
-          if (($listing | Measure-Object).Count -le 0) {
-            throw "NSIS installer payload listing is empty."
-          }
-          $listingText = ($listing -join "`n").Replace("\", "/")
-          foreach ($expected in @("native/bin/june-agent-runtime.exe", "native/bin/june-agent-runtime.exe.sha256")) {
-            if ($listingText -notmatch [regex]::Escape($expected)) {
-              throw "NSIS installer payload does not include agent runtime file $expected."
-            }
-          }
-          foreach ($forbidden in @("native/hermes", "python.exe", ".pyd", "hermes-agent")) {
-            if ($listingText -match [regex]::Escape($forbidden)) {
-              throw "NSIS installer payload still includes forbidden Hermes or Python content: $forbidden."
-            }
-          }
+        run: ./scripts/build-windows.ps1
 
       - name: Upload Windows installer
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: june-windows-debug-nsis
-          path: src-tauri/target/debug/bundle/nsis/*-setup.exe
+          name: june-windows-unsigned-release-nsis
+          path: artifacts/windows-unsigned/*-setup.exe
+          if-no-files-found: error
 
 # Coverage reruns of these suites live in coverage.yml (manual-only). They
 # duplicated this workflow's jobs on a macOS runner for every push and PR

--- a/.github/workflows/production-desktop-windows.yml
+++ b/.github/workflows/production-desktop-windows.yml
@@ -285,10 +285,9 @@ jobs:
             throw "Could not inspect NSIS installer payload."
           }
           $listingText = ($listing -join "`n").Replace("\", "/")
-          foreach ($expected in @("os-june.exe", "WebView2Loader.dll")) {
-            if ($listingText -notmatch [regex]::Escape($expected)) {
-              throw "NSIS installer payload does not include $expected."
-            }
+          # The MSVC target statically links WebView2Loader; only GNU builds ship its DLL.
+          if ($listingText -notmatch [regex]::Escape("os-june.exe")) {
+            throw "NSIS installer payload does not include os-june.exe."
           }
           foreach ($expected in @("native/bin/june-agent-runtime.exe", "native/bin/june-agent-runtime.exe.sha256", "native/bin/june-dictation-helper.exe")) {
             if ($listingText -notmatch [regex]::Escape($expected)) {

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ keys/
 coverage
 .tauri-hermes/
 .tauri-agent-runtime/
+/artifacts/windows-unsigned/
 
 # Scratch verification captures (screenshots etc.). Root-anchored so committed
 # proof under docs/verification/ is unaffected.

--- a/docs/release-windows.md
+++ b/docs/release-windows.md
@@ -1,9 +1,10 @@
 # Releasing June for Windows
 
 June ships Windows builds as an NSIS installer. The production Windows release
-workflow builds from `main`, signs the app executable and installer with
-Authenticode, signs updater artifacts with the Tauri updater key, and attaches
-Windows assets to the existing `open-software-network/os-june-releases` release.
+workflow builds from the promoted commit recorded by `stable-build.json`, signs
+the app executable and installer with Authenticode, signs updater artifacts with
+the Tauri updater key, and attaches Windows assets to the existing
+`open-software-network/os-june-releases` release.
 
 ## Windows support
 

--- a/docs/release-windows.md
+++ b/docs/release-windows.md
@@ -93,6 +93,34 @@ The Windows workflow performs the release steps in order:
     `latest.json` without removing macOS updater entries or the generated
     release changelog.
 
+## Qualifying an unsigned build on native Windows
+
+Before merging Windows build changes, run the tracked qualification helper in
+PowerShell 7 on a native x64 Windows machine. Pass the standalone repository,
+branch, and exact 40-character commit SHA to qualify:
+
+```powershell
+$repo = "E:\clones\work\os-june-butler"
+$branch = "<branch-to-qualify>"
+$expectedSha = "<exact-40-character-commit-sha>"
+
+& "$repo\scripts\qualify-windows-build.ps1" `
+  -RepoPath $repo `
+  -Branch $branch `
+  -ExpectedSha $expectedSha
+```
+
+The helper fetches `origin` and `upstream`, synchronizes the named GitButler
+branch to its remote state, and fails unless both resolve to the expected SHA.
+It then runs two complete unsigned builders and an additional explicit artifact
+verification after each build. It does not install dependencies, sign or upload
+artifacts, push branches, or discard source changes.
+
+The default evidence directory is
+`.tmp/windows-qualification/<branch>/<short-sha>/`. Pass
+`-EvidenceDirectory` to use another location. Each run writes `evidence.md` and
+`build-transcript.txt`; certificate values are not included.
+
 ## Validation
 
 After the workflow publishes assets, download `June_x64-setup.exe` from

--- a/scripts/build-agent-runtime.mjs
+++ b/scripts/build-agent-runtime.mjs
@@ -21,6 +21,16 @@ if (args.smoke) {
   await smoke(resolve(args.smoke), args.smokeArch);
   process.exit(0);
 }
+if (args.finalize) {
+  await finalize(resolve(args.finalize));
+  process.exit(0);
+}
+if (args.verify) {
+  const executable = resolve(args.verify);
+  await verifyChecksum(executable);
+  await smoke(executable);
+  process.exit(0);
+}
 
 const target = args.target ?? process.env.JUNE_AGENT_RUNTIME_TARGET ?? defaultTarget();
 const output = resolve(
@@ -100,20 +110,40 @@ if (target === "universal-apple-darwin") {
   fail(`Unsupported target: ${target}`);
 }
 
-await writeChecksum(output);
-await smoke(output);
+await finalize(output);
 process.stdout.write(`Built June agent runtime: ${output}\n`);
 
 function parseArgs(raw) {
+  const supported = new Set([
+    "smoke",
+    "smokeArch",
+    "finalize",
+    "verify",
+    "target",
+    "output",
+    "node",
+    "nodeX64",
+    "nodeArm64",
+  ]);
   const parsed = {};
   for (let index = 0; index < raw.length; index += 1) {
     const key = raw[index];
     if (!key?.startsWith("--")) fail(`Unknown argument: ${key}`);
     const name = key.slice(2).replaceAll(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    if (!supported.has(name)) fail(`Unknown option: ${key}`);
+    if (name in parsed) fail(`Option may only be specified once: ${key}`);
     const value = raw[index + 1];
     if (!value || value.startsWith("--")) fail(`${key} requires a value`);
     parsed[name] = value;
     index += 1;
+  }
+  const operationModes = ["smoke", "finalize", "verify"].filter((name) => parsed[name]);
+  if (operationModes.length > 1) fail("--smoke, --finalize, and --verify are mutually exclusive");
+  if (parsed.smokeArch && !parsed.smoke) fail("--smoke-arch requires --smoke");
+  if (operationModes.length > 0) {
+    const allowed = new Set([...operationModes, ...(parsed.smoke ? ["smokeArch"] : [])]);
+    const invalid = Object.keys(parsed).filter((name) => !allowed.has(name));
+    if (invalid.length > 0) fail(`Mode option cannot be combined with --${invalid[0]}`);
   }
   return parsed;
 }
@@ -182,6 +212,13 @@ async function writeChecksum(executable) {
     .update(await readFile(executable))
     .digest("hex");
   await writeFile(`${executable}.sha256`, `${digest}\n`);
+}
+
+async function finalize(executable) {
+  await assertFile(executable, "Runtime executable does not exist");
+  await writeChecksum(executable);
+  await verifyChecksum(executable);
+  await smoke(executable);
 }
 
 async function verifyChecksum(executable) {

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -12,6 +12,7 @@ $hadPrebuilt = Test-Path Env:JUNE_AGENT_RUNTIME_PREBUILT
 $previousPrebuilt = $env:JUNE_AGENT_RUNTIME_PREBUILT
 $hadRuntimeTarget = Test-Path Env:JUNE_AGENT_RUNTIME_TARGET
 $previousRuntimeTarget = $env:JUNE_AGENT_RUNTIME_TARGET
+$previousPath = $env:PATH
 
 function Require-Command([string]$Name) {
   if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) { throw "Required tool is unavailable: $Name" }
@@ -24,7 +25,7 @@ try {
     [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -ne [System.Runtime.InteropServices.Architecture]::X64 -or
     [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -ne [System.Runtime.InteropServices.Architecture]::X64
   ) { throw "Native x64 Windows is required." }
-  foreach ($tool in @("node", "pnpm", "rustc", "cargo", "makensis")) { Require-Command $tool }
+  foreach ($tool in @("node", "pnpm", "rustc", "cargo")) { Require-Command $tool }
   $nodeVersionOutput = & node --version
   $nodeVersionExit = $LASTEXITCODE
   $nodeVersion = "$nodeVersionOutput".Trim()
@@ -48,6 +49,17 @@ try {
   if (-not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)) {
     throw "Unsigned Windows builds require WINDOWS_CERTIFICATE_PASSWORD to be unset."
   }
+  $makensisCommand = Get-Command makensis.exe -ErrorAction SilentlyContinue
+  $makensisCandidates = @()
+  if (${env:ProgramFiles(x86)}) { $makensisCandidates += Join-Path ${env:ProgramFiles(x86)} "NSIS\makensis.exe" }
+  if ($env:ProgramFiles) { $makensisCandidates += Join-Path $env:ProgramFiles "NSIS\makensis.exe" }
+  $makensisPath = if ($makensisCommand) {
+    $makensisCommand.Source
+  } else {
+    $makensisCandidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1
+  }
+  if (-not $makensisPath) { throw "A usable NSIS makensis.exe is required." }
+  $env:PATH = "$(Split-Path -Parent $makensisPath);$env:PATH"
   $sevenZipCommand = Get-Command 7z.exe -ErrorAction SilentlyContinue
   $sevenZipPath = if ($sevenZipCommand) { $sevenZipCommand.Source } else { Join-Path $env:ProgramFiles "7-Zip\7z.exe" }
   if (-not (Test-Path -LiteralPath $sevenZipPath -PathType Leaf)) { throw "A usable 7-Zip executable is required." }
@@ -97,6 +109,7 @@ try {
 }
 finally {
   Set-Location -LiteralPath $callerLocation
+  $env:PATH = $previousPath
   if ($hadPrebuilt) { $env:JUNE_AGENT_RUNTIME_PREBUILT = $previousPrebuilt }
   else { Remove-Item Env:JUNE_AGENT_RUNTIME_PREBUILT -ErrorAction SilentlyContinue }
   if ($hadRuntimeTarget) { $env:JUNE_AGENT_RUNTIME_TARGET = $previousRuntimeTarget }

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -38,6 +38,11 @@ try {
   }
   $cargoVersion = & cargo --version
   if ($LASTEXITCODE -ne 0 -or "$cargoVersion" -notmatch '^cargo ') { throw "cargo is not usable." }
+  $targetTriple = "x86_64-pc-windows-msvc"
+  $targetLibDirectory = & rustc --print target-libdir --target $targetTriple
+  if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath "$targetLibDirectory" -PathType Container)) {
+    throw "The $targetTriple Rust target is required."
+  }
   if (-not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)) {
     throw "Unsigned Windows builds require WINDOWS_CERTIFICATE_PASSWORD to be unset."
   }
@@ -48,19 +53,24 @@ try {
   Set-Location -LiteralPath $repoRoot
   New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
   Get-ChildItem -LiteralPath $OutputDirectory -File -Filter "*-setup.exe" | Remove-Item -Force
+  $cargoMetadataOutput = & cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1
+  if ($LASTEXITCODE -ne 0) { throw "Could not resolve Cargo's target directory." }
+  $cargoTargetDirectory = ("$cargoMetadataOutput" | ConvertFrom-Json).target_directory
+  if ([string]::IsNullOrWhiteSpace($cargoTargetDirectory)) { throw "Cargo metadata did not report a target directory." }
   & pnpm agent-runtime:build
   if ($LASTEXITCODE -ne 0) { throw "Agent runtime TypeScript build failed." }
   & node scripts/build-agent-runtime.mjs
   if ($LASTEXITCODE -ne 0) { throw "Windows agent runtime SEA build failed." }
 
-  $nsisDirectory = Join-Path $repoRoot "src-tauri\target\release\bundle\nsis"
+  $releaseDirectory = Join-Path $cargoTargetDirectory "$targetTriple\release"
+  $nsisDirectory = Join-Path $releaseDirectory "bundle\nsis"
   if (Test-Path -LiteralPath $nsisDirectory -PathType Container) {
     Get-ChildItem -LiteralPath $nsisDirectory -File -Filter "*-setup.exe" | Remove-Item -Force
   }
-  $appExecutable = Join-Path $repoRoot "src-tauri\target\release\os-june.exe"
+  $appExecutable = Join-Path $releaseDirectory "os-june.exe"
   Remove-Item -LiteralPath $appExecutable -Force -ErrorAction SilentlyContinue
   $env:JUNE_AGENT_RUNTIME_PREBUILT = "1"
-  & node scripts/tauri-build.mjs --no-sign
+  & node scripts/tauri-build.mjs --target $targetTriple --no-sign
   if ($LASTEXITCODE -ne 0) { throw "Unsigned Tauri release build failed." }
   if ($hadPrebuilt) { $env:JUNE_AGENT_RUNTIME_PREBUILT = $previousPrebuilt } else { Remove-Item Env:JUNE_AGENT_RUNTIME_PREBUILT }
 

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -59,6 +59,7 @@ try {
   if ([string]::IsNullOrWhiteSpace($cargoTargetDirectory)) { throw "Cargo metadata did not report a target directory." }
   & pnpm agent-runtime:build
   if ($LASTEXITCODE -ne 0) { throw "Agent runtime TypeScript build failed." }
+  Remove-Item Env:JUNE_AGENT_RUNTIME_PREBUILT -ErrorAction SilentlyContinue
   & node scripts/build-agent-runtime.mjs
   if ($LASTEXITCODE -ne 0) { throw "Windows agent runtime SEA build failed." }
 

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -57,6 +57,8 @@ try {
   if (Test-Path -LiteralPath $nsisDirectory -PathType Container) {
     Get-ChildItem -LiteralPath $nsisDirectory -File -Filter "*-setup.exe" | Remove-Item -Force
   }
+  $appExecutable = Join-Path $repoRoot "src-tauri\target\release\os-june.exe"
+  Remove-Item -LiteralPath $appExecutable -Force -ErrorAction SilentlyContinue
   $env:JUNE_AGENT_RUNTIME_PREBUILT = "1"
   & node scripts/tauri-build.mjs --no-sign
   if ($LASTEXITCODE -ne 0) { throw "Unsigned Tauri release build failed." }

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -10,6 +10,8 @@ elseif (-not [System.IO.Path]::IsPathRooted($OutputDirectory)) { $OutputDirector
 $callerLocation = Get-Location
 $hadPrebuilt = Test-Path Env:JUNE_AGENT_RUNTIME_PREBUILT
 $previousPrebuilt = $env:JUNE_AGENT_RUNTIME_PREBUILT
+$hadRuntimeTarget = Test-Path Env:JUNE_AGENT_RUNTIME_TARGET
+$previousRuntimeTarget = $env:JUNE_AGENT_RUNTIME_TARGET
 
 function Require-Command([string]$Name) {
   if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) { throw "Required tool is unavailable: $Name" }
@@ -71,9 +73,11 @@ try {
   $appExecutable = Join-Path $releaseDirectory "os-june.exe"
   Remove-Item -LiteralPath $appExecutable -Force -ErrorAction SilentlyContinue
   $env:JUNE_AGENT_RUNTIME_PREBUILT = "1"
+  $env:JUNE_AGENT_RUNTIME_TARGET = "windows"
   & node scripts/tauri-build.mjs --target $targetTriple --no-sign
   if ($LASTEXITCODE -ne 0) { throw "Unsigned Tauri release build failed." }
   if ($hadPrebuilt) { $env:JUNE_AGENT_RUNTIME_PREBUILT = $previousPrebuilt } else { Remove-Item Env:JUNE_AGENT_RUNTIME_PREBUILT }
+  if ($hadRuntimeTarget) { $env:JUNE_AGENT_RUNTIME_TARGET = $previousRuntimeTarget } else { Remove-Item Env:JUNE_AGENT_RUNTIME_TARGET }
 
   $installers = @(Get-ChildItem -LiteralPath $nsisDirectory -File -Filter "*-setup.exe")
   if ($installers.Count -ne 1) { throw "Expected exactly one release NSIS installer; found $($installers.Count)." }
@@ -95,4 +99,6 @@ finally {
   Set-Location -LiteralPath $callerLocation
   if ($hadPrebuilt) { $env:JUNE_AGENT_RUNTIME_PREBUILT = $previousPrebuilt }
   else { Remove-Item Env:JUNE_AGENT_RUNTIME_PREBUILT -ErrorAction SilentlyContinue }
+  if ($hadRuntimeTarget) { $env:JUNE_AGENT_RUNTIME_TARGET = $previousRuntimeTarget }
+  else { Remove-Item Env:JUNE_AGENT_RUNTIME_TARGET -ErrorAction SilentlyContinue }
 }

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -1,0 +1,85 @@
+[CmdletBinding()]
+param([string]$OutputDirectory)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if (-not $OutputDirectory) { $OutputDirectory = Join-Path $repoRoot "artifacts\windows-unsigned" }
+elseif (-not [System.IO.Path]::IsPathRooted($OutputDirectory)) { $OutputDirectory = Join-Path $repoRoot $OutputDirectory }
+$callerLocation = Get-Location
+$hadPrebuilt = Test-Path Env:JUNE_AGENT_RUNTIME_PREBUILT
+$previousPrebuilt = $env:JUNE_AGENT_RUNTIME_PREBUILT
+
+function Require-Command([string]$Name) {
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) { throw "Required tool is unavailable: $Name" }
+}
+
+try {
+  if ($PSVersionTable.PSVersion.Major -lt 7) { throw "PowerShell 7 or newer is required." }
+  if (
+    -not $IsWindows -or
+    [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -ne [System.Runtime.InteropServices.Architecture]::X64 -or
+    [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -ne [System.Runtime.InteropServices.Architecture]::X64
+  ) { throw "Native x64 Windows is required." }
+  foreach ($tool in @("node", "pnpm", "rustc", "cargo", "makensis")) { Require-Command $tool }
+  $nodeVersionOutput = & node --version
+  $nodeVersionExit = $LASTEXITCODE
+  $nodeVersion = "$nodeVersionOutput".Trim()
+  if ($nodeVersionExit -ne 0 -or $nodeVersion -notmatch '^v24\.') { throw "Node 24 is required; got '$nodeVersion'." }
+  $nodeHostOutput = & node -p "process.platform + ':' + process.arch"
+  $nodeHostExit = $LASTEXITCODE
+  $nodeHost = "$nodeHostOutput".Trim()
+  if ($nodeHostExit -ne 0 -or $nodeHost -ne "win32:x64") { throw "Native x64 Node 24 is required; got '$nodeHost'." }
+  $rustDetails = & rustc -vV
+  $rustExit = $LASTEXITCODE
+  if ($rustExit -ne 0 -or ($rustDetails -join "`n") -notmatch '(?m)^host: x86_64-pc-windows-msvc$') {
+    throw "The x86_64-pc-windows-msvc Rust host is required."
+  }
+  $cargoVersion = & cargo --version
+  if ($LASTEXITCODE -ne 0 -or "$cargoVersion" -notmatch '^cargo ') { throw "cargo is not usable." }
+  if (-not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)) {
+    throw "Unsigned Windows builds require WINDOWS_CERTIFICATE_PASSWORD to be unset."
+  }
+  $sevenZipCommand = Get-Command 7z.exe -ErrorAction SilentlyContinue
+  $sevenZipPath = if ($sevenZipCommand) { $sevenZipCommand.Source } else { Join-Path $env:ProgramFiles "7-Zip\7z.exe" }
+  if (-not (Test-Path -LiteralPath $sevenZipPath -PathType Leaf)) { throw "A usable 7-Zip executable is required." }
+
+  Set-Location -LiteralPath $repoRoot
+  New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
+  Get-ChildItem -LiteralPath $OutputDirectory -File -Filter "*-setup.exe" | Remove-Item -Force
+  & pnpm agent-runtime:build
+  if ($LASTEXITCODE -ne 0) { throw "Agent runtime TypeScript build failed." }
+  & node scripts/build-agent-runtime.mjs
+  if ($LASTEXITCODE -ne 0) { throw "Windows agent runtime SEA build failed." }
+
+  $nsisDirectory = Join-Path $repoRoot "src-tauri\target\release\bundle\nsis"
+  if (Test-Path -LiteralPath $nsisDirectory -PathType Container) {
+    Get-ChildItem -LiteralPath $nsisDirectory -File -Filter "*-setup.exe" | Remove-Item -Force
+  }
+  $env:JUNE_AGENT_RUNTIME_PREBUILT = "1"
+  & node scripts/tauri-build.mjs --no-sign
+  if ($LASTEXITCODE -ne 0) { throw "Unsigned Tauri release build failed." }
+  if ($hadPrebuilt) { $env:JUNE_AGENT_RUNTIME_PREBUILT = $previousPrebuilt } else { Remove-Item Env:JUNE_AGENT_RUNTIME_PREBUILT }
+
+  $installers = @(Get-ChildItem -LiteralPath $nsisDirectory -File -Filter "*-setup.exe")
+  if ($installers.Count -ne 1) { throw "Expected exactly one release NSIS installer; found $($installers.Count)." }
+  if ($installers[0].Length -le 0) { throw "Release NSIS installer is empty." }
+
+  $stagedPath = Join-Path $OutputDirectory $installers[0].Name
+  Copy-Item -LiteralPath $installers[0].FullName -Destination $stagedPath -Force
+  try {
+    & (Join-Path $PSScriptRoot "verify-windows-artifacts.ps1") -InstallerPath $stagedPath -SevenZipPath $sevenZipPath
+    if ($LASTEXITCODE -ne 0) { throw "Staged installer verification failed." }
+  }
+  catch {
+    Remove-Item -LiteralPath $stagedPath -Force -ErrorAction SilentlyContinue
+    throw
+  }
+  Write-Host "Unsigned Windows installer: $stagedPath"
+}
+finally {
+  Set-Location -LiteralPath $callerLocation
+  if ($hadPrebuilt) { $env:JUNE_AGENT_RUNTIME_PREBUILT = $previousPrebuilt }
+  else { Remove-Item Env:JUNE_AGENT_RUNTIME_PREBUILT -ErrorAction SilentlyContinue }
+}

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -60,7 +60,7 @@ try {
   & pnpm agent-runtime:build
   if ($LASTEXITCODE -ne 0) { throw "Agent runtime TypeScript build failed." }
   Remove-Item Env:JUNE_AGENT_RUNTIME_PREBUILT -ErrorAction SilentlyContinue
-  & node scripts/build-agent-runtime.mjs
+  & node scripts/build-agent-runtime.mjs --target windows
   if ($LASTEXITCODE -ne 0) { throw "Windows agent runtime SEA build failed." }
 
   $releaseDirectory = Join-Path $cargoTargetDirectory "$targetTriple\release"

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -13,12 +13,22 @@ $previousPrebuilt = $env:JUNE_AGENT_RUNTIME_PREBUILT
 $hadRuntimeTarget = Test-Path Env:JUNE_AGENT_RUNTIME_TARGET
 $previousRuntimeTarget = $env:JUNE_AGENT_RUNTIME_TARGET
 $previousPath = $env:PATH
+$mutexPath = [System.IO.Path]::GetFullPath($repoRoot).TrimEnd([char[]]"\/").ToUpperInvariant()
+$mutexBytes = [System.Text.Encoding]::UTF8.GetBytes($mutexPath)
+$mutexHasher = [System.Security.Cryptography.SHA256]::Create()
+try { $mutexHash = [Convert]::ToHexString($mutexHasher.ComputeHash($mutexBytes)) }
+finally { $mutexHasher.Dispose() }
+$buildMutex = [System.Threading.Mutex]::new($false, "Local\JuneWindowsBuild-$mutexHash")
+$hasBuildMutex = $false
 
 function Require-Command([string]$Name) {
   if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) { throw "Required tool is unavailable: $Name" }
 }
 
 try {
+  try { $hasBuildMutex = $buildMutex.WaitOne(0) }
+  catch [System.Threading.AbandonedMutexException] { $hasBuildMutex = $true }
+  if (-not $hasBuildMutex) { throw "Another Windows build is active against this repository." }
   if ($PSVersionTable.PSVersion.Major -lt 7) { throw "PowerShell 7 or newer is required." }
   if (
     -not $IsWindows -or
@@ -108,10 +118,16 @@ try {
   Write-Host "Unsigned Windows installer: $stagedPath"
 }
 finally {
-  Set-Location -LiteralPath $callerLocation
-  $env:PATH = $previousPath
-  if ($hadPrebuilt) { $env:JUNE_AGENT_RUNTIME_PREBUILT = $previousPrebuilt }
-  else { Remove-Item Env:JUNE_AGENT_RUNTIME_PREBUILT -ErrorAction SilentlyContinue }
-  if ($hadRuntimeTarget) { $env:JUNE_AGENT_RUNTIME_TARGET = $previousRuntimeTarget }
-  else { Remove-Item Env:JUNE_AGENT_RUNTIME_TARGET -ErrorAction SilentlyContinue }
+  try {
+    $env:PATH = $previousPath
+    if ($hadPrebuilt) { $env:JUNE_AGENT_RUNTIME_PREBUILT = $previousPrebuilt }
+    else { Remove-Item Env:JUNE_AGENT_RUNTIME_PREBUILT -ErrorAction SilentlyContinue }
+    if ($hadRuntimeTarget) { $env:JUNE_AGENT_RUNTIME_TARGET = $previousRuntimeTarget }
+    else { Remove-Item Env:JUNE_AGENT_RUNTIME_TARGET -ErrorAction SilentlyContinue }
+    Set-Location -LiteralPath $callerLocation
+  }
+  finally {
+    if ($hasBuildMutex) { $buildMutex.ReleaseMutex() }
+    $buildMutex.Dispose()
+  }
 }

--- a/scripts/qualify-windows-build.ps1
+++ b/scripts/qualify-windows-build.ps1
@@ -1,0 +1,402 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$RepoPath,
+
+  [Parameter(Mandatory = $true)]
+  [string]$Branch,
+
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^[0-9a-fA-F]{40}$')]
+  [string]$ExpectedSha,
+
+  [string]$EvidenceDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+if (Get-Variable PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue) {
+  $PSNativeCommandUseErrorActionPreference = $false
+}
+
+$repo = (Resolve-Path -LiteralPath $RepoPath).Path
+$ExpectedSha = $ExpectedSha.ToLowerInvariant()
+$shortSha = $ExpectedSha.Substring(0, 12)
+$safeBranch = $Branch -replace '[^A-Za-z0-9._-]', '-'
+$repoParent = Split-Path -Parent $repo
+$caller = Join-Path $repoParent "June Windows Qualification"
+if ($caller -eq $repo) { $caller = Join-Path $repoParent "June Windows Qualification Runner" }
+$outputDirectory = Join-Path $repo "artifacts\windows-unsigned"
+if (-not $EvidenceDirectory) {
+  $EvidenceDirectory = Join-Path $repo ".tmp\windows-qualification\$safeBranch\$shortSha"
+} elseif (-not [System.IO.Path]::IsPathRooted($EvidenceDirectory)) {
+  $EvidenceDirectory = Join-Path $repo $EvidenceDirectory
+}
+$EvidenceDirectory = [System.IO.Path]::GetFullPath($EvidenceDirectory)
+$transcriptPath = Join-Path $EvidenceDirectory "build-transcript.txt"
+$reportPath = Join-Path $EvidenceDirectory "evidence.md"
+$builder = Join-Path $repo "scripts\build-windows.ps1"
+$verifier = Join-Path $repo "scripts\verify-windows-artifacts.ps1"
+$originalLocation = Get-Location
+$mutexPath = [System.IO.Path]::GetFullPath($repo).TrimEnd([char[]]"\/").ToUpperInvariant()
+$mutexBytes = [System.Text.Encoding]::UTF8.GetBytes($mutexPath)
+$mutexHasher = [System.Security.Cryptography.SHA256]::Create()
+try { $mutexHash = [Convert]::ToHexString($mutexHasher.ComputeHash($mutexBytes)) }
+finally { $mutexHasher.Dispose() }
+$buildMutex = [System.Threading.Mutex]::new($false, "Local\JuneWindowsBuild-$mutexHash")
+$hasBuildMutex = $false
+
+function Find-Application([string]$Name, [string[]]$Candidates) {
+  $command = Get-Command $Name -CommandType Application -ErrorAction SilentlyContinue
+  if ($command) { return $command.Source }
+  return $Candidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1
+}
+
+$sevenZipCandidates = @()
+if ($env:ProgramFiles) { $sevenZipCandidates += Join-Path $env:ProgramFiles "7-Zip\7z.exe" }
+if (${env:ProgramFiles(x86)}) { $sevenZipCandidates += Join-Path ${env:ProgramFiles(x86)} "7-Zip\7z.exe" }
+$sevenZip = Find-Application "7z.exe" $sevenZipCandidates
+$makensisCandidates = @()
+if (${env:ProgramFiles(x86)}) { $makensisCandidates += Join-Path ${env:ProgramFiles(x86)} "NSIS\makensis.exe" }
+if ($env:ProgramFiles) { $makensisCandidates += Join-Path $env:ProgramFiles "NSIS\makensis.exe" }
+$makensis = Find-Application "makensis.exe" $makensisCandidates
+
+if (-not (Test-Path -LiteralPath (Join-Path $repo ".git"))) {
+  throw "RepoPath is not a Git repository: $repo"
+}
+if (-not (Test-Path -LiteralPath $builder -PathType Leaf) -or
+    -not (Test-Path -LiteralPath $verifier -PathType Leaf)) {
+  throw "RepoPath does not contain the expected Windows build scripts: $repo"
+}
+foreach ($tool in @("git", "but", "node", "pnpm", "rustc", "cargo")) {
+  if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+    throw "Required tool is unavailable: $tool"
+  }
+}
+
+New-Item -ItemType Directory -Force -Path $caller, $EvidenceDirectory | Out-Null
+
+$originalPath = $env:PATH
+$hadPrebuilt = Test-Path Env:JUNE_AGENT_RUNTIME_PREBUILT
+$originalPrebuilt = if ($hadPrebuilt) { (Get-Item Env:JUNE_AGENT_RUNTIME_PREBUILT).Value } else { $null }
+$hadTarget = Test-Path Env:JUNE_AGENT_RUNTIME_TARGET
+$originalTarget = if ($hadTarget) { (Get-Item Env:JUNE_AGENT_RUNTIME_TARGET).Value } else { $null }
+$hadCertificatePassword = Test-Path Env:WINDOWS_CERTIFICATE_PASSWORD
+$originalCertificatePassword = if ($hadCertificatePassword) {
+  (Get-Item Env:WINDOWS_CERTIFICATE_PASSWORD).Value
+} else {
+  $null
+}
+
+$result = [ordered]@{
+  status = "FAIL"
+  branch = $Branch
+  expectedSha = $ExpectedSha
+  exactSha = $null
+  firstBuild = $false
+  firstInBuilderVerifier = $false
+  firstExplicitVerifier = $false
+  firstPathRestored = $false
+  firstJuneEnvironmentRestored = $false
+  firstArtifact = $null
+  secondBuild = $false
+  secondInBuilderVerifier = $false
+  secondExplicitVerifier = $false
+  secondPathRestored = $false
+  secondJuneEnvironmentRestored = $false
+  secondArtifact = $null
+  finalPathRestored = $false
+  finalJuneEnvironmentRestored = $false
+  finalCertificateEnvironmentRestored = $false
+  finalContentClean = $false
+  finalStatusClean = $false
+  failure = $null
+}
+
+function Invoke-Checked([scriptblock]$Command, [string]$Description) {
+  & $Command
+  if (-not $?) { throw "$Description failed." }
+}
+
+function Get-ArtifactInfo([System.IO.FileInfo]$Installer) {
+  $signature = Get-AuthenticodeSignature -LiteralPath $Installer.FullName
+  [ordered]@{
+    name = $Installer.Name
+    sizeBytes = $Installer.Length
+    sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $Installer.FullName).Hash
+    authenticodeStatus = $signature.Status.ToString()
+  }
+}
+
+function Get-OneStagedInstaller {
+  $installers = @(Get-ChildItem -LiteralPath $outputDirectory -File -Filter "*-setup.exe")
+  if ($installers.Count -ne 1) {
+    throw "Expected exactly one staged installer; found $($installers.Count)."
+  }
+  $installers[0]
+}
+
+function Assert-GitDiffIsEmpty([string[]]$Arguments, [string]$Description) {
+  & git @Arguments
+  $exitCode = $LASTEXITCODE
+  if ($exitCode -eq 1) { throw "$Description has a content change." }
+  if ($exitCode -ne 0) { throw "Could not inspect $Description (git exit $exitCode)." }
+}
+
+function Assert-CargoTomlIsStatOnly {
+  Assert-GitDiffIsEmpty @("diff", "--quiet", "--", "src-tauri/Cargo.toml") "Cargo.toml worktree"
+  Assert-GitDiffIsEmpty @("diff", "--cached", "--quiet", "--", "src-tauri/Cargo.toml") "Cargo.toml index"
+
+  $indexBlob = & git rev-parse ":src-tauri/Cargo.toml"
+  if ($LASTEXITCODE -ne 0) { throw "Could not resolve the Cargo.toml index blob." }
+  $worktreeBlob = & git hash-object --path=src-tauri/Cargo.toml src-tauri/Cargo.toml
+  if ($LASTEXITCODE -ne 0) { throw "Could not hash the normalized Cargo.toml worktree content." }
+  $indexBlob = "$indexBlob".Trim()
+  $worktreeBlob = "$worktreeBlob".Trim()
+  if ($indexBlob -ne $worktreeBlob) {
+    throw "Cargo.toml normalized index/worktree blob IDs differ."
+  }
+  Write-Host "Cargo.toml normalized content is identical: $indexBlob"
+}
+
+function Assert-AllTrackedContentIsClean {
+  Assert-GitDiffIsEmpty @("diff", "--quiet") "worktree"
+  Assert-GitDiffIsEmpty @("diff", "--cached", "--quiet") "index"
+}
+
+function Assert-WorkspaceMatchesExpectedCommit {
+  $headTree = & git rev-parse "HEAD^{tree}"
+  if ($LASTEXITCODE -ne 0) { throw "Could not resolve the GitButler workspace tree." }
+  $expectedTree = & git rev-parse "$ExpectedSha^{tree}"
+  if ($LASTEXITCODE -ne 0) { throw "Could not resolve the expected commit tree." }
+  if ("$headTree".Trim() -ne "$expectedTree".Trim()) {
+    throw "The GitButler workspace tree does not match the expected commit."
+  }
+
+  $untracked = @(& git ls-files --others --exclude-standard)
+  if ($LASTEXITCODE -ne 0) { throw "Could not inspect untracked repository files." }
+  if ($untracked.Count -gt 0) {
+    throw "The repository has non-ignored untracked files, so its build input is not exact."
+  }
+}
+
+function Restore-Environment {
+  $env:PATH = $originalPath
+  if ($hadPrebuilt) { $env:JUNE_AGENT_RUNTIME_PREBUILT = $originalPrebuilt }
+  else { Remove-Item Env:JUNE_AGENT_RUNTIME_PREBUILT -ErrorAction SilentlyContinue }
+  if ($hadTarget) { $env:JUNE_AGENT_RUNTIME_TARGET = $originalTarget }
+  else { Remove-Item Env:JUNE_AGENT_RUNTIME_TARGET -ErrorAction SilentlyContinue }
+  if ($hadCertificatePassword) { $env:WINDOWS_CERTIFICATE_PASSWORD = $originalCertificatePassword }
+  else { Remove-Item Env:WINDOWS_CERTIFICATE_PASSWORD -ErrorAction SilentlyContinue }
+}
+
+Start-Transcript -LiteralPath $transcriptPath -Force | Out-Null
+try {
+  Set-Location -LiteralPath $repo
+
+  try { $hasBuildMutex = $buildMutex.WaitOne(0) }
+  catch [System.Threading.AbandonedMutexException] { $hasBuildMutex = $true }
+  if (-not $hasBuildMutex) {
+    throw "Another tracked Windows build or qualification is active against this repository."
+  }
+
+  # The mutex coordinates tracked scripts. This scan also catches common
+  # unmanaged build commands whose command line includes the repository path.
+  $repoPattern = [regex]::Escape($repo)
+  $scriptPattern = "build-windows\.ps1|verify-windows-artifacts\.ps1|qualify-windows-build\.ps1"
+  $activeBuilds = @(Get-CimInstance Win32_Process | Where-Object {
+      $_.ProcessId -ne $PID -and
+      $_.Name -match "^(cargo|rustc|pnpm|npm|powershell|pwsh|node)\.exe$" -and
+      $_.CommandLine -match $repoPattern -and
+      ($_.CommandLine -match $scriptPattern -or $_.CommandLine -match "tauri|cargo|pnpm")
+    })
+  if ($activeBuilds.Count -gt 0) {
+    $activeBuilds | Select-Object ProcessId, ParentProcessId, Name, CommandLine | Format-List
+    throw "Another build or qualification process is active against this repository."
+  }
+
+  Assert-CargoTomlIsStatOnly
+  & git update-index --refresh
+  if ($LASTEXITCODE -ne 0) {
+    Write-Warning "Git retained the known stat-only Cargo.toml marker after refresh."
+  }
+  Assert-AllTrackedContentIsClean
+
+  Invoke-Checked { & git check-ref-format "refs/heads/$Branch" } "branch name validation"
+  Invoke-Checked { & git fetch origin --prune } "origin fetch"
+  Invoke-Checked { & git fetch upstream --prune } "upstream fetch"
+  $dryRunOutput = & but branch update $Branch --strategy pick-remote --dry-run --verbose --format agent 2>&1
+  $dryRunExit = $LASTEXITCODE
+  $dryRunOutput | Write-Host
+  if ($dryRunExit -eq 0) {
+    Invoke-Checked {
+      & but branch update $Branch --strategy pick-remote --format agent
+    } "GitButler branch update"
+  } else {
+    if ($dryRunExit -ne 1) {
+      throw "GitButler dry run failed with unexpected exit code $dryRunExit."
+    }
+    $preUpdateBranchSha = & git rev-parse $Branch
+    if ($LASTEXITCODE -ne 0) { throw "GitButler dry run failed and the local branch could not be resolved." }
+    $preUpdateRemoteSha = & git rev-parse "refs/remotes/origin/$Branch"
+    if ($LASTEXITCODE -ne 0) { throw "GitButler dry run failed and the remote branch could not be resolved." }
+    if ("$preUpdateBranchSha".Trim() -ne $ExpectedSha -or "$preUpdateRemoteSha".Trim() -ne $ExpectedSha) {
+      throw "GitButler dry run failed before the branch reached the expected remote SHA."
+    }
+    if (($dryRunOutput -join "`n") -notmatch "Integration steps cannot be empty") {
+      throw "GitButler dry run failed for an unexpected reason."
+    }
+    Write-Host "GitButler dry run had no integration steps; branch is already exact."
+  }
+
+  $branchSha = & git rev-parse $Branch
+  if ($LASTEXITCODE -ne 0) { throw "Could not resolve branch: $Branch" }
+  $remoteSha = & git rev-parse "refs/remotes/origin/$Branch"
+  if ($LASTEXITCODE -ne 0) { throw "Could not resolve origin branch: $Branch" }
+  $branchSha = "$branchSha".Trim().ToLowerInvariant()
+  $remoteSha = "$remoteSha".Trim().ToLowerInvariant()
+  if ($branchSha -ne $ExpectedSha -or $remoteSha -ne $ExpectedSha) {
+    throw "Branch SHA mismatch: branch=$branchSha remote=$remoteSha expected=$ExpectedSha"
+  }
+  $result.exactSha = $branchSha
+  Assert-AllTrackedContentIsClean
+  Assert-WorkspaceMatchesExpectedCommit
+
+  Write-Host "Exact SHA: $branchSha"
+  Write-Host "PowerShell: $($PSVersionTable.PSVersion) $($PSVersionTable.PSEdition)"
+  Write-Host "Node: $(& node --version) $(& node -p `"process.platform + ':' + process.arch`")"
+  Write-Host "pnpm: $(& pnpm --version)"
+  & rustc -vV
+  & cargo --version
+  & rustup target list --installed
+  Write-Host "makensis initially on PATH: $([bool](Get-Command makensis.exe -CommandType Application -ErrorAction SilentlyContinue))"
+  if (-not $makensis) { throw "A usable NSIS makensis.exe installation was not found." }
+  if (-not $sevenZip) { throw "A usable 7-Zip installation was not found." }
+  Write-Host "makensis path: $makensis"
+  & $makensis /VERSION
+  Write-Host "7-Zip path: $sevenZip"
+  & $sevenZip | Select-String "^7-Zip " | Select-Object -First 1
+
+  Remove-Item Env:WINDOWS_CERTIFICATE_PASSWORD -ErrorAction SilentlyContinue
+  $env:JUNE_AGENT_RUNTIME_PREBUILT = "qualification-sentinel-prebuilt"
+  $env:JUNE_AGENT_RUNTIME_TARGET = "qualification-sentinel-target"
+  Set-Location -LiteralPath $caller
+
+  Write-Host "=== First full builder run ==="
+  Invoke-Checked { & $builder -OutputDirectory $outputDirectory } "first builder"
+  $result.firstBuild = $true
+  $result.firstInBuilderVerifier = $true
+  $result.firstPathRestored = $env:PATH -ceq $originalPath
+  $result.firstJuneEnvironmentRestored =
+    $env:JUNE_AGENT_RUNTIME_PREBUILT -ceq "qualification-sentinel-prebuilt" -and
+    $env:JUNE_AGENT_RUNTIME_TARGET -ceq "qualification-sentinel-target"
+  if (-not $result.firstPathRestored) { throw "First builder did not restore PATH exactly." }
+  if (-not $result.firstJuneEnvironmentRestored) { throw "First builder did not restore June environment exactly." }
+
+  $firstInstaller = Get-OneStagedInstaller
+  $result.firstArtifact = Get-ArtifactInfo $firstInstaller
+  Write-Host "=== Explicit verifier after first build ==="
+  Invoke-Checked {
+    & $verifier -InstallerPath $firstInstaller.FullName -SevenZipPath $sevenZip
+  } "first explicit verifier"
+  $result.firstExplicitVerifier = $true
+
+  Write-Host "=== Second full builder run ==="
+  Invoke-Checked { & $builder -OutputDirectory $outputDirectory } "second builder"
+  $result.secondBuild = $true
+  $result.secondInBuilderVerifier = $true
+  $result.secondPathRestored = $env:PATH -ceq $originalPath
+  $result.secondJuneEnvironmentRestored =
+    $env:JUNE_AGENT_RUNTIME_PREBUILT -ceq "qualification-sentinel-prebuilt" -and
+    $env:JUNE_AGENT_RUNTIME_TARGET -ceq "qualification-sentinel-target"
+  if (-not $result.secondPathRestored) { throw "Second builder did not restore PATH exactly." }
+  if (-not $result.secondJuneEnvironmentRestored) { throw "Second builder did not restore June environment exactly." }
+
+  $secondInstaller = Get-OneStagedInstaller
+  $result.secondArtifact = Get-ArtifactInfo $secondInstaller
+  Write-Host "=== Explicit verifier after second build ==="
+  Invoke-Checked {
+    & $verifier -InstallerPath $secondInstaller.FullName -SevenZipPath $sevenZip
+  } "second explicit verifier"
+  $result.secondExplicitVerifier = $true
+}
+catch {
+  $result.failure = $_.Exception.Message
+  Write-Warning $_
+}
+finally {
+  try {
+    Restore-Environment
+    $result.finalPathRestored = $env:PATH -ceq $originalPath
+    $result.finalJuneEnvironmentRestored =
+      ((Test-Path Env:JUNE_AGENT_RUNTIME_PREBUILT) -eq $hadPrebuilt) -and
+      ((-not $hadPrebuilt) -or ($env:JUNE_AGENT_RUNTIME_PREBUILT -ceq $originalPrebuilt)) -and
+      ((Test-Path Env:JUNE_AGENT_RUNTIME_TARGET) -eq $hadTarget) -and
+      ((-not $hadTarget) -or ($env:JUNE_AGENT_RUNTIME_TARGET -ceq $originalTarget))
+    $result.finalCertificateEnvironmentRestored =
+      ((Test-Path Env:WINDOWS_CERTIFICATE_PASSWORD) -eq $hadCertificatePassword) -and
+      ((-not $hadCertificatePassword) -or ($env:WINDOWS_CERTIFICATE_PASSWORD -ceq $originalCertificatePassword))
+
+    Set-Location -LiteralPath $repo
+    try {
+      Assert-CargoTomlIsStatOnly
+      & git update-index --refresh
+      if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Git retained the known stat-only Cargo.toml marker after final refresh."
+      }
+      Assert-AllTrackedContentIsClean
+      Assert-WorkspaceMatchesExpectedCommit
+      $result.finalContentClean = $true
+      $porcelain = @(git status --porcelain=v2 --untracked-files=all)
+      if ($LASTEXITCODE -ne 0) { throw "Could not read final Git status." }
+      $result.finalStatusClean = $porcelain.Count -eq 0
+      git status --short --branch
+      but status
+    }
+    catch {
+      if (-not $result.failure) { $result.failure = $_.Exception.Message }
+    }
+
+    $allPassed =
+      (-not $result.failure) -and $result.exactSha -eq $ExpectedSha -and
+      $result.firstBuild -and $result.firstInBuilderVerifier -and $result.firstExplicitVerifier -and
+      $result.secondBuild -and $result.secondInBuilderVerifier -and $result.secondExplicitVerifier -and
+      $result.firstPathRestored -and $result.secondPathRestored -and $result.finalPathRestored -and
+      $result.firstJuneEnvironmentRestored -and $result.secondJuneEnvironmentRestored -and
+      $result.finalJuneEnvironmentRestored -and $result.finalCertificateEnvironmentRestored -and
+      $result.finalContentClean
+    $result.status = if ($allPassed) { "PASS" } else { "FAIL" }
+
+    $firstJson = if ($result.firstArtifact) { $result.firstArtifact | ConvertTo-Json -Compress } else { "Not produced" }
+    $secondJson = if ($result.secondArtifact) { $result.secondArtifact | ConvertTo-Json -Compress } else { "Not produced" }
+    @"
+# Native Windows build qualification
+
+- Result: **$($result.status)**
+- Branch: $Branch
+- Expected SHA: $ExpectedSha
+- Exact SHA: $($result.exactSha)
+- First build/in-builder verifier/explicit verifier: $($result.firstBuild) / $($result.firstInBuilderVerifier) / $($result.firstExplicitVerifier)
+- Second build/in-builder verifier/explicit verifier: $($result.secondBuild) / $($result.secondInBuilderVerifier) / $($result.secondExplicitVerifier)
+- First PATH/JUNE restoration: $($result.firstPathRestored) / $($result.firstJuneEnvironmentRestored)
+- Second PATH/JUNE restoration: $($result.secondPathRestored) / $($result.secondJuneEnvironmentRestored)
+- Final PATH/JUNE/certificate restoration: $($result.finalPathRestored) / $($result.finalJuneEnvironmentRestored) / $($result.finalCertificateEnvironmentRestored)
+- Final content clean: $($result.finalContentClean)
+- Final porcelain status clean: $($result.finalStatusClean)
+- First artifact: $firstJson
+- Second artifact: $secondJson
+- Failure: $($result.failure)
+- Transcript: $transcriptPath
+"@ | Set-Content -LiteralPath $reportPath -Encoding utf8
+
+    $result | ConvertTo-Json -Depth 5
+  }
+  finally {
+    Set-Location -LiteralPath $originalLocation -ErrorAction SilentlyContinue
+    Stop-Transcript -ErrorAction SilentlyContinue | Out-Null
+    if ($hasBuildMutex) { $buildMutex.ReleaseMutex() }
+    $buildMutex.Dispose()
+  }
+}
+
+if ($result.status -ne "PASS") { exit 1 }

--- a/scripts/verify-windows-artifacts.ps1
+++ b/scripts/verify-windows-artifacts.ps1
@@ -67,7 +67,7 @@ try {
   }
 
   $app = Require-One "os-june.exe"
-  $null = Require-One "WebView2Loader.dll"
+  # The MSVC target statically links WebView2Loader; only GNU builds ship its DLL.
   $runtime = Require-One "june-agent-runtime.exe"
   $checksum = Require-One "june-agent-runtime.exe.sha256"
   $helper = Require-One "june-dictation-helper.exe"

--- a/scripts/verify-windows-artifacts.ps1
+++ b/scripts/verify-windows-artifacts.ps1
@@ -1,0 +1,96 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$InstallerPath,
+  [string]$SevenZipPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ($PSVersionTable.PSVersion.Major -lt 7) { throw "PowerShell 7 or newer is required." }
+if (
+  -not $IsWindows -or
+  [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -ne [System.Runtime.InteropServices.Architecture]::X64 -or
+  [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -ne [System.Runtime.InteropServices.Architecture]::X64
+) {
+  throw "Native x64 Windows is required."
+}
+$nodeVersionOutput = & node --version
+$nodeVersionExit = $LASTEXITCODE
+$nodeVersion = "$nodeVersionOutput".Trim()
+if ($nodeVersionExit -ne 0 -or $nodeVersion -notmatch '^v24\.') { throw "Node 24 is required; got '$nodeVersion'." }
+$nodeHostOutput = & node -p "process.platform + ':' + process.arch"
+$nodeHostExit = $LASTEXITCODE
+$nodeHost = "$nodeHostOutput".Trim()
+if ($nodeHostExit -ne 0 -or $nodeHost -ne "win32:x64") { throw "Native x64 Node 24 is required; got '$nodeHost'." }
+
+$installer = Get-Item -LiteralPath $InstallerPath
+if ($installer.Length -le 0) { throw "Installer is empty: $($installer.FullName)" }
+
+if (-not $SevenZipPath) {
+  $command = Get-Command 7z.exe -ErrorAction SilentlyContinue
+  if ($command) { $SevenZipPath = $command.Source }
+  elseif ($env:ProgramFiles) { $SevenZipPath = Join-Path $env:ProgramFiles "7-Zip\7z.exe" }
+}
+if (-not $SevenZipPath -or -not (Test-Path -LiteralPath $SevenZipPath -PathType Leaf)) {
+  throw "A usable 7-Zip executable is required."
+}
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("June Windows payload " + [guid]::NewGuid())
+try {
+  New-Item -ItemType Directory -Path $tempRoot | Out-Null
+  $installerRoot = Join-Path $tempRoot "installer contents"
+  New-Item -ItemType Directory -Path $installerRoot | Out-Null
+  & $SevenZipPath x "-o$installerRoot" -y -- $installer.FullName | Out-Null
+  if ($LASTEXITCODE -ne 0) { throw "7-Zip could not extract the NSIS installer." }
+
+  $archives = @(Get-ChildItem -LiteralPath $installerRoot -Recurse -File -Filter "app-*.7z")
+  $payloadRoots = @($installerRoot)
+  if ($archives.Count -gt 0) {
+    for ($index = 0; $index -lt $archives.Count; $index++) {
+      $archiveRoot = Join-Path $tempRoot ("nested payload {0}" -f $index)
+      New-Item -ItemType Directory -Path $archiveRoot | Out-Null
+      & $SevenZipPath x "-o$archiveRoot" -y -- $archives[$index].FullName | Out-Null
+      if ($LASTEXITCODE -ne 0) { throw "7-Zip could not extract $($archives[$index].FullName)." }
+      $payloadRoots += $archiveRoot
+    }
+  }
+
+  $items = @($payloadRoots | ForEach-Object { Get-ChildItem -LiteralPath $_ -Recurse })
+  $files = @($items | Where-Object { -not $_.PSIsContainer })
+  function Require-One([string]$Name) {
+    $matches = @($files | Where-Object { $_.Name -ieq $Name })
+    if ($matches.Count -ne 1) { throw "Expected exactly one $Name in the final payload; found $($matches.Count)." }
+    if ($matches[0].Length -le 0) { throw "Payload file is empty: $($matches[0].FullName)" }
+    return $matches[0]
+  }
+
+  $null = Require-One "os-june.exe"
+  $null = Require-One "WebView2Loader.dll"
+  $runtime = Require-One "june-agent-runtime.exe"
+  $checksum = Require-One "june-agent-runtime.exe.sha256"
+  $helper = Require-One "june-dictation-helper.exe"
+  if ($runtime.DirectoryName -ne $checksum.DirectoryName -or $runtime.DirectoryName -ne $helper.DirectoryName) {
+    throw "Runtime, checksum, and dictation helper are not adjacent in the payload."
+  }
+  $nativeBin = $runtime.DirectoryName.Replace('\', '/').ToLowerInvariant()
+  if (-not $nativeBin.EndsWith('/native/bin')) { throw "Native helpers are not under native/bin." }
+
+  foreach ($item in $items) {
+    $relative = $item.FullName.Replace('\', '/').ToLowerInvariant()
+    if ($relative.Contains('/native/hermes/') -or $relative.EndsWith('/native/hermes') -or
+        $item.Name -ieq 'python.exe' -or $item.Extension -ieq '.pyd' -or
+        $relative.Contains('hermes-agent')) {
+      throw "Legacy Hermes or Python payload found: $($item.FullName)"
+    }
+  }
+
+  $repoRoot = Split-Path -Parent $PSScriptRoot
+  & node (Join-Path $repoRoot "scripts/build-agent-runtime.mjs") --verify $runtime.FullName
+  if ($LASTEXITCODE -ne 0) { throw "Extracted agent runtime verification failed." }
+  Write-Host "Verified unsigned Windows installer payload: $($installer.FullName)"
+}
+finally {
+  if (Test-Path -LiteralPath $tempRoot) { Remove-Item -LiteralPath $tempRoot -Recurse -Force }
+}

--- a/scripts/verify-windows-artifacts.ps1
+++ b/scripts/verify-windows-artifacts.ps1
@@ -66,7 +66,7 @@ try {
     return $matches[0]
   }
 
-  $null = Require-One "os-june.exe"
+  $app = Require-One "os-june.exe"
   $null = Require-One "WebView2Loader.dll"
   $runtime = Require-One "june-agent-runtime.exe"
   $checksum = Require-One "june-agent-runtime.exe.sha256"
@@ -84,6 +84,19 @@ try {
         $relative.Contains('hermes-agent')) {
       throw "Legacy Hermes or Python payload found: $($item.FullName)"
     }
+  }
+
+  foreach ($unsignedFile in @($installer, $app, $helper)) {
+    $signature = Get-AuthenticodeSignature -LiteralPath $unsignedFile.FullName
+    if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::NotSigned) {
+      throw "Expected an unsigned file, but Authenticode status is $($signature.Status): $($unsignedFile.FullName)"
+    }
+  }
+  # postject can retain invalid signature metadata from the Node executable.
+  # It must never retain a valid publisher signature after SEA injection.
+  $runtimeSignature = Get-AuthenticodeSignature -LiteralPath $runtime.FullName
+  if ($runtimeSignature.Status -eq [System.Management.Automation.SignatureStatus]::Valid) {
+    throw "Expected an unsigned agent runtime, but its Authenticode signature is valid: $($runtime.FullName)"
   }
 
   $repoRoot = Split-Path -Parent $PSScriptRoot

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -577,6 +577,7 @@ fn build_windows_dictation_helper() {
         .join("native")
         .join("bin")
         .join("june-dictation-helper.exe");
+    println!("cargo:rerun-if-changed={}", destination.display());
     if let Some(parent) = destination.parent() {
         std::fs::create_dir_all(parent)
             .expect("Windows dictation helper destination should be created");


### PR DESCRIPTION
## Summary

- add one prepared-tree PowerShell command for native x64 Windows release builds without signing
- verify the final extracted NSIS payload, agent runtime checksum, JSON-RPC startup, expected helper cardinality, and absence of legacy Hermes/Python content
- make desktop CI call the same checked-in builder and correct the Windows release source-commit documentation
- fail closed on stale signed outputs, ambient runtime configuration, wrong architecture, and ambiguous installers

## Validation

- `pnpm agent-runtime:typecheck`
- `pnpm agent-runtime:test` (53 passed after rebasing onto current `upstream/main`)
- `pnpm agent-runtime:build`
- SEA `--finalize`, `--verify`, and tamper-rejection probes
- `node --check scripts/build-agent-runtime.mjs`
- workflow YAML parse
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `git diff --check upstream/main...win-release/01-unsigned-build-verify`
- Standards, Spec, and two consecutive independent adversarial review passes approved
- `make verify` passed Biome, TypeScript, Vitest, and Rust formatting, then stopped at Tauri Clippy because this Ubuntu host lacks the `dbus-1` development package
- native x64 Windows build and extracted-payload qualification are pending on the Windows test machine; keep this PR in draft until evidence is attached

- [x] Tested visually where it matters (not applicable: no UI changes).
- [ ] Needs a June API (backend) deploy before it works end to end. No June API deploy is required.

## Out of scope

- version stamping and detached source-worktree orchestration
- required signing mode and production signing identity
- clean Windows 11 install qualification
- RC/stable manifest assembly, publication, and provenance

## Followups

- PR2 adds deterministic four-file version stamping in a parallel branch
- later roadmap PRs add exact-source orchestration, signed qualification, and cross-platform release transactions

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. Owner review is pending while this draft is qualified on Windows.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable).
- [x] User-facing copy follows the repo UI conventions (no UI copy changed).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787884366&installation_model_id=425925&pr_number=1007&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1007&signature=0df382d002a0e0ef4f9acee8466fed6ac9df9f6ae09809a641a8f64e3485ad50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->