### PR TITLE
Keep grouped agent activity render identity stable

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2587,7 +2587,7 @@ export function AgentWorkspace({
                       <div className="agent-home-day">{juneHomeDayLabel(turn.createdAt)}</div>
                     ) : null;
                   return (
-                    <Fragment key={turn.id}>
+                    <Fragment key={turn.renderId ?? turn.id}>
                       {dayMarker}
                       <AgentChatTurnRow
                         turn={turn}
@@ -2702,7 +2702,7 @@ export function AgentWorkspace({
               <div className="agent-timeline">
                 {visibleTurns.map((turn) => (
                   <AgentChatTurnRow
-                    key={turn.id}
+                    key={turn.renderId ?? turn.id}
                     turn={turn}
                     approvalSubmitting={approvalSubmitting}
                     clarifySubmitting={clarifySubmitting}

--- a/src/components/agent/chat-turns/AgentChatTurnRow.tsx
+++ b/src/components/agent/chat-turns/AgentChatTurnRow.tsx
@@ -133,6 +133,7 @@ export function AgentChatTurnRow({
   homeUserRunEnd?: boolean;
   turn: AgentChatTurn;
 }) {
+  const presentationId = turn.renderId ?? turn.id;
   const textParts = turn.parts.filter(
     (part): part is Extract<AgentChatPart, { type: "text" }> => part.type === "text",
   );
@@ -195,8 +196,8 @@ export function AgentChatTurnRow({
       parts: [part],
       completedKey:
         reasoningGroups.size === 0
-          ? `turn:${turn.id}:thinking`
-          : `turn:${turn.id}:thinking:${index}`,
+          ? `turn:${presentationId}:thinking`
+          : `turn:${presentationId}:thinking:${index}`,
       startIndex: index,
     };
     reasoningGroups.set(part, reasoningGroup);
@@ -209,7 +210,7 @@ export function AgentChatTurnRow({
     group.parts.some((part) => part.status === "running"),
   );
   const lastRunningCompletedKeyRef = useRef(
-    runningReasoningGroup?.completedKey ?? `turn:${turn.id}:thinking`,
+    runningReasoningGroup?.completedKey ?? `turn:${presentationId}:thinking`,
   );
   if (runningReasoningGroup) {
     lastRunningCompletedKeyRef.current = runningReasoningGroup.completedKey;
@@ -234,7 +235,7 @@ export function AgentChatTurnRow({
     const key = running && activeThinkingKey ? activeThinkingKey : group.completedKey;
     return (
       <AgentThinkingGroup
-        key={`${turn.id}:reasoning:${group.startIndex}`}
+        key={`${presentationId}:reasoning:${group.startIndex}`}
         reasoning={group.parts}
         running={running}
         open={thinkingOpen(key) || (carriedOpen && group.completedKey === completedThinkingKey)}
@@ -298,15 +299,15 @@ export function AgentChatTurnRow({
     return (
       (hasAgentCliAccessRequest(part.text) &&
         cliAccess?.enabled !== true &&
-        !dismissedAccessRequestCards.has(accessRequestCardKey(turn.id, index, "cli"))) ||
+        !dismissedAccessRequestCards.has(accessRequestCardKey(presentationId, index, "cli"))) ||
       (hasBrowserAccessRequest(part.text) &&
         browserAccess?.enabled !== true &&
-        !dismissedAccessRequestCards.has(accessRequestCardKey(turn.id, index, "browser")))
+        !dismissedAccessRequestCards.has(accessRequestCardKey(presentationId, index, "browser")))
     );
   });
 
   function dismissAccessRequestCard(index: number, kind: AccessRequestCardKind) {
-    const key = accessRequestCardKey(turn.id, index, kind);
+    const key = accessRequestCardKey(presentationId, index, kind);
     setDismissedAccessRequestCards((current) => {
       if (current.has(key)) return current;
       const next = new Set(current);
@@ -408,7 +409,7 @@ export function AgentChatTurnRow({
     return (
       <>
         {contextParts.map((part, index) => (
-          <ContextCompactionPart key={`${turn.id}:context:${index}`} part={part} />
+          <ContextCompactionPart key={`${presentationId}:context:${index}`} part={part} />
         ))}
       </>
     );
@@ -474,7 +475,7 @@ export function AgentChatTurnRow({
             const markdown = displayedComposerUserMessageText(part.text);
             return markdown ? (
               <MarkdownContent
-                key={`${turn.id}:text:${index}`}
+                key={`${presentationId}:text:${index}`}
                 // Issue-report sessions open with the wrapped investigation
                 // prompt; the transcript shows only what the user typed.
                 markdown={markdown}
@@ -516,7 +517,7 @@ export function AgentChatTurnRow({
           ) : part.type === "tool" ? (
             visibleToolStacks.has(part.id) ? (
               <AgentToolStack
-                key={`${turn.id}:tools:${part.id}`}
+                key={`${presentationId}:tools:${part.id}`}
                 parts={visibleToolStacks.get(part.id) ?? []}
               />
             ) : null
@@ -526,7 +527,7 @@ export function AgentChatTurnRow({
               // access or Browser use setting; each token renders as an
               // approval card, never as text. A reply carrying both tokens
               // gets both cards.
-              <div key={`${turn.id}:text:${index}`}>
+              <div key={`${presentationId}:text:${index}`}>
                 {stripBrowserAccessRequest(stripAgentCliAccessRequest(part.text)) ? (
                   <MarkdownContent
                     markdown={stripBrowserAccessRequest(stripAgentCliAccessRequest(part.text))}
@@ -537,7 +538,7 @@ export function AgentChatTurnRow({
                   <AgentCliAccessCard
                     cliAccess={cliAccess}
                     dismissed={dismissedAccessRequestCards.has(
-                      accessRequestCardKey(turn.id, index, "cli"),
+                      accessRequestCardKey(presentationId, index, "cli"),
                     )}
                     onDismiss={() => dismissAccessRequestCard(index, "cli")}
                   />
@@ -546,14 +547,14 @@ export function AgentChatTurnRow({
                   <AgentBrowserAccessCard
                     browserAccess={browserAccess}
                     dismissed={dismissedAccessRequestCards.has(
-                      accessRequestCardKey(turn.id, index, "browser"),
+                      accessRequestCardKey(presentationId, index, "browser"),
                     )}
                     onDismiss={() => dismissAccessRequestCard(index, "browser")}
                   />
                 ) : null}
               </div>
             ) : (
-              <div key={`${turn.id}:text:${index}`}>
+              <div key={`${presentationId}:text:${index}`}>
                 {/* A part can retain raw MEDIA deltas while streaming or when
                     a terminal/error event arrives without message.complete.
                     Those transport references never belong in assistant prose. */}
@@ -566,43 +567,43 @@ export function AgentChatTurnRow({
               </div>
             )
           ) : part.type === "context" ? (
-            <ContextCompactionPart key={`${turn.id}:context:${index}`} part={part} />
+            <ContextCompactionPart key={`${presentationId}:context:${index}`} part={part} />
           ) : part.type === "approval" ? (
             <ApprovalPart
-              key={`${turn.id}:approval:${part.id}`}
+              key={`${presentationId}:approval:${part.id}`}
               part={part}
               submitting={approvalSubmitting[part.id]}
               onApproval={onApproval}
             />
           ) : part.type === "clarify" ? (
             <ClarifyPart
-              key={`${turn.id}:clarify:${part.id}`}
+              key={`${presentationId}:clarify:${part.id}`}
               part={part}
               submitting={clarifySubmitting[part.id]}
               onClarify={onClarify}
             />
           ) : part.type === "sudo" ? (
             <SudoPart
-              key={`${turn.id}:sudo:${part.id}`}
+              key={`${presentationId}:sudo:${part.id}`}
               part={part}
               submitting={sudoSubmitting[part.id]}
               onSudo={onSudo}
             />
           ) : part.type === "secret" ? (
             <SecretPart
-              key={`${turn.id}:secret:${part.id}`}
+              key={`${presentationId}:secret:${part.id}`}
               part={part}
               submitting={secretSubmitting[part.id]}
               onSecret={onSecret}
             />
           ) : part.type === "notice" ? (
             part.kind === "context-overflow" ? (
-              <ContextOverflowNoticePart key={`${turn.id}:notice:${index}`} />
+              <ContextOverflowNoticePart key={`${presentationId}:notice:${index}`} />
             ) : part.kind === "upstream-provider" ||
               part.kind === "tool" ||
               part.kind === "runtime" ? (
               <UpstreamProviderFailureNoticePart
-                key={`${turn.id}:notice:${index}`}
+                key={`${presentationId}:notice:${index}`}
                 kind={part.kind}
                 attempted={upstreamFailureRetryAttempted}
                 disabled={upstreamFailureRetryDisabled}
@@ -614,17 +615,17 @@ export function AgentChatTurnRow({
               />
             ) : (
               <CreditsNoticePart
-                key={`${turn.id}:notice:${index}`}
+                key={`${presentationId}:notice:${index}`}
                 onTopUp={onTopUp}
                 topUpLabel={topUpLabel}
                 tier={fundingTier}
               />
             )
           ) : part.type === "steering" ? (
-            <SteeringPart key={`${turn.id}:steering:${index}`} part={part} />
+            <SteeringPart key={`${presentationId}:steering:${index}`} part={part} />
           ) : part.type === "image" ? (
             <AgentGeneratedImage
-              key={`${turn.id}:image:${index}`}
+              key={`${presentationId}:image:${index}`}
               part={part}
               onOpen={onOpenImage}
               onDownload={onDownloadImage}
@@ -632,7 +633,7 @@ export function AgentChatTurnRow({
             />
           ) : part.type === "video" ? (
             <AgentGeneratedVideo
-              key={`${turn.id}:video:${index}`}
+              key={`${presentationId}:video:${index}`}
               part={part}
               onDownload={onDownloadVideo}
               onRetry={onRetryVideo ? () => onRetryVideo(turn.id, part) : undefined}

--- a/src/components/note-chat/NoteChatPanel.tsx
+++ b/src/components/note-chat/NoteChatPanel.tsx
@@ -467,11 +467,11 @@ export function NoteChatPanel({
             <div className="note-chat-thread">
               {turns.map((turn) =>
                 turn.role === "user" ? (
-                  <div key={turn.id} className="note-chat-turn-user">
+                  <div key={turn.renderId ?? turn.id} className="note-chat-turn-user">
                     {userTurnText(turn)}
                   </div>
                 ) : (
-                  <div key={turn.id} className="note-chat-turn-assistant">
+                  <div key={turn.renderId ?? turn.id} className="note-chat-turn-assistant">
                     {turn.parts.map((part, index) =>
                       assistantPartNode(
                         part,

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -123,6 +123,8 @@ export type AgentChatPart =
 
 export type AgentChatTurn = {
   id: string;
+  /** Stable React/presentation identity when a live activity cluster adopts newer item ids. */
+  renderId?: string;
   branchMessageId?: string;
   role: "user" | "assistant" | "system";
   createdAt: string;

--- a/src/lib/agent-runtime-adapter.ts
+++ b/src/lib/agent-runtime-adapter.ts
@@ -493,10 +493,11 @@ type AgentRunTurn = {
 
 /**
  * Presents consecutive reasoning, tool, and interruption items from one agent
- * run as a single activity cluster. The latest item owns the cluster identity
- * and timestamp; when a visible assistant output follows, it owns the combined
- * turn instead. User/system turns, visible outputs, and run changes remain
- * boundaries.
+ * run as a single activity cluster. The latest item owns the actionable turn
+ * identity and timestamp, while renderId preserves the first item's stable
+ * presentation identity. When a visible assistant output follows, it owns the
+ * actionable turn instead. User/system turns, visible outputs, and run changes
+ * remain boundaries.
  */
 function coalesceAgentActivityTurns(items: AgentRunTurn[]): AgentChatTurn[] {
   const turns: AgentChatTurn[] = [];
@@ -513,7 +514,11 @@ function coalesceAgentActivityTurns(items: AgentRunTurn[]): AgentChatTurn[] {
       if (pending && pending.runId === item.runId) {
         pending = {
           ...item,
-          turn: { ...item.turn, parts: [...pending.turn.parts, ...item.turn.parts] },
+          turn: {
+            ...item.turn,
+            renderId: pending.turn.renderId ?? pending.turn.id,
+            parts: [...pending.turn.parts, ...item.turn.parts],
+          },
         };
       } else {
         flushPending();
@@ -523,7 +528,11 @@ function coalesceAgentActivityTurns(items: AgentRunTurn[]): AgentChatTurn[] {
     }
 
     if (pending && item.turn.role === "assistant" && pending.runId === item.runId) {
-      turns.push({ ...item.turn, parts: [...pending.turn.parts, ...item.turn.parts] });
+      turns.push({
+        ...item.turn,
+        renderId: pending.turn.renderId ?? pending.turn.id,
+        parts: [...pending.turn.parts, ...item.turn.parts],
+      });
       pending = undefined;
       continue;
     }

--- a/src/test/agent-chat-turn-row.test.tsx
+++ b/src/test/agent-chat-turn-row.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AgentChatTurnRow } from "../components/agent/chat-turns/AgentChatTurnRow";
 import type { AgentChatTurn } from "../lib/agent-chat-runtime";
@@ -120,5 +120,58 @@ describe("AgentChatTurnRow", () => {
       "run_shell",
     ]);
     expect(container.querySelectorAll(".agent-turn-timestamp")).toHaveLength(1);
+  });
+
+  it("keeps disclosure state keyed to the first activity item as newer ids arrive", () => {
+    const openKeys = new Set<string>();
+    const onThinkingOpenChange = vi.fn((key: string, open: boolean) => {
+      if (open) openKeys.add(key);
+      else openKeys.delete(key);
+    });
+    const baseTurn: AgentChatTurn = {
+      id: "tool-result-2",
+      renderId: "reasoning-1",
+      role: "assistant",
+      createdAt: "2026-08-07T21:00:04Z",
+      status: "complete",
+      parts: [{ type: "reasoning", text: "Inspect the file", status: "complete" }],
+    };
+    const props = {
+      approvalSubmitting: {},
+      clarifySubmitting: {},
+      sudoSubmitting: {},
+      secretSubmitting: {},
+      thinkingOpen: (key: string) => openKeys.has(key),
+      onThinkingOpenChange,
+      onApproval: vi.fn(),
+      onClarify: vi.fn(),
+      onSudo: vi.fn(),
+      onSecret: vi.fn(),
+    };
+    const { container, rerender } = render(<AgentChatTurnRow {...props} turn={baseTurn} />);
+
+    const disclosure = container.querySelector(".agent-reasoning") as HTMLDetailsElement | null;
+    expect(disclosure).not.toBeNull();
+    if (disclosure) {
+      disclosure.open = true;
+      fireEvent(disclosure, new Event("toggle"));
+    }
+    expect(onThinkingOpenChange).toHaveBeenLastCalledWith("turn:reasoning-1:thinking", true);
+
+    rerender(
+      <AgentChatTurnRow
+        {...props}
+        turn={{
+          ...baseTurn,
+          id: "message-1",
+          parts: [
+            ...baseTurn.parts,
+            { type: "text", text: "The file is ready.", status: "complete" },
+          ],
+        }}
+      />,
+    );
+
+    expect(container.querySelector(".agent-reasoning")?.hasAttribute("open")).toBe(true);
   });
 });

--- a/src/test/agent-runtime-adapter.test.ts
+++ b/src/test/agent-runtime-adapter.test.ts
@@ -81,6 +81,7 @@ describe("agent runtime adapter", () => {
     expect(turns).toHaveLength(1);
     expect(turns[0]).toMatchObject({
       id: "tool-result-2",
+      renderId: "reasoning-1",
       role: "assistant",
       createdAt: "2026-07-22T12:00:04Z",
       parts: [
@@ -90,6 +91,44 @@ describe("agent runtime adapter", () => {
         { type: "tool", id: "call-2", name: "run_shell" },
       ],
     });
+  });
+
+  it("keeps the activity render identity when the final answer arrives", () => {
+    const turns = agentItemsToChatTurns([
+      {
+        id: "reasoning-1",
+        sessionId: "session-1",
+        runId: "run-1",
+        sequence: 1,
+        createdAt: "2026-07-22T12:00:01Z",
+        kind: "reasoning",
+        text: "Inspect the file",
+        status: "complete",
+      },
+      {
+        id: "message-1",
+        sessionId: "session-1",
+        runId: "run-1",
+        sequence: 2,
+        createdAt: "2026-07-22T12:00:02Z",
+        kind: "message",
+        role: "assistant",
+        text: "The file is ready.",
+        status: "complete",
+      },
+    ]);
+
+    expect(turns).toMatchObject([
+      {
+        id: "message-1",
+        renderId: "reasoning-1",
+        createdAt: "2026-07-22T12:00:02Z",
+        parts: [
+          { type: "reasoning", text: "Inspect the file" },
+          { type: "text", text: "The file is ready." },
+        ],
+      },
+    ]);
   });
 
   it("keeps adjacent activity from different agent runs in separate turns", () => {


### PR DESCRIPTION
## Summary

- Preserve a stable presentation identity while consecutive reasoning, tools, approvals, and the final answer coalesce into one live activity cluster.
- Keep the latest persisted item ID for branching, retry, timestamp, and runtime semantics.
- Use the stable identity for React keys, reasoning disclosure state, and presentation-only child keys across Agent, Home, and note chat surfaces.

## Root cause

PR #1030 made each newer activity item own the combined turn ID. React and disclosure-state keys were derived from that mutable ID, so a new tool, reasoning item, or final answer remounted/re-keyed the cluster and collapsed user-expanded activity.

## Validation

- `pnpm exec vitest run src/test/agent-runtime-adapter.test.ts src/test/agent-chat-turn-row.test.tsx` — 18/18 passed
- `pnpm exec vitest run` — 156 files / 1,696 tests passed
- `pnpm typecheck` — passed
- `pnpm exec biome check <changed files>` — zero errors; pre-existing warnings only
- `git diff --check` and `git show --check` — passed

- [x] Tested visually where it matters. The regression is state/key behavior covered deterministically; no visual styling changed.
- [ ] Needs a June API (backend) deploy before it works end to end. No; desktop-only.

## Out of scope

- No runtime wire-contract, persistence, grouping-boundary, styling, backend, billing, or release change.
- No merge, release, or deployment.

## Followups

- Review before the next desktop release; stable v0.0.39 is unaffected.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. Not applicable.
- [x] Workflow action references are pinned to full-length commit SHAs. Not applicable.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. Not applicable.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. Not applicable.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788786836&installation_model_id=425925&pr_number=1032&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1032&signature=c76ab5dd12ac0d00268308b9525e4b3add2dd547debbf67290b7ff6932a21876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->