### PR TITLE
JUN-463 Keep Usage Escape modal-scoped

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -375,6 +375,7 @@ export function AgentWorkspace({
     function onKey(event: KeyboardEvent) {
       if (event.key === "Escape") {
         event.preventDefault();
+        event.stopPropagation();
         setUsageOpen(false);
         return;
       }
@@ -396,11 +397,11 @@ export function AgentWorkspace({
         first.focus();
       }
     }
-    window.addEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, true);
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
-      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("keydown", onKey, true);
       document.body.style.overflow = previousOverflow;
     };
   }, [usageOpen]);

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -1052,6 +1052,45 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(sessionActions).toHaveFocus();
   });
 
+  it("keeps the background files panel open when Usage claims Escape", async () => {
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "list_agent_artifacts") {
+        return Promise.resolve([
+          {
+            id: "artifact-1",
+            sessionId: session.id,
+            name: "results.md",
+            path: "/tmp/session-1/results.md",
+            mimeType: "text/markdown",
+            action: "created",
+            available: true,
+            createdAt: session.createdAt,
+          },
+        ]);
+      }
+      return defaultInvoke?.(command, args);
+    });
+
+    const user = userEvent.setup();
+    render(
+      <div className="app-shell">
+        <AgentWorkspace initialSession={session} />
+      </div>,
+    );
+    await screen.findByText("Earlier answer");
+
+    await user.click(screen.getByRole("button", { name: "View files (1)" }));
+    expect(screen.getByRole("complementary", { name: "Files" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Session actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Usage" }));
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("dialog", { name: "Usage" })).not.toBeInTheDocument();
+    expect(screen.getByRole("complementary", { name: "Files" })).toBeInTheDocument();
+  });
+
   it("shows route-only persisted usage without crashing", async () => {
     const autoSession = { ...session, model: "__june_auto_generation__:20" };
     mocks.invoke.mockImplementation(async (command: string) => {


### PR DESCRIPTION
## What changed

- register the Usage dialog Escape handler in capture phase
- stop Escape propagation after the top modal claims dismissal
- remove the listener with matching capture options
- add a layered regression test proving one Escape closes Usage while leaving the background Files panel open

## Why

PR #1026 restored the centered Usage dialog, but its bubble-phase Escape handler could run after the background artifact panel listener. One Escape could therefore dismiss both layers instead of only the visually topmost modal.

## User impact

Keyboard dismissal now follows modal hierarchy: the first Escape closes Usage and preserves the underlying Files panel.

## Verification

- focused layered and focus-restoration tests: 2/2 passed
- full `agent-workspace-runtime.test.tsx`: 42/42 passed
- full frontend suite: 155 files / 1,676 tests passed
- `pnpm typecheck`: passed
- `git diff --check`: passed
- Impeccable detector: no findings
- independent review: no actionable findings

No merge, release, or deployment is included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788613831&installation_model_id=425925&pr_number=1029&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1029&signature=b22ef83b81ad8bd84ed290986846a85147970395a3ca534c36a4f374a62b26f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->