### PR TITLE
JUN-469 Keep attachments scoped to their messages

### DIFF
--- a/src-tauri/migrations/034_agent_artifact_display_names.sql
+++ b/src-tauri/migrations/034_agent_artifact_display_names.sql
@@ -1,0 +1,12 @@
+UPDATE agent_artifacts
+SET display_name = (
+  SELECT json_extract(attachment.value, '$.name')
+  FROM agent_items
+  JOIN json_each(agent_items.payload_json, '$.attachments') AS attachment
+  WHERE agent_items.id = agent_artifacts.item_id
+    AND json_extract(attachment.value, '$.path') = agent_artifacts.path
+  LIMIT 1
+)
+WHERE provenance = 'attachment'
+  AND display_name IS NULL
+  AND item_id IS NOT NULL;

--- a/src-tauri/src/agent_runtime/api.rs
+++ b/src-tauri/src/agent_runtime/api.rs
@@ -474,7 +474,7 @@ pub async fn branch_agent_session(
         item_ids.insert(source_item_id, branch_item_id);
     }
     let artifacts = sqlx::query::query(
-        "SELECT id, item_id, provenance, action, path, original_path, mime_type, size_bytes, available, created_at
+        "SELECT id, item_id, provenance, action, path, original_path, display_name, mime_type, size_bytes, available, created_at
          FROM agent_artifacts WHERE session_id = ? AND created_at <= ? ORDER BY created_at ASC",
     )
     .bind(&session_id)
@@ -514,8 +514,8 @@ pub async fn branch_agent_session(
         let source_item_id: Option<String> = artifact.get("item_id");
         sqlx::query::query(
             "INSERT INTO agent_artifacts
-             (id, session_id, item_id, provenance, action, path, original_path, mime_type, size_bytes, available, created_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+             (id, session_id, item_id, provenance, action, path, original_path, display_name, mime_type, size_bytes, available, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(uuid::Uuid::new_v4().to_string())
         .bind(&branch.id)
@@ -524,6 +524,7 @@ pub async fn branch_agent_session(
         .bind(artifact.get::<String, _>("action"))
         .bind(destination.to_string_lossy().as_ref())
         .bind(artifact.get::<Option<String>, _>("original_path"))
+        .bind(artifact.get::<Option<String>, _>("display_name"))
         .bind(artifact.get::<Option<String>, _>("mime_type"))
         .bind(artifact.get::<Option<i64>, _>("size_bytes"))
         .bind(i64::from(available))
@@ -1626,7 +1627,70 @@ pub async fn list_agent_artifacts(
     app: AppHandle,
     session_id: String,
 ) -> Result<Vec<Value>, AppError> {
-    Ok(repository(&app).await?.artifacts(&session_id).await?.into_iter().map(|artifact| json!({ "id": artifact.id, "sessionId": artifact.session_id, "runId": artifact.run_id, "itemId": artifact.item_id, "name": PathBuf::from(&artifact.path).file_name().map(|v| v.to_string_lossy().into_owned()).unwrap_or_else(|| "Artifact".into()), "path": artifact.path, "mimeType": artifact.mime_type, "sizeBytes": artifact.size_bytes, "action": artifact.action, "available": artifact.available, "createdAt": artifact.created_at })).collect())
+    let repository = repository(&app).await?;
+    Ok(repository.artifacts(&session_id).await?.into_iter().map(|artifact| {
+        let name = artifact_display_name(
+            &artifact.path,
+            artifact.original_path.as_deref(),
+            &artifact.provenance,
+            artifact.display_name.as_deref(),
+        );
+        json!({ "id": artifact.id, "sessionId": artifact.session_id, "runId": artifact.run_id, "itemId": artifact.item_id, "name": name, "path": artifact.path, "mimeType": artifact.mime_type, "sizeBytes": artifact.size_bytes, "action": artifact.action, "available": artifact.available, "createdAt": artifact.created_at })
+    }).collect())
+}
+
+fn artifact_display_name(
+    path: &str,
+    original_path: Option<&str>,
+    provenance: &str,
+    persisted_name: Option<&str>,
+) -> String {
+    if let Some(name) = persisted_name {
+        return name.to_string();
+    }
+    let stored_name = PathBuf::from(path)
+        .file_name()
+        .map(|value| value.to_string_lossy().into_owned());
+    if provenance == "attachment" {
+        let original_name = original_path
+            .and_then(|value| PathBuf::from(value).file_name().map(|name| name.to_owned()))
+            .map(|value| value.to_string_lossy().into_owned());
+        if let Some(name) = stored_name
+            .as_deref()
+            .and_then(|name| copied_attachment_name(name, original_name.as_deref()))
+        {
+            return name.to_string();
+        }
+        if let Some(name) = original_name {
+            return name;
+        }
+    }
+    stored_name.unwrap_or_else(|| "Artifact".into())
+}
+
+fn copied_attachment_name<'a>(
+    stored_name: &'a str,
+    original_name: Option<&str>,
+) -> Option<&'a str> {
+    let mut name = stored_name;
+    let mut stripped = false;
+    while let Some(remainder) = strip_copy_prefix(name) {
+        stripped = true;
+        name = remainder;
+        if original_name == Some(name) {
+            break;
+        }
+    }
+    stripped.then_some(name)
+}
+
+fn strip_copy_prefix(name: &str) -> Option<&str> {
+    let uuid_prefix = name.get(..36)?;
+    let remainder = name.get(37..)?;
+    (name.as_bytes().get(36) == Some(&b'-')
+        && uuid::Uuid::parse_str(uuid_prefix).is_ok()
+        && !remainder.is_empty())
+    .then_some(remainder)
 }
 
 #[tauri::command]
@@ -2610,8 +2674,8 @@ async fn persist_attachments(
         sqlx::query::query(
             "INSERT INTO agent_artifacts (
                 id, session_id, run_id, item_id, provenance, action, path,
-                original_path, mime_type, size_bytes, available, created_at
-             ) VALUES (?, ?, ?, ?, 'attachment', 'imported', ?, ?, ?, ?, 1, ?)",
+                original_path, display_name, mime_type, size_bytes, available, created_at
+             ) VALUES (?, ?, ?, ?, 'attachment', 'imported', ?, ?, ?, ?, ?, 1, ?)",
         )
         .bind(&attachment.id)
         .bind(session_id)
@@ -2619,6 +2683,7 @@ async fn persist_attachments(
         .bind(item_id)
         .bind(&attachment.path)
         .bind(original_paths.get(index))
+        .bind(&attachment.name)
         .bind(&attachment.mime_type)
         .bind(attachment.size_bytes)
         .bind(&attachment.created_at)
@@ -2706,6 +2771,87 @@ fn attachment_mime_type(path: &std::path::Path) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn attachment_display_name_strips_the_internal_copy_prefix() {
+        assert_eq!(
+            artifact_display_name(
+                "/workspace/attachments/1fb34e2e-e4e7-45d7-b538-a87aefa4c8e4-Pool Day.pdf",
+                Some("/tmp/companion/content"),
+                "attachment",
+                None,
+            ),
+            "Pool Day.pdf"
+        );
+    }
+
+    #[test]
+    fn attachment_display_name_falls_back_to_the_original_path() {
+        assert_eq!(
+            artifact_display_name(
+                "/workspace/attachments/staged-content",
+                Some("/Users/andrew/Documents/Pool Day.pdf"),
+                "attachment",
+                None,
+            ),
+            "Pool Day.pdf"
+        );
+    }
+
+    #[test]
+    fn attachment_display_name_strips_copy_prefixes_from_repeated_branches() {
+        assert_eq!(
+            artifact_display_name(
+                "/workspace/artifacts/9bc2de72-d7b9-4f2a-ae01-cce9bacb2664-1fb34e2e-e4e7-45d7-b538-a87aefa4c8e4-Pool Day.pdf",
+                Some("/Users/andrew/Documents/Pool Day.pdf"),
+                "attachment",
+                None,
+            ),
+            "Pool Day.pdf"
+        );
+    }
+
+    #[test]
+    fn attachment_display_name_preserves_a_uuid_prefixed_original_name() {
+        assert_eq!(
+            artifact_display_name(
+                "/workspace/attachments/1fb34e2e-e4e7-45d7-b538-a87aefa4c8e4-9bc2de72-d7b9-4f2a-ae01-cce9bacb2664-notes.pdf",
+                Some("/Users/andrew/Documents/9bc2de72-d7b9-4f2a-ae01-cce9bacb2664-notes.pdf"),
+                "attachment",
+                None,
+            ),
+            "9bc2de72-d7b9-4f2a-ae01-cce9bacb2664-notes.pdf"
+        );
+    }
+
+    #[test]
+    fn attachment_display_name_prefers_the_persisted_metadata_name() {
+        let path = "/workspace/attachments/1fb34e2e-e4e7-45d7-b538-a87aefa4c8e4-9bc2de72-d7b9-4f2a-ae01-cce9bacb2664-notes.pdf";
+        let persisted_name = "9bc2de72-d7b9-4f2a-ae01-cce9bacb2664-notes.pdf";
+
+        assert_eq!(
+            artifact_display_name(
+                path,
+                Some("/tmp/companion/content"),
+                "attachment",
+                Some(persisted_name),
+            ),
+            persisted_name
+        );
+    }
+
+    #[test]
+    fn generated_artifact_display_name_keeps_its_workspace_name() {
+        assert_eq!(
+            artifact_display_name(
+                "/workspace/artifacts/generated-report.pdf",
+                Some("/Users/andrew/Documents/source.pdf"),
+                "tool",
+                None,
+            ),
+            "generated-report.pdf"
+        );
+    }
 
     #[test]
     fn staged_attachment_file_names_must_be_safe_bare_names() {

--- a/src-tauri/src/agent_runtime/domain.rs
+++ b/src-tauri/src/agent_runtime/domain.rs
@@ -167,6 +167,7 @@ pub struct AgentArtifactDto {
     pub action: String,
     pub path: String,
     pub original_path: Option<String>,
+    pub display_name: Option<String>,
     pub mime_type: Option<String>,
     pub size_bytes: Option<i64>,
     pub available: bool,

--- a/src-tauri/src/agent_runtime/repository.rs
+++ b/src-tauri/src/agent_runtime/repository.rs
@@ -1027,7 +1027,7 @@ impl AgentRepository {
     }
 
     pub async fn artifacts(&self, session_id: &str) -> Result<Vec<AgentArtifactDto>, sqlx::Error> {
-        let rows = query("SELECT id, session_id, run_id, item_id, provenance, action, path, original_path, mime_type, size_bytes, available, created_at FROM agent_artifacts WHERE session_id = ? ORDER BY created_at ASC")
+        let rows = query("SELECT id, session_id, run_id, item_id, provenance, action, path, original_path, display_name, mime_type, size_bytes, available, created_at FROM agent_artifacts WHERE session_id = ? ORDER BY created_at ASC")
             .bind(session_id).fetch_all(&self.pool).await?;
         Ok(rows
             .into_iter()
@@ -1040,6 +1040,7 @@ impl AgentRepository {
                 action: row.get("action"),
                 path: row.get("path"),
                 original_path: row.get("original_path"),
+                display_name: row.get("display_name"),
                 mime_type: row.get("mime_type"),
                 size_bytes: row.get("size_bytes"),
                 available: row.get::<i64, _>("available") != 0,

--- a/src-tauri/src/companion/media.rs
+++ b/src-tauri/src/companion/media.rs
@@ -673,6 +673,7 @@ mod tests {
             action: "generate_image".to_string(),
             path: "/tmp/artifact".to_string(),
             original_path: None,
+            display_name: None,
             mime_type: Some(media_type.to_string()),
             size_bytes: Some(1),
             available: true,

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -1330,6 +1330,23 @@ const MIGRATIONS: &[Migration] = &[
             "../../migrations/033_linear_managed_mcp.sql"
         ))],
     },
+    Migration {
+        version: 50,
+        name: "agent_artifact_display_names",
+        requirements: &[SchemaRequirement::Column {
+            table: "agent_artifacts",
+            column: "display_name",
+        }],
+        steps: &[
+            MigrationStep::EnsureColumns {
+                table: "agent_artifacts",
+                columns: AGENT_ARTIFACT_DISPLAY_NAME_COLUMN,
+            },
+            MigrationStep::Sql(include_str!(
+                "../../migrations/034_agent_artifact_display_names.sql"
+            )),
+        ],
+    },
 ];
 
 const NOTE_REVISION_COLUMN: &[ColumnDefinition] = &[ColumnDefinition {
@@ -1347,6 +1364,10 @@ const COMPANION_ACCOUNT_USER_COLUMN: &[ColumnDefinition] = &[ColumnDefinition {
 const COMPANION_OPERATION_STATE_COLUMN: &[ColumnDefinition] = &[ColumnDefinition {
     name: "operation_state",
     definition: "TEXT NOT NULL DEFAULT 'completed'",
+}];
+const AGENT_ARTIFACT_DISPLAY_NAME_COLUMN: &[ColumnDefinition] = &[ColumnDefinition {
+    name: "display_name",
+    definition: "TEXT",
 }];
 
 struct AppliedMigration {
@@ -2324,9 +2345,83 @@ mod tests {
                 (47, "companion_computer_use_approval_audit".to_string()),
                 (48, "linear_managed_mcp".to_string()),
                 (49, "linear_managed_mcp_repair".to_string()),
+                (50, "agent_artifact_display_names".to_string()),
             ]
         );
         assert_latest_stamp(&pool).await;
+    }
+
+    #[tokio::test]
+    async fn artifact_display_name_survives_message_compaction() {
+        let pool = test_pool().await;
+        run_migration_catalog(&pool, &MIGRATIONS[..49])
+            .await
+            .expect("schema before artifact display names");
+        query(
+            "INSERT INTO agent_sessions (
+                id, title, status, model, safety_mode, source, created_at, updated_at
+             ) VALUES ('session', 'title', 'idle', 'auto', 'sandboxed', 'user', 'now', 'now')",
+        )
+        .execute(&pool)
+        .await
+        .expect("agent session");
+        let path = "/workspace/attachments/1fb34e2e-e4e7-45d7-b538-a87aefa4c8e4-9bc2de72-d7b9-4f2a-ae01-cce9bacb2664-notes.pdf";
+        let display_name = "9bc2de72-d7b9-4f2a-ae01-cce9bacb2664-notes.pdf";
+        let payload = serde_json::json!({
+            "role": "user",
+            "content": "Review this",
+            "attachments": [{
+                "id": "attachment",
+                "name": display_name,
+                "path": path,
+                "mimeType": "application/pdf",
+                "sizeBytes": 42,
+                "available": true,
+                "createdAt": "now"
+            }]
+        })
+        .to_string();
+        query(
+            "INSERT INTO agent_items (
+                id, session_id, sequence, kind, payload_json, created_at
+             ) VALUES ('message', 'session', 1, 'user_message', ?, 'now')",
+        )
+        .bind(payload)
+        .execute(&pool)
+        .await
+        .expect("agent message");
+        query(
+            "INSERT INTO agent_artifacts (
+                id, session_id, item_id, provenance, action, path, original_path,
+                mime_type, size_bytes, available, created_at
+             ) VALUES (
+                'artifact', 'session', 'message', 'attachment', 'imported', ?,
+                '/tmp/companion/content', 'application/pdf', 42, 1, 'now'
+             )",
+        )
+        .bind(path)
+        .execute(&pool)
+        .await
+        .expect("agent artifact");
+
+        run_migrations(&pool)
+            .await
+            .expect("artifact display-name migration");
+        query("DELETE FROM agent_items WHERE id = 'message'")
+            .execute(&pool)
+            .await
+            .expect("compact message");
+        let artifact =
+            query("SELECT item_id, display_name FROM agent_artifacts WHERE id = 'artifact'")
+                .fetch_one(&pool)
+                .await
+                .expect("persisted artifact");
+
+        assert_eq!(artifact.get::<Option<String>, _>("item_id"), None);
+        assert_eq!(
+            artifact.get::<Option<String>, _>("display_name").as_deref(),
+            Some(display_name)
+        );
     }
 
     #[tokio::test]
@@ -2570,6 +2665,7 @@ mod tests {
                 (47, "companion_computer_use_approval_audit".to_string()),
                 (48, "linear_managed_mcp".to_string()),
                 (49, "linear_managed_mcp_repair".to_string()),
+                (50, "agent_artifact_display_names".to_string()),
             ]
         );
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2608,6 +2608,7 @@ export function AgentWorkspace({
                         onSecret={(part, secret) =>
                           void respondToSecret(part.runId, part.id, secret)
                         }
+                        onOpenArtifact={openArtifact}
                         homeTaskHandoff={homeHandoffsByTurnId.get(turn.id)}
                         onOpenHomeTaskSession={onOpenHomeTaskSession}
                         onRetryHomeTask={retryHomeTask}
@@ -2719,6 +2720,7 @@ export function AgentWorkspace({
                     }
                     onSudo={() => undefined}
                     onSecret={(part, secret) => void respondToSecret(part.runId, part.id, secret)}
+                    onOpenArtifact={openArtifact}
                     onRetryUpstreamFailure={(turnId) => void retryFailure(turnId)}
                     onBranch={(itemId) => void branchFrom(itemId)}
                     branching={branchingItemId === turn.id}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -108,7 +108,6 @@ import {
 } from "../../lib/agent-project-context";
 import { AgentChatTurnRow } from "./chat-turns/AgentChatTurnRow";
 import {
-  AgentArtifactList,
   AgentArtifactPanel,
   type AgentArtifact,
   type AgentArtifactPanelState,
@@ -2727,11 +2726,6 @@ export function AgentWorkspace({
                     upstreamFailureRetryDisabled={running || waiting || submitting}
                   />
                 ))}
-                <AgentArtifactList
-                  artifacts={renderedArtifacts}
-                  onOpen={openArtifact}
-                  onDownload={(artifact) => void downloadArtifact(artifact)}
-                />
                 <AgentThinking
                   visible={(running || submitting) && visibleTurns.at(-1)?.role === "user"}
                 />

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -212,6 +212,82 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(agentComposerClearance(600, 620)).toBe(0);
   });
 
+  it("keeps persisted files on their user message instead of repeating them after the thread", async () => {
+    const defaultInvoke = mocks.invoke.getMockImplementation();
+    mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "list_agent_items") {
+        return Promise.resolve([
+          {
+            id: "message-with-attachment",
+            sessionId: session.id,
+            runId: "run-1",
+            sequence: 1,
+            createdAt: session.createdAt,
+            kind: "message",
+            role: "user",
+            text: "Review this contract.",
+            status: "complete",
+            attachments: [
+              {
+                id: "attachment-1",
+                sessionId: session.id,
+                runId: "run-1",
+                itemId: "message-with-attachment",
+                name: "Pool Day.pdf",
+                path: "/tmp/session-1/attachments/internal-Pool Day.pdf",
+                mimeType: "application/pdf",
+                sizeBytes: 115_000,
+                action: "imported",
+                available: true,
+                createdAt: session.createdAt,
+              },
+            ],
+          },
+        ]);
+      }
+      if (command === "list_agent_artifacts") {
+        return Promise.resolve([
+          {
+            id: "attachment-1",
+            sessionId: session.id,
+            runId: "run-1",
+            itemId: "message-with-attachment",
+            name: "Pool Day.pdf",
+            path: "/tmp/session-1/attachments/internal-Pool Day.pdf",
+            mimeType: "application/pdf",
+            sizeBytes: 115_000,
+            action: "imported",
+            available: true,
+            createdAt: session.createdAt,
+          },
+        ]);
+      }
+      return defaultInvoke?.(command, args);
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<AgentWorkspace initialSession={session} />);
+    const userTurn = await screen
+      .findByText("Review this contract.")
+      .then((text) => text.closest(".agent-user-turn"));
+    expect(userTurn).not.toBeNull();
+    const attachmentGroup = within(userTurn as HTMLElement).getByRole("group", {
+      name: "Attachments",
+    });
+    expect(attachmentGroup).toHaveTextContent("Pool Day.pdf");
+    const turnActions = userTurn?.querySelector(".agent-turn-actions");
+    expect(turnActions).toBeTruthy();
+    expect(
+      attachmentGroup.compareDocumentPosition(turnActions as Node) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(container.querySelector(".agent-timeline > .agent-artifact-list")).toBeNull();
+    expect(screen.getAllByText("Pool Day.pdf")).toHaveLength(1);
+
+    await user.click(screen.getByRole("button", { name: "View files (1)" }));
+    expect(screen.getByRole("complementary", { name: "Files" })).toHaveTextContent("Pool Day.pdf");
+  });
+
   it("reserves the fixed composer before Home has a persisted session", async () => {
     mocks.invoke.mockImplementation((command: string) => {
       if (command === "list_agent_sessions") return Promise.resolve([]);

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -284,6 +284,12 @@ describe("AgentWorkspace runtime wiring", () => {
     expect(container.querySelector(".agent-timeline > .agent-artifact-list")).toBeNull();
     expect(screen.getAllByText("Pool Day.pdf")).toHaveLength(1);
 
+    await user.click(
+      within(userTurn as HTMLElement).getByRole("button", { name: "Open Pool Day.pdf" }),
+    );
+    expect(screen.getByRole("complementary", { name: "Files" })).toHaveTextContent("Pool Day.pdf");
+    await user.click(screen.getByRole("button", { name: "Close files" }));
+
     await user.click(screen.getByRole("button", { name: "View files (1)" }));
     expect(screen.getByRole("complementary", { name: "Files" })).toHaveTextContent("Pool Day.pdf");
   });


### PR DESCRIPTION
## Summary\n\n- Keep persisted attachments inside the user message that submitted them.\n- Remove the duplicate session-wide attachment gallery from the bottom of the conversation.\n- Keep the Files panel as the session-wide archive.\n- Persist original artifact display names across session branching and context compaction.\n\nCloses JUN-469\n\n## Root cause\n\nThe conversation rendered artifact history in two places: inside message payloads and again as a session-level artifact list after the timeline. Artifact names were reconstructed from copied storage paths, so branch UUID prefixes could leak into the visible filename, and message compaction could remove the only canonical name source.\n\n## Validation\n\n- Independent QA agent: PASS using fabricated local-only files.\n- Verified two attachments render exactly once in their originating user messages.\n- Verified footer, timestamp, and actions follow and sit below each attachment group.\n- Verified no session-wide artifact gallery remains at the bottom of the timeline.\n- Verified the Files panel still lists all session artifacts.\n- Verified targeted frontend suite: 55/55.\n- Verified display-name rules: 5/5; compaction migration: 1/1; branch path rewrite: 1/1.\n- Verified full frontend suite: 156 files and 1,695 tests passed.\n- Verified full Tauri test suite, migration suite, formatting, lint, typecheck, and diff checks.\n- [x] Tested visually where it matters. Evidence was inspected locally with synthetic data; no screenshot or recording is attached to protect reporter-provided material.\n- [ ] Needs a June API (backend) deploy before it works end to end. No June API deploy is required.\n\n## Out of scope\n\n- Changing the Files panel layout or file-retention behavior.\n- Exercising real user documents, accounts, or sidecars.\n- Native WKWebView end-to-end branch-session QA.\n\n## Followups\n\n- None required for this fix.\n\n## Security and release checklist\n\n- [x] No secrets, local environment values, signing material, tokens, or customer data are committed.\n- [x] Security-sensitive changes were called out in the summary. No security-sensitive behavior changed.\n- [x] Workflow action references are pinned to full-length commit SHAs. No workflow files changed.\n- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. None changed.\n- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. None changed.\n- [x] User-facing copy follows the repo UI conventions. No new user-facing copy was added.