### PR TITLE
fix(agent): make session policy host-owned

### DIFF
--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -12,6 +12,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use tauri::{AppHandle, Manager, State};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const INSTRUCTIONS: &str = "You are June, a private personal AI assistant. Use the tools provided by the June app when they help answer the user's request. Never claim a tool succeeded unless its result confirms success. If an MCP tool returns elicitationRequired, call request_clarification with its clarificationQuestion exactly, then retry the same MCP tool after the user answers.";
 const MAX_INLINE_VISION_BYTES: i64 = 6 * 1024 * 1024;
@@ -685,8 +686,12 @@ pub async fn retry_agent_run(
         })?;
     let prompt = message.content;
     let workspace = authoritative_session_workspace(&app, &repository, &session.id).await?;
-    let prepared_attachments =
-        prepare_persisted_attachments(&message.attachments, Path::new(&workspace)).await;
+    let prepared_attachments = prepare_persisted_attachments(
+        &message.attachments,
+        Path::new(&workspace),
+        PersistedAttachmentPolicy::RetryStrict,
+    )
+    .await?;
     let original_attachment_paths = prepared_attachments
         .iter()
         .map(|(original_path, _)| original_path.clone())
@@ -1488,7 +1493,7 @@ async fn run_params(
         request.excluded_history_run_id,
         Path::new(request.workspace),
     )
-    .await;
+    .await?;
     if !supports_vision {
         for item in &mut history {
             if let Some(object) = item.as_object_mut() {
@@ -1754,7 +1759,7 @@ async fn normalized_runtime_history(
     items: Vec<AgentItemDto>,
     excluded_run_id: Option<&str>,
     workspace: &Path,
-) -> Vec<Value> {
+) -> Result<Vec<Value>, AppError> {
     let mut history = Vec::new();
     for mut item in items {
         if item.run_id.as_deref() == excluded_run_id {
@@ -1764,12 +1769,15 @@ async fn normalized_runtime_history(
             AgentItemPayload::UserMessage(message)
             | AgentItemPayload::AssistantMessage(message)
             | AgentItemPayload::SystemMessage(message) => {
-                message.attachments =
-                    prepare_persisted_attachments(&message.attachments, workspace)
-                        .await
-                        .into_iter()
-                        .map(|(_, attachment)| attachment)
-                        .collect();
+                message.attachments = prepare_persisted_attachments(
+                    &message.attachments,
+                    workspace,
+                    PersistedAttachmentPolicy::HistoricalBestEffort,
+                )
+                .await?
+                .into_iter()
+                .map(|(_, attachment)| attachment)
+                .collect();
             }
             _ => {}
         }
@@ -1777,7 +1785,7 @@ async fn normalized_runtime_history(
             history.push(item);
         }
     }
-    history
+    Ok(history)
 }
 
 fn session_json(session: super::AgentSessionDto) -> Value {
@@ -1942,55 +1950,140 @@ async fn prepare_attachments(
     }
     let mut attachments = Vec::with_capacity(source_paths.len());
     for source_path in source_paths {
-        attachments.push(prepare_attachment(source_path, workspace, None).await?);
+        attachments.push(
+            prepare_attachment(source_path, workspace, None)
+                .await
+                .map_err(AttachmentStageError::into_app_error)?,
+        );
     }
     Ok(attachments)
+}
+
+enum AttachmentStageError {
+    SourceUnavailable(AppError),
+    Fatal(AppError),
+}
+
+impl AttachmentStageError {
+    fn source_unavailable(error: AppError) -> Self {
+        Self::SourceUnavailable(error)
+    }
+
+    fn into_app_error(self) -> AppError {
+        match self {
+            Self::SourceUnavailable(error) | Self::Fatal(error) => error,
+        }
+    }
+}
+
+fn retry_attachment_unavailable() -> AppError {
+    AppError::new(
+        "agent_attachment_unavailable",
+        "One or more attachments from this message are no longer available. Restore them before retrying.",
+    )
+}
+
+#[derive(Clone, Copy)]
+enum PersistedAttachmentPolicy {
+    RetryStrict,
+    HistoricalBestEffort,
+}
+
+async fn copy_attachment_file(
+    source: &Path,
+    destination: &Path,
+) -> Result<(), AttachmentStageError> {
+    let mut source_file = tokio::fs::File::open(source).await.map_err(|error| {
+        AttachmentStageError::source_unavailable(AppError::new(
+            "agent_workspace_failed",
+            error.to_string(),
+        ))
+    })?;
+    let mut destination_file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(destination)
+        .await
+        .map_err(|error| AttachmentStageError::Fatal(io_error(error)))?;
+    let copy = async {
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = source_file.read(&mut buffer).await.map_err(|error| {
+                AttachmentStageError::source_unavailable(AppError::new(
+                    "agent_workspace_failed",
+                    error.to_string(),
+                ))
+            })?;
+            if read == 0 {
+                break;
+            }
+            destination_file
+                .write_all(&buffer[..read])
+                .await
+                .map_err(|error| AttachmentStageError::Fatal(io_error(error)))?;
+        }
+        destination_file
+            .flush()
+            .await
+            .map_err(|error| AttachmentStageError::Fatal(io_error(error)))?;
+        Ok(())
+    }
+    .await;
+    if copy.is_err() {
+        let _ = tokio::fs::remove_file(destination).await;
+    }
+    copy
 }
 
 async fn prepare_attachment(
     source_path: &str,
     workspace: &Path,
     stable_key: Option<&str>,
-) -> Result<MessageAttachmentPayload, AppError> {
+) -> Result<MessageAttachmentPayload, AttachmentStageError> {
     let destination_root = workspace.join("attachments");
     tokio::fs::create_dir_all(&destination_root)
         .await
-        .map_err(io_error)?;
-    let canonical_workspace = workspace.canonicalize().map_err(io_error)?;
+        .map_err(|error| AttachmentStageError::Fatal(io_error(error)))?;
+    let canonical_workspace = workspace
+        .canonicalize()
+        .map_err(|error| AttachmentStageError::Fatal(io_error(error)))?;
     let destination_metadata = tokio::fs::symlink_metadata(&destination_root)
         .await
-        .map_err(io_error)?;
-    let destination_root = destination_root.canonicalize().map_err(io_error)?;
+        .map_err(|error| AttachmentStageError::Fatal(io_error(error)))?;
+    let destination_root = destination_root
+        .canonicalize()
+        .map_err(|error| AttachmentStageError::Fatal(io_error(error)))?;
     if destination_metadata.file_type().is_symlink()
         || !destination_metadata.is_dir()
         || !destination_root.starts_with(&canonical_workspace)
     {
-        return Err(AppError::new(
+        return Err(AttachmentStageError::Fatal(AppError::new(
             "agent_attachment_invalid",
             "Attachment destination is outside the session workspace.",
-        ));
+        )));
     }
     let source = PathBuf::from(source_path)
         .canonicalize()
-        .map_err(io_error)?;
+        .map_err(|error| AttachmentStageError::source_unavailable(io_error(error)))?;
     if !source.is_file() {
-        return Err(AppError::new(
+        return Err(AttachmentStageError::source_unavailable(AppError::new(
             "agent_attachment_invalid",
             "Attachment source is not a file.",
-        ));
+        )));
     }
     let name = source
         .file_name()
         .and_then(|value| value.to_str())
         .filter(|value| !value.is_empty())
         .ok_or_else(|| {
-            AppError::new(
+            AttachmentStageError::source_unavailable(AppError::new(
                 "agent_attachment_invalid",
                 "Attachment source has no valid file name.",
-            )
+            ))
         })?
         .to_string();
-    let destination = if source.starts_with(&canonical_workspace) {
+    let source_in_workspace = source.starts_with(&canonical_workspace);
+    let destination = if source_in_workspace {
         source
     } else {
         let destination_name = match stable_key {
@@ -2009,26 +2102,32 @@ async fn prepare_attachment(
         let destination = destination_root.join(destination_name);
         if !destination.exists() {
             let temporary = destination_root.join(format!(".{}.tmp", uuid::Uuid::new_v4()));
-            tokio::fs::copy(&source, &temporary)
-                .await
-                .map_err(io_error)?;
+            copy_attachment_file(&source, &temporary).await?;
             if let Err(error) = tokio::fs::rename(&temporary, &destination).await {
                 let _ = tokio::fs::remove_file(&temporary).await;
                 if !destination.exists() {
-                    return Err(io_error(error));
+                    return Err(AttachmentStageError::Fatal(io_error(error)));
                 }
             }
         }
-        let destination = destination.canonicalize().map_err(io_error)?;
+        let destination = destination
+            .canonicalize()
+            .map_err(|error| AttachmentStageError::Fatal(io_error(error)))?;
         if !destination.starts_with(&canonical_workspace) || !destination.is_file() {
-            return Err(AppError::new(
+            return Err(AttachmentStageError::Fatal(AppError::new(
                 "agent_attachment_invalid",
                 "Attachment destination is outside the session workspace.",
-            ));
+            )));
         }
         destination
     };
-    let metadata = tokio::fs::metadata(&destination).await.map_err(io_error)?;
+    let metadata = match tokio::fs::metadata(&destination).await {
+        Ok(metadata) => metadata,
+        Err(error) if source_in_workspace => {
+            return Err(AttachmentStageError::source_unavailable(io_error(error)));
+        }
+        Err(error) => return Err(AttachmentStageError::Fatal(io_error(error))),
+    };
     Ok(MessageAttachmentPayload {
         id: uuid::Uuid::new_v4().to_string(),
         name,
@@ -2043,16 +2142,29 @@ async fn prepare_attachment(
 async fn prepare_persisted_attachments(
     attachments: &[MessageAttachmentPayload],
     workspace: &Path,
-) -> Vec<(String, MessageAttachmentPayload)> {
+    policy: PersistedAttachmentPolicy,
+) -> Result<Vec<(String, MessageAttachmentPayload)>, AppError> {
     let mut prepared = Vec::new();
-    for attachment in attachments.iter().filter(|attachment| attachment.available) {
+    for attachment in attachments {
+        if !attachment.available {
+            if matches!(policy, PersistedAttachmentPolicy::RetryStrict) {
+                return Err(retry_attachment_unavailable());
+            }
+            continue;
+        }
         let original_path = attachment.path.clone();
         let stable_key = format!("{}\0{}", attachment.id, original_path);
-        if let Ok(copied) = prepare_attachment(&original_path, workspace, Some(&stable_key)).await {
-            prepared.push((original_path, copied));
+        match prepare_attachment(&original_path, workspace, Some(&stable_key)).await {
+            Ok(copied) => prepared.push((original_path, copied)),
+            Err(AttachmentStageError::SourceUnavailable(_))
+                if matches!(policy, PersistedAttachmentPolicy::HistoricalBestEffort) => {}
+            Err(AttachmentStageError::SourceUnavailable(_)) => {
+                return Err(retry_attachment_unavailable());
+            }
+            Err(error) => return Err(error.into_app_error()),
         }
     }
-    prepared
+    Ok(prepared)
 }
 
 async fn persist_attachments(
@@ -2321,13 +2433,14 @@ mod tests {
         let source_directory = tempfile::tempdir().expect("source directory");
         let workspace = tempfile::tempdir().expect("workspace");
         let source = source_directory.path().join("historical.png");
+        let missing = source_directory.path().join("missing.png");
         tokio::fs::write(&source, b"old image")
             .await
             .expect("historical attachment");
-        let attachment = |id: &str, available: bool| MessageAttachmentPayload {
+        let attachment = |id: &str, path: &Path, available: bool| MessageAttachmentPayload {
             id: id.into(),
             name: "historical.png".into(),
-            path: source.to_string_lossy().into_owned(),
+            path: path.to_string_lossy().into_owned(),
             mime_type: Some("image/png".into()),
             size_bytes: 1,
             available,
@@ -2341,13 +2454,21 @@ mod tests {
             payload: AgentItemPayload::UserMessage(super::super::MessagePayload {
                 role: "user".into(),
                 content: "Review this.".into(),
-                attachments: vec![attachment("available", true), attachment("stale", false)],
+                attachments: vec![
+                    attachment("available", &source, true),
+                    attachment("stale-positive", &missing, true),
+                    attachment("unavailable", &source, false),
+                ],
             }),
             external_id: None,
             created_at: "2026-07-24T12:00:00Z".into(),
         };
-        let history = normalized_runtime_history(vec![item.clone()], None, workspace.path()).await;
-        let repeated = normalized_runtime_history(vec![item], None, workspace.path()).await;
+        let history = normalized_runtime_history(vec![item.clone()], None, workspace.path())
+            .await
+            .expect("historical normalization");
+        let repeated = normalized_runtime_history(vec![item], None, workspace.path())
+            .await
+            .expect("repeated historical normalization");
 
         let normalized = PathBuf::from(
             history[0]["attachments"][0]["path"]
@@ -2379,6 +2500,65 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn retry_attachment_preparation_fails_when_any_attachment_is_unavailable() {
+        let source_directory = tempfile::tempdir().expect("source directory");
+        let workspace = tempfile::tempdir().expect("workspace");
+        let source = source_directory.path().join("available.md");
+        let missing = source_directory.path().join("missing.md");
+        tokio::fs::write(&source, "available")
+            .await
+            .expect("available attachment");
+        let attachment = |id: &str, path: &Path, available: bool| MessageAttachmentPayload {
+            id: id.into(),
+            name: "brief.md".into(),
+            path: path.to_string_lossy().into_owned(),
+            mime_type: Some("text/markdown".into()),
+            size_bytes: 1,
+            available,
+            created_at: "2026-07-24T12:00:00Z".into(),
+        };
+
+        for attachments in [
+            vec![
+                attachment("available", &source, true),
+                attachment("missing", &missing, true),
+            ],
+            vec![attachment("marked-unavailable", &source, false)],
+        ] {
+            let error = prepare_persisted_attachments(
+                &attachments,
+                workspace.path(),
+                PersistedAttachmentPolicy::RetryStrict,
+            )
+            .await
+            .expect_err("retry must preserve its complete attachment context");
+
+            assert_eq!(error.code, "agent_attachment_unavailable");
+        }
+    }
+
+    #[tokio::test]
+    async fn attachment_copy_classifies_a_source_open_race_as_unavailable() {
+        let source_directory = tempfile::tempdir().expect("source directory");
+        let destination_directory = tempfile::tempdir().expect("destination directory");
+        let source = source_directory.path().join("removed.md");
+        let destination = destination_directory.path().join("copy.md");
+        tokio::fs::write(&source, "removed")
+            .await
+            .expect("source attachment");
+        tokio::fs::remove_file(&source)
+            .await
+            .expect("remove source before open");
+
+        let error = copy_attachment_file(&source, &destination)
+            .await
+            .expect_err("source open failures must remain best-effort eligible");
+
+        assert!(matches!(error, AttachmentStageError::SourceUnavailable(_)));
+        assert!(!destination.exists());
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn attachment_staging_rejects_a_symlinked_destination_directory() {
@@ -2405,6 +2585,24 @@ mod tests {
                 .count(),
             0
         );
+
+        let persisted = MessageAttachmentPayload {
+            id: "attachment-1".into(),
+            name: "brief.md".into(),
+            path: source.to_string_lossy().into_owned(),
+            mime_type: Some("text/markdown".into()),
+            size_bytes: 7,
+            available: true,
+            created_at: "2026-07-24T12:00:00Z".into(),
+        };
+        let error = prepare_persisted_attachments(
+            &[persisted],
+            workspace.path(),
+            PersistedAttachmentPolicy::HistoricalBestEffort,
+        )
+        .await
+        .expect_err("historical replay cannot suppress a containment failure");
+        assert_eq!(error.code, "agent_attachment_invalid");
     }
 
     #[test]

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -6,6 +6,7 @@ use crate::domain::types::AppError;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde::Deserialize;
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -521,35 +522,14 @@ pub async fn start_agent_run(
     request: StartRunRequest,
 ) -> Result<Value, AppError> {
     let repository = repository(&app).await?;
-    let session = repository.get_session(&request.session_id).await?;
+    let session = start_run_session(&repository, &request.session_id, request.safety_mode).await?;
     let model = normalize_agent_model(&request.model);
-    if session.status == "running" || session.status == "waiting_for_user" {
-        return Err(AppError::new(
-            "agent_run_active",
-            "This session already has an active run.",
-        ));
-    }
-    let workspace = if request.workspace_path.trim().is_empty() {
-        session.workspace_path.clone().unwrap_or(
-            session_workspace(&app, Some(&session.id))?
-                .to_string_lossy()
-                .into_owned(),
-        )
-    } else {
-        request.workspace_path.clone()
-    };
-    tokio::fs::create_dir_all(&workspace)
-        .await
-        .map_err(io_error)?;
-    sqlx::query::query(
-        "UPDATE agent_sessions SET model = ?, safety_mode = ?, workspace_path = ? WHERE id = ?",
-    )
-    .bind(&model)
-    .bind(request.safety_mode.as_db())
-    .bind(&workspace)
-    .bind(&session.id)
-    .execute(&repository.pool)
-    .await?;
+    let workspace = authoritative_session_workspace(&app, &repository, &session.id).await?;
+    sqlx::query::query("UPDATE agent_sessions SET model = ? WHERE id = ?")
+        .bind(&model)
+        .bind(&session.id)
+        .execute(&repository.pool)
+        .await?;
     let prepared_attachments =
         prepare_attachments(&request.attachments, std::path::Path::new(&workspace)).await?;
     let available_skills = agent_skill_catalog(&app, &repository).await?;
@@ -580,7 +560,7 @@ pub async fn start_agent_run(
                 run_id: &run.id,
                 model: &model,
                 reasoning_effort,
-                safety_mode: request.safety_mode,
+                safety_mode: session.safety_mode,
                 workspace: &workspace,
                 input: &request.prompt,
                 skills: &requested_skills,
@@ -704,13 +684,17 @@ pub async fn retry_agent_run(
             )
         })?;
     let prompt = message.content;
-    let attachments = message.attachments;
-    let workspace = session.workspace_path.clone().ok_or_else(|| {
-        AppError::new(
-            "agent_workspace_missing",
-            "Session workspace is unavailable.",
-        )
-    })?;
+    let workspace = authoritative_session_workspace(&app, &repository, &session.id).await?;
+    let prepared_attachments =
+        prepare_persisted_attachments(&message.attachments, Path::new(&workspace)).await;
+    let original_attachment_paths = prepared_attachments
+        .iter()
+        .map(|(original_path, _)| original_path.clone())
+        .collect::<Vec<_>>();
+    let attachments = prepared_attachments
+        .into_iter()
+        .map(|(_, attachment)| attachment)
+        .collect::<Vec<_>>();
     let model = normalize_agent_model(&session.model);
     if model != session.model {
         sqlx::query::query("UPDATE agent_sessions SET model = ? WHERE id = ?")
@@ -747,7 +731,7 @@ pub async fn retry_agent_run(
         repository
             .set_run_config(&run.id, &resumable_run_config(&params))
             .await?;
-        repository
+        let user_item = repository
             .append_item(
                 &session.id,
                 Some(&run.id),
@@ -755,7 +739,7 @@ pub async fn retry_agent_run(
                 &AgentItemPayload::UserMessage(super::MessagePayload {
                     role: "user".into(),
                     content: prompt.clone(),
-                    attachments,
+                    attachments: attachments.clone(),
                 }),
                 Some(&format!("user:{}", run.id)),
             )
@@ -766,6 +750,15 @@ pub async fn retry_agent_run(
                     "The user message could not be persisted.",
                 )
             })?;
+        persist_attachments(
+            &repository,
+            &session.id,
+            &run.id,
+            &user_item.id,
+            &attachments,
+            &original_attachment_paths,
+        )
+        .await?;
         Ok::<_, AppError>(params)
     }
     .await;
@@ -879,12 +872,7 @@ pub async fn resolve_agent_interruption(
             ));
         }
     };
-    let workspace = session.workspace_path.clone().ok_or_else(|| {
-        AppError::new(
-            "agent_workspace_missing",
-            "Session workspace is unavailable.",
-        )
-    })?;
+    let workspace = authoritative_session_workspace(&app, &repository, &session.id).await?;
     let model = normalize_agent_model(&run.model);
     let auto_run = crate::june_api::is_agent_auto_model(&model);
     let resolved_model = resolved_model_from_usage(run.usage.as_ref());
@@ -931,7 +919,7 @@ pub async fn resolve_agent_interruption(
             ),
         },
     };
-    params["model"] = json!(model);
+    reassert_run_policy(&mut params, &model, session.safety_mode, &workspace);
     params
         .as_object_mut()
         .expect("run params object")
@@ -1431,6 +1419,46 @@ fn normalize_reasoning_effort(effort: Option<&str>) -> Result<Option<&str>, AppE
     }
 }
 
+fn validate_requested_safety_mode(
+    stored: AgentSafetyMode,
+    requested: AgentSafetyMode,
+) -> Result<(), AppError> {
+    if requested != stored {
+        return Err(AppError::new(
+            "agent_safety_mode_mismatch",
+            "The requested safety mode does not match this session.",
+        ));
+    }
+    Ok(())
+}
+
+async fn start_run_session(
+    repository: &AgentRepository,
+    session_id: &str,
+    requested_safety_mode: AgentSafetyMode,
+) -> Result<super::AgentSessionDto, AppError> {
+    let session = repository.get_session(session_id).await?;
+    validate_requested_safety_mode(session.safety_mode, requested_safety_mode)?;
+    if matches!(session.status.as_str(), "running" | "waiting_for_user") {
+        return Err(AppError::new(
+            "agent_run_active",
+            "This session already has an active run.",
+        ));
+    }
+    Ok(session)
+}
+
+fn reassert_run_policy(
+    params: &mut Value,
+    model: &str,
+    safety_mode: AgentSafetyMode,
+    workspace: &str,
+) {
+    params["model"] = json!(model);
+    params["safetyMode"] = json!(safety_mode.as_db());
+    params["workspace"] = json!(workspace);
+}
+
 struct RunParamsInput<'a> {
     session_id: &'a str,
     run_id: &'a str,
@@ -1455,10 +1483,12 @@ async fn run_params(
         .context_tokens
         .unwrap_or(128_000)
         .max(1_024);
-    let mut history = runtime_history(
+    let mut history = normalized_runtime_history(
         repository.items(request.session_id).await?,
         request.excluded_history_run_id,
-    );
+        Path::new(request.workspace),
+    )
+    .await;
     if !supports_vision {
         for item in &mut history {
             if let Some(object) = item.as_object_mut() {
@@ -1711,12 +1741,43 @@ fn history_item(item: AgentItemDto) -> Option<Value> {
     }
 }
 
+#[cfg(test)]
 fn runtime_history(items: Vec<AgentItemDto>, excluded_run_id: Option<&str>) -> Vec<Value> {
     items
         .into_iter()
         .filter(|item| item.run_id.as_deref() != excluded_run_id)
         .filter_map(history_item)
         .collect()
+}
+
+async fn normalized_runtime_history(
+    items: Vec<AgentItemDto>,
+    excluded_run_id: Option<&str>,
+    workspace: &Path,
+) -> Vec<Value> {
+    let mut history = Vec::new();
+    for mut item in items {
+        if item.run_id.as_deref() == excluded_run_id {
+            continue;
+        }
+        match &mut item.payload {
+            AgentItemPayload::UserMessage(message)
+            | AgentItemPayload::AssistantMessage(message)
+            | AgentItemPayload::SystemMessage(message) => {
+                message.attachments =
+                    prepare_persisted_attachments(&message.attachments, workspace)
+                        .await
+                        .into_iter()
+                        .map(|(_, attachment)| attachment)
+                        .collect();
+            }
+            _ => {}
+        }
+        if let Some(item) = history_item(item) {
+            history.push(item);
+        }
+    }
+    history
 }
 
 fn session_json(session: super::AgentSessionDto) -> Value {
@@ -1801,13 +1862,54 @@ fn item_json_with_active_run(
 }
 
 fn session_workspace(app: &AppHandle, session_id: Option<&str>) -> Result<PathBuf, AppError> {
-    let root = crate::app_paths::app_data_dir(app)
-        .map_err(|error| AppError::new("agent_workspace_failed", error.to_string()))?
-        .join("agent-workspaces");
-    Ok(session_id.map_or_else(
+    let data_dir = crate::app_paths::app_data_dir(app)
+        .map_err(|error| AppError::new("agent_workspace_failed", error.to_string()))?;
+    Ok(session_workspace_in(&data_dir, session_id))
+}
+
+fn session_workspace_in(data_dir: &Path, session_id: Option<&str>) -> PathBuf {
+    let root = data_dir.join("agent-workspaces");
+    session_id.map_or_else(
         || root.join(uuid::Uuid::new_v4().to_string()),
-        |id| root.join(id),
-    ))
+        |id| root.join(session_workspace_component(id)),
+    )
+}
+
+fn session_workspace_component(session_id: &str) -> String {
+    if uuid::Uuid::parse_str(session_id).is_ok_and(|id| id.hyphenated().to_string() == session_id) {
+        return session_id.to_string();
+    }
+    format!("legacy-{:x}", Sha256::digest(session_id.as_bytes()))
+}
+
+pub(crate) async fn authoritative_session_workspace(
+    app: &AppHandle,
+    repository: &AgentRepository,
+    session_id: &str,
+) -> Result<String, AppError> {
+    let workspace = session_workspace(app, Some(session_id))?;
+    persist_authoritative_session_workspace(repository, session_id, &workspace).await?;
+    Ok(workspace.to_string_lossy().into_owned())
+}
+
+async fn persist_authoritative_session_workspace(
+    repository: &AgentRepository,
+    session_id: &str,
+    workspace: &Path,
+) -> Result<(), AppError> {
+    tokio::fs::create_dir_all(workspace)
+        .await
+        .map_err(io_error)?;
+    let workspace = workspace.to_string_lossy();
+    sqlx::query::query(
+        "UPDATE agent_sessions SET workspace_path = ? WHERE id = ? AND (workspace_path IS NULL OR workspace_path != ?)",
+    )
+    .bind(workspace.as_ref())
+    .bind(session_id)
+    .bind(workspace.as_ref())
+    .execute(&repository.pool)
+    .await?;
+    Ok(())
 }
 fn io_error(error: std::io::Error) -> AppError {
     AppError::new("agent_workspace_failed", error.to_string())
@@ -1838,54 +1940,119 @@ async fn prepare_attachments(
     if source_paths.is_empty() {
         return Ok(Vec::new());
     }
+    let mut attachments = Vec::with_capacity(source_paths.len());
+    for source_path in source_paths {
+        attachments.push(prepare_attachment(source_path, workspace, None).await?);
+    }
+    Ok(attachments)
+}
+
+async fn prepare_attachment(
+    source_path: &str,
+    workspace: &Path,
+    stable_key: Option<&str>,
+) -> Result<MessageAttachmentPayload, AppError> {
     let destination_root = workspace.join("attachments");
     tokio::fs::create_dir_all(&destination_root)
         .await
         .map_err(io_error)?;
     let canonical_workspace = workspace.canonicalize().map_err(io_error)?;
-    let mut attachments = Vec::with_capacity(source_paths.len());
-    for source_path in source_paths {
-        let source = PathBuf::from(source_path)
-            .canonicalize()
-            .map_err(io_error)?;
-        if !source.is_file() {
-            return Err(AppError::new(
+    let destination_metadata = tokio::fs::symlink_metadata(&destination_root)
+        .await
+        .map_err(io_error)?;
+    let destination_root = destination_root.canonicalize().map_err(io_error)?;
+    if destination_metadata.file_type().is_symlink()
+        || !destination_metadata.is_dir()
+        || !destination_root.starts_with(&canonical_workspace)
+    {
+        return Err(AppError::new(
+            "agent_attachment_invalid",
+            "Attachment destination is outside the session workspace.",
+        ));
+    }
+    let source = PathBuf::from(source_path)
+        .canonicalize()
+        .map_err(io_error)?;
+    if !source.is_file() {
+        return Err(AppError::new(
+            "agent_attachment_invalid",
+            "Attachment source is not a file.",
+        ));
+    }
+    let name = source
+        .file_name()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            AppError::new(
                 "agent_attachment_invalid",
-                "Attachment source is not a file.",
-            ));
-        }
-        let name = source
-            .file_name()
-            .and_then(|value| value.to_str())
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| {
-                AppError::new(
-                    "agent_attachment_invalid",
-                    "Attachment source has no valid file name.",
-                )
-            })?
-            .to_string();
-        let destination = if source.starts_with(&canonical_workspace) {
-            source
-        } else {
-            let destination = destination_root.join(format!("{}-{name}", uuid::Uuid::new_v4()));
-            tokio::fs::copy(&source, &destination)
+                "Attachment source has no valid file name.",
+            )
+        })?
+        .to_string();
+    let destination = if source.starts_with(&canonical_workspace) {
+        source
+    } else {
+        let destination_name = match stable_key {
+            Some(key) => {
+                let extension = source
+                    .extension()
+                    .and_then(|value| value.to_str())
+                    .filter(|value| {
+                        value.len() <= 10 && value.bytes().all(|byte| byte.is_ascii_alphanumeric())
+                    })
+                    .map_or_else(String::new, |value| format!(".{value}"));
+                format!("persisted-{:x}{extension}", Sha256::digest(key.as_bytes()))
+            }
+            None => format!("{}-{name}", uuid::Uuid::new_v4()),
+        };
+        let destination = destination_root.join(destination_name);
+        if !destination.exists() {
+            let temporary = destination_root.join(format!(".{}.tmp", uuid::Uuid::new_v4()));
+            tokio::fs::copy(&source, &temporary)
                 .await
                 .map_err(io_error)?;
-            destination
-        };
-        let metadata = tokio::fs::metadata(&destination).await.map_err(io_error)?;
-        attachments.push(MessageAttachmentPayload {
-            id: uuid::Uuid::new_v4().to_string(),
-            name,
-            path: destination.to_string_lossy().into_owned(),
-            mime_type: attachment_mime_type(&destination).map(str::to_string),
-            size_bytes: metadata.len() as i64,
-            available: true,
-            created_at: chrono::Utc::now().to_rfc3339(),
-        });
+            if let Err(error) = tokio::fs::rename(&temporary, &destination).await {
+                let _ = tokio::fs::remove_file(&temporary).await;
+                if !destination.exists() {
+                    return Err(io_error(error));
+                }
+            }
+        }
+        let destination = destination.canonicalize().map_err(io_error)?;
+        if !destination.starts_with(&canonical_workspace) || !destination.is_file() {
+            return Err(AppError::new(
+                "agent_attachment_invalid",
+                "Attachment destination is outside the session workspace.",
+            ));
+        }
+        destination
+    };
+    let metadata = tokio::fs::metadata(&destination).await.map_err(io_error)?;
+    Ok(MessageAttachmentPayload {
+        id: uuid::Uuid::new_v4().to_string(),
+        name,
+        path: destination.to_string_lossy().into_owned(),
+        mime_type: attachment_mime_type(&destination).map(str::to_string),
+        size_bytes: metadata.len() as i64,
+        available: true,
+        created_at: chrono::Utc::now().to_rfc3339(),
+    })
+}
+
+async fn prepare_persisted_attachments(
+    attachments: &[MessageAttachmentPayload],
+    workspace: &Path,
+) -> Vec<(String, MessageAttachmentPayload)> {
+    let mut prepared = Vec::new();
+    for attachment in attachments.iter().filter(|attachment| attachment.available) {
+        let original_path = attachment.path.clone();
+        let stable_key = format!("{}\0{}", attachment.id, original_path);
+        if let Ok(copied) = prepare_attachment(&original_path, workspace, Some(&stable_key)).await {
+            prepared.push((original_path, copied));
+        }
     }
-    Ok(attachments)
+    prepared
 }
 
 async fn persist_attachments(
@@ -1996,6 +2163,271 @@ fn attachment_mime_type(path: &std::path::Path) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn start_run_requires_the_stored_safety_mode() {
+        for (stored, requested) in [
+            (AgentSafetyMode::Sandboxed, AgentSafetyMode::Unrestricted),
+            (AgentSafetyMode::Unrestricted, AgentSafetyMode::Sandboxed),
+        ] {
+            let error = validate_requested_safety_mode(stored, requested)
+                .expect_err("a renderer cannot change the stored mode");
+            assert_eq!(error.code, "agent_safety_mode_mismatch");
+        }
+
+        assert!(validate_requested_safety_mode(
+            AgentSafetyMode::Sandboxed,
+            AgentSafetyMode::Sandboxed
+        )
+        .is_ok());
+        assert!(validate_requested_safety_mode(
+            AgentSafetyMode::Unrestricted,
+            AgentSafetyMode::Unrestricted
+        )
+        .is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejected_safety_mode_does_not_create_a_run_or_mutate_the_session() {
+        use sqlx::{query::query, row::Row};
+        use sqlx_sqlite::SqlitePoolOptions;
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("memory database");
+        crate::db::migrations::run_migrations(&pool)
+            .await
+            .expect("migrations");
+        let repository = AgentRepository::new(pool.clone());
+        let session = repository
+            .create_session(
+                "Session",
+                "model-before",
+                AgentSafetyMode::Sandboxed,
+                Some("/workspace-before"),
+            )
+            .await
+            .expect("session");
+
+        let error = start_run_session(&repository, &session.id, AgentSafetyMode::Unrestricted)
+            .await
+            .expect_err("mismatched mode");
+
+        assert_eq!(error.code, "agent_safety_mode_mismatch");
+        let stored = repository
+            .get_session(&session.id)
+            .await
+            .expect("stored session");
+        assert_eq!(stored.safety_mode, AgentSafetyMode::Sandboxed);
+        assert_eq!(stored.model, "model-before");
+        assert_eq!(stored.workspace_path.as_deref(), Some("/workspace-before"));
+        let run_count: i64 = query("SELECT COUNT(*) AS count FROM agent_runs")
+            .fetch_one(&pool)
+            .await
+            .expect("run count")
+            .get("count");
+        assert_eq!(run_count, 0);
+    }
+
+    #[tokio::test]
+    async fn session_workspace_is_host_derived_created_and_persisted() {
+        use sqlx::query::query;
+        use sqlx_sqlite::SqlitePoolOptions;
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("memory database");
+        crate::db::migrations::run_migrations(&pool)
+            .await
+            .expect("migrations");
+        let repository = AgentRepository::new(pool.clone());
+        let session = repository
+            .create_session("Session", "model", AgentSafetyMode::Sandboxed, None)
+            .await
+            .expect("session");
+        let data_dir = tempfile::tempdir().expect("data directory");
+        let expected = session_workspace_in(data_dir.path(), Some(&session.id));
+
+        persist_authoritative_session_workspace(&repository, &session.id, &expected)
+            .await
+            .expect("persist missing workspace");
+        assert!(expected.is_dir());
+        assert_eq!(
+            repository
+                .get_session(&session.id)
+                .await
+                .expect("session with workspace")
+                .workspace_path
+                .as_deref(),
+            expected.to_str()
+        );
+
+        query("UPDATE agent_sessions SET workspace_path = '/forged/workspace' WHERE id = ?")
+            .bind(&session.id)
+            .execute(&pool)
+            .await
+            .expect("forge workspace");
+        persist_authoritative_session_workspace(&repository, &session.id, &expected)
+            .await
+            .expect("restore authoritative workspace");
+        assert_eq!(
+            repository
+                .get_session(&session.id)
+                .await
+                .expect("restored session")
+                .workspace_path
+                .as_deref(),
+            expected.to_str()
+        );
+    }
+
+    #[test]
+    fn imported_session_ids_cannot_escape_or_collide_as_workspace_components() {
+        let data_dir = Path::new("/app-data");
+        let workspace_root = data_dir.join("agent-workspaces");
+        let canonical_id = "123e4567-e89b-12d3-a456-426614174000";
+        assert_eq!(session_workspace_component(canonical_id), canonical_id);
+        let long_id = "x".repeat(300);
+
+        for unsafe_id in [
+            "../escape",
+            "/absolute",
+            r"C:\escape",
+            r"\\server\share",
+            "CON",
+            &long_id,
+        ] {
+            let workspace = session_workspace_in(data_dir, Some(unsafe_id));
+            assert_eq!(workspace.parent(), Some(workspace_root.as_path()));
+        }
+        let hashed = session_workspace_component("../escape");
+        assert_ne!(session_workspace_component(&hashed), hashed);
+        assert_ne!(
+            session_workspace_component("LEGACY-ID"),
+            session_workspace_component("legacy-id")
+        );
+        assert_ne!(
+            session_workspace_component("legacy/a"),
+            session_workspace_component(r"legacy\a")
+        );
+    }
+
+    #[tokio::test]
+    async fn historical_attachments_are_copied_into_the_authoritative_workspace() {
+        let source_directory = tempfile::tempdir().expect("source directory");
+        let workspace = tempfile::tempdir().expect("workspace");
+        let source = source_directory.path().join("historical.png");
+        tokio::fs::write(&source, b"old image")
+            .await
+            .expect("historical attachment");
+        let attachment = |id: &str, available: bool| MessageAttachmentPayload {
+            id: id.into(),
+            name: "historical.png".into(),
+            path: source.to_string_lossy().into_owned(),
+            mime_type: Some("image/png".into()),
+            size_bytes: 1,
+            available,
+            created_at: "2026-07-24T12:00:00Z".into(),
+        };
+        let item = AgentItemDto {
+            id: "message-1".into(),
+            session_id: "session-1".into(),
+            run_id: Some("run-1".into()),
+            sequence: 0,
+            payload: AgentItemPayload::UserMessage(super::super::MessagePayload {
+                role: "user".into(),
+                content: "Review this.".into(),
+                attachments: vec![attachment("available", true), attachment("stale", false)],
+            }),
+            external_id: None,
+            created_at: "2026-07-24T12:00:00Z".into(),
+        };
+        let history = normalized_runtime_history(vec![item.clone()], None, workspace.path()).await;
+        let repeated = normalized_runtime_history(vec![item], None, workspace.path()).await;
+
+        let normalized = PathBuf::from(
+            history[0]["attachments"][0]["path"]
+                .as_str()
+                .expect("normalized path"),
+        );
+        assert!(normalized.starts_with(workspace.path()));
+        assert_eq!(history[0]["attachments"].as_array().unwrap().len(), 1);
+        assert_eq!(history[0]["attachments"][0]["sizeBytes"], 9);
+        assert!(history[0]["text"]
+            .as_str()
+            .expect("attachment manifest")
+            .contains(normalized.to_string_lossy().as_ref()));
+        assert_eq!(
+            repeated[0]["attachments"][0]["path"],
+            history[0]["attachments"][0]["path"]
+        );
+        assert_eq!(
+            std::fs::read_dir(workspace.path().join("attachments"))
+                .expect("attachment directory")
+                .count(),
+            1
+        );
+        assert_eq!(
+            tokio::fs::read(normalized)
+                .await
+                .expect("copied historical attachment"),
+            b"old image"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn attachment_staging_rejects_a_symlinked_destination_directory() {
+        use std::os::unix::fs::symlink;
+
+        let source_directory = tempfile::tempdir().expect("source directory");
+        let workspace = tempfile::tempdir().expect("workspace");
+        let outside = tempfile::tempdir().expect("outside directory");
+        let source = source_directory.path().join("brief.md");
+        tokio::fs::write(&source, "private")
+            .await
+            .expect("source attachment");
+        symlink(outside.path(), workspace.path().join("attachments"))
+            .expect("symlinked attachment directory");
+
+        let error = prepare_attachments(&[source.to_string_lossy().into_owned()], workspace.path())
+            .await
+            .expect_err("symlinked destination must be rejected");
+
+        assert_eq!(error.code, "agent_attachment_invalid");
+        assert_eq!(
+            std::fs::read_dir(outside.path())
+                .expect("outside directory")
+                .count(),
+            0
+        );
+    }
+
+    #[test]
+    fn resume_reasserts_stored_policy_over_stale_run_configuration() {
+        let mut params = json!({
+            "model": "old-model",
+            "safetyMode": "unrestricted",
+            "workspace": "/stale/workspace",
+            "tools": [{ "name": "read_file" }]
+        });
+
+        reassert_run_policy(
+            &mut params,
+            "stored-model",
+            AgentSafetyMode::Sandboxed,
+            "/host/workspace",
+        );
+
+        assert_eq!(params["model"], "stored-model");
+        assert_eq!(params["safetyMode"], "sandboxed");
+        assert_eq!(params["workspace"], "/host/workspace");
+        assert_eq!(params["tools"][0]["name"], "read_file");
+    }
 
     #[test]
     fn extracts_a_concrete_model_from_persisted_usage() {

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -1,6 +1,6 @@
 use super::{
-    repository::ContextSummaryReplacement, AgentItemDto, AgentItemPayload, AgentRepository,
-    AgentRuntimeHost, AgentSafetyMode, MessageAttachmentPayload,
+    repository::ContextSummaryReplacement, AgentArtifactDto, AgentItemDto, AgentItemPayload,
+    AgentRepository, AgentRuntimeHost, AgentSafetyMode, MessageAttachmentPayload,
 };
 use crate::domain::types::AppError;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
@@ -533,6 +533,12 @@ pub async fn start_agent_run(
         .await?;
     let prepared_attachments =
         prepare_attachments(&request.attachments, std::path::Path::new(&workspace)).await?;
+    let original_attachment_paths = request
+        .attachments
+        .iter()
+        .cloned()
+        .map(Some)
+        .collect::<Vec<_>>();
     let available_skills = agent_skill_catalog(&app, &repository).await?;
     let requested_skills = request
         .enabled_skill_ids
@@ -598,7 +604,7 @@ pub async fn start_agent_run(
             &run.id,
             &user_item.id,
             &prepared_attachments,
-            &request.attachments,
+            &original_attachment_paths,
         )
         .await?;
         Ok::<_, AppError>(params)
@@ -684,6 +690,9 @@ pub async fn retry_agent_run(
                 "No user message is available to retry.",
             )
         })?;
+    let persisted_artifacts = repository.artifacts(&session.id).await?;
+    let original_attachment_paths =
+        persisted_attachment_original_paths(&message.attachments, &persisted_artifacts);
     let prompt = message.content;
     let workspace = authoritative_session_workspace(&app, &repository, &session.id).await?;
     let prepared_attachments = prepare_persisted_attachments(
@@ -692,10 +701,6 @@ pub async fn retry_agent_run(
         PersistedAttachmentPolicy::RetryStrict,
     )
     .await?;
-    let original_attachment_paths = prepared_attachments
-        .iter()
-        .map(|(original_path, _)| original_path.clone())
-        .collect::<Vec<_>>();
     let attachments = prepared_attachments
         .into_iter()
         .map(|(_, attachment)| attachment)
@@ -2155,7 +2160,11 @@ async fn prepare_persisted_attachments(
         let original_path = attachment.path.clone();
         let stable_key = format!("{}\0{}", attachment.id, original_path);
         match prepare_attachment(&original_path, workspace, Some(&stable_key)).await {
-            Ok(copied) => prepared.push((original_path, copied)),
+            Ok(mut copied) => {
+                copied.name.clone_from(&attachment.name);
+                copied.mime_type.clone_from(&attachment.mime_type);
+                prepared.push((original_path, copied));
+            }
             Err(AttachmentStageError::SourceUnavailable(_))
                 if matches!(policy, PersistedAttachmentPolicy::HistoricalBestEffort) => {}
             Err(AttachmentStageError::SourceUnavailable(_)) => {
@@ -2167,15 +2176,40 @@ async fn prepare_persisted_attachments(
     Ok(prepared)
 }
 
+fn persisted_attachment_original_paths(
+    attachments: &[MessageAttachmentPayload],
+    artifacts: &[AgentArtifactDto],
+) -> Vec<Option<String>> {
+    let original_paths = artifacts
+        .iter()
+        .map(|artifact| (artifact.id.as_str(), artifact.original_path.clone()))
+        .collect::<HashMap<_, _>>();
+    attachments
+        .iter()
+        .map(|attachment| {
+            original_paths
+                .get(attachment.id.as_str())
+                .cloned()
+                .unwrap_or_else(|| Some(attachment.path.clone()))
+        })
+        .collect()
+}
+
 async fn persist_attachments(
     repository: &AgentRepository,
     session_id: &str,
     run_id: &str,
     item_id: &str,
     attachments: &[MessageAttachmentPayload],
-    original_paths: &[String],
+    original_paths: &[Option<String>],
 ) -> Result<(), AppError> {
-    for (index, attachment) in attachments.iter().enumerate() {
+    if attachments.len() != original_paths.len() {
+        return Err(AppError::new(
+            "agent_attachment_provenance_invalid",
+            "Attachment provenance does not match the staged attachments.",
+        ));
+    }
+    for (attachment, original_path) in attachments.iter().zip(original_paths) {
         sqlx::query::query(
             "INSERT INTO agent_artifacts (
                 id, session_id, run_id, item_id, provenance, action, path,
@@ -2187,7 +2221,7 @@ async fn persist_attachments(
         .bind(run_id)
         .bind(item_id)
         .bind(&attachment.path)
-        .bind(original_paths.get(index))
+        .bind(original_path)
         .bind(&attachment.mime_type)
         .bind(attachment.size_bytes)
         .bind(&attachment.created_at)
@@ -2536,6 +2570,112 @@ mod tests {
 
             assert_eq!(error.code, "agent_attachment_unavailable");
         }
+    }
+
+    #[tokio::test]
+    async fn successful_retry_staging_preserves_attachment_semantics_and_order() {
+        let source_directory = tempfile::tempdir().expect("source directory");
+        let workspace = tempfile::tempdir().expect("workspace");
+        let markdown = source_directory.path().join("brief.md");
+        let image = source_directory.path().join("diagram.png");
+        tokio::fs::write(&markdown, "brief")
+            .await
+            .expect("markdown attachment");
+        tokio::fs::write(&image, b"image")
+            .await
+            .expect("image attachment");
+        let mut persisted = prepare_attachments(
+            &[
+                markdown.to_string_lossy().into_owned(),
+                image.to_string_lossy().into_owned(),
+            ],
+            workspace.path(),
+        )
+        .await
+        .expect("initial staging");
+        persisted[1].mime_type = None;
+        let persisted_ids = persisted
+            .iter()
+            .map(|attachment| attachment.id.clone())
+            .collect::<Vec<_>>();
+
+        let retried = prepare_persisted_attachments(
+            &persisted,
+            workspace.path(),
+            PersistedAttachmentPolicy::RetryStrict,
+        )
+        .await
+        .expect("retry staging")
+        .into_iter()
+        .map(|(_, attachment)| attachment)
+        .collect::<Vec<_>>();
+
+        assert_eq!(
+            retried
+                .iter()
+                .map(|attachment| attachment.name.as_str())
+                .collect::<Vec<_>>(),
+            ["brief.md", "diagram.png"]
+        );
+        assert_eq!(retried[0].mime_type.as_deref(), Some("text/markdown"));
+        assert_eq!(retried[1].mime_type, None);
+        assert_eq!(retried[0].size_bytes, 5);
+        assert_eq!(retried[1].size_bytes, 5);
+        assert!(retried
+            .iter()
+            .all(|attachment| Path::new(&attachment.path).starts_with(workspace.path())));
+        assert!(retried
+            .iter()
+            .zip(persisted_ids)
+            .all(|(attachment, persisted_id)| attachment.id != persisted_id));
+        let manifest = message_with_attachment_context("Review these.", &retried);
+        assert!(manifest.contains("- brief.md ("));
+        assert!(manifest.contains("- diagram.png ("));
+    }
+
+    #[test]
+    fn retry_provenance_preserves_original_paths_in_descriptor_order() {
+        let attachment = |id: &str, path: &str| MessageAttachmentPayload {
+            id: id.into(),
+            name: format!("{id}.md"),
+            path: path.into(),
+            mime_type: Some("text/markdown".into()),
+            size_bytes: 1,
+            available: true,
+            created_at: "2026-07-24T12:00:00Z".into(),
+        };
+        let artifact = |id: &str, original_path: Option<&str>| AgentArtifactDto {
+            id: id.into(),
+            session_id: "session-1".into(),
+            run_id: Some("run-1".into()),
+            item_id: Some("item-1".into()),
+            provenance: "attachment".into(),
+            action: "imported".into(),
+            path: format!("/workspace/{id}.md"),
+            original_path: original_path.map(str::to_string),
+            mime_type: Some("text/markdown".into()),
+            size_bytes: Some(1),
+            available: true,
+            created_at: "2026-07-24T12:00:00Z".into(),
+        };
+        let attachments = vec![
+            attachment("with-source", "/workspace/staged-1.md"),
+            attachment("without-source", "/workspace/staged-2.md"),
+            attachment("missing-row", "/workspace/staged-3.md"),
+        ];
+        let artifacts = vec![
+            artifact("without-source", None),
+            artifact("with-source", Some("/Users/jimmy/Documents/brief.md")),
+        ];
+
+        assert_eq!(
+            persisted_attachment_original_paths(&attachments, &artifacts),
+            vec![
+                Some("/Users/jimmy/Documents/brief.md".into()),
+                None,
+                Some("/workspace/staged-3.md".into()),
+            ]
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/agent_runtime/host.rs
+++ b/src-tauri/src/agent_runtime/host.rs
@@ -501,13 +501,12 @@ async fn handle_runtime_request(
                 drop(scopes);
                 return poll_model_stream(model_streams, &stream_id).await;
             }
-            let session = repository.get_session(&frame.session_id).await?;
-            let workspace = session.workspace_path.map(PathBuf::from).ok_or_else(|| {
-                AppError::new(
-                    "agent_workspace_missing",
-                    "Session workspace is unavailable.",
-                )
-            })?;
+            let run = repository.get_run(&frame.run_id).await?;
+            validate_run_session(&run.session_id, &frame.session_id)?;
+            let session = repository.get_session(&run.session_id).await?;
+            let workspace = PathBuf::from(
+                super::api::authoritative_session_workspace(app, repository, &session.id).await?,
+            );
             dispatch_tool(
                 &ToolContext {
                     app: app.clone(),
@@ -1060,6 +1059,16 @@ fn steering_stable_id(params: &Value, event_id: &str) -> String {
     )
 }
 
+fn validate_run_session(run_session_id: &str, requested_session_id: &str) -> Result<(), AppError> {
+    if run_session_id != requested_session_id {
+        return Err(AppError::new(
+            "agent_run_session_mismatch",
+            "The agent run does not belong to the requested session.",
+        ));
+    }
+    Ok(())
+}
+
 fn sanitize_log(value: &str) -> String {
     let value = redact_bearer_tokens(value);
     let value = redact_key_tokens(&value);
@@ -1149,6 +1158,14 @@ fn redact_key_tokens(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tool_requests_must_match_the_persisted_run_session() {
+        assert!(validate_run_session("session-1", "session-1").is_ok());
+        let error = validate_run_session("session-1", "session-2")
+            .expect_err("a run cannot borrow another session's policy");
+        assert_eq!(error.code, "agent_run_session_mismatch");
+    }
 
     #[test]
     fn consumed_steering_uses_message_id_as_its_persisted_external_id() {


### PR DESCRIPTION
## Summary

- Make the Rust host authoritative for each agent session's persisted safety mode and app-data-derived workspace.
- Preserve the existing start request fields and macOS behavior for compatibility.
- Reassert host-owned policy across start, retry, interruption resume, and tool dispatch.
- Normalize new and historical attachments into the authoritative workspace with traversal, aliasing, and symlink protections.
- Validate that sidecar tool requests use the session belonging to the persisted run.

## Root cause

Run setup and tool dispatch accepted policy-bearing values from renderer and sidecar messages even though the persisted session is the trusted source of truth. Historical retry and resume data could also retain stale workspace paths. That left multiple paths where untrusted or stale values could diverge from the session's persisted safety boundary.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `git diff --check upstream/main...1ef1934f189708115f92726de16fb3e7a9a62198`
- `cargo check --manifest-path src-tauri/Cargo.toml --lib --locked`
- Targeted security review completed with no remaining merge blockers in the renderer/sidecar input threat boundary.
- `pnpm test:rust` is blocked on the unchanged Linux baseline by `E0283` at `src-tauri/src/shutdown.rs:560` (ambiguous `.sum()` type).
- `make tauri-lint` is blocked by existing platform-gated unused/dead-code warnings promoted to errors.
- Windows validation is intentionally pending before this draft is marked ready.

- [x] Tested visually where it matters (not applicable: no UI changes).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Windows access-mode labels and presentation.
- Windows-specific tool-catalog filtering or tool policy changes.
- Routine, MCP, starter-prompt, CI, release, and backend changes.
- Renaming persisted safety-mode values, database columns, or request fields.

## Followups

- Validate this branch on Windows before marking the PR ready.
- Continue JUN-451 in separately reviewable branches for Windows presentation and tool availability behavior.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs (not applicable: no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable: no such changes).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable: no backend changes).
- [x] User-facing copy follows the repo UI conventions (not applicable: no user-facing copy changes).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787898344&installation_model_id=425925&pr_number=1009&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1009&signature=c0434ea0d71fcd91447c6e0e3daf43f846b689f517da67260c4e9e47af642fc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->