### PR TITLE
JUN-468 Restore drafts after prefilled sessions

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -870,15 +870,8 @@ export function AgentWorkspace({
       .catch(() => setVeniceApiKeyConfigured(false));
   }, [homeMode, initialAgentSession, initialSessionId, refreshSessions]);
 
-  const pendingDraftTakesPriorityRef = useRef(Boolean(pendingRequestRef.current?.prompt));
   useEffect(() => {
     if (!selectedId) return;
-    // A request that opens a new session deliberately pre-fills the composer;
-    // do not let a stale session draft replace that navigation intent.
-    if (pendingDraftTakesPriorityRef.current) {
-      pendingDraftTakesPriorityRef.current = false;
-      return;
-    }
     // The first session id is assigned while its initial send is still in
     // flight. Its composer may already contain a follow-up, which is not a
     // stored draft to restore over.

--- a/src/test/agent-workspace-runtime.test.tsx
+++ b/src/test/agent-workspace-runtime.test.tsx
@@ -320,6 +320,23 @@ describe("AgentWorkspace runtime wiring", () => {
     });
   });
 
+  it("restores a stored draft after leaving a prefilled new session", async () => {
+    writeAgentSessionDraft(session.id, "Saved session draft");
+    markAgentNewSessionPending("Prefilled new request");
+
+    const { rerender } = render(<AgentWorkspace />);
+    await screen.findByRole("textbox", { name: "Message June" });
+
+    rerender(<AgentWorkspace initialSession={session} />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Message June" })).toHaveTextContent(
+        "Saved session draft",
+      ),
+    );
+    expect(readAgentSessionDraft(session.id)).toBe("Saved session draft");
+  });
+
   it("finishes IME composition under the source draft owner before switching", async () => {
     const user = userEvent.setup();
     const { rerender } = render(<AgentWorkspace initialSession={session} />);


### PR DESCRIPTION
## Summary
- restore the selected stored session's draft when leaving a prefilled new-session composer
- keep the existing in-flight session-creation fence
- add a regression test for the prefill-to-stored-session handoff

## Verification
- `vitest run src/test/agent-workspace-runtime.test.tsx` — 69/69 passed
- `tsc --noEmit` — passed
- `biome check` — passed with 9 pre-existing warnings
- Impeccable detector — no issues

## Design evidence
Interaction hierarchy was checked against [Perplexity's file-aware assistant screen](https://mobbin.com/screens/ca6adb06-446a-4a4d-af32-1aea14f53de0). This patch changes state ownership only; it intentionally makes no visual change.

OS Platform is not configured in this environment, so issue synchronization was skipped. This draft PR is not authorized for merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789046225&installation_model_id=425925&pr_number=1036&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F1036&signature=391836da6ee2430aec5592b8c5d51b619f6480ba1371ac0703cd706a0675aa10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->