### PR TITLE
JUN-463 Restore centered Usage dialog overlay

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -25,6 +25,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import {
   agentItemsToChatTurns,
   applyAgentRuntimeEvent,
@@ -2553,138 +2554,151 @@ export function AgentWorkspace({
           onClose={() => setArtifactPanel(null)}
         />
       ) : null}
-      {usageOpen && selectedSession ? (
-        <aside className="agent-usage-panel" aria-label="Session usage">
-          <div className="agent-usage-header">
-            <h2 className="agent-usage-title">Usage</h2>
-            <button
-              type="button"
-              className="icon-button"
-              aria-label="Close usage"
-              onClick={() => setUsageOpen(false)}
+      {usageOpen && selectedSession
+        ? createPortal(
+            <div
+              className="agent-usage-overlay"
+              role="presentation"
+              onClick={(event) => {
+                if (event.target === event.currentTarget) setUsageOpen(false);
+              }}
             >
-              <IconCrossSmall size={14} />
-            </button>
-          </div>
-          <div className="agent-usage-body">
-            <div className="agent-usage-row">
-              <span className="agent-usage-primary">Model</span>
-              <span className="agent-usage-value">{usageModel?.name ?? sessionDisplayModel}</span>
-            </div>
-            {projection.run?.usage?.provider || usageModel?.provider ? (
-              <div className="agent-usage-row">
-                <span className="agent-usage-primary">Provider</span>
-                <span className="agent-usage-value">
-                  {projection.run?.usage?.provider ?? usageModel?.provider}
-                </span>
-              </div>
-            ) : null}
-            {projection.run?.usage?.privacyLevel || usageModel?.privacy ? (
-              <div className="agent-usage-row">
-                <span className="agent-usage-primary">Privacy</span>
-                <span className="agent-usage-value">
-                  {projection.run?.usage?.privacyLevel ?? usageModel?.privacy}
-                </span>
-              </div>
-            ) : null}
-            {projection.run?.usage?.endpoint ? (
-              <div className="agent-usage-row">
-                <span className="agent-usage-primary">Route</span>
-                <span className="agent-usage-value">{projection.run.usage.endpoint}</span>
-              </div>
-            ) : null}
-            {projection.run?.reasoningEffort ? (
-              <div className="agent-usage-row">
-                <span className="agent-usage-primary">Reasoning effort</span>
-                <span className="agent-usage-value">{projection.run.reasoningEffort}</span>
-              </div>
-            ) : null}
-            {projection.run?.usage ? (
-              <>
-                {projection.run.usage.inputTokens !== undefined ? (
+              <aside className="agent-usage-panel" aria-label="Session usage">
+                <div className="agent-usage-header">
+                  <h2 className="agent-usage-title">Usage</h2>
+                  <button
+                    type="button"
+                    className="icon-button"
+                    aria-label="Close usage"
+                    onClick={() => setUsageOpen(false)}
+                  >
+                    <IconCrossSmall size={14} />
+                  </button>
+                </div>
+                <div className="agent-usage-body">
                   <div className="agent-usage-row">
-                    <span className="agent-usage-primary">Input</span>
+                    <span className="agent-usage-primary">Model</span>
                     <span className="agent-usage-value">
-                      {projection.run.usage.inputTokens.toLocaleString()}
+                      {usageModel?.name ?? sessionDisplayModel}
                     </span>
                   </div>
-                ) : null}
-                {projection.run.usage.outputTokens !== undefined ? (
-                  <div className="agent-usage-row">
-                    <span className="agent-usage-primary">Output</span>
-                    <span className="agent-usage-value">
-                      {projection.run.usage.outputTokens.toLocaleString()}
-                    </span>
-                  </div>
-                ) : null}
-                {projection.run.usage.totalTokens !== undefined ? (
-                  <div className="agent-usage-row">
-                    <span className="agent-usage-primary">Total</span>
-                    <span className="agent-usage-value">
-                      {projection.run.usage.totalTokens.toLocaleString()}
-                    </span>
-                  </div>
-                ) : null}
-                {projection.run.usage.inputTokens === undefined &&
-                projection.run.usage.outputTokens === undefined &&
-                projection.run.usage.totalTokens === undefined ? (
-                  <p className="agent-usage-empty">
-                    Token counts were not reported for this request.
-                  </p>
-                ) : null}
-                {contextPercent !== undefined && contextUsed !== undefined && contextLimit ? (
-                  <div className="agent-usage-context">
+                  {projection.run?.usage?.provider || usageModel?.provider ? (
                     <div className="agent-usage-row">
-                      <span className="agent-usage-primary">Latest request context</span>
+                      <span className="agent-usage-primary">Provider</span>
                       <span className="agent-usage-value">
-                        {contextUsed.toLocaleString()} of {contextLimit.toLocaleString()} (
-                        {contextPercent.toFixed(1)}%)
+                        {projection.run?.usage?.provider ?? usageModel?.provider}
                       </span>
                     </div>
-                    <div
-                      className="agent-usage-context-track"
-                      role="progressbar"
-                      aria-label="Context used"
-                      aria-valuemin={0}
-                      aria-valuemax={100}
-                      aria-valuenow={Math.round(contextPercent)}
-                    >
-                      <span style={{ transform: `scaleX(${contextPercent / 100})` }} />
+                  ) : null}
+                  {projection.run?.usage?.privacyLevel || usageModel?.privacy ? (
+                    <div className="agent-usage-row">
+                      <span className="agent-usage-primary">Privacy</span>
+                      <span className="agent-usage-value">
+                        {projection.run?.usage?.privacyLevel ?? usageModel?.privacy}
+                      </span>
                     </div>
-                  </div>
-                ) : null}
-                {estimatedCredits !== undefined ? (
-                  <div className="agent-usage-row">
-                    <span className="agent-usage-primary">Estimated charge</span>
-                    <span className="agent-usage-value">
-                      {estimatedCredits.toLocaleString(undefined, {
-                        maximumFractionDigits: estimatedCredits < 1 ? 3 : 1,
-                      })}{" "}
-                      credits (about ${(estimatedCredits / 1_000).toFixed(4)})
-                    </span>
-                  </div>
-                ) : null}
-                {toolUsage.size > 0 ? (
-                  <div className="agent-usage-tools">
-                    <p className="agent-usage-section-title">Tools</p>
-                    {[...toolUsage.entries()].map(([name, usage]) => (
-                      <div className="agent-usage-row" key={name}>
-                        <span className="agent-usage-primary">{name}</span>
-                        <span className="agent-usage-value">
-                          {usage.calls} {usage.calls === 1 ? "call" : "calls"}
-                          {usage.failures > 0 ? `, ${usage.failures} failed` : ""}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                ) : null}
-              </>
-            ) : (
-              <p className="agent-usage-empty">No usage reported for this session yet.</p>
-            )}
-          </div>
-        </aside>
-      ) : null}
+                  ) : null}
+                  {projection.run?.usage?.endpoint ? (
+                    <div className="agent-usage-row">
+                      <span className="agent-usage-primary">Route</span>
+                      <span className="agent-usage-value">{projection.run.usage.endpoint}</span>
+                    </div>
+                  ) : null}
+                  {projection.run?.reasoningEffort ? (
+                    <div className="agent-usage-row">
+                      <span className="agent-usage-primary">Reasoning effort</span>
+                      <span className="agent-usage-value">{projection.run.reasoningEffort}</span>
+                    </div>
+                  ) : null}
+                  {projection.run?.usage ? (
+                    <>
+                      {projection.run.usage.inputTokens !== undefined ? (
+                        <div className="agent-usage-row">
+                          <span className="agent-usage-primary">Input</span>
+                          <span className="agent-usage-value">
+                            {projection.run.usage.inputTokens.toLocaleString()}
+                          </span>
+                        </div>
+                      ) : null}
+                      {projection.run.usage.outputTokens !== undefined ? (
+                        <div className="agent-usage-row">
+                          <span className="agent-usage-primary">Output</span>
+                          <span className="agent-usage-value">
+                            {projection.run.usage.outputTokens.toLocaleString()}
+                          </span>
+                        </div>
+                      ) : null}
+                      {projection.run.usage.totalTokens !== undefined ? (
+                        <div className="agent-usage-row">
+                          <span className="agent-usage-primary">Total</span>
+                          <span className="agent-usage-value">
+                            {projection.run.usage.totalTokens.toLocaleString()}
+                          </span>
+                        </div>
+                      ) : null}
+                      {projection.run.usage.inputTokens === undefined &&
+                      projection.run.usage.outputTokens === undefined &&
+                      projection.run.usage.totalTokens === undefined ? (
+                        <p className="agent-usage-empty">
+                          Token counts were not reported for this request.
+                        </p>
+                      ) : null}
+                      {contextPercent !== undefined && contextUsed !== undefined && contextLimit ? (
+                        <div className="agent-usage-context">
+                          <div className="agent-usage-row">
+                            <span className="agent-usage-primary">Latest request context</span>
+                            <span className="agent-usage-value">
+                              {contextUsed.toLocaleString()} of {contextLimit.toLocaleString()} (
+                              {contextPercent.toFixed(1)}%)
+                            </span>
+                          </div>
+                          <div
+                            className="agent-usage-context-track"
+                            role="progressbar"
+                            aria-label="Context used"
+                            aria-valuemin={0}
+                            aria-valuemax={100}
+                            aria-valuenow={Math.round(contextPercent)}
+                          >
+                            <span style={{ transform: `scaleX(${contextPercent / 100})` }} />
+                          </div>
+                        </div>
+                      ) : null}
+                      {estimatedCredits !== undefined ? (
+                        <div className="agent-usage-row">
+                          <span className="agent-usage-primary">Estimated charge</span>
+                          <span className="agent-usage-value">
+                            {estimatedCredits.toLocaleString(undefined, {
+                              maximumFractionDigits: estimatedCredits < 1 ? 3 : 1,
+                            })}{" "}
+                            credits (about ${(estimatedCredits / 1_000).toFixed(4)})
+                          </span>
+                        </div>
+                      ) : null}
+                      {toolUsage.size > 0 ? (
+                        <div className="agent-usage-tools">
+                          <p className="agent-usage-section-title">Tools</p>
+                          {[...toolUsage.entries()].map(([name, usage]) => (
+                            <div className="agent-usage-row" key={name}>
+                              <span className="agent-usage-primary">{name}</span>
+                              <span className="agent-usage-value">
+                                {usage.calls} {usage.calls === 1 ? "call" : "calls"}
+                                {usage.failures > 0 ? `, ${usage.failures} failed` : ""}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+                    </>
+                  ) : (
+                    <p className="agent-usage-empty">No usage reported for this session yet.</p>
+                  )}
+                </div>
+              </aside>
+            </div>,
+            document.querySelector(".app-shell") ?? document.body,
+          )
+        : null}
       {selectedSession ? (
         <ShareDialog
           key={selectedSession.id}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -20,6 +20,7 @@ import {
   type RefObject,
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -210,6 +211,8 @@ const AGENT_AUTO_MODEL: VeniceModelDto = {
   capabilities: [],
 };
 const projectContextSignaturesBySessionId = new ProjectContextSignatureStore();
+const USAGE_FOCUSABLE =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 export function composerInSteerStateFor(input: {
   selectedSessionId?: string;
@@ -348,11 +351,60 @@ export function AgentWorkspace({
   const [shareOpen, setShareOpen] = useState(false);
   const [shareUrl, setShareUrl] = useState<string>();
   const [usageOpen, setUsageOpen] = useState(false);
+  const usagePanelRef = useRef<HTMLElement>(null);
+  const usageReturnFocusRef = useRef<HTMLElement | null>(null);
+  const usageTitleId = useId();
   const [compactOpen, setCompactOpen] = useState(false);
   const [compacting, setCompacting] = useState(false);
   const [compactResult, setCompactResult] = useState<string>();
   const [models, setModels] = useState<VeniceModelDto[]>([]);
   const [veniceApiKeyConfigured, setVeniceApiKeyConfigured] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!usageOpen || !usagePanelRef.current) return;
+    usageReturnFocusRef.current = document.activeElement as HTMLElement | null;
+    usagePanelRef.current.querySelector<HTMLElement>(USAGE_FOCUSABLE)?.focus();
+    return () => {
+      usageReturnFocusRef.current?.focus?.();
+      usageReturnFocusRef.current = null;
+    };
+  }, [usageOpen]);
+
+  useEffect(() => {
+    if (!usageOpen) return;
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setUsageOpen(false);
+        return;
+      }
+      if (event.key !== "Tab" || !usagePanelRef.current) return;
+      const focusables = Array.from(
+        usagePanelRef.current.querySelectorAll<HTMLElement>(USAGE_FOCUSABLE),
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (!usagePanelRef.current.contains(document.activeElement)) {
+        event.preventDefault();
+        first.focus();
+      } else if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [usageOpen]);
+
   const focusedHomeModelRef = useRef(DEFAULT_MODEL);
   const focusedHomeThinkingLevelRef = useRef(loadThinkingLevel());
   const initialModelSelection = agentModelSelection(initialAgentSession?.model || DEFAULT_MODEL);
@@ -2563,9 +2615,17 @@ export function AgentWorkspace({
                 if (event.target === event.currentTarget) setUsageOpen(false);
               }}
             >
-              <aside className="agent-usage-panel" aria-label="Session usage">
+              <aside
+                ref={usagePanelRef}
+                className="agent-usage-panel"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={usageTitleId}
+              >
                 <div className="agent-usage-header">
-                  <h2 className="agent-usage-title">Usage</h2>
+                  <h2 id={usageTitleId} className="agent-usage-title">
+                    Usage
+                  </h2>
                   <button
                     type="button"
                     className="icon-button"

--- a/src/components/agent/chat-turns/AgentSessionBar.tsx
+++ b/src/components/agent/chat-turns/AgentSessionBar.tsx
@@ -63,6 +63,7 @@ export function AgentSessionBar({
   const [menuOpen, setMenuOpen] = useState(false);
   const [instructionsOpen, setInstructionsOpen] = useState(false);
   const menuWrapRef = useRef<HTMLDivElement>(null);
+  const menuTriggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (!menuOpen) return;
@@ -188,6 +189,7 @@ export function AgentSessionBar({
         {hasMenu ? (
           <div className="agent-session-menu-wrap" ref={menuWrapRef}>
             <button
+              ref={menuTriggerRef}
               type="button"
               className="icon-button agent-session-menu-trigger"
               aria-label="Session actions"
@@ -231,6 +233,7 @@ export function AgentSessionBar({
                     type="button"
                     role="menuitem"
                     onClick={() => {
+                      menuTriggerRef.current?.focus();
                       setMenuOpen(false);
                       onUsage();
                     }}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4484,7 +4484,7 @@ button.agent-user-attachment:hover {
 .agent-usage-overlay {
   position: fixed;
   inset: 0;
-  z-index: 100;
+  z-index: 112;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -943,7 +943,11 @@ describe("AgentWorkspace runtime wiring", () => {
 
   it("shows context, estimated charge, and per-tool usage for the latest run", async () => {
     const user = userEvent.setup();
-    render(<AgentWorkspace initialSession={session} />);
+    render(
+      <div className="app-shell">
+        <AgentWorkspace initialSession={session} />
+      </div>,
+    );
     await screen.findByText("Earlier answer");
     const composer = screen.getByRole("textbox", { name: "Message June" });
     await user.type(composer, "Use a tool");
@@ -994,6 +998,9 @@ describe("AgentWorkspace runtime wiring", () => {
     await user.click(screen.getByRole("button", { name: "Session actions" }));
     await user.click(screen.getByRole("menuitem", { name: "Usage" }));
     const usagePanel = screen.getByLabelText("Session usage");
+    const usageOverlay = usagePanel.closest(".agent-usage-overlay");
+    expect(usageOverlay).not.toBeNull();
+    expect(usageOverlay?.parentElement).toBe(document.querySelector(".app-shell"));
     expect(usagePanel).toHaveTextContent("10,000 of 200,000 (5.0%)");
     expect(usagePanel).toHaveTextContent("28 credits (about $0.0280)");
     expect(usagePanel).toHaveTextContent("read_file");
@@ -1001,6 +1008,18 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(usagePanel).toHaveTextContent("phala");
     expect(usagePanel).toHaveTextContent("tee");
     expect(usagePanel).toHaveTextContent("phala-glm-5.2");
+
+    await user.click(usagePanel);
+    expect(screen.getByLabelText("Session usage")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Close usage" }));
+    expect(screen.queryByLabelText("Session usage")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Session actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Usage" }));
+    const reopenedOverlay = screen.getByLabelText("Session usage").closest(".agent-usage-overlay");
+    expect(reopenedOverlay).not.toBeNull();
+    await user.click(reopenedOverlay as HTMLElement);
+    expect(screen.queryByLabelText("Session usage")).not.toBeInTheDocument();
   });
 
   it("shows route-only persisted usage without crashing", async () => {

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -997,7 +997,7 @@ describe("AgentWorkspace runtime wiring", () => {
 
     await user.click(screen.getByRole("button", { name: "Session actions" }));
     await user.click(screen.getByRole("menuitem", { name: "Usage" }));
-    const usagePanel = screen.getByLabelText("Session usage");
+    const usagePanel = screen.getByRole("dialog", { name: "Usage" });
     const usageOverlay = usagePanel.closest(".agent-usage-overlay");
     expect(usageOverlay).not.toBeNull();
     expect(usageOverlay?.parentElement).toBe(document.querySelector(".app-shell"));
@@ -1010,16 +1010,46 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(usagePanel).toHaveTextContent("phala-glm-5.2");
 
     await user.click(usagePanel);
-    expect(screen.getByLabelText("Session usage")).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Usage" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Close usage" }));
-    expect(screen.queryByLabelText("Session usage")).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Usage" })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Session actions" }));
     await user.click(screen.getByRole("menuitem", { name: "Usage" }));
-    const reopenedOverlay = screen.getByLabelText("Session usage").closest(".agent-usage-overlay");
+    const reopenedOverlay = screen
+      .getByRole("dialog", { name: "Usage" })
+      .closest(".agent-usage-overlay");
     expect(reopenedOverlay).not.toBeNull();
     await user.click(reopenedOverlay as HTMLElement);
-    expect(screen.queryByLabelText("Session usage")).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Usage" })).not.toBeInTheDocument();
+  });
+
+  it("traps focus in Usage and restores it to Session actions after Escape", async () => {
+    const user = userEvent.setup();
+    render(
+      <div className="app-shell">
+        <AgentWorkspace initialSession={session} />
+      </div>,
+    );
+    await screen.findByText("Earlier answer");
+
+    const sessionActions = screen.getByRole("button", { name: "Session actions" });
+    await user.click(sessionActions);
+    await user.click(screen.getByRole("menuitem", { name: "Usage" }));
+
+    const usageDialog = screen.getByRole("dialog", { name: "Usage" });
+    const closeUsage = within(usageDialog).getByRole("button", { name: "Close usage" });
+    expect(usageDialog).toHaveAttribute("aria-modal", "true");
+    expect(closeUsage).toHaveFocus();
+
+    await user.tab();
+    expect(closeUsage).toHaveFocus();
+    await user.tab({ shift: true });
+    expect(closeUsage).toHaveFocus();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog", { name: "Usage" })).not.toBeInTheDocument();
+    expect(sessionActions).toHaveFocus();
   });
 
   it("shows route-only persisted usage without crashing", async () => {
@@ -1064,7 +1094,7 @@ describe("AgentWorkspace runtime wiring", () => {
     await user.click(screen.getByRole("button", { name: "Session actions" }));
     await user.click(screen.getByRole("menuitem", { name: "Usage" }));
 
-    const usagePanel = screen.getByLabelText("Session usage");
+    const usagePanel = screen.getByRole("dialog", { name: "Usage" });
     expect(usagePanel).toHaveTextContent("qa-fixture");
     expect(usagePanel).toHaveTextContent("isolated");
     expect(usagePanel).toHaveTextContent("localhost");

--- a/src/test/dialog-layering.test.ts
+++ b/src/test/dialog-layering.test.ts
@@ -17,6 +17,14 @@ describe("dialog layering", () => {
     expect(zIndexFor(".dialog-backdrop")).toBeGreaterThan(zIndexFor(".chrome-sidebar-toggle"));
   });
 
+  it("keeps the Usage overlay on the canonical modal layer above app chrome", () => {
+    const usageOverlay = zIndexFor(".agent-usage-overlay");
+
+    expect(usageOverlay).toBe(zIndexFor(".dialog-backdrop"));
+    expect(usageOverlay).toBe(zIndexFor(".command-prompt-backdrop"));
+    expect(usageOverlay).toBeGreaterThan(zIndexFor(".chrome-sidebar-toggle"));
+  });
+
   it("keeps hover tips above dialogs", () => {
     expect(zIndexFor(".hover-tip")).toBeGreaterThan(zIndexFor(".dialog-backdrop"));
   });


### PR DESCRIPTION
## What changed

- Restore the existing full-screen Usage overlay and portal it to `.app-shell`.
- Keep panel clicks contained while allowing backdrop dismissal.
- Add regression coverage for portal placement, close-button dismissal, and backdrop dismissal.

## Why

The Usage surface was reintroduced as a bare workspace child in `257e902`. Its stylesheet still expected the missing fixed overlay, so the panel participated in workspace layout instead of appearing centered over the app.

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run src/test/agent-workspace-runtime.test.tsx`: 40/40 passed before the machine became heavily loaded; a post-rebase rerun hit existing 5-second timing failures across unrelated cases.
- `pnpm check`: completed with the existing warning backlog and no errors.
- `pnpm typecheck`: passed.
- Live Chromium walkthrough with mocked local session: Usage centered within 0.001 px at 1180×780 in light mode and exactly in dark mode; close button and backdrop dismissal passed.
- Full frontend suite was sampled but not used as a blocker because unrelated NoteEditor/HUD tests timed out under load.

## Visual testing

Tested visually in light and dark themes. The dialog is centered over the complete app shell with the existing scrim and blur.

## Deployment

No June API deploy is required.

## Scope

Out of scope: redesigning the Usage contents or migrating this existing surface to the shared Dialog primitive.

## Followups

None.

Closes JUN-463

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788499940&installation_model_id=425925&pr_number=1026&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1026&signature=ce9677fcb87e0072b2b35d7396e56373ea56e3036c401df6bbc490906b78a202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->