### PR TITLE
fix(routines): preserve explicit tool catalogs

### DIFF
--- a/src-tauri/src/routines.rs
+++ b/src-tauri/src/routines.rs
@@ -1359,17 +1359,13 @@ fn enabled_toolsets_from_metadata(metadata: &Value, legacy_catalog: bool) -> Vec
         _ => Vec::new(),
     };
 
-    // Sandboxed routine catalogs created before read-only skill loading omit
-    // only `skills`. Upgrade those snapshots at run time so an existing routine
-    // benefits without needing a no-op edit and save. Memory was optional, so
-    // it is not part of the historical-base fingerprint. Explicit-empty and
-    // imported catalogs remain unchanged.
-    let previous_sandbox_base = ["web", "vision", "todo", "session_search", "context_engine"];
-    if (!imported_catalog
-        && ((legacy_catalog && !has_explicit_catalog)
-            || previous_sandbox_base
-                .iter()
-                .all(|required| toolsets.iter().any(|toolset| toolset == required))))
+    // Only rows durably marked as pre-catalog may gain a toolset that was not
+    // explicitly saved. A current explicit catalog can match an old default
+    // exactly, so inferring its provenance from the selected entries would
+    // override a user's decision to keep skills disabled.
+    if !imported_catalog
+        && legacy_catalog
+        && !has_explicit_catalog
         && !toolsets.iter().any(|toolset| toolset == "skills")
     {
         toolsets.push("skills".to_string());
@@ -2002,7 +1998,7 @@ mod tests {
     }
 
     #[test]
-    fn old_sandbox_catalogs_gain_only_read_only_skill_loading() {
+    fn explicit_sandbox_catalogs_preserve_disabled_skill_loading() {
         let metadata = json!({
             "enabledToolsets": [
                 "web",
@@ -2016,7 +2012,7 @@ mod tests {
         });
 
         let toolsets = enabled_toolsets_from_metadata(&metadata, false);
-        assert!(toolsets.iter().any(|toolset| toolset == "skills"));
+        assert!(!toolsets.iter().any(|toolset| toolset == "skills"));
         assert!(toolsets.iter().any(|toolset| toolset == "june_notion"));
         assert!(!toolsets
             .iter()
@@ -2024,7 +2020,7 @@ mod tests {
     }
 
     #[test]
-    fn old_sandbox_catalogs_without_memory_gain_skill_loading() {
+    fn explicit_sandbox_catalogs_without_memory_preserve_disabled_skills() {
         let metadata = json!({
             "enabledToolsets": [
                 "web",
@@ -2036,7 +2032,7 @@ mod tests {
         });
 
         let toolsets = enabled_toolsets_from_metadata(&metadata, false);
-        assert!(toolsets.iter().any(|toolset| toolset == "skills"));
+        assert!(!toolsets.iter().any(|toolset| toolset == "skills"));
         assert!(!toolsets.iter().any(|toolset| toolset == "memory"));
     }
 


### PR DESCRIPTION
## Summary

- preserve every explicitly saved routine tool catalog exactly
- add the read-only `skills` toolset only for rows durably marked as pre-catalog and lacking an explicit selection
- add regression coverage for explicit catalogs that intentionally omit skills

## Why

The compatibility fingerprint added in #1006 could not distinguish an old default catalog from a current explicit catalog containing the same base toolsets. That caused `list_skills` and `load_skill` to become available even when the saved catalog omitted `skills`.

This release blocker was identified while validating `0.0.38-rc.1` for stable promotion.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked routines::tests:: -- --nocapture` (32 passed)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --locked -- -D warnings`

No new UI behavior is introduced. The `0.0.38-rc.1` live walkthrough covered updater relaunch, signatures and Gatekeeper, Home, navigation, and the Active/Archived sessions view; this patch only narrows backend routine authorization to the saved catalog.

## Release impact

Existing explicit catalogs remain deny-by-default for skills until the user enables that toolset. Truly pre-catalog routines retain the compatibility upgrade.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787889413&installation_model_id=425925&pr_number=1008&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1008&signature=151d54491e9343dbf07dd821520d3a8eab6c7c9f632ea0d3970c5384629788a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->