### PR TITLE
JUN-466 Group consecutive agent activity

### DIFF
--- a/src/components/agent/chat-turns/AgentChatTurnRow.tsx
+++ b/src/components/agent/chat-turns/AgentChatTurnRow.tsx
@@ -160,25 +160,88 @@ export function AgentChatTurnRow({
     if (part.status === "running") return false;
     return part.media === "image" ? !hasGeneratedImage : !hasGeneratedVideo;
   });
+  const visibleToolPartSet = new Set(visibleToolParts);
+  const visibleToolStacks = new Map<string, typeof visibleToolParts>();
+  let visibleToolStack: typeof visibleToolParts | undefined;
+  for (const part of turn.parts) {
+    if (part.type !== "tool" || !visibleToolPartSet.has(part)) {
+      visibleToolStack = undefined;
+      continue;
+    }
+    if (visibleToolStack) {
+      visibleToolStack.push(part);
+      continue;
+    }
+    visibleToolStack = [part];
+    visibleToolStacks.set(part.id, visibleToolStack);
+  }
+  const reasoningGroups = new Map<
+    Extract<AgentChatPart, { type: "reasoning" }>,
+    { parts: typeof reasoningParts; completedKey: string; startIndex: number }
+  >();
+  let reasoningGroup:
+    | { parts: typeof reasoningParts; completedKey: string; startIndex: number }
+    | undefined;
+  for (const [index, part] of turn.parts.entries()) {
+    if (part.type !== "reasoning") {
+      reasoningGroup = undefined;
+      continue;
+    }
+    if (reasoningGroup) {
+      reasoningGroup.parts.push(part);
+      continue;
+    }
+    reasoningGroup = {
+      parts: [part],
+      completedKey:
+        reasoningGroups.size === 0
+          ? `turn:${turn.id}:thinking`
+          : `turn:${turn.id}:thinking:${index}`,
+      startIndex: index,
+    };
+    reasoningGroups.set(part, reasoningGroup);
+  }
   // The disclosure owns internal reasoning only. Tool/action rows stay visible
   // outside it so users can see what June is doing without expanding Thought;
   // a running media tool is represented by its canvas instead, just above.
   const thinkingRunning = reasoningParts.some((part) => part.status === "running");
-  const completedThinkingKey = `turn:${turn.id}:thinking`;
-  const thinkingKey =
-    thinkingRunning && activeThinkingKey ? activeThinkingKey : completedThinkingKey;
+  const runningReasoningGroup = [...reasoningGroups.values()].find((group) =>
+    group.parts.some((part) => part.status === "running"),
+  );
+  const lastRunningCompletedKeyRef = useRef(
+    runningReasoningGroup?.completedKey ?? `turn:${turn.id}:thinking`,
+  );
+  if (runningReasoningGroup) {
+    lastRunningCompletedKeyRef.current = runningReasoningGroup.completedKey;
+  }
+  const completedThinkingKey = lastRunningCompletedKeyRef.current;
   const wasThinkingRunningRef = useRef(thinkingRunning);
   const carriedOpen =
     !thinkingRunning &&
     wasThinkingRunningRef.current &&
     activeThinkingKey !== undefined &&
     thinkingOpen(activeThinkingKey);
-  const thinkingIsOpen = thinkingOpen(thinkingKey) || carriedOpen;
   const [copied, setCopied] = useState(false);
   const [dismissedAccessRequestCards, setDismissedAccessRequestCards] = useState<
     ReadonlySet<string>
   >(() => new Set());
   const copyResetTimerRef = useRef<number | undefined>(undefined);
+
+  function renderReasoningGroup(part: Extract<AgentChatPart, { type: "reasoning" }>) {
+    const group = reasoningGroups.get(part);
+    if (!group) return null;
+    const running = group.parts.some((reasoningPart) => reasoningPart.status === "running");
+    const key = running && activeThinkingKey ? activeThinkingKey : group.completedKey;
+    return (
+      <AgentThinkingGroup
+        key={`${turn.id}:reasoning:${group.startIndex}`}
+        reasoning={group.parts}
+        running={running}
+        open={thinkingOpen(key) || (carriedOpen && group.completedKey === completedThinkingKey)}
+        onOpenChange={(open) => onThinkingOpenChange(key, open)}
+      />
+    );
+  }
 
   useEffect(() => {
     const wasRunning = wasThinkingRunningRef.current;
@@ -434,15 +497,6 @@ export function AgentChatTurnRow({
           hasActionCard ? " agent-assistant-turn-body-action-card" : ""
         }`}
       >
-        {reasoningParts.length > 0 ? (
-          <AgentThinkingGroup
-            reasoning={reasoningParts}
-            running={thinkingRunning}
-            open={thinkingIsOpen}
-            onOpenChange={(open) => onThinkingOpenChange(thinkingKey, open)}
-          />
-        ) : null}
-        {visibleToolParts.length > 0 ? <AgentToolStack parts={visibleToolParts} /> : null}
         {runningMediaTools.map((tool) =>
           tool.media === "image" ? (
             <AgentGeneratedImage
@@ -457,7 +511,16 @@ export function AgentChatTurnRow({
           ),
         )}
         {turn.parts.map((part, index) =>
-          part.type === "text" ? (
+          part.type === "reasoning" ? (
+            renderReasoningGroup(part)
+          ) : part.type === "tool" ? (
+            visibleToolStacks.has(part.id) ? (
+              <AgentToolStack
+                key={`${turn.id}:tools:${part.id}`}
+                parts={visibleToolStacks.get(part.id) ?? []}
+              />
+            ) : null
+          ) : part.type === "text" ? (
             hasAgentCliAccessRequest(part.text) || hasBrowserAccessRequest(part.text) ? (
               // June's soul emits a literal token to request the Agent CLI
               // access or Browser use setting; each token renders as an

--- a/src/components/agent/chat-turns/TurnPresentation.tsx
+++ b/src/components/agent/chat-turns/TurnPresentation.tsx
@@ -15,7 +15,11 @@ export function SudoPart({
   part: Extract<AgentChatPart, { type: "sudo" }>;
   [key: string]: unknown;
 }) {
-  return <div className="agent-system-notice">{part.reason || "Approval required"}</div>;
+  return (
+    <div className="agent-system-notice" data-status={part.status}>
+      {part.reason || "Approval required"}
+    </div>
+  );
 }
 
 export function SecretPart({
@@ -45,6 +49,7 @@ export function SecretPart({
   return (
     <form
       className="agent-action-card"
+      data-status={part.status}
       onSubmit={(event) => {
         event.preventDefault();
         if (!value || disabled) return;

--- a/src/lib/agent-runtime-adapter.ts
+++ b/src/lib/agent-runtime-adapter.ts
@@ -316,8 +316,9 @@ export function agentItemsToChatTurns(items: AgentItemDto[]): AgentChatTurn[] {
       .filter((item) => item.kind === "tool_result")
       .map((item) => toolCallKey(item.runId, item.callId)),
   );
+  const runIdsByItemId = new Map(orderedItems.map((item) => [item.id, item.runId]));
 
-  return orderedItems
+  const turns = orderedItems
     .filter(
       (item) =>
         item.kind !== "tool_call" || !settledToolCalls.has(toolCallKey(item.runId, item.callId)),
@@ -388,8 +389,9 @@ export function agentItemsToChatTurns(items: AgentItemDto[]): AgentChatTurn[] {
               },
             ],
           };
-        case "tool_result":
-          if (!item.isError && generatedImagePart(item.output)) {
+        case "tool_result": {
+          const image = item.isError ? undefined : generatedImagePart(item.output);
+          if (image) {
             return {
               ...base,
               role: "assistant",
@@ -401,11 +403,12 @@ export function agentItemsToChatTurns(items: AgentItemDto[]): AgentChatTurn[] {
                   text: readableValue(item.output),
                   status: "complete",
                 },
-                generatedImagePart(item.output)!,
+                image,
               ],
             };
           }
-          if (!item.isError && generatedVideoPart(item.output)) {
+          const video = item.isError ? undefined : generatedVideoPart(item.output);
+          if (video) {
             return {
               ...base,
               role: "assistant",
@@ -417,7 +420,7 @@ export function agentItemsToChatTurns(items: AgentItemDto[]): AgentChatTurn[] {
                   text: readableValue(item.output),
                   status: "complete",
                 },
-                generatedVideoPart(item.output)!,
+                video,
               ],
             };
           }
@@ -434,6 +437,7 @@ export function agentItemsToChatTurns(items: AgentItemDto[]): AgentChatTurn[] {
               },
             ],
           };
+        }
         case "interruption":
           return {
             ...base,
@@ -476,6 +480,76 @@ export function agentItemsToChatTurns(items: AgentItemDto[]): AgentChatTurn[] {
           return assertNever(item);
       }
     });
+
+  return coalesceAgentActivityTurns(
+    turns.map((turn) => ({ runId: runIdsByItemId.get(turn.id), turn })),
+  );
+}
+
+type AgentRunTurn = {
+  runId?: string;
+  turn: AgentChatTurn;
+};
+
+/**
+ * Presents consecutive reasoning, tool, and interruption items from one agent
+ * run as a single activity cluster. The latest item owns the cluster identity
+ * and timestamp; when a visible assistant output follows, it owns the combined
+ * turn instead. User/system turns, visible outputs, and run changes remain
+ * boundaries.
+ */
+function coalesceAgentActivityTurns(items: AgentRunTurn[]): AgentChatTurn[] {
+  const turns: AgentChatTurn[] = [];
+  let pending: AgentRunTurn | undefined;
+
+  const flushPending = () => {
+    if (!pending) return;
+    turns.push(pending.turn);
+    pending = undefined;
+  };
+
+  for (const item of items) {
+    if (isInternalAgentActivity(item.turn)) {
+      if (pending && pending.runId === item.runId) {
+        pending = {
+          ...item,
+          turn: { ...item.turn, parts: [...pending.turn.parts, ...item.turn.parts] },
+        };
+      } else {
+        flushPending();
+        pending = item;
+      }
+      continue;
+    }
+
+    if (pending && item.turn.role === "assistant" && pending.runId === item.runId) {
+      turns.push({ ...item.turn, parts: [...pending.turn.parts, ...item.turn.parts] });
+      pending = undefined;
+      continue;
+    }
+
+    flushPending();
+    turns.push(item.turn);
+  }
+
+  flushPending();
+  return turns;
+}
+
+function isInternalAgentActivity(turn: AgentChatTurn) {
+  return (
+    turn.role === "assistant" &&
+    turn.parts.length > 0 &&
+    turn.parts.every(
+      (part) =>
+        part.type === "reasoning" ||
+        part.type === "tool" ||
+        part.type === "approval" ||
+        part.type === "clarify" ||
+        part.type === "sudo" ||
+        part.type === "secret",
+    )
+  );
 }
 
 function generatedImagePart(output: unknown): AgentChatPart | undefined {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3526,8 +3526,32 @@ button.agent-user-attachment:hover {
 .agent-tool-stack {
   display: flex;
   flex-direction: column;
-  gap: var(--sp-2);
+  gap: var(--sp-1);
   width: 100%;
+}
+
+/* Consecutive internal activity reads as one compact sequence. Pull only those
+ * neighboring rows to --sp-1; answer text keeps the turn's full gap so the
+ * handoff from activity to response remains clear. */
+.agent-assistant-turn-body > :is(
+    .agent-reasoning,
+    .agent-tool-stack,
+    .agent-resolved-row,
+    .agent-approval-card[data-status="pending"],
+    .agent-clarify-card[data-status="pending"],
+    .agent-action-card[data-status="pending"],
+    .agent-system-notice[data-status="pending"]
+  )
+  + :is(
+    .agent-reasoning,
+    .agent-tool-stack,
+    .agent-resolved-row,
+    .agent-approval-card[data-status="pending"],
+    .agent-clarify-card[data-status="pending"],
+    .agent-action-card[data-status="pending"],
+    .agent-system-notice[data-status="pending"]
+  ) {
+  margin-top: calc(-1 * var(--sp-2));
 }
 
 .agent-tool-disclosure {

--- a/src/test/agent-chat-turn-row.test.tsx
+++ b/src/test/agent-chat-turn-row.test.tsx
@@ -1,0 +1,124 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AgentChatTurnRow } from "../components/agent/chat-turns/AgentChatTurnRow";
+import type { AgentChatTurn } from "../lib/agent-chat-runtime";
+
+describe("AgentChatTurnRow", () => {
+  it("renders interleaved reasoning at its chronological direct-child position", () => {
+    const turn: AgentChatTurn = {
+      id: "interleaved-reasoning",
+      role: "assistant",
+      createdAt: "2026-08-07T21:00:04Z",
+      status: "running",
+      parts: [
+        {
+          type: "tool",
+          id: "preview-call",
+          name: "preview_file",
+          text: "Previewed document.pdf",
+          status: "complete",
+        },
+        {
+          type: "reasoning",
+          text: "I should ask before extracting the full document.",
+          status: "complete",
+        },
+        {
+          type: "approval",
+          id: "approval-1",
+          runId: "run-1",
+          command: "run_shell pdftotext document.pdf -",
+          description: "June wants to extract text from the document.",
+          allowPermanent: false,
+          status: "pending",
+        },
+      ],
+    };
+    const { container } = render(
+      <AgentChatTurnRow
+        turn={turn}
+        approvalSubmitting={{}}
+        clarifySubmitting={{}}
+        sudoSubmitting={{}}
+        secretSubmitting={{}}
+        thinkingOpen={() => false}
+        onThinkingOpenChange={vi.fn()}
+        onApproval={vi.fn()}
+        onClarify={vi.fn()}
+        onSudo={vi.fn()}
+        onSecret={vi.fn()}
+      />,
+    );
+
+    const body = container.querySelector(".agent-assistant-turn-body");
+    expect(body).not.toBeNull();
+    const childClasses = body ? [...body.children].slice(0, 3).map((child) => child.className) : [];
+    expect(childClasses).toEqual([
+      "agent-tool-stack",
+      "agent-reasoning",
+      "agent-approval-card agent-action-card",
+    ]);
+    expect(body?.querySelector(":scope > .agent-reasoning summary")?.textContent).toContain(
+      "Thought",
+    );
+  });
+
+  it("keeps interleaved tool and approval activity in chronological order", () => {
+    const turn: AgentChatTurn = {
+      id: "activity-cluster",
+      role: "assistant",
+      createdAt: "2026-08-07T21:00:04Z",
+      status: "complete",
+      parts: [
+        {
+          type: "tool",
+          id: "preview-call",
+          name: "preview_file",
+          text: "Previewed document.pdf",
+          status: "complete",
+        },
+        {
+          type: "approval",
+          id: "approval-1",
+          runId: "run-1",
+          command: "run_shell pdftotext document.pdf -",
+          description: "June wants to extract text from the document.",
+          allowPermanent: false,
+          choice: "once",
+          status: "resolved",
+        },
+        {
+          type: "tool",
+          id: "shell-call",
+          name: "run_shell",
+          text: "Extracted 14 pages of text",
+          status: "complete",
+        },
+      ],
+    };
+    const { container } = render(
+      <AgentChatTurnRow
+        turn={turn}
+        approvalSubmitting={{}}
+        clarifySubmitting={{}}
+        sudoSubmitting={{}}
+        secretSubmitting={{}}
+        thinkingOpen={() => false}
+        onThinkingOpenChange={vi.fn()}
+        onApproval={vi.fn()}
+        onClarify={vi.fn()}
+        onSudo={vi.fn()}
+        onSecret={vi.fn()}
+        onBranch={vi.fn()}
+      />,
+    );
+
+    const rows = [...container.querySelectorAll(".agent-tool-disclosure")];
+    expect(rows.map((row) => row.querySelector(".agent-tool-name")?.textContent)).toEqual([
+      "preview_file",
+      "Approved once",
+      "run_shell",
+    ]);
+    expect(container.querySelectorAll(".agent-turn-timestamp")).toHaveLength(1);
+  });
+});

--- a/src/test/agent-runtime-adapter.test.ts
+++ b/src/test/agent-runtime-adapter.test.ts
@@ -18,6 +18,111 @@ const frame = {
 };
 
 describe("agent runtime adapter", () => {
+  it("coalesces consecutive internal activity from one agent run", () => {
+    const turns = agentItemsToChatTurns([
+      {
+        id: "reasoning-1",
+        sessionId: "session-1",
+        runId: "run-1",
+        sequence: 1,
+        createdAt: "2026-07-22T12:00:01Z",
+        kind: "reasoning",
+        text: "Inspect the file",
+        status: "complete",
+      },
+      {
+        id: "tool-result-1",
+        sessionId: "session-1",
+        runId: "run-1",
+        sequence: 2,
+        createdAt: "2026-07-22T12:00:02Z",
+        kind: "tool_result",
+        callId: "call-1",
+        name: "preview_file",
+        output: "Previewed the file",
+        isError: false,
+      },
+      {
+        id: "approval-1",
+        sessionId: "session-1",
+        runId: "run-1",
+        sequence: 3,
+        createdAt: "2026-07-22T12:00:03Z",
+        kind: "interruption",
+        interruption: {
+          id: "approval-1",
+          kind: "approval",
+          sessionId: "session-1",
+          runId: "run-1",
+          status: "resolved",
+          createdAt: "2026-07-22T12:00:03Z",
+          toolName: "run_shell",
+          title: "Run a shell command",
+          description: "June wants to inspect the document.",
+          command: "run_shell pdftotext document.pdf -",
+          allowAlways: false,
+          resolution: "once",
+        },
+      },
+      {
+        id: "tool-result-2",
+        sessionId: "session-1",
+        runId: "run-1",
+        sequence: 4,
+        createdAt: "2026-07-22T12:00:04Z",
+        kind: "tool_result",
+        callId: "call-2",
+        name: "run_shell",
+        output: "Extracted the text",
+        isError: false,
+      },
+    ]);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]).toMatchObject({
+      id: "tool-result-2",
+      role: "assistant",
+      createdAt: "2026-07-22T12:00:04Z",
+      parts: [
+        { type: "reasoning", text: "Inspect the file" },
+        { type: "tool", id: "call-1", name: "preview_file" },
+        { type: "approval", id: "approval-1", status: "resolved", choice: "once" },
+        { type: "tool", id: "call-2", name: "run_shell" },
+      ],
+    });
+  });
+
+  it("keeps adjacent activity from different agent runs in separate turns", () => {
+    const turns = agentItemsToChatTurns([
+      {
+        id: "tool-result-1",
+        sessionId: "session-1",
+        runId: "run-1",
+        sequence: 1,
+        createdAt: "2026-07-22T12:00:01Z",
+        kind: "tool_result",
+        callId: "call-1",
+        name: "preview_file",
+        output: "First run",
+        isError: false,
+      },
+      {
+        id: "tool-result-2",
+        sessionId: "session-1",
+        runId: "run-2",
+        sequence: 2,
+        createdAt: "2026-07-22T12:00:02Z",
+        kind: "tool_result",
+        callId: "call-2",
+        name: "preview_file",
+        output: "Second run",
+        isError: false,
+      },
+    ]);
+
+    expect(turns.map((turn) => turn.id)).toEqual(["tool-result-1", "tool-result-2"]);
+  });
+
   it("renders generated image and video tool results as media", () => {
     const items = [
       {
@@ -356,10 +461,6 @@ describe("agent runtime adapter", () => {
             allowPermanent: true,
             status: "pending",
           },
-        ],
-      },
-      {
-        parts: [
           {
             type: "clarify",
             id: "clarification-1",
@@ -368,10 +469,6 @@ describe("agent runtime adapter", () => {
             choices: ["June", "Platform"],
             status: "pending",
           },
-        ],
-      },
-      {
-        parts: [
           {
             type: "secret",
             id: "secret-1",
@@ -410,13 +507,11 @@ describe("agent runtime adapter", () => {
 
     expect(agentItemsToChatTurns(projection.items)).toMatchObject([
       {
-        parts: [{ type: "approval", status: "resolved", choice: "once" }],
-      },
-      {
-        parts: [{ type: "clarify", status: "resolved", answer: "June" }],
-      },
-      {
-        parts: [{ type: "secret", status: "resolved" }],
+        parts: [
+          { type: "approval", status: "resolved", choice: "once" },
+          { type: "clarify", status: "resolved", answer: "June" },
+          { type: "secret", status: "resolved" },
+        ],
       },
     ]);
   });

--- a/src/test/approval-card-css.test.ts
+++ b/src/test/approval-card-css.test.ts
@@ -243,6 +243,38 @@ describe("inline notice centering", () => {
 });
 
 describe("resolved action row styles", () => {
+  it("tightens consecutive activity rows without tightening the answer gap", () => {
+    const activitySelector = `.agent-assistant-turn-body > :is(
+    .agent-reasoning,
+    .agent-tool-stack,
+    .agent-resolved-row,
+    .agent-approval-card[data-status="pending"],
+    .agent-clarify-card[data-status="pending"],
+    .agent-action-card[data-status="pending"],
+    .agent-system-notice[data-status="pending"]
+  )
+  + :is(
+    .agent-reasoning,
+    .agent-tool-stack,
+    .agent-resolved-row,
+    .agent-approval-card[data-status="pending"],
+    .agent-clarify-card[data-status="pending"],
+    .agent-action-card[data-status="pending"],
+    .agent-system-notice[data-status="pending"]
+  )`;
+    const compactActivity = cssRuleFor(activitySelector);
+    // The turn's base gap is --sp-4 (10px). Only an adjacent tool/receipt row
+    // pulls back by --sp-2 (6px), yielding --sp-1 (4px).
+    // Text is absent from both selector lists, so the response keeps 10px.
+    expect(cssRuleFor(".agent-assistant-turn-body")).toContain("gap: var(--sp-4);");
+    expect(cssRuleFor(".agent-tool-stack")).toContain("gap: var(--sp-1);");
+    expect(compactActivity).toContain("margin-top: calc(-1 * var(--sp-2));");
+    expect(activitySelector).toContain('.agent-approval-card[data-status="pending"]');
+    expect(activitySelector).toContain('.agent-clarify-card[data-status="pending"]');
+    expect(activitySelector).toContain('.agent-action-card[data-status="pending"]');
+    expect(activitySelector).toContain('.agent-system-notice[data-status="pending"]');
+  });
+
   it("reuses the tool-disclosure row treatment so the receipt matches the tool rows", () => {
     // The receipt carries .agent-tool-disclosure (verified in the DOM tests), so
     // its sizing/hover/icon-swap come from that shared block — no duplicated


### PR DESCRIPTION
## Summary

- Group consecutive reasoning, tool, and action activity from the same agent run into one chat turn and one timestamp.
- Preserve chronological rendering for interleaved activity while retaining user, system, visible-output, and run boundaries.
- Use a 4px gap inside the activity cluster while keeping 10px before the answer.

## Root cause

The agent runtime item projection emitted every persisted internal activity item as a separate `AgentChatTurn` after the runtime cutover. The row renderer also collected reasoning and tool groups outside the ordered part loop, which could reorder interleaved activity once those items were coalesced.

## Validation

- `make check typecheck test-web` (156 test files, 1,680 tests passed)
- Focused adapter, chronological-rendering, thinking-state, and CSS regression tests
- Browser preview in light and dark themes confirmed one timestamp, chronological rows, 4px internal gaps, and a 10px answer boundary with no console errors

- [x] Tested visually where it matters.
- [ ] Needs a June API (backend) deploy before it works end to end. No, this is desktop-only.

## Out of scope

- No persistence schema or runtime wire-contract changes.
- No grouping across agent runs, user/system turns, or visible assistant-output boundaries.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. Not applicable.
- [x] Workflow action references are pinned to full-length commit SHAs. Not applicable.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788736040&installation_model_id=425925&pr_number=1030&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1030&signature=e7b8127a9b507134ef73700c3503526fcade83c354966d55fef8c785ca7b9307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->