### PR TITLE
Add Buzz ACP runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,24 @@ Windows builds cover the app shell, sign-in, microphone recording, notes, and
 the bundled agent runtime, but not global dictation paste, system audio
 capture, or the macOS sandbox. macOS is the primary target.
 
+### Use June with Buzz
+
+June can run as an [Agent Client Protocol](https://agentclientprotocol.com/)
+agent for Buzz. Sign in to the June desktop app first, then add a custom
+harness in Buzz with these values:
+
+| Field | Value |
+| --- | --- |
+| Name | `June` |
+| Command | `/Applications/June.app/Contents/MacOS/June` |
+| Arguments | `acp` |
+
+No environment variables are required. The headless process uses June's
+existing OS Accounts session for private model routing and accepts Buzz's MCP
+server configuration at session creation. Buzz credentials stay in that
+session-scoped child process and are not written to June's database or
+keychain. Conversations started by Buzz are saved as June agent sessions.
+
 ## Repository layout
 
 This repo contains the full product: the desktop app and the service that

--- a/agent-runtime/src/sdk-engine.ts
+++ b/agent-runtime/src/sdk-engine.ts
@@ -177,9 +177,11 @@ export class OpenAIAgentsEngine implements AgentEngine {
     runId: string,
     emit: (event: EngineEvent) => void,
   ): Agent {
-    const descriptors = params.tools.some((descriptor) => descriptor.name === REQUEST_CLARIFICATION_TOOL.name)
-      ? params.tools
-      : [...params.tools, REQUEST_CLARIFICATION_TOOL];
+    const descriptors =
+      params.includeClarificationTool === false ||
+      params.tools.some((descriptor) => descriptor.name === REQUEST_CLARIFICATION_TOOL.name)
+        ? params.tools
+        : [...params.tools, REQUEST_CLARIFICATION_TOOL];
     const tools = descriptors.map((descriptor) =>
       this.createTool(descriptor, sessionId, runId, emit),
     );

--- a/agent-runtime/src/types.ts
+++ b/agent-runtime/src/types.ts
@@ -56,6 +56,7 @@ export type RunStartParams = {
   skills: RuntimeSkillDescriptor[];
   contextWindow: number;
   maxOutputTokens?: number;
+  includeClarificationTool?: boolean;
 };
 
 export type InterruptionResolution =

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -90,7 +90,7 @@ tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 tauri-plugin-updater = "2.10.1"
 thiserror = "2.0"
 tempfile = "3.14"
-tokio = { version = "1.42", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.42", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 tracing = "0.1"
 # Untrusted URL parsing for the managed browser's public-web policy.

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -1,0 +1,638 @@
+//! Headless Agent Client Protocol entrypoint for external hosts such as Buzz.
+//! The wire transport is newline-delimited JSON-RPC 2.0 over stdin/stdout.
+
+use crate::{
+    agent_mcp::{EphemeralMcpServer, RuntimeToolDescriptorJson},
+    agent_runtime::{api::start_acp_run, AgentRepository, AgentRuntimeHost, AgentSafetyMode},
+    domain::types::AppError,
+};
+use serde_json::{json, Value};
+use std::{collections::BTreeMap, path::Path, sync::Arc};
+use tauri::{AppHandle, Listener, Manager};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    sync::{mpsc, Mutex},
+};
+
+const ACP_PROTOCOL_VERSION: u64 = 2;
+const MAX_PROMPT_CHARS: usize = 1_000_000;
+const DEFAULT_SESSION_TITLE: &str = "Buzz session";
+
+#[derive(Clone)]
+struct SessionState {
+    system_prompt: Option<String>,
+    tools: Vec<RuntimeToolDescriptorJson>,
+    active: Option<ActivePrompt>,
+}
+
+#[derive(Clone)]
+struct ActivePrompt {
+    request_id: Value,
+    run_id: String,
+}
+
+#[derive(Debug)]
+enum Input {
+    Message(Value),
+    Invalid(String),
+    Closed,
+}
+
+#[derive(Debug)]
+struct RuntimeEvent {
+    session_id: String,
+    run_id: String,
+    method: String,
+    data: Value,
+}
+
+pub async fn serve(app: AppHandle) -> Result<(), AppError> {
+    let output = Arc::new(Mutex::new(tokio::io::stdout()));
+    let (input_tx, mut input_rx) = mpsc::unbounded_channel();
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+    tauri::async_runtime::spawn(read_input(input_tx));
+    let listener_id = app.listen(
+        crate::agent_runtime::host::AGENT_RUNTIME_EVENT,
+        move |event| {
+            let parsed = serde_json::from_str::<Value>(event.payload())
+                .ok()
+                .and_then(parse_runtime_event);
+            if let Some(event) = parsed {
+                let _ = event_tx.send(event);
+            }
+        },
+    );
+
+    let mut initialized = false;
+    let mut sessions = BTreeMap::<String, SessionState>::new();
+    loop {
+        tokio::select! {
+            Some(input) = input_rx.recv() => {
+                match input {
+                    Input::Closed => break,
+                    Input::Invalid(message) => {
+                        write_value(&output, &rpc_error(Value::Null, -32700, &message)).await?;
+                    }
+                    Input::Message(message) => {
+                        if let Err(error) = handle_message(
+                            &app,
+                            &output,
+                            &mut initialized,
+                            &mut sessions,
+                            message,
+                        ).await {
+                            eprintln!("June ACP request failed: {}", error.message);
+                        }
+                    }
+                }
+            }
+            Some(event) = event_rx.recv() => {
+                handle_runtime_event(&output, &mut sessions, event).await?;
+            }
+            else => break,
+        }
+    }
+
+    app.unlisten(listener_id);
+    let host = app.state::<AgentRuntimeHost>();
+    for session_id in sessions.keys() {
+        host.unregister_ephemeral_mcp(session_id).await;
+    }
+    host.shutdown().await;
+    Ok(())
+}
+
+async fn read_input(sender: mpsc::UnboundedSender<Input>) {
+    let mut lines = BufReader::new(tokio::io::stdin()).lines();
+    loop {
+        match lines.next_line().await {
+            Ok(Some(line)) if line.trim().is_empty() => continue,
+            Ok(Some(line)) => match serde_json::from_str::<Value>(&line) {
+                Ok(value) => {
+                    if sender.send(Input::Message(value)).is_err() {
+                        return;
+                    }
+                }
+                Err(_) => {
+                    if sender.send(Input::Invalid("Invalid JSON".into())).is_err() {
+                        return;
+                    }
+                }
+            },
+            Ok(None) => {
+                let _ = sender.send(Input::Closed);
+                return;
+            }
+            Err(error) => {
+                let _ = sender.send(Input::Invalid(error.to_string()));
+                let _ = sender.send(Input::Closed);
+                return;
+            }
+        }
+    }
+}
+
+async fn handle_message(
+    app: &AppHandle,
+    output: &Arc<Mutex<tokio::io::Stdout>>,
+    initialized: &mut bool,
+    sessions: &mut BTreeMap<String, SessionState>,
+    message: Value,
+) -> Result<(), AppError> {
+    let id = message.get("id").cloned();
+    let method = message
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if message.get("jsonrpc").and_then(Value::as_str) != Some("2.0") || method.is_empty() {
+        if let Some(id) = id {
+            write_value(output, &rpc_error(id, -32600, "Invalid JSON-RPC request")).await?;
+        }
+        return Ok(());
+    }
+    if !*initialized && method != "initialize" {
+        if let Some(id) = id {
+            write_value(
+                output,
+                &rpc_error(id, -32002, "Initialize June before creating a session"),
+            )
+            .await?;
+        }
+        return Ok(());
+    }
+    let params = message.get("params").cloned().unwrap_or_else(|| json!({}));
+    match method {
+        "initialize" => {
+            let Some(id) = id else {
+                return Ok(());
+            };
+            let requested = params
+                .get("protocolVersion")
+                .and_then(Value::as_u64)
+                .unwrap_or_default();
+            if requested != ACP_PROTOCOL_VERSION {
+                write_value(
+                    output,
+                    &rpc_error(id, -32602, "June supports ACP protocol version 2"),
+                )
+                .await?;
+                return Ok(());
+            }
+            *initialized = true;
+            write_value(output, &rpc_result(id, initialize_result())).await?;
+        }
+        "session/new" => {
+            let Some(id) = id else {
+                return Ok(());
+            };
+            match create_session(app, &params).await {
+                Ok((session_id, state)) => {
+                    sessions.insert(session_id.clone(), state);
+                    write_value(output, &rpc_result(id, json!({ "sessionId": session_id })))
+                        .await?;
+                }
+                Err(error) => {
+                    write_value(output, &rpc_error(id, -32602, &error.message)).await?;
+                }
+            }
+        }
+        "session/prompt" => {
+            let Some(id) = id else {
+                return Ok(());
+            };
+            let session_id = match params.get("sessionId").and_then(Value::as_str) {
+                Some(value) => value.to_string(),
+                None => {
+                    write_value(output, &rpc_error(id, -32602, "sessionId is required")).await?;
+                    return Ok(());
+                }
+            };
+            let prompt = match prompt_text(&params) {
+                Ok(prompt) => prompt,
+                Err(message) => {
+                    write_value(output, &rpc_error(id, -32602, &message)).await?;
+                    return Ok(());
+                }
+            };
+            let Some(state) = sessions.get(&session_id) else {
+                write_value(output, &rpc_error(id, -32001, "ACP session was not found")).await?;
+                return Ok(());
+            };
+            if state.active.is_some() {
+                write_value(
+                    output,
+                    &rpc_error(id, -32003, "ACP session already has an active turn"),
+                )
+                .await?;
+                return Ok(());
+            }
+            let tools = state.tools.clone();
+            let system_prompt = state.system_prompt.clone();
+            let host = app.state::<AgentRuntimeHost>();
+            match start_acp_run(
+                app,
+                &host,
+                &session_id,
+                &prompt,
+                system_prompt.as_deref(),
+                &tools,
+            )
+            .await
+            {
+                Ok(run) => {
+                    if let Some(state) = sessions.get_mut(&session_id) {
+                        state.active = Some(ActivePrompt {
+                            request_id: id,
+                            run_id: run.id,
+                        });
+                    }
+                }
+                Err(error) => {
+                    write_value(output, &rpc_error(id, -32000, &error.message)).await?;
+                }
+            }
+        }
+        "session/cancel" => {
+            if let Some(session_id) = params.get("sessionId").and_then(Value::as_str) {
+                if let Some(active) = sessions
+                    .get(session_id)
+                    .and_then(|state| state.active.as_ref())
+                    .cloned()
+                {
+                    let host = app.state::<AgentRuntimeHost>();
+                    let _ = host
+                        .request("run.cancel", session_id, &active.run_id, json!({}))
+                        .await;
+                    host.cancel_run_streams(&active.run_id).await;
+                }
+            }
+        }
+        _ => {
+            if let Some(id) = id {
+                write_value(output, &rpc_error(id, -32601, "Method not found")).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn create_session(
+    app: &AppHandle,
+    params: &Value,
+) -> Result<(String, SessionState), AppError> {
+    let cwd = params
+        .get("cwd")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| AppError::new("acp_invalid_session", "cwd is required"))?;
+    if !Path::new(cwd).is_absolute() || !Path::new(cwd).is_dir() {
+        return Err(AppError::new(
+            "acp_invalid_session",
+            "cwd must be an existing absolute directory",
+        ));
+    }
+    let servers = parse_mcp_servers(params)?;
+    let title = params
+        .pointer("/_meta/sessionTitle")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_SESSION_TITLE)
+        .chars()
+        .take(100)
+        .collect::<String>();
+    let repositories = crate::commands::repositories(app).await?;
+    let repository = AgentRepository::new(repositories.pool);
+    let session = repository
+        .create_session_in_profile(
+            &title,
+            crate::providers::AUTO_GENERATION_MODEL,
+            AgentSafetyMode::Unrestricted,
+            Some(cwd),
+            "default",
+        )
+        .await?;
+    let host = app.state::<AgentRuntimeHost>();
+    let tools = match host.register_ephemeral_mcp(&session.id, servers).await {
+        Ok(tools) => tools,
+        Err(error) => {
+            let _ = repository.delete_session(&session.id).await;
+            return Err(error);
+        }
+    };
+    Ok((
+        session.id,
+        SessionState {
+            system_prompt: params
+                .get("systemPrompt")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string),
+            tools,
+            active: None,
+        },
+    ))
+}
+
+fn parse_mcp_servers(params: &Value) -> Result<Vec<EphemeralMcpServer>, AppError> {
+    let values = params
+        .get("mcpServers")
+        .and_then(Value::as_array)
+        .ok_or_else(|| AppError::new("acp_invalid_session", "mcpServers must be an array"))?;
+    values
+        .iter()
+        .map(|value| {
+            let required = |key: &str| {
+                value
+                    .get(key)
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+                    .ok_or_else(|| {
+                        AppError::new(
+                            "acp_invalid_session",
+                            format!("MCP server {key} is required"),
+                        )
+                    })
+            };
+            let args = value
+                .get("args")
+                .and_then(Value::as_array)
+                .ok_or_else(|| {
+                    AppError::new("acp_invalid_session", "MCP server args must be an array")
+                })?
+                .iter()
+                .map(|argument| {
+                    argument.as_str().map(str::to_string).ok_or_else(|| {
+                        AppError::new(
+                            "acp_invalid_session",
+                            "MCP server args must contain strings",
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let env = value
+                .get("env")
+                .and_then(Value::as_array)
+                .ok_or_else(|| {
+                    AppError::new("acp_invalid_session", "MCP server env must be an array")
+                })?
+                .iter()
+                .map(|entry| {
+                    let name = entry
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .ok_or_else(|| {
+                            AppError::new(
+                                "acp_invalid_session",
+                                "MCP environment variable name is required",
+                            )
+                        })?;
+                    let value = entry.get("value").and_then(Value::as_str).ok_or_else(|| {
+                        AppError::new(
+                            "acp_invalid_session",
+                            "MCP environment variable value must be a string",
+                        )
+                    })?;
+                    Ok((name.to_string(), value.to_string()))
+                })
+                .collect::<Result<BTreeMap<_, _>, AppError>>()?;
+            Ok(EphemeralMcpServer {
+                name: required("name")?,
+                command: required("command")?,
+                args,
+                env,
+            })
+        })
+        .collect()
+}
+
+fn prompt_text(params: &Value) -> Result<String, String> {
+    let blocks = params
+        .get("prompt")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "prompt must be an array".to_string())?;
+    let text = blocks
+        .iter()
+        .map(|block| {
+            if block.get("type").and_then(Value::as_str) != Some("text") {
+                return Err("June ACP currently accepts text prompt blocks".to_string());
+            }
+            block
+                .get("text")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .ok_or_else(|| "Text prompt blocks require text".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .join("\n\n");
+    if text.trim().is_empty() {
+        return Err("prompt must contain text".into());
+    }
+    if text.chars().count() > MAX_PROMPT_CHARS {
+        return Err("prompt is too large".into());
+    }
+    Ok(text)
+}
+
+fn parse_runtime_event(value: Value) -> Option<RuntimeEvent> {
+    Some(RuntimeEvent {
+        session_id: value.get("sessionId")?.as_str()?.to_string(),
+        run_id: value.get("runId")?.as_str()?.to_string(),
+        method: value.get("method")?.as_str()?.to_string(),
+        data: value.get("data").cloned().unwrap_or_else(|| json!({})),
+    })
+}
+
+async fn handle_runtime_event(
+    output: &Arc<Mutex<tokio::io::Stdout>>,
+    sessions: &mut BTreeMap<String, SessionState>,
+    event: RuntimeEvent,
+) -> Result<(), AppError> {
+    let Some(state) = sessions.get_mut(&event.session_id) else {
+        return Ok(());
+    };
+    let Some(active) = state.active.as_ref() else {
+        return Ok(());
+    };
+    if active.run_id != event.run_id {
+        return Ok(());
+    }
+    if let Some(update) = acp_update(&event.method, &event.data) {
+        write_value(
+            output,
+            &json!({
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": { "sessionId": event.session_id, "update": update },
+            }),
+        )
+        .await?;
+    }
+    match event.method.as_str() {
+        "run.completed" => {
+            let active = state.active.take().expect("active prompt checked");
+            write_value(
+                output,
+                &rpc_result(active.request_id, json!({ "stopReason": "end_turn" })),
+            )
+            .await?;
+        }
+        "run.cancelled" => {
+            let active = state.active.take().expect("active prompt checked");
+            write_value(
+                output,
+                &rpc_result(active.request_id, json!({ "stopReason": "cancelled" })),
+            )
+            .await?;
+        }
+        "run.failed" | "interruption.requested" => {
+            let active = state.active.take().expect("active prompt checked");
+            let message = event
+                .data
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("June could not complete the ACP turn");
+            write_value(output, &rpc_error(active.request_id, -32000, message)).await?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn acp_update(method: &str, data: &Value) -> Option<Value> {
+    match method {
+        "message.delta" => Some(json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": { "type": "text", "text": data.get("delta")?.as_str()? },
+        })),
+        "reasoning.delta" => Some(json!({
+            "sessionUpdate": "agent_thought_chunk",
+            "content": { "type": "text", "text": data.get("delta")?.as_str()? },
+        })),
+        "tool.started" => Some(json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": data.get("callId")?.as_str()?,
+            "title": data.get("name").and_then(Value::as_str).unwrap_or("Tool"),
+            "kind": "other",
+            "status": "in_progress",
+            "rawInput": data.get("arguments").cloned().unwrap_or(Value::Null),
+        })),
+        "tool.completed" | "tool.failed" => Some(json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": data.get("callId")?.as_str()?,
+            "status": if method == "tool.completed" { "completed" } else { "failed" },
+            "rawOutput": data.get("output").cloned().or_else(|| data.get("error").cloned()).unwrap_or(Value::Null),
+        })),
+        _ => None,
+    }
+}
+
+fn initialize_result() -> Value {
+    json!({
+        "protocolVersion": ACP_PROTOCOL_VERSION,
+        "agentCapabilities": {
+            "loadSession": false,
+            "promptCapabilities": { "image": false, "audio": false, "embeddedContext": false },
+            "mcpCapabilities": { "http": false, "sse": false },
+        },
+        "agentInfo": {
+            "name": "june",
+            "title": "June",
+            "version": env!("CARGO_PKG_VERSION"),
+        },
+    })
+}
+
+fn rpc_result(id: Value, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn rpc_error(id: Value, code: i64, message: &str) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}
+
+async fn write_value(
+    output: &Arc<Mutex<tokio::io::Stdout>>,
+    value: &Value,
+) -> Result<(), AppError> {
+    let mut output = output.lock().await;
+    let mut bytes = serde_json::to_vec(value)
+        .map_err(|error| AppError::new("acp_encode_failed", error.to_string()))?;
+    bytes.push(b'\n');
+    output
+        .write_all(&bytes)
+        .await
+        .map_err(|error| AppError::new("acp_write_failed", error.to_string()))?;
+    output
+        .flush()
+        .await
+        .map_err(|error| AppError::new("acp_write_failed", error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initialize_advertises_buzz_protocol_version() {
+        let result = initialize_result();
+        assert_eq!(result["protocolVersion"], 2);
+        assert_eq!(result["agentInfo"]["name"], "june");
+    }
+
+    #[test]
+    fn joins_buzz_text_blocks_in_order() {
+        let text = prompt_text(&json!({
+            "prompt": [
+                { "type": "text", "text": "/goal ship it" },
+                { "type": "text", "text": "[Buzz context]" }
+            ]
+        }))
+        .unwrap();
+        assert_eq!(text, "/goal ship it\n\n[Buzz context]");
+    }
+
+    #[test]
+    fn maps_streaming_and_tool_events_to_acp_updates() {
+        assert_eq!(
+            acp_update("message.delta", &json!({ "delta": "hello" })).unwrap(),
+            json!({
+                "sessionUpdate": "agent_message_chunk",
+                "content": { "type": "text", "text": "hello" }
+            })
+        );
+        assert_eq!(
+            acp_update(
+                "tool.started",
+                &json!({ "callId": "call-1", "name": "send_message", "arguments": { "text": "hi" } })
+            )
+            .unwrap()["sessionUpdate"],
+            "tool_call"
+        );
+    }
+
+    #[test]
+    fn parses_buzz_mcp_server_shape() {
+        let parsed = parse_mcp_servers(&json!({
+            "mcpServers": [{
+                "name": "buzz",
+                "command": "/usr/local/bin/buzz-cli",
+                "args": ["mcp"],
+                "env": [{ "name": "BUZZ_PRIVATE_KEY", "value": "secret" }]
+            }]
+        }))
+        .unwrap();
+        assert_eq!(parsed[0].name, "buzz");
+        assert_eq!(parsed[0].args, vec!["mcp"]);
+        assert_eq!(
+            parsed[0].env.get("BUZZ_PRIVATE_KEY"),
+            Some(&"secret".to_string())
+        );
+    }
+}

--- a/src-tauri/src/agent_mcp.rs
+++ b/src-tauri/src/agent_mcp.rs
@@ -1273,6 +1273,163 @@ pub struct AgentMcpSubsystem<S: McpSecretStore> {
     pub secrets: S,
     pub registry: Mutex<McpToolRegistry>,
 }
+
+/// One stdio MCP server supplied by an external ACP client for the lifetime of
+/// a single June session. These definitions never enter June's database or
+/// keychain: the ACP client owns both the process configuration and its
+/// credentials, and June drops them when that ACP session ends.
+#[derive(Debug, Clone)]
+pub struct EphemeralMcpServer {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+struct EphemeralMcpTool {
+    server_index: usize,
+    remote_name: String,
+    descriptor: RuntimeToolDescriptorJson,
+}
+
+/// Session-scoped MCP bridge used by the ACP entrypoint. Tool names stay
+/// unchanged when they cross ACP so a host-provided instruction that names
+/// `send_message` still matches the tool the model sees.
+pub struct EphemeralMcpRuntime {
+    servers: Vec<(McpServerDefinition, McpSecretBundle)>,
+    tools: BTreeMap<String, EphemeralMcpTool>,
+}
+
+impl EphemeralMcpRuntime {
+    pub async fn connect(
+        supplied: Vec<EphemeralMcpServer>,
+    ) -> Result<(Self, Vec<RuntimeToolDescriptorJson>), AgentMcpError> {
+        let mut servers = Vec::with_capacity(supplied.len());
+        let mut tools = BTreeMap::new();
+        for (server_index, supplied_server) in supplied.into_iter().enumerate() {
+            let mut definition =
+                McpServerDefinition::new(supplied_server.name.trim(), McpTransport::Stdio);
+            // Persistent MCP sessions are process-global, so a generated id
+            // keeps two concurrent Buzz sessions from sharing a child process.
+            definition.id = format!("acp-{}", Uuid::new_v4());
+            definition.command = Some(supplied_server.command);
+            definition.args = supplied_server.args;
+            definition.safety = McpSafetyPolicy {
+                requires_approval: false,
+                allow_sandboxed: true,
+                timeout_ms: 120_000,
+                max_output_bytes: DEFAULT_MAX_OUTPUT_BYTES,
+                approval_tools: Vec::new(),
+            };
+            definition.validate()?;
+            let secrets = McpSecretBundle {
+                env: supplied_server.env,
+                headers: BTreeMap::new(),
+                oauth: BTreeMap::new(),
+            };
+            let discovered = match discover_server(&definition, &secrets, None).await {
+                Ok(discovered) => discovered,
+                Err(error) => {
+                    close_ephemeral_servers(&servers, Some(&definition)).await;
+                    return Err(error);
+                }
+            };
+            for tool in discovered {
+                if let Err(error) = validate_ephemeral_tool_name(&tool.name) {
+                    close_ephemeral_servers(&servers, Some(&definition)).await;
+                    return Err(error);
+                }
+                if tools.contains_key(&tool.name) {
+                    close_ephemeral_servers(&servers, Some(&definition)).await;
+                    return Err(AgentMcpError::InvalidDefinition(format!(
+                        "ACP MCP tool name is duplicated: {}",
+                        tool.name
+                    )));
+                }
+                let descriptor = RuntimeToolDescriptorJson {
+                    id: format!("mcp:{}/{}", definition.id, tool.name),
+                    name: tool.name.clone(),
+                    description: tool.description,
+                    parameters: object_schema(tool.input_schema),
+                    requires_approval: None,
+                };
+                tools.insert(
+                    tool.name.clone(),
+                    EphemeralMcpTool {
+                        server_index,
+                        remote_name: tool.name,
+                        descriptor,
+                    },
+                );
+            }
+            servers.push((definition, secrets));
+        }
+        let descriptors = tools.values().map(|tool| tool.descriptor.clone()).collect();
+        Ok((Self { servers, tools }, descriptors))
+    }
+
+    pub async fn invoke(
+        &self,
+        runtime_name: &str,
+        arguments: Value,
+    ) -> Result<Value, AgentMcpError> {
+        let registered = self
+            .tools
+            .get(runtime_name)
+            .ok_or(AgentMcpError::ToolUnavailable)?;
+        let (server, secrets) = self
+            .servers
+            .get(registered.server_index)
+            .ok_or(AgentMcpError::ToolUnavailable)?;
+        call_server(
+            server,
+            secrets,
+            &registered.remote_name,
+            arguments,
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub fn contains_tool(&self, runtime_name: &str) -> bool {
+        self.tools.contains_key(runtime_name)
+    }
+
+    pub async fn close(&self) {
+        for (server, _) in &self.servers {
+            retire_server_sessions(&server.id).await;
+        }
+    }
+}
+
+async fn close_ephemeral_servers(
+    servers: &[(McpServerDefinition, McpSecretBundle)],
+    current: Option<&McpServerDefinition>,
+) {
+    for (server, _) in servers {
+        retire_server_sessions(&server.id).await;
+    }
+    if let Some(current) = current {
+        retire_server_sessions(&current.id).await;
+    }
+}
+
+fn validate_ephemeral_tool_name(name: &str) -> Result<(), AgentMcpError> {
+    if name.is_empty()
+        || name.len() > 128
+        || name.starts_with("__june_")
+        || !name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+    {
+        return Err(AgentMcpError::InvalidDefinition(
+            "ACP MCP tool names must use letters, numbers, underscores, or hyphens".into(),
+        ));
+    }
+    Ok(())
+}
 impl<S: McpSecretStore> AgentMcpSubsystem<S> {
     pub fn new(repository: AgentMcpRepository, secrets: S) -> Self {
         Self {
@@ -3019,6 +3176,58 @@ fn string_array(value: Option<&Value>) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn acp_tools_keep_protocol_names_and_reject_unsafe_names() {
+        assert!(validate_ephemeral_tool_name("send_message").is_ok());
+        assert!(validate_ephemeral_tool_name("feed-actions").is_ok());
+        assert!(validate_ephemeral_tool_name("send message").is_err());
+        assert!(validate_ephemeral_tool_name("__june_model_chat_completions").is_err());
+        assert!(validate_ephemeral_tool_name("").is_err());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn acp_ephemeral_runtime_discovers_and_invokes_host_tools() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let script = r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{},"serverInfo":{"name":"fake-buzz","version":"1"}}}'
+      ;;
+    *'"method":"tools/list"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"send_message","description":"Send a Buzz message","inputSchema":{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}}]}}'
+      ;;
+    *'"method":"tools/call"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"sent"}]}}'
+      ;;
+  esac
+done
+"#;
+        let temp = tempfile::tempdir().unwrap();
+        let server_path = temp.path().join("fake-buzz-mcp");
+        std::fs::write(&server_path, script).unwrap();
+        std::fs::set_permissions(&server_path, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let (runtime, descriptors) = EphemeralMcpRuntime::connect(vec![EphemeralMcpServer {
+            name: "buzz".into(),
+            command: server_path.to_string_lossy().into_owned(),
+            args: Vec::new(),
+            env: BTreeMap::new(),
+        }])
+        .await
+        .unwrap();
+        assert_eq!(descriptors.len(), 1);
+        assert_eq!(descriptors[0].name, "send_message");
+        assert_eq!(descriptors[0].requires_approval, None);
+        let result = runtime
+            .invoke("send_message", json!({ "text": "hello" }))
+            .await
+            .unwrap();
+        assert_eq!(result["content"][0]["text"], "sent");
+        runtime.close().await;
+    }
     use sqlx_sqlite::{SqliteConnectOptions, SqlitePoolOptions};
     use std::collections::HashMap;
     use std::str::FromStr;

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -656,6 +656,83 @@ pub async fn start_agent_run(
     Ok(run_json(repository.get_run(&run.id).await?))
 }
 
+/// Starts a turn for an ACP-owned session using only the MCP tools supplied by
+/// that client. The normal June desktop tool catalog is intentionally omitted:
+/// Buzz owns the execution boundary for these headless sessions, while June
+/// continues to own model routing, history, cancellation, and persistence.
+pub(crate) async fn start_acp_run(
+    app: &AppHandle,
+    host: &AgentRuntimeHost,
+    session_id: &str,
+    prompt: &str,
+    system_prompt: Option<&str>,
+    tools: &[crate::agent_mcp::RuntimeToolDescriptorJson],
+) -> Result<super::AgentRunDto, AppError> {
+    let repository = repository(app).await?;
+    let session = repository.get_session(session_id).await?;
+    if matches!(session.status.as_str(), "running" | "waiting_for_user") {
+        return Err(AppError::new(
+            "agent_run_active",
+            "This ACP session already has an active turn.",
+        ));
+    }
+    let workspace = session.workspace_path.as_deref().ok_or_else(|| {
+        AppError::new(
+            "agent_workspace_missing",
+            "The ACP workspace is unavailable.",
+        )
+    })?;
+    let model = crate::providers::AUTO_GENERATION_MODEL;
+    let capabilities = crate::providers::june_model_runtime_capabilities(model).await;
+    let context_window = capabilities.context_tokens.unwrap_or(128_000).max(1_024);
+    let history = runtime_history(repository.items(session_id).await?, None);
+    let instructions = system_prompt
+        .map(str::trim)
+        .filter(|prompt| !prompt.is_empty())
+        .map(|prompt| format!("{INSTRUCTIONS}\n\nACP host instructions:\n{prompt}"))
+        .unwrap_or_else(|| INSTRUCTIONS.to_string());
+    let run = repository.create_run(session_id, model, None).await?;
+    let params = json!({
+        "model": model,
+        "instructions": instructions,
+        "workspace": workspace,
+        "safetyMode": AgentSafetyMode::Unrestricted.as_db(),
+        "input": prompt,
+        "attachments": [],
+        "history": history,
+        "tools": tools,
+        "skills": [],
+        "contextWindow": context_window,
+        "maxOutputTokens": agent_model_output_reserve(context_window),
+        "includeClarificationTool": false,
+    });
+    repository
+        .set_run_config(&run.id, &resumable_run_config(&params))
+        .await?;
+    repository
+        .append_item(
+            session_id,
+            Some(&run.id),
+            0,
+            &AgentItemPayload::UserMessage(super::MessagePayload {
+                role: "user".into(),
+                content: prompt.to_string(),
+                attachments: Vec::new(),
+            }),
+            Some(&format!("user:{}", run.id)),
+        )
+        .await?;
+    if let Err(error) = host.ensure_started(app, repository.clone()).await {
+        mark_dispatch_failed(&repository, &run.id, &error).await;
+        return Err(error);
+    }
+    if let Err(error) = host.request("run.start", session_id, &run.id, params).await {
+        mark_dispatch_failed(&repository, &run.id, &error).await;
+        return Err(error);
+    }
+    repository.get_run(&run.id).await.map_err(AppError::from)
+}
+
 #[tauri::command]
 pub async fn cancel_agent_run(
     host: State<'_, AgentRuntimeHost>,

--- a/src-tauri/src/agent_runtime/host.rs
+++ b/src-tauri/src/agent_runtime/host.rs
@@ -56,6 +56,7 @@ pub struct AgentRuntimeHost {
     interruption_resolutions: Mutex<HashMap<String, Weak<Mutex<()>>>>,
     model_streams: Arc<Mutex<HashMap<String, ModelStream>>>,
     model_scopes: Arc<Mutex<HashSet<String>>>,
+    ephemeral_mcp: Arc<Mutex<HashMap<String, Arc<crate::agent_mcp::EphemeralMcpRuntime>>>>,
     cancellations: ToolCancellationRegistry,
 }
 
@@ -147,6 +148,7 @@ impl AgentRuntimeHost {
             pending.clone(),
             self.model_streams.clone(),
             self.model_scopes.clone(),
+            self.ephemeral_mcp.clone(),
             self.cancellations.clone(),
         );
         tauri::async_runtime::spawn(async move {
@@ -256,6 +258,16 @@ impl AgentRuntimeHost {
     pub async fn shutdown(&self) {
         let _startup = self.startup.lock().await;
         crate::agent_mcp::shutdown_sessions().await;
+        let ephemeral = self
+            .ephemeral_mcp
+            .lock()
+            .await
+            .drain()
+            .map(|(_, runtime)| runtime)
+            .collect::<Vec<_>>();
+        for runtime in ephemeral {
+            runtime.close().await;
+        }
         cancel_all_model_scopes(&self.model_streams, &self.model_scopes, &self.cancellations).await;
         let mut guard = self.inner.lock().await;
         let Some(mut runtime) = guard.take() else {
@@ -282,6 +294,31 @@ impl AgentRuntimeHost {
             run_id,
         )
         .await;
+    }
+
+    pub async fn register_ephemeral_mcp(
+        &self,
+        session_id: &str,
+        servers: Vec<crate::agent_mcp::EphemeralMcpServer>,
+    ) -> Result<Vec<crate::agent_mcp::RuntimeToolDescriptorJson>, AppError> {
+        let (runtime, descriptors) = crate::agent_mcp::EphemeralMcpRuntime::connect(servers)
+            .await
+            .map_err(|error| AppError::new("agent_mcp_failed", error.to_string()))?;
+        let previous = self
+            .ephemeral_mcp
+            .lock()
+            .await
+            .insert(session_id.to_string(), Arc::new(runtime));
+        if let Some(previous) = previous {
+            previous.close().await;
+        }
+        Ok(descriptors)
+    }
+
+    pub async fn unregister_ephemeral_mcp(&self, session_id: &str) {
+        if let Some(runtime) = self.ephemeral_mcp.lock().await.remove(session_id) {
+            runtime.close().await;
+        }
     }
 }
 
@@ -317,6 +354,7 @@ async fn await_runtime_response(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn spawn_stdout_reader(
     app: AppHandle,
     repository: AgentRepository,
@@ -325,6 +363,7 @@ fn spawn_stdout_reader(
     pending: PendingRequests,
     model_streams: Arc<Mutex<HashMap<String, ModelStream>>>,
     model_scopes: Arc<Mutex<HashSet<String>>>,
+    ephemeral_mcp: Arc<Mutex<HashMap<String, Arc<crate::agent_mcp::EphemeralMcpRuntime>>>>,
     cancellations: ToolCancellationRegistry,
 ) {
     tauri::async_runtime::spawn(async move {
@@ -380,6 +419,7 @@ fn spawn_stdout_reader(
             let request_repository = repository.clone();
             let request_streams = model_streams.clone();
             let request_scopes = model_scopes.clone();
+            let request_ephemeral_mcp = ephemeral_mcp.clone();
             let request_cancellations = cancellations.clone();
             let request_stdin = stdin.clone();
             tauri::async_runtime::spawn(async move {
@@ -388,6 +428,7 @@ fn spawn_stdout_reader(
                     &request_repository,
                     &request_streams,
                     &request_scopes,
+                    &request_ephemeral_mcp,
                     &request_cancellations,
                     &frame,
                 )
@@ -418,6 +459,7 @@ async fn handle_runtime_request(
     repository: &AgentRepository,
     model_streams: &Arc<Mutex<HashMap<String, ModelStream>>>,
     model_scopes: &Arc<Mutex<HashSet<String>>>,
+    ephemeral_mcp: &Arc<Mutex<HashMap<String, Arc<crate::agent_mcp::EphemeralMcpRuntime>>>>,
     cancellations: &ToolCancellationRegistry,
     frame: &RpcFrame,
 ) -> Result<Value, AppError> {
@@ -540,6 +582,14 @@ async fn handle_runtime_request(
                 );
                 drop(scopes);
                 return poll_model_stream(model_streams, &stream_id).await;
+            }
+            if let Some(runtime) = ephemeral_mcp.lock().await.get(&frame.session_id).cloned() {
+                if runtime.contains_tool(name) {
+                    return runtime
+                        .invoke(name, arguments)
+                        .await
+                        .map_err(|error| AppError::new("agent_mcp_failed", error.to_string()));
+                }
             }
             let session = repository.get_session(&frame.session_id).await?;
             let workspace = session.workspace_path.map(PathBuf::from).ok_or_else(|| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 
+pub mod acp;
 pub mod agent_hud;
 pub mod agent_mcp;
 pub mod agent_recorder;
@@ -106,7 +107,7 @@ type MainWindowSendEventImp = unsafe extern "C-unwind" fn(
 
 pub fn run() {
     providers::load_local_env();
-    let context = tauri::generate_context!();
+    let context = app_context();
     let mut builder = tauri::Builder::default();
 
     // Single-instance MUST register before the deep-link plugin so it owns
@@ -475,6 +476,41 @@ pub fn run() {
             tauri::RunEvent::Reopen { .. } => show_main_window(app),
             _ => {}
         });
+}
+
+/// Runs June as a headless ACP agent over stdin/stdout. This mode deliberately
+/// omits desktop plugins and windows, but retains the app identity and resource
+/// directory so it can use June's keychain session and bundled agent runtime.
+pub fn run_acp() {
+    providers::load_local_env();
+    let mut context = app_context();
+    context.config_mut().app.windows.clear();
+    tauri::Builder::default()
+        .manage(agent_runtime::AgentRuntimeHost::default())
+        .setup(|app| {
+            #[cfg(target_os = "macos")]
+            app.set_activation_policy(tauri::ActivationPolicy::Prohibited);
+            providers::setup(app);
+            let handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                let exit_code = match acp::serve(handle.clone()).await {
+                    Ok(()) => 0,
+                    Err(error) => {
+                        eprintln!("June ACP stopped: {}", error.message);
+                        1
+                    }
+                };
+                handle.exit(exit_code);
+            });
+            Ok(())
+        })
+        .build(context)
+        .expect("failed to build June ACP")
+        .run(|_, _| {});
+}
+
+fn app_context() -> tauri::Context<tauri::Wry> {
+    tauri::generate_context!()
 }
 
 /// Registers the generated-video directory in the asset-protocol scope so the

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,13 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    if std::env::args_os()
+        .nth(1)
+        .is_some_and(|argument| argument == "acp" || argument == "--acp")
+    {
+        os_june_lib::run_acp();
+        return;
+    }
     #[cfg(target_os = "macos")]
     {
         let arguments: Vec<_> = std::env::args_os().collect();


### PR DESCRIPTION
## What changed

- add a headless `June acp` mode that speaks ACP v2 over NDJSON stdin/stdout
- translate June runtime streaming, tool, completion, failure, and cancellation events to ACP
- mount Buzz-provided stdio MCP servers for each session without persisting their environment or credentials
- reuse June OS Accounts authentication and private model routing, while saving Buzz conversations as June agent sessions
- document the Buzz custom harness command

## Why

Buzz can launch any ACP-speaking command as a custom harness. June previously had no ACP entrypoint, so it could not be selected as a Buzz runtime.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --lib --locked` (1,404 passed, 5 ignored)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --locked -- -D warnings`
- `pnpm test` (1,665 passed)
- `pnpm typecheck`
- `pnpm --filter @june/agent-runtime test` (54 passed)
- `pnpm run agent-runtime:build`
- `pnpm check` (exit 0; baseline hook-dependency warnings remain)
- live process smoke: piped Buzz-shaped `initialize` into `src-tauri/target/debug/os-june acp`, received one clean ACP response, and observed a clean headless exit
- live MCP subprocess contract test: discovery preserved `send_message`, invocation returned the fake Buzz result, and shutdown retired the child

## Live QA

This is a headless stdio integration with no visible UI state, so a screen recording would not add reviewer evidence. The real process handshake and subprocess MCP test above cover the changed user workflow without contacting a relay, spending credits, or sending messages.

## Known gaps

- no production Buzz relay message was sent because that would require a live identity and external side effect
- Windows can compile the ACP path, but the documented Buzz command targets the primary macOS release surface

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787947479&installation_model_id=425925&pr_number=1013&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1013&signature=5b87811c251fb18894760ef7b6f150a31f3ec983a27d2df46dece5768447adf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->