### PR TITLE
docs: adopt OS Platform shared-brain fragment + skill update (JUN-462)

### DIFF
--- a/.agents/skills/os-platform/SKILL.md
+++ b/.agents/skills/os-platform/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: os-platform
-description: Query and update live Open Software os-platform production data through the platform API. Use when an agent needs current Issues/Bounties, Orgs, Projects, Submissions, Comments, Activity, Contributors, or API status, or needs to create, assign, move, or comment on tracked work.
+description: Query and update live Open Software os-platform production data through the platform API. Use when an agent needs current Issues/Bounties, Orgs, Projects, Submissions, Comments, Activity, Contributors, Product Memory, the team Timeline, or API status, or needs to create, assign, move, or comment on tracked work.
 ---
 
 # os-platform
 
-Use this skill when the user asks about current Open Software / os-platform state or an agent needs to keep tracked work current: Issues, Bounties, Projects, Orgs, Submissions, Comments, Activity, Contributors, or whether API endpoints are real-backed. Prefer the bundled script over reading code, seed data, frontend fixtures, or docs when the question is about production data.
+Use this skill when the user asks about current Open Software / os-platform state or an agent needs to keep tracked work current: Issues, Bounties, Projects, Orgs, Submissions, Comments, Activity, Contributors, Product Memory, the team Timeline, or whether API endpoints are real-backed. Prefer the bundled script over reading code, seed data, frontend fixtures, or docs when the question is about production data.
+
+The authoritative workflow convention (memory before work, one Issue per
+reviewable outcome, milestone posts, offline degrade) is AGENTS.md → "OS
+Platform (shared brain)". This skill is the REST tooling that implements it.
 
 ## Quick Start
 
@@ -72,6 +76,34 @@ Use the platform as the source of truth for tracked work whenever it is availabl
 - Reference the Issue id in the PR, for example `JUN-123` or a `Closes JUN-123` line. The Org's GitHub `pr-links` webhook integration creates the platform PR link automatically; there is no CLI PR-link write command. If the integration does not link it, add the PR URL with `comments add`.
 - Add comments for durable progress or handoff context when useful. Do not replace or rewrite the Issue body to record progress.
 - Read the Issue after each write to verify the platform applied it. A write response alone is not durable evidence.
+
+## Product Memory, Teams, Timeline (live since 2026-08)
+
+The platform now carries per-Product Memory (distilled facts: decision |
+convention | context | reference), Teams (platform-level rosters), and a
+team-scoped Timeline (derived Issue/Memory/membership events + posted updates).
+
+Reads via the script's `raw` escape hatch (GET-only):
+
+```bash
+python3 scripts/os_platform.py raw GET /v1/orgs/june/memories
+python3 scripts/os_platform.py raw GET /v1/orgs/june/memories/<slug>
+python3 scripts/os_platform.py raw GET /v1/teams/os-core/timeline --query actor=<handle> --query since=<iso>
+python3 scripts/os_platform.py raw GET /v1/me/teams
+```
+
+Writes: prefer the `os_platform_*` MCP tools when connected (schema-validated).
+On raw REST (curl), field gotchas: memories take `body`, posts take
+`body_markdown` + `product_handle`; the API silently ignores unknown JSON
+fields by design, so verify the response echoes what you set.
+
+- Read the Product Memory index (embedded in `GET /v1/orgs/<org>`
+  via MCP `os_platform_get_product`) before non-trivial work; write durable
+  learnings back instead of local notes files.
+- Post to the team wall only at milestones a teammate would act on (blocked and
+  stopping, consequential decision, non-obvious ship, cross-person start) —
+  routine status flips are already derived timeline events.
+- Read the timeline before asking a human "what's the status?".
 
 ## Specific Issue Triage
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,42 @@ inside a TEE (Phala) so prompt data is not readable by its own infra.
 > Read **[CONTEXT.md](CONTEXT.md)** before naming anything, and
 > **[docs/index.md](docs/index.md)** to find the doc for the area you touch.
 
+## OS Platform (shared brain)
+
+Platform-enabled repo — Product `june`, Team `os-core`, Issue prefix `JUN`.
+Use the `os_platform_*` MCP tools (https://platform-api.opensoftware.co/mcp);
+REST fallback `https://app.opensoftware.co/api` + `Authorization: Bearer
+$OS_PLATFORM_API_KEY`. Never print or store credentials.
+
+**Before work that will produce a branch** (skip for Q&A, typos, exploration, CI):
+1. `os_platform_get_product{handle:"june"}` — response embeds the Product
+   Memory index; `os_platform_get_memory` only entries whose description touches
+   your task.
+2. Find-or-create the Issue: `os_platform_search_product_issues` first; create
+   only if no open Issue matches the outcome. One Issue per independently
+   reviewable outcome; reuse it across sessions.
+3. Set the Issue `in_progress` (`os_platform_set_issue_status` with the Product
+   handle, Issue number, and status), branch `JUN-<number>-<slug>`, and
+   put `JUN-<number>` in commit subjects and the PR title/body. PR-Links
+   advances in_review/completed automatically where installed; if it doesn't,
+   set them yourself. Leave unfinished work in its true status.
+
+**After the work lands**: for each durable fact (decision, convention, gotcha
+that cost >10 min) — check the memory index, then `os_platform_create_memory` or
+`os_platform_update_memory` the existing slug; never a near-duplicate, never
+secrets, never a local notes file.
+
+**Posts** (`os_platform_create_post{team:"os-core"}`): only when a teammate
+would act differently for reading it — blocked and stopping, a decision that
+changes someone's work, a shipped result the derived events don't convey, or a
+start of cross-person/cross-session work. Normally ≤1 per Issue per day. Read
+`os_platform_get_team_timeline` before asking anyone "what's the status?".
+
+**No access** (no MCP tools, no key): say once — "OS Platform not configured;
+see README → OS Platform" — then work normally, fully offline. No local memory
+substitute; put durable learnings in the PR description. At handoff, state
+"platform sync skipped"; never imply the platform steps ran.
+
 ## Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -214,3 +214,12 @@ report security vulnerabilities privately per [SECURITY.md](SECURITY.md).
 
 June is MIT licensed. See [LICENSE](LICENSE). Bundled third-party runtime
 notices are tracked in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+
+## OS Platform
+
+Agents and humans share product knowledge (memory, Issues, team timeline) through
+the OS Platform. Connect the MCP endpoint `https://platform-api.opensoftware.co/mcp`
+(OAuth via OS Accounts) in your agent client, or export an API key as
+`OS_PLATFORM_API_KEY` for REST access (`https://app.opensoftware.co/api`, keys
+under your platform profile → API keys). Conventions agents follow live in
+[`AGENTS.md`](AGENTS.md) → "OS Platform (shared brain)".


### PR DESCRIPTION
Issue: JUN-462

Two pieces:
1. **AGENTS.md fragment** — the OS Platform adoption convention (Product `june`, Team `os-core`, prefix `JUN`): Product Memory before work, one Issue per reviewable outcome with `JUN-N` refs, milestone posts to the os-core wall, honest offline degrade. Plus README → OS Platform setup section. Settled by a 3-model advisory council; first adopted in os-platform (open-software-network/os-platform#158).
2. **os-platform skill update** (`.agents/skills/os-platform/SKILL.md`) — the skill predates Product Memory / Teams / Timeline (shipped 2026-08). Adds reads via the existing GET-only `raw` escape hatch, MCP-first guidance for writes (REST gotchas: memories `body`, posts `body_markdown`+`product_handle`, unknown fields silently ignored by design), and points at the AGENTS.md fragment as the authoritative convention.

This PR follows the convention it ships (JUN-462 created + in_progress before branching).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788426301&installation_model_id=425925&pr_number=1024&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1024&signature=f2a84303bfaf942e56152b124b01ddb0045ac491a078262632debf0a09db3919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->