### PR TITLE
fix(companion): camelCase wire fields and a relay heartbeat

### DIFF
--- a/crates/june-companion-protocol/src/lib.rs
+++ b/crates/june-companion-protocol/src/lib.rs
@@ -170,11 +170,13 @@ impl Frame {
 pub enum Body {
     NotesList(PageRequest),
     NoteGet {
+        #[serde(rename = "noteId", alias = "note_id")]
         note_id: String,
     },
     NoteEdit(NoteEditRequest),
     AgentSessionsList(PageRequest),
     AgentMessagesList {
+        #[serde(rename = "storedSessionId", alias = "stored_session_id")]
         stored_session_id: String,
         page: PageRequest,
     },
@@ -196,6 +198,7 @@ pub enum Body {
     },
     MediaFetch(MediaFetchRequest),
     AgentCancel {
+        #[serde(rename = "storedSessionId", alias = "stored_session_id")]
         stored_session_id: String,
     },
     ModelsList,
@@ -207,12 +210,15 @@ pub enum Body {
     SettingsGet,
     SettingsEditSafe(SafeSettingsPatch),
     RecordingPause {
+        #[serde(rename = "recordingSessionId", alias = "recording_session_id")]
         recording_session_id: String,
     },
     RecordingResume {
+        #[serde(rename = "recordingSessionId", alias = "recording_session_id")]
         recording_session_id: String,
     },
     RecordingStop {
+        #[serde(rename = "recordingSessionId", alias = "recording_session_id")]
         recording_session_id: String,
     },
     RecordingGetActive,
@@ -663,8 +669,14 @@ pub enum DictationStyle {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum FocusTarget {
-    Agent { stored_session_id: Option<String> },
-    Note { note_id: String },
+    Agent {
+        #[serde(rename = "storedSessionId", alias = "stored_session_id")]
+        stored_session_id: Option<String>,
+    },
+    Note {
+        #[serde(rename = "noteId", alias = "note_id")]
+        note_id: String,
+    },
     Settings,
 }
 
@@ -739,7 +751,10 @@ pub enum ResultPayload {
     Note(NoteRecord),
     AgentSessions(Page<AgentSession>),
     AgentMessages(Page<AgentMessage>),
-    AgentAccepted { stored_session_id: String },
+    AgentAccepted {
+        #[serde(rename = "storedSessionId", alias = "stored_session_id")]
+        stored_session_id: String,
+    },
     Upload(UploadProgress),
     BrowseRoots(Vec<BrowseRoot>),
     BrowseEntries(Page<BrowseEntry>),
@@ -1200,10 +1215,12 @@ pub enum FailureCode {
 #[serde(tag = "type", content = "data", rename_all = "camelCase")]
 pub enum Event {
     AgentDelta {
+        #[serde(rename = "storedSessionId", alias = "stored_session_id")]
         stored_session_id: String,
         text: String,
     },
     AgentStatus {
+        #[serde(rename = "storedSessionId", alias = "stored_session_id")]
         stored_session_id: String,
         status: AgentStatus,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1584,6 +1601,52 @@ mod tests {
         }))
         .unwrap();
         assert!(decode_peer_hello(&too_many_unknown).is_err());
+    }
+
+    #[test]
+    fn agent_accepted_uses_the_camel_case_session_id_wire_field() {
+        let encoded = r#"{"type":"agentAccepted","data":{"storedSessionId":"stored-1"}}"#;
+        let payload: ResultPayload = serde_json::from_str(encoded).unwrap();
+        assert_eq!(
+            payload,
+            ResultPayload::AgentAccepted {
+                stored_session_id: "stored-1".to_string(),
+            }
+        );
+        assert_eq!(serde_json::to_string(&payload).unwrap(), encoded);
+    }
+
+    #[test]
+    fn agent_message_reads_use_the_camel_case_session_id_wire_field() {
+        let encoded = r#"{"type":"agentMessagesList","data":{"storedSessionId":"stored-1","page":{"cursor":null,"limit":100}}}"#;
+        let body: Body = serde_json::from_str(encoded).unwrap();
+        assert_eq!(
+            body,
+            Body::AgentMessagesList {
+                stored_session_id: "stored-1".to_string(),
+                page: PageRequest {
+                    cursor: None,
+                    limit: 100,
+                },
+            }
+        );
+        assert_eq!(serde_json::to_string(&body).unwrap(), encoded);
+    }
+
+    #[test]
+    fn agent_events_use_the_camel_case_session_id_wire_field() {
+        let encoded =
+            r#"{"type":"agentStatus","data":{"storedSessionId":"stored-1","status":"completed"}}"#;
+        let event: Event = serde_json::from_str(encoded).unwrap();
+        assert_eq!(
+            event,
+            Event::AgentStatus {
+                stored_session_id: "stored-1".to_string(),
+                status: AgentStatus::Completed,
+                media: Vec::new(),
+            }
+        );
+        assert_eq!(serde_json::to_string(&event).unwrap(), encoded);
     }
 
     #[test]

--- a/june-api/crates/api/src/handlers/companion.rs
+++ b/june-api/crates/api/src/handlers/companion.rs
@@ -41,6 +41,7 @@ const PAIRING_TTL_MS: u64 = 5 * 60 * 1_000;
 const MAX_DEVICE_NAME_BYTES: usize = 128;
 const OUTBOUND_QUEUE_CAPACITY: usize = 64;
 const MAX_MESSAGES_PER_MINUTE: usize = 120;
+const RELAY_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(20);
 const MIN_APNS_TOKEN_BYTES: usize = 16;
 const MAX_APNS_TOKEN_BYTES: usize = 256;
 const APNS_WAKE_COOLDOWN: Duration = Duration::from_secs(30);
@@ -564,8 +565,14 @@ async fn relay_connection(state: ApiState, user_id: UserId, device_id: Uuid, soc
         return;
     };
     let (mut sender, mut receiver) = socket.split();
+    let mut heartbeat = tokio::time::interval(RELAY_HEARTBEAT_INTERVAL);
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    heartbeat.tick().await;
     loop {
         tokio::select! {
+            _ = heartbeat.tick() => {
+                if sender.send(Message::Ping(Vec::new().into())).await.is_err() { break; }
+            }
             outbound_message = outbound.recv() => {
                 let Some(outbound_message) = outbound_message else { break };
                 let message = outbound_websocket_message(outbound_message);

--- a/june-api/crates/api/src/handlers/companion.rs
+++ b/june-api/crates/api/src/handlers/companion.rs
@@ -230,6 +230,33 @@ struct Connection {
     outbound: mpsc::Sender<Outbound>,
 }
 
+#[derive(Default)]
+struct RelayHeartbeat {
+    next_sequence: u64,
+    awaiting_pong: Option<[u8; size_of::<u64>()]>,
+}
+
+impl RelayHeartbeat {
+    fn next_ping(&mut self) -> Option<[u8; size_of::<u64>()]> {
+        if self.awaiting_pong.is_some() {
+            return None;
+        }
+        let payload = self.next_sequence.to_be_bytes();
+        self.next_sequence = self.next_sequence.wrapping_add(1);
+        self.awaiting_pong = Some(payload);
+        Some(payload)
+    }
+
+    fn receive_pong(&mut self, payload: &[u8]) {
+        if self
+            .awaiting_pong
+            .is_some_and(|expected| expected.as_slice() == payload)
+        {
+            self.awaiting_pong = None;
+        }
+    }
+}
+
 enum Outbound {
     Ciphertext(Vec<u8>),
     Revoked,
@@ -568,10 +595,12 @@ async fn relay_connection(state: ApiState, user_id: UserId, device_id: Uuid, soc
     let mut heartbeat = tokio::time::interval(RELAY_HEARTBEAT_INTERVAL);
     heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     heartbeat.tick().await;
+    let mut heartbeat_state = RelayHeartbeat::default();
     loop {
         tokio::select! {
             _ = heartbeat.tick() => {
-                if sender.send(Message::Ping(Vec::new().into())).await.is_err() { break; }
+                let Some(payload) = heartbeat_state.next_ping() else { break };
+                if sender.send(Message::Ping(payload.to_vec().into())).await.is_err() { break; }
             }
             outbound_message = outbound.recv() => {
                 let Some(outbound_message) = outbound_message else { break };
@@ -588,7 +617,10 @@ async fn relay_connection(state: ApiState, user_id: UserId, device_id: Uuid, soc
                         if sender.send(Message::Pong(payload)).await.is_err() { break; }
                         continue;
                     }
-                    Message::Pong(_) => continue,
+                    Message::Pong(payload) => {
+                        heartbeat_state.receive_pong(&payload);
+                        continue;
+                    }
                 };
                 if !state.companion().allow_relay_message(device_id) { break; }
                 if bytes.len() > MAX_RELAY_ENVELOPE_BYTES { break; }
@@ -2057,6 +2089,27 @@ RIka62gMy7ZimPaKaOpY0TuAiZjxiQ7MsSwyGrt766jyZ3XWBg3s4tWO";
 
         relay.disconnect(desktop, stale_connection_id);
         assert!(relay.connect(&user(), desktop).is_ok());
+    }
+
+    #[test]
+    fn relay_heartbeat_expires_when_a_pong_is_missing() {
+        let mut heartbeat = RelayHeartbeat::default();
+
+        assert!(heartbeat.next_ping().is_some());
+        assert!(heartbeat.next_ping().is_none());
+    }
+
+    #[test]
+    fn relay_heartbeat_accepts_only_the_matching_pong() {
+        let mut heartbeat = RelayHeartbeat::default();
+        let first_ping = heartbeat.next_ping().unwrap();
+        let wrong_pong = 1_u64.to_be_bytes();
+
+        heartbeat.receive_pong(&wrong_pong);
+        assert_eq!(heartbeat.awaiting_pong, Some(first_ping));
+
+        heartbeat.receive_pong(&first_ping);
+        assert_eq!(heartbeat.next_ping(), Some(wrong_pong));
     }
 
     #[tokio::test]

--- a/src-tauri/src/companion/controller.rs
+++ b/src-tauri/src/companion/controller.rs
@@ -25,18 +25,26 @@ const MAX_COMPANION_NOTE_CONTENT_JSON_BYTES: usize = 30 * 1024;
 /// here. Attachment paths are injected only after the controller resolves
 /// authenticated, device-scoped opaque references.
 #[derive(Debug, Clone, serde::Serialize)]
-#[serde(tag = "type", content = "data", rename_all = "camelCase")]
+#[serde(
+    tag = "type",
+    content = "data",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 pub enum FrontendIntent {
     AgentSessionsList {
+        #[serde(skip_serializing_if = "Option::is_none")]
         cursor: Option<String>,
         limit: u16,
     },
     AgentMessagesList {
         stored_session_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         cursor: Option<String>,
         limit: u16,
     },
     AgentSend {
+        #[serde(skip_serializing_if = "Option::is_none")]
         stored_session_id: Option<String>,
         message: String,
         attachments: Vec<super::files::ResolvedAttachment>,
@@ -894,6 +902,74 @@ mod tests {
         assert_eq!(encoded[1]["data"]["storedSessionId"], "session-1");
         assert_eq!(encoded[2]["type"], "sessionModelSet");
         assert_eq!(encoded[2]["data"]["modelId"], "kimi-k2-6");
+    }
+
+    #[test]
+    fn frontend_intents_omit_absent_optional_fields() {
+        let sessions = serde_json::to_value(FrontendIntent::AgentSessionsList {
+            cursor: None,
+            limit: 50,
+        })
+        .unwrap();
+        assert_eq!(
+            sessions,
+            serde_json::json!({
+                "type": "agentSessionsList",
+                "data": { "limit": 50 },
+            })
+        );
+
+        let send = serde_json::to_value(FrontendIntent::AgentSend {
+            stored_session_id: None,
+            message: "Hello".to_string(),
+            attachments: Vec::new(),
+            attachment_reference_ids: Vec::new(),
+        })
+        .unwrap();
+        assert_eq!(
+            send,
+            serde_json::json!({
+                "type": "agentSend",
+                "data": {
+                    "message": "Hello",
+                    "attachments": [],
+                    "attachmentReferenceIds": [],
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn frontend_intents_use_camel_case_fields() {
+        let messages = serde_json::to_value(FrontendIntent::AgentMessagesList {
+            stored_session_id: "stored-1".to_string(),
+            cursor: Some("next".to_string()),
+            limit: 50,
+        })
+        .unwrap();
+        assert_eq!(
+            messages,
+            serde_json::json!({
+                "type": "agentMessagesList",
+                "data": {
+                    "storedSessionId": "stored-1",
+                    "cursor": "next",
+                    "limit": 50,
+                },
+            })
+        );
+
+        let cancel = serde_json::to_value(FrontendIntent::AgentCancel {
+            stored_session_id: "stored-1".to_string(),
+        })
+        .unwrap();
+        assert_eq!(
+            cancel,
+            serde_json::json!({
+                "type": "agentCancel",
+                "data": { "storedSessionId": "stored-1" },
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two small companion-protocol fixes that predate the capability build-out and rebased cleanly over #998:

1. **camelCase wire fields with snake_case aliases.** `serde(rename_all = "camelCase")` on an enum renames variant tags, not the fields inside variants, so `storedSessionId`, `noteId`, and `recordingSessionId` crossed the wire as snake_case while both peers - the iPhone app (`CompanionService.swift` sends `storedSessionId`) and the desktop frontend (`tauri.ts` types expect `storedSessionId`) - speak camelCase. Each side was internally consistent, so no single-repo test could catch it. Fields now emit camelCase with `alias` attributes keeping snake_case accepted (additive; older peers unaffected), and round-trip tests pin the exact JSON on the protocol enums and the FrontendIntent boundary. #998 already adopted `rename_all_fields` for the controller's new intents; this completes the protocol-crate side.
2. **20s relay heartbeat.** An idle relay WebSocket carries no frames while the phone is quiet, so load balancers/ingress reap it and the desktop churns through reconnects. A server-side ping every 20s keeps intermediaries satisfied and turns a dead peer into an immediate send error. This substantially defuses JUN-448 (idle closes miscounted as failed reconnects).

## Root cause

serde's enum `rename_all` scoping (variants vs fields) - a boundary-only mismatch invisible to per-repo tests; and a relay socket with no unsolicited server traffic.

## Validation

- Protocol crate 30 tests, src-tauri companion 73 tests, june-api companion 24 tests - all green after rebasing over #998 (tests adapted to the new `media` and attachment fields).
- fmt + clippy (warnings-denied companion gates) clean across all three crates.

- [ ] Tested visually where it matters. <!-- no UI change -->
- [x] Needs a June API (backend) deploy before it works end to end - the heartbeat is relay-side.

## Out of scope

- The remaining JUN-448 desktop-side backoff classification and the JUN-447/449 admission/polish items (before-flag-on ledger).

## Followups

- JUN-448: re-evaluate severity once this heartbeat is deployed; the idle-close scenario largely disappears.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787909455&installation_model_id=425925&pr_number=1011&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1011&signature=42cfb9080a48d33d7817d94b62a7ab7e9211debc1085ac499b21b629446b1a82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->