### PR TITLE
Relax public-share IP limits for VPN users

### DIFF
--- a/docs/private-sharing-design.md
+++ b/docs/private-sharing-design.md
@@ -81,11 +81,14 @@ rows.
 
 ### Rate-limit bounds
 
-Share requests keep the deployed fixed-window budget of 60 requests per
-minute. Authenticated endpoints consume both `user:{user_id}` and
-`ip:{client_address}` counters. Anonymous link views use
+Authenticated share requests use a fixed-window budget of 60 requests per
+minute keyed by `user:{user_id}`. They do not also consume an IP budget, which
+prevents unrelated signed-in users behind the same NAT or VPN exit from
+exhausting one another's allowance. Anonymous link views use
 `link-ip:{client_address}`, while viewer token exchanges use
-`ip:{client_address}`.
+`ip:{client_address}`. These unauthenticated client-address counters allow 300
+requests per minute, preserving an abuse ceiling while accommodating shared
+networks.
 
 The in-memory limiter has 64 independently locked shards, tracks at most
 100,000 keys across them, and caps each shard at 4,096 keys so retained hash

--- a/june-api/crates/api/src/handlers/share.rs
+++ b/june-api/crates/api/src/handlers/share.rs
@@ -248,7 +248,7 @@ pub(crate) async fn view(
 ) -> Result<Json<ApiResponse<ShareViewResponse>>, ApiError> {
     let service = state.share().ok_or(ApiError::SharingUnavailable)?;
     let user = authenticated_user_with_scope(&state, &headers, PROFILE_READ_SCOPE).await?;
-    enforce_share_rate(&state, &headers, &user)?;
+    enforce_share_rate(&state, &user)?;
     let token = bearer_token(&headers)?.to_string();
     let record = service
         .view(&user, &token, &share_id, query.invite.as_deref())
@@ -284,7 +284,7 @@ pub(crate) async fn link_view(
 ) -> Result<Json<ApiResponse<ShareViewResponse>>, ApiError> {
     let service = state.share().ok_or(ApiError::SharingUnavailable)?;
     let client_key = format!("link-ip:{}", client_address(&headers));
-    if !state.share_rate().allow(&client_key) {
+    if !state.share_rate().allow_client(&client_key) {
         return Err(ApiError::AuthorizationDenied);
     }
     let record = service.view_link(&share_id, &query.link).await?;
@@ -308,18 +308,13 @@ async fn share_context<'a>(
 ) -> Result<(&'a ShareService, UserId), ApiError> {
     let service = state.share().ok_or(ApiError::SharingUnavailable)?;
     let user = authenticated_user(state, headers).await?;
-    enforce_share_rate(state, headers, &user)?;
+    enforce_share_rate(state, &user)?;
     Ok((service, user))
 }
 
-fn enforce_share_rate(
-    state: &ApiState,
-    headers: &HeaderMap,
-    user: &UserId,
-) -> Result<(), ApiError> {
+fn enforce_share_rate(state: &ApiState, user: &UserId) -> Result<(), ApiError> {
     let user_key = format!("user:{}", user.0);
-    let client_key = format!("ip:{}", client_address(headers));
-    if !state.share_rate().allow(&user_key) || !state.share_rate().allow(&client_key) {
+    if !state.share_rate().allow(&user_key) {
         return Err(ApiError::AuthorizationDenied);
     }
     Ok(())

--- a/june-api/crates/api/src/handlers/share_viewer.rs
+++ b/june-api/crates/api/src/handlers/share_viewer.rs
@@ -118,11 +118,11 @@ pub(crate) async fn token_exchange(
     // our ingress appended); earlier entries are client-controlled and
     // spoofable, so a caller cannot vary this to escape their own budget. A
     // single global counter is deliberately NOT used here: sizing one small
-    // enough to bound abuse would let one client's 60/min exhaust it and lock
+    // enough to bound abuse would let one client's budget exhaust it and lock
     // every recipient out of sign-in platform-wide, and the non-spoofable
     // per-address key already caps each source.
     let client_key = format!("ip:{}", client_address(&headers));
-    if !state.share_rate().allow(&client_key) {
+    if !state.share_rate().allow_client(&client_key) {
         return Err(ApiError::AuthorizationDenied);
     }
     if request.code.len() > 4096

--- a/june-api/crates/api/src/share_rate_limit.rs
+++ b/june-api/crates/api/src/share_rate_limit.rs
@@ -12,7 +12,8 @@ const SHARD_COUNT: usize = 64;
 const MAX_TRACKED_KEYS: usize = 100_000;
 const MAX_KEYS_PER_SHARD: usize = 4_096;
 const WINDOW: Duration = Duration::from_mins(1);
-const MAX_PER_WINDOW: u32 = 60;
+const MAX_PER_USER_WINDOW: u32 = 60;
+const MAX_PER_CLIENT_WINDOW: u32 = 300;
 const CLEANUP_INTERVAL: Duration = Duration::from_millis(100);
 
 #[derive(Clone, Copy)]
@@ -31,11 +32,13 @@ struct ShareRateLimiterInner {
 
 /// Fixed-window limiter for public-share endpoints.
 ///
-/// Keys retain the deployed 60 requests/minute semantics. A keyed request
-/// locks only one of 64 shards, while a detached maintenance task expires one
-/// shard at a time outside the request path. The table tracks at most 100,000
-/// keys; once full, unknown keys fail closed instead of evicting an active
-/// counter that an attacker could deliberately reset.
+/// Authenticated users retain a 60 requests/minute budget. Unauthenticated
+/// client-address keys receive a larger 300 requests/minute budget so users
+/// sharing a NAT or VPN exit do not exhaust one another's allowance as easily.
+/// A keyed request locks only one of 64 shards, while a detached maintenance
+/// task expires one shard at a time outside the request path. The table tracks
+/// at most 100,000 keys; once full, unknown keys fail closed instead of
+/// evicting an active counter that an attacker could deliberately reset.
 #[derive(Clone)]
 pub struct ShareRateLimiter {
     inner: Arc<ShareRateLimiterInner>,
@@ -67,10 +70,16 @@ impl ShareRateLimiter {
     /// Returns false when the caller is over budget or the bounded table
     /// cannot safely admit a new key.
     pub fn allow(&self, key: &str) -> bool {
-        self.allow_at(key, Instant::now())
+        self.allow_at(key, Instant::now(), MAX_PER_USER_WINDOW)
     }
 
-    fn allow_at(&self, key: &str, now: Instant) -> bool {
+    /// Applies the more permissive budget used for unauthenticated requests
+    /// that can only be attributed to a client address.
+    pub(crate) fn allow_client(&self, key: &str) -> bool {
+        self.allow_at(key, Instant::now(), MAX_PER_CLIENT_WINDOW)
+    }
+
+    fn allow_at(&self, key: &str, now: Instant, max_per_window: u32) -> bool {
         let shard_index = self.shard_index(key);
         // A poisoned lock must not fail OPEN on a security gate. HashMap
         // operations preserve structural validity across unwinding, so recover
@@ -88,7 +97,7 @@ impl ShareRateLimiter {
                 return true;
             }
             counter.hits = counter.hits.saturating_add(1);
-            return counter.hits <= MAX_PER_WINDOW;
+            return counter.hits <= max_per_window;
         }
 
         // The global count bounds live key strings. The per-shard ceiling also
@@ -192,7 +201,9 @@ async fn cleanup_loop(inner: Weak<ShareRateLimiterInner>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{MAX_KEYS_PER_SHARD, MAX_PER_WINDOW, ShareRateLimiter, WINDOW};
+    use super::{
+        MAX_KEYS_PER_SHARD, MAX_PER_CLIENT_WINDOW, MAX_PER_USER_WINDOW, ShareRateLimiter, WINDOW,
+    };
     use std::{
         collections::HashMap,
         sync::{
@@ -218,7 +229,7 @@ mod tests {
                 *entry = (now, 0);
             }
             entry.1 += 1;
-            entry.1 <= MAX_PER_WINDOW
+            entry.1 <= MAX_PER_USER_WINDOW
         }
     }
 
@@ -234,7 +245,7 @@ mod tests {
             for identity in identities {
                 for _ in 0..75 {
                     assert_eq!(
-                        limiter.allow_at(identity, now),
+                        limiter.allow_at(identity, now, MAX_PER_USER_WINDOW),
                         reference.allow_at(identity, now),
                         "semantic drift for {identity} at second {second}"
                     );
@@ -248,16 +259,28 @@ mod tests {
         let limiter = ShareRateLimiter::with_capacity(2);
         let start = Instant::now();
 
-        for _ in 0..MAX_PER_WINDOW {
-            assert!(limiter.allow_at("ip:198.51.100.7", start));
+        for _ in 0..MAX_PER_USER_WINDOW {
+            assert!(limiter.allow_at("user:usr_owner", start, MAX_PER_USER_WINDOW));
         }
         assert!(!limiter.allow_at(
-            "ip:198.51.100.7",
-            start + WINDOW.saturating_sub(Duration::from_nanos(1))
+            "user:usr_owner",
+            start + WINDOW.saturating_sub(Duration::from_nanos(1)),
+            MAX_PER_USER_WINDOW,
         ));
-        assert!(limiter.allow_at("user:usr_other", start));
-        assert!(limiter.allow_at("ip:198.51.100.7", start + WINDOW));
+        assert!(limiter.allow_at("user:usr_other", start, MAX_PER_USER_WINDOW));
+        assert!(limiter.allow_at("user:usr_owner", start + WINDOW, MAX_PER_USER_WINDOW));
         assert_eq!(limiter.tracked_key_count(), 2);
+    }
+
+    #[test]
+    fn client_address_budget_accommodates_shared_vpn_exits() {
+        let limiter = ShareRateLimiter::with_capacity(1);
+        let shared_exit = "link-ip:198.51.100.7";
+
+        for _ in 0..MAX_PER_CLIENT_WINDOW {
+            assert!(limiter.allow_client(shared_exit));
+        }
+        assert!(!limiter.allow_client(shared_exit));
     }
 
     #[test]
@@ -266,24 +289,32 @@ mod tests {
         let start = Instant::now();
         let attacker = "link-ip:203.0.113.9";
 
-        for _ in 0..MAX_PER_WINDOW {
-            assert!(limiter.allow_at(attacker, start));
+        for _ in 0..MAX_PER_USER_WINDOW {
+            assert!(limiter.allow_at(attacker, start, MAX_PER_USER_WINDOW));
         }
-        assert!(!limiter.allow_at(attacker, start));
+        assert!(!limiter.allow_at(attacker, start, MAX_PER_USER_WINDOW));
         for index in 0..3 {
-            assert!(limiter.allow_at(&format!("ip:198.51.100.{index}"), start));
+            assert!(limiter.allow_at(
+                &format!("ip:198.51.100.{index}"),
+                start,
+                MAX_PER_USER_WINDOW,
+            ));
         }
 
         for index in 0..1_000 {
             assert!(
-                !limiter.allow_at(&format!("link-ip:192.0.2.{index}"), start),
+                !limiter.allow_at(
+                    &format!("link-ip:192.0.2.{index}"),
+                    start,
+                    MAX_PER_USER_WINDOW,
+                ),
                 "a churn key was admitted after the table reached its cap"
             );
         }
 
         assert_eq!(limiter.tracked_key_count(), 4);
         assert!(
-            !limiter.allow_at(attacker, start),
+            !limiter.allow_at(attacker, start, MAX_PER_USER_WINDOW),
             "key churn evicted and reset the attacker's blocked counter"
         );
     }
@@ -292,14 +323,22 @@ mod tests {
     fn expiry_cleanup_reclaims_capacity_without_evicting_live_keys() {
         let limiter = ShareRateLimiter::with_capacity(2);
         let start = Instant::now();
-        assert!(limiter.allow_at("ip:expired", start));
-        assert!(limiter.allow_at("ip:live", start + Duration::from_secs(30)));
-        assert!(!limiter.allow_at("ip:new", start + Duration::from_secs(30)));
+        assert!(limiter.allow_at("ip:expired", start, MAX_PER_USER_WINDOW));
+        assert!(limiter.allow_at(
+            "ip:live",
+            start + Duration::from_secs(30),
+            MAX_PER_USER_WINDOW,
+        ));
+        assert!(!limiter.allow_at(
+            "ip:new",
+            start + Duration::from_secs(30),
+            MAX_PER_USER_WINDOW,
+        ));
 
         limiter.cleanup_all_at(start + WINDOW);
 
         assert_eq!(limiter.tracked_key_count(), 1);
-        assert!(limiter.allow_at("ip:new", start + WINDOW));
+        assert!(limiter.allow_at("ip:new", start + WINDOW, MAX_PER_USER_WINDOW));
         assert_eq!(limiter.tracked_key_count(), 2);
     }
 
@@ -357,7 +396,10 @@ mod tests {
             assert!(worker.join().is_ok(), "worker thread panicked");
         }
 
-        assert_eq!(allowed.load(Ordering::Relaxed), MAX_PER_WINDOW as usize);
+        assert_eq!(
+            allowed.load(Ordering::Relaxed),
+            MAX_PER_USER_WINDOW as usize
+        );
     }
 
     #[test]

--- a/june-api/crates/api/tests/share_boundary.rs
+++ b/june-api/crates/api/tests/share_boundary.rs
@@ -360,6 +360,30 @@ fn invite_wire(email: &str) -> Value {
 const OWNER: &str = "user:usr_owner|owner@example.com";
 const RECIPIENT: &str = "user:usr_friend|friend@example.com";
 const STRANGER: &str = "user:usr_stranger|stranger@example.com";
+const SHARED_VPN_ADDRESS: &str = "198.51.100.42";
+
+fn list_request(token: &str) -> Request<Body> {
+    authed(Request::builder().method("GET").uri("/v1/shares"), token)
+        .header("x-forwarded-for", SHARED_VPN_ADDRESS)
+        .body(Body::empty())
+        .expect("request builds")
+}
+
+#[tokio::test]
+async fn authenticated_users_behind_one_vpn_have_independent_budgets() {
+    let router = share_router();
+
+    for _ in 0..60 {
+        let (status, _) = call(&router, list_request(OWNER)).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    let (other_user_status, _) = call(&router, list_request(STRANGER)).await;
+    assert_eq!(other_user_status, StatusCode::OK);
+
+    let (owner_over_limit_status, _) = call(&router, list_request(OWNER)).await;
+    assert_eq!(owner_over_limit_status, StatusCode::TOO_MANY_REQUESTS);
+}
 
 #[tokio::test]
 async fn share_endpoints_answer_501_until_configured() {


### PR DESCRIPTION
## Summary

- keep authenticated share requests limited to 60 requests per minute per user without also charging a shared IP counter
- raise anonymous link-view and viewer token-exchange client-address budgets from 60 to 300 requests per minute
- add limiter and HTTP-boundary regressions for users sharing a VPN exit

## Why

The previous authenticated policy required both the user and client IP counters to pass. Multiple legitimate users behind one NAT or VPN exit could therefore exhaust the same 60-request IP budget and block one another.

## Validation

- `make june-api-fmt-check june-api-lint june-api-test`
- `cargo test --manifest-path june-api/Cargo.toml -p june-api --test share_boundary --locked`
- `cargo test --manifest-path june-api/Cargo.toml -p june-api client_address_budget_accommodates_shared_vpn_exits --locked`

Live app walkthrough skipped because this is a server-side admission policy with no UI change and deterministic HTTP-boundary coverage.

## Known gaps

- No tracker issue was provided.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787968741&installation_model_id=425925&pr_number=1014&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1014&signature=8fe9a255b3ca552b1a9014a9efac1397dd009806ee6c7c69c72dade4f5b12622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->