### PR TITLE
JUN-468 Preserve session message drafts across navigation

### DIFF
--- a/src/app/use-agent-session-sync.ts
+++ b/src/app/use-agent-session-sync.ts
@@ -7,6 +7,7 @@ import {
 import { assignSessionToFolder } from "../lib/tauri";
 import { AGENT_SESSION_STATUS_EVENT, type AgentSessionStatusDetail } from "../lib/agent-events";
 import { getCurrentDataPartitionName } from "../lib/data-partition";
+import { clearAgentSessionDraft } from "../lib/agent-session-drafts";
 import { updateMenuBarSessionStatus } from "./app-effects/update-ui";
 import type { UseAgentSessionSyncDependencies } from "./use-agent-session-sync-types";
 
@@ -107,14 +108,15 @@ export function useAgentSessionSync(dependencies: UseAgentSessionSyncDependencie
 
     function handleAgentSessionDeleted(event: Event) {
       const detail = (event as CustomEvent<{ sessionId?: string }>).detail;
-      const sessionId = detail?.sessionId;
-      if (!sessionId) return;
+      const storedSessionId = detail?.sessionId;
+      if (!storedSessionId) return;
+      clearAgentSessionDraft(storedSessionId);
       agentMenuBarSessionsRef.current = agentMenuBarSessionsRef.current.filter(
-        (session) => session.id !== sessionId,
+        (session) => session.id !== storedSessionId,
       );
-      setAgentSessions((current) => current.filter((session) => session.id !== sessionId));
-      agentMenuBarWorkingSessionIdsRef.current.delete(sessionId);
-      agentMenuBarWaitingSessionIdsRef.current.delete(sessionId);
+      setAgentSessions((current) => current.filter((session) => session.id !== storedSessionId));
+      agentMenuBarWorkingSessionIdsRef.current.delete(storedSessionId);
+      agentMenuBarWaitingSessionIdsRef.current.delete(storedSessionId);
       setAgentWorkingSessionIds(new Set(agentMenuBarWorkingSessionIdsRef.current));
       setAgentWaitingSessionIds(new Set(agentMenuBarWaitingSessionIdsRef.current));
       publishAgentMenuBarState();

--- a/src/app/use-agent-session-sync.ts
+++ b/src/app/use-agent-session-sync.ts
@@ -7,7 +7,7 @@ import {
 import { assignSessionToFolder } from "../lib/tauri";
 import { AGENT_SESSION_STATUS_EVENT, type AgentSessionStatusDetail } from "../lib/agent-events";
 import { getCurrentDataPartitionName } from "../lib/data-partition";
-import { clearAgentSessionDraft } from "../lib/agent-session-drafts";
+import { invalidateAgentSessionDraft } from "../lib/agent-session-drafts";
 import { updateMenuBarSessionStatus } from "./app-effects/update-ui";
 import type { UseAgentSessionSyncDependencies } from "./use-agent-session-sync-types";
 
@@ -110,7 +110,7 @@ export function useAgentSessionSync(dependencies: UseAgentSessionSyncDependencie
       const detail = (event as CustomEvent<{ sessionId?: string }>).detail;
       const storedSessionId = detail?.sessionId;
       if (!storedSessionId) return;
-      clearAgentSessionDraft(storedSessionId);
+      invalidateAgentSessionDraft(storedSessionId);
       agentMenuBarSessionsRef.current = agentMenuBarSessionsRef.current.filter(
         (session) => session.id !== storedSessionId,
       );

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -93,9 +93,9 @@ import {
   rememberSessionModel,
 } from "../../lib/agent-session-models";
 import {
-  clearAgentSessionDraft,
   clearAgentSessionDraftRevision,
   clearPendingAgentSessionDraft,
+  invalidateAgentSessionDraft,
   readAgentSessionDraft,
   readAgentSessionDraftRevision,
   transferPendingAgentSessionDraft,
@@ -580,7 +580,6 @@ export function AgentWorkspace({
   const [submittedScrollRevision, setSubmittedScrollRevision] = useState(0);
   const selectedIdRef = useRef(selectedId);
   selectedIdRef.current = selectedId;
-  const deletedStoredSessionIdsRef = useRef(new Set<string>());
   const projectContextRef = useRef(projectContext);
   projectContextRef.current = projectContext;
   const resolveSessionProjectContextRef = useRef(resolveSessionProjectContext);
@@ -941,8 +940,7 @@ export function AgentWorkspace({
     const handleDeletedSession = (event: Event) => {
       const storedSessionId = (event as CustomEvent<{ sessionId?: string }>).detail?.sessionId;
       if (!storedSessionId) return;
-      deletedStoredSessionIdsRef.current.add(storedSessionId);
-      clearAgentSessionDraft(storedSessionId);
+      invalidateAgentSessionDraft(storedSessionId);
     };
     window.addEventListener(AGENT_DELETE_SESSION_EVENT, handleDeletedSession);
     return () => window.removeEventListener(AGENT_DELETE_SESSION_EVENT, handleDeletedSession);
@@ -1646,10 +1644,14 @@ export function AgentWorkspace({
         }
         return;
       }
-      if (creatingSession && !selectedIdRef.current) {
-        pendingSessionCreationRef.current = undefined;
-        setPendingInitialTurn(undefined);
-        setNewSessionMode(true);
+      if (creatingSession) {
+        if (pendingSessionCreationRef.current === creationRequestId) {
+          pendingSessionCreationRef.current = undefined;
+        }
+        if (!selectedIdRef.current) {
+          setPendingInitialTurn(undefined);
+          setNewSessionMode(true);
+        }
       }
       if (!queuedSnapshot) {
         const failedSubmission = {
@@ -2353,12 +2355,11 @@ export function AgentWorkspace({
     if (!selectedId) return;
     const removedStoredSessionId = selectedId;
     await agentRuntimeBindings.deleteSession(removedStoredSessionId);
-    deletedStoredSessionIdsRef.current.add(removedStoredSessionId);
     projectContextSignaturesBySessionId.delete(removedStoredSessionId);
     forgetSessionThinkingLevel(removedStoredSessionId);
     forgetSessionModel(removedStoredSessionId);
     forgetLastOpenSessionId(removedStoredSessionId);
-    clearAgentSessionDraft(removedStoredSessionId);
+    invalidateAgentSessionDraft(removedStoredSessionId);
     updateQueuedFollowUps((current) => {
       if (!(removedStoredSessionId in current)) return current;
       const next = { ...current };
@@ -2368,6 +2369,7 @@ export function AgentWorkspace({
     abandonComposerAttachments();
     setSelectedId(undefined);
     selectedIdRef.current = undefined;
+    setComposerDraft("", { persist: false });
     setProjection(createAgentRuntimeProjection());
     setArtifacts([]);
     setNewSessionMode(true);
@@ -2556,22 +2558,24 @@ export function AgentWorkspace({
       </span>
     </div>
   ) : null;
-  function persistComposerDraftForOwner(text: string, draftOwnerId?: string | null) {
-    if (!draftOwnerId) return;
+  function persistComposerDraftForOwner(
+    text: string,
+    draftOwnerId?: string | null,
+  ): string | undefined {
+    if (!draftOwnerId) return undefined;
     if (creationDraftDestinationsRef.current.has(draftOwnerId)) {
       const destinationStoredSessionId = creationDraftDestinationsRef.current.get(draftOwnerId);
       if (destinationStoredSessionId) {
-        if (!deletedStoredSessionIdsRef.current.has(destinationStoredSessionId)) {
-          writeAgentSessionDraft(destinationStoredSessionId, text);
-        }
+        writeAgentSessionDraft(destinationStoredSessionId, text);
+        return destinationStoredSessionId;
       } else if (destinationStoredSessionId === undefined) {
         writePendingAgentSessionDraft(draftOwnerId, text);
+        return draftOwnerId;
       }
-      return;
+      return undefined;
     }
-    if (!deletedStoredSessionIdsRef.current.has(draftOwnerId)) {
-      writeAgentSessionDraft(draftOwnerId, text);
-    }
+    writeAgentSessionDraft(draftOwnerId, text);
+    return draftOwnerId;
   }
 
   const draftOwnerId =
@@ -2585,14 +2589,18 @@ export function AgentWorkspace({
       setDraft={setComposerDraft}
       draftOwnerId={draftOwnerId}
       onEditorDraftChange={(text, changedDraftOwnerId) => {
-        persistComposerDraftForOwner(text, changedDraftOwnerId);
+        const resolvedDraftOwnerId = persistComposerDraftForOwner(text, changedDraftOwnerId);
         const currentDraftOwnerId =
           selectedIdRef.current ??
           pendingSessionCreationRef.current ??
           homeSessionCreationDraftOwnerRef.current;
-        if (changedDraftOwnerId === currentDraftOwnerId) {
+        if (
+          resolvedDraftOwnerId === currentDraftOwnerId ||
+          (!resolvedDraftOwnerId && !currentDraftOwnerId && !changedDraftOwnerId)
+        ) {
           setComposerDraft(text, { persist: false });
         }
+        return resolvedDraftOwnerId;
       }}
       onPendingDraftPersist={persistComposerDraftForOwner}
       onDraftContentChange={(hasContent) => {
@@ -3229,7 +3237,10 @@ function AgentComposer({
   draftRevision: number;
   setDraft: (value: string) => void;
   draftOwnerId?: string;
-  onEditorDraftChange: (text: string, draftOwnerId: string | null | undefined) => void;
+  onEditorDraftChange: (
+    text: string,
+    draftOwnerId: string | null | undefined,
+  ) => string | undefined;
   onPendingDraftPersist: (text: string, draftOwnerId: string | null | undefined) => void;
   onDraftContentChange: (hasContent: boolean) => void;
   model: string;
@@ -3259,6 +3270,8 @@ function AgentComposer({
   showModelPicker?: boolean;
 }) {
   const editorRef = useRef<ComposerEditorHandle>(null);
+  const [editorDraftOwnerId, setEditorDraftOwnerId] = useState(draftOwnerId);
+  const ownerTransitionHandledRef = useRef(false);
   const publishedDraftRef = useRef(draft);
   const appliedDraftRevisionRef = useRef(draftRevision);
   const [hasEditorContent, setHasEditorContent] = useState(Boolean(draft.trim()));
@@ -3291,25 +3304,36 @@ function AgentComposer({
   });
 
   useEffect(() => {
+    if (draftOwnerId === editorDraftOwnerId) return;
+    const editor = editorRef.current;
+    if (!editor) {
+      setEditorDraftOwnerId(draftOwnerId);
+      return;
+    }
+    // An active IME composition cannot be serialized yet. Keep the old owner
+    // and document in place; compositionend publishes them, then the onChange
+    // path below advances to the latest requested owner.
+    ownerTransitionHandledRef.current = false;
+    if (!editor.flushPendingChange() || ownerTransitionHandledRef.current) return;
+    appliedDraftRevisionRef.current = draftRevision;
+    publishedDraftRef.current = draft;
+    editor.setContent(draft, null, { focus: false, changeKey: draftOwnerId });
+    setEditorDraftOwnerId(draftOwnerId);
+  }, [draft, draftOwnerId, draftRevision, editorDraftOwnerId]);
+
+  useEffect(() => {
+    if (draftOwnerId !== editorDraftOwnerId) return;
     if (appliedDraftRevisionRef.current === draftRevision && draft === publishedDraftRef.current) {
       return;
     }
     appliedDraftRevisionRef.current = draftRevision;
     if (draft === publishedDraftRef.current) return;
     publishedDraftRef.current = draft;
-    editorRef.current?.setContent(draft, null, { focus: false });
-  }, [draft, draftRevision]);
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: the draft owner intentionally schedules the previous editor's cleanup.
-  useEffect(
-    () => () => {
-      // Session changes keep the composer component mounted. Flush the old
-      // editor document under its captured session key before the destination
-      // draft replaces it.
-      editorRef.current?.flushPendingChange({ persistWithoutRender: true });
-    },
-    [draftOwnerId],
-  );
+    editorRef.current?.setContent(draft, null, {
+      focus: false,
+      changeKey: editorDraftOwnerId,
+    });
+  }, [draft, draftOwnerId, draftRevision, editorDraftOwnerId]);
 
   useEffect(() => {
     if (!modelOpen && !safetyOpen && !attachOpen) return;
@@ -3397,6 +3421,7 @@ function AgentComposer({
       data-drop-active={dropActive ? "true" : undefined}
       onSubmit={(event) => {
         event.preventDefault();
+        if (draftOwnerId !== editorDraftOwnerId) return;
         if (editorRef.current?.flushPendingChange() === false) return;
         void onSubmit(event);
       }}
@@ -3436,10 +3461,22 @@ function AgentComposer({
         <ComposerEditor
           ref={editorRef}
           placeholder={hero ? "Ask June anything, run / commands" : "Send a message"}
-          changeKey={draftOwnerId}
+          changeKey={editorDraftOwnerId}
           onChange={(text, _category, changedDraftOwnerId) => {
             publishedDraftRef.current = text;
-            onEditorDraftChange(text, changedDraftOwnerId);
+            const resolvedDraftOwnerId = onEditorDraftChange(text, changedDraftOwnerId);
+            if (draftOwnerId !== editorDraftOwnerId && changedDraftOwnerId === editorDraftOwnerId) {
+              ownerTransitionHandledRef.current = true;
+              if (resolvedDraftOwnerId !== draftOwnerId) {
+                appliedDraftRevisionRef.current = draftRevision;
+                publishedDraftRef.current = draft;
+                editorRef.current?.setContent(draft, null, {
+                  focus: false,
+                  changeKey: draftOwnerId,
+                });
+              }
+              setEditorDraftOwnerId(draftOwnerId);
+            }
           }}
           onPendingChangePersist={(text, _category, changedDraftOwnerId) => {
             publishedDraftRef.current = text;
@@ -3449,7 +3486,10 @@ function AgentComposer({
             setHasEditorContent(hasContent);
             onDraftContentChange(hasContent);
           }}
-          onSubmit={() => void onSubmit()}
+          onSubmit={() => {
+            if (draftOwnerId !== editorDraftOwnerId) return;
+            void onSubmit();
+          }}
         />
         <div className="agent-composer-toolbar">
           <button
@@ -3556,7 +3596,13 @@ function AgentComposer({
                 type="submit"
                 className="agent-composer-send"
                 aria-label="Send message"
-                disabled={submitting || attaching || !hasEditorContent || Boolean(disabledReason)}
+                disabled={
+                  submitting ||
+                  attaching ||
+                  draftOwnerId !== editorDraftOwnerId ||
+                  !hasEditorContent ||
+                  Boolean(disabledReason)
+                }
                 title={attaching ? "Wait for files to finish attaching" : disabledReason}
               >
                 {submitting ? <Spinner /> : <IconArrowUp size={18} />}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -94,7 +94,12 @@ import {
 } from "../../lib/agent-session-models";
 import {
   clearAgentSessionDraft,
+  clearAgentSessionDraftRevision,
+  clearPendingAgentSessionDraft,
   readAgentSessionDraft,
+  readAgentSessionDraftRevision,
+  transferPendingAgentSessionDraft,
+  writePendingAgentSessionDraft,
   writeAgentSessionDraft,
 } from "../../lib/agent-session-drafts";
 import {
@@ -552,6 +557,7 @@ export function AgentWorkspace({
     turn: AgentChatTurn;
   }>();
   const pendingSessionCreationRef = useRef<string>();
+  const creationDraftDestinationsRef = useRef(new Map<string, string | null | undefined>());
   const hydrationRequestRef = useRef<string>();
   const submissionOwnerRef = useRef<string>();
   const [submitting, setSubmitting] = useState(false);
@@ -573,6 +579,7 @@ export function AgentWorkspace({
   const [submittedScrollRevision, setSubmittedScrollRevision] = useState(0);
   const selectedIdRef = useRef(selectedId);
   selectedIdRef.current = selectedId;
+  const deletedStoredSessionIdsRef = useRef(new Set<string>());
   const projectContextRef = useRef(projectContext);
   projectContextRef.current = projectContext;
   const resolveSessionProjectContextRef = useRef(resolveSessionProjectContext);
@@ -1332,17 +1339,25 @@ export function AgentWorkspace({
       clearQueuedSubmissionAttempt();
       return;
     }
+    const submittedStoredSessionId = selectedIdRef.current;
+    const submittedDraftRevision =
+      !queuedSubmission &&
+      !recoveredSubmission &&
+      submittedStoredSessionId &&
+      readAgentSessionDraft(submittedStoredSessionId)?.trim() === prompt
+        ? readAgentSessionDraftRevision(submittedStoredSessionId)
+        : undefined;
     if (running) {
       const submittedAttachments = queuedSubmission?.attachments ?? attachmentsRef.current;
       const submittedModel = queuedSubmission?.model ?? agentRunModelId(model, costQuality);
       const submittedThinkingLevel = queuedSubmission?.thinkingLevel ?? thinkingLevel;
       clearQueuedSubmissionAttempt();
-      const ownerSessionId = selectedIdRef.current;
-      if (!ownerSessionId) return;
+      const ownerStoredSessionId = selectedIdRef.current;
+      if (!ownerStoredSessionId) return;
       const messageId = crypto.randomUUID();
       updateQueuedFollowUps((current) => ({
         ...current,
-        [ownerSessionId]: mergeQueuedAgentFollowUp(current[ownerSessionId], {
+        [ownerStoredSessionId]: mergeQueuedAgentFollowUp(current[ownerStoredSessionId], {
           messageId,
           prompt,
           attachments: submittedAttachments,
@@ -1354,7 +1369,7 @@ export function AgentWorkspace({
       }));
       setComposerDraft("", { persist: false });
       setComposerAttachments([]);
-      clearAgentSessionDraft(ownerSessionId, prompt);
+      clearAgentSessionDraftRevision(ownerStoredSessionId, submittedDraftRevision);
       requestSubmittedMessageScroll();
       if (projection.run) {
         const activeRunId = projection.run.id;
@@ -1363,7 +1378,7 @@ export function AgentWorkspace({
           .then((result) => {
             if (result.accepted) {
               updateQueuedFollowUps((current) =>
-                withQueuedSteering(current, ownerSessionId, messageId, "accepted"),
+                withQueuedSteering(current, ownerStoredSessionId, messageId, "accepted"),
               );
               return;
             }
@@ -1374,7 +1389,7 @@ export function AgentWorkspace({
               messageId,
             });
             updateQueuedFollowUps((current) =>
-              withQueuedSteering(current, ownerSessionId, messageId, undefined),
+              withQueuedSteering(current, ownerStoredSessionId, messageId, undefined),
             );
           })
           .catch((cause: unknown) => {
@@ -1385,7 +1400,7 @@ export function AgentWorkspace({
               messageId,
             });
             updateQueuedFollowUps((current) =>
-              withQueuedSteering(current, ownerSessionId, messageId, undefined),
+              withQueuedSteering(current, ownerStoredSessionId, messageId, undefined),
             );
           });
       }
@@ -1414,6 +1429,9 @@ export function AgentWorkspace({
     }
     if (creatingSession) {
       pendingSessionCreationRef.current = creationRequestId;
+      if (creationRequestId) {
+        creationDraftDestinationsRef.current.set(creationRequestId, undefined);
+      }
       setPendingInitialTurn({
         prompt,
         title: titleFromPrompt(prompt),
@@ -1460,13 +1478,21 @@ export function AgentWorkspace({
           createdSession,
           ...current.filter((item) => item.id !== createdSession.id),
         ]);
+        if (creationRequestId) {
+          creationDraftDestinationsRef.current.set(creationRequestId, createdSession.id);
+        }
+        const transferredPendingDraft = creationRequestId
+          ? transferPendingAgentSessionDraft(creationRequestId, createdSession.id)
+          : false;
         const shouldPresentCreatedSession =
           pendingSessionCreationRef.current === creationRequestId &&
           selectedIdRef.current === undefined;
         if (shouldPresentCreatedSession) {
           setSelectedId(createdSession.id);
           selectedIdRef.current = createdSession.id;
-          writeAgentSessionDraft(createdSession.id, draftRef.current);
+          if (!transferredPendingDraft) {
+            writeAgentSessionDraft(createdSession.id, draftRef.current);
+          }
           setNewSessionMode(false);
           setPendingInitialTurn((current) =>
             current ? { ...current, storedSessionId: createdSession.id } : current,
@@ -1530,7 +1556,7 @@ export function AgentWorkspace({
         attachments: attachedPaths,
       });
       void discardStagedAgentAttachments(attachedPaths).catch(() => undefined);
-      clearAgentSessionDraft(activeSession.id, prompt);
+      clearAgentSessionDraftRevision(activeSession.id, submittedDraftRevision);
       inFlightAttachmentLeasesRef.current.delete(submissionId);
       if (queuedSnapshot) {
         attemptedQueuedMessageIdsRef.current.delete(queuedSnapshot.messageId);
@@ -1577,6 +1603,14 @@ export function AgentWorkspace({
       });
       await refreshSessions();
     } catch (cause) {
+      if (
+        creationRequestId &&
+        creationDraftDestinationsRef.current.has(creationRequestId) &&
+        creationDraftDestinationsRef.current.get(creationRequestId) === undefined
+      ) {
+        clearPendingAgentSessionDraft(creationRequestId);
+        creationDraftDestinationsRef.current.set(creationRequestId, null);
+      }
       if (queuedSnapshot) {
         setFailedQueuedMessageIds((current) => new Set([...current, queuedSnapshot.messageId]));
       }
@@ -1814,6 +1848,12 @@ export function AgentWorkspace({
       setError("Home messages must be 64,000 characters or less.");
       return;
     }
+    const submittedHomeStoredSessionId = selectedIdRef.current;
+    const submittedHomeDraftRevision =
+      submittedHomeStoredSessionId &&
+      readAgentSessionDraft(submittedHomeStoredSessionId)?.trim() === message
+        ? readAgentSessionDraftRevision(submittedHomeStoredSessionId)
+        : undefined;
     const profile = getCurrentDataPartitionName();
     const messageAttachments = attachmentsRef.current;
     const attachmentLeaseId = `home:${crypto.randomUUID()}`;
@@ -1855,7 +1895,7 @@ export function AgentWorkspace({
       const greetingReply = homeConversationGreetingReply(message);
       const directConversationReply = acknowledgesTaskHandoff ? "Got it." : greetingReply;
       commitHomeDirectTurns(storedSessionId, [...priorDirectTurns, userTurn]);
-      clearAgentSessionDraft(storedSessionId, message);
+      clearAgentSessionDraftRevision(storedSessionId, submittedHomeDraftRevision);
       requestSubmittedMessageScroll();
 
       if (directConversationReply && messageAttachments.length === 0) {
@@ -2285,20 +2325,23 @@ export function AgentWorkspace({
 
   async function remove() {
     if (!selectedId) return;
-    await agentRuntimeBindings.deleteSession(selectedId);
-    projectContextSignaturesBySessionId.delete(selectedId);
-    forgetSessionThinkingLevel(selectedId);
-    forgetSessionModel(selectedId);
-    forgetLastOpenSessionId(selectedId);
-    clearAgentSessionDraft(selectedId);
+    const removedStoredSessionId = selectedId;
+    await agentRuntimeBindings.deleteSession(removedStoredSessionId);
+    deletedStoredSessionIdsRef.current.add(removedStoredSessionId);
+    projectContextSignaturesBySessionId.delete(removedStoredSessionId);
+    forgetSessionThinkingLevel(removedStoredSessionId);
+    forgetSessionModel(removedStoredSessionId);
+    forgetLastOpenSessionId(removedStoredSessionId);
+    clearAgentSessionDraft(removedStoredSessionId);
     updateQueuedFollowUps((current) => {
-      if (!(selectedId in current)) return current;
+      if (!(removedStoredSessionId in current)) return current;
       const next = { ...current };
-      delete next[selectedId];
+      delete next[removedStoredSessionId];
       return next;
     });
     abandonComposerAttachments();
     setSelectedId(undefined);
+    selectedIdRef.current = undefined;
     setProjection(createAgentRuntimeProjection());
     setArtifacts([]);
     setNewSessionMode(true);
@@ -2494,11 +2537,23 @@ export function AgentWorkspace({
       draft={draft}
       draftRevision={draftRevision}
       setDraft={setComposerDraft}
-      draftSessionId={selectedId}
-      onPendingDraftPersist={(text, sessionId) => {
-        const ownerSessionId =
-          sessionId ?? (pendingSessionCreationRef.current ? selectedIdRef.current : undefined);
-        if (ownerSessionId) writeAgentSessionDraft(ownerSessionId, text);
+      draftOwnerId={selectedId ?? pendingSessionCreationRef.current}
+      onPendingDraftPersist={(text, draftOwnerId) => {
+        if (!draftOwnerId) return;
+        if (creationDraftDestinationsRef.current.has(draftOwnerId)) {
+          const destinationStoredSessionId = creationDraftDestinationsRef.current.get(draftOwnerId);
+          if (destinationStoredSessionId) {
+            if (!deletedStoredSessionIdsRef.current.has(destinationStoredSessionId)) {
+              writeAgentSessionDraft(destinationStoredSessionId, text);
+            }
+          } else if (destinationStoredSessionId === undefined) {
+            writePendingAgentSessionDraft(draftOwnerId, text);
+          }
+          return;
+        }
+        if (!deletedStoredSessionIdsRef.current.has(draftOwnerId)) {
+          writeAgentSessionDraft(draftOwnerId, text);
+        }
       }}
       onDraftContentChange={(hasContent) => {
         draftHasContentRef.current = hasContent;
@@ -3098,7 +3153,7 @@ function AgentComposer({
   draft,
   draftRevision,
   setDraft,
-  draftSessionId,
+  draftOwnerId,
   onPendingDraftPersist,
   onDraftContentChange,
   model,
@@ -3132,8 +3187,8 @@ function AgentComposer({
   draft: string;
   draftRevision: number;
   setDraft: (value: string) => void;
-  draftSessionId?: string;
-  onPendingDraftPersist: (text: string, sessionId: string | null | undefined) => void;
+  draftOwnerId?: string;
+  onPendingDraftPersist: (text: string, draftOwnerId: string | null | undefined) => void;
   onDraftContentChange: (hasContent: boolean) => void;
   model: string;
   setModel: (value: string, costQuality?: number) => void;
@@ -3203,7 +3258,7 @@ function AgentComposer({
     editorRef.current?.setContent(draft, null, { focus: false });
   }, [draft, draftRevision]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: the session key intentionally schedules the previous editor's cleanup.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the draft owner intentionally schedules the previous editor's cleanup.
   useEffect(
     () => () => {
       // Session changes keep the composer component mounted. Flush the old
@@ -3211,7 +3266,7 @@ function AgentComposer({
       // draft replaces it.
       editorRef.current?.flushPendingChange({ persistWithoutRender: true });
     },
-    [draftSessionId],
+    [draftOwnerId],
   );
 
   useEffect(() => {
@@ -3339,14 +3394,14 @@ function AgentComposer({
         <ComposerEditor
           ref={editorRef}
           placeholder={hero ? "Ask June anything, run / commands" : "Send a message"}
-          changeKey={draftSessionId}
+          changeKey={draftOwnerId}
           onChange={(text) => {
             publishedDraftRef.current = text;
             setDraft(text);
           }}
-          onPendingChangePersist={(text, _category, sessionId) => {
+          onPendingChangePersist={(text, _category, changedDraftOwnerId) => {
             publishedDraftRef.current = text;
-            onPendingDraftPersist(text, sessionId);
+            onPendingDraftPersist(text, changedDraftOwnerId);
           }}
           onContentChange={(hasContent) => {
             setHasEditorContent(hasContent);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -127,6 +127,7 @@ import { AgentSessionBar } from "./chat-turns/AgentSessionBar";
 import { AgentThinking } from "./AgentThinking";
 import {
   advanceHeroGreeting,
+  AGENT_DELETE_SESSION_EVENT,
   AGENT_NEW_SESSION_EVENT,
   AGENT_SHORTCUTS,
   rememberUnrestrictedAcknowledged,
@@ -607,6 +608,7 @@ export function AgentWorkspace({
   const [homeStreamingReply, setHomeStreamingReply] = useState<AgentChatTurn | null>(null);
   const [homeDirectPendingCount, setHomeDirectPendingCount] = useState(0);
   const homeSessionPromiseRef = useRef<Promise<string> | null>(null);
+  const homeSessionCreationDraftOwnerRef = useRef<string>();
   const [homeSessionCreating, setHomeSessionCreating] = useState(false);
   const handledHomeTaskToolCallsRef = useRef(new Set<string>());
 
@@ -934,6 +936,17 @@ export function AgentWorkspace({
     window.addEventListener(AGENT_NEW_SESSION_EVENT, handleNewSession);
     return () => window.removeEventListener(AGENT_NEW_SESSION_EVENT, handleNewSession);
   }, [startNewSession]);
+
+  useEffect(() => {
+    const handleDeletedSession = (event: Event) => {
+      const storedSessionId = (event as CustomEvent<{ sessionId?: string }>).detail?.sessionId;
+      if (!storedSessionId) return;
+      deletedStoredSessionIdsRef.current.add(storedSessionId);
+      clearAgentSessionDraft(storedSessionId);
+    };
+    window.addEventListener(AGENT_DELETE_SESSION_EVENT, handleDeletedSession);
+    return () => window.removeEventListener(AGENT_DELETE_SESSION_EVENT, handleDeletedSession);
+  }, []);
 
   useEffect(() => {
     let disposed = false;
@@ -1663,6 +1676,9 @@ export function AgentWorkspace({
     if (selected) return selected;
     if (homeSessionPromiseRef.current) return homeSessionPromiseRef.current;
 
+    const draftOwnerId = crypto.randomUUID();
+    homeSessionCreationDraftOwnerRef.current = draftOwnerId;
+    creationDraftDestinationsRef.current.set(draftOwnerId, undefined);
     const creation = agentRuntimeBindings
       .createSession({
         title: "Home",
@@ -1671,6 +1687,8 @@ export function AgentWorkspace({
         profile: getCurrentDataPartitionName(),
       })
       .then((createdSession) => {
+        creationDraftDestinationsRef.current.set(draftOwnerId, createdSession.id);
+        transferPendingAgentSessionDraft(draftOwnerId, createdSession.id);
         setSelectedId(createdSession.id);
         selectedIdRef.current = createdSession.id;
         setNewSessionMode(false);
@@ -1682,6 +1700,11 @@ export function AgentWorkspace({
         rememberSessionThinkingLevel(createdSession.id, "instant");
         onHomeSessionCreated?.(createdSession.id);
         return createdSession.id;
+      })
+      .catch((cause) => {
+        clearPendingAgentSessionDraft(draftOwnerId);
+        creationDraftDestinationsRef.current.set(draftOwnerId, null);
+        throw cause;
       });
     homeSessionPromiseRef.current = creation;
     setHomeSessionCreating(true);
@@ -1690,6 +1713,9 @@ export function AgentWorkspace({
     } finally {
       if (homeSessionPromiseRef.current === creation) {
         homeSessionPromiseRef.current = null;
+        if (homeSessionCreationDraftOwnerRef.current === draftOwnerId) {
+          homeSessionCreationDraftOwnerRef.current = undefined;
+        }
         setHomeSessionCreating(false);
       }
     }
@@ -2530,6 +2556,26 @@ export function AgentWorkspace({
       </span>
     </div>
   ) : null;
+  function persistComposerDraftForOwner(text: string, draftOwnerId?: string | null) {
+    if (!draftOwnerId) return;
+    if (creationDraftDestinationsRef.current.has(draftOwnerId)) {
+      const destinationStoredSessionId = creationDraftDestinationsRef.current.get(draftOwnerId);
+      if (destinationStoredSessionId) {
+        if (!deletedStoredSessionIdsRef.current.has(destinationStoredSessionId)) {
+          writeAgentSessionDraft(destinationStoredSessionId, text);
+        }
+      } else if (destinationStoredSessionId === undefined) {
+        writePendingAgentSessionDraft(draftOwnerId, text);
+      }
+      return;
+    }
+    if (!deletedStoredSessionIdsRef.current.has(draftOwnerId)) {
+      writeAgentSessionDraft(draftOwnerId, text);
+    }
+  }
+
+  const draftOwnerId =
+    selectedId ?? pendingSessionCreationRef.current ?? homeSessionCreationDraftOwnerRef.current;
   const composer = (
     <AgentComposer
       formRef={composerRef}
@@ -2537,24 +2583,18 @@ export function AgentWorkspace({
       draft={draft}
       draftRevision={draftRevision}
       setDraft={setComposerDraft}
-      draftOwnerId={selectedId ?? pendingSessionCreationRef.current}
-      onPendingDraftPersist={(text, draftOwnerId) => {
-        if (!draftOwnerId) return;
-        if (creationDraftDestinationsRef.current.has(draftOwnerId)) {
-          const destinationStoredSessionId = creationDraftDestinationsRef.current.get(draftOwnerId);
-          if (destinationStoredSessionId) {
-            if (!deletedStoredSessionIdsRef.current.has(destinationStoredSessionId)) {
-              writeAgentSessionDraft(destinationStoredSessionId, text);
-            }
-          } else if (destinationStoredSessionId === undefined) {
-            writePendingAgentSessionDraft(draftOwnerId, text);
-          }
-          return;
-        }
-        if (!deletedStoredSessionIdsRef.current.has(draftOwnerId)) {
-          writeAgentSessionDraft(draftOwnerId, text);
+      draftOwnerId={draftOwnerId}
+      onEditorDraftChange={(text, changedDraftOwnerId) => {
+        persistComposerDraftForOwner(text, changedDraftOwnerId);
+        const currentDraftOwnerId =
+          selectedIdRef.current ??
+          pendingSessionCreationRef.current ??
+          homeSessionCreationDraftOwnerRef.current;
+        if (changedDraftOwnerId === currentDraftOwnerId) {
+          setComposerDraft(text, { persist: false });
         }
       }}
+      onPendingDraftPersist={persistComposerDraftForOwner}
       onDraftContentChange={(hasContent) => {
         draftHasContentRef.current = hasContent;
       }}
@@ -3154,6 +3194,7 @@ function AgentComposer({
   draftRevision,
   setDraft,
   draftOwnerId,
+  onEditorDraftChange,
   onPendingDraftPersist,
   onDraftContentChange,
   model,
@@ -3188,6 +3229,7 @@ function AgentComposer({
   draftRevision: number;
   setDraft: (value: string) => void;
   draftOwnerId?: string;
+  onEditorDraftChange: (text: string, draftOwnerId: string | null | undefined) => void;
   onPendingDraftPersist: (text: string, draftOwnerId: string | null | undefined) => void;
   onDraftContentChange: (hasContent: boolean) => void;
   model: string;
@@ -3395,9 +3437,9 @@ function AgentComposer({
           ref={editorRef}
           placeholder={hero ? "Ask June anything, run / commands" : "Send a message"}
           changeKey={draftOwnerId}
-          onChange={(text) => {
+          onChange={(text, _category, changedDraftOwnerId) => {
             publishedDraftRef.current = text;
-            setDraft(text);
+            onEditorDraftChange(text, changedDraftOwnerId);
           }}
           onPendingChangePersist={(text, _category, changedDraftOwnerId) => {
             publishedDraftRef.current = text;

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -93,6 +93,11 @@ import {
   rememberSessionModel,
 } from "../../lib/agent-session-models";
 import {
+  clearAgentSessionDraft,
+  readAgentSessionDraft,
+  writeAgentSessionDraft,
+} from "../../lib/agent-session-drafts";
+import {
   forgetSessionThinkingLevel,
   loadSessionThinkingLevels,
   loadThinkingLevel,
@@ -444,9 +449,12 @@ export function AgentWorkspace({
   const draftRef = useRef(draft);
   draftRef.current = draft;
   const draftHasContentRef = useRef(Boolean(draft.trim()));
-  const setComposerDraft = useCallback((value: string) => {
+  const setComposerDraft = useCallback((value: string, options?: { persist?: boolean }) => {
     draftRef.current = value;
     draftHasContentRef.current = Boolean(value.trim());
+    if (options?.persist !== false && selectedIdRef.current) {
+      writeAgentSessionDraft(selectedIdRef.current, value);
+    }
     setDraft(value);
     setDraftRevision((revision) => revision + 1);
   }, []);
@@ -854,6 +862,22 @@ export function AgentWorkspace({
       })
       .catch(() => setVeniceApiKeyConfigured(false));
   }, [homeMode, initialAgentSession, initialSessionId, refreshSessions]);
+
+  const pendingDraftTakesPriorityRef = useRef(Boolean(pendingRequestRef.current?.prompt));
+  useEffect(() => {
+    if (!selectedId) return;
+    // A request that opens a new session deliberately pre-fills the composer;
+    // do not let a stale session draft replace that navigation intent.
+    if (pendingDraftTakesPriorityRef.current) {
+      pendingDraftTakesPriorityRef.current = false;
+      return;
+    }
+    // The first session id is assigned while its initial send is still in
+    // flight. Its composer may already contain a follow-up, which is not a
+    // stored draft to restore over.
+    if (pendingSessionCreationRef.current) return;
+    setComposerDraft(readAgentSessionDraft(selectedId) ?? "", { persist: false });
+  }, [selectedId, setComposerDraft]);
 
   useEffect(() => {
     const nextId = initialSession?.id ?? initialSessionId;
@@ -1328,8 +1352,9 @@ export function AgentWorkspace({
           steering: "pending",
         }),
       }));
-      setComposerDraft("");
+      setComposerDraft("", { persist: false });
       setComposerAttachments([]);
+      clearAgentSessionDraft(ownerSessionId, prompt);
       requestSubmittedMessageScroll();
       if (projection.run) {
         const activeRunId = projection.run.id;
@@ -1409,7 +1434,7 @@ export function AgentWorkspace({
         },
       });
       if (submissionOwnerRef.current === submissionId && !recoveredSnapshot) {
-        setComposerDraft("");
+        setComposerDraft("", { persist: false });
         setComposerAttachments([]);
       }
     }
@@ -1441,6 +1466,7 @@ export function AgentWorkspace({
         if (shouldPresentCreatedSession) {
           setSelectedId(createdSession.id);
           selectedIdRef.current = createdSession.id;
+          writeAgentSessionDraft(createdSession.id, draftRef.current);
           setNewSessionMode(false);
           setPendingInitialTurn((current) =>
             current ? { ...current, storedSessionId: createdSession.id } : current,
@@ -1483,7 +1509,7 @@ export function AgentWorkspace({
         !creatingSession &&
         submissionOwnerRef.current === submissionId
       ) {
-        setComposerDraft("");
+        setComposerDraft("", { persist: false });
         setComposerAttachments([]);
       }
       const enabledSkillIds = (await agentRuntimeBindings.listSkills())
@@ -1504,6 +1530,7 @@ export function AgentWorkspace({
         attachments: attachedPaths,
       });
       void discardStagedAgentAttachments(attachedPaths).catch(() => undefined);
+      clearAgentSessionDraft(activeSession.id, prompt);
       inFlightAttachmentLeasesRef.current.delete(submissionId);
       if (queuedSnapshot) {
         attemptedQueuedMessageIdsRef.current.delete(queuedSnapshot.messageId);
@@ -1794,7 +1821,7 @@ export function AgentWorkspace({
       inFlightAttachmentLeasesRef.current.set(attachmentLeaseId, [...new Set(messageAttachments)]);
     }
     const messageAttachmentGeneration = attachmentGenerationRef.current;
-    setComposerDraft("");
+    setComposerDraft("", { persist: false });
     setComposerAttachments([]);
     setHomeDirectPendingCount((count) => count + 1);
 
@@ -1828,6 +1855,7 @@ export function AgentWorkspace({
       const greetingReply = homeConversationGreetingReply(message);
       const directConversationReply = acknowledgesTaskHandoff ? "Got it." : greetingReply;
       commitHomeDirectTurns(storedSessionId, [...priorDirectTurns, userTurn]);
+      clearAgentSessionDraft(storedSessionId, message);
       requestSubmittedMessageScroll();
 
       if (directConversationReply && messageAttachments.length === 0) {
@@ -2262,6 +2290,7 @@ export function AgentWorkspace({
     forgetSessionThinkingLevel(selectedId);
     forgetSessionModel(selectedId);
     forgetLastOpenSessionId(selectedId);
+    clearAgentSessionDraft(selectedId);
     updateQueuedFollowUps((current) => {
       if (!(selectedId in current)) return current;
       const next = { ...current };
@@ -2465,6 +2494,12 @@ export function AgentWorkspace({
       draft={draft}
       draftRevision={draftRevision}
       setDraft={setComposerDraft}
+      draftSessionId={selectedId}
+      onPendingDraftPersist={(text, sessionId) => {
+        const ownerSessionId =
+          sessionId ?? (pendingSessionCreationRef.current ? selectedIdRef.current : undefined);
+        if (ownerSessionId) writeAgentSessionDraft(ownerSessionId, text);
+      }}
       onDraftContentChange={(hasContent) => {
         draftHasContentRef.current = hasContent;
       }}
@@ -3063,6 +3098,8 @@ function AgentComposer({
   draft,
   draftRevision,
   setDraft,
+  draftSessionId,
+  onPendingDraftPersist,
   onDraftContentChange,
   model,
   setModel,
@@ -3095,6 +3132,8 @@ function AgentComposer({
   draft: string;
   draftRevision: number;
   setDraft: (value: string) => void;
+  draftSessionId?: string;
+  onPendingDraftPersist: (text: string, sessionId: string | null | undefined) => void;
   onDraftContentChange: (hasContent: boolean) => void;
   model: string;
   setModel: (value: string, costQuality?: number) => void;
@@ -3163,6 +3202,17 @@ function AgentComposer({
     publishedDraftRef.current = draft;
     editorRef.current?.setContent(draft, null, { focus: false });
   }, [draft, draftRevision]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the session key intentionally schedules the previous editor's cleanup.
+  useEffect(
+    () => () => {
+      // Session changes keep the composer component mounted. Flush the old
+      // editor document under its captured session key before the destination
+      // draft replaces it.
+      editorRef.current?.flushPendingChange({ persistWithoutRender: true });
+    },
+    [draftSessionId],
+  );
 
   useEffect(() => {
     if (!modelOpen && !safetyOpen && !attachOpen) return;
@@ -3289,9 +3339,14 @@ function AgentComposer({
         <ComposerEditor
           ref={editorRef}
           placeholder={hero ? "Ask June anything, run / commands" : "Send a message"}
+          changeKey={draftSessionId}
           onChange={(text) => {
             publishedDraftRef.current = text;
             setDraft(text);
+          }}
+          onPendingChangePersist={(text, _category, sessionId) => {
+            publishedDraftRef.current = text;
+            onPendingDraftPersist(text, sessionId);
           }}
           onContentChange={(hasContent) => {
             setHasEditorContent(hasContent);

--- a/src/lib/agent-session-drafts.ts
+++ b/src/lib/agent-session-drafts.ts
@@ -3,27 +3,73 @@
  * Keep this process-local: drafts can contain sensitive material and should
  * not survive an app restart.
  */
-const draftsBySessionId = new Map<string, string>();
+type AgentSessionDraft = {
+  revision: number;
+  text: string;
+};
 
-export function readAgentSessionDraft(sessionId: string): string | undefined {
-  return draftsBySessionId.get(sessionId);
+const draftsByStoredSessionId = new Map<string, AgentSessionDraft>();
+const draftsByCreationRequestId = new Map<string, AgentSessionDraft>();
+let nextRevision = 0;
+
+function snapshot(text: string): AgentSessionDraft {
+  return { revision: ++nextRevision, text };
 }
 
-export function writeAgentSessionDraft(sessionId: string, draft: string) {
-  if (!sessionId) return;
+export function readAgentSessionDraft(storedSessionId: string): string | undefined {
+  return draftsByStoredSessionId.get(storedSessionId)?.text;
+}
+
+export function readAgentSessionDraftRevision(storedSessionId: string): number | undefined {
+  return draftsByStoredSessionId.get(storedSessionId)?.revision;
+}
+
+export function writeAgentSessionDraft(storedSessionId: string, draft: string) {
+  if (!storedSessionId) return;
   if (draft.length === 0) {
-    draftsBySessionId.delete(sessionId);
+    draftsByStoredSessionId.delete(storedSessionId);
     return;
   }
-  draftsBySessionId.set(sessionId, draft);
+  draftsByStoredSessionId.set(storedSessionId, snapshot(draft));
 }
 
-export function clearAgentSessionDraft(sessionId: string, expectedDraft?: string) {
-  if (expectedDraft !== undefined && draftsBySessionId.get(sessionId) !== expectedDraft) return;
-  draftsBySessionId.delete(sessionId);
+export function writePendingAgentSessionDraft(creationRequestId: string, draft: string) {
+  if (!creationRequestId) return;
+  if (draft.length === 0) {
+    draftsByCreationRequestId.delete(creationRequestId);
+    return;
+  }
+  draftsByCreationRequestId.set(creationRequestId, snapshot(draft));
 }
 
-/** Test-only reset because workspace tests intentionally reuse session ids. */
+export function transferPendingAgentSessionDraft(
+  creationRequestId: string,
+  storedSessionId: string,
+): boolean {
+  const pending = draftsByCreationRequestId.get(creationRequestId);
+  draftsByCreationRequestId.delete(creationRequestId);
+  if (!pending) return false;
+  draftsByStoredSessionId.set(storedSessionId, pending);
+  return true;
+}
+
+export function clearPendingAgentSessionDraft(creationRequestId: string) {
+  draftsByCreationRequestId.delete(creationRequestId);
+}
+
+export function clearAgentSessionDraft(storedSessionId: string) {
+  draftsByStoredSessionId.delete(storedSessionId);
+}
+
+export function clearAgentSessionDraftRevision(storedSessionId: string, revision?: number) {
+  if (revision === undefined) return;
+  if (draftsByStoredSessionId.get(storedSessionId)?.revision !== revision) return;
+  draftsByStoredSessionId.delete(storedSessionId);
+}
+
+/** Test-only reset because workspace tests intentionally reuse stored session ids. */
 export function resetAgentSessionDraftsForTests() {
-  draftsBySessionId.clear();
+  draftsByStoredSessionId.clear();
+  draftsByCreationRequestId.clear();
+  nextRevision = 0;
 }

--- a/src/lib/agent-session-drafts.ts
+++ b/src/lib/agent-session-drafts.ts
@@ -1,0 +1,29 @@
+/**
+ * Unsent composer text follows its stored agent session while June stays open.
+ * Keep this process-local: drafts can contain sensitive material and should
+ * not survive an app restart.
+ */
+const draftsBySessionId = new Map<string, string>();
+
+export function readAgentSessionDraft(sessionId: string): string | undefined {
+  return draftsBySessionId.get(sessionId);
+}
+
+export function writeAgentSessionDraft(sessionId: string, draft: string) {
+  if (!sessionId) return;
+  if (draft.length === 0) {
+    draftsBySessionId.delete(sessionId);
+    return;
+  }
+  draftsBySessionId.set(sessionId, draft);
+}
+
+export function clearAgentSessionDraft(sessionId: string, expectedDraft?: string) {
+  if (expectedDraft !== undefined && draftsBySessionId.get(sessionId) !== expectedDraft) return;
+  draftsBySessionId.delete(sessionId);
+}
+
+/** Test-only reset because workspace tests intentionally reuse session ids. */
+export function resetAgentSessionDraftsForTests() {
+  draftsBySessionId.clear();
+}

--- a/src/lib/agent-session-drafts.ts
+++ b/src/lib/agent-session-drafts.ts
@@ -10,6 +10,7 @@ type AgentSessionDraft = {
 
 const draftsByStoredSessionId = new Map<string, AgentSessionDraft>();
 const draftsByCreationRequestId = new Map<string, AgentSessionDraft>();
+const invalidatedStoredSessionIds = new Set<string>();
 let nextRevision = 0;
 
 function snapshot(text: string): AgentSessionDraft {
@@ -25,7 +26,7 @@ export function readAgentSessionDraftRevision(storedSessionId: string): number |
 }
 
 export function writeAgentSessionDraft(storedSessionId: string, draft: string) {
-  if (!storedSessionId) return;
+  if (!storedSessionId || invalidatedStoredSessionIds.has(storedSessionId)) return;
   if (draft.length === 0) {
     draftsByStoredSessionId.delete(storedSessionId);
     return;
@@ -48,7 +49,7 @@ export function transferPendingAgentSessionDraft(
 ): boolean {
   const pending = draftsByCreationRequestId.get(creationRequestId);
   draftsByCreationRequestId.delete(creationRequestId);
-  if (!pending) return false;
+  if (!pending || invalidatedStoredSessionIds.has(storedSessionId)) return false;
   draftsByStoredSessionId.set(storedSessionId, pending);
   return true;
 }
@@ -57,7 +58,8 @@ export function clearPendingAgentSessionDraft(creationRequestId: string) {
   draftsByCreationRequestId.delete(creationRequestId);
 }
 
-export function clearAgentSessionDraft(storedSessionId: string) {
+export function invalidateAgentSessionDraft(storedSessionId: string) {
+  invalidatedStoredSessionIds.add(storedSessionId);
   draftsByStoredSessionId.delete(storedSessionId);
 }
 
@@ -71,5 +73,6 @@ export function clearAgentSessionDraftRevision(storedSessionId: string, revision
 export function resetAgentSessionDraftsForTests() {
   draftsByStoredSessionId.clear();
   draftsByCreationRequestId.clear();
+  invalidatedStoredSessionIds.clear();
   nextRevision = 0;
 }

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -38,6 +38,10 @@ import {
   setCurrentDataPartitionName,
 } from "../lib/data-partition";
 import { rememberSessionModel } from "../lib/agent-session-models";
+import {
+  readAgentSessionDraft,
+  resetAgentSessionDraftsForTests,
+} from "../lib/agent-session-drafts";
 import { readJuneHomeStoredSessionId, writeJuneHomeStoredSessionId } from "../lib/june-home";
 import { ATTACHMENT_FOLLOW_UP_NOTE, saveQueuedAgentFollowUps } from "../lib/agent-follow-up-queue";
 
@@ -109,6 +113,7 @@ function mockAgentLayoutBounds() {
 
 describe("AgentWorkspace runtime wiring", () => {
   beforeEach(() => {
+    resetAgentSessionDraftsForTests();
     resetCurrentDataPartitionForTests();
     window.localStorage.clear();
     mocks.runtimeListener = undefined;
@@ -210,6 +215,65 @@ describe("AgentWorkspace runtime wiring", () => {
   it("reserves the overlap between the transcript and fixed composer", () => {
     expect(agentComposerClearance(800, 620)).toBe(180);
     expect(agentComposerClearance(600, 620)).toBe(0);
+  });
+
+  it("keeps pending serialized drafts isolated by stored session through an immediate switch", async () => {
+    const user = userEvent.setup();
+    const draft = 'Review @note:note-7 ("Research")';
+    const { rerender } = render(<AgentWorkspace initialSession={session} />);
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+
+    await user.type(composer, draft);
+    // Do not wait for ComposerEditor's 75ms trailing publish: switching must
+    // preserve the live document using its teardown persistence callback.
+    rerender(<AgentWorkspace initialSession={newSession} />);
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "Message June" }).textContent).toBe("");
+    });
+
+    rerender(<AgentWorkspace initialSession={session} />);
+    await waitFor(() => {
+      expect(readAgentSessionDraft(session.id)).toBe(draft);
+    });
+  });
+
+  it("persists a pending draft when the workspace unmounts before the editor debounce", async () => {
+    const user = userEvent.setup();
+    const draft = "Keep this unfinished message";
+    const view = render(<AgentWorkspace initialSession={session} />);
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+
+    await user.type(composer, draft);
+    view.unmount();
+
+    render(<AgentWorkspace initialSession={session} />);
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "Message June" }).textContent).toBe(draft);
+    });
+  });
+
+  it("does not restore a session draft after its message is accepted", async () => {
+    const user = userEvent.setup();
+    const view = render(<AgentWorkspace initialSession={session} />);
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+
+    await user.type(composer, "Send this message");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => {
+      expect(mocks.invoke).toHaveBeenCalledWith(
+        "start_agent_run",
+        expect.objectContaining({
+          request: expect.objectContaining({ prompt: "Send this message" }),
+        }),
+      );
+      expect(readAgentSessionDraft(session.id)).toBeUndefined();
+    });
+
+    view.unmount();
+    render(<AgentWorkspace initialSession={session} />);
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "Message June" }).textContent).toBe("");
+    });
   });
 
   it("reserves the fixed composer before Home has a persisted session", async () => {
@@ -2749,6 +2813,7 @@ describe("AgentWorkspace runtime wiring", () => {
     );
     expect(screen.getByRole("button", { name: "Session actions" })).toBeVisible();
     expect(followUpComposer).toHaveTextContent("Follow-up draft");
+    expect(readAgentSessionDraft(newSession.id)).toBe("Follow-up draft");
     rerender(<AgentWorkspace initialSession={newSession} onSessionSelected={onSessionSelected} />);
     await waitFor(() =>
       expect(container.querySelector(".agent-user-turn")).toHaveTextContent("Fresh request"),

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -41,6 +41,7 @@ import { rememberSessionModel } from "../lib/agent-session-models";
 import {
   readAgentSessionDraft,
   resetAgentSessionDraftsForTests,
+  writeAgentSessionDraft,
 } from "../lib/agent-session-drafts";
 import { readJuneHomeStoredSessionId, writeJuneHomeStoredSessionId } from "../lib/june-home";
 import { ATTACHMENT_FOLLOW_UP_NOTE, saveQueuedAgentFollowUps } from "../lib/agent-follow-up-queue";
@@ -237,6 +238,40 @@ describe("AgentWorkspace runtime wiring", () => {
     });
   });
 
+  it("finishes IME composition under the source draft owner before switching", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<AgentWorkspace initialSession={session} />);
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+
+    fireEvent.compositionStart(composer);
+    await user.type(composer, "編集中");
+    rerender(<AgentWorkspace initialSession={newSession} />);
+
+    await waitFor(() => expect(composer).toHaveTextContent("編集中"));
+    fireEvent.compositionEnd(composer);
+    await waitFor(() => expect(readAgentSessionDraft(session.id)).toBe("編集中"));
+    await waitFor(() => expect(screen.getByRole("textbox").textContent).toBe(""));
+
+    rerender(<AgentWorkspace initialSession={session} />);
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveTextContent("編集中"));
+  });
+
+  it("does not submit a destination draft during an IME owner handoff", async () => {
+    const user = userEvent.setup();
+    writeAgentSessionDraft(newSession.id, "Destination draft");
+    const { rerender } = render(<AgentWorkspace initialSession={session} />);
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+
+    fireEvent.compositionStart(composer);
+    await user.type(composer, "Source composition");
+    rerender(<AgentWorkspace initialSession={newSession} />);
+
+    fireEvent.compositionEnd(composer);
+    fireEvent.keyDown(composer, { key: "Enter" });
+    expect(mocks.invoke).not.toHaveBeenCalledWith("start_agent_run", expect.anything());
+    await waitFor(() => expect(composer).toHaveTextContent("Destination draft"));
+  });
+
   it("persists a pending draft when the workspace unmounts before the editor debounce", async () => {
     const user = userEvent.setup();
     const draft = "Keep this unfinished message";
@@ -411,6 +446,38 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(readAgentSessionDraft(session.id)).toBeUndefined();
   });
 
+  it("does not let a late failed send recreate an externally deleted draft", async () => {
+    let rejectStart: ((cause: Error) => void) | undefined;
+    const pendingStart = new Promise((_, reject) => {
+      rejectStart = reject;
+    });
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "start_agent_run") return pendingStart;
+      return defaultInvoke?.(command, args);
+    });
+    const user = userEvent.setup();
+    const view = render(<AgentWorkspace initialSession={session} />);
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+
+    await user.type(composer, "Do not resurrect this");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", expect.anything()),
+    );
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_DELETE_SESSION_EVENT, { detail: { sessionId: session.id } }),
+      );
+    });
+    await act(async () => rejectStart?.(new Error("Runtime failed after deletion")));
+    expect(readAgentSessionDraft(session.id)).toBeUndefined();
+
+    view.unmount();
+    render(<AgentWorkspace initialSession={session} />);
+    await waitFor(() => expect(screen.getByRole("textbox").textContent).toBe(""));
+  });
+
   it("does not re-cache a pending draft after its stored session is deleted", async () => {
     const user = userEvent.setup();
     render(<AgentWorkspace initialSession={session} />);
@@ -428,6 +495,22 @@ describe("AgentWorkspace runtime wiring", () => {
     );
     await new Promise((resolve) => window.setTimeout(resolve, 100));
     expect(readAgentSessionDraft(session.id)).toBeUndefined();
+  });
+
+  it("clears a published draft from the composer when its session is deleted", async () => {
+    const user = userEvent.setup();
+    render(<AgentWorkspace initialSession={session} />);
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+    await user.type(composer, "Delete this published draft");
+    await waitFor(() =>
+      expect(readAgentSessionDraft(session.id)).toBe("Delete this published draft"),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Session actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete session" }));
+
+    await waitFor(() => expect(readAgentSessionDraft(session.id)).toBeUndefined());
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveTextContent(""));
   });
 
   it("reserves the fixed composer before Home has a persisted session", async () => {
@@ -3021,6 +3104,113 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(laterComposer).toHaveTextContent("Later draft");
     expect(screen.getByText("later.pdf")).toBeVisible();
     expect(screen.queryByText("Unsent message")).not.toBeInTheDocument();
+  });
+
+  it("restores a branch draft after a first session run fails and is retried", async () => {
+    const user = userEvent.setup();
+    let rejectFirstStart: ((error: Error) => void) | undefined;
+    const firstStart = new Promise((_, reject) => {
+      rejectFirstStart = reject;
+    });
+    let startCount = 0;
+    const branchSession: AgentSessionDto = {
+      ...newSession,
+      id: "session-branch",
+      title: "Branch",
+      workspacePath: "/tmp/session-branch",
+    };
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "start_agent_run" && startCount++ === 0) return firstStart;
+      if (command === "start_agent_run") {
+        return Promise.resolve({
+          id: "run-retry",
+          sessionId: newSession.id,
+          status: "running",
+          model: "auto",
+        });
+      }
+      if (command === "branch_agent_session") return Promise.resolve(branchSession);
+      if (
+        command === "get_agent_session" &&
+        [newSession.id, branchSession.id].includes(
+          (args as { sessionId?: string } | undefined)?.sessionId ?? "",
+        )
+      ) {
+        return Promise.resolve(
+          (args as { sessionId?: string }).sessionId === branchSession.id
+            ? branchSession
+            : newSession,
+        );
+      }
+      if (
+        command === "list_agent_items" &&
+        [newSession.id, branchSession.id].includes(
+          (args as { sessionId?: string } | undefined)?.sessionId ?? "",
+        )
+      ) {
+        return Promise.resolve([]);
+      }
+      return defaultInvoke?.(command, args);
+    });
+
+    render(<AgentWorkspace />);
+    const composer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(composer, "First submission");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", expect.anything()),
+    );
+    const followUpComposer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(followUpComposer, "Later draft");
+    await waitFor(() => expect(followUpComposer).toHaveTextContent("Later draft"));
+    await waitFor(() => expect(readAgentSessionDraft(newSession.id)).toBe("Later draft"));
+    await act(async () => rejectFirstStart?.(new Error("first run failed")));
+
+    await user.click(await screen.findByRole("button", { name: "Retry unsent message" }));
+    await waitFor(() => {
+      const starts = mocks.invoke.mock.calls.filter(([command]) => command === "start_agent_run");
+      expect(starts).toHaveLength(2);
+    });
+    act(() => {
+      mocks.runtimeListener?.({
+        payload: {
+          protocolVersion: 1,
+          eventId: "retry-message-completed",
+          sessionId: newSession.id,
+          runId: "run-retry",
+          sequence: 2,
+          method: "message.completed",
+          data: {
+            itemId: "retry-answer",
+            role: "assistant",
+            text: "Retry answer",
+            createdAt: "2026-07-22T12:01:00Z",
+          },
+        },
+      });
+      mocks.runtimeListener?.({
+        payload: {
+          protocolVersion: 1,
+          eventId: "retry-run-completed",
+          sessionId: newSession.id,
+          runId: "run-retry",
+          sequence: 3,
+          method: "run.completed",
+          data: { completedAt: "2026-07-22T12:02:00Z" },
+        },
+      });
+    });
+
+    writeAgentSessionDraft(branchSession.id, "Branch draft");
+    await screen.findAllByRole("button", { name: "Branch from here" });
+    fireEvent.click(screen.getAllByRole("button", { name: "Branch from here" }).at(-1) as Element);
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("branch_agent_session", expect.anything()),
+    );
+    await screen.findByText("Branch");
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveTextContent("Branch draft"));
+    expect(readAgentSessionDraft(branchSession.id)).toBe("Branch draft");
   });
 
   it("discards staged attachments when an unsent message is explicitly discarded", async () => {

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -32,7 +32,7 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({ open: mocks.openDialog }));
 import { AgentWorkspace } from "../components/agent/AgentWorkspace";
 import { markAgentNewSessionPending } from "../components/agent/session-persistence";
 import { agentComposerClearance } from "../components/agent/composer/layout";
-import { AGENT_NEW_SESSION_EVENT } from "../lib/agent-events";
+import { AGENT_DELETE_SESSION_EVENT, AGENT_NEW_SESSION_EVENT } from "../lib/agent-events";
 import {
   resetCurrentDataPartitionForTests,
   setCurrentDataPartitionName,
@@ -335,6 +335,7 @@ describe("AgentWorkspace runtime wiring", () => {
     );
     const followUpComposer = screen.getByRole("textbox", { name: "Message June" });
     await user.type(followUpComposer, "Keep this follow-up");
+    await new Promise((resolve) => window.setTimeout(resolve, 100));
     view.unmount();
 
     await act(async () => resolveCreate?.(newSession));
@@ -347,6 +348,67 @@ describe("AgentWorkspace runtime wiring", () => {
         "Keep this follow-up",
       ),
     );
+  });
+
+  it("transfers a first Home follow-up after its editor publishes normally", async () => {
+    const homeSession: AgentSessionDto = {
+      ...session,
+      id: "home-first-session",
+      title: "Home",
+      workspacePath: "/tmp/home-first-session",
+    };
+    let resolveCreate: ((value: AgentSessionDto) => void) | undefined;
+    const pendingCreate = new Promise<AgentSessionDto>((resolve) => {
+      resolveCreate = resolve;
+    });
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "list_agent_sessions") return Promise.resolve([]);
+      if (command === "create_agent_session") return pendingCreate;
+      if (command === "june_home_chat") return Promise.resolve({ reply: "Working on it." });
+      return defaultInvoke?.(command, args);
+    });
+    const user = userEvent.setup();
+    const view = render(<AgentWorkspace homeMode />);
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+
+    await user.type(composer, "First Home message");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("create_agent_session", expect.anything()),
+    );
+    await user.type(screen.getByRole("textbox"), "Keep this Home follow-up");
+    await new Promise((resolve) => window.setTimeout(resolve, 100));
+    view.unmount();
+
+    await act(async () => resolveCreate?.(homeSession));
+    render(<AgentWorkspace homeMode initialSession={homeSession} />);
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Message June" })).toHaveTextContent(
+        "Keep this Home follow-up",
+      ),
+    );
+  });
+
+  it("clears and fences drafts deleted by another session surface", async () => {
+    const user = userEvent.setup();
+    const view = render(<AgentWorkspace initialSession={session} />);
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+    await user.type(composer, "Published draft");
+    await waitFor(() => expect(readAgentSessionDraft(session.id)).toBe("Published draft"));
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_DELETE_SESSION_EVENT, { detail: { sessionId: session.id } }),
+      );
+    });
+    expect(readAgentSessionDraft(session.id)).toBeUndefined();
+
+    composer.textContent = "Late pending draft";
+    fireEvent.input(composer);
+    view.unmount();
+    await new Promise((resolve) => window.setTimeout(resolve, 100));
+    expect(readAgentSessionDraft(session.id)).toBeUndefined();
   });
 
   it("does not re-cache a pending draft after its stored session is deleted", async () => {

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -276,6 +276,98 @@ describe("AgentWorkspace runtime wiring", () => {
     });
   });
 
+  it("keeps a newer same-text draft when an older send finishes", async () => {
+    let resolveStart: ((value: unknown) => void) | undefined;
+    const pendingStart = new Promise((resolve) => {
+      resolveStart = resolve;
+    });
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "start_agent_run") return pendingStart;
+      return defaultInvoke?.(command, args);
+    });
+    const user = userEvent.setup();
+    const view = render(<AgentWorkspace initialSession={session} />);
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+
+    await user.type(composer, "Same message");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", expect.anything()),
+    );
+    await waitFor(() => expect(composer.textContent).toBe(""));
+    await user.type(composer, "Same message");
+    await waitFor(() => expect(readAgentSessionDraft(session.id)).toBe("Same message"));
+
+    await act(async () => {
+      resolveStart?.({
+        id: "run-same-message",
+        sessionId: session.id,
+        status: "running",
+        model: "fast",
+      });
+    });
+    await waitFor(() => expect(readAgentSessionDraft(session.id)).toBe("Same message"));
+
+    view.unmount();
+    render(<AgentWorkspace initialSession={session} />);
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveTextContent("Same message"));
+  });
+
+  it("transfers a fresh-session follow-up when navigation unmounts the workspace", async () => {
+    let resolveCreate: ((value: AgentSessionDto) => void) | undefined;
+    const pendingCreate = new Promise<AgentSessionDto>((resolve) => {
+      resolveCreate = resolve;
+    });
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "create_agent_session") return pendingCreate;
+      return defaultInvoke?.(command, args);
+    });
+    const user = userEvent.setup();
+    const view = render(<AgentWorkspace />);
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+
+    await user.type(composer, "Start a fresh session");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("create_agent_session", expect.anything()),
+    );
+    const followUpComposer = screen.getByRole("textbox", { name: "Message June" });
+    await user.type(followUpComposer, "Keep this follow-up");
+    view.unmount();
+
+    await act(async () => resolveCreate?.(newSession));
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("start_agent_run", expect.anything()),
+    );
+    render(<AgentWorkspace initialSession={newSession} />);
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Message June" })).toHaveTextContent(
+        "Keep this follow-up",
+      ),
+    );
+  });
+
+  it("does not re-cache a pending draft after its stored session is deleted", async () => {
+    const user = userEvent.setup();
+    render(<AgentWorkspace initialSession={session} />);
+    const composer = await screen.findByRole("textbox", { name: "Message June" });
+    await user.click(screen.getByRole("button", { name: "Session actions" }));
+
+    composer.textContent = "Delete this pending draft";
+    fireEvent.input(composer);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete session" }));
+
+    await waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("delete_agent_session", {
+        sessionId: session.id,
+      }),
+    );
+    await new Promise((resolve) => window.setTimeout(resolve, 100));
+    expect(readAgentSessionDraft(session.id)).toBeUndefined();
+  });
+
   it("reserves the fixed composer before Home has a persisted session", async () => {
     mocks.invoke.mockImplementation((command: string) => {
       if (command === "list_agent_sessions") return Promise.resolve([]);


### PR DESCRIPTION
## Summary

- Preserve each stored session's unfinished composer draft when navigating to meeting notes, another session, or another app surface.
- Restore the exact serialized composer content, including note references, without leaking drafts between sessions.
- Clear drafts after accepted sends or deletion, and fence late asynchronous writes from recreating deleted content.

## Root cause

The composer document lived only in the mounted editor and parent component state. Navigating away unmounted or retargeted the editor before its debounced text publication completed, so there was no session-owned draft to restore. Creation, send, deletion, and IME handoff races also lacked a stable revision and ownership boundary.

## Validation

- `pnpm exec vitest run src/test/agent-workspace-runtime.test.tsx src/test/composer-editor-change-publishing.test.tsx` (73 passed)
- `pnpm typecheck`
- `pnpm check` (passes with the existing warning baseline)
- Live browser walkthrough: type a draft in a stored session, open Meeting notes, return to the session, and confirm exact restoration with no browser errors.
- Full frontend suite was also exercised; 1,648 of 1,697 tests passed, with 49 unrelated pre-existing `connectors-section.test.tsx` failures caused by its incomplete `CONNECTORS_CHANGED_EVENT` mock.

- [x] Tested visually where it matters. A local screenshot and recording were captured under `.tmp/qa-recordings/jun-468/`; they were not published externally.
- [ ] Needs a June API (backend) deploy before it works end to end. No backend deploy is required.

## Out of scope

- Persisting drafts across a full application restart. Drafts intentionally remain process-local, matching the existing privacy posture.
- Changing the behavior of the ownerless blank new-session composer.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary (none).
- [x] Workflow action references are pinned to full-length commit SHAs (no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review (not applicable).
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review (not applicable).
- [x] User-facing copy follows the repo UI conventions (no user-facing copy changes).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788980338&installation_model_id=425925&pr_number=1034&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1034&signature=e655ac5307ac68ebf8e97a9e2e34913bc44145706f0689881977dc0272db48cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->