### PR TITLE
Fix stuck Auto approval sessions

### DIFF
--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -670,15 +670,15 @@ pub async fn cancel_agent_run(
         for interruption_id in pending_interruption_ids {
             _resolution_guards.push(host.lock_interruption_resolution(&interruption_id).await);
         }
-        if repository.cancel_waiting_run(&run.id).await?.is_none() {
+        let Some(cancelled_run) = repository.cancel_waiting_run(&run.id).await? else {
             return Err(AppError::new(
                 "agent_waiting_cancel_conflict",
                 "This request is already resuming. Wait for June to continue before stopping it.",
             ));
-        }
+        };
         crate::companion::cancel_computer_use_approvals_for_session(&app, &run.session_id);
         host.cancel_run_streams(&run.id).await;
-        crate::routines::mark_agent_run_terminal(&repository.pool, &run.id).await?;
+        super::host::emit_persisted_run_cancelled(&app, &cancelled_run)?;
         return Ok(());
     }
     host.request("run.cancel", &run.session_id, &run.id, json!({}))

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -666,12 +666,8 @@ pub async fn cancel_agent_run(
     let run = repository.get_run(&run_id).await?;
     if run.status == "waiting_for_user" {
         repository.cancel_waiting_run(&run.id).await?;
-        if let Err(error) =
-            crate::routines::mark_agent_run_terminal(&repository.pool, &run.id).await
-        {
-            tracing::warn!(agent_run_id = %run.id, error_code = %error.code, "routine waiting-run cancellation projection failed");
-        }
         crate::companion::cancel_computer_use_approvals_for_session(&app, &run.session_id);
+        crate::routines::mark_agent_run_terminal(&repository.pool, &run.id).await?;
         return Ok(());
     }
     host.request("run.cancel", &run.session_id, &run.id, json!({}))

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -665,8 +665,19 @@ pub async fn cancel_agent_run(
     let repository = repository(&app).await?;
     let run = repository.get_run(&run_id).await?;
     if run.status == "waiting_for_user" {
-        repository.cancel_waiting_run(&run.id).await?;
+        let pending_interruption_ids = repository.pending_interruption_ids(&run.id).await?;
+        let mut _resolution_guards = Vec::with_capacity(pending_interruption_ids.len());
+        for interruption_id in pending_interruption_ids {
+            _resolution_guards.push(host.lock_interruption_resolution(&interruption_id).await);
+        }
+        if repository.cancel_waiting_run(&run.id).await?.is_none() {
+            return Err(AppError::new(
+                "agent_waiting_cancel_conflict",
+                "This request is already resuming. Wait for June to continue before stopping it.",
+            ));
+        }
         crate::companion::cancel_computer_use_approvals_for_session(&app, &run.session_id);
+        host.cancel_run_streams(&run.id).await;
         crate::routines::mark_agent_run_terminal(&repository.pool, &run.id).await?;
         return Ok(());
     }

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -664,6 +664,16 @@ pub async fn cancel_agent_run(
 ) -> Result<(), AppError> {
     let repository = repository(&app).await?;
     let run = repository.get_run(&run_id).await?;
+    if run.status == "waiting_for_user" {
+        repository.cancel_waiting_run(&run.id).await?;
+        if let Err(error) =
+            crate::routines::mark_agent_run_terminal(&repository.pool, &run.id).await
+        {
+            tracing::warn!(agent_run_id = %run.id, error_code = %error.code, "routine waiting-run cancellation projection failed");
+        }
+        crate::companion::cancel_computer_use_approvals_for_session(&app, &run.session_id);
+        return Ok(());
+    }
     host.request("run.cancel", &run.session_id, &run.id, json!({}))
         .await?;
     host.cancel_run_streams(&run.id).await;
@@ -1015,7 +1025,7 @@ async fn resolve_agent_interruption_inner(
     if auto_run && resolved_model.is_none() {
         return Err(AppError::new(
             "agent_auto_resume_model_missing",
-            "This approval cannot safely resume because its Auto model was not recorded. Retry the agent run.",
+            "This older Auto run cannot resume because its model was not recorded. Stop the run to continue.",
         ));
     }
     let enabled_skill_ids = repository.run_enabled_skills(&run.id).await?;

--- a/src-tauri/src/agent_runtime/host.rs
+++ b/src-tauri/src/agent_runtime/host.rs
@@ -1,7 +1,7 @@
 use super::{
     protocol::{RpcFrame, PROTOCOL_VERSION},
     tools::{dispatch_tool, ToolCancellationRegistry, ToolContext},
-    AgentItemPayload, AgentRepository, TextPayload, ToolPayload,
+    AgentItemPayload, AgentRepository, AgentRunDto, TextPayload, ToolPayload,
 };
 use crate::domain::types::AppError;
 use serde_json::{json, Value};
@@ -26,6 +26,27 @@ pub const AGENT_RUNTIME_EVENT: &str = "june://agent-runtime-event";
 const RUNTIME_CONTROL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 const HISTORY_COMPACTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 type PendingRequests = Arc<Mutex<HashMap<String, oneshot::Sender<Result<Value, AppError>>>>>;
+
+pub(crate) fn emit_persisted_run_cancelled(
+    app: &AppHandle,
+    run: &AgentRunDto,
+) -> Result<(), AppError> {
+    app.emit(
+        AGENT_RUNTIME_EVENT,
+        json!({
+            "protocolVersion": PROTOCOL_VERSION,
+            "sessionId": run.session_id,
+            "runId": run.id,
+            "sequence": run.last_sequence.saturating_add(1),
+            "eventId": Uuid::new_v4(),
+            "method": "run.cancelled",
+            "data": {
+                "completedAt": run.completed_at,
+            },
+        }),
+    )
+    .map_err(|error| AppError::new("agent_event_emit_failed", error.to_string()))
+}
 
 #[derive(Default)]
 pub struct AgentRuntimeHost {

--- a/src-tauri/src/agent_runtime/repository.rs
+++ b/src-tauri/src/agent_runtime/repository.rs
@@ -197,6 +197,25 @@ impl AgentRepository {
         Ok(run_from_row(row))
     }
 
+    pub async fn pending_interruption_ids(&self, run_id: &str) -> Result<Vec<String>, sqlx::Error> {
+        let rows = query(
+            "SELECT json_extract(payload_json, '$.id') AS interruption_id
+             FROM agent_items
+             WHERE run_id = ?
+               AND kind = 'interruption'
+               AND json_extract(payload_json, '$.status') = 'pending'
+             ORDER BY interruption_id",
+        )
+        .bind(run_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|row| row.get::<Option<String>, _>("interruption_id"))
+            .filter(|id| !id.is_empty())
+            .collect())
+    }
+
     pub async fn reset_run_sequence_for_resume(&self, run_id: &str) -> Result<(), sqlx::Error> {
         query("UPDATE agent_runs SET last_sequence = 0, updated_at = ? WHERE id = ?")
             .bind(now())
@@ -901,13 +920,32 @@ impl AgentRepository {
     /// longer active in the sidecar, so they cannot use the ordinary
     /// `run.cancel` path. Retire their pending cards in the same transaction
     /// that releases the session for another turn.
-    pub async fn cancel_waiting_run(&self, run_id: &str) -> Result<AgentRunDto, sqlx::Error> {
+    pub async fn cancel_waiting_run(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<AgentRunDto>, sqlx::Error> {
         let run = self.get_run(run_id).await?;
         if run.status != "waiting_for_user" {
-            return Ok(run);
+            return Ok(None);
         }
         let timestamp = now();
         let mut transaction = self.pool.begin().await?;
+        let retired = query(
+            "UPDATE agent_items
+             SET payload_json = json_set(payload_json, '$.status', 'expired', '$.resolvedAt', ?)
+             WHERE run_id = ?
+               AND kind = 'interruption'
+               AND json_extract(payload_json, '$.status') = 'pending'",
+        )
+        .bind(&timestamp)
+        .bind(run_id)
+        .execute(&mut *transaction)
+        .await?
+        .rows_affected();
+        if retired == 0 {
+            transaction.rollback().await?;
+            return Ok(None);
+        }
         let updated = query(
             "UPDATE agent_runs
              SET status = 'cancelled', updated_at = ?, completed_at = ?, error_code = NULL, error_message = NULL
@@ -921,19 +959,8 @@ impl AgentRepository {
         .rows_affected();
         if updated == 0 {
             transaction.rollback().await?;
-            return self.get_run(run_id).await;
+            return Ok(None);
         }
-        query(
-            "UPDATE agent_items
-             SET payload_json = json_set(payload_json, '$.status', 'expired', '$.resolvedAt', ?)
-             WHERE run_id = ?
-               AND kind = 'interruption'
-               AND json_extract(payload_json, '$.status') = 'pending'",
-        )
-        .bind(&timestamp)
-        .bind(run_id)
-        .execute(&mut *transaction)
-        .await?;
         query(
             "UPDATE agent_sessions
              SET status = 'idle', updated_at = ?, last_error = NULL
@@ -950,7 +977,7 @@ impl AgentRepository {
         .execute(&mut *transaction)
         .await?;
         transaction.commit().await?;
-        self.get_run(run_id).await
+        self.get_run(run_id).await.map(Some)
     }
 
     pub async fn mark_active_runs_interrupted(&self, message: &str) -> Result<u64, sqlx::Error> {
@@ -1275,7 +1302,8 @@ mod tests {
         let cancelled = repository
             .cancel_waiting_run(&run.id)
             .await
-            .expect("cancel waiting run");
+            .expect("cancel waiting run")
+            .expect("cancellation won the pending interruption race");
 
         assert_eq!(cancelled.status, "cancelled");
         assert!(cancelled.completed_at.is_some());
@@ -1294,6 +1322,68 @@ mod tests {
                 if value.get("status").and_then(serde_json::Value::as_str) == Some("expired")
                     && value.get("resolvedAt").and_then(serde_json::Value::as_str).is_some()
         ));
+    }
+
+    #[tokio::test]
+    async fn waiting_run_cancellation_loses_to_an_already_resolved_interruption() {
+        let repository = repository().await;
+        let session = repository
+            .create_session("Resuming", "auto", AgentSafetyMode::Sandboxed, None)
+            .await
+            .expect("resuming session");
+        let run = repository
+            .create_run(&session.id, "auto", None)
+            .await
+            .expect("resuming run");
+        repository
+            .append_item(
+                &session.id,
+                Some(&run.id),
+                1,
+                &AgentItemPayload::Interruption(serde_json::json!({
+                    "id": "clarify-1",
+                    "kind": "clarification",
+                    "status": "resolved",
+                    "question": "Which project?",
+                    "answer": "June"
+                })),
+                Some("interruption:clarify-1"),
+            )
+            .await
+            .expect("resolved interruption");
+        repository
+            .update_run_status(
+                &run.id,
+                "waiting_for_user",
+                None,
+                Some(&serde_json::json!("serialized")),
+                None,
+            )
+            .await
+            .expect("waiting status");
+
+        let cancelled = repository
+            .cancel_waiting_run(&run.id)
+            .await
+            .expect("race check");
+
+        assert!(cancelled.is_none());
+        assert_eq!(
+            repository
+                .get_run(&run.id)
+                .await
+                .expect("unchanged run")
+                .status,
+            "waiting_for_user"
+        );
+        assert_eq!(
+            repository
+                .get_session(&session.id)
+                .await
+                .expect("unchanged session")
+                .status,
+            "waiting_for_user"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/agent_runtime/repository.rs
+++ b/src-tauri/src/agent_runtime/repository.rs
@@ -2,6 +2,7 @@ use super::domain::{
     AgentArtifactDto, AgentItemDto, AgentItemPayload, AgentRunDto, AgentSafetyMode,
     AgentSessionDto, AgentSkillDto,
 };
+use crate::domain::types::AppError;
 use chrono::{SecondsFormat, Utc};
 use sqlx::{query::query, row::Row};
 use sqlx_sqlite::{SqlitePool, SqliteRow};
@@ -920,10 +921,7 @@ impl AgentRepository {
     /// longer active in the sidecar, so they cannot use the ordinary
     /// `run.cancel` path. Retire their pending cards in the same transaction
     /// that releases the session for another turn.
-    pub async fn cancel_waiting_run(
-        &self,
-        run_id: &str,
-    ) -> Result<Option<AgentRunDto>, sqlx::Error> {
+    pub async fn cancel_waiting_run(&self, run_id: &str) -> Result<Option<AgentRunDto>, AppError> {
         let run = self.get_run(run_id).await?;
         if run.status != "waiting_for_user" {
             return Ok(None);
@@ -976,8 +974,9 @@ impl AgentRepository {
         .bind(&run.session_id)
         .execute(&mut *transaction)
         .await?;
+        crate::routines::project_agent_run_terminal(&mut transaction, run_id, &timestamp).await?;
         transaction.commit().await?;
-        self.get_run(run_id).await.map(Some)
+        self.get_run(run_id).await.map(Some).map_err(Into::into)
     }
 
     pub async fn mark_active_runs_interrupted(&self, message: &str) -> Result<u64, sqlx::Error> {
@@ -1384,6 +1383,134 @@ mod tests {
                 .status,
             "waiting_for_user"
         );
+    }
+
+    #[tokio::test]
+    async fn waiting_run_cancellation_rolls_back_when_routine_claim_release_fails() {
+        let repository = repository().await;
+        crate::routines::create(
+            &repository.pool,
+            crate::routines::CreateAgentRoutineRequest {
+                id: Some("routine-atomic".into()),
+                legacy_job_id: None,
+                name: Some("Atomic cancellation".into()),
+                prompt: "Prepare a brief".into(),
+                schedule: "every 1h".into(),
+                timezone: "UTC".into(),
+                repeat: None,
+                deliver: None,
+                model: "auto".into(),
+                safety_mode: Some(AgentSafetyMode::Sandboxed),
+                state: None,
+                enabled: None,
+                metadata: serde_json::json!({}),
+                enabled_toolsets: None,
+            },
+        )
+        .await
+        .expect("routine");
+        let claim = crate::routines::claim(&repository.pool, "routine-atomic", "manual", false)
+            .await
+            .expect("claim")
+            .expect("available claim");
+        let session = repository
+            .create_session(
+                "Atomic cancellation",
+                "auto",
+                AgentSafetyMode::Sandboxed,
+                None,
+            )
+            .await
+            .expect("session");
+        let run = repository
+            .create_run(&session.id, "auto", None)
+            .await
+            .expect("run");
+        repository
+            .append_item(
+                &session.id,
+                Some(&run.id),
+                1,
+                &AgentItemPayload::Interruption(serde_json::json!({
+                    "id": "clarify-atomic",
+                    "kind": "clarification",
+                    "status": "pending",
+                    "question": "Which project?"
+                })),
+                Some("interruption:clarify-atomic"),
+            )
+            .await
+            .expect("pending interruption");
+        repository
+            .update_run_status(
+                &run.id,
+                "waiting_for_user",
+                None,
+                Some(&serde_json::json!("serialized")),
+                None,
+            )
+            .await
+            .expect("waiting run");
+        let timestamp = now();
+        query(
+            "UPDATE routine_runs
+             SET agent_session_id = ?, agent_run_id = ?, status = 'waiting_for_user',
+                 started_at = ?, updated_at = ?
+             WHERE id = ? AND claim_token = ?",
+        )
+        .bind(&session.id)
+        .bind(&run.id)
+        .bind(&timestamp)
+        .bind(&timestamp)
+        .bind(&claim.routine_run_id)
+        .bind(&claim.token)
+        .execute(&repository.pool)
+        .await
+        .expect("attach run");
+        query("UPDATE routines SET schedule = 'not a schedule' WHERE id = 'routine-atomic'")
+            .execute(&repository.pool)
+            .await
+            .expect("invalid schedule");
+
+        let error = repository
+            .cancel_waiting_run(&run.id)
+            .await
+            .expect_err("claim release must fail");
+
+        assert_eq!(error.code, "routine_schedule_invalid");
+        assert_eq!(
+            repository
+                .get_run(&run.id)
+                .await
+                .expect("unchanged run")
+                .status,
+            "waiting_for_user"
+        );
+        assert!(matches!(
+            &repository.items(&session.id).await.expect("items")[0].payload,
+            AgentItemPayload::Interruption(value)
+                if value.get("status").and_then(serde_json::Value::as_str) == Some("pending")
+        ));
+        assert_eq!(
+            repository
+                .get_session(&session.id)
+                .await
+                .expect("unchanged session")
+                .status,
+            "waiting_for_user"
+        );
+        let routine_run = crate::routines::list_runs(&repository.pool, Some("routine-atomic"))
+            .await
+            .expect("routine runs")
+            .remove(0);
+        assert_eq!(routine_run.status, "waiting_for_user");
+        let claim_token: Option<String> =
+            query("SELECT claim_token FROM routines WHERE id = 'routine-atomic'")
+                .fetch_one(&repository.pool)
+                .await
+                .expect("routine claim")
+                .get("claim_token");
+        assert_eq!(claim_token.as_deref(), Some(claim.token.as_str()));
     }
 
     #[tokio::test]

--- a/src-tauri/src/agent_runtime/repository.rs
+++ b/src-tauri/src/agent_runtime/repository.rs
@@ -897,6 +897,62 @@ impl AgentRepository {
         self.get_run(run_id).await
     }
 
+    /// Cancel a run that is durably paused for user input. Paused runs are no
+    /// longer active in the sidecar, so they cannot use the ordinary
+    /// `run.cancel` path. Retire their pending cards in the same transaction
+    /// that releases the session for another turn.
+    pub async fn cancel_waiting_run(&self, run_id: &str) -> Result<AgentRunDto, sqlx::Error> {
+        let run = self.get_run(run_id).await?;
+        if run.status != "waiting_for_user" {
+            return Ok(run);
+        }
+        let timestamp = now();
+        let mut transaction = self.pool.begin().await?;
+        let updated = query(
+            "UPDATE agent_runs
+             SET status = 'cancelled', updated_at = ?, completed_at = ?, error_code = NULL, error_message = NULL
+             WHERE id = ? AND status = 'waiting_for_user'",
+        )
+        .bind(&timestamp)
+        .bind(&timestamp)
+        .bind(run_id)
+        .execute(&mut *transaction)
+        .await?
+        .rows_affected();
+        if updated == 0 {
+            transaction.rollback().await?;
+            return self.get_run(run_id).await;
+        }
+        query(
+            "UPDATE agent_items
+             SET payload_json = json_set(payload_json, '$.status', 'expired', '$.resolvedAt', ?)
+             WHERE run_id = ?
+               AND kind = 'interruption'
+               AND json_extract(payload_json, '$.status') = 'pending'",
+        )
+        .bind(&timestamp)
+        .bind(run_id)
+        .execute(&mut *transaction)
+        .await?;
+        query(
+            "UPDATE agent_sessions
+             SET status = 'idle', updated_at = ?, last_error = NULL
+             WHERE id = ?
+               AND NOT EXISTS (
+                   SELECT 1 FROM agent_runs
+                   WHERE session_id = ?
+                     AND status IN ('queued', 'running', 'waiting_for_user')
+               )",
+        )
+        .bind(&timestamp)
+        .bind(&run.session_id)
+        .bind(&run.session_id)
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        self.get_run(run_id).await
+    }
+
     pub async fn mark_active_runs_interrupted(&self, message: &str) -> Result<u64, sqlx::Error> {
         let now = now();
         let result = query("UPDATE agent_runs SET status = 'interrupted', updated_at = ?, completed_at = ?, error_code = 'runtime_crashed', error_message = ? WHERE status IN ('queued', 'running')")
@@ -1177,6 +1233,67 @@ mod tests {
                 .status,
             "idle"
         );
+    }
+
+    #[tokio::test]
+    async fn cancelling_a_waiting_run_expires_its_interruption_and_releases_the_session() {
+        let repository = repository().await;
+        let session = repository
+            .create_session("Waiting", "auto", AgentSafetyMode::Sandboxed, None)
+            .await
+            .expect("waiting session");
+        let run = repository
+            .create_run(&session.id, "auto", None)
+            .await
+            .expect("waiting run");
+        repository
+            .append_item(
+                &session.id,
+                Some(&run.id),
+                1,
+                &AgentItemPayload::Interruption(serde_json::json!({
+                    "id": "clarify-1",
+                    "kind": "clarification",
+                    "status": "pending",
+                    "question": "Which project?"
+                })),
+                Some("interruption:clarify-1"),
+            )
+            .await
+            .expect("pending interruption");
+        repository
+            .update_run_status(
+                &run.id,
+                "waiting_for_user",
+                None,
+                Some(&serde_json::json!("serialized")),
+                None,
+            )
+            .await
+            .expect("waiting status");
+
+        let cancelled = repository
+            .cancel_waiting_run(&run.id)
+            .await
+            .expect("cancel waiting run");
+
+        assert_eq!(cancelled.status, "cancelled");
+        assert!(cancelled.completed_at.is_some());
+        assert_eq!(
+            repository
+                .get_session(&session.id)
+                .await
+                .expect("released session")
+                .status,
+            "idle"
+        );
+        let items = repository.items(&session.id).await.expect("retired items");
+        assert!(matches!(
+            &items[0].payload,
+            AgentItemPayload::Interruption(value)
+                if value.get("status").and_then(serde_json::Value::as_str) == Some("expired")
+                    && value.get("resolvedAt").and_then(serde_json::Value::as_str).is_some()
+        ));
     }
 
     #[tokio::test]

--- a/src-tauri/src/routines.rs
+++ b/src-tauri/src/routines.rs
@@ -681,16 +681,25 @@ pub async fn mark_agent_run_terminal(
         .begin_with("BEGIN IMMEDIATE")
         .await
         .map_err(app_error)?;
+    project_agent_run_terminal(&mut transaction, agent_run_id, &timestamp).await?;
+    transaction.commit().await.map_err(app_error)
+}
+
+pub(crate) async fn project_agent_run_terminal(
+    transaction: &mut Transaction<'_, Sqlite>,
+    agent_run_id: &str,
+    timestamp: &str,
+) -> Result<(), AppError> {
     let changed = query("UPDATE routine_runs SET status = (SELECT status FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), completed_at = COALESCE((SELECT completed_at FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), completed_at), error_code = COALESCE((SELECT error_code FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), error_code), error_message = COALESCE((SELECT error_message FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id), error_message), updated_at = ? WHERE agent_run_id = ? AND status IN ('running', 'waiting_for_user') AND EXISTS (SELECT 1 FROM agent_runs WHERE agent_runs.id = routine_runs.agent_run_id AND agent_runs.status IN ('completed', 'cancelled', 'interrupted', 'failed'))")
-        .bind(&timestamp)
+        .bind(timestamp)
         .bind(agent_run_id)
-        .execute(&mut *transaction)
+        .execute(&mut **transaction)
         .await
         .map_err(app_error)?;
     if changed.rows_affected() != 0 {
-        release_terminal_claims(&mut transaction, &timestamp, Some(agent_run_id)).await?;
+        release_terminal_claims(transaction, timestamp, Some(agent_run_id)).await?;
     }
-    transaction.commit().await.map_err(app_error)
+    Ok(())
 }
 
 /// Start the single local scheduler for June-owned routines. Claims are stored

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -422,6 +422,8 @@ export function AgentWorkspace({
   const hydrationRequestRef = useRef<string>();
   const submissionOwnerRef = useRef<string>();
   const [submitting, setSubmitting] = useState(false);
+  const [stoppingRunId, setStoppingRunId] = useState<string>();
+  const stoppingRunIdRef = useRef<string>();
   const [error, setError] = useState<string>();
   const [approvalSubmitting, setApprovalSubmitting] = useState<
     Partial<Record<string, "once" | "session" | "always" | "deny">>
@@ -1810,15 +1812,30 @@ export function AgentWorkspace({
   }
 
   async function stop() {
-    if (!projection.run) return;
+    const runId = projection.run?.id;
+    if (!runId || stoppingRunIdRef.current === runId) return;
+    stoppingRunIdRef.current = runId;
+    setStoppingRunId(runId);
+    let cancellationFailed = false;
     try {
-      await agentRuntimeBindings.cancelRun(projection.run.id);
-      const sessionId = selectedIdRef.current;
-      if (sessionId) {
-        await Promise.all([hydrate(sessionId), refreshSessions()]);
-      }
+      await agentRuntimeBindings.cancelRun(runId);
     } catch (cause) {
+      cancellationFailed = true;
       setError(messageFromError(cause));
+    } finally {
+      const sessionId = selectedIdRef.current;
+      try {
+        if (sessionId) {
+          await Promise.all([hydrate(sessionId), refreshSessions()]);
+        }
+      } catch (cause) {
+        if (!cancellationFailed) setError(messageFromError(cause));
+      } finally {
+        if (stoppingRunIdRef.current === runId) {
+          stoppingRunIdRef.current = undefined;
+          setStoppingRunId(undefined);
+        }
+      }
     }
   }
 
@@ -2199,6 +2216,7 @@ export function AgentWorkspace({
       onStop={stop}
       running={running}
       waiting={waiting}
+      stopping={stoppingRunId === projection.run?.id}
       submitting={submitting}
       disabledReason={textActionsDisabledReason}
       notice={!heroMode ? error : undefined}
@@ -2726,6 +2744,7 @@ function AgentComposer({
   onStop,
   running,
   waiting,
+  stopping,
   submitting,
   disabledReason,
   notice,
@@ -2755,6 +2774,7 @@ function AgentComposer({
   onStop: () => Promise<void>;
   running: boolean;
   waiting: boolean;
+  stopping: boolean;
   submitting: boolean;
   disabledReason?: string;
   notice?: string;
@@ -2998,6 +3018,7 @@ function AgentComposer({
                   type="button"
                   className="agent-composer-stop"
                   aria-label="Stop June"
+                  disabled={stopping}
                   onClick={() => void onStop()}
                 >
                   <IconStop size={16} />
@@ -3008,6 +3029,7 @@ function AgentComposer({
                 type="button"
                 className="agent-composer-stop"
                 aria-label="Stop June"
+                disabled={stopping}
                 onClick={() => void onStop()}
               >
                 <IconStop size={16} />

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1813,6 +1813,10 @@ export function AgentWorkspace({
     if (!projection.run) return;
     try {
       await agentRuntimeBindings.cancelRun(projection.run.id);
+      const sessionId = selectedIdRef.current;
+      if (sessionId) {
+        await Promise.all([hydrate(sessionId), refreshSessions()]);
+      }
     } catch (cause) {
       setError(messageFromError(cause));
     }
@@ -2194,6 +2198,7 @@ export function AgentWorkspace({
       onSubmit={homeMode ? submitHomeMessage : submit}
       onStop={stop}
       running={running}
+      waiting={waiting}
       submitting={submitting}
       disabledReason={textActionsDisabledReason}
       notice={!heroMode ? error : undefined}
@@ -2720,6 +2725,7 @@ function AgentComposer({
   onSubmit,
   onStop,
   running,
+  waiting,
   submitting,
   disabledReason,
   notice,
@@ -2748,6 +2754,7 @@ function AgentComposer({
   onSubmit: (event?: FormEvent) => Promise<void>;
   onStop: () => Promise<void>;
   running: boolean;
+  waiting: boolean;
   submitting: boolean;
   disabledReason?: string;
   notice?: string;
@@ -2996,6 +3003,15 @@ function AgentComposer({
                   <IconStop size={16} />
                 </button>
               </>
+            ) : waiting ? (
+              <button
+                type="button"
+                className="agent-composer-stop"
+                aria-label="Stop June"
+                onClick={() => void onStop()}
+              >
+                <IconStop size={16} />
+              </button>
             ) : (
               <button
                 type="submit"

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -1912,6 +1912,10 @@ describe("AgentWorkspace runtime wiring", () => {
       status: "waiting_for_user",
     };
     let cancelled = false;
+    let finishCancellation: (() => void) | undefined;
+    const cancellation = new Promise<void>((resolve) => {
+      finishCancellation = resolve;
+    });
     const interruption = () => ({
       id: "clarify-item",
       sessionId: session.id,
@@ -1963,8 +1967,9 @@ describe("AgentWorkspace runtime wiring", () => {
         });
       }
       if (command === "cancel_agent_run") {
-        cancelled = true;
-        return Promise.resolve();
+        return cancellation.then(() => {
+          cancelled = true;
+        });
       }
       return Promise.resolve(undefined);
     });
@@ -1975,7 +1980,14 @@ describe("AgentWorkspace runtime wiring", () => {
     const composer = screen.getByRole("textbox", { name: "Message June" });
     await user.type(composer, "Continue from here");
     expect(screen.queryByRole("button", { name: "Send message" })).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Stop June" }));
+    const stopButton = screen.getByRole("button", { name: "Stop June" });
+    await user.click(stopButton);
+    expect(stopButton).toBeDisabled();
+    fireEvent.click(stopButton);
+    expect(
+      mocks.invoke.mock.calls.filter(([command]) => command === "cancel_agent_run"),
+    ).toHaveLength(1);
+    finishCancellation?.();
 
     await waitFor(() =>
       expect(mocks.invoke).toHaveBeenCalledWith("cancel_agent_run", { runId: "run-waiting" }),

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -1905,6 +1905,88 @@ describe("AgentWorkspace runtime wiring", () => {
     );
   });
 
+  it("lets a user stop a waiting clarification and continue with a new message", async () => {
+    const user = userEvent.setup();
+    const waitingSession: AgentSessionDto = {
+      ...session,
+      status: "waiting_for_user",
+    };
+    let cancelled = false;
+    const interruption = () => ({
+      id: "clarify-item",
+      sessionId: session.id,
+      runId: "run-waiting",
+      sequence: 2,
+      createdAt: "2026-07-22T12:00:02Z",
+      kind: "interruption" as const,
+      interruption: {
+        id: "clarify-1",
+        kind: "clarification" as const,
+        sessionId: session.id,
+        runId: "run-waiting",
+        status: cancelled ? ("expired" as const) : ("pending" as const),
+        createdAt: "2026-07-22T12:00:02Z",
+        question: "Which project?",
+        choices: [],
+      },
+    });
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "list_agent_sessions") {
+        return Promise.resolve([
+          cancelled ? { ...waitingSession, status: "idle" } : waitingSession,
+        ]);
+      }
+      if (command === "get_agent_session") {
+        return Promise.resolve(cancelled ? { ...waitingSession, status: "idle" } : waitingSession);
+      }
+      if (command === "get_latest_agent_run") {
+        return Promise.resolve({
+          id: "run-waiting",
+          sessionId: session.id,
+          status: cancelled ? "cancelled" : "waiting_for_user",
+          model: "__june_auto_generation__:20",
+          startedAt: "2026-07-22T12:00:01Z",
+          ...(cancelled ? { completedAt: "2026-07-22T12:00:03Z" } : {}),
+        });
+      }
+      if (command === "list_agent_items") return Promise.resolve([interruption()]);
+      if (command === "list_agent_artifacts" || command === "list_agent_skills") {
+        return Promise.resolve([]);
+      }
+      if (command === "list_venice_models") {
+        return Promise.resolve({ mode: "generation", models: [] });
+      }
+      if (command === "provider_model_settings") {
+        return Promise.resolve({
+          settings: { costQuality: 100 },
+          effectiveSettings: { veniceApiKeyConfigured: false },
+        });
+      }
+      if (command === "cancel_agent_run") {
+        cancelled = true;
+        return Promise.resolve();
+      }
+      return Promise.resolve(undefined);
+    });
+
+    render(<AgentWorkspace initialSession={waitingSession} />);
+
+    expect(await screen.findByText("Which project?")).toBeVisible();
+    const composer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(composer, "Continue from here");
+    expect(screen.queryByRole("button", { name: "Send message" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Stop June" }));
+
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("cancel_agent_run", { runId: "run-waiting" }),
+    );
+    expect(await screen.findByText("Skipped")).toBeVisible();
+    expect(screen.getByRole("textbox", { name: "Message June" })).toHaveTextContent(
+      "Continue from here",
+    );
+    expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
+  });
+
   it("presents retryable runtime failures as a retry action and resumes through the typed host command", async () => {
     mocks.invoke.mockImplementation((command: string) => {
       if (command === "list_agent_sessions") return Promise.resolve([session]);


### PR DESCRIPTION
## What changed

- show a Stop control while an agent run is waiting for approval or clarification
- cancel waiting runs directly in persistence because the runtime sidecar is no longer active
- expire pending interruption cards and release the session in one transaction
- refresh the conversation after stopping while preserving the composer draft
- clarify the missing Auto model recovery message

## Why

Older paused Auto runs can lack the resolved model metadata now required for safe continuation. Resolution correctly fails closed, but the composer previously showed a nonfunctional Send control and offered no way to leave the waiting state.

## Validation

- `pnpm run check` (passes with existing exhaustive-dependency warnings)
- `pnpm test` (153 files, 1665 tests)
- `pnpm run typecheck`
- `pnpm run build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml cancelling_a_waiting_run_expires_its_interruption_and_releases_the_session --locked`
- isolated browser walkthrough with a fake Tauri bridge: waiting clarification showed Stop, cancellation collapsed it to Skipped, the typed draft remained, Send became enabled, and no console/page errors were emitted

## QA evidence

Local screenshots and compressed video were captured under `.tmp/qa-recordings/`. They were not uploaded publicly because public artifact sharing was not explicitly authorized.

## Known gaps

- native WKWebView was not driven against shared development app data; the real Rust persistence path is covered by the targeted repository test
- full Rust suite was not rerun; the targeted Rust test passed and the frontend suite, typecheck, and production build passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787923432&installation_model_id=425925&pr_number=1012&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1012&signature=d27f4f4e92a8bcdec81a9e9d6425e3aadd4626b4054130b5a9da58f19100429a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->